### PR TITLE
Deletes: refactored readers process deletes.

### DIFF
--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -36,6 +36,7 @@
 #include "tiledb/sm/enums/query_condition_combination_op.h"
 #include "tiledb/sm/enums/query_condition_op.h"
 #include "tiledb/sm/misc/utils.h"
+#include "tiledb/storage_format/uri/parse_uri.h"
 
 #include <algorithm>
 #include <functional>
@@ -144,6 +145,20 @@ std::unordered_set<std::string>& QueryCondition::field_names() const {
   }
 
   return field_names_;
+}
+
+uint64_t QueryCondition::condition_timestamp() const {
+  if (condition_marker_.empty()) {
+    return 0;
+  }
+
+  std::pair<uint64_t, uint64_t> timestamps;
+  if (!utils::parse::get_timestamp_range(URI(condition_marker_), &timestamps)
+           .ok()) {
+    throw std::logic_error("Error parsing condition marker.");
+  }
+
+  return timestamps.first;
 }
 
 /** Full template specialization for `char*` and `QueryConditionOp::LT`. */

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -145,6 +145,11 @@ class QueryCondition {
   std::unordered_set<std::string>& field_names() const;
 
   /**
+   * Returns the timestamp for this condition.
+   */
+  uint64_t condition_timestamp() const;
+
+  /**
    * Applies this query condition to `result_cell_slabs`.
    *
    * @param array_schema The array schema associated with `result_cell_slabs`.

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -80,6 +80,7 @@ ReaderBase::ReaderBase(
     , use_timestamps_(false) {
   if (array != nullptr)
     fragment_metadata_ = array->fragment_metadata();
+  timestamps_for_deletes_.resize(fragment_metadata_.size());
 }
 
 /* ********************************* */
@@ -277,8 +278,8 @@ bool ReaderBase::include_timestamps(const unsigned f) const {
       array_->timestamp_start(), array_->timestamp_end_opened_at());
   auto dups = array_schema_.allows_dups();
 
-  return frag_has_ts &&
-         (user_requested_timestamps_ || partial_overlap || !dups);
+  return frag_has_ts && (user_requested_timestamps_ || partial_overlap ||
+                         !dups || timestamps_for_deletes_[f]);
 }
 
 Status ReaderBase::load_tile_offsets(

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -161,6 +161,13 @@ class ReaderBase : public StrategyBase {
   /** The query condition. */
   QueryCondition& condition_;
 
+  /** The delete conditions. */
+  std::vector<QueryCondition> delete_conditions_;
+
+  /** Timestamped delete conditions, used for consolidated fragments with
+   * timestamps. */
+  std::vector<QueryCondition> timestamped_delete_conditions_;
+
   /** The fragment metadata that the reader will focus on. */
   std::vector<shared_ptr<FragmentMetadata>> fragment_metadata_;
 
@@ -181,6 +188,12 @@ class ReaderBase : public StrategyBase {
    * this query
    */
   bool use_timestamps_;
+
+  /**
+   * Boolean, per fragment, to specify that we need to load timestamps for
+   * deletes.
+   */
+  std::vector<bool> timestamps_for_deletes_;
 
   /* ********************************* */
   /*         PROTECTED METHODS         */

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1359,7 +1359,7 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
         // For dimensions or query condition fields, tiles are already all
         // loaded in memory.
         if (array_schema_.is_dim(name) ||
-            condition_.field_names().count(name) != 0 || is_timestamps)
+            qc_loaded_names_set_.count(name) != 0 || is_timestamps)
           return Status::Ok();
 
         // Get the size for all tiles.
@@ -1638,7 +1638,7 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
         *buffers_[name].validity_vector_.buffer_size() = total_cells;
 
       // Clear tiles from memory.
-      if (!is_dim && condition_.field_names().count(name) == 0 &&
+      if (!is_dim && qc_loaded_names_set_.count(name) == 0 &&
           name != constants::timestamps &&
           name != constants::delete_timestamps) {
         clear_tiles(name, result_tiles);

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -297,6 +297,9 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Names of dim/attr loaded for query condition. */
   std::vector<std::string> qc_loaded_names_;
 
+  /** Names of dim/attr loaded for query condition. */
+  std::unordered_set<std::string> qc_loaded_names_set_;
+
   /* Are the users buffers full. */
   bool buffers_full_;
 


### PR DESCRIPTION
This change allows the refactored readers to process deletes conditions.
For regular fragments, the delete conditions are processed only if the
delete timestamp is greater than the fragment start timestamp. For
fragments consolidated with timestamps, the reader needs to generate a
new condition including the timestamp of the delete and apply this
condition to the fragment.

---
TYPE: IMPROVEMENT
DESC: Deletes: refactored readers process deletes.
