### PR TITLE
Sparse global order reader: consider qc results after deduplication.

### DIFF
--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -149,7 +149,7 @@ TEST_CASE(
   REQUIRE(rc == TILEDB_OK);
   tiledb_domain_free(&domain);
 
-  ResultTileWithBitmap<uint8_t> tile(
+  UnorderedWithDupsResultTile<uint8_t> tile(
       0, 0, *(array_schema->array_schema_.get()));
   tile.bitmap_result_num_ = 100;
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -805,7 +805,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   if (dups) {
-    CHECK(3 * sizeof(int) == data_r_size);
+    CHECK(3 * sizeof(int) == coords_r_size);
     CHECK(3 * sizeof(int) == data_r_size);
 
     int coords_c[] = {1, 2, 3};
@@ -859,7 +859,7 @@ TEST_CASE_METHOD(
 
   // One value.
   CHECK(sizeof(int) == data_r_size);
-  CHECK(4 == coords_r_size);
+  CHECK(sizeof(int) == coords_r_size);
 
   int coords_c[] = {2};
   int data_c[] = {4};

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -767,6 +767,97 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CSparseGlobalOrderFx,
+    "Sparse global order reader: qc removes tile from second fragment "
+    "replacing data from first fragment",
+    "[sparse-global-order][qc-removes-replacement-data]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d();
+
+  bool use_subarray = false;
+  SECTION("- No subarray") {
+    use_subarray = false;
+  }
+  SECTION("- Subarray") {
+    use_subarray = true;
+  }
+
+  int coords_1[] = {1, 2, 3};
+  int data_1[] = {2, 2, 2};
+
+  int coords_2[] = {1, 2, 3};
+  int data_2[] = {12, 12, 12};
+
+  uint64_t coords_size = sizeof(coords_1);
+  uint64_t data_size = sizeof(data_1);
+  write_1d_fragment(coords_1, &coords_size, data_1, &data_size);
+  write_1d_fragment(coords_2, &coords_size, data_2, &data_size);
+
+  // Read.
+  int coords_r[6];
+  int data_r[6];
+  uint64_t coords_r_size = sizeof(coords_r);
+  uint64_t data_r_size = sizeof(data_r);
+
+  auto rc =
+      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Should read nothing.
+  CHECK(0 == data_r_size);
+  CHECK(0 == coords_r_size);
+}
+
+TEST_CASE_METHOD(
+    CSparseGlobalOrderFx,
+    "Sparse global order reader: qc removes tile from second fragment "
+    "replacing data from first fragment, 2",
+    "[sparse-global-order][qc-removes-replacement-data]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d();
+
+  bool use_subarray = false;
+  SECTION("- No subarray") {
+    use_subarray = false;
+  }
+  SECTION("- Subarray") {
+    use_subarray = true;
+  }
+
+  int coords_1[] = {1, 2, 3};
+  int data_1[] = {2, 2, 2};
+
+  int coords_2[] = {1, 2, 3};
+  int data_2[] = {12, 4, 12};
+
+  uint64_t coords_size = sizeof(coords_1);
+  uint64_t data_size = sizeof(data_1);
+  write_1d_fragment(coords_1, &coords_size, data_1, &data_size);
+  write_1d_fragment(coords_2, &coords_size, data_2, &data_size);
+
+  // Read.
+  int coords_r[6];
+  int data_r[6];
+  uint64_t coords_r_size = sizeof(coords_r);
+  uint64_t data_r_size = sizeof(data_r);
+
+  auto rc =
+      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Should read nothing.
+  CHECK(4 == data_r_size);
+  CHECK(4 == coords_r_size);
+
+  int coords_c[] = {2};
+  int data_c[] = {4};
+  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
+  CHECK(!std::memcmp(data_c, data_r, data_r_size));
+}
+
+TEST_CASE_METHOD(
+    CSparseGlobalOrderFx,
     "Sparse global order reader: merge with subarray and dups",
     "[sparse-global-order][merge][subarray][dups]") {
   // Create default array.

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1094,8 +1094,8 @@ TEST_CASE_METHOD(
   CHECK(status == TILEDB_COMPLETED);
 
   // Should read last tile (1 value).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
+  CHECK(sizeof(int) == data_r_size);
+  CHECK(sizeof(int) == coords_r_size);
 
   int coords_c_3[] = {5};
   int data_c_3[] = {5};
@@ -1188,8 +1188,8 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   // Should read two tile (6 values).
-  CHECK(24 == data_r_size);
-  CHECK(24 == coords_r_size);
+  CHECK(6 * sizeof(int) == data_r_size);
+  CHECK(6 * sizeof(int) == coords_r_size);
 
   int coords_c[] = {1, 2, 3, 4, 5, 6};
   int data_c[] = {1, 2, 3, 4, 5, 6};
@@ -1245,8 +1245,8 @@ TEST_CASE_METHOD(
   CHECK(status == TILEDB_INCOMPLETE);
 
   // Should only read one cell (1 values).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
+  CHECK(sizeof(int) == data_r_size);
+  CHECK(sizeof(int) == coords_r_size);
 
   int coords_c_1[] = {1};
   int data_c_1[] = {1};
@@ -1262,8 +1262,8 @@ TEST_CASE_METHOD(
   CHECK(status == TILEDB_COMPLETED);
 
   // Should read last cell (1 values).
-  CHECK(4 == data_r_size);
-  CHECK(4 == coords_r_size);
+  CHECK(sizeof(int) == data_r_size);
+  CHECK(sizeof(int) == coords_r_size);
 
   int coords_c_2[] = {2};
   int data_c_2[] = {2};

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1303,9 +1303,9 @@ TEST_CASE_METHOD(
   auto&& [array, fragments] = open_default_array_1d_with_fragments();
 
   // Make a vector of tiles.
-  ResultTileWithBitmap<uint64_t> result_tile(
+  UnorderedWithDupsResultTile<uint64_t> result_tile(
       0, 0, array->array_->array_schema_latest());
-  std::vector<ResultTileWithBitmap<uint64_t>> rt;
+  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
   rt.push_back(std::move(result_tile));
 
   SECTION("- No bitmap") {
@@ -1371,9 +1371,9 @@ TEST_CASE_METHOD(
   auto&& [array, fragments] = open_default_array_1d_with_fragments();
 
   // Make a vector of tiles.
-  ResultTileWithBitmap<uint64_t> result_tile(
+  UnorderedWithDupsResultTile<uint64_t> result_tile(
       0, 0, array->array_->array_schema_latest());
-  std::vector<ResultTileWithBitmap<uint64_t>> rt;
+  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
   rt.push_back(std::move(result_tile));
   rt[0].bitmap_.resize(5);
   rt[0].bitmap_ = {0, 1, 2, 0, 2};
@@ -1433,9 +1433,9 @@ TEST_CASE_METHOD(
   auto&& [array, fragments] = open_default_array_1d_with_fragments();
 
   // Make a vector of tiles.
-  ResultTileWithBitmap<uint64_t> result_tile(
+  UnorderedWithDupsResultTile<uint64_t> result_tile(
       0, 0, array->array_->array_schema_latest());
-  std::vector<ResultTileWithBitmap<uint64_t>> rt;
+  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
   rt.push_back(std::move(result_tile));
 
   SECTION("- No bitmap") {

--- a/tiledb/sm/query/readers/result_coords.h
+++ b/tiledb/sm/query/readers/result_coords.h
@@ -184,7 +184,7 @@ struct GlobalOrderResultCoords
     uint64_t cell_num = base::tile_->cell_num();
     uint64_t next_pos = base::pos_ + 1;
     if (base::tile_->has_post_qc_bmp()) {
-      auto& bitmap = base::tile_->post_qc_bitmap();
+      auto& bitmap = base::tile_->bitmap_with_qc();
 
       // Current cell is not in the bitmap.
       if (!bitmap[base::pos_]) {
@@ -228,7 +228,7 @@ struct GlobalOrderResultCoords
     uint64_t orig_pos = base::pos_;
 
     if (base::tile_->has_post_qc_bmp()) {
-      auto& bitmap = base::tile_->post_qc_bitmap();
+      auto& bitmap = base::tile_->bitmap_with_qc();
 
       // Current cell is not in the bitmap.
       if (!bitmap[base::pos_]) {

--- a/tiledb/sm/query/readers/result_coords.h
+++ b/tiledb/sm/query/readers/result_coords.h
@@ -183,9 +183,11 @@ struct GlobalOrderResultCoords
     uint64_t ret = 1;
     uint64_t cell_num = base::tile_->cell_num();
     uint64_t next_pos = base::pos_ + 1;
-    if (base::tile_->has_bmp()) {
+    if (base::tile_->has_post_qc_bmp()) {
+      auto& bitmap = base::tile_->post_qc_bitmap();
+
       // Current cell is not in the bitmap.
-      if (!base::tile_->bitmap_[base::pos_]) {
+      if (!bitmap[base::pos_]) {
         return 0;
       }
 
@@ -193,14 +195,14 @@ struct GlobalOrderResultCoords
       // return 1.
       const bool overlapping_ranges = std::is_same<BitmapType, uint64_t>::value;
       if constexpr (overlapping_ranges) {
-        if (base::tile_->bitmap_[base::pos_] != 1) {
+        if (bitmap[base::pos_] != 1) {
           return 1;
         }
       }
 
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position.
-      while (next_pos < cell_num && base::tile_->bitmap_[next_pos] == 1) {
+      while (next_pos < cell_num && bitmap[next_pos] == 1) {
         next_pos++;
         ret++;
       }
@@ -225,9 +227,11 @@ struct GlobalOrderResultCoords
     // Store the original position.
     uint64_t orig_pos = base::pos_;
 
-    if (base::tile_->has_bmp()) {
+    if (base::tile_->has_post_qc_bmp()) {
+      auto& bitmap = base::tile_->post_qc_bitmap();
+
       // Current cell is not in the bitmap.
-      if (!base::tile_->bitmap_[base::pos_]) {
+      if (!bitmap[base::pos_]) {
         return 0;
       }
 
@@ -235,7 +239,7 @@ struct GlobalOrderResultCoords
       // return 1.
       const bool overlapping_ranges = std::is_same<BitmapType, uint64_t>::value;
       if constexpr (overlapping_ranges) {
-        if (base::tile_->bitmap_[base::pos_] != 1) {
+        if (bitmap[base::pos_] != 1) {
           return 1;
         }
       }
@@ -244,8 +248,7 @@ struct GlobalOrderResultCoords
       // from the current position, with coordinares smaller than the next one
       // in the queue.
       base::pos_++;
-      while (base::pos_ < cell_num && base::tile_->bitmap_[base::pos_] &&
-             !cmp(*this, next)) {
+      while (base::pos_ < cell_num && bitmap[base::pos_] && !cmp(*this, next)) {
         base::pos_++;
         ret++;
       }

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -501,7 +501,7 @@ class ResultTile {
 /** Result tile with bitmap. */
 template <class BitmapType>
 class ResultTileWithBitmap : public ResultTile {
- public:
+ protected:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -531,6 +531,7 @@ class ResultTileWithBitmap : public ResultTile {
 
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTileWithBitmap);
 
+ public:
   /* ********************************* */
   /*          PUBLIC METHODS           */
   /* ********************************* */
@@ -587,40 +588,6 @@ class ResultTileWithBitmap : public ResultTile {
     return bitmap_.size() > 0;
   }
 
-  /**
-   * Does this tile have a post query condition bitmap. As there is no post
-   * qc bitmap for this result tile type. Use the regular bitmap.
-   */
-  inline bool has_post_qc_bmp() {
-    return has_bmp();
-  }
-
-  /**
-   * Ensures there is a post query condition bitmap allocated. But as there is
-   * no post qc bitmap for this result tile type. Use the regular bitmap.
-   */
-  void ensure_post_qc_bitmap(uint64_t cell_num) {
-    if (bitmap_.size() == 0) {
-      bitmap_.resize(cell_num, 1);
-      bitmap_result_num_ = cell_num;
-    }
-  }
-
-  /**
-   * Returns the post query condition bitmap, which for this tile type is the
-   * regular bitmap.
-   */
-  inline std::vector<BitmapType>& post_qc_bitmap() {
-    return bitmap_;
-  }
-
-  /*
-   * Return the variable to update the number of cells post query condition.
-   */
-  inline uint64_t* qc_result_num_ptr() {
-    return &bitmap_result_num_;
-  }
-
   /** Swaps the contents (all field values) of this tile with the given tile. */
   void swap(ResultTileWithBitmap<BitmapType>& tile) {
     ResultTile::swap(tile);
@@ -653,6 +620,7 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   GlobalOrderResultTile(
       unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
       : ResultTileWithBitmap<BitmapType>(frag_idx, tile_idx, array_schema)
+      , dups_(array_schema.allows_dups())
       , used_(false) {
   }
 
@@ -679,7 +647,10 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   /** Swaps the contents (all field values) of this tile with the given tile. */
   void swap(GlobalOrderResultTile& tile) {
     ResultTileWithBitmap<uint8_t>::swap(tile);
+    std::swap(used_, tile.used_);
+    std::swap(dups_, tile.dups_);
     std::swap(hilbert_values_, tile.hilbert_values_);
+    std::swap(extra_bitmap_, tile.extra_bitmap_);
   }
 
   /** Returns if the tile was used by the merge or not. */
@@ -693,44 +664,53 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   }
 
   /**
-   * Does this tile have a post query condition bitmap, or a normal bitmap.
+   * Returns whether this tile has a post query condition bitmap. For this
+   * tile type, it will either be extra_bitmap_ or the normal bitmap.
    */
   inline bool has_post_qc_bmp() {
     return ResultTileWithBitmap<BitmapType>::has_bmp() ||
-           post_qc_bitmap_.size() > 0;
+           extra_bitmap_.size() > 0;
   }
 
   /**
    * Ensures there is a post query condition bitmap allocated. If there is a
-   * bitmap already for this tile, 'post_qc_bitmap_' will contain the
-   * combination of the existing bitmap and query condition results.
+   * regular bitmap already for this tile, 'extra_bitmap_' will contain the
+   * combination of the existing bitmap with query condition results. Otherwise
+   * it will only contain the query condition results.
    */
-  void ensure_post_qc_bitmap(uint64_t cell_num) {
-    if (ResultTileWithBitmap<BitmapType>::has_bmp()) {
-      post_qc_bitmap_ = ResultTileWithBitmap<BitmapType>::bitmap_;
+  void ensure_bitmap_for_query_condition(uint64_t cell_num) {
+    if (!dups_) {
+      if (ResultTileWithBitmap<BitmapType>::has_bmp()) {
+        extra_bitmap_ = ResultTileWithBitmap<BitmapType>::bitmap_;
+      } else {
+        extra_bitmap_.resize(cell_num, 1);
+      }
     } else {
-      post_qc_bitmap_.resize(cell_num, 1);
+      ResultTileWithBitmap<BitmapType>::bitmap_.resize(cell_num, 1);
     }
   }
 
   /**
-   * Returns the post query condition bitmap, if allocated, or the normal
-   * bitmap.
+   * Returns the bitmap that included query condition results. For this tile
+   * type, this is 'extra_bitmap_' if allocated, or the regular bitmap.
    */
-  inline std::vector<BitmapType>& post_qc_bitmap() {
-    return post_qc_bitmap_.size() > 0 ?
-               post_qc_bitmap_ :
-               ResultTileWithBitmap<BitmapType>::bitmap_;
+  inline std::vector<BitmapType>& bitmap_with_qc() {
+    return extra_bitmap_.size() > 0 ? extra_bitmap_ :
+                                      ResultTileWithBitmap<BitmapType>::bitmap_;
   }
 
   /*
    * Return the variable to update the number of cells post query condition.
-   * We don't change the cell number for query condition as it is used to
-   * entirely remove tiles that have no more cells in them. For Global order
+   * If there is an extra bitmap, we don't change the cell number as it is used
+   * to entirely remove tiles that have no more cells in them. For Global order
    * reads, we still need the tile for deduplication, so return nullptr.
    */
   inline uint64_t* qc_result_num_ptr() {
-    return nullptr;
+    if (extra_bitmap_.size() > 0) {
+      return nullptr;
+    }
+
+    return &(ResultTileWithBitmap<BitmapType>::bitmap_result_num_);
   }
 
   /** Allocate space for the hilbert values vector. */
@@ -776,11 +756,90 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   /** Hilbert values for this tile. */
   std::vector<uint64_t> hilbert_values_;
 
-  /** Tile bitmap after query condition is applied. */
-  std::vector<BitmapType> post_qc_bitmap_;
+  /**
+   * An extra bitmap will be needed for array with no duplicates. For those,
+   * deduplication need to be run before query condition is applied. So bitmap_
+   * will contain the results before query condition, and extra_bitmap_ will
+   * contain results after query condition.
+   */
+  std::vector<BitmapType> extra_bitmap_;
+
+  /** Are duplicates allowed. */
+  bool dups_;
 
   /** Was the tile used in the merge. */
   bool used_;
+};
+
+template <class BitmapType>
+class UnorderedWithDupsResultTile : public ResultTileWithBitmap<BitmapType> {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  UnorderedWithDupsResultTile(
+      unsigned frag_idx, uint64_t tile_idx, const ArraySchema& array_schema)
+      : ResultTileWithBitmap<BitmapType>(frag_idx, tile_idx, array_schema) {
+  }
+
+  /** Move constructor. */
+  UnorderedWithDupsResultTile(UnorderedWithDupsResultTile&& other) noexcept {
+    // Swap with the argument
+    swap(other);
+  }
+
+  /** Move-assign operator. */
+  UnorderedWithDupsResultTile& operator=(UnorderedWithDupsResultTile&& other) {
+    // Swap with the argument
+    swap(other);
+
+    return *this;
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(UnorderedWithDupsResultTile);
+
+  /* ********************************* */
+  /*          PUBLIC METHODS           */
+  /* ********************************* */
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(UnorderedWithDupsResultTile& tile) {
+    ResultTileWithBitmap<BitmapType>::swap(tile);
+  }
+
+  /**
+   * Returns whether this tile has a post query condition bitmap. For this
+   * tile type, this is stored in the regular bitmap.
+   */
+  inline bool has_post_qc_bmp() {
+    return ResultTileWithBitmap<BitmapType>::has_bmp();
+  }
+
+  /**
+   * Ensures there is a post query condition bitmap allocated. For this tile
+   * type, this is stored in the regular bitmap.
+   */
+  void ensure_bitmap_for_query_condition(uint64_t cell_num) {
+    if (ResultTileWithBitmap<BitmapType>::bitmap_.size() == 0) {
+      ResultTileWithBitmap<BitmapType>::bitmap_.resize(cell_num, 1);
+      ResultTileWithBitmap<BitmapType>::bitmap_result_num_ = cell_num;
+    }
+  }
+
+  /**
+   * Returns the bitmap that included query condition results. For this tile
+   * type, this is stored in the regular bitmap.
+   */
+  inline std::vector<BitmapType>& bitmap_with_qc() {
+    return ResultTileWithBitmap<BitmapType>::bitmap_;
+  }
+
+  /*
+   * Return the variable to update the number of cells post query condition.
+   */
+  inline uint64_t* qc_result_num_ptr() {
+    return &(ResultTileWithBitmap<BitmapType>::bitmap_result_num_);
+  }
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -299,8 +299,8 @@ SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
         fragment_metadata_[f]->cell_num(t) * sizeof(BitmapType);
   }
 
-  // Add the post query condition bitmap size if there is a query condition.
-  if (!condition_.empty()) {
+  // Add the extra bitmap size if there is a query condition and no dups.
+  if (!array_schema_.allows_dups() && !condition_.empty()) {
     tiles_sizes->first +=
         fragment_metadata_[f]->cell_num(t) * sizeof(BitmapType);
   }

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -187,6 +187,18 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /* ********************************* */
 
   /**
+   * Get the coordinate tiles size for a dimension.
+   *
+   * @param dim_num Number of dimensions.
+   * @param f Fragment index.
+   * @param t Tile index.
+   *
+   * @return Status, tiles_size, tiles_size_qc.
+   */
+  tuple<Status, optional<std::pair<uint64_t, uint64_t>>> get_coord_tiles_size(
+      unsigned dim_num, unsigned f, uint64_t t);
+
+  /**
    * Add a result tile to process, making sure maximum budget is respected.
    *
    * @param dim_num Number of dimensions.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -599,11 +599,11 @@ Status SparseIndexReaderBase::apply_query_condition(
 
           // Compute the result of the query condition for this tile.
           if (!condition_.empty()) {
-            rt->ensure_post_qc_bitmap(cell_num);
+            rt->ensure_bitmap_for_query_condition(cell_num);
             RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
                 *(frag_meta->array_schema().get()),
                 *rt,
-                rt->post_qc_bitmap(),
+                rt->bitmap_with_qc(),
                 rt->qc_result_num_ptr()));
           }
 
@@ -758,10 +758,10 @@ template tuple<Status, optional<std::pair<uint64_t, uint64_t>>>
 SparseIndexReaderBase::get_coord_tiles_size<uint8_t>(
     bool, unsigned, unsigned, uint64_t);
 template Status SparseIndexReaderBase::apply_query_condition<
-    ResultTileWithBitmap<uint64_t>,
+    UnorderedWithDupsResultTile<uint64_t>,
     uint64_t>(std::vector<ResultTile*>&);
 template Status SparseIndexReaderBase::apply_query_condition<
-    ResultTileWithBitmap<uint8_t>,
+    UnorderedWithDupsResultTile<uint8_t>,
     uint8_t>(std::vector<ResultTile*>&);
 template Status SparseIndexReaderBase::apply_query_condition<
     GlobalOrderResultTile<uint64_t>,

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -177,14 +177,6 @@ SparseIndexReaderBase::get_coord_tiles_size(
     }
   }
 
-  // Add the result tile structure size.
-  tiles_size += sizeof(ResultTileWithBitmap<BitmapType>);
-
-  // Add the tile bitmap size if there is a subarray.
-  if (subarray_.is_set()) {
-    tiles_size += fragment_metadata_[f]->cell_num(t) * sizeof(BitmapType);
-  }
-
   if (include_timestamps(f)) {
     tiles_size +=
         fragment_metadata_[f]->cell_num(t) * constants::timestamp_size;
@@ -567,7 +559,7 @@ Status SparseIndexReaderBase::count_tile_bitmap_cells(
   return Status::Ok();
 }
 
-template <class BitmapType>
+template <class ResultTileType, class BitmapType>
 Status SparseIndexReaderBase::apply_query_condition(
     std::vector<ResultTile*>& result_tiles) {
   auto timer_se = stats_->start_timer("apply_query_condition");
@@ -580,30 +572,10 @@ Status SparseIndexReaderBase::apply_query_condition(
         result_tiles.size(),
         [&](uint64_t t) {
           // For easy reference.
-          auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[t];
+          auto rt = static_cast<ResultTileType*>(result_tiles[t]);
           const auto frag_meta = fragment_metadata_[rt->frag_idx()];
 
           auto cell_num = frag_meta->cell_num(rt->tile_idx());
-
-          // Set num_cells if no subarray as it's used to filter below.
-          if (!subarray_.is_set()) {
-            rt->bitmap_result_num_ = cell_num;
-          }
-
-          // Full overlap in bitmap calculation, make a bitmap.
-          if (!rt->has_bmp()) {
-            rt->bitmap_.resize(cell_num, 1);
-            rt->bitmap_result_num_ = cell_num;
-          }
-
-          // Compute the result of the query condition for this tile.
-          if (!condition_.empty()) {
-            RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
-                *(frag_meta->array_schema().get()),
-                *rt,
-                rt->bitmap_,
-                &rt->bitmap_result_num_));
-          }
 
           // If timestamps are present and fragment is partially included,
           // filter out tiles based on time by applying the query condition
@@ -611,11 +583,28 @@ Status SparseIndexReaderBase::apply_query_condition(
               frag_meta->partial_time_overlap(
                   array_->timestamp_start(),
                   array_->timestamp_end_opened_at())) {
+            // Full overlap in bitmap calculation, make a bitmap.
+            if (!rt->has_bmp()) {
+              rt->bitmap_.resize(cell_num, 1);
+              rt->bitmap_result_num_ = cell_num;
+            }
+
+            // Remove cells with partial overlap from the bitmap.
             RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<BitmapType>(
                 *(frag_meta->array_schema().get()),
                 *rt,
                 rt->bitmap_,
                 &rt->bitmap_result_num_));
+          }
+
+          // Compute the result of the query condition for this tile.
+          if (!condition_.empty()) {
+            rt->ensure_post_qc_bitmap(cell_num);
+            RETURN_NOT_OK(condition_.apply_sparse<BitmapType>(
+                *(frag_meta->array_schema().get()),
+                *rt,
+                rt->post_qc_bitmap(),
+                rt->qc_result_num_ptr()));
           }
 
           return Status::Ok();
@@ -768,10 +757,18 @@ SparseIndexReaderBase::get_coord_tiles_size<uint64_t>(
 template tuple<Status, optional<std::pair<uint64_t, uint64_t>>>
 SparseIndexReaderBase::get_coord_tiles_size<uint8_t>(
     bool, unsigned, unsigned, uint64_t);
-template Status SparseIndexReaderBase::apply_query_condition<uint64_t>(
-    std::vector<ResultTile*>&);
-template Status SparseIndexReaderBase::apply_query_condition<uint8_t>(
-    std::vector<ResultTile*>&);
+template Status SparseIndexReaderBase::apply_query_condition<
+    ResultTileWithBitmap<uint64_t>,
+    uint64_t>(std::vector<ResultTile*>&);
+template Status SparseIndexReaderBase::apply_query_condition<
+    ResultTileWithBitmap<uint8_t>,
+    uint8_t>(std::vector<ResultTile*>&);
+template Status SparseIndexReaderBase::apply_query_condition<
+    GlobalOrderResultTile<uint64_t>,
+    uint64_t>(std::vector<ResultTile*>&);
+template Status SparseIndexReaderBase::apply_query_condition<
+    GlobalOrderResultTile<uint8_t>,
+    uint8_t>(std::vector<ResultTile*>&);
 template Status SparseIndexReaderBase::compute_tile_bitmaps<uint64_t>(
     std::vector<ResultTile*>&);
 template Status SparseIndexReaderBase::compute_tile_bitmaps<uint8_t>(

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -386,7 +386,7 @@ class SparseIndexReaderBase : public ReaderBase {
    *
    * @return Status.
    */
-  template <class BitmapType>
+  template <class ResultTileType, class BitmapType>
   Status apply_query_condition(std::vector<ResultTile*>& result_tiles);
 
   /**

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -215,15 +215,15 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
       RETURN_NOT_OK(compute_tile_bitmaps<BitmapType>(result_tiles_created));
 
       // Apply query condition.
-      auto st =
-          apply_query_condition<ResultTileWithBitmap<BitmapType>, BitmapType>(
-              result_tiles_created);
+      auto st = apply_query_condition<
+          UnorderedWithDupsResultTile<BitmapType>,
+          BitmapType>(result_tiles_created);
       RETURN_NOT_OK(st);
 
       // Clear result tiles that are not necessary anymore.
       uint64_t current = 0;
       for (uint64_t i = 0; i < result_tiles_created.size(); i++) {
-        if (((ResultTileWithBitmap<uint64_t>*)result_tiles_created[i])
+        if (((UnorderedWithDupsResultTile<uint64_t>*)result_tiles_created[i])
                 ->bitmap_result_num_ != 0) {
           result_tiles_created[current++] = result_tiles_created[i];
         }
@@ -287,7 +287,7 @@ SparseUnorderedWithDupsReader<BitmapType>::get_coord_tiles_size(
   RETURN_NOT_OK_TUPLE(st, nullopt);
 
   // Add the result tile structure size.
-  tiles_sizes->first += sizeof(ResultTileWithBitmap<BitmapType>);
+  tiles_sizes->first += sizeof(UnorderedWithDupsResultTile<BitmapType>);
 
   // Add the tile bitmap size if there is a subarray or query condition set.
   if (subarray_.is_set() || !condition_.empty()) {
@@ -464,7 +464,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_parallelization_parameters(
     const uint64_t min_pos_tile,
     const uint64_t max_pos_tile,
     const uint64_t cell_offset,
-    const ResultTileWithBitmap<BitmapType>* rt) {
+    const UnorderedWithDupsResultTile<BitmapType>* rt) {
   // Prevent processing past the end of the cells in case there are more
   // threads than cells.
   auto cell_num = max_pos_tile - min_pos_tile;
@@ -498,7 +498,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
     const std::string& name,
     const bool nullable,
     const OffType offset_div,
-    ResultTileWithBitmap<uint64_t>* rt,
+    UnorderedWithDupsResultTile<uint64_t>* rt,
     uint64_t src_min_pos,
     uint64_t src_max_pos,
     OffType* buffer,
@@ -557,7 +557,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     const std::string& name,
     const bool nullable,
     const OffType offset_div,
-    ResultTileWithBitmap<uint8_t>* rt,
+    UnorderedWithDupsResultTile<uint8_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
     OffType* buffer,
@@ -659,7 +659,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
       num_range_threads,
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
-        auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[i];
+        auto rt = (UnorderedWithDupsResultTile<BitmapType>*)result_tiles[i];
 
         // We might have a partially processed result tile from last run.
         auto min_pos_tile = 0;
@@ -818,7 +818,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
     const bool nullable,
     const unsigned dim_idx,
     const uint64_t cell_size,
-    ResultTileWithBitmap<uint64_t>* rt,
+    UnorderedWithDupsResultTile<uint64_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
     uint8_t* buffer,
@@ -873,7 +873,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
     const bool nullable,
     const unsigned dim_idx,
     const uint64_t cell_size,
-    ResultTileWithBitmap<uint8_t>* rt,
+    UnorderedWithDupsResultTile<uint8_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
     uint8_t* buffer,
@@ -969,7 +969,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
 
 template <>
 Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
-    ResultTileWithBitmap<uint64_t>* rt,
+    UnorderedWithDupsResultTile<uint64_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
     uint8_t* buffer) {
@@ -1002,7 +1002,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
 
 template <>
 Status SparseUnorderedWithDupsReader<uint8_t>::copy_timestamp_data_tile(
-    ResultTileWithBitmap<uint8_t>* rt,
+    UnorderedWithDupsResultTile<uint8_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
     uint8_t* buffer) {
@@ -1092,7 +1092,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
       num_range_threads,
       [&](uint64_t i, uint64_t range_thread_idx) {
         // For easy reference.
-        auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[i];
+        auto rt = (UnorderedWithDupsResultTile<BitmapType>*)result_tiles[i];
 
         // We might have a partially processed result tile from last run.
         auto min_pos_tile = 0;
@@ -1200,7 +1200,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
   // in the fragment metadata to do so.
   uint64_t cell_offset = cells_copied(names);
   for (uint64_t i = 0; i < result_tiles.size(); i++) {
-    auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[i];
+    auto rt = (UnorderedWithDupsResultTile<BitmapType>*)result_tiles[i];
     auto cell_num =
         rt->bitmap_result_num_ != std::numeric_limits<uint64_t>::max() ?
             rt->bitmap_result_num_ :
@@ -1275,7 +1275,7 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
         uint64_t idx = 0;
         for (; idx < max_rt_idx; idx++) {
           // Size of the tile in memory.
-          auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[idx];
+          auto rt = (UnorderedWithDupsResultTile<BitmapType>*)result_tiles[idx];
 
           auto&& [st, tile_size] =
               get_attribute_tile_size(name, rt->frag_idx(), rt->tile_idx());
@@ -1361,7 +1361,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
 
     // Add in a partial tile if the buffer is not full.
     if (query_buffer.original_buffer_var_size_ != new_var_buffer_size) {
-      auto last_tile = (ResultTileWithBitmap<BitmapType>*)
+      auto last_tile = (UnorderedWithDupsResultTile<BitmapType>*)
           result_tiles[new_result_tiles_size];
 
       auto last_tile_num_cells =
@@ -1553,7 +1553,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
 
   // Compute the number of cells copied for the last tile before updating tile
   // index.
-  auto last_tile = (ResultTileWithBitmap<BitmapType>*)result_tiles.back();
+  auto last_tile =
+      (UnorderedWithDupsResultTile<BitmapType>*)result_tiles.back();
   auto& frag_tile_idx = read_state_.frag_idx_[last_tile->frag_idx()];
   auto last_tile_cells_copied =
       cell_offsets[result_tiles.size()] - cell_offsets[result_tiles.size() - 1];
@@ -1593,7 +1594,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
 template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
     const unsigned frag_idx,
-    typename std::list<ResultTileWithBitmap<BitmapType>>::iterator rt) {
+    typename std::list<UnorderedWithDupsResultTile<BitmapType>>::iterator rt) {
   // Remove coord tile size from memory budget.
   const auto tile_idx = rt->tile_idx();
   auto&& [st, tiles_sizes] =

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -175,6 +175,18 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   /* ********************************* */
 
   /**
+   * Get the coordinate tiles size for a dimension.
+   *
+   * @param dim_num Number of dimensions.
+   * @param f Fragment index.
+   * @param t Tile index.
+   *
+   * @return Status, tiles_size, tiles_size_qc.
+   */
+  tuple<Status, optional<std::pair<uint64_t, uint64_t>>> get_coord_tiles_size(
+      unsigned dim_num, unsigned f, uint64_t t);
+
+  /**
    * Add a result tile to process, making sure maximum budget is respected.
    *
    * @param dim_num Number of dimensions.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -168,7 +168,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
   /** Result tiles currently loaded. */
-  std::list<ResultTileWithBitmap<BitmapType>> result_tiles_;
+  std::list<UnorderedWithDupsResultTile<BitmapType>> result_tiles_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -233,7 +233,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const uint64_t min_pos_tile,
       const uint64_t max_pos_tile,
       const uint64_t cell_offset,
-      const ResultTileWithBitmap<BitmapType>* rt);
+      const UnorderedWithDupsResultTile<BitmapType>* rt);
 
   /**
    * Copy offsets tile.
@@ -255,7 +255,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const std::string& name,
       const bool nullable,
       const OffType offset_div,
-      ResultTileWithBitmap<BitmapType>* rt,
+      UnorderedWithDupsResultTile<BitmapType>* rt,
       const uint64_t src_min_pos,
       const uint64_t src_max_pos,
       OffType* buffer,
@@ -359,7 +359,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const bool nullable,
       const unsigned dim_idx,
       const uint64_t cell_size,
-      ResultTileWithBitmap<BitmapType>* rt,
+      UnorderedWithDupsResultTile<BitmapType>* rt,
       const uint64_t src_min_pos,
       const uint64_t src_max_pos,
       uint8_t* buffer,
@@ -376,7 +376,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @return Status.
    */
   Status copy_timestamp_data_tile(
-      ResultTileWithBitmap<BitmapType>* rt,
+      UnorderedWithDupsResultTile<BitmapType>* rt,
       const uint64_t src_min_pos,
       const uint64_t src_max_pos,
       uint8_t* buffer);
@@ -458,7 +458,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    */
   Status remove_result_tile(
       const unsigned frag_idx,
-      typename std::list<ResultTileWithBitmap<BitmapType>>::iterator rt);
+      typename std::list<UnorderedWithDupsResultTile<BitmapType>>::iterator rt);
 
   /**
    * Clean up processed data after copying and get ready for the next


### PR DESCRIPTION
This fixes an algorithmic issue in the sparse global order reader where
we need to consider the results of a query condition only after we run
deduplication. The reason is the following: if we have data in a later
fragment that replaces previous data, and the query condition would be
false only for the new replacement data, the cells from the new fragment
need to first replace the cells from the earlier fragment in
deduplication, then the new cells can be ignored in the results because
they don't match the query condition.

The behavior prior to this change would be that the new cells would get
erased in the bitmaps, then deduplication would only see the old cells
and return those in the results.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: consider qc results after deduplication.
