### PR TITLE
Remove usage of Buffer for rtree on disk serialization.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,6 +427,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_capi_handle unit_capi_filter)
   add_dependencies(tests unit_delete_condition)
   add_dependencies(tests unit_ast)
+  add_dependencies(tests unit_serializers)
 
   if (TILEDB_WEBP)
     add_dependencies(tests unit_link_webp)

--- a/format_spec/delete_commit_file.md
+++ b/format_spec/delete_commit_file.md
@@ -35,7 +35,7 @@ Value nodes have the following on disk format:
 | :--- | :--- | :--- |
 | Node type | `uint8_t` | 1 for value node |
 | Op | `uint8_t` | LT(0), LE(1), GT(2), GE(3), EQ(4), NE(5) |
-| Field name size | `uint64_t` | Size of the field name |
+| Field name size | `uint32_t` | Size of the field name |
 | Field name value | `uint8_t[]` | Field name value |
 | Value size | `uint64_t` | Value size |
 | Value content | `uint8_t[]` | Value |

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -336,7 +336,7 @@ bool DeletesFx::is_array(const std::string& array_name) {
 
 TEST_CASE_METHOD(
     DeletesFx,
-    "CPP API: Test writting delete condition",
+    "CPP API: Test writing delete condition",
     "[cppapi][deletes][write-check]") {
   remove_sparse_array();
 
@@ -365,7 +365,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     DeletesFx,
-    "CPP API: Test writting invalid delete condition",
+    "CPP API: Test writing invalid delete condition",
     "[cppapi][deletes][write-check][invalid]") {
   remove_sparse_array();
   create_sparse_array();

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -4165,14 +4165,14 @@ Status FragmentMetadata::store_rtree(
 
 Tile FragmentMetadata::write_rtree() {
   rtree_.build_tree();
-  Serializer null_serializer;
-  rtree_.serialize(null_serializer);
+  SizeComputationSerializer size_computation_serializer;
+  rtree_.serialize(size_computation_serializer);
 
   Tile tile;
   if (!tile.init_unfiltered(
                0,
                constants::generic_tile_datatype,
-               null_serializer.size(),
+               size_computation_serializer.size(),
                constants::generic_tile_cell_size,
                0)
            .ok()) {
@@ -4181,7 +4181,6 @@ Tile FragmentMetadata::write_rtree() {
 
   Serializer serializer(tile.data(), tile.size());
   rtree_.serialize(serializer);
-  serializer.ensure_full_buffer_written();
 
   return tile;
 }

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1477,8 +1477,8 @@ class FragmentMetadata {
   /** Stores a footer with the basic information. */
   Status store_footer(const EncryptionKey& encryption_key);
 
-  /** Writes the R-tree to the input buffer. */
-  Status write_rtree(Buffer* buff);
+  /** Writes the R-tree to a tile. */
+  Tile write_rtree();
 
   /** Writes the non-empty domain to the input buffer. */
   Status write_non_empty_domain(Buffer* buff) const;
@@ -1674,9 +1674,9 @@ class FragmentMetadata {
 
   /**
    * Reads the contents of a generic tile starting at the input offset,
-   * and stores them into buffer ``buff``.
+   * and returns a tile.
    */
-  tuple<Status, optional<Buffer>> read_generic_tile_from_file(
+  tuple<Status, optional<Tile>> read_generic_tile_from_file(
       const EncryptionKey& encryption_key, uint64_t offset) const;
 
   /**
@@ -1699,6 +1699,18 @@ class FragmentMetadata {
       const EncryptionKey& encryption_key,
       Buffer& buff,
       uint64_t* nbytes) const;
+
+  /**
+   * Writes the contents of the input tile as a separate
+   * generic tile to the metadata file.
+   *
+   * @param encryption_key The encryption key.
+   * @param tile The tile whose contents the function will write.
+   * @param nbytes The total number of bytes written to the file.
+   * @return Status
+   */
+  Status write_generic_tile_to_file(
+      const EncryptionKey& encryption_key, Tile& tile, uint64_t* nbytes) const;
 
   /**
    * Writes the contents of the input buffer at the end of the fragment

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -87,10 +87,10 @@ storage_size_t get_serialized_condition_size(
     return 0;
   }
 
-  Serializer serializer;
-  serialize_condition_impl(node, serializer);
+  SizeComputationSerializer size_computation_serializer;
+  serialize_condition_impl(node, size_computation_serializer);
 
-  return serializer.size();
+  return size_computation_serializer.size();
 }
 
 std::vector<uint8_t> serialize_condition(
@@ -100,7 +100,6 @@ std::vector<uint8_t> serialize_condition(
 
   Serializer serializer(ret.data(), ret.size());
   serialize_condition_impl(query_condition.ast(), serializer);
-  serializer.ensure_full_buffer_written();
 
   return ret;
 }

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -31,8 +31,55 @@
  * to/from disk.
  */
 #include "serialization.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 namespace tiledb::sm::deletes_and_updates::serialization {
+
+void serialize_condition_impl(
+    const tdb_unique_ptr<tiledb::sm::ASTNode>& node, Serializer& serializer) {
+  if (node == nullptr) {
+    return;
+  }
+
+  // Serialize is_expr.
+  const auto node_type =
+      node->is_expr() ? NodeType::EXPRESSION : NodeType::VALUE;
+  serializer.write(static_cast<uint8_t>(node_type));
+  if (!node->is_expr()) {
+    // Get values.
+    const auto op = node->get_op();
+    const auto field_name = node->get_field_name();
+    const uint32_t field_name_length =
+        static_cast<uint32_t>(field_name.length());
+    const auto& value = node->get_condition_value_view();
+    const storage_size_t value_length = value.size();
+    // Serialize op.
+    serializer.write(op);
+
+    // Serialize field name.
+    serializer.write(field_name_length);
+    serializer.write(field_name.data(), field_name_length);
+
+    // Serialize value.
+    serializer.write(value_length);
+    serializer.write(value.content(), value.size());
+  } else {
+    // Get values.
+    const auto& nodes = node->get_children();
+    const auto nodes_size = nodes.size();
+    const auto combinatin_op = node->get_combination_op();
+
+    // Serialize combination op.
+    serializer.write(combinatin_op);
+
+    // Serialize children num.
+    serializer.write(nodes_size);
+
+    for (storage_size_t i = 0; i < nodes.size(); i++) {
+      serialize_condition_impl(nodes[i], serializer);
+    }
+  }
+}
 
 storage_size_t get_serialized_condition_size(
     const tdb_unique_ptr<tiledb::sm::ASTNode>& node) {
@@ -40,85 +87,10 @@ storage_size_t get_serialized_condition_size(
     return 0;
   }
 
-  storage_size_t size = sizeof(bool);  // is_expr
-  if (!node->is_expr()) {
-    size += sizeof(QueryConditionOp);                 // Query condition op.
-    size += sizeof(storage_size_t);                   // Field name size.
-    size += node->get_field_name().length();          // Field name.
-    size += sizeof(storage_size_t);                   // Value size.
-    size += node->get_condition_value_view().size();  // Value.
-    return size;
-  } else {
-    const auto& nodes = node->get_children();
-    size += sizeof(QueryConditionCombinationOp);  // Query condition op.
-    size += sizeof(storage_size_t);               // Children num.
-    for (storage_size_t i = 0; i < nodes.size(); i++) {
-      size += get_serialized_condition_size(nodes[i]);
-    }
-  }
+  Serializer serializer;
+  serialize_condition_impl(node, serializer);
 
-  return size;
-}
-
-void serialize_condition_impl(
-    const tdb_unique_ptr<tiledb::sm::ASTNode>& node,
-    std::vector<uint8_t>& buff,
-    storage_size_t& idx) {
-  if (node == nullptr) {
-    return;
-  }
-
-  assert(idx <= buff.size());
-
-  // Serialize is_expr.
-  const auto node_type =
-      node->is_expr() ? NodeType::EXPRESSION : NodeType::VALUE;
-  buff[idx++] = static_cast<uint8_t>(node_type);
-  if (!node->is_expr()) {
-    // Get values.
-    const auto op = node->get_op();
-    const auto field_name_length = node->get_field_name().length();
-    const auto& value = node->get_condition_value_view();
-    const auto value_length = value.size();
-    assert(
-        idx + sizeof(op) + sizeof(field_name_length) + field_name_length +
-            sizeof(value_length) + value_length <=
-        buff.size());
-
-    // Serialize op.
-    memcpy(&buff[idx], &op, sizeof(op));
-    idx += sizeof(op);
-
-    // Serialize field name, size then value.
-    memcpy(&buff[idx], &field_name_length, sizeof(field_name_length));
-    idx += sizeof(field_name_length);
-    memcpy(&buff[idx], node->get_field_name().data(), field_name_length);
-    idx += field_name_length;
-
-    // Serialize value, size then content.
-    memcpy(&buff[idx], &value_length, sizeof(value_length));
-    idx += sizeof(value_length);
-    memcpy(&buff[idx], value.content(), value_length);
-    idx += value_length;
-  } else {
-    // Get values.
-    const auto& nodes = node->get_children();
-    const auto nodes_size = nodes.size();
-    const auto combinatin_op = node->get_combination_op();
-    assert(idx + sizeof(nodes_size) + sizeof(combinatin_op) <= buff.size());
-
-    // Serialize combination op.
-    memcpy(&buff[idx], &combinatin_op, sizeof(combinatin_op));
-    idx += sizeof(combinatin_op);
-
-    // Serialize children num.
-    memcpy(&buff[idx], &nodes_size, sizeof(nodes_size));
-    idx += sizeof(nodes_size);
-
-    for (storage_size_t i = 0; i < nodes.size(); i++) {
-      serialize_condition_impl(nodes[i], buff, idx);
-    }
-  }
+  return serializer.size();
 }
 
 std::vector<uint8_t> serialize_condition(
@@ -126,57 +98,43 @@ std::vector<uint8_t> serialize_condition(
   std::vector<uint8_t> ret(
       get_serialized_condition_size(query_condition.ast()));
 
-  storage_size_t size = 0;
-  serialize_condition_impl(query_condition.ast(), ret, size);
+  Serializer serializer(ret.data(), ret.size());
+  serialize_condition_impl(query_condition.ast(), serializer);
+  serializer.ensure_full_buffer_written();
 
   return ret;
 }
 
-tdb_unique_ptr<ASTNode> deserialize_condition_impl(
-    const char* buff, const storage_size_t size, storage_size_t& idx) {
-  assert(idx < size);
-
+tdb_unique_ptr<ASTNode> deserialize_condition_impl(Deserializer& deserializer) {
   // Deserialize is_expr.
-  NodeType node_type = static_cast<NodeType>(buff[idx++]);
+  auto node_type = deserializer.read<NodeType>();
   if (node_type == NodeType::VALUE) {
     // Deserialize op.
-    auto op = QueryConditionOp::LT;
-    memcpy(&op, buff + idx, sizeof(op));
-    idx += sizeof(op);
+    auto op = deserializer.read<QueryConditionOp>();
     ensure_qc_op_is_valid(op);
 
-    // Deserialize field name, size then value.
-    storage_size_t field_name_length;
-    memcpy(&field_name_length, buff + idx, sizeof(field_name_length));
-    idx += sizeof(field_name_length);
-    auto field_name_value = buff + idx;
-    idx += field_name_length;
-    auto field_name = std::string(field_name_value, field_name_length);
+    // Deserialize field name.
+    auto field_name_size = deserializer.read<uint32_t>();
+    auto field_name_data = deserializer.get_ptr<char>(field_name_size);
+    std::string field_name(field_name_data, field_name_size);
 
-    // Deserialize value, size then content.
-    storage_size_t value_length;
-    memcpy(&value_length, buff + idx, sizeof(value_length));
-    idx += sizeof(value_length);
-    const void* value = buff + idx;
-    idx += value_length;
+    // Deserialize value.
+    auto value_size = deserializer.read<storage_size_t>();
+    auto value_data = deserializer.get_ptr<void>(value_size);
 
     return tdb_unique_ptr<ASTNode>(
-        tdb_new(ASTNodeVal, field_name, value, value_length, op));
+        tdb_new(ASTNodeVal, field_name, value_data, value_size, op));
   } else if (node_type == NodeType::EXPRESSION) {
     // Deserialize combination op.
-    auto combination_op = QueryConditionCombinationOp::AND;
-    memcpy(&combination_op, &buff[idx], sizeof(combination_op));
-    idx += sizeof(combination_op);
+    auto combination_op = deserializer.read<QueryConditionCombinationOp>();
     ensure_qc_combo_op_is_valid(combination_op);
 
     // Deserialize children num.
-    storage_size_t nodes_size = 0;
-    memcpy(&nodes_size, &buff[idx], sizeof(nodes_size));
-    idx += sizeof(nodes_size);
+    auto nodes_size = deserializer.read<storage_size_t>();
 
     std::vector<tdb_unique_ptr<ASTNode>> ast_nodes;
     for (storage_size_t i = 0; i < nodes_size; i++) {
-      ast_nodes.push_back(deserialize_condition_impl(buff, size, idx));
+      ast_nodes.push_back(deserialize_condition_impl(deserializer));
     }
 
     return tdb_unique_ptr<ASTNode>(
@@ -190,10 +148,9 @@ QueryCondition deserialize_condition(
     const std::string& condition_marker,
     const void* buff,
     const storage_size_t size) {
-  storage_size_t idx = 0;
+  Deserializer deserializer(buff, size);
   return QueryCondition(
-      condition_marker,
-      deserialize_condition_impl(static_cast<const char*>(buff), size, idx));
+      condition_marker, deserialize_condition_impl(deserializer));
 }
 
 }  // namespace tiledb::sm::deletes_and_updates::serialization

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -37,6 +37,7 @@
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/utils.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 #include <cassert>
 #include <cmath>
@@ -93,16 +94,18 @@ RTree& RTree::operator=(RTree&& rtree) noexcept {
 /*               API              */
 /* ****************************** */
 
-Status RTree::build_tree() {
-  if (levels_.empty())
-    return Status::Ok();
+void RTree::build_tree() {
+  if (levels_.empty()) {
+    return;
+  }
 
   assert(levels_.size() == 1);
 
   auto leaf_num = levels_[0].size();
   assert(leaf_num >= 1);
-  if (leaf_num == 1)
-    return Status::Ok();
+  if (leaf_num == 1) {
+    return;
+  }
 
   // Build the tree bottom up
   auto height = (size_t)std::ceil(utils::math::log(fanout_, leaf_num)) + 1;
@@ -113,8 +116,6 @@ Status RTree::build_tree() {
 
   // Make the root as the first level
   std::reverse(std::begin(levels_), std::end(levels_));
-
-  return Status::Ok();
 }
 
 uint64_t RTree::free_memory() {
@@ -257,34 +258,30 @@ uint64_t RTree::subtree_leaf_num(uint64_t level) const {
   return leaf_num;
 }
 
-Status RTree::serialize(Buffer* buff) const {
-  RETURN_NOT_OK(buff->write(&fanout_, sizeof(fanout_)));
+void RTree::serialize(Serializer& serializer) const {
+  serializer.write(fanout_);
   auto level_num = (unsigned)levels_.size();
-  RETURN_NOT_OK(buff->write(&level_num, sizeof(level_num)));
+  serializer.write(level_num);
   auto dim_num = domain_->dim_num();
 
   for (unsigned l = 0; l < level_num; ++l) {
     auto mbr_num = (uint64_t)levels_[l].size();
-    RETURN_NOT_OK(buff->write(&mbr_num, sizeof(uint64_t)));
+    serializer.write(mbr_num);
     for (uint64_t m = 0; m < mbr_num; ++m) {
       for (unsigned d = 0; d < dim_num; ++d) {
         const auto& r = levels_[l][m][d];
         if (!domain_->dimension_ptr(d)->var_size()) {  // Fixed-sized
           // Just write the plain range
-          RETURN_NOT_OK(buff->write(r.data(), r.size()));
+          serializer.write(r.data(), r.size());
         } else {  // Var-sized
           // range_size | start_size | range
-          auto size = r.size();
-          auto start_size = r.start_size();
-          RETURN_NOT_OK(buff->write(&size, sizeof(uint64_t)));
-          RETURN_NOT_OK(buff->write(&start_size, sizeof(uint64_t)));
-          RETURN_NOT_OK(buff->write(r.data(), size));
+          serializer.write(r.size());
+          serializer.write(r.start_size());
+          serializer.write(r.data(), r.size());
         }
       }
     }
   }
-
-  return Status::Ok();
 }
 
 Status RTree::set_leaf(uint64_t leaf_id, const NDRange& mbr) {
@@ -321,11 +318,14 @@ Status RTree::set_leaf_num(uint64_t num) {
   return Status::Ok();
 }
 
-Status RTree::deserialize(
-    ConstBuffer* cbuff, const Domain* domain, uint32_t version) {
-  if (version < 5)
-    return deserialize_v1_v4(cbuff, domain);
-  return deserialize_v5(cbuff, domain);
+void RTree::deserialize(
+    Deserializer& deserializer, const Domain* domain, uint32_t version) {
+  if (version < 5) {
+    deserialize_v1_v4(deserializer, domain);
+    return;
+  }
+
+  deserialize_v5(deserializer, domain);
 }
 
 /* ****************************** */
@@ -356,56 +356,52 @@ RTree RTree::clone() const {
   return clone;
 }
 
-Status RTree::deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain) {
-  // For backwards compatibility, they will be ignored
-  unsigned dim_num_i;
-  uint8_t type_i;
+void RTree::deserialize_v1_v4(
+    Deserializer& deserializer, const Domain* domain) {
+  deserialized_buffer_size_ = deserializer.size();
 
-  RETURN_NOT_OK(cbuff->read(&dim_num_i, sizeof(dim_num_i)));
-  RETURN_NOT_OK(cbuff->read(&fanout_, sizeof(fanout_)));
-  RETURN_NOT_OK(cbuff->read(&type_i, sizeof(type_i)));
-  unsigned level_num;
-  RETURN_NOT_OK(cbuff->read(&level_num, sizeof(level_num)));
+  // For backwards compatibility, ignored
+  auto dim_num_i = deserializer.read<unsigned>();
+  (void)dim_num_i;
 
+  fanout_ = deserializer.read<unsigned>();
+
+  // For backwards compatibility, ignored
+  auto type_i = deserializer.read<uint8_t>();
+  (void)type_i;
+
+  auto level_num = deserializer.read<unsigned>();
   levels_.clear();
   levels_.resize(level_num);
   auto dim_num = domain->dim_num();
-  uint64_t mbr_num;
   for (unsigned l = 0; l < level_num; ++l) {
-    RETURN_NOT_OK(cbuff->read(&mbr_num, sizeof(uint64_t)));
+    auto mbr_num = deserializer.read<uint64_t>();
     levels_[l].resize(mbr_num);
     for (uint64_t m = 0; m < mbr_num; ++m) {
       levels_[l][m].resize(dim_num);
       for (unsigned d = 0; d < dim_num; ++d) {
         auto r_size{2 * domain->dimension_ptr(d)->coord_size()};
-        levels_[l][m][d].set_range(cbuff->cur_data(), r_size);
-        cbuff->advance_offset(r_size);
+        auto data = deserializer.get_ptr<void>(r_size);
+        levels_[l][m][d].set_range(data, r_size);
       }
     }
   }
 
   domain_ = domain;
-  deserialized_buffer_size_ = cbuff->size();
-
-  return Status::Ok();
 }
 
-Status RTree::deserialize_v5(ConstBuffer* cbuff, const Domain* domain) {
-  RETURN_NOT_OK(cbuff->read(&fanout_, sizeof(fanout_)));
-  unsigned level_num;
+void RTree::deserialize_v5(Deserializer& deserializer, const Domain* domain) {
+  deserialized_buffer_size_ = deserializer.size();
 
-  RETURN_NOT_OK(cbuff->read(&level_num, sizeof(level_num)));
-
-  if (level_num == 0)
-    return Status::Ok();
+  fanout_ = deserializer.read<unsigned>();
+  auto level_num = deserializer.read<unsigned>();
 
   levels_.clear();
   levels_.resize(level_num);
   auto dim_num = domain->dim_num();
 
-  uint64_t mbr_num;
   for (unsigned l = 0; l < level_num; ++l) {
-    RETURN_NOT_OK(cbuff->read(&mbr_num, sizeof(uint64_t)));
+    auto mbr_num = deserializer.read<uint64_t>();
     levels_[l].resize(mbr_num);
 
     for (uint64_t m = 0; m < mbr_num; ++m) {
@@ -414,24 +410,20 @@ Status RTree::deserialize_v5(ConstBuffer* cbuff, const Domain* domain) {
         auto dim{domain->dimension_ptr(d)};
         if (!dim->var_size()) {  // Fixed-sized
           auto r_size = 2 * dim->coord_size();
-          levels_[l][m][d].set_range(cbuff->cur_data(), r_size);
-          cbuff->advance_offset(r_size);
+          auto data = deserializer.get_ptr<void>(r_size);
+          levels_[l][m][d].set_range(data, r_size);
         } else {  // Var-sized
           // range_size | start_size | range
-          uint64_t r_size, start_size;
-          RETURN_NOT_OK(cbuff->read(&r_size, sizeof(uint64_t)));
-          RETURN_NOT_OK(cbuff->read(&start_size, sizeof(uint64_t)));
-          levels_[l][m][d].set_range(cbuff->cur_data(), r_size, start_size);
-          cbuff->advance_offset(r_size);
+          auto r_size = deserializer.read<uint64_t>();
+          auto start_size = deserializer.read<uint64_t>();
+          auto data = deserializer.get_ptr<void>(r_size);
+          levels_[l][m][d].set_range(data, r_size, start_size);
         }
       }
     }
   }
 
   domain_ = domain;
-  deserialized_buffer_size_ = cbuff->size();
-
-  return Status::Ok();
 }
 
 void RTree::swap(RTree& rtree) {

--- a/tiledb/sm/rtree/rtree.h
+++ b/tiledb/sm/rtree/rtree.h
@@ -39,6 +39,7 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/misc/tile_overlap.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 using namespace tiledb::common;
 
@@ -88,7 +89,7 @@ class RTree {
   /* ********************************* */
 
   /** Builds the RTree bottom-up on the current leaf level. */
-  Status build_tree();
+  void build_tree();
 
   /** Frees the memory associated with the rtree. */
   uint64_t free_memory();
@@ -136,7 +137,7 @@ class RTree {
    * Serializes the contents of the object to the input buffer.
    * Note that `domain_` is not serialized in the buffer.
    */
-  Status serialize(Buffer* buff) const;
+  void serialize(Serializer& serializer) const;
 
   /**
    * Sets the RTree domain.
@@ -172,8 +173,8 @@ class RTree {
    * on the format version.
    * It also sets the input domain, as that is not serialized.
    */
-  Status deserialize(
-      ConstBuffer* cbuff, const Domain* domain, uint32_t version);
+  void deserialize(
+      Deserializer& deserializer, const Domain* domain, uint32_t version);
 
  private:
   /* ********************************* */
@@ -261,7 +262,7 @@ class RTree {
    *
    * Applicable to versions 1-4
    */
-  Status deserialize_v1_v4(ConstBuffer* cbuff, const Domain* domain);
+  void deserialize_v1_v4(Deserializer& deserializer, const Domain* domain);
 
   /**
    * Deserializes the contents of the object from the input buffer based
@@ -270,7 +271,7 @@ class RTree {
    *
    * Applicable to versions >= 5
    */
-  Status deserialize_v5(ConstBuffer* cbuff, const Domain* domain);
+  void deserialize_v5(Deserializer& deserializer, const Domain* domain);
 
   /**
    * Swaps the contents (all field values) of this RTree with the

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1443,15 +1443,15 @@ StorageManager::load_array_schema_from_uri(
     const URI& schema_uri, const EncryptionKey& encryption_key) {
   auto timer_se = stats_->start_timer("sm_load_array_schema_from_uri");
 
-  auto&& [st, buffer_opt] =
+  auto&& [st, tile_opt] =
       load_data_from_generic_tile(schema_uri, 0, encryption_key);
   RETURN_NOT_OK_TUPLE(st, nullopt);
-  auto& buffer = *buffer_opt;
+  auto& tile = *tile_opt;
 
-  stats_->add_counter("read_array_schema_size", buffer.size());
+  stats_->add_counter("read_array_schema_size", tile.size());
 
   // Deserialize
-  ConstBuffer cbuff(&buffer);
+  ConstBuffer cbuff(tile.data(), tile.size());
   try {
     return {Status::Ok(),
             make_shared<ArraySchema>(
@@ -1565,9 +1565,14 @@ Status StorageManager::load_array_metadata(
   auto status = parallel_for(compute_tp_, 0, metadata_num, [&](size_t m) {
     const auto& uri = array_metadata_to_load[m].uri_;
 
-    auto&& [st, buffer] = load_data_from_generic_tile(uri, 0, encryption_key);
+    auto&& [st, tile] = load_data_from_generic_tile(uri, 0, encryption_key);
     RETURN_NOT_OK(st);
-    metadata_buffs[m] = make_shared<Buffer>(HERE(), std::move(*buffer));
+
+    metadata_buffs[m] = tdb::make_shared<Buffer>(HERE());
+    RETURN_NOT_OK(metadata_buffs[m]->realloc(tile->size()));
+    metadata_buffs[m]->set_size(tile->size());
+    RETURN_NOT_OK(
+        tile->read(metadata_buffs[m]->data(), 0, metadata_buffs[m]->size()));
 
     return Status::Ok();
   });
@@ -1605,13 +1610,13 @@ StorageManager::load_delete_conditions(const Array& array) {
         0, condition_marker.length() - constants::delete_file_suffix.length());
 
     // Read the condition from storage.
-    auto&& [st, buff_opt] = load_data_from_generic_tile(
+    auto&& [st, tile_opt] = load_data_from_generic_tile(
         uri, locations[i].offset(), *array.encryption_key());
     RETURN_NOT_OK(st);
 
     delete_conditions[i] =
         tiledb::sm::deletes_and_updates::serialization::deserialize_condition(
-            condition_marker, buff_opt->data(), buff_opt->size());
+            condition_marker, tile_opt->data(), tile_opt->size());
 
     delete_conditions[i].check(array.array_schema_latest());
     return Status::Ok();
@@ -2048,14 +2053,14 @@ tuple<Status, optional<shared_ptr<Group>>> StorageManager::load_group_from_uri(
     const URI& group_uri, const URI& uri, const EncryptionKey& encryption_key) {
   auto timer_se = stats_->start_timer("sm_load_group_from_uri");
 
-  auto&& [st, buffer_opt] = load_data_from_generic_tile(uri, 0, encryption_key);
+  auto&& [st, tile_opt] = load_data_from_generic_tile(uri, 0, encryption_key);
   RETURN_NOT_OK_TUPLE(st, nullopt);
-  auto& buffer = *buffer_opt;
+  auto& tile = *tile_opt;
 
-  stats_->add_counter("read_group_size", buffer.size());
+  stats_->add_counter("read_group_size", tile.size());
 
   // Deserialize
-  ConstBuffer cbuff(&buffer);
+  ConstBuffer cbuff(tile.data(), tile.size());
   return Group::deserialize(&cbuff, group_uri, this);
 }
 
@@ -2136,9 +2141,14 @@ Status StorageManager::load_group_metadata(
   auto status = parallel_for(compute_tp_, 0, metadata_num, [&](size_t m) {
     const auto& uri = group_metadata_to_load[m].uri_;
 
-    auto&& [st, buffer] = load_data_from_generic_tile(uri, 0, encryption_key);
+    auto&& [st, tile] = load_data_from_generic_tile(uri, 0, encryption_key);
     RETURN_NOT_OK(st);
-    metadata_buffs[m] = tdb::make_shared<Buffer>(HERE(), std::move(*buffer));
+
+    metadata_buffs[m] = tdb::make_shared<Buffer>(HERE());
+    RETURN_NOT_OK(metadata_buffs[m]->realloc(tile->size()));
+    metadata_buffs[m]->set_size(tile->size());
+    RETURN_NOT_OK(
+        tile->read(metadata_buffs[m]->data(), 0, metadata_buffs[m]->size()));
 
     return Status::Ok();
   });
@@ -2163,7 +2173,7 @@ Status StorageManager::load_group_metadata(
   return Status::Ok();
 }
 
-tuple<Status, optional<Buffer>> StorageManager::load_data_from_generic_tile(
+tuple<Status, optional<Tile>> StorageManager::load_data_from_generic_tile(
     const URI& uri, uint64_t offset, const EncryptionKey& encryption_key) {
   GenericTileIO tile_io(this, uri);
 
@@ -2204,17 +2214,17 @@ tuple<Status, optional<Buffer>> StorageManager::load_data_from_generic_tile(
           nullopt);
     }
 
-    auto&& [st1, buff_opt] =
+    auto&& [st1, tile_opt] =
         tile_io.read_generic(0, encryption_key_cfg, config_);
     RETURN_NOT_OK_TUPLE(st1, nullopt);
 
-    return {Status::Ok(), std::move(*buff_opt)};
+    return {Status::Ok(), std::move(*tile_opt)};
   } else {
-    auto&& [st1, buff_opt] =
+    auto&& [st1, tile_opt] =
         tile_io.read_generic(offset, encryption_key, config_);
     RETURN_NOT_OK_TUPLE(st1, nullopt);
 
-    return {Status::Ok(), std::move(*buff_opt)};
+    return {Status::Ok(), std::move(*tile_opt)};
   }
 
   assert(false);
@@ -2315,11 +2325,17 @@ StorageManager::load_consolidated_fragment_meta(
   if (uri.to_string().empty())
     return {Status::Ok(), nullopt, nullopt};
 
-  auto&& [st, buffer_opt] = load_data_from_generic_tile(uri, 0, enc_key);
+  auto&& [st, tile_opt] = load_data_from_generic_tile(uri, 0, enc_key);
   RETURN_NOT_OK_TUPLE(st, nullopt, nullopt);
-  auto& buffer = *buffer_opt;
+  auto& tile = *tile_opt;
 
-  stats_->add_counter("consolidated_frag_meta_size", buffer.size());
+  stats_->add_counter("consolidated_frag_meta_size", tile.size());
+
+  Buffer buffer;
+  RETURN_NOT_OK_TUPLE(buffer.realloc(tile.size()), nullopt, nullopt);
+  buffer.set_size(tile.size());
+  RETURN_NOT_OK_TUPLE(
+      tile.read(buffer.data(), 0, buffer.size()), nullopt, nullopt);
 
   uint32_t fragment_num;
   buffer.reset_offset();

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -189,9 +189,9 @@ class StorageManager {
    * @param uri The object URI.
    * @param offset The offset into the file to read from.
    * @param encryption_key The encryption key to use.
-   * @return Status, Buffer with the data.
+   * @return Status, Tile with the data.
    */
-  tuple<Status, optional<Buffer>> load_data_from_generic_tile(
+  tuple<Status, optional<Tile>> load_data_from_generic_tile(
       const URI& uri, uint64_t offset, const EncryptionKey& encryption_key);
 
   /**

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -59,7 +59,7 @@ GenericTileIO::GenericTileIO(StorageManager* storage_manager, const URI& uri)
 /*               API              */
 /* ****************************** */
 
-tuple<Status, optional<Buffer>> GenericTileIO::read_generic(
+tuple<Status, optional<Tile>> GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
@@ -116,12 +116,7 @@ tuple<Status, optional<Buffer>> GenericTileIO::read_generic(
       nullopt);
   assert(!tile.filtered());
 
-  Buffer ret;
-  RETURN_NOT_OK_TUPLE(ret.realloc(tile.size()), std::nullopt);
-  ret.set_size(tile.size());
-  RETURN_NOT_OK_TUPLE(tile.read(ret.data(), 0, ret.size()), nullopt);
-
-  return {Status::Ok(), std::move(ret)};
+  return {Status::Ok(), std::move(tile)};
 }
 
 tuple<Status, optional<GenericTileIO::GenericTileHeader>>

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -127,7 +127,7 @@ class GenericTileIO {
    * @param config The storage manager's config.
    * @return Status, Tile
    */
-  tuple<Status, optional<Buffer>> read_generic(
+  tuple<Status, optional<Tile>> read_generic(
       uint64_t file_offset,
       const EncryptionKey& encryption_key,
       const Config& config);

--- a/tiledb/storage_format/serialization/CMakeLists.txt
+++ b/tiledb/storage_format/serialization/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# tiledb/storage_format/CMakeLists.txt
+# tiledb/storage_format/serialization/CMakeLists.txt
 #
 # The MIT License
 #
@@ -23,5 +23,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_subdirectory(serialization)
-add_subdirectory(uri)
+include(common NO_POLICY_SCOPE)
+
+if (TILEDB_TESTS)
+    add_executable(unit_serializers EXCLUDE_FROM_ALL)
+    find_package(Catch_EP REQUIRED)
+    target_link_libraries(unit_serializers PUBLIC Catch2::Catch2)
+
+    # Sources for tests
+    target_sources(unit_serializers PUBLIC test/main.cc test/unit_serializers.cc)
+
+    add_test(
+        NAME "unit_serializers"
+        COMMAND $<TARGET_FILE:unit_serializers>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/tiledb/storage_format/serialization/serializers.h
+++ b/tiledb/storage_format/serialization/serializers.h
@@ -39,21 +39,11 @@
 namespace tiledb::sm {
 
 /**
- * A serializer that allows to write data to a preallocated buffer. Once the
- * serialization is completed, the user should call ensure_full_buffer_written
- * to make sure the right buffer was allocated for serialization. The class can
- * also be created with no arguments to run serialization without copying the
- * data, which will be used to compute the required buffer size.
+ * A serializer that allows to write data to a preallocated buffer.
  */
 class Serializer {
  public:
-  /**
-   * Constructor with no buffer, used to compute required size.
-   */
-  Serializer()
-      : ptr_(nullptr)
-      , size_(0) {
-  }
+  Serializer() = delete;
 
   /**
    * Constructor using a preallocated buffer.
@@ -115,16 +105,6 @@ class Serializer {
   }
 
   /**
-   * Ensures the full data buffer was writter to. Should be called at the end
-   * of serialization.
-   */
-  void ensure_full_buffer_written() {
-    if (ptr_ && size_ != 0) {
-      throw std::logic_error("Didn't write full buffer.");
-    }
-  }
-
-  /**
    * Returns the size.
    */
   inline storage_size_t size() {
@@ -140,6 +120,19 @@ class Serializer {
 
   /* Size left to be written or total size. */
   storage_size_t size_;
+};
+
+/**
+ * A serializer that is used to compute the size of the data.
+ */
+class SizeComputationSerializer : public Serializer {
+ public:
+  /**
+   * Constructor with no buffer, used to compute required size.
+   */
+  SizeComputationSerializer()
+      : Serializer(nullptr, 0) {
+  }
 };
 
 /**

--- a/tiledb/storage_format/serialization/serializers.h
+++ b/tiledb/storage_format/serialization/serializers.h
@@ -1,0 +1,228 @@
+/**
+ * @file serializers.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains classes used for serialization/deserialization.
+ */
+
+#ifndef TILEDB_SERIALIZERS_H
+#define TILEDB_SERIALIZERS_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/status.h"
+
+namespace tiledb::sm {
+
+/**
+ * A serializer that allows to write data to a preallocated buffer. Once the
+ * serialization is completed, the user should call ensure_full_buffer_written
+ * to make sure the right buffer was allocated for serialization. The class can
+ * also be created with no arguments to run serialization without copying the
+ * data, which will be used to compute the required buffer size.
+ */
+class Serializer {
+ public:
+  /**
+   * Constructor with no buffer, used to compute required size.
+   */
+  Serializer()
+      : ptr_(nullptr)
+      , size_(0) {
+  }
+
+  /**
+   * Constructor using a preallocated buffer.
+   *
+   * @param data Preallocated buffer.
+   * @param size Size of the buffer.
+   */
+  Serializer(void* data, storage_size_t size)
+      : ptr_(static_cast<uint8_t*>(data))
+      , size_(size) {
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(Serializer);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(Serializer);
+
+  /**
+   * Serialize fixed size data.
+   *
+   * @tparam T Type of the data to write.
+   * @param v data to write.
+   */
+  template <class T>
+  void write(const T& v) {
+    if (!ptr_) {
+      size_ += sizeof(T);
+      return;
+    }
+
+    if (sizeof(T) > size_) {
+      throw std::logic_error(
+          "Writting serialized data past end of allocated size.");
+    }
+
+    memcpy(ptr_, &v, sizeof(T));
+    ptr_ += sizeof(T);
+    size_ -= sizeof(T);
+  }
+
+  /**
+   * Serialize a buffer.
+   *
+   * @param data data to write.
+   * @param size size of the data.
+   */
+  void write(const void* data, storage_size_t size) {
+    if (!ptr_) {
+      size_ += size;
+      return;
+    }
+
+    if (size > size_) {
+      throw std::logic_error(
+          "Writting serialized data past end of allocated size.");
+    }
+
+    memcpy(ptr_, data, size);
+    ptr_ += size;
+    size_ -= size;
+  }
+
+  /**
+   * Ensures the full data buffer was writter to. Should be called at the end
+   * of serialization.
+   */
+  void ensure_full_buffer_written() {
+    if (ptr_ && size_ != 0) {
+      throw std::logic_error("Didn't write full buffer.");
+    }
+  }
+
+  /**
+   * Returns the size.
+   */
+  inline storage_size_t size() {
+    return size_;
+  }
+
+ private:
+  /**
+   * Pointer to the current data to be written. Will be nullptr when the
+   * serializer is used to compute total size.
+   */
+  uint8_t* ptr_;
+
+  /* Size left to be written or total size. */
+  storage_size_t size_;
+};
+
+/**
+ * A deserializer implementation using a preallocated buffer.
+ */
+class Deserializer {
+ public:
+  /**
+   * Deleted default constructor.
+   */
+  Deserializer() = delete;
+
+  /**
+   * Constructor using a preallocated buffer.
+   *
+   * @param data Preallocated buffer.
+   * @param size Size of the buffer.
+   */
+  Deserializer(const void* data, storage_size_t size)
+      : ptr_(static_cast<const uint8_t*>(data))
+      , size_(size) {
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(Deserializer);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(Deserializer);
+
+  /**
+   * Deserialize fixed size data.
+   *
+   * @tparam T Type of the data to write.
+   * @return Data read.
+   */
+  template <class T>
+  T read() {
+    if (sizeof(T) > size_) {
+      throw std::logic_error("Reading data past end of serialized data size.");
+    }
+
+    T ret;
+    memcpy(&ret, ptr_, sizeof(T));
+    ptr_ += sizeof(T);
+    size_ -= sizeof(T);
+
+    return ret;
+  }
+
+  /**
+   * Return a pointer to serialized data.
+   *
+   * @tparam T Type of the data.
+   * @param size Size of the data.
+   * @return Pointer to the data.
+   */
+  template <class T>
+  const T* get_ptr(storage_size_t size) {
+    if (size > size_) {
+      throw std::logic_error("Reading data past end of serialized data size.");
+    }
+
+    auto ptr = static_cast<const T*>(static_cast<const void*>(ptr_));
+    ptr_ += size;
+    size_ -= size;
+
+    return ptr;
+  }
+
+  /**
+   * Return the size left to be read.
+   *
+   * @return Size left to be read.
+   */
+  inline storage_size_t size() {
+    return size_;
+  }
+
+ private:
+  /* Pointer to the current data to be read. */
+  const uint8_t* ptr_;
+
+  /* Size left to be read. */
+  storage_size_t size_;
+};
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_SERIALIZERS_H

--- a/tiledb/storage_format/serialization/serializers.h
+++ b/tiledb/storage_format/serialization/serializers.h
@@ -67,19 +67,7 @@ class Serializer {
    */
   template <class T>
   void write(const T& v) {
-    if (!ptr_) {
-      size_ += sizeof(T);
-      return;
-    }
-
-    if (sizeof(T) > size_) {
-      throw std::logic_error(
-          "Writting serialized data past end of allocated size.");
-    }
-
-    memcpy(ptr_, &v, sizeof(T));
-    ptr_ += sizeof(T);
-    size_ -= sizeof(T);
+    write(&v, sizeof(v));
   }
 
   /**
@@ -89,6 +77,7 @@ class Serializer {
    * @param size size of the data.
    */
   void write(const void* data, storage_size_t size) {
+    // Size compute mode.
     if (!ptr_) {
       size_ += size;
       return;
@@ -96,7 +85,7 @@ class Serializer {
 
     if (size > size_) {
       throw std::logic_error(
-          "Writting serialized data past end of allocated size.");
+          "Writing serialized data past end of allocated size.");
     }
 
     memcpy(ptr_, data, size);

--- a/tiledb/storage_format/serialization/test/main.cc
+++ b/tiledb/storage_format/serialization/test/main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file tiledb/storage_format/serialization/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>

--- a/tiledb/storage_format/serialization/test/unit_serializers.cc
+++ b/tiledb/storage_format/serialization/test/unit_serializers.cc
@@ -1,0 +1,70 @@
+/**
+ * @file unit_validity_vector.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `ValidityVector` class.
+ */
+
+#include "tiledb/storage_format/serialization/serializers.h"
+
+#include <catch.hpp>
+#include <iostream>
+
+using namespace std;
+using namespace tiledb::sm;
+
+typedef tuple<
+    unsigned char,  // Used for TILEDB_CHAR.
+    char,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    float,
+    double>
+    TypesUnderTest;
+TEMPLATE_LIST_TEST_CASE(
+    "Serializer/Deserializer Test", "[Serializer]", TypesUnderTest) {
+  Serializer null_serializer;
+  TestType data = 1;
+  null_serializer.write(data);
+  REQUIRE(null_serializer.size() == sizeof(TestType));
+
+  std::vector<uint8_t> buff(null_serializer.size());
+  Serializer serializer(buff.data(), buff.size());
+  serializer.write(data);
+  serializer.ensure_full_buffer_written();
+
+  Deserializer deserializer(buff.data(), buff.size());
+  auto read = deserializer.read<TestType>();
+  CHECK(data == read);
+}

--- a/tiledb/storage_format/serialization/test/unit_serializers.cc
+++ b/tiledb/storage_format/serialization/test/unit_serializers.cc
@@ -54,15 +54,14 @@ typedef tuple<
     TypesUnderTest;
 TEMPLATE_LIST_TEST_CASE(
     "Serializer/Deserializer Test", "[Serializer]", TypesUnderTest) {
-  Serializer null_serializer;
+  SizeComputationSerializer size_computation_serializer;
   TestType data = 1;
-  null_serializer.write(data);
-  REQUIRE(null_serializer.size() == sizeof(TestType));
+  size_computation_serializer.write(data);
+  REQUIRE(size_computation_serializer.size() == sizeof(TestType));
 
-  std::vector<uint8_t> buff(null_serializer.size());
+  std::vector<uint8_t> buff(size_computation_serializer.size());
   Serializer serializer(buff.data(), buff.size());
   serializer.write(data);
-  serializer.ensure_full_buffer_written();
 
   Deserializer deserializer(buff.data(), buff.size());
   auto read = deserializer.read<TestType>();


### PR DESCRIPTION
First, this PR implements a Serializer class that is used to first
compute the size of serialized data by running through the serialization
without copying to a buffer, but summing the size of all serialized
data. Then the caller can allocate the correct buffer size and
serialize the data into it using another construction of the same class
and run through the exact same serialization code.

Deserialization is done through the Deserializer class which gets
constructed on an already existing in memory buffer.

Both of these classes were used to remove the usage of buffer for the
serialization/deserialization of the rtree data to disk.

Also, the code for serializing/deserializing the delete condiiton was
simplified by using the new classes.

---
TYPE: IMPROVEMENT
DESC: Remove some usage of Buffer for on disk serialization.
