### PR TITLE
Print seed in unit_thread_pool on failure

### DIFF
--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -35,14 +35,17 @@
 #include <stdint.h>
 #include <atomic>
 #include <catch.hpp>
+#include <cstdio>
 #include <iostream>
+#include <sstream>
 
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
 
 size_t random_ms(size_t max = 3) {
-  thread_local static uint64_t generator_seed =
-      std::hash<std::thread::id>()(std::this_thread::get_id());
+  // Using a fixed seed for determinism. 
+  thread_local static uint64_t generator_seed = 0x4E996D11;
+  thread_local static std::ostringstream ss;
   thread_local static std::mt19937_64 generator(generator_seed);
   std::uniform_int_distribution<size_t> distribution(0, max);
   return distribution(generator);

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -42,28 +42,51 @@
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
 
-// Fixed seed for determinism.
+// Fixed seed for determinism.                                                                                                      
 static std::vector<uint64_t> generator_seed_arr = {
-    0xBE08D299, 0x4E996D11, 0x402A1E10, 0x95379958, 0x22101AA9};
-static uint64_t generator_seed = 0;
+  0xBE08D299, 0x4E996D11, 0x402A1E10, 0x95379958, 0x22101AA9};
 
+static std::atomic<uint64_t> generator_seed = 0;
+
+std::once_flag once_flag;
+thread_local static uint64_t local_seed {0};
+thread_local static std::mt19937_64 generator;
+
+/**                                                                                                                                 
+ * Get one of the pre-set seeds.                                                                                                    
+ */
 void set_generator_seed() {
-  static std::random_device rd;
-  static std::mt19937 gen(rd());
-  static std::uniform_int_distribution<> dis(0, generator_seed_arr.size() - 1);
-  generator_seed = generator_seed_arr[dis(gen)];
+
+  // Set the global seed only once                                                                                                  
+  std::call_once(once_flag, []() {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dis(0, generator_seed_arr.size() - 1);
+    generator_seed = generator_seed_arr[dis(gen)];
+    std::string gen_seed_str =
+      "Generator seed: " + std::to_string(generator_seed);
+    puts(gen_seed_str.c_str());
+  });
+
+  // Different threads need different seeds.                                                                                        
+  // Safely increment the generator seed and assign to local seed.                                                                  
+  if (local_seed == 0) {
+    do {
+      local_seed = generator_seed;
+    } while (!generator_seed.compare_exchange_strong(local_seed, local_seed+1));
+    generator.seed(local_seed);
+  }
 }
 
+/**                                                                                                                                 
+ * Generate a random number from a uniform distribution, between 0 and specified max.                                               
+ */
 size_t random_ms(size_t max = 3) {
-  // Pick generator seed at random.
-  if (generator_seed == 0) {
-    set_generator_seed();
-    std::string gen_seed_str =
-        "Generator seed: " + std::to_string(generator_seed);
-    puts(gen_seed_str.c_str());
-  }
-  thread_local static std::mt19937_64 generator(generator_seed);
-  std::uniform_int_distribution<size_t> distribution(0, max);
+
+  // Pick generator seed at random.                                                                                                 
+  set_generator_seed();
+
+  thread_local static std::uniform_int_distribution<size_t> distribution(0, max);
   return distribution(generator);
 }
 

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -37,15 +37,31 @@
 #include <catch.hpp>
 #include <cstdio>
 #include <iostream>
-#include <sstream>
+#include <vector>
 
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/misc/cancelable_tasks.h"
 
+// Fixed seed for determinism.
+static std::vector<uint64_t> generator_seed_arr = {
+    0xBE08D299, 0x4E996D11, 0x402A1E10, 0x95379958, 0x22101AA9};
+static uint64_t generator_seed = 0;
+
+void set_generator_seed() {
+  static std::random_device rd;
+  static std::mt19937 gen(rd());
+  static std::uniform_int_distribution<> dis(0, generator_seed_arr.size() - 1);
+  generator_seed = generator_seed_arr[dis(gen)];
+}
+
 size_t random_ms(size_t max = 3) {
-  // Using a fixed seed for determinism. 
-  thread_local static uint64_t generator_seed = 0x4E996D11;
-  thread_local static std::ostringstream ss;
+  // Pick generator seed at random.
+  if (generator_seed == 0) {
+    set_generator_seed();
+    std::string gen_seed_str =
+        "Generator seed: " + std::to_string(generator_seed);
+    puts(gen_seed_str.c_str());
+  }
   thread_local static std::mt19937_64 generator(generator_seed);
   std::uniform_int_distribution<size_t> distribution(0, max);
   return distribution(generator);


### PR DESCRIPTION
We now have an array of 5 seeds and print them when we reset them.

---
TYPE: IMPROVEMENT
DESC: Print seed in unit_thread_pool on failure
