### PR TITLE
Deletes: legacy reader process deletes.

### DIFF
--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -418,8 +418,14 @@ TEST_CASE_METHOD(
   // Write another fragment that will not be affected by the condition.
   write_sparse({1}, {4}, {4}, 5);
 
+  // Test read for both refactored and legacy.
+  bool legacy = GENERATE(true, false);
+  if (legacy) {
+    set_legacy();
+  }
+
   // Reading before the delete condition timestamp.
-  uint64_t buffer_size = 4;
+  uint64_t buffer_size = legacy ? 100 : 4;
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);
@@ -434,7 +440,7 @@ TEST_CASE_METHOD(
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
 
   // Reading after delete condition timestamp.
-  buffer_size = 2;
+  buffer_size = legacy ? 100 : 2;
   std::vector<int> a1_2(buffer_size);
   std::vector<uint64_t> dim1_2(buffer_size);
   std::vector<uint64_t> dim2_2(buffer_size);
@@ -450,7 +456,7 @@ TEST_CASE_METHOD(
       c_dim2_2.data(), dim2_2.data(), c_dim2_2.size() * sizeof(uint64_t)));
 
   // Reading after new fragment.
-  buffer_size = 3;
+  buffer_size = legacy ? 100 : 3;
   std::vector<int> a1_3(buffer_size);
   std::vector<uint64_t> dim1_3(buffer_size);
   std::vector<uint64_t> dim2_3(buffer_size);
@@ -494,8 +500,14 @@ TEST_CASE_METHOD(
   // Write condition.
   write_delete_condition(qc, 3);
 
+  // Test read for both refactored and legacy.
+  bool legacy = GENERATE(true, false);
+  if (legacy) {
+    set_legacy();
+  }
+
   // Reading before the delete condition timestamp.
-  uint64_t buffer_size = 4;
+  uint64_t buffer_size = legacy ? 100 : 4;
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);
@@ -510,7 +522,7 @@ TEST_CASE_METHOD(
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
 
   // Reading after delete condition timestamp.
-  buffer_size = 2;
+  buffer_size = legacy ? 100 : 2;
   std::vector<int> a1_2(buffer_size);
   std::vector<uint64_t> dim1_2(buffer_size);
   std::vector<uint64_t> dim2_2(buffer_size);
@@ -526,7 +538,7 @@ TEST_CASE_METHOD(
       c_dim2_2.data(), dim2_2.data(), c_dim2_2.size() * sizeof(uint64_t)));
 
   // Reading after new fragment.
-  buffer_size = 3;
+  buffer_size = legacy ? 100 : 3;
   std::vector<int> a1_3(buffer_size);
   std::vector<uint64_t> dim1_3(buffer_size);
   std::vector<uint64_t> dim2_3(buffer_size);
@@ -568,8 +580,14 @@ TEST_CASE_METHOD(
   // Write condition.
   write_delete_condition(qc, 5);
 
+  // Test read for both refactored and legacy.
+  bool legacy = GENERATE(true, false);
+  if (legacy) {
+    set_legacy();
+  }
+
   // Reading.
-  uint64_t buffer_size = allows_dups ? 4 : 3;
+  uint64_t buffer_size = legacy ? 100 : (allows_dups ? 4 : 3);
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -293,12 +293,9 @@ void DeletesFx::check_delete_conditions(
         ctx_, SPARSE_ARRAY_NAME, TILEDB_READ, timestamp);
   }
   auto array_ptr = array->ptr()->array_;
-  auto& array_dir = array_ptr->array_directory();
-  auto& enc_key = *array_ptr->encryption_key();
 
   // Load delete conditions.
-  auto&& [st, delete_conditions] =
-      sm_->load_delete_conditions(array_dir, enc_key);
+  auto&& [st, delete_conditions] = sm_->load_delete_conditions(*array_ptr);
   REQUIRE(st.ok());
   REQUIRE(delete_conditions->size() == qcs.size());
 

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -271,8 +271,8 @@ Status Reader::load_initial_data() {
   }
 
   // Load delete conditions.
-  auto&& [st, delete_conditions] = storage_manager_->load_delete_conditions(
-      array_->array_directory(), *array_->encryption_key());
+  auto&& [st, delete_conditions] =
+      storage_manager_->load_delete_conditions(*array_);
   RETURN_CANCEL_OR_ERROR(st);
   delete_conditions_ = std::move(*delete_conditions);
 
