### PR TITLE
Fix and regression test for SC-19240

### DIFF
--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -37,6 +37,10 @@ if (TILEDB_SERIALIZATION)
   list(APPEND SOURCES targets/sc-18250.cc)
 endif()
 
+if (TILEDB_CPP_API)
+  list(APPEND SOURCES targets/sc-19240_cppapi-vfs-exception.cc)
+endif()
+
 add_executable(tiledb_regression
   EXCLUDE_FROM_ALL
   regression.cc

--- a/test/regression/targets/sc-19240_cppapi-vfs-exception.cc
+++ b/test/regression/targets/sc-19240_cppapi-vfs-exception.cc
@@ -1,0 +1,19 @@
+#include <iostream>
+#include <tiledb/tiledb>
+
+#include "catch.hpp"
+
+TEST_CASE(
+    "C++ API: test exception handling in VFSFileBuf interface",
+    "[cppapi][regression]") {
+  tiledb::Context context;
+
+  tiledb::VFS vfs{context};
+  tiledb::VFS::filebuf fb{vfs};
+
+  const std::string uri{"/dir/not/exists/hello.txt"};
+
+  /* currently segfaults (11/July/2022) */
+  REQUIRE(fb.open(uri, std::ios::out));
+  fb.close();
+}

--- a/test/src/unit-capi-filestore.cc
+++ b/test/src/unit-capi-filestore.cc
@@ -375,6 +375,12 @@ TEST_CASE_METHOD(
   // Check correctness
   CHECK(!std::memcmp(buffer, file_content.data(), file_content.size()));
 
+  // Exporting to a non-existent directory should return an error, not abort
+  // (SC-19240)
+  REQUIRE(
+      tiledb_filestore_uri_export(
+          ctx_, "/dir/not/exists/hello.txt", array_name.c_str()) == TILEDB_ERR);
+
   // Clean up
   tiledb_vfs_close(ctx_, fh);
   tiledb_array_close(ctx_, array);

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -92,7 +92,7 @@ class VFSFilebuf : public std::streambuf {
   VFSFilebuf& operator=(const VFSFilebuf&) = default;
   VFSFilebuf& operator=(VFSFilebuf&&) = default;
   ~VFSFilebuf() override {
-    close();
+    close(false);
   }
 
   /* ********************************* */
@@ -114,7 +114,7 @@ class VFSFilebuf : public std::streambuf {
   }
 
   /** Close a file. **/
-  VFSFilebuf* close();
+  VFSFilebuf* close(bool should_throw = true);
 
   /** Current opened URI. **/
   const std::string& get_uri() const {
@@ -631,10 +631,11 @@ inline VFSFilebuf* VFSFilebuf::open(
   return this;
 }
 
-inline VFSFilebuf* VFSFilebuf::close() {
+inline VFSFilebuf* VFSFilebuf::close(bool should_throw) {
   if (is_open()) {
     auto& ctx = vfs_.get().context();
-    ctx.handle_error(tiledb_vfs_close(ctx.ptr().get(), fh_.get()));
+    if (should_throw)
+      ctx.handle_error(tiledb_vfs_close(ctx.ptr().get(), fh_.get()));
   }
   uri_ = "";
   fh_ = nullptr;

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -318,7 +318,7 @@ class VFS {
    * // Create new file, truncating it if it exists.
    * buff.open("file.txt", std::ios::out);
    * std::ostream os(&buff);
-   * if (!os.good()) throw std::runtime_error("Error opening file);
+   * if (!os.good()) throw std::runtime_error("Error opening file");
    *
    * std::string str = "This will be written to the file.";
    *


### PR DESCRIPTION
1. New regression test demonstrates an issue found while investigating SC-19240, in `test/regression/targets/sc-19240_cppapi-vfs-exception.cc`. `tiledb::VFS::filebuf` triggers an exception if opened and closed with a path that is in a non-existent directory. This _at least_ breaks the default exception interface of the parent `streambuf` class.
2. Fix for the exception and original bug, which was caused by throwing in a destructor in the public C++ API.

---
TYPE: BUG
DESC: Fix and regression test for SC-19240
