### PR TITLE
Use api_entry_void to fix GCC 11 build error

### DIFF
--- a/.github/workflows/build-ubuntu22.04-EXPERIMENTAL.yml
+++ b/.github/workflows/build-ubuntu22.04-EXPERIMENTAL.yml
@@ -23,7 +23,8 @@ on:
 
 env:
   TILEDB_SERIALIZATION: ON # NOTE: currently defined directly inline
-  CXX: g++
+  CXX: g++-11
+  CC: gcc-11
   TILEDB_EXPERIMENTAL_FEATURES: ON
   BACKWARDS_COMPATIBILITY_ARRAYS: ON
 
@@ -33,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: 120
     name: Build - ${{matrix.os}} - EXPERIMENTAL ${{ matrix.cxx }}

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
@@ -118,6 +118,6 @@ int32_t tiledb_dimension_label_schema_alloc(
 
 void tiledb_dimension_label_schema_free(
     tiledb_dimension_label_schema_t** dim_label_schema) noexcept {
-  return api_entry<detail::tiledb_dimension_label_schema_free>(
+  return api_entry_void<detail::tiledb_dimension_label_schema_free>(
       dim_label_schema);
 }


### PR DESCRIPTION
- Fix experimental build error due to void api_entry template ambiguity on GCC 11
- Bump the experimental build CI job to ubuntu 22.04 and gcc 11

---
TYPE: NO_HISTORY
DESC: Use api_entry_void to fix GCC 11 build error
