### PR TITLE
Use zlib from tiledb-deps-mirror with fallback

### DIFF
--- a/cmake/Modules/FindZlib_EP.cmake
+++ b/cmake/Modules/FindZlib_EP.cmake
@@ -83,7 +83,9 @@ if (NOT ZLIB_FOUND)
 
     ExternalProject_Add(ep_zlib
       PREFIX "externals"
-      URL "https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip"
+      URL
+        "https://github.com/TileDB-Inc/tiledb-deps-mirror/releases/download/2.10-deps/zlib1211.zip"
+        "https://downloads.sourceforge.net/project/libpng/zlib/1.2.11/zlib1211.zip"
       URL_HASH SHA1=bccd93ad3cee39c3d08eee68d45b3e11910299f2
       DOWNLOAD_NAME "zlib1211.zip"
       CMAKE_ARGS


### PR DESCRIPTION
This PR updates zlib superbuild to use https://github.com/TileDB-Inc/tiledb-deps-mirror as the primary source for zlib download, to mitigate the CI impact of upstream host network issues. The original URL is kept as a fallback (EP_Add now supports multiple URLs).

Part of SC-11085.

---
TYPE: NO_HISTORY
