### PR TITLE
Bugfix: deserialize array_schema_all_ into array object

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2102,25 +2102,50 @@ TEST_CASE_METHOD(
   rc = tiledb_array_open(ctx_, new_array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
 
+  // Check the retrieved array schema
+  tiledb_array_schema_t* new_array_schema;
+  rc = tiledb_array_schema_load(ctx_, array_name.c_str(), &new_array_schema);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_array_schema_check(ctx_, new_array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_layout_t cell_order;
+  rc = tiledb_array_schema_get_cell_order(ctx_, new_array_schema, &cell_order);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(cell_order == TILEDB_ROW_MAJOR);
+
+  tiledb_layout_t tile_order;
+  rc = tiledb_array_schema_get_tile_order(ctx_, new_array_schema, &tile_order);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(tile_order == TILEDB_ROW_MAJOR);
+
+  unsigned int num_attributes = 0;
+  rc = tiledb_array_schema_get_attribute_num(
+      ctx_, new_array_schema, &num_attributes);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(num_attributes == 1);
+
+  tiledb_domain_t* dom;
+  rc = tiledb_array_schema_get_domain(ctx_, new_array_schema, &dom);
+  REQUIRE(rc == TILEDB_OK);
+
+  unsigned int ndim = 0;
+  rc = tiledb_domain_get_ndim(ctx_, dom, &ndim);
+  REQUIRE(rc == TILEDB_OK);
+  CHECK(ndim == 2);
+
+  // TODO: Check the retrieved array_schemas list. Currently there is no
+  // CAPI to get it, should we introduce one?
+
+  // Check the retrieved non empty domain
   int is_empty;
   uint64_t domain[4];
   rc = tiledb_array_get_non_empty_domain(ctx_, new_array, domain, &is_empty);
   CHECK(rc == TILEDB_OK);
   CHECK(is_empty == 1);
 
-  // Close new_array
-  rc = tiledb_array_close(ctx_, new_array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&new_array);
-
-  /** Validate metadata. **/
-  // Open new_array in read mode
-  rc = tiledb_array_alloc(ctx_, array_name.c_str(), &new_array);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_array_open(ctx_, new_array, TILEDB_READ);
-  REQUIRE(rc == TILEDB_OK);
-
-  // Read
+  // Check the retrieved metadata
   const void* v_r;
   tiledb_datatype_t v_type;
   uint32_t v_num;

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -98,6 +98,11 @@ shared_ptr<const ArraySchema> Array::array_schema_latest_ptr() const {
   return array_schema_latest_;
 }
 
+void Array::set_array_schemas_all(
+    std::unordered_map<std::string, shared_ptr<ArraySchema>>& all_schemas) {
+  array_schemas_all_ = all_schemas;
+}
+
 const URI& Array::array_uri() const {
   return array_uri_;
 }

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -100,6 +100,13 @@ class Array {
     return array_schemas_all_;
   }
 
+  /**
+   * Sets all array schemas.
+   * @param all_schemas The array schemas to set.
+   */
+  void set_array_schemas_all(
+      std::unordered_map<std::string, shared_ptr<ArraySchema>>& all_schemas);
+
   /** Returns the array URI. */
   const URI& array_uri() const;
 

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -182,6 +182,7 @@ Status array_from_capnp(
         all_schemas[array_schema_build.getKey()] = std::move(schema);
       }
     }
+    array->set_array_schemas_all(all_schemas);
   }
 
   if (array_reader.hasArraySchemaLatest()) {


### PR DESCRIPTION
#2844  introduced a new Cap'n'p object for `Array` class that is serializing among others `array_schema_all_` field.

However, #2923 introduced a regression by removing (by mistake?) the line that sets the `array_schema_all_` field on the `Array` object during deserialization. Unfortunately, the array serialization unit test wasn't checking if this field is properly set, hence the regression.

_NOTE: The new array open serialization code is not used at the moment so this is not a bug in production_

I enhanced the existing `Array` serialization UT to check for the deserialized `array_schema` but not for `array_schema_all_` as I'd like so that we have a regression test. The reason is that we currently don't have a C API to retrieve all the `array_schemas` list if I am not mistaken. Open to ideas on how to proceed.

---
TYPE: IMPROVEMENT
DESC: Fix deserialize to set array_schema_all_ into array object
