### PR TITLE
Demonstrating mingw handle leakage (tiledb_unit extract)

### DIFF
--- a/.github/workflows/mingw-w64-tiledb/PKGBUILD
+++ b/.github/workflows/mingw-w64-tiledb/PKGBUILD
@@ -28,6 +28,8 @@ build() {
   export CXXFLAGS="-mfpmath=sse -msse2"
   fi
 
+#    -DTILEDB_S3=ON \
+
   export MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G"MSYS Makefiles" \
@@ -35,12 +37,19 @@ build() {
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DTILEDB_STATIC=ON \
-    -DTILEDB_S3=ON \
     -DCOMPILER_SUPPORTS_AVX2=OFF \
     -DTILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK=ON \
+    -DTILEDB_WERROR=OFF \
     ..
   make
   make -C tiledb
+  
+# in a local environ, can build to demo/check for previously seen (windows event) handle leakge
+# apparently due to issues with mingw std library implementation.
+# note that with S3 enabled above, and minio not running, the aws sdk may fatally error on exit.
+  make -C tiledb/test tiledb_unit # need the support lib built
+  make -C tiledb/test/performance tiledb_explore_msys_handle_leakage
+  . ../test/performance/msys_handle_leakage/trials.sh
 }
 
 package() {

--- a/.github/workflows/mingw-w64-tiledb/PKGBUILD
+++ b/.github/workflows/mingw-w64-tiledb/PKGBUILD
@@ -28,7 +28,6 @@ build() {
   export CXXFLAGS="-mfpmath=sse -msse2"
   fi
 
-#    -DTILEDB_S3=ON \
 
   export MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX="
   ${MINGW_PREFIX}/bin/cmake.exe \
@@ -37,6 +36,7 @@ build() {
     -DBUILD_SHARED_LIBS=OFF \
     -DCMAKE_BUILD_TYPE=Release \
     -DTILEDB_STATIC=ON \
+    -DTILEDB_S3=ON \
     -DCOMPILER_SUPPORTS_AVX2=OFF \
     -DTILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK=ON \
     -DTILEDB_WERROR=OFF \
@@ -47,9 +47,9 @@ build() {
 # in a local environ, can build to demo/check for previously seen (windows event) handle leakge
 # apparently due to issues with mingw std library implementation.
 # note that with S3 enabled above, and minio not running, the aws sdk may fatally error on exit.
-  make -C tiledb/test tiledb_unit # need the support lib built
-  make -C tiledb/test/performance tiledb_explore_msys_handle_leakage
-  . ../test/performance/msys_handle_leakage/trials.sh
+#  make -C tiledb/test tiledb_unit # need the support lib built
+#  make -C tiledb/test/performance tiledb_explore_msys_handle_leakage
+#  . ../test/performance/msys_handle_leakage/trials.sh
 }
 
 package() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,13 +103,12 @@ set(TILEDB_TEST_SUPPORT_SOURCES
   src/helpers.cc
   src/helpers-dimension.h
   src/vfs_helpers.cc
+  src/serialization_wrappers.cc
   )
 
 set(TILEDB_UNIT_TEST_SOURCES
   src/helpers.h
-  src/helpers.cc
   src/helpers-dimension.h
-  src/serialization_wrappers.cc
   src/unit-azure.cc
   src/unit-backwards_compat.cc
   src/unit-bufferlist.cc
@@ -405,3 +404,6 @@ add_custom_target(
 
 # CI tests
 add_subdirectory(ci)
+if(WIN32)
+  add_subdirectory(performance)
+endif()

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -1,0 +1,106 @@
+#
+# test/performanace/CMakeLists.txt (derived from test/CMakeLists.txt)
+#
+#
+# The MIT License
+#
+# Copyright (c) 2017-2022 TileDB, Inc.
+# Copyright (c) 2016 MIT and Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+find_package(Catch_EP REQUIRED)
+
+# These options not exposed in bootstrap script.
+option(TILEDB_TESTS_AWS_S3_CONFIG "Use an S3 config appropriate for AWS in tests" OFF)
+option(TILEDB_TESTS_ENABLE_REST "Enables REST tests (requires running REST server)" OFF)
+
+
+# Include TileDB core header directories
+set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+# Include the C API directory so that the C++ 'tiledb' file can directly
+# include "tiledb.h".
+list(APPEND TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../tiledb/sm/c_api")
+
+#set(TILEDB_MSYS_HANDLE_LEAKAGE_SOURCES
+#  src/helpers.h
+#  src/helpers-dimension.h
+#  )
+
+message(STATUS "CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}")
+list(APPEND TILEDB_MSYS_HANDLE_LEAKAGE_SOURCES
+#  "performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc"
+  "msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc"
+)
+
+if (TILEDB_VERBOSE)
+  add_definitions(-DTILEDB_VERBOSE)
+endif()
+
+
+# unit test executable
+add_executable(
+  tiledb_explore_msys_handle_leakage EXCLUDE_FROM_ALL
+  $<TARGET_OBJECTS:TILEDB_CORE_OBJECTS>
+  ${TILEDB_MSYS_HANDLE_LEAKAGE_SOURCES}
+#  "performance/msys_handle_leakage/unit.cc"
+  "msys_handle_leakage/unit.cc"
+)
+
+add_dependencies(tiledb_explore_msys_handle_leakage tiledb_test_support_lib)
+
+# We want tests to continue as normal even as the API is changing,
+# so don't warn for deprecations, since they'll be escalated to errors.
+if (NOT MSVC)
+  target_compile_options(tiledb_unit PRIVATE -Wno-deprecated-declarations)
+  target_compile_options(tiledb_test_support_lib PRIVATE -Wno-deprecated-declarations)
+endif()
+
+target_include_directories(
+  tiledb_explore_msys_handle_leakage BEFORE PRIVATE
+    ${TILEDB_CORE_INCLUDE_DIR}
+    ${TILEDB_EXPORT_HEADER_DIR}
+)
+
+target_link_libraries(tiledb_explore_msys_handle_leakage
+  PUBLIC
+    TILEDB_CORE_OBJECTS_ILIB
+    Catch2::Catch2
+    tiledb_test_support_lib
+)
+
+# need to properly link the signal chaining library for catch to work with the jni hdfs interface
+# see: https://docs.oracle.com/javase/9/vm/signal-chaining.htm
+
+
+# This is necessary only because we are linking directly to the core objects.
+# Other users (e.g. the examples) do not need this flag.
+target_compile_definitions(tiledb_explore_msys_handle_leakage PRIVATE -DTILEDB_CORE_OBJECTS_EXPORTS)
+
+target_compile_definitions(tiledb_explore_msys_handle_leakage PRIVATE
+  -DTILEDB_TEST_INPUTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/inputs"
+)
+
+# Linking dl is only needed on linux with gcc
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_target_properties(tiledb_explore_msys_handle_leakage PROPERTIES
+      LINK_FLAGS "-Wl,--no-as-needed -ldl"
+    )
+endif()

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -35,18 +35,13 @@ option(TILEDB_TESTS_ENABLE_REST "Enables REST tests (requires running REST serve
 
 # Include TileDB core header directories
 set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+
 # Include the C API directory so that the C++ 'tiledb' file can directly
 # include "tiledb.h".
 list(APPEND TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../tiledb/sm/c_api")
 
-#set(TILEDB_MSYS_HANDLE_LEAKAGE_SOURCES
-#  src/helpers.h
-#  src/helpers-dimension.h
-#  )
-
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND TILEDB_MSYS_HANDLE_LEAKAGE_SOURCES
-#  "performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc"
   "msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc"
 )
 

--- a/test/performance/msys_handle_leakage/notes.txt
+++ b/test/performance/msys_handle_leakage/notes.txt
@@ -1,3 +1,6 @@
+(from
+https://app.shortcut.com/tiledb-inc/story/19067/rtools40-msys-builds-of-tiledb-unit-leaking-handles)
+
 (Event) Handle leakage in mingw builds (rtools40, rtools42) seems to be issue within
 those cpp std libraries that tiledb usage aggravates, as visual studio builds are not exhibiting this leakage.
 
@@ -16,6 +19,7 @@ rtools42 so this may not be important.
 
 The ('recent') msys2 mingw versions I have installed of both gdb and lldb seem to have (differing) issues of their own
 making it difficult to try and gather a complete picture of exactly what/where all may be involved in calls to the
-CreateEventA (windows api) routine presumed to be at least responsible for the direct creation of the handles being leaked.
+CreateEventA (windows api) routine presumed to be at least responsible for the direct creation of the handles being
+leaked.
 
 See notes on building this module and running some trials in the top of unit.cc along with some previously observed results.

--- a/test/performance/msys_handle_leakage/notes.txt
+++ b/test/performance/msys_handle_leakage/notes.txt
@@ -1,0 +1,21 @@
+(Event) Handle leakage in mingw builds (rtools40, rtools42) seems to be issue within
+those cpp std libraries that tiledb usage aggravates, as visual studio builds are not exhibiting this leakage.
+
+The leakage itself does not seem to be completely deterministic, as repeatedly running with the same parameters
+(available with modified unit test) multiple times generally results in different numbers of handles leaked on
+any given run.  Leakage can be demonstrated with tiledb_unit filtering on "CPP API: Test consolidation with timestamps,
+full and partial read with dups"
+
+Modifications to unit-cppapi-consolidation-with-timestamps.cc which implements that TEST_CASE indicate that in
+particular the activity of the .query .submit()d in read_sparse() routine seems to be at least the largest culprit,
+without the query there seems little/no leakage.
+
+The handle leakage may be causing some of the 32bit unit test failures in mingw, as some of the tests that fail in an
+unfiltered run work acceptably when run individually, but it seems 32bit builds are not going to be supported with
+rtools42 so this may not be important.
+
+The ('recent') msys2 mingw versions I have installed of both gdb and lldb seem to have (differing) issues of their own
+making it difficult to try and gather a complete picture of exactly what/where all may be involved in calls to the
+CreateEventA (windows api) routine presumed to be at least responsible for the direct creation of the handles being leaked.
+
+See notes on building this module and running some trials in the top of unit.cc along with some previously observed results.

--- a/test/performance/msys_handle_leakage/trials.bat
+++ b/test/performance/msys_handle_leakage/trials.bat
@@ -1,0 +1,14 @@
+rem run from root of build tree...
+if not exist .\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe goto err
+rem .\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=0 --consolidate-sparse-iters=1 --wait-for-keypress both
+.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=0 --consolidate-sparse-iters=1
+.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1
+.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=150 --perform-query=1 --consolidate-sparse-iters=1
+.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=300 --perform-query=1 --consolidate-sparse-iters=1
+goto done
+
+:err
+echo "Failed to find %cd%\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe
+goto done
+
+:done

--- a/test/performance/msys_handle_leakage/trials.sh
+++ b/test/performance/msys_handle_leakage/trials.sh
@@ -1,0 +1,11 @@
+# run from root of build tree
+if [ ! -f ./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe ]; then
+  echo "failed to find `pwd`/tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe"
+  return 1
+fi
+set -x
+# ./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1 --wait-for-keypress both
+./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=0 --consolidate-sparse-iters=1
+./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1
+./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=150 --perform-query=1 --consolidate-sparse-iters=1
+./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=300 --perform-query=1 --consolidate-sparse-iters=1

--- a/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
@@ -1,0 +1,441 @@
+/**
+ * @file   unit-cppapi-consolidation-with-timestamps.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the CPP API consolidation with timestamps.
+ */
+
+#include "catch.hpp"
+#include "test/src/helpers.h"
+#include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/cpp_api/tiledb"
+//#include "tiledb/sm/query/sparse_global_order_reader.h"
+
+using namespace tiledb;
+using namespace tiledb::test;
+
+unsigned int read_sparse_iters = 1;
+unsigned int perform_query = 1;
+unsigned int consolidate_sparse_iters = 1;
+
+/** Tests for C API consolidation with timestamps. */
+struct ConsolidationWithTimestampsFx {
+  // Constants.
+  const char* SPARSE_ARRAY_NAME = "test_consolidate_sparse_array";
+  const char* SPARSE_ARRAY_FRAG_DIR =
+      "test_consolidate_sparse_array/__fragments";
+
+  // TileDB context.
+  Context ctx_;
+  VFS vfs_;
+  sm::StorageManager* sm_;
+
+  // Constructors/destructors.
+  ConsolidationWithTimestampsFx();
+  ~ConsolidationWithTimestampsFx();
+
+  // Functions.
+  void set_legacy();
+  void create_sparse_array(bool allows_dups = false);
+  void create_sparse_array_v11();
+  void write_sparse(
+      std::vector<int> a1,
+      std::vector<uint64_t> dim1,
+      std::vector<uint64_t> dim2,
+      uint64_t timestamp);
+  void write_sparse_v11(uint64_t timestamp);
+  void consolidate_sparse(bool vacuum = false);
+  void consolidate_sparse(
+      uint64_t start_time, uint64_t end_time, bool vacuum = false);
+  void check_timestamps_file(std::vector<uint64_t> expected);
+  void read_sparse(
+      std::vector<int>& a1,
+      std::vector<uint64_t>& dim1,
+      std::vector<uint64_t>& dim2,
+      std::string& stats,
+      tiledb_layout_t layout,
+      uint64_t timestamp,
+      std::vector<uint64_t>* timestamps_ptr = nullptr,
+      bool skip_query = false);
+  void reopen_sparse(
+      std::vector<int>& a1,
+      std::vector<uint64_t>& dim1,
+      std::vector<uint64_t>& dim2,
+      std::string& stats,
+      tiledb_layout_t layout,
+      uint64_t start_time,
+      uint64_t end_time,
+      std::vector<uint64_t>* timestamps_ptr = nullptr);
+
+  void remove_sparse_array();
+  void remove_array(const std::string& array_name);
+  bool is_array(const std::string& array_name);
+};
+
+ConsolidationWithTimestampsFx::ConsolidationWithTimestampsFx()
+    : vfs_(ctx_) {
+  Config config;
+  config.set("sm.consolidation.buffer_size", "1000");
+  ctx_ = Context(config);
+  sm_ = ctx_.ptr().get()->ctx_->storage_manager();
+  vfs_ = VFS(ctx_);
+}
+
+ConsolidationWithTimestampsFx::~ConsolidationWithTimestampsFx() {
+}
+
+void ConsolidationWithTimestampsFx::set_legacy() {
+  Config config;
+  config.set("sm.consolidation.buffer_size", "1000");
+  config.set("sm.query.sparse_global_order.reader", "legacy");
+  config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+
+  ctx_ = Context(config);
+  sm_ = ctx_.ptr().get()->ctx_->storage_manager();
+  vfs_ = VFS(ctx_);
+}
+
+void ConsolidationWithTimestampsFx::create_sparse_array(bool allows_dups) {
+  // Create dimensions.
+  auto d1 = Dimension::create<uint64_t>(ctx_, "d1", {{1, 4}}, 2);
+  auto d2 = Dimension::create<uint64_t>(ctx_, "d2", {{1, 4}}, 2);
+
+  // Create domain.
+  Domain domain(ctx_);
+  domain.add_dimension(d1);
+  domain.add_dimension(d2);
+
+  // Create attributes.
+  auto a1 = Attribute::create<int32_t>(ctx_, "a1");
+
+  // Create array schmea.
+  ArraySchema schema(ctx_, TILEDB_SPARSE);
+  schema.set_domain(domain);
+  schema.set_capacity(20);
+  schema.add_attributes(a1);
+
+  if (allows_dups) {
+    schema.set_allows_dups(true);
+  }
+
+  // Set up filters.
+  Filter filter(ctx_, TILEDB_FILTER_NONE);
+  FilterList filter_list(ctx_);
+  filter_list.add_filter(filter);
+  schema.set_coords_filter_list(filter_list);
+
+  Array::create(SPARSE_ARRAY_NAME, schema);
+}
+
+void ConsolidationWithTimestampsFx::create_sparse_array_v11() {
+  // Get the v11 sparse array.
+  std::string v11_arrays_dir =
+      std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays/sparse_array_v11";
+  REQUIRE(
+      tiledb_vfs_copy_dir(
+          ctx_.ptr().get(),
+          vfs_.ptr().get(),
+          v11_arrays_dir.c_str(),
+          SPARSE_ARRAY_NAME) == TILEDB_OK);
+}
+
+void ConsolidationWithTimestampsFx::write_sparse(
+    std::vector<int> a1,
+    std::vector<uint64_t> dim1,
+    std::vector<uint64_t> dim2,
+    uint64_t timestamp) {
+  // Open array.
+  Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_WRITE, timestamp);
+
+  // Create query.
+  Query query(ctx_, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_GLOBAL_ORDER);
+  query.set_data_buffer("a1", a1);
+  query.set_data_buffer("d1", dim1);
+  query.set_data_buffer("d2", dim2);
+
+  // Submit/finalize the query.
+  query.submit();
+  query.finalize();
+
+  // Close array.
+  array.close();
+}
+
+void ConsolidationWithTimestampsFx::write_sparse_v11(uint64_t timestamp) {
+  // Prepare cell buffers.
+  std::vector<int> buffer_a1{0, 1, 2, 3};
+  std::vector<uint64_t> buffer_a2{0, 1, 3, 6};
+  std::string buffer_var_a2("abbcccdddd");
+  std::vector<float> buffer_a3{0.1f, 0.2f, 1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f};
+  std::vector<uint64_t> buffer_coords_dim1{1, 1, 1, 2};
+  std::vector<uint64_t> buffer_coords_dim2{1, 2, 4, 3};
+
+  // Open array.
+  Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_WRITE, timestamp);
+
+  // Create query.
+  Query query(ctx_, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_GLOBAL_ORDER);
+  query.set_data_buffer("a1", buffer_a1);
+  query.set_data_buffer(
+      "a2", (void*)buffer_var_a2.c_str(), buffer_var_a2.size());
+  query.set_offsets_buffer("a2", buffer_a2);
+  query.set_data_buffer("a3", buffer_a3);
+  query.set_data_buffer("d1", buffer_coords_dim1);
+  query.set_data_buffer("d2", buffer_coords_dim2);
+
+  // Submit/finalize the query.
+  query.submit();
+  query.finalize();
+
+  // Close array.
+  array.close();
+}
+
+void ConsolidationWithTimestampsFx::consolidate_sparse(bool vacuum) {
+  auto config = ctx_.config();
+  Array::consolidate(ctx_, SPARSE_ARRAY_NAME, &config);
+
+  if (vacuum) {
+    REQUIRE_NOTHROW(Array::vacuum(ctx_, SPARSE_ARRAY_NAME, &config));
+  }
+}
+
+void ConsolidationWithTimestampsFx::consolidate_sparse(
+    uint64_t start_time, uint64_t end_time, bool vacuum) {
+  auto config = ctx_.config();
+  config.set("sm.consolidation.timestamp_start", std::to_string(start_time));
+  config.set("sm.consolidation.timestamp_end", std::to_string(end_time));
+  Array::consolidate(ctx_, SPARSE_ARRAY_NAME, &config);
+
+  if (vacuum) {
+    REQUIRE_NOTHROW(Array::vacuum(ctx_, SPARSE_ARRAY_NAME, &config));
+  }
+}
+
+void ConsolidationWithTimestampsFx::check_timestamps_file(
+    std::vector<uint64_t> expected) {
+  // Find consolidated fragment URI.
+  std::string consolidated_fragment_uri;
+  auto uris = vfs_.ls(SPARSE_ARRAY_FRAG_DIR);
+  for (auto& uri : uris) {
+    if (uri.find("__1_2_") != std::string::npos) {
+      consolidated_fragment_uri = uri;
+      break;
+    }
+  }
+
+  auto timestamps_file = consolidated_fragment_uri + "/t.tdb";
+
+  VFS::filebuf buf(vfs_);
+  buf.open(timestamps_file, std::ios::in);
+  std::istream is(&buf);
+  REQUIRE(is.good());
+
+  uint64_t num_tiles;
+  is.read((char*)&num_tiles, sizeof(uint64_t));
+  REQUIRE(num_tiles == 1);
+
+  uint32_t filtered_size;
+  is.read((char*)&filtered_size, sizeof(uint32_t));
+  REQUIRE(filtered_size == expected.size() * sizeof(uint64_t));
+
+  uint32_t unfiltered_size;
+  is.read((char*)&unfiltered_size, sizeof(uint32_t));
+  REQUIRE(unfiltered_size == expected.size() * sizeof(uint64_t));
+
+  uint32_t md_size;
+  is.read((char*)&md_size, sizeof(uint32_t));
+  REQUIRE(md_size == 0);
+
+  std::vector<uint64_t> written(unfiltered_size / sizeof(uint64_t));
+  is.read((char*)written.data(), unfiltered_size);
+
+  for (uint64_t i = 0; i < expected.size(); i++) {
+    if (expected[i] == std::numeric_limits<uint64_t>::max()) {
+      CHECK((written[i] == 1 || written[i] == 2));
+    } else {
+      CHECK(expected[i] == written[i]);
+    }
+  }
+}
+
+void ConsolidationWithTimestampsFx::read_sparse(
+    std::vector<int>& a1,
+    std::vector<uint64_t>& dim1,
+    std::vector<uint64_t>& dim2,
+    std::string& stats,
+    tiledb_layout_t layout,
+    uint64_t timestamp,
+    std::vector<uint64_t>* timestamps_ptr,
+    bool skip_query) {
+  // Open array.
+  Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_READ, timestamp);
+
+  if(!skip_query){
+    // Create query.
+    Query query(ctx_, array, TILEDB_READ);
+    query.set_layout(layout);
+    query.set_data_buffer("a1", a1);
+    query.set_data_buffer("d1", dim1);
+    query.set_data_buffer("d2", dim2);
+    if (timestamps_ptr != nullptr) {
+      query.set_data_buffer(tiledb_timestamps(), *timestamps_ptr);
+    }
+
+    // Submit the query.
+    query.submit();
+    CHECK(query.query_status() == Query::Status::COMPLETE);
+
+    // Get the query stats.
+    stats = query.stats();
+  }
+
+  // Close array.
+  array.close();
+}
+
+void ConsolidationWithTimestampsFx::reopen_sparse(
+    std::vector<int>& a1,
+    std::vector<uint64_t>& dim1,
+    std::vector<uint64_t>& dim2,
+    std::string& stats,
+    tiledb_layout_t layout,
+    uint64_t start_time,
+    uint64_t end_time,
+    std::vector<uint64_t>* timestamps_ptr) {
+  // Re-open array.
+  Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_READ);
+  array.set_open_timestamp_start(start_time);
+  array.set_open_timestamp_end(end_time);
+  array.reopen();
+
+  // Create query.
+  Query query(ctx_, array, TILEDB_READ);
+  query.set_layout(layout);
+  query.set_data_buffer("a1", a1);
+  query.set_data_buffer("d1", dim1);
+  query.set_data_buffer("d2", dim2);
+  if (timestamps_ptr != nullptr) {
+    query.set_data_buffer(tiledb_timestamps(), *timestamps_ptr);
+  }
+
+  // Submit the query.
+  query.submit();
+  CHECK(query.query_status() == Query::Status::COMPLETE);
+
+  // Get the query stats.
+  stats = query.stats();
+
+  // Close array.
+  array.close();
+}
+
+void ConsolidationWithTimestampsFx::remove_array(
+    const std::string& array_name) {
+  if (!is_array(array_name))
+    return;
+
+  vfs_.remove_dir(array_name);
+}
+
+void ConsolidationWithTimestampsFx::remove_sparse_array() {
+  remove_array(SPARSE_ARRAY_NAME);
+}
+
+bool ConsolidationWithTimestampsFx::is_array(const std::string& array_name) {
+  return vfs_.is_dir(array_name);
+}
+
+TEST_CASE_METHOD(
+    ConsolidationWithTimestampsFx,
+    "CPP API: Test consolidation with timestamps, full and partial read with "
+    "dups",
+    "[cppapi][consolidation-with-timestamps][partial-read][dups]") {
+  remove_sparse_array();
+  // Enable duplicates.
+  create_sparse_array(true);
+
+  // Write first fragment.
+  write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
+  // Write second fragment.
+  write_sparse({4, 5, 6, 7}, {2, 2, 3, 3}, {2, 4, 2, 3}, 3);
+
+  // Consolidate.
+  bool vacuum = GENERATE(true, false);
+  consolidate_sparse(vacuum);
+
+  // Write third fragment.
+  write_sparse({8, 9, 10, 11}, {2, 1, 3, 4}, {1, 3, 1, 1}, 4);
+  // Write fourth fragment.
+  write_sparse({12, 13, 14, 15}, {4, 3, 3, 4}, {2, 3, 4, 4}, 6);
+
+  for(auto ux=0u; ux < consolidate_sparse_iters; ++ux) {
+    // Consolidate.
+    consolidate_sparse(3, 7, vacuum);
+  }
+
+  tiledb_layout_t layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
+
+  // Test read for both refactored and legacy.
+  bool legacy = GENERATE(true, false);
+  if (legacy) {
+    set_legacy();
+  }
+
+  std::string stats;
+  std::vector<int> a(16);
+  std::vector<uint64_t> dim1(16);
+  std::vector<uint64_t> dim2(16);
+  std::vector<uint64_t> timestamps(16);
+  auto timestamps_ptr =
+      GENERATE_REF(as<std::vector<uint64_t>*>{}, nullptr, &timestamps);
+
+  uint64_t tstamp = 7;  
+  SECTION("Read after all writes") {
+    // Read after both writes - should see everything.
+    tstamp = 7;
+    //read_sparse(a, dim1, dim2, stats, layout, 7, timestamps_ptr);
+
+  }
+
+  // Read with full coverage on first 2 consolidated, partial coverage on second
+  // 2 consolidated.
+  SECTION("Read between the 2 writes") {
+    tstamp = 5;
+    //read_sparse(a, dim1, dim2, stats, layout, 5, timestamps_ptr);
+
+  }
+  for(auto ux=0u ; ux < read_sparse_iters; ++ux)
+    read_sparse(a, dim1, dim2, stats, layout, tstamp, timestamps_ptr, perform_query == 0);
+
+  remove_sparse_array();
+}
+

--- a/test/performance/msys_handle_leakage/unit.cc
+++ b/test/performance/msys_handle_leakage/unit.cc
@@ -1,5 +1,32 @@
 // cmake --build tiledb/test/performance --target tiledb_explore_msys_handle_leakage --config RelWithDebInfo
 
+/*
+(from                                                                                                                   
+* https://app.shortcut.com/tiledb-inc/story/19067/rtools40-msys-builds-of-tiledb-unit-leaking-handles)
+*                                                                                                                                             
+* (Event) Handle leakage in mingw builds (rtools40, rtools42) seems to be issue within
+* those cpp std libraries that tiledb usage aggravates, as visual studio builds are not exhibiting this leakage.
+* 
+* The leakage itself does not seem to be completely deterministic, as repeatedly running with the same parameters
+* (available with modified unit test) multiple times generally results in different numbers of handles leaked on
+* any given run.  Leakage can be demonstrated with tiledb_unit filtering on "CPP API: Test consolidation with timestamps, full and partial read with dups"
+* 
+* Modifications to unit-cppapi-consolidation-with-timestamps.cc which implements that TEST_CASE indicate that in
+* particular the activity of the .query .submit()d in read_sparse() routine seems to be at least the largest culprit,
+* without the query there seems little/no leakage.
+* 
+* The handle leakage may be causing some of the 32bit unit test failures in mingw, as some of the tests that fail in an
+* unfiltered run work acceptably when run individually, but it seems 32bit builds are not going to be supported with
+* rtools42 so this may not be important.
+* 
+* The ('recent') msys2 mingw versions I have installed of both gdb and lldb seem to have (differing) issues of their own
+* making it difficult to try and gather a complete picture of exactly what/where all may be involved in calls to the
+* CreateEventA (windows api) routine presumed to be at least responsible for the direct creation of the handles being 
+* leaked.
+* 
+* See notes on building this module and running some trials in the top of unit.cc along with some previously observed results.
+*/
+
 //.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1 --wait-for-keypress both
 //./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-sparse-iters=1 --wait-for-keypress both
 

--- a/test/performance/msys_handle_leakage/unit.cc
+++ b/test/performance/msys_handle_leakage/unit.cc
@@ -1,0 +1,160 @@
+// cmake --build tiledb/test/performance --target tiledb_explore_msys_handle_leakage --config RelWithDebInfo
+
+//.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1 --wait-for-keypress both
+//./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-sparse-iters=1 --wait-for-keypress both
+
+/* msys (from root of build tree, see <build_root>/test/performance/msys_handle_leakge/trials.sh
+$ . ../test/performance/msys_handle_leakage/trials.sh
+++ ./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=0 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (32 assertions in 1 test case)
+
+handle_count
+before 65
+after  305
+++ ./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (64 assertions in 1 test case)
+
+handle_count
+before 65
+after  314
+++ ./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=150 --perform-query=1 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (4832 assertions in 1 test case)
+
+handle_count
+before 65
+after  1140
+++ ./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=300 --perform-query=1 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (9632 assertions in 1 test case)
+
+handle_count
+before 65
+after  1966
+ */
+ 
+ /* visual studio from root of build tree, see <build_tree>\test\performance\msys_handle_leakage\trials.bat
+d:\dev\tiledb\gh.sc-19067-msys-handle-leakage.git\bld.vs19.A>rem .\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=0 --consolidate-sparse-iters=1 --wait-for-keypress both
+
+d:\dev\tiledb\gh.sc-19067-msys-handle-leakage.git\bld.vs19.A>.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=0 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (32 assertions in 1 test case)
+
+handle_count
+before 52
+after  70
+
+d:\dev\tiledb\gh.sc-19067-msys-handle-leakage.git\bld.vs19.A>.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (64 assertions in 1 test case)
+
+handle_count
+before 52
+after  70
+
+d:\dev\tiledb\gh.sc-19067-msys-handle-leakage.git\bld.vs19.A>.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=150 --perform-query=1 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (4832 assertions in 1 test case)
+
+handle_count
+before 52
+after  70
+
+d:\dev\tiledb\gh.sc-19067-msys-handle-leakage.git\bld.vs19.A>.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=300 --perform-query=1 --consolidate-sparse-iters=1
+===============================================================================
+All tests passed (9632 assertions in 1 test case)
+
+handle_count
+before 52
+after  70
+  */
+
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+extern unsigned int read_sparse_iters;
+extern unsigned int perform_query;
+extern unsigned int consolidate_sparse_iters;
+
+namespace tiledb {
+namespace test {
+
+// Command line arguments.
+int store_g_vfs(std::string&& vfs, std::vector<std::string> vfs_fs);
+
+}  // namespace test
+}  // namespace tiledb
+
+int main(const int argc, char** const argv) {
+  Catch::Session session;
+
+  // Define acceptable VFS values.
+  const std::vector<std::string> vfs_fs = {"native", "s3", "hdfs", "azure"};
+
+  // Build a pipe-separated string of acceptable VFS values.
+  std::ostringstream vfs_fs_oss;
+  for (size_t i = 0; i < vfs_fs.size(); ++i) {
+    vfs_fs_oss << vfs_fs[i];
+    if (i != (vfs_fs.size() - 1)) {
+      vfs_fs_oss << "|";
+    }
+  }
+
+  // Add a '--vfs' command line argument to override the default VFS.
+  std::string vfs;
+  Catch::clara::Parser cli =
+      session.cli() |
+      Catch::clara::Opt(vfs, vfs_fs_oss.str())["--vfs"](
+          "Override the VFS filesystem to use for generic tests")
+      | Catch::clara::Opt(read_sparse_iters, "read_sparse_iters")["--read-sparse-iters"]("specify read_sparse_iters (default 1)")
+      | Catch::clara::Opt(perform_query, "perform_query")["--perform-query"]("specify whether to perform query (default non-zero)")
+      | Catch::clara::Opt(consolidate_sparse_iters, "consolidate_sparse_iters")["--consolidate-sparse-iters"]("how many read_sparse iters to perform (default 1)")
+      ;
+
+  session.cli(cli);
+
+  int rc = session.applyCommandLine(argc, argv);
+  if (rc != 0)
+    return rc;
+
+  // Validate and store the VFS command line argument.
+  rc = tiledb::test::store_g_vfs(std::move(vfs), std::move(vfs_fs));
+  if (rc != 0)
+    return rc;
+
+  DWORD handle_count_before=0, handle_count_after;
+  BOOL got_before, got_after;
+  got_before = GetProcessHandleCount(GetCurrentProcess(),&handle_count_before);
+  //return session.run();
+  auto retval =  session.run();
+  got_after = GetProcessHandleCount(GetCurrentProcess(),&handle_count_after);
+  std::cout << "handle_count" << std::endl
+      << "before " << handle_count_before << std::endl
+      << "after  " << handle_count_after << std::endl;
+  return retval;
+}
+
+struct CICompletionStatusListener : Catch::TestEventListenerBase {
+  using TestEventListenerBase::TestEventListenerBase;  // inherit constructor
+
+  // Successful completion hook
+  void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+    if (std::getenv("GITHUB_RUN_ID") != nullptr ||
+        std::getenv("AGENT_NAME") != nullptr) {
+      if (testRunStats.totals.testCases.allOk() == 1) {
+        // set TILEDB_CI_SUCCESS job-level variable in azure pipelines
+        // note: this variable is only set in subsequest tasks.
+        printf("::set-output name=TILEDB_CI_SUCCESS::1\n");
+        printf("##vso[task.setvariable variable=TILEDB_CI_SUCCESS]1\n");
+      }
+    }
+  }
+};
+CATCH_REGISTER_LISTENER(CICompletionStatusListener)


### PR DESCRIPTION
Extract/isolate portion of unit test that can show handle leakage seemingly occurring due to mingw cpp std library implementation

---
TYPE: BUG
DESC: Demonstrating mingw handle leakage (tiledb_unit extract)