@@ -290,7 +290,7 @@ Status Reader::load_initial_data() {
   }
 
   // Legacy reader always uses timestamped conditions. As we process all cell
-  // slabs at once and they could be from fagments consolidated with
+  // slabs at once and they could be from fragments consolidated with
   // timestamps, there is not way to know if we need the regular condition
   // or the timestamped condition. This reader will have worst performance
   // for deletes.
@@ -298,14 +298,10 @@ Status Reader::load_initial_data() {
 
   // Make a list of dim/attr that will be loaded for query condition.
   if (!condition_.empty()) {
-    for (auto& name : condition_.field_names()) {
-      qc_loaded_attr_names_set_.insert(name);
-    }
+    qc_loaded_attr_names_set_.merge(condition_.field_names());
   }
   for (auto delete_condition : delete_conditions_) {
-    for (auto& name : delete_condition.field_names()) {
-      qc_loaded_attr_names_set_.insert(name);
-    }
+    qc_loaded_attr_names_set_.merge(delete_condition.field_names());
   }
 
   initial_data_loaded_ = true;

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -986,8 +986,9 @@ Status Reader::copy_partitioned_fixed_cells(
     const bool split_buffer_for_zipped_coords =
         array_schema_.is_dim(*name) && cs.tile_->stores_zipped_coords();
     if ((cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) &&
-        !split_buffer_for_zipped_coords) {  // Empty range or attributed added
-                                            // in schema evolution
+        !split_buffer_for_zipped_coords &&
+        !is_timestamps) {  // Empty range or attributed added
+                           // in schema evolution
       auto bytes_to_copy = cs_length * cell_size;
       auto fill_num = bytes_to_copy / fill_value_size;
       for (uint64_t j = 0; j < fill_num; ++j) {

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -239,6 +239,13 @@ class Reader : public ReaderBase, public IQueryStrategy {
   /* ********************************* */
 
   /**
+   * Load data used for sparse reads.
+   *
+   * @return Status.
+   */
+  Status load_initial_data();
+
+  /**
    * Applies the query condition, `condition_`, to filter cell indexes
    * within `result_cell_slabs`. This mutates `result_cell_slabs`.
    *

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -153,6 +153,7 @@ class QueryCondition {
    * Applies this query condition to `result_cell_slabs`.
    *
    * @param array_schema The array schema associated with `result_cell_slabs`.
+   * @param fragment_metadata The fragment metadata.
    * @param result_cell_slabs The cell slabs to filter. Mutated to remove cell
    *   slabs that do not meet the criteria in this query condition.
    * @param stride The stride between cells.
@@ -160,6 +161,7 @@ class QueryCondition {
    */
   Status apply(
       const ArraySchema& array_schema,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       std::vector<ResultCellSlab>& result_cell_slabs,
       uint64_t stride) const;
 
@@ -260,6 +262,7 @@ class QueryCondition {
    * templated for a query condition operator.
    *
    * @param node The value node to apply.
+   * @param fragment_metadata The fragment metadata.
    * @param stride The stride between cells.
    * @param var_size The attribute is var sized or not.
    * @param nullable The attribute is nullable or not.
@@ -271,6 +274,7 @@ class QueryCondition {
   template <typename T, QueryConditionOp Op, typename CombinationOp>
   void apply_ast_node(
       const tdb_unique_ptr<ASTNode>& node,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       uint64_t stride,
       const bool var_size,
       const bool nullable,
@@ -283,6 +287,7 @@ class QueryCondition {
    * Applies a value node on primitive-typed result cell slabs.
    *
    * @param node The value node to apply.
+   * @param fragment_metadata The fragment metadata.
    * @param stride The stride between cells.
    * @param var_size The attribute is var sized or not.
    * @param nullable The attribute is nullable or not.
@@ -294,6 +299,7 @@ class QueryCondition {
   template <typename T, typename CombinationOp>
   void apply_ast_node(
       const tdb_unique_ptr<ASTNode>& node,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       uint64_t stride,
       const bool var_size,
       const bool nullable,
@@ -308,6 +314,7 @@ class QueryCondition {
    *
    * @param node The value node to apply.
    * @param array_schema The current array schema.
+   * @param fragment_metadata The fragment metadata.
    * @param stride The stride between cells.
    * @param combination_op The combination op.
    * @param result_cell_bitmap The input cell bitmap.
@@ -317,6 +324,7 @@ class QueryCondition {
   void apply_ast_node(
       const tdb_unique_ptr<ASTNode>& node,
       const ArraySchema& array_schema,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       uint64_t stride,
       const std::vector<ResultCellSlab>& result_cell_slabs,
       CombinationOp combination_op,
@@ -328,6 +336,7 @@ class QueryCondition {
    *
    * @param node The node to apply.
    * @param array_schema The array schema associated with `result_cell_slabs`.
+   * @param fragment_metadata The fragment metadata.
    * @param stride The stride between cells.
    * @param combination_op The combination op.
    * @param result_cell_bitmap A bitmap representation of cell slabs to filter.
@@ -339,6 +348,7 @@ class QueryCondition {
   void apply_tree(
       const tdb_unique_ptr<ASTNode>& node,
       const ArraySchema& array_schema,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       uint64_t stride,
       const std::vector<ResultCellSlab>& result_cell_slabs,
       CombinationOp combination_op,

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -77,7 +77,8 @@ ReaderBase::ReaderBase(
     , condition_(condition)
     , disable_cache_(false)
     , user_requested_timestamps_(false)
-    , use_timestamps_(false) {
+    , use_timestamps_(false)
+    , initial_data_loaded_(false) {
   if (array != nullptr)
     fragment_metadata_ = array->fragment_metadata();
   timestamps_needed_for_deletes_.resize(fragment_metadata_.size());

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -199,6 +199,12 @@ class ReaderBase : public StrategyBase {
    */
   std::vector<bool> timestamps_needed_for_deletes_;
 
+  /** Names of dim/attr loaded for query condition. */
+  std::unordered_set<std::string> qc_loaded_attr_names_set_;
+
+  /** Have ve loaded the initial data. */
+  bool initial_data_loaded_;
+
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -202,7 +202,7 @@ class ReaderBase : public StrategyBase {
   /** Names of dim/attr loaded for query condition. */
   std::unordered_set<std::string> qc_loaded_attr_names_set_;
 
-  /** Have ve loaded the initial data. */
+  /** Have we loaded the initial data. */
   bool initial_data_loaded_;
 
   /* ********************************* */

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -205,7 +205,7 @@ ResultTile::TileTuple* ResultTile::tile_tuple(const std::string& name) {
 
   // Handle timestamps tile
   if (name == constants::timestamps) {
-    return &*timestamps_tile_;
+    return timestamps_tile_.has_value() ? &*timestamps_tile_ : nullptr;
   }
 
   // Handle delete timestamps tile

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -90,6 +90,7 @@ void ResultTile::swap(ResultTile& tile) {
   std::swap(tile_idx_, tile.tile_idx_);
   std::swap(attr_tiles_, tile.attr_tiles_);
   std::swap(timestamps_tile_, tile.timestamps_tile_);
+  std::swap(delete_timestamps_tile_, tile.delete_timestamps_tile_);
   std::swap(coords_tile_, tile.coords_tile_);
   std::swap(coord_tiles_, tile.coord_tiles_);
   std::swap(compute_results_dense_func_, tile.compute_results_dense_func_);

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -205,12 +205,14 @@ ResultTile::TileTuple* ResultTile::tile_tuple(const std::string& name) {
 
   // Handle timestamps tile
   if (name == constants::timestamps) {
-    return timestamps_tile_.has_value() ? &*timestamps_tile_ : nullptr;
+    return timestamps_tile_.has_value() ? &timestamps_tile_.value() : nullptr;
   }
 
   // Handle delete timestamps tile
   if (name == constants::delete_timestamps) {
-    return &*delete_timestamps_tile_;
+    return delete_timestamps_tile_.has_value() ?
+               &delete_timestamps_tile_.value() :
+               nullptr;
   }
 
   // Handle attribute tile

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1289,10 +1289,6 @@ Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
             result_cell_slabs[i].tile_);
         const uint64_t cell_size = constants::timestamp_size;
 
-        // Get source buffers.
-        const auto tile_tuple = rt->tile_tuple(constants::timestamps);
-        const auto t = &std::get<0>(*tile_tuple);
-
         // Compute parallelization parameters.
         auto&& [min_pos, max_pos, dest_cell_offset, skip_copy] =
             compute_parallelization_parameters(
@@ -1310,6 +1306,10 @@ Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
             static_cast<uint64_t*>(query_buffer.buffer_) + dest_cell_offset;
 
         if (fragment_metadata_[rt->frag_idx()]->has_timestamps()) {
+          // Get source buffers.
+          const auto tile_tuple = rt->tile_tuple(constants::timestamps);
+          const auto t = &std::get<0>(*tile_tuple);
+
           // Copy tile.
           const auto src_buff = t->template data_as<uint8_t>();
           memcpy(

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -209,8 +209,8 @@ Status SparseIndexReaderBase::load_initial_data(bool include_coords) {
   read_state_.done_adding_result_tiles_ = false;
 
   // Load delete conditions.
-  auto&& [st, delete_conditions] = storage_manager_->load_delete_conditions(
-      array_->array_directory(), *array_->encryption_key());
+  auto&& [st, delete_conditions] =
+      storage_manager_->load_delete_conditions(*array_);
   RETURN_CANCEL_OR_ERROR(st);
   delete_conditions_ = std::move(*delete_conditions);
   bool make_timestamped_conditions = need_timestamped_conditions();

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -74,7 +74,6 @@ SparseIndexReaderBase::SparseIndexReaderBase(
           subarray,
           layout,
           condition)
-    , initial_data_loaded_(false)
     , memory_budget_(0)
     , array_memory_tracker_(array->memory_tracker())
     , memory_used_for_coords_total_(0)
@@ -202,8 +201,9 @@ SparseIndexReaderBase::get_coord_tiles_size(
 }
 
 Status SparseIndexReaderBase::load_initial_data(bool include_coords) {
-  if (initial_data_loaded_)
+  if (initial_data_loaded_) {
     return Status::Ok();
+  }
 
   auto timer_se = stats_->start_timer("load_initial_data");
   read_state_.done_adding_result_tiles_ = false;

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -258,9 +258,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * set. */
   std::vector<std::vector<std::pair<uint64_t, uint64_t>>> result_tile_ranges_;
 
-  /** Have ve loaded the initial data. */
-  bool initial_data_loaded_;
-
   /** Total memory budget. */
   uint64_t memory_budget_;
 
@@ -296,9 +293,6 @@ class SparseIndexReaderBase : public ReaderBase {
 
   /** Names of dim/attr loaded for query condition. */
   std::vector<std::string> qc_loaded_attr_names_;
-
-  /** Names of dim/attr loaded for query condition. */
-  std::unordered_set<std::string> qc_loaded_attr_names_set_;
 
   /* Are the users buffers full. */
   bool buffers_full_;

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -1520,7 +1520,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
         *query_buffer.validity_vector_.buffer_size() = total_cells;
 
       // Clear tiles from memory.
-      if (condition_.field_names().count(name) == 0 &&
+      if (qc_loaded_attr_names_set_.count(name) == 0 &&
           (!subarray_.is_set() || !is_dim) && name != constants::timestamps &&
           name != constants::delete_timestamps) {
         clear_tiles(name, result_tiles);

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -55,7 +55,9 @@ TEST_CASE(
 
   ArraySchema array_schema;
   std::vector<ResultCellSlab> result_cell_slabs;
-  REQUIRE(query_condition.apply(array_schema, result_cell_slabs, 1).ok());
+  std::vector<shared_ptr<FragmentMetadata>> frag_md;
+  REQUIRE(
+      query_condition.apply(array_schema, frag_md, result_cell_slabs, 1).ok());
 }
 
 TEST_CASE("QueryCondition: Test init", "[QueryCondition][value_constructor]") {
@@ -1134,7 +1136,9 @@ void test_apply_cells<char*>(
   ResultCellSlab result_cell_slab(result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, result_cell_slabs, 1).ok());
+  std::vector<shared_ptr<FragmentMetadata>> frag_md;
+  REQUIRE(
+      query_condition.apply(array_schema, frag_md, result_cell_slabs, 1).ok());
 
   // Verify the result cell slabs contain the expected cells.
   auto expected_iter = expected_cell_idx_vec.begin();
@@ -1161,8 +1165,9 @@ void test_apply_cells<char*>(
       std::vector<ResultCellSlab> result_cell_slabs_eq_null;
       result_cell_slabs_eq_null.emplace_back(
           std::move(result_cell_slab_eq_null));
+      std::vector<shared_ptr<FragmentMetadata>> frag_md;
       REQUIRE(query_condition_eq_null
-                  .apply(array_schema, result_cell_slabs_eq_null, 1)
+                  .apply(array_schema, frag_md, result_cell_slabs_eq_null, 1)
                   .ok());
 
       REQUIRE(result_cell_slabs_eq_null.size() == (cells / 2));
@@ -1227,7 +1232,9 @@ void test_apply_cells<char*>(
   ResultCellSlab fill_result_cell_slab(nullptr, 0, cells);
   std::vector<ResultCellSlab> fill_result_cell_slabs;
   fill_result_cell_slabs.emplace_back(std::move(fill_result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, fill_result_cell_slabs, 1).ok());
+  REQUIRE(
+      query_condition.apply(array_schema, frag_md, fill_result_cell_slabs, 1)
+          .ok());
 
   // Verify the fill result cell slabs contain the expected cells.
   auto fill_expected_iter = fill_expected_cell_idx_vec.begin();
@@ -1299,7 +1306,9 @@ void test_apply_cells(
   ResultCellSlab result_cell_slab(result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, result_cell_slabs, 1).ok());
+  std::vector<shared_ptr<FragmentMetadata>> frag_md;
+  REQUIRE(
+      query_condition.apply(array_schema, frag_md, result_cell_slabs, 1).ok());
 
   // Verify the result cell slabs contain the expected cells.
   auto expected_iter = expected_cell_idx_vec.begin();
@@ -1357,7 +1366,9 @@ void test_apply_cells(
   ResultCellSlab fill_result_cell_slab(nullptr, 0, cells);
   std::vector<ResultCellSlab> fill_result_cell_slabs;
   fill_result_cell_slabs.emplace_back(std::move(fill_result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, fill_result_cell_slabs, 1).ok());
+  REQUIRE(
+      query_condition.apply(array_schema, frag_md, fill_result_cell_slabs, 1)
+          .ok());
 
   // Verify the fill result cell slabs contain the expected cells.
   auto fill_expected_iter = fill_expected_cell_idx_vec.begin();
@@ -1829,7 +1840,9 @@ TEST_CASE(
   ResultCellSlab result_cell_slab(&result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(query_condition.apply(array_schema, result_cell_slabs, 1).ok());
+  std::vector<shared_ptr<FragmentMetadata>> frag_md;
+  REQUIRE(
+      query_condition.apply(array_schema, frag_md, result_cell_slabs, 1).ok());
 
   // Verify the result cell slabs contain the expected cells.
   auto expected_iter = expected_cell_idx_vec.begin();
@@ -3073,7 +3086,8 @@ void validate_qc_apply(
   ResultCellSlab result_cell_slab(&result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  REQUIRE(tp.qc_.apply(array_schema, result_cell_slabs, 1).ok());
+  std::vector<shared_ptr<FragmentMetadata>> frag_md;
+  REQUIRE(tp.qc_.apply(array_schema, frag_md, result_cell_slabs, 1).ok());
   REQUIRE(result_cell_slabs.size() == tp.expected_slabs_.size());
   uint64_t result_cell_slabs_size = result_cell_slabs.size();
   for (uint64_t i = 0; i < result_cell_slabs_size; ++i) {

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -780,12 +780,11 @@ class StorageManager {
   /**
    * Loads the delete conditions from storage.
    *
-   * @param array_dir The array directory.
-   * @param enc_key The encryption key that may be needed to access the file.
+   * @param array The array.
    * @return Status, vector of the delete conditions.
    */
   tuple<Status, optional<std::vector<QueryCondition>>> load_delete_conditions(
-      const ArrayDirectory& array_dir, const EncryptionKey& enc_key);
+      const Array& array);
 
   /** Removes a TileDB object (group, array). */
   Status object_remove(const char* path) const;


### PR DESCRIPTION
This implements the processing of deletes for the legacy reader. As the
legacy reader processes the query condition on cell slabs, and we don't
know for which cell slabs the is or not timestamps, we unfortunately
cannot optimize as we did with the refactored readers by having a
regular delete condition and timestamped delete condition. As we are not
too concerned with the performance of the reader moving forward, we are
always going to use the delete condition with timestamp. At the lower
level, in query condition, we will evaluate the timestamp condition
either on the full fragment, or do it cell by cell, depending on if the
tile has timestamps or not. This also meant that the apply path of query
condition need to pass the fragment metadata at all levels.

---
TYPE: IMPROVEMENT
DESC: Deletes: legacy reader process deletes.
