### PR TITLE
Move 'is_element_of' API from Consistency to StorageFormat

### DIFF
--- a/tiledb/sm/array/consistency.cc
+++ b/tiledb/sm/array/consistency.cc
@@ -84,17 +84,4 @@ bool ConsistencyController::is_open(const URI uri) {
   }
   return false;
 }
-
-bool ConsistencyController::is_element_of(
-    const URI uri, const URI intersecting_uri) {
-  std::string prefix = uri.to_string().substr(
-      0, std::string(uri.c_str()).size() - (uri.last_path_part()).size());
-
-  std::string intersecting_prefix = intersecting_uri.to_string().substr(
-      0,
-      std::string(intersecting_uri.c_str()).size() -
-          (intersecting_uri.last_path_part()).size());
-
-  return (prefix == intersecting_prefix);
-}
 }  // namespace tiledb::sm

--- a/tiledb/sm/array/consistency.h
+++ b/tiledb/sm/array/consistency.h
@@ -104,16 +104,6 @@ class ConsistencyController {
   /** Returns true if the array is open, i.e. registered in the multimap. */
   bool is_open(const URI uri);
 
-  /**
-   * Returns true if the given URIs have the same "prefix" and could
-   * potentially intersect one another.
-   * i.e. The second URI is an element of the first (or vice versa).
-   *
-   * Note: The order of the arguments does not matter;
-   * the API is checking for working tree intersection.
-   */
-  bool is_element_of(const URI uri, const URI intersecting_uri);
-
  private:
   /**
    * Wrapper around a multimap registration operation.

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -76,12 +76,14 @@ TEST_CASE(
   // Check registration
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
-  REQUIRE(x.is_element_of(uri_empty, uri) == false);
+  REQUIRE(tiledb::sm::utils::parse::is_element_of(uri_empty, uri) == false);
 
   // Ensure a non-registered URI is not registered
   const URI uri_not_contained = URI("not_contained");
   REQUIRE(x.is_open(uri_not_contained) == false);
-  REQUIRE(x.is_element_of(uri_empty, uri_not_contained) == false);
+  REQUIRE(
+      tiledb::sm::utils::parse::is_element_of(uri_empty, uri_not_contained) ==
+      false);
 
   // Deregister uri
   x.deregister_array(iter);
@@ -92,7 +94,7 @@ TEST_CASE(
   iter = x.register_array(uri, *array);
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
-  REQUIRE(x.is_element_of(uri_empty, uri) == false);
+  REQUIRE(tiledb::sm::utils::parse::is_element_of(uri_empty, uri) == false);
 
   // Deregister
   x.deregister_array(iter);
@@ -120,7 +122,7 @@ TEST_CASE(
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri_empty) == false);
   REQUIRE(x.is_open(uri) == true);
-  REQUIRE(x.is_element_of(uri_empty, uri) == false);
+  REQUIRE(tiledb::sm::utils::parse::is_element_of(uri_empty, uri) == false);
 }
 
 TEST_CASE(
@@ -174,7 +176,7 @@ TEST_CASE(
   tdb_unique_ptr<Array> array = x.open_array(uri, &sm);
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
-  REQUIRE(x.is_element_of(uri, uri) == true);
+  REQUIRE(tiledb::sm::utils::parse::is_element_of(uri, uri) == true);
 
   // Deregister array
   array.get()->close();
@@ -211,7 +213,9 @@ TEST_CASE(
     REQUIRE(x.registry_size() == count);
     REQUIRE(x.is_open(uri) == true);
     if (count % 2 == 0)
-      REQUIRE(x.is_element_of(uri, uris[count - 1]) == true);
+      REQUIRE(
+          tiledb::sm::utils::parse::is_element_of(uri, uris[count - 1]) ==
+          true);
   }
 
   // Deregister arrays

--- a/tiledb/sm/array/test/unit_consistency.h
+++ b/tiledb/sm/array/test/unit_consistency.h
@@ -43,6 +43,7 @@
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/enums/layout.h"
+#include "tiledb/storage_format/uri/parse_uri.h"
 
 using namespace tiledb;
 using namespace tiledb::common;
@@ -77,10 +78,6 @@ class WhiteboxConsistencyController : public ConsistencyController {
 
   bool is_open(const URI uri) {
     return ConsistencyController::is_open(uri);
-  }
-
-  bool is_element_of(URI uri1, URI uri2) {
-    return ConsistencyController::is_element_of(uri1, uri2);
   }
 
   size_t registry_size() {

--- a/tiledb/storage_format/uri/parse_uri.cc
+++ b/tiledb/storage_format/uri/parse_uri.cc
@@ -121,4 +121,16 @@ Status get_fragment_version(const std::string& name, uint32_t* version) {
   return Status::Ok();
 }
 
+bool is_element_of(const URI uri, const URI intersecting_uri) {
+  std::string prefix = uri.to_string().substr(
+      0, std::string(uri.c_str()).size() - (uri.last_path_part()).size());
+
+  std::string intersecting_prefix = intersecting_uri.to_string().substr(
+      0,
+      std::string(intersecting_uri.c_str()).size() -
+          (intersecting_uri.last_path_part()).size());
+
+  return (prefix == intersecting_prefix);
+}
+
 }  // namespace tiledb::sm::utils::parse

--- a/tiledb/storage_format/uri/parse_uri.h
+++ b/tiledb/storage_format/uri/parse_uri.h
@@ -64,6 +64,16 @@ Status get_fragment_name_version(const std::string& name, uint32_t* version);
  */
 Status get_fragment_version(const std::string& name, uint32_t* version);
 
+/**
+ * Returns true if the given URIs have the same "prefix" and could
+ * potentially intersect one another.
+ * i.e. The second URI is an element of the first (or vice versa).
+ *
+ * Note: The order of the arguments does not matter;
+ * the API is checking for working tree intersection.
+ */
+bool is_element_of(const URI uri, const URI intersecting_uri);
+
 }  // namespace tiledb::sm::utils::parse
 
 #endif  // TILEDB_PARSE_URI_H


### PR DESCRIPTION
A new API, `is_element_of` was added by the `Consistency` class. It checks for URI working tree intersection and doesn't directly interact with the ConsistencyController so it has been moved to the `parse_uri` class in the `StorageFormat`.

---

TYPE: IMPROVEMENT
DESC: Move is_element_of to StorageFormat
