### PR TITLE
Deletes: adding support for commits consolidation.

### DIFF
--- a/format_spec/consolidated_commits_file.md
+++ b/format_spec/consolidated_commits_file.md
@@ -31,7 +31,7 @@ For fragment commits, the URIs is written delimited by a new line character:
 | :--- | :--- | :--- |
 | URI  followed by a new line character | `uint8_t[]` | URI |
 
-For delete commits, the URIs is written delimited by a new line character and then followed by the delete condition tile [tile](./tile.md), preceded by its size:
+For delete commits, the URIs is written delimited by a new line character and then followed by the delete condition [tile](./tile.md), preceded by its size:
 
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |

--- a/format_spec/consolidated_commits_file.md
+++ b/format_spec/consolidated_commits_file.md
@@ -18,10 +18,23 @@ my_array                              # array folder
 * `uuid` is a unique identifier
 * `v` is the format version
 
-There may be multiple such files in the array commits folder. Each consolidated commits file combines a list of fragments commits URIs delimited by a new line character. The URI is the relative URI based on the top level array URI.
+There may be multiple such files in the array commits folder. Each consolidated commits file combines a list of fragments commits or delete commits. 
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| Commit 1 | `uint8_t[]` | Commit 1 |
+| … | … | … |
+| Commit N | `uint8_t[]` | Commit N |
+
+For fragment commits, the URIs is written delimited by a new line character:
 
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |
-| URI 1 followed by a new line character | `uint8_t[]` | URI 1 |
-| … | … | … |
-| URI N followed by a new line character | `uint8_t[]` | URI N |
+| URI  followed by a new line character | `uint8_t[]` | URI |
+
+For delete commits, the URIs is written delimited by a new line character and then followed by the delete condition tile [tile](./tile.md), preceded by its size:
+
+| **Field** | **Type** | **Description** |
+| :--- | :--- | :--- |
+| URI  followed by a new line character | `uint8_t[]` | URI |
+| Delete condition size | `uint64_t` | Delete condition size |
+| Delete condition tile | `uint8_t[]` | Delete condition tile |

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -236,7 +236,9 @@ Status ArrayDirectory::load() {
           fragment_meta_uris_v12_or_higher.end(),
           std::back_inserter(fragment_meta_uris_));
 
-      // Sort the delete commits by timestamp.
+      // Sort the delete commits by timestamp. Delete tiles locations come from
+      // both the consolidated file and the directory listing, and they might
+      // have interleaved times, so we need to sort.
       std::sort(delete_tiles_location_.begin(), delete_tiles_location_.end());
     }
   }

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -235,6 +235,9 @@ Status ArrayDirectory::load() {
           fragment_meta_uris_v12_or_higher.begin(),
           fragment_meta_uris_v12_or_higher.end(),
           std::back_inserter(fragment_meta_uris_));
+
+      // Sort the delete commits by timestamp.
+      std::sort(delete_tiles_location_.begin(), delete_tiles_location_.end());
     }
   }
 


### PR DESCRIPTION
This adds support, for deletes, for commits file consolidation. The
delete files can now be consolidated inside of the consolidated commits
file by first adding the delete file relative path, followed by the
delete condition tile size, then the delete condition tile. This format
allows to read the old format with the same code.

---
TYPE: IMPROVEMENT
DESC: Deletes: adding support for commits consolidation.
