### PR TITLE
Strategy refactor: move init to constructor.

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -37,6 +37,7 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/legacy/reader.h"
 #include "tiledb/type/range/range.h"
@@ -88,12 +89,53 @@ ReaderFx::ReaderFx()
   create_dir(temp_dir_, ctx_, vfs_);
 
   array_name_ = temp_dir_ + ARRAY_NAME;
-  int rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
+
+  int64_t dim_domain[] = {-1, 2};
+  int64_t tile_extent = 2;
+
+  // Create domain
+  tiledb_domain_t* domain;
+  auto rc = tiledb_domain_alloc(ctx_, &domain);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_dimension_t* dim;
+  rc = tiledb_dimension_alloc(
+      ctx_, "d1", TILEDB_INT64, dim_domain, &tile_extent, &dim);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_domain_add_dimension(ctx_, domain, dim);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create attribute
+  tiledb_attribute_t* attr;
+  rc = tiledb_attribute_alloc(ctx_, "a", TILEDB_INT32, &attr);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  rc = tiledb_array_schema_alloc(ctx_, TILEDB_SPARSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_tile_order(ctx_, array_schema, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_set_domain(ctx_, array_schema, domain);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_schema_add_attribute(ctx_, array_schema, attr);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_array_schema_check(ctx_, array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create array
+  rc = tiledb_array_create(ctx_, array_name_.c_str(), array_schema);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_attribute_free(&attr);
+  tiledb_dimension_free(&dim);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
   CHECK(rc == TILEDB_OK);
 }
 
 ReaderFx::~ReaderFx() {
-  tiledb_array_free(&array_);
   remove_dir(temp_dir_, ctx_, vfs_);
   tiledb_ctx_free(&ctx_);
   tiledb_vfs_free(&vfs_);
@@ -107,18 +149,21 @@ TEST_CASE_METHOD(
     ReaderFx,
     "Reader: Compute result space tiles, 2D",
     "[Reader][2d][compute_result_space_tiles]") {
+  uint64_t tmp_size = 0;
   Config config;
+  Context context(config);
   std::unordered_map<std::string, tiledb::sm::QueryBuffer> buffers;
-  Subarray subarray;
+  buffers.emplace(
+      "a", tiledb::sm::QueryBuffer(nullptr, nullptr, &tmp_size, &tmp_size));
   QueryCondition condition;
   ThreadPool tp_cpu(4), tp_io(4);
-  StorageManager storage_manager(
-      &tp_cpu, &tp_io, &g_helper_stats, g_helper_logger());
-  Array array(URI("my_array"), &storage_manager);
+  Array array(URI(array_name_), context.storage_manager());
+  array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+  Subarray subarray(&array, &g_helper_stats, g_helper_logger());
   Reader reader(
       &g_helper_stats,
       g_helper_logger(),
-      nullptr,
+      context.storage_manager(),
       &array,
       config,
       buffers,

--- a/tiledb/sm/query/deletes_and_updates/deletes.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes.cc
@@ -111,10 +111,6 @@ Status Deletes::finalize() {
   return Status::Ok();
 }
 
-Status Deletes::init() {
-  return Status::Ok();
-}
-
 Status Deletes::initialize_memory_budget() {
   return Status::Ok();
 }

--- a/tiledb/sm/query/deletes_and_updates/deletes.h
+++ b/tiledb/sm/query/deletes_and_updates/deletes.h
@@ -85,9 +85,6 @@ class Deletes : public StrategyBase, public IQueryStrategy {
     return QueryStatusDetailsReason::REASON_NONE;
   }
 
-  /** Initializes the delete. */
-  Status init();
-
   /** Initialize the memory budget variables. */
   Status initialize_memory_budget();
 

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -47,9 +47,6 @@ class IQueryStrategy {
   /** Destructor. */
   virtual ~IQueryStrategy() = default;
 
-  /** Initializes the strategy. */
-  virtual Status init() = 0;
-
   /** Initialize the memory budget variables. */
   virtual Status initialize_memory_budget() = 0;
 

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -57,6 +57,13 @@ using namespace tiledb::sm::stats;
 namespace tiledb {
 namespace sm {
 
+class ReaderStatusException : public StatusException {
+ public:
+  explicit ReaderStatusException(const std::string& message)
+      : StatusException("Reader", message) {
+  }
+};
+
 namespace {
 /**
  * If the given iterator points to an "invalid" element, advance it until the
@@ -114,6 +121,31 @@ Reader::Reader(
           subarray,
           layout,
           condition) {
+  // Sanity checks
+  if (storage_manager_ == nullptr) {
+    throw ReaderStatusException(
+        "Cannot initialize reader; Storage manager not set");
+  }
+
+  if (buffers_.empty()) {
+    throw ReaderStatusException("Cannot initialize reader; Buffers not set");
+  }
+
+  if (array_schema_.dense() && !subarray_.is_set()) {
+    throw ReaderStatusException(
+        "Cannot initialize reader; Dense reads must have a subarray set");
+  }
+
+  // Check subarray
+  check_subarray();
+
+  // Initialize the read state
+  init_read_state();
+
+  // Check the validity buffer sizes. This must be performed
+  // after `init_read_state` to ensure we have set the
+  // member state correctly from the config.
+  check_validity_buffer_sizes();
 }
 
 /* ****************************** */
@@ -131,32 +163,6 @@ bool Reader::incomplete() const {
 QueryStatusDetailsReason Reader::status_incomplete_reason() const {
   return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
                         QueryStatusDetailsReason::REASON_NONE;
-}
-
-Status Reader::init() {
-  // Sanity checks
-  if (storage_manager_ == nullptr)
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize reader; Storage manager not set"));
-  if (buffers_.empty())
-    return logger_->status(
-        Status_ReaderError("Cannot initialize reader; Buffers not set"));
-  if (array_schema_.dense() && !subarray_.is_set())
-    return logger_->status(Status_ReaderError(
-        "Cannot initialize reader; Dense reads must have a subarray set"));
-
-  // Check subarray
-  RETURN_NOT_OK(check_subarray());
-
-  // Initialize the read state
-  RETURN_NOT_OK(init_read_state());
-
-  // Check the validity buffer sizes. This must be performed
-  // after `init_read_state` to ensure we have set the
-  // member state correctly from the config.
-  RETURN_NOT_OK(check_validity_buffer_sizes());
-
-  return Status::Ok();
 }
 
 Status Reader::initialize_memory_budget() {
@@ -1773,43 +1779,59 @@ bool Reader::has_separate_coords() const {
   return false;
 }
 
-Status Reader::init_read_state() {
+void Reader::init_read_state() {
   auto timer_se = stats_->start_timer("init_state");
 
   // Check subarray
-  if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
-    return logger_->status(
-        Status_ReaderError("Cannot initialize read "
-                           "state; Multi-range "
-                           "subarrays do not "
-                           "support global order"));
+  if (subarray_.layout() == Layout::GLOBAL_ORDER &&
+      subarray_.range_num() != 1) {
+    throw ReaderStatusException(
+        "Cannot initialize read state; Multi-range subarrays do not support "
+        "global order");
+  }
 
   // Get config
   bool found = false;
   uint64_t memory_budget = 0;
-  RETURN_NOT_OK(
-      config_.get<uint64_t>("sm.memory_budget", &memory_budget, &found));
+  if (!config_.get<uint64_t>("sm.memory_budget", &memory_budget, &found).ok()) {
+    throw ReaderStatusException("Cannot get setting");
+  }
   assert(found);
+
   uint64_t memory_budget_var = 0;
-  RETURN_NOT_OK(config_.get<uint64_t>(
-      "sm.memory_budget_var", &memory_budget_var, &found));
+  if (!config_.get<uint64_t>("sm.memory_budget_var", &memory_budget_var, &found)
+           .ok()) {
+    throw ReaderStatusException("Cannot get setting");
+  }
   assert(found);
+
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(
-        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
-                           "format in configuration"));
+    throw ReaderStatusException(
+        "Cannot initialize reader; Unsupported offsets"
+        " format in configuration");
   }
-  RETURN_NOT_OK(config_.get<bool>(
-      "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
+
+  if (!config_
+           .get<bool>(
+               "sm.var_offsets.extra_element", &offsets_extra_element_, &found)
+           .ok()) {
+    throw ReaderStatusException("Cannot get setting");
+  }
   assert(found);
-  RETURN_NOT_OK(config_.get<uint32_t>(
-      "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
+
+  if (!config_
+           .get<uint32_t>("sm.var_offsets.bitsize", &offsets_bitsize_, &found)
+           .ok()) {
+    throw ReaderStatusException("Cannot get setting");
+  }
+  assert(found);
+
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(
-        Status_ReaderError("Cannot initialize reader; Unsupported offsets "
-                           "bitsize in configuration"));
+    throw ReaderStatusException(
+        "Cannot initialize reader; Unsupported offsets"
+        " bitsize in configuration");
   }
   assert(found);
 
@@ -1839,22 +1861,37 @@ Status Reader::init_read_state() {
     auto buffer_validity_size = a.second.validity_vector_.buffer_size();
     if (!array_schema_.var_size(attr_name)) {
       if (!array_schema_.is_nullable(attr_name)) {
-        RETURN_NOT_OK(read_state_.partitioner_.set_result_budget(
-            attr_name.c_str(), *buffer_size));
+        if (!read_state_.partitioner_
+                 .set_result_budget(attr_name.c_str(), *buffer_size)
+                 .ok()) {
+          throw ReaderStatusException("Cannot set result budget");
+        }
       } else {
-        RETURN_NOT_OK(read_state_.partitioner_.set_result_budget_nullable(
-            attr_name.c_str(), *buffer_size, *buffer_validity_size));
+        if (!read_state_.partitioner_
+                 .set_result_budget_nullable(
+                     attr_name.c_str(), *buffer_size, *buffer_validity_size)
+                 .ok()) {
+          throw ReaderStatusException("Cannot set result budget");
+        }
       }
     } else {
       if (!array_schema_.is_nullable(attr_name)) {
-        RETURN_NOT_OK(read_state_.partitioner_.set_result_budget(
-            attr_name.c_str(), *buffer_size, *buffer_var_size));
+        if (!read_state_.partitioner_
+                 .set_result_budget(
+                     attr_name.c_str(), *buffer_size, *buffer_var_size)
+                 .ok()) {
+          throw ReaderStatusException("Cannot set result budget");
+        }
       } else {
-        RETURN_NOT_OK(read_state_.partitioner_.set_result_budget_nullable(
-            attr_name.c_str(),
-            *buffer_size,
-            *buffer_var_size,
-            *buffer_validity_size));
+        if (!read_state_.partitioner_
+                 .set_result_budget_nullable(
+                     attr_name.c_str(),
+                     *buffer_size,
+                     *buffer_var_size,
+                     *buffer_validity_size)
+                 .ok()) {
+          throw ReaderStatusException("Cannot set result budget");
+        }
       }
     }
   }
@@ -1862,8 +1899,6 @@ Status Reader::init_read_state() {
   read_state_.unsplittable_ = false;
   read_state_.overflowed_ = false;
   read_state_.initialized_ = true;
-
-  return Status::Ok();
 }
 
 Status Reader::sort_result_coords(

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -110,7 +110,8 @@ Reader::Reader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition)
+    QueryCondition& condition,
+    bool skip_checks_serialization)
     : ReaderBase(
           stats,
           logger->clone("Reader", ++logger_id_),
@@ -127,11 +128,12 @@ Reader::Reader(
         "Cannot initialize reader; Storage manager not set");
   }
 
-  if (buffers_.empty()) {
+  if (!skip_checks_serialization && buffers_.empty()) {
     throw ReaderStatusException("Cannot initialize reader; Buffers not set");
   }
 
-  if (array_schema_.dense() && !subarray_.is_set()) {
+  if (!skip_checks_serialization && array_schema_.dense() &&
+      !subarray_.is_set()) {
     throw ReaderStatusException(
         "Cannot initialize reader; Dense reads must have a subarray set");
   }

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -73,7 +73,8 @@ class Reader : public ReaderBase, public IQueryStrategy {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition);
+      QueryCondition& condition,
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~Reader() = default;

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -98,9 +98,6 @@ class Reader : public ReaderBase, public IQueryStrategy {
   /** Returns the status details reason. */
   QueryStatusDetailsReason status_incomplete_reason() const;
 
-  /** Initializes the reader. */
-  Status init();
-
   /** Initialize the memory budget variables. */
   Status initialize_memory_budget();
 
@@ -613,7 +610,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
   bool has_separate_coords() const;
 
   /** Initializes the read state. */
-  Status init_read_state();
+  void init_read_state();
 
   /**
    * Sorts the input result coordinates according to the subarray layout.

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1009,7 +1009,6 @@ Status Query::init() {
 
     RETURN_NOT_OK(check_buffer_names());
     RETURN_NOT_OK(create_strategy());
-    RETURN_NOT_OK(strategy_->init());
   }
 
   status_ = QueryStatus::INPROGRESS;
@@ -2181,7 +2180,6 @@ Status Query::submit() {
 
     if (status_ == QueryStatus::UNINITIALIZED) {
       RETURN_NOT_OK(create_strategy());
-      RETURN_NOT_OK(strategy_->init());
     }
     return rest_client->submit_query_to_rest(array_->array_uri(), this);
   }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1087,193 +1087,20 @@ Status Query::process() {
   return Status::Ok();
 }
 
-Status Query::create_strategy() {
-  if (type_ == QueryType::WRITE) {
-    if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
-      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-          OrderedWriter,
-          stats_->create_child("Writer"),
-          logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
-          written_fragment_info_,
-          coords_info_,
-          fragment_uri_));
-    } else if (layout_ == Layout::UNORDERED) {
-      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-          UnorderedWriter,
-          stats_->create_child("Writer"),
-          logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
-          written_fragment_info_,
-          coords_info_,
-          fragment_uri_));
-    } else if (layout_ == Layout::GLOBAL_ORDER) {
-      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-          GlobalOrderWriter,
-          stats_->create_child("Writer"),
-          logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
-          written_fragment_info_,
-          disable_checks_consolidation_,
-          coords_info_,
-          fragment_uri_));
-    } else {
-      assert(false);
-    }
-  } else if (type_ == QueryType::READ) {
-    bool use_default = true;
-    bool all_dense = true;
-    for (auto& frag_md : fragment_metadata_) {
-      all_dense &= frag_md->dense();
-    }
-
-    if (use_refactored_sparse_unordered_with_dups_reader(
-            layout_, *array_schema_)) {
-      use_default = false;
-
-      auto&& [st, non_overlapping_ranges]{Query::non_overlapping_ranges()};
-      RETURN_NOT_OK(st);
-
-      if (*non_overlapping_ranges || !subarray_.is_set() ||
-          subarray_.range_num() == 1) {
-        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-            SparseUnorderedWithDupsReader<uint8_t>,
-            stats_->create_child("Reader"),
-            logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            subarray_,
-            layout_,
-            condition_));
-      } else {
-        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-            SparseUnorderedWithDupsReader<uint64_t>,
-            stats_->create_child("Reader"),
-            logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            subarray_,
-            layout_,
-            condition_));
-      }
-    } else if (
-        use_refactored_sparse_global_order_reader(layout_, *array_schema_) &&
-        !array_schema_->dense() &&
-        (layout_ == Layout::GLOBAL_ORDER || layout_ == Layout::UNORDERED)) {
-      // Using the reader for unordered queries to do deduplication.
-      use_default = false;
-
-      auto&& [st, non_overlapping_ranges]{Query::non_overlapping_ranges()};
-      RETURN_NOT_OK(st);
-
-      if (*non_overlapping_ranges || !subarray_.is_set() ||
-          subarray_.range_num() == 1) {
-        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-            SparseGlobalOrderReader<uint8_t>,
-            stats_->create_child("Reader"),
-            logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            subarray_,
-            layout_,
-            condition_,
-            consolidation_with_timestamps_));
-      } else {
-        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-            SparseGlobalOrderReader<uint64_t>,
-            stats_->create_child("Reader"),
-            logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            subarray_,
-            layout_,
-            condition_,
-            consolidation_with_timestamps_));
-      }
-    } else if (use_refactored_dense_reader(*array_schema_, all_dense)) {
-      use_default = false;
-      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-          DenseReader,
-          stats_->create_child("Reader"),
-          logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
-          condition_));
-    }
-
-    if (use_default) {
-      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-          Reader,
-          stats_->create_child("Reader"),
-          logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
-          condition_));
-    }
-  } else if (type_ == QueryType::DELETE) {
-    strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
-        Deletes,
-        stats_->create_child("Deletes"),
-        logger_,
-        storage_manager_,
-        array_,
-        config_,
-        buffers_,
-        subarray_,
-        layout_,
-        condition_));
-  } else {
-    return logger_->status(
-        Status_QueryError("Cannot create strategy; unsupported query type"));
-  }
-
-  if (strategy_ == nullptr)
-    return logger_->status(
-        Status_QueryError("Cannot create strategy; allocation failed"));
-
-  return Status::Ok();
-}
-
-IQueryStrategy* Query::strategy() {
+IQueryStrategy* Query::strategy(bool skip_checks_serialization) {
   if (strategy_ == nullptr) {
-    create_strategy();
+    create_strategy(skip_checks_serialization);
   }
   return strategy_.get();
 }
 
-void Query::clear_strategy() {
+Status Query::reset_strategy_with_layout(Layout layout) {
   strategy_ = nullptr;
+  layout_ = layout;
+  subarray_.set_layout(layout);
+  RETURN_NOT_OK(create_strategy(true));
+
+  return Status::Ok();
 }
 
 Status Query::disable_checks_consolidation() {
@@ -1334,6 +1161,193 @@ Status Query::check_buffer_names() {
           Status_WriterError("Writes expect all attributes (and coordinates in "
                              "the sparse/unordered case) to be set"));
   }
+
+  return Status::Ok();
+}
+
+Status Query::create_strategy(bool skip_checks_serialization) {
+  if (type_ == QueryType::WRITE) {
+    if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
+      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+          OrderedWriter,
+          stats_->create_child("Writer"),
+          logger_,
+          storage_manager_,
+          array_,
+          config_,
+          buffers_,
+          subarray_,
+          layout_,
+          written_fragment_info_,
+          coords_info_,
+          fragment_uri_,
+          skip_checks_serialization));
+    } else if (layout_ == Layout::UNORDERED) {
+      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+          UnorderedWriter,
+          stats_->create_child("Writer"),
+          logger_,
+          storage_manager_,
+          array_,
+          config_,
+          buffers_,
+          subarray_,
+          layout_,
+          written_fragment_info_,
+          coords_info_,
+          fragment_uri_,
+          skip_checks_serialization));
+    } else if (layout_ == Layout::GLOBAL_ORDER) {
+      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+          GlobalOrderWriter,
+          stats_->create_child("Writer"),
+          logger_,
+          storage_manager_,
+          array_,
+          config_,
+          buffers_,
+          subarray_,
+          layout_,
+          written_fragment_info_,
+          disable_checks_consolidation_,
+          coords_info_,
+          fragment_uri_,
+          skip_checks_serialization));
+    } else {
+      assert(false);
+    }
+  } else if (type_ == QueryType::READ) {
+    bool use_default = true;
+    bool all_dense = true;
+    for (auto& frag_md : fragment_metadata_) {
+      all_dense &= frag_md->dense();
+    }
+
+    if (use_refactored_sparse_unordered_with_dups_reader(
+            layout_, *array_schema_)) {
+      use_default = false;
+
+      auto&& [st, non_overlapping_ranges]{Query::non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
+
+      if (*non_overlapping_ranges || !subarray_.is_set() ||
+          subarray_.range_num() == 1) {
+        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+            SparseUnorderedWithDupsReader<uint8_t>,
+            stats_->create_child("Reader"),
+            logger_,
+            storage_manager_,
+            array_,
+            config_,
+            buffers_,
+            subarray_,
+            layout_,
+            condition_,
+            skip_checks_serialization));
+      } else {
+        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+            SparseUnorderedWithDupsReader<uint64_t>,
+            stats_->create_child("Reader"),
+            logger_,
+            storage_manager_,
+            array_,
+            config_,
+            buffers_,
+            subarray_,
+            layout_,
+            condition_,
+            skip_checks_serialization));
+      }
+    } else if (
+        use_refactored_sparse_global_order_reader(layout_, *array_schema_) &&
+        !array_schema_->dense() &&
+        (layout_ == Layout::GLOBAL_ORDER || layout_ == Layout::UNORDERED)) {
+      // Using the reader for unordered queries to do deduplication.
+      use_default = false;
+
+      auto&& [st, non_overlapping_ranges]{Query::non_overlapping_ranges()};
+      RETURN_NOT_OK(st);
+
+      if (*non_overlapping_ranges || !subarray_.is_set() ||
+          subarray_.range_num() == 1) {
+        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+            SparseGlobalOrderReader<uint8_t>,
+            stats_->create_child("Reader"),
+            logger_,
+            storage_manager_,
+            array_,
+            config_,
+            buffers_,
+            subarray_,
+            layout_,
+            condition_,
+            consolidation_with_timestamps_,
+            skip_checks_serialization));
+      } else {
+        strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+            SparseGlobalOrderReader<uint64_t>,
+            stats_->create_child("Reader"),
+            logger_,
+            storage_manager_,
+            array_,
+            config_,
+            buffers_,
+            subarray_,
+            layout_,
+            condition_,
+            consolidation_with_timestamps_,
+            skip_checks_serialization));
+      }
+    } else if (use_refactored_dense_reader(*array_schema_, all_dense)) {
+      use_default = false;
+      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+          DenseReader,
+          stats_->create_child("Reader"),
+          logger_,
+          storage_manager_,
+          array_,
+          config_,
+          buffers_,
+          subarray_,
+          layout_,
+          condition_,
+          skip_checks_serialization));
+    }
+
+    if (use_default) {
+      strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+          Reader,
+          stats_->create_child("Reader"),
+          logger_,
+          storage_manager_,
+          array_,
+          config_,
+          buffers_,
+          subarray_,
+          layout_,
+          condition_,
+          skip_checks_serialization));
+    }
+  } else if (type_ == QueryType::DELETE) {
+    strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
+        Deletes,
+        stats_->create_child("Deletes"),
+        logger_,
+        storage_manager_,
+        array_,
+        config_,
+        buffers_,
+        subarray_,
+        layout_,
+        condition_));
+  } else {
+    return logger_->status(
+        Status_QueryError("Cannot create strategy; unsupported query type"));
+  }
+
+  if (strategy_ == nullptr)
+    return logger_->status(
+        Status_QueryError("Cannot create strategy; allocation failed"));
 
   return Status::Ok();
 }
@@ -1944,12 +1958,6 @@ Status Query::set_est_result_size(
   }
 
   return subarray_.set_est_result_size(est_result_size, max_mem_size);
-}
-
-Status Query::set_layout_unsafe(Layout layout) {
-  layout_ = layout;
-  subarray_.set_layout(layout);
-  return Status::Ok();
 }
 
 Status Query::set_layout(Layout layout) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -551,14 +551,16 @@ class Query {
   /** Processes a query. */
   Status process();
 
-  /** Create the strategy. */
-  Status create_strategy();
-
   /** Gets the strategy of the query. */
-  IQueryStrategy* strategy();
+  IQueryStrategy* strategy(bool skip_checks_serialization = false);
 
-  /** Remove the current strategy. Used by serialization. */
-  void clear_strategy();
+  /**
+   * Switch the strategy depending on layout. Used by serialization.
+   *
+   * @param layout New layout
+   * @return Status
+   */
+  Status reset_strategy_with_layout(Layout layout);
 
   /**
    * Disables checking the global order and coordinate duplicates. Applicable
@@ -799,11 +801,6 @@ class Query {
       std::unordered_map<std::string, Subarray::MemorySize>& max_mem_size);
 
   /**
-   * Sets the cell layout of the query without performing any checks.
-   */
-  Status set_layout_unsafe(Layout layout);
-
-  /**
    * Sets the cell layout of the query.
    */
   Status set_layout(Layout layout);
@@ -1012,6 +1009,13 @@ class Query {
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /**
+   * Create the strategy.
+   *
+   * @param skip_checks_serialization Skip checks during serialization.
+   */
+  Status create_strategy(bool skip_checks_serialization = false);
 
   Status check_set_fixed_buffer(const std::string& name);
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -72,7 +72,8 @@ DenseReader::DenseReader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition)
+    QueryCondition& condition,
+    bool skip_checks_serialization)
     : ReaderBase(
           stats,
           logger->clone("DenseReader", ++logger_id_),
@@ -91,12 +92,12 @@ DenseReader::DenseReader(
         "Cannot initialize dense reader; Storage manager not set");
   }
 
-  if (buffers_.empty()) {
+  if (!skip_checks_serialization && buffers_.empty()) {
     throw DenseReaderStatusException(
         "Cannot initialize dense reader; Buffers not set");
   }
 
-  if (!subarray_.is_set()) {
+  if (!skip_checks_serialization && !subarray_.is_set()) {
     throw DenseReaderStatusException(
         "Cannot initialize reader; Dense reads must have a subarray set");
   }

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -123,9 +123,6 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   /** Returns the status details reason. */
   QueryStatusDetailsReason status_incomplete_reason() const;
 
-  /** Initializes the reader. */
-  Status init();
-
   /** Initialize the memory budget variables. */
   Status initialize_memory_budget();
 
@@ -168,7 +165,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   Status dense_read();
 
   /** Initializes the read state. */
-  Status init_read_state();
+  void init_read_state();
 
   /** Apply the query condition. */
   template <class DimType, class OffType>

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -96,7 +96,8 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition);
+      QueryCondition& condition,
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~DenseReader() = default;

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -51,6 +51,13 @@
 namespace tiledb {
 namespace sm {
 
+class ReaderBaseStatusException : public StatusException {
+ public:
+  explicit ReaderBaseStatusException(const std::string& message)
+      : StatusException("ReaderBase", message) {
+  }
+};
+
 /* ****************************** */
 /*          CONSTRUCTORS          */
 /* ****************************** */
@@ -232,16 +239,16 @@ void ReaderBase::zero_out_buffer_sizes() {
   }
 }
 
-Status ReaderBase::check_subarray() const {
-  if (subarray_.layout() == Layout::GLOBAL_ORDER && subarray_.range_num() != 1)
-    return logger_->status(Status_ReaderError(
+void ReaderBase::check_subarray() const {
+  if (subarray_.layout() == Layout::GLOBAL_ORDER &&
+      subarray_.range_num() != 1) {
+    throw ReaderBaseStatusException(
         "Cannot initialize reader; Multi-range subarrays with "
-        "global order layout are not supported"));
-
-  return Status::Ok();
+        "global order layout are not supported");
+  }
 }
 
-Status ReaderBase::check_validity_buffer_sizes() const {
+void ReaderBase::check_validity_buffer_sizes() const {
   // Verify that the validity buffer size for each
   // nullable attribute is large enough to contain
   // a validity value for each cell.
@@ -274,12 +281,10 @@ Status ReaderBase::check_validity_buffer_sizes() const {
               "given for ";
         ss << "attribute '" << name << "'";
         ss << " (" << cell_validity_num << " < " << min_cell_num << ")";
-        return logger_->status(Status_ReaderError(ss.str()));
+        throw ReaderBaseStatusException(ss.str());
       }
     }
   }
-
-  return Status::Ok();
 }
 
 bool ReaderBase::partial_consolidated_fragment_overlap() const {

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -241,10 +241,10 @@ class ReaderBase : public StrategyBase {
   void zero_out_buffer_sizes();
 
   /** Correctness checks for `subarray_`. */
-  Status check_subarray() const;
+  void check_subarray() const;
 
   /** Correctness checks validity buffer sizes in `buffers_`. */
-  Status check_validity_buffer_sizes() const;
+  void check_validity_buffer_sizes() const;
 
   /**
    * Skip read/unfilter operations for timestamps attribute and fragments

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -78,7 +78,8 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
     Subarray& subarray,
     Layout layout,
     QueryCondition& condition,
-    bool consolidation_with_timestamps)
+    bool consolidation_with_timestamps,
+    bool skip_checks_serialization)
     : SparseIndexReaderBase(
           stats,
           logger->clone("SparseGlobalOrderReader", ++logger_id_),
@@ -94,7 +95,7 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
     , memory_used_for_qc_tiles_(array->fragment_metadata().size())
     , consolidation_with_timestamps_(consolidation_with_timestamps)
     , last_cells_(array->fragment_metadata().size()) {
-  SparseIndexReaderBase::init();
+  SparseIndexReaderBase::init(skip_checks_serialization);
 
   // Initialize memory budget variables.
   if (!initialize_memory_budget().ok()) {
@@ -1734,6 +1735,7 @@ template SparseGlobalOrderReader<uint8_t>::SparseGlobalOrderReader(
     Subarray&,
     Layout,
     QueryCondition&,
+    bool,
     bool);
 template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
     stats::Stats*,
@@ -1745,6 +1747,7 @@ template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
     Subarray&,
     Layout,
     QueryCondition&,
+    bool,
     bool);
 
 }  // namespace sm

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -76,7 +76,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       Subarray& subarray,
       Layout layout,
       QueryCondition& condition,
-      bool consolidation_with_timestamps);
+      bool consolidation_with_timestamps,
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~SparseGlobalOrderReader() = default;

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -112,13 +112,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   QueryStatusDetailsReason status_incomplete_reason() const;
 
   /**
-   * Initializes the reader.
-   *
-   * @return Status.
-   */
-  Status init();
-
-  /**
    * Initialize the memory budget variables.
    *
    * @return Status.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -109,7 +109,7 @@ typename SparseIndexReaderBase::ReadState* SparseIndexReaderBase::read_state() {
   return &read_state_;
 }
 
-void SparseIndexReaderBase::init() {
+void SparseIndexReaderBase::init(bool skip_checks_serialization) {
   // Sanity checks
   if (storage_manager_ == nullptr) {
     throw SparseIndexReaderBaseStatusException(
@@ -117,7 +117,7 @@ void SparseIndexReaderBase::init() {
         "set");
   }
 
-  if (buffers_.empty()) {
+  if (!skip_checks_serialization && buffers_.empty()) {
     throw SparseIndexReaderBaseStatusException(
         "Cannot initialize sparse global order reader; Buffers not set");
   }

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -226,7 +226,7 @@ class SparseIndexReaderBase : public ReaderBase {
    *
    * @return Status.
    */
-  Status init();
+  void init();
 
   /**
    * Resize the output buffers to the correct size after copying.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -224,9 +224,10 @@ class SparseIndexReaderBase : public ReaderBase {
   /**
    * Initializes the reader.
    *
+   * @param skip_checks_serialization Skip checks during serialization.
    * @return Status.
    */
-  void init();
+  void init(bool skip_checks_serialization);
 
   /**
    * Resize the output buffers to the correct size after copying.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -75,7 +75,8 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition)
+    QueryCondition& condition,
+    bool skip_checks_serialization)
     : SparseIndexReaderBase(
           stats,
           logger->clone("SparseUnorderedWithDupsReader", ++logger_id_),
@@ -86,7 +87,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           subarray,
           layout,
           condition) {
-  SparseIndexReaderBase::init();
+  SparseIndexReaderBase::init(skip_checks_serialization);
 
   // Initialize memory budget variables.
   if (!initialize_memory_budget().ok()) {
@@ -1622,7 +1623,8 @@ template SparseUnorderedWithDupsReader<uint8_t>::SparseUnorderedWithDupsReader(
     std::unordered_map<std::string, QueryBuffer>&,
     Subarray&,
     Layout,
-    QueryCondition&);
+    QueryCondition&,
+    bool);
 template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
     stats::Stats*,
     shared_ptr<Logger>,
@@ -1632,7 +1634,8 @@ template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
     std::unordered_map<std::string, QueryBuffer>&,
     Subarray&,
     Layout,
-    QueryCondition&);
+    QueryCondition&,
+    bool);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -53,6 +53,14 @@ using namespace tiledb::sm::stats;
 namespace tiledb {
 namespace sm {
 
+class SparseUnorderedWithDupsReaderStatusException : public StatusException {
+ public:
+  explicit SparseUnorderedWithDupsReaderStatusException(
+      const std::string& message)
+      : StatusException("SparseUnorderedWithDupsReader", message) {
+  }
+};
+
 /* ****************************** */
 /*          CONSTRUCTORS          */
 /* ****************************** */
@@ -78,6 +86,13 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           subarray,
           layout,
           condition) {
+  SparseIndexReaderBase::init();
+
+  // Initialize memory budget variables.
+  if (!initialize_memory_budget().ok()) {
+    throw SparseUnorderedWithDupsReaderStatusException(
+        "Cannot initialize memory budget");
+  }
 }
 
 /* ****************************** */
@@ -101,16 +116,6 @@ SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
   return result_tiles_.empty() ?
              QueryStatusDetailsReason::REASON_MEMORY_BUDGET :
              QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
-}
-
-template <class BitmapType>
-Status SparseUnorderedWithDupsReader<BitmapType>::init() {
-  RETURN_NOT_OK(SparseIndexReaderBase::init());
-
-  // Initialize memory budget variables.
-  RETURN_NOT_OK(initialize_memory_budget());
-
-  return Status::Ok();
 }
 
 template <class BitmapType>

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -136,13 +136,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   QueryStatusDetailsReason status_incomplete_reason() const;
 
   /**
-   * Initializes the reader.
-   *
-   * @return Status.
-   */
-  Status init();
-
-  /**
    * Initialize the memory budget variables.
    *
    * @return Status.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -74,7 +74,8 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition);
+      QueryCondition& condition,
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~SparseUnorderedWithDupsReader() = default;

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -77,7 +77,8 @@ GlobalOrderWriter::GlobalOrderWriter(
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     bool disable_checks_consolidation,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri)
+    URI fragment_uri,
+    bool skip_checks_serialization)
     : WriterBase(
           stats,
           logger,
@@ -90,7 +91,8 @@ GlobalOrderWriter::GlobalOrderWriter(
           written_fragment_info,
           disable_checks_consolidation,
           coords_info,
-          fragment_uri) {
+          fragment_uri,
+          skip_checks_serialization) {
 }
 
 GlobalOrderWriter::~GlobalOrderWriter() {

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -109,7 +109,8 @@ class GlobalOrderWriter : public WriterBase {
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""));
+      URI fragment_uri = URI(""),
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~GlobalOrderWriter();

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -76,7 +76,8 @@ OrderedWriter::OrderedWriter(
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri)
+    URI fragment_uri,
+    bool skip_checks_serialization)
     : WriterBase(
           stats,
           logger,
@@ -89,7 +90,8 @@ OrderedWriter::OrderedWriter(
           written_fragment_info,
           false,
           coords_info,
-          fragment_uri) {
+          fragment_uri,
+          skip_checks_serialization) {
 }
 
 OrderedWriter::~OrderedWriter() {

--- a/tiledb/sm/query/writers/ordered_writer.h
+++ b/tiledb/sm/query/writers/ordered_writer.h
@@ -63,7 +63,8 @@ class OrderedWriter : public WriterBase {
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""));
+      URI fragment_uri = URI(""),
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~OrderedWriter();

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -76,7 +76,8 @@ UnorderedWriter::UnorderedWriter(
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri)
+    URI fragment_uri,
+    bool skip_checks_serialization)
     : WriterBase(
           stats,
           logger,
@@ -89,7 +90,8 @@ UnorderedWriter::UnorderedWriter(
           written_fragment_info,
           false,
           coords_info,
-          fragment_uri) {
+          fragment_uri,
+          skip_checks_serialization) {
 }
 
 UnorderedWriter::~UnorderedWriter() {

--- a/tiledb/sm/query/writers/unordered_writer.h
+++ b/tiledb/sm/query/writers/unordered_writer.h
@@ -63,7 +63,8 @@ class UnorderedWriter : public WriterBase {
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""));
+      URI fragment_uri = URI(""),
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~UnorderedWriter();

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -85,7 +85,8 @@ WriterBase::WriterBase(
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     bool disable_checks_consolidation,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri)
+    URI fragment_uri,
+    bool skip_checks_serialization)
     : StrategyBase(
           stats,
           logger->clone("Writer", ++logger_id_),
@@ -110,7 +111,7 @@ WriterBase::WriterBase(
         "Cannot initialize query; Storage manager not set");
   }
 
-  if (buffers_.empty()) {
+  if (!skip_checks_serialization && buffers_.empty()) {
     throw WriterBaseStatusException(
         "Cannot initialize writer; Buffers not set");
   }
@@ -192,7 +193,9 @@ WriterBase::WriterBase(
   }
 
   check_subarray();
-  check_buffer_sizes();
+  if (!skip_checks_serialization) {
+    check_buffer_sizes();
+  }
 
   optimize_layout_for_1D();
   check_var_attr_offsets();

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -62,6 +62,13 @@ using namespace tiledb::sm::stats;
 namespace tiledb {
 namespace sm {
 
+class WriterBaseStatusException : public StatusException {
+ public:
+  explicit WriterBaseStatusException(const std::string& message)
+      : StatusException("WriterBase", message) {
+  }
+};
+
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -96,6 +103,99 @@ WriterBase::WriterBase(
     , dedup_coords_(false)
     , written_fragment_info_(written_fragment_info) {
   fragment_uri_ = fragment_uri;
+
+  // Sanity checks
+  if (storage_manager_ == nullptr) {
+    throw WriterBaseStatusException(
+        "Cannot initialize query; Storage manager not set");
+  }
+
+  if (buffers_.empty()) {
+    throw WriterBaseStatusException(
+        "Cannot initialize writer; Buffers not set");
+  }
+
+  if (array_schema_.dense() &&
+      (layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR)) {
+    for (const auto& b : buffers_) {
+      if (array_schema_.is_dim(b.first)) {
+        throw WriterBaseStatusException(
+            "Cannot initialize writer; Sparse coordinates for dense arrays "
+            "cannot be provided if the query layout is ROW_MAJOR or COL_MAJOR");
+      }
+    }
+  }
+
+  // Get configuration parameters
+  const char *check_coord_dups, *check_coord_oob, *check_global_order;
+  const char* dedup_coords;
+  if (!config_.get("sm.check_coord_dups", &check_coord_dups).ok()) {
+    throw WriterBaseStatusException("Cannot get setting");
+  }
+
+  if (!config_.get("sm.check_coord_oob", &check_coord_oob).ok()) {
+    throw WriterBaseStatusException("Cannot get setting");
+  }
+
+  if (!config_.get("sm.check_global_order", &check_global_order).ok()) {
+    throw WriterBaseStatusException("Cannot get setting");
+  }
+
+  if (!config_.get("sm.dedup_coords", &dedup_coords).ok()) {
+    throw WriterBaseStatusException("Cannot get setting");
+  }
+
+  assert(check_coord_dups != nullptr && dedup_coords != nullptr);
+  check_coord_dups_ =
+      disable_checks_consolidation_ ? false : !strcmp(check_coord_dups, "true");
+  check_coord_oob_ = !strcmp(check_coord_oob, "true");
+  check_global_order_ = disable_checks_consolidation_ ?
+                            false :
+                            !strcmp(check_global_order, "true");
+  dedup_coords_ = !strcmp(dedup_coords, "true");
+  bool found = false;
+  offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
+  assert(found);
+  if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
+    throw WriterBaseStatusException(
+        "Cannot initialize writer; Unsupported offsets format in "
+        "configuration");
+  }
+  if (!config_
+           .get<bool>(
+               "sm.var_offsets.extra_element", &offsets_extra_element_, &found)
+           .ok()) {
+    throw WriterBaseStatusException("Cannot get setting");
+  }
+  assert(found);
+
+  if (!config_
+           .get<uint32_t>("sm.var_offsets.bitsize", &offsets_bitsize_, &found)
+           .ok()) {
+    throw WriterBaseStatusException("Cannot get setting");
+  }
+  assert(found);
+
+  if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
+    throw WriterBaseStatusException(
+        "Cannot initialize writer; Unsupported offsets bitsize in "
+        "configuration");
+  }
+
+  // Set a default subarray
+  if (!subarray_.is_set()) {
+    subarray_ = Subarray(array_, layout_, stats_, logger_);
+  }
+
+  if (offsets_extra_element_) {
+    check_extra_element();
+  }
+
+  check_subarray();
+  check_buffer_sizes();
+
+  optimize_layout_for_1D();
+  check_var_attr_offsets();
 }
 
 WriterBase::~WriterBase() {
@@ -130,7 +230,7 @@ void WriterBase::set_dedup_coords(bool b) {
   dedup_coords_ = b;
 }
 
-Status WriterBase::check_var_attr_offsets() const {
+void WriterBase::check_var_attr_offsets() const {
   for (const auto& it : buffers_) {
     const auto& attr = it.first;
     if (!array_schema_.var_size(attr)) {
@@ -142,25 +242,27 @@ Status WriterBase::check_var_attr_offsets() const {
         get_offset_buffer_size(*it.second.buffer_size_);
     const uint64_t* buffer_val_size = it.second.buffer_var_size_;
     auto num_offsets = buffer_off_size / constants::cell_var_offset_size;
-    if (num_offsets == 0)
-      return Status::Ok();
+    if (num_offsets == 0) {
+      return;
+    }
 
     uint64_t prev_offset = get_offset_buffer_element(buffer_off, 0);
     // Allow the initial offset to be equal to the size, this indicates
     // the first and only value in the buffer is to be empty
-    if (prev_offset > *buffer_val_size)
-      return logger_->status(Status_WriterError(
+    if (prev_offset > *buffer_val_size) {
+      throw WriterBaseStatusException(
           "Invalid offsets for attribute " + attr + "; offset " +
           std::to_string(prev_offset) + " specified for buffer of size " +
-          std::to_string(*buffer_val_size)));
+          std::to_string(*buffer_val_size));
+    }
 
     for (uint64_t i = 1; i < num_offsets; i++) {
       uint64_t cur_offset = get_offset_buffer_element(buffer_off, i);
       if (cur_offset < prev_offset)
-        return logger_->status(Status_WriterError(
+        throw WriterBaseStatusException(
             "Invalid offsets for attribute " + attr +
             "; offsets must be given in "
-            "strictly ascending order."));
+            "strictly ascending order.");
 
       // Allow the last offset(s) to be equal to the size, this indicates the
       // last value(s) are to be empty
@@ -169,88 +271,15 @@ Status WriterBase::check_var_attr_offsets() const {
            get_offset_buffer_element(
                buffer_off, (i < num_offsets - 1 ? i + 1 : i)) !=
                *buffer_val_size))
-        return logger_->status(Status_WriterError(
+        throw WriterBaseStatusException(
             "Invalid offsets for attribute " + attr + "; offset " +
             std::to_string(cur_offset) + " specified at index " +
             std::to_string(i) + " for buffer of size " +
-            std::to_string(*buffer_val_size)));
+            std::to_string(*buffer_val_size));
 
       prev_offset = cur_offset;
     }
   }
-
-  return Status::Ok();
-}
-
-Status WriterBase::init() {
-  // Sanity checks
-  if (storage_manager_ == nullptr)
-    return logger_->status(
-        Status_WriterError("Cannot initialize query; Storage manager not set"));
-  if (buffers_.empty())
-    return logger_->status(
-        Status_WriterError("Cannot initialize writer; Buffers not set"));
-  if (array_schema_.dense() &&
-      (layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR)) {
-    for (const auto& b : buffers_) {
-      if (array_schema_.is_dim(b.first)) {
-        return logger_->status(Status_WriterError(
-            "Cannot initialize writer; Sparse coordinates "
-            "for dense arrays cannot be provided "
-            "if the query layout is ROW_MAJOR or COL_MAJOR"));
-      }
-    }
-  }
-
-  // Get configuration parameters
-  const char *check_coord_dups, *check_coord_oob, *check_global_order;
-  const char* dedup_coords;
-  RETURN_NOT_OK(config_.get("sm.check_coord_dups", &check_coord_dups));
-  RETURN_NOT_OK(config_.get("sm.check_coord_oob", &check_coord_oob));
-  RETURN_NOT_OK(config_.get("sm.check_global_order", &check_global_order));
-  RETURN_NOT_OK(config_.get("sm.dedup_coords", &dedup_coords));
-  assert(check_coord_dups != nullptr && dedup_coords != nullptr);
-  check_coord_dups_ =
-      disable_checks_consolidation_ ? false : !strcmp(check_coord_dups, "true");
-  check_coord_oob_ = !strcmp(check_coord_oob, "true");
-  check_global_order_ = disable_checks_consolidation_ ?
-                            false :
-                            !strcmp(check_global_order, "true");
-  dedup_coords_ = !strcmp(dedup_coords, "true");
-  bool found = false;
-  offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
-  assert(found);
-  if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    return logger_->status(
-        Status_WriterError("Cannot initialize writer; Unsupported offsets "
-                           "format in configuration"));
-  }
-  RETURN_NOT_OK(config_.get<bool>(
-      "sm.var_offsets.extra_element", &offsets_extra_element_, &found));
-  assert(found);
-  RETURN_NOT_OK(config_.get<uint32_t>(
-      "sm.var_offsets.bitsize", &offsets_bitsize_, &found));
-  if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    return logger_->status(
-        Status_WriterError("Cannot initialize writer; Unsupported offsets "
-                           "bitsize in configuration"));
-  }
-  assert(found);
-
-  // Set a default subarray
-  if (!subarray_.is_set())
-    subarray_ = Subarray(array_, layout_, stats_, logger_);
-
-  if (offsets_extra_element_)
-    RETURN_NOT_OK(check_extra_element());
-
-  RETURN_NOT_OK(check_subarray());
-  RETURN_NOT_OK(check_buffer_sizes());
-
-  optimize_layout_for_1D();
-  RETURN_NOT_OK(check_var_attr_offsets());
-
-  return Status::Ok();
 }
 
 Status WriterBase::initialize_memory_budget() {
@@ -299,11 +328,12 @@ Status WriterBase::calculate_hilbert_values(
   return Status::Ok();
 }
 
-Status WriterBase::check_buffer_sizes() const {
+void WriterBase::check_buffer_sizes() const {
   // This is applicable only to dense arrays and ordered layout
   if (!array_schema_.dense() ||
-      (layout_ != Layout::ROW_MAJOR && layout_ != Layout::COL_MAJOR))
-    return Status::Ok();
+      (layout_ != Layout::ROW_MAJOR && layout_ != Layout::COL_MAJOR)) {
+    return;
+  }
 
   auto cell_num = array_schema_.domain().cell_num(subarray_.ndrange(0));
   uint64_t expected_cell_num = 0;
@@ -331,7 +361,7 @@ Status WriterBase::check_buffer_sizes() const {
               "given for ";
         ss << "attribute '" << attr << "'";
         ss << " (" << expected_validity_num << " != " << cell_num << ")";
-        return logger_->status(Status_WriterError(ss.str()));
+        throw WriterBaseStatusException(ss.str());
       }
     } else {
       if (expected_cell_num != cell_num) {
@@ -339,12 +369,10 @@ Status WriterBase::check_buffer_sizes() const {
         ss << "Buffer sizes check failed; Invalid number of cells given for ";
         ss << "attribute '" << attr << "'";
         ss << " (" << expected_cell_num << " != " << cell_num << ")";
-        return logger_->status(Status_WriterError(ss.str()));
+        throw WriterBaseStatusException(ss.str());
       }
     }
   }
-
-  return Status::Ok();
 }
 
 Status WriterBase::check_coord_oob() const {
@@ -392,20 +420,19 @@ Status WriterBase::check_coord_oob() const {
   return Status::Ok();
 }
 
-Status WriterBase::check_subarray() const {
+void WriterBase::check_subarray() const {
   if (array_schema_.dense()) {
-    if (subarray_.range_num() != 1)
-      return LOG_STATUS(
-          Status_WriterError("Multi-range dense writes "
-                             "are not supported"));
+    if (subarray_.range_num() != 1) {
+      throw WriterBaseStatusException(
+          "Multi-range dense writes are not supported");
+    }
 
-    if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles())
-      return logger_->status(
-          Status_WriterError("Cannot initialize query; In global writes for "
-                             "dense arrays, the subarray "
-                             "must coincide with the tile bounds"));
+    if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles()) {
+      throw WriterBaseStatusException(
+          "Cannot initialize query; In global writes for dense arrays, the "
+          "subarray must coincide with the tile bounds");
+    }
   }
-  return Status::Ok();
 }
 
 void WriterBase::clear_coord_buffers() {
@@ -795,7 +822,7 @@ void WriterBase::optimize_layout_for_1D() {
     layout_ = array_schema_.cell_order();
 }
 
-Status WriterBase::check_extra_element() {
+void WriterBase::check_extra_element() {
   for (const auto& it : buffers_) {
     const auto& attr = it.first;
     if (!array_schema_.var_size(attr) || array_schema_.is_dim(attr))
@@ -812,15 +839,14 @@ Status WriterBase::check_extra_element() {
     const uint64_t last_offset =
         get_offset_buffer_element(buffer_off, num_offsets - 1);
 
-    if (last_offset != max_offset)
-      return logger_->status(Status_WriterError(
+    if (last_offset != max_offset) {
+      throw WriterBaseStatusException(
           "Invalid offsets for attribute " + attr +
           "; the last offset: " + std::to_string(last_offset) +
           " is not equal to the size of the data buffer: " +
-          std::to_string(max_offset)));
+          std::to_string(max_offset));
+    }
   }
-
-  return Status::Ok();
 }
 
 Status WriterBase::split_coords_buffer() {

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -113,9 +113,6 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   /** Returns current setting of dedup_coords_ */
   bool get_dedup_coords() const;
 
-  /** Initializes the writer. */
-  Status init();
-
   /** Initialize the memory budget variables. */
   Status initialize_memory_budget();
 
@@ -198,7 +195,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   Status add_written_fragment_info(const URI& uri);
 
   /** Correctness checks for buffer sizes. */
-  Status check_buffer_sizes() const;
+  void check_buffer_sizes() const;
 
   /**
    * Throws an error if there are coordinates falling out-of-bounds, i.e.,
@@ -209,14 +206,14 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   Status check_coord_oob() const;
 
   /** Correctness checks for `subarray_`. */
-  Status check_subarray() const;
+  void check_subarray() const;
 
   /**
    * Check the validity of the provided buffer offsets for a variable attribute.
    *
    * @return Status
    */
-  Status check_var_attr_offsets() const;
+  void check_var_attr_offsets() const;
 
   /**
    * Cleans up the coordinate buffers. Applicable only if the coordinate
@@ -348,7 +345,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    * Checks the validity of the extra element from var-sized offsets of
    * attributes
    */
-  Status check_extra_element();
+  void check_extra_element();
 
   /**
    * Return an element of the offsets buffer at a certain position

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -79,7 +79,8 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""));
+      URI fragment_uri = URI(""),
+      bool skip_checks_serialization = false);
 
   /** Destructor. */
   ~WriterBase();


### PR DESCRIPTION
This makes the strategy closer to be C.41 compliant by moving the init()
functions into the constructors.

---
TYPE: IMPROVEMENT
DESC: Strategy refactor: move init to constructor.
