### PR TITLE
Implement class for TileTuple.

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -170,7 +170,7 @@ void set_result_tile_dim(
     std::string dim,
     uint64_t dim_idx,
     std::vector<uint64_t> v) {
-  result_tile.init_coord_tile(dim, dim_idx);
+  result_tile.init_coord_tile(dim, false, dim_idx);
 
   uint64_t* data =
       static_cast<uint64_t*>(tdb_malloc(v.size() * sizeof(uint64_t)));

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -182,7 +182,7 @@ void set_result_tile_dim(
       Datatype::UINT64, sizeof(uint64_t), 0, data, v.size() * sizeof(uint64_t));
   auto tile_tuple = result_tile.tile_tuple(dim);
   REQUIRE(tile_tuple != nullptr);
-  std::get<0>(*tile_tuple) = std::move(tile);
+  tile_tuple->fixed_tile() = std::move(tile);
 }
 
 /* ********************************* */

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -672,4 +672,6 @@ TEST_CASE_METHOD(
   write_delete_condition(qc3, 4);
 
   check_delete_conditions({qc, qc3, qc2}, 8);
+
+  remove_sparse_array();
 }

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -128,6 +128,7 @@ CResultCoordsFx::~CResultCoordsFx() {
 GlobalOrderResultTile<uint8_t> CResultCoordsFx::make_tile_with_num_cells(
     uint64_t num_cells) {
   GlobalOrderResultTile<uint8_t> result_tile(0, 0, false, *frag_md);
+  result_tile.init_attr_tile(constants::coords);
   auto tile_tuple = result_tile.tile_tuple(constants::coords);
   Tile* const tile = &tile_tuple->fixed_tile();
   auto cell_size = sizeof(int64_t);

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -128,7 +128,7 @@ CResultCoordsFx::~CResultCoordsFx() {
 GlobalOrderResultTile<uint8_t> CResultCoordsFx::make_tile_with_num_cells(
     uint64_t num_cells) {
   GlobalOrderResultTile<uint8_t> result_tile(0, 0, false, *frag_md);
-  result_tile.init_attr_tile(constants::coords);
+  result_tile.init_attr_tile(constants::coords, false, false);
   auto tile_tuple = result_tile.tile_tuple(constants::coords);
   Tile* const tile = &tile_tuple->fixed_tile();
   auto cell_size = sizeof(int64_t);

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -129,7 +129,7 @@ GlobalOrderResultTile<uint8_t> CResultCoordsFx::make_tile_with_num_cells(
     uint64_t num_cells) {
   GlobalOrderResultTile<uint8_t> result_tile(0, 0, false, *frag_md);
   auto tile_tuple = result_tile.tile_tuple(constants::coords);
-  Tile* const tile = &std::get<0>(*tile_tuple);
+  Tile* const tile = &tile_tuple->fixed_tile();
   auto cell_size = sizeof(int64_t);
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -189,7 +189,7 @@ TEST_CASE_METHOD(
 
   // Make sure cell_num() will return the correct value.
   if (!first_dim) {
-    rt.init_coord_tile("d1", 0);
+    rt.init_coord_tile("d1", true, 0);
     auto tile_tuple = rt.tile_tuple("d1");
     Tile* const t = &tile_tuple->fixed_tile();
     t->init_unfiltered(
@@ -200,7 +200,7 @@ TEST_CASE_METHOD(
         0);
   }
 
-  rt.init_coord_tile(dim_name, dim_idx);
+  rt.init_coord_tile(dim_name, true, dim_idx);
   auto tile_tuple = rt.tile_tuple(dim_name);
   Tile* const t = &tile_tuple->fixed_tile();
   Tile* const t_var = &tile_tuple->var_tile();
@@ -279,7 +279,7 @@ TEST_CASE_METHOD(
 
   // Make sure cell_num() will return the correct value.
   if (!first_dim) {
-    rt.init_coord_tile("d1", 0);
+    rt.init_coord_tile("d1", true, 0);
     auto tile_tuple = rt.tile_tuple("d1");
     Tile* const t = &tile_tuple->fixed_tile();
     t->init_unfiltered(
@@ -290,7 +290,7 @@ TEST_CASE_METHOD(
         0);
   }
 
-  rt.init_coord_tile(dim_name, dim_idx);
+  rt.init_coord_tile(dim_name, true, dim_idx);
   auto tile_tuple = rt.tile_tuple(dim_name);
   Tile* const t = &tile_tuple->fixed_tile();
   Tile* const t_var = &tile_tuple->var_tile();

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -191,7 +191,7 @@ TEST_CASE_METHOD(
   if (!first_dim) {
     rt.init_coord_tile("d1", 0);
     auto tile_tuple = rt.tile_tuple("d1");
-    Tile* const t = &std::get<0>(*tile_tuple);
+    Tile* const t = &tile_tuple->fixed_tile();
     t->init_unfiltered(
         constants::format_version,
         constants::cell_var_offset_type,
@@ -202,8 +202,8 @@ TEST_CASE_METHOD(
 
   rt.init_coord_tile(dim_name, dim_idx);
   auto tile_tuple = rt.tile_tuple(dim_name);
-  Tile* const t = &std::get<0>(*tile_tuple);
-  Tile* const t_var = &std::get<1>(*tile_tuple);
+  Tile* const t = &tile_tuple->fixed_tile();
+  Tile* const t_var = &tile_tuple->var_tile();
 
   // Initialize offsets, use 1 character strings.
   t->init_unfiltered(
@@ -281,7 +281,7 @@ TEST_CASE_METHOD(
   if (!first_dim) {
     rt.init_coord_tile("d1", 0);
     auto tile_tuple = rt.tile_tuple("d1");
-    Tile* const t = &std::get<0>(*tile_tuple);
+    Tile* const t = &tile_tuple->fixed_tile();
     t->init_unfiltered(
         constants::format_version,
         constants::cell_var_offset_type,
@@ -292,8 +292,8 @@ TEST_CASE_METHOD(
 
   rt.init_coord_tile(dim_name, dim_idx);
   auto tile_tuple = rt.tile_tuple(dim_name);
-  Tile* const t = &std::get<0>(*tile_tuple);
-  Tile* const t_var = &std::get<1>(*tile_tuple);
+  Tile* const t = &tile_tuple->fixed_tile();
+  Tile* const t_var = &tile_tuple->var_tile();
 
   // Initialize offsets, use 1 character strings.
   t->init_unfiltered(

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -424,7 +424,7 @@ TEST_CASE_METHOD(
   // Two result tile (2 * (~504 + 8) will be bigger than the per fragment budget
   // (1000).
   total_budget_ = "10000";
-  ratio_coords_ = "0.2";
+  ratio_coords_ = "0.21";
   update_config();
 
   tiledb_array_t* array = nullptr;

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1194,8 +1194,8 @@ Status Reader::compute_var_cell_destinations(
     uint64_t tile_var_size = 0;
     if (cs.tile_ != nullptr && cs.tile_->tile_tuple(name) != nullptr) {
       const auto tile_tuple = cs.tile_->tile_tuple(name);
-      const auto& tile = std::get<0>(*tile_tuple);
-      const auto& tile_var = std::get<1>(*tile_tuple);
+      const auto& tile = tile_tuple->fixed_tile();
+      const auto& tile_var = tile_tuple->var_tile();
 
       // Get the internal buffer to the offset values.
       tile_offsets = (uint64_t*)tile.data();
@@ -1302,9 +1302,9 @@ Status Reader::copy_partitioned_var_cells(
     uint64_t tile_cell_num = 0;
     if (cs.tile_ != nullptr && cs.tile_->tile_tuple(*name) != nullptr) {
       const auto tile_tuple = cs.tile_->tile_tuple(*name);
-      Tile* const tile = &std::get<0>(*tile_tuple);
-      tile_var = &std::get<1>(*tile_tuple);
-      tile_validity = &std::get<2>(*tile_tuple);
+      Tile* const tile = &tile_tuple->fixed_tile();
+      tile_var = &tile_tuple->var_tile();
+      tile_validity = &tile_tuple->validity_tile();
 
       // Get the internal buffer to the offset values.
       tile_offsets = (uint64_t*)tile->data();

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -959,9 +959,11 @@ Status Reader::copy_partitioned_fixed_cells(
   auto buffer = (unsigned char*)it->second.buffer_;
   auto buffer_validity = (unsigned char*)it->second.validity_vector_.buffer();
   auto cell_size = array_schema_.cell_size(*name);
+  const auto is_attr = array_schema_.is_attr(*name);
+  const auto is_dim = array_schema_.is_dim(*name);
   ByteVecValue fill_value;
   uint8_t fill_value_validity = 0;
-  if (array_schema_.is_attr(*name)) {
+  if (is_attr) {
     fill_value = array_schema_.attribute(*name)->fill_value();
     fill_value_validity = array_schema_.attribute(*name)->fill_value_validity();
   }
@@ -983,16 +985,17 @@ Status Reader::copy_partitioned_fixed_cells(
 
     // First we check if this is an older (pre TileDB 2.0) array with zipped
     // coordinates and the user has requested split buffer if so we should
-    // proceed to copying the tile If not, and there is no tile or the tile is
+    // proceed to copying the tile. If not, and there is no tile or the tile is
     // empty for the field then this is a read of an older fragment in schema
     // evolution. In that case we want to set the field to fill values for this
     // for this tile.
     const bool split_buffer_for_zipped_coords =
-        array_schema_.is_dim(*name) && cs.tile_->stores_zipped_coords();
-    if ((cs.tile_ == nullptr || cs.tile_->tile_tuple(*name) == nullptr) &&
-        !split_buffer_for_zipped_coords &&
-        !is_timestamps) {  // Empty range or attributed added
-                           // in schema evolution
+        is_dim && cs.tile_->stores_zipped_coords();
+    const bool field_not_present =
+        (is_dim || is_attr) && cs.tile_->tile_tuple(*name) == nullptr;
+    if ((cs.tile_ == nullptr || field_not_present) &&
+        !split_buffer_for_zipped_coords) {  // Empty range or attributed added
+                                            // in schema evolution
       auto bytes_to_copy = cs_length * cell_size;
       auto fill_num = bytes_to_copy / fill_value_size;
       for (uint64_t j = 0; j < fill_num; ++j) {

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1307,7 +1307,7 @@ Status Reader::copy_partitioned_var_cells(
       const auto tile_tuple = cs.tile_->tile_tuple(*name);
       Tile* const tile = &tile_tuple->fixed_tile();
       tile_var = &tile_tuple->var_tile();
-      tile_validity = &tile_tuple->validity_tile();
+      tile_validity = nullable ? &tile_tuple->validity_tile() : nullptr;
 
       // Get the internal buffer to the offset values.
       tile_offsets = (uint64_t*)tile->data();

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -395,7 +395,7 @@ void QueryCondition::apply_ast_node(
       uint8_t* buffer_validity = nullptr;
 
       if (nullable) {
-        const auto& tile_validity = std::get<2>(*tile_tuple);
+        const auto& tile_validity = tile_tuple->validity_tile();
         buffer_validity = static_cast<uint8_t*>(tile_validity.data());
       }
 
@@ -404,11 +404,11 @@ void QueryCondition::apply_ast_node(
       uint64_t c = 0;
 
       if (var_size) {
-        const auto& tile = std::get<1>(*tile_tuple);
+        const auto& tile = tile_tuple->var_tile();
         const char* buffer = static_cast<char*>(tile.data());
         const uint64_t buffer_size = tile.size();
 
-        const auto& tile_offsets = std::get<0>(*tile_tuple);
+        const auto& tile_offsets = tile_tuple->fixed_tile();
         const uint64_t* buffer_offsets =
             static_cast<uint64_t*>(tile_offsets.data());
         const uint64_t buffer_offsets_el =
@@ -458,7 +458,7 @@ void QueryCondition::apply_ast_node(
             c++;
           }
         } else {
-          const auto& tile = std::get<0>(*tile_tuple);
+          const auto& tile = tile_tuple->fixed_tile();
           const char* buffer = static_cast<char*>(tile.data());
           const uint64_t cell_size = tile.cell_size();
           uint64_t buffer_offset = start * cell_size;
@@ -990,17 +990,17 @@ void QueryCondition::apply_ast_node_dense(
   const auto tile_tuple = result_tile->tile_tuple(field_name);
   uint8_t* buffer_validity = nullptr;
   if (nullable) {
-    const auto& tile_validity = std::get<2>(*tile_tuple);
+    const auto& tile_validity = tile_tuple->validity_tile();
     buffer_validity = static_cast<uint8_t*>(tile_validity.data()) + src_cell;
   }
 
   if (var_size) {
     // Get var data buffer and tile offsets buffer.
-    const auto& tile = std::get<1>(*tile_tuple);
+    const auto& tile = tile_tuple->var_tile();
     const char* buffer = static_cast<char*>(tile.data());
     const uint64_t buffer_size = tile.size();
 
-    const auto& tile_offsets = std::get<0>(*tile_tuple);
+    const auto& tile_offsets = tile_tuple->fixed_tile();
     const uint64_t* buffer_offsets =
         static_cast<uint64_t*>(tile_offsets.data()) + src_cell;
     const uint64_t buffer_offsets_el =
@@ -1034,7 +1034,7 @@ void QueryCondition::apply_ast_node_dense(
     }
   } else {
     // Get the fixed size data buffers.
-    const auto& tile = std::get<0>(*tile_tuple);
+    const auto& tile = tile_tuple->fixed_tile();
     const char* buffer = static_cast<char*>(tile.data());
     const uint64_t cell_size = tile.cell_size();
     uint64_t buffer_offset = (start + src_cell) * cell_size;
@@ -1171,7 +1171,7 @@ void QueryCondition::apply_ast_node_dense(
   // Process the validity buffer now.
   if (nullable && node->get_condition_value_view().content() == nullptr) {
     const auto tile_tuple = result_tile->tile_tuple(node->get_field_name());
-    const auto& tile_validity = std::get<2>(*tile_tuple);
+    const auto& tile_validity = tile_tuple->validity_tile();
     const auto buffer_validity =
         static_cast<uint8_t*>(tile_validity.data()) + src_cell;
 
@@ -1701,17 +1701,17 @@ void QueryCondition::apply_ast_node_sparse(
   // Check if the combination op = OR and the attribute is nullable.
   if constexpr (
       std::is_same_v<CombinationOp, QCMax<BitmapType>> && nullable::value) {
-    const auto& tile_validity = std::get<2>(*tile_tuple);
+    const auto& tile_validity = tile_tuple->validity_tile();
     buffer_validity = static_cast<uint8_t*>(tile_validity.data());
   }
 
   if (var_size) {
     // Get var data buffer and tile offsets buffer.
-    const auto& tile = std::get<1>(*tile_tuple);
+    const auto& tile = tile_tuple->var_tile();
     const char* buffer = static_cast<char*>(tile.data());
     const uint64_t buffer_size = tile.size();
 
-    const auto& tile_offsets = std::get<0>(*tile_tuple);
+    const auto& tile_offsets = tile_tuple->fixed_tile();
     const uint64_t* buffer_offsets =
         static_cast<uint64_t*>(tile_offsets.data());
     const uint64_t buffer_offsets_el =
@@ -1746,7 +1746,7 @@ void QueryCondition::apply_ast_node_sparse(
     }
   } else {
     // Get the fixed size data buffers.
-    const auto& tile = std::get<0>(*tile_tuple);
+    const auto& tile = tile_tuple->fixed_tile();
     const char* buffer = static_cast<char*>(tile.data());
     const uint64_t cell_size = tile.cell_size();
     const uint64_t buffer_el = tile.size() / cell_size;
@@ -1872,7 +1872,7 @@ void QueryCondition::apply_ast_node_sparse(
   // Process the validity buffer now.
   if (nullable) {
     const auto tile_tuple = result_tile.tile_tuple(node_field_name);
-    const auto& tile_validity = std::get<2>(*tile_tuple);
+    const auto& tile_validity = tile_tuple->validity_tile();
     const auto buffer_validity = static_cast<uint8_t*>(tile_validity.data());
     const auto cell_num = result_tile.cell_num();
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -1222,8 +1222,7 @@ Status DenseReader::copy_offset_tiles(
               static_cast<uint8_t*>(tile_tuples[fd]->validity_tile().data()) +
               start + src_cell;
 
-          i = 0;
-          for (; i < end - start; ++i) {
+          for (i = 0; i < end - start; ++i) {
             dest_validity_ptr[start + i] = src_buff_validity[i * stride];
           }
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -995,8 +995,7 @@ Status DenseReader::copy_fixed_tiles(
         auto dest_validity_ptr = dst_val_buf + cell_offset;
 
         // Get the tile buffers.
-        const Tile* const tile = &tile_tuples[fd]->fixed_tile();
-        const Tile* const tile_nullable = &tile_tuples[fd]->validity_tile();
+        const auto& tile = tile_tuples[fd]->fixed_tile();
 
         auto src_offset = iter.pos_in_tile() + start * stride;
 
@@ -1005,28 +1004,31 @@ Status DenseReader::copy_fixed_tiles(
         if (stride == 1) {
           std::memcpy(
               dest_ptr + cell_size * start,
-              tile->data_as<char>() + cell_size * src_offset,
+              tile.data_as<char>() + cell_size * src_offset,
               cell_size * (end - start + 1));
 
           if (nullable) {
+            const auto& tile_nullable = tile_tuples[fd]->validity_tile();
             std::memcpy(
                 dest_validity_ptr + start,
-                tile_nullable->data_as<char>() + src_offset,
+                tile_nullable.data_as<char>() + src_offset,
                 (end - start + 1));
           }
         } else {
           // Go cell by cell.
-          auto src = tile->data_as<char>() + cell_size * src_offset;
-          auto src_validity =
-              nullable ? tile_nullable->data_as<char>() + src_offset : nullptr;
+          auto src = tile.data_as<char>() + cell_size * src_offset;
           auto dest = dest_ptr + cell_size * start;
-          auto dest_validity = dest_validity_ptr + start;
           for (uint64_t i = 0; i < end - start + 1; ++i) {
             std::memcpy(dest, src, cell_size);
             src += cell_size * stride;
             dest += cell_size;
+          }
 
-            if (nullable) {
+          if (nullable) {
+            const auto& tile_nullable = tile_tuples[fd]->validity_tile();
+            auto src_validity = tile_nullable.data_as<char>() + src_offset;
+            auto dest_validity = dest_validity_ptr + start;
+            for (uint64_t i = 0; i < end - start + 1; ++i) {
               memcpy(dest_validity, src_validity, 1);
               src_validity += stride;
               dest_validity++;
@@ -1187,17 +1189,12 @@ Status DenseReader::copy_offset_tiles(
         auto dest_validity_ptr = dst_val_buf + cell_offset;
 
         // Get the tile buffers.
-        const Tile* const t_var = &tile_tuples[fd]->var_tile();
+        const auto& t_var = tile_tuples[fd]->var_tile();
 
         // Setup variables for the copy.
         auto src_buff =
             static_cast<uint64_t*>(tile_tuples[fd]->fixed_tile().data()) +
             start * stride + src_cell;
-        auto src_buff_validity =
-            nullable ?
-                static_cast<uint8_t*>(tile_tuples[fd]->validity_tile().data()) +
-                    start + src_cell :
-                nullptr;
         auto div = elements_mode_ ? data_type_size : 1;
         auto dest = (OffType*)dest_ptr + start;
 
@@ -1207,28 +1204,30 @@ Status DenseReader::copy_offset_tiles(
         for (; i < end - start; ++i) {
           auto i_src = i * stride;
           dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
-          var_data_buff[i + start] = t_var->data_as<char>() + src_buff[i_src];
-        }
-
-        if (nullable) {
-          i = 0;
-          for (; i < end - start; ++i) {
-            dest_validity_ptr[start + i] = src_buff_validity[i * stride];
-          }
+          var_data_buff[i + start] = t_var.data_as<char>() + src_buff[i_src];
         }
 
         // Copy the last value.
         if (start + src_cell + (end - start) * stride >=
             cell_num_per_tile - 1) {
-          dest[i] = (t_var->size() - src_buff[i * stride]) / div;
+          dest[i] = (t_var.size() - src_buff[i * stride]) / div;
         } else {
           auto i_src = i * stride;
           dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
         }
-        var_data_buff[i + start] =
-            t_var->data_as<char>() + src_buff[i * stride];
+        var_data_buff[i + start] = t_var.data_as<char>() + src_buff[i * stride];
 
         if (nullable) {
+          auto src_buff_validity =
+              static_cast<uint8_t*>(tile_tuples[fd]->validity_tile().data()) +
+              start + src_cell;
+
+          i = 0;
+          for (; i < end - start; ++i) {
+            dest_validity_ptr[start + i] = src_buff_validity[i * stride];
+          }
+
+          // Copy last validity value.
           dest_validity_ptr[start + i] = src_buff_validity[i * stride];
         }
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -995,8 +995,8 @@ Status DenseReader::copy_fixed_tiles(
         auto dest_validity_ptr = dst_val_buf + cell_offset;
 
         // Get the tile buffers.
-        const Tile* const tile = &std::get<0>(*tile_tuples[fd]);
-        const Tile* const tile_nullable = &std::get<2>(*tile_tuples[fd]);
+        const Tile* const tile = &tile_tuples[fd]->fixed_tile();
+        const Tile* const tile_nullable = &tile_tuples[fd]->validity_tile();
 
         auto src_offset = iter.pos_in_tile() + start * stride;
 
@@ -1187,15 +1187,15 @@ Status DenseReader::copy_offset_tiles(
         auto dest_validity_ptr = dst_val_buf + cell_offset;
 
         // Get the tile buffers.
-        const Tile* const t_var = &std::get<1>(*tile_tuples[fd]);
+        const Tile* const t_var = &tile_tuples[fd]->var_tile();
 
         // Setup variables for the copy.
         auto src_buff =
-            static_cast<uint64_t*>(std::get<0>(*tile_tuples[fd]).data()) +
+            static_cast<uint64_t*>(tile_tuples[fd]->fixed_tile().data()) +
             start * stride + src_cell;
         auto src_buff_validity =
             nullable ?
-                static_cast<uint8_t*>(std::get<2>(*tile_tuples[fd]).data()) +
+                static_cast<uint8_t*>(tile_tuples[fd]->validity_tile().data()) +
                     start + src_cell :
                 nullptr;
         auto div = elements_mode_ ? data_type_size : 1;

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -609,9 +609,9 @@ Status ReaderBase::read_tiles(
       }
 
       assert(tile_tuple != nullptr);
-      Tile* const t = &std::get<0>(*tile_tuple);
-      Tile* const t_var = &std::get<1>(*tile_tuple);
-      Tile* const t_validity = &std::get<2>(*tile_tuple);
+      Tile* const t = &tile_tuple->fixed_tile();
+      Tile* const t_var = &tile_tuple->var_tile();
+      Tile* const t_validity = &tile_tuple->validity_tile();
       if (!var_size) {
         if (nullable)
           RETURN_NOT_OK(
@@ -847,7 +847,7 @@ ReaderBase::load_tile_chunk_data(
     // Skip non-existent attributes/dimensions (e.g. coords in the
     // dense case).
     if (tile_tuple == nullptr ||
-        std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
+        tile_tuple->fixed_tile().filtered_buffer().size() == 0) {
       return {Status::Ok(), 0, 0, 0};
     }
 
@@ -856,9 +856,9 @@ ReaderBase::load_tile_chunk_data(
       return {Status::Ok(), 0, 0, 0};
     }
 
-    const auto t = &std::get<0>(*tile_tuple);
-    const auto t_var = &std::get<1>(*tile_tuple);
-    const auto t_validity = &std::get<2>(*tile_tuple);
+    const auto t = &tile_tuple->fixed_tile();
+    const auto t_var = &tile_tuple->var_tile();
+    const auto t_validity = &tile_tuple->validity_tile();
 
     auto&& [st, tile_size] = load_chunk_data(t, tile_chunk_data);
     RETURN_NOT_OK_TUPLE(st, nullopt, nullopt, nullopt);
@@ -905,7 +905,7 @@ Status ReaderBase::unfilter_tile_chunk_range(
     // Skip non-existent attributes/dimensions (e.g. coords in the
     // dense case).
     if (tile_tuple == nullptr ||
-        std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
+        tile_tuple->fixed_tile().filtered_buffer().size() == 0) {
       return Status::Ok();
     }
 
@@ -914,9 +914,9 @@ Status ReaderBase::unfilter_tile_chunk_range(
       return Status::Ok();
     }
 
-    auto t = &std::get<0>(*tile_tuple);
-    auto t_var = &std::get<1>(*tile_tuple);
-    auto t_validity = &std::get<2>(*tile_tuple);
+    auto t = &tile_tuple->fixed_tile();
+    auto t_var = &tile_tuple->var_tile();
+    auto t_validity = &tile_tuple->validity_tile();
 
     // Unfilter 't' for fixed-sized tiles, otherwise unfilter both 't' and
     // 't_var' for var-sized tiles.
@@ -994,7 +994,7 @@ Status ReaderBase::post_process_unfiltered_tile(
     // Skip non-existent attributes/dimensions (e.g. coords in the
     // dense case).
     if (tile_tuple == nullptr ||
-        std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
+        tile_tuple->fixed_tile().filtered_buffer().size() == 0) {
       return Status::Ok();
     }
 
@@ -1003,9 +1003,9 @@ Status ReaderBase::post_process_unfiltered_tile(
       return Status::Ok();
     }
 
-    auto t = &std::get<0>(*tile_tuple);
-    auto t_var = &std::get<1>(*tile_tuple);
-    auto t_validity = &std::get<2>(*tile_tuple);
+    auto t = &tile_tuple->fixed_tile();
+    auto t_var = &tile_tuple->var_tile();
+    auto t_validity = &tile_tuple->validity_tile();
 
     t->filtered_buffer().clear();
 
@@ -1400,7 +1400,7 @@ Status ReaderBase::unfilter_tiles(
           // Skip non-existent attributes/dimensions (e.g. coords in the
           // dense case).
           if (tile_tuple == nullptr ||
-              std::get<0>(*tile_tuple).filtered_buffer().size() == 0) {
+              tile_tuple->fixed_tile().filtered_buffer().size() == 0) {
             return Status::Ok();
           }
 
@@ -1409,9 +1409,9 @@ Status ReaderBase::unfilter_tiles(
             return Status::Ok();
           }
 
-          auto& t = std::get<0>(*tile_tuple);
-          auto& t_var = std::get<1>(*tile_tuple);
-          auto& t_validity = std::get<2>(*tile_tuple);
+          auto& t = tile_tuple->fixed_tile();
+          auto& t_var = tile_tuple->var_tile();
+          auto& t_validity = tile_tuple->validity_tile();
 
           if (disable_cache_ == false) {
             logger_->info("using cache");

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -166,34 +166,37 @@ void ResultTile::erase_tile(const std::string& name) {
   }
 }
 
-void ResultTile::init_attr_tile(const std::string& name) {
+void ResultTile::init_attr_tile(
+    const std::string& name, bool var_size, bool nullable) {
   // Nothing to do for the special zipped coordinates tile
   if (name == constants::coords) {
-    coords_tile_ = TileTuple();
+    coords_tile_ = TileTuple(false, false);
     return;
   }
 
   if (name == constants::timestamps) {
-    timestamps_tile_ = TileTuple();
+    timestamps_tile_ = TileTuple(false, false);
     return;
   }
 
   if (name == constants::delete_timestamps) {
-    delete_timestamps_tile_ = TileTuple();
+    delete_timestamps_tile_ = TileTuple(false, false);
     return;
   }
 
   // Handle attributes
   for (auto& at : attr_tiles_) {
     if (at.first == name && at.second == nullopt) {
-      at.second = TileTuple();
+      at.second = TileTuple(var_size, nullable);
       return;
     }
   }
 }
 
-void ResultTile::init_coord_tile(const std::string& name, unsigned dim_idx) {
-  coord_tiles_[dim_idx] = std::pair<std::string, TileTuple>(name, TileTuple());
+void ResultTile::init_coord_tile(
+    const std::string& name, bool var_size, unsigned dim_idx) {
+  coord_tiles_[dim_idx] =
+      std::pair<std::string, TileTuple>(name, TileTuple(var_size, false));
 
   // When at least one unzipped coordinate has been initialized, we will
   // use the unzipped `coord()` implementation.

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -116,13 +116,6 @@ class ResultTile {
       return validity_tile_;
     }
 
-    /** Clear the content of the tuple. */
-    void clear_data() {
-      fixed_tile_.clear_data();
-      var_tile_.clear_data();
-      validity_tile_.clear_data();
-    }
-
    private:
     /** Stores the fixed data tile. */
     Tile fixed_tile_;
@@ -453,13 +446,13 @@ class ResultTile {
   optional<TileTuple> delete_timestamps_tile_;
 
   /** The zipped coordinates tile. */
-  TileTuple coords_tile_;
+  optional<TileTuple> coords_tile_;
 
   /**
    * The separate coordinate tiles along with their names, sorted on the
    * dimension order.
    */
-  std::vector<std::pair<std::string, TileTuple>> coord_tiles_;
+  std::vector<std::pair<std::string, optional<TileTuple>>> coord_tiles_;
 
   /**
    * Stores the appropriate templated compute_results_dense() function based for

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -71,12 +71,68 @@ class Subarray;
 class ResultTile {
  public:
   /**
-   * For each fixed-sized attributes, the second tile in the tuple is ignored.
-   * For var-sized attributes, the first tile is the offsets tile and the second
-   * tile is the var-sized values tile. If the attribute is nullable, the third
-   * tile contains the validity vector.
+   * Class definition for the tile tuple.
    */
-  typedef tuple<Tile, Tile, Tile> TileTuple;
+  class TileTuple {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+
+    /** Default constructor. */
+    TileTuple() = default;
+
+    /* ********************************* */
+    /*                API                */
+    /* ********************************* */
+
+    /** @returns Fixed tile. */
+    Tile& fixed_tile() {
+      return fixed_tile_;
+    }
+
+    /** @returns Var tile. */
+    Tile& var_tile() {
+      return var_tile_;
+    }
+
+    /** @returns Validity tile. */
+    Tile& validity_tile() {
+      return validity_tile_;
+    }
+
+    /** @returns Fixed tile. */
+    const Tile& fixed_tile() const {
+      return fixed_tile_;
+    }
+
+    /** @returns Var tile. */
+    const Tile& var_tile() const {
+      return var_tile_;
+    }
+
+    /** @returns Validity tile. */
+    const Tile& validity_tile() const {
+      return validity_tile_;
+    }
+
+    /** Clear the content of the tuple. */
+    void clear_data() {
+      fixed_tile_.clear_data();
+      var_tile_.clear_data();
+      validity_tile_.clear_data();
+    }
+
+   private:
+    /** Stores the fixed data tile. */
+    Tile fixed_tile_;
+
+    /** Stores the var data tile. */
+    Tile var_tile_;
+
+    /** Stores the validity data tile. */
+    Tile validity_tile_;
+  };
 
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -80,7 +80,18 @@ class ResultTile {
     /* ********************************* */
 
     /** Default constructor. */
-    TileTuple() = default;
+    TileTuple() = delete;
+
+    /** Constructor with var_size and nullable parameters. */
+    TileTuple(bool var_size, bool nullable) {
+      if (var_size) {
+        var_tile_ = Tile();
+      }
+
+      if (nullable) {
+        validity_tile_ = Tile();
+      }
+    }
 
     /* ********************************* */
     /*                API                */
@@ -93,12 +104,12 @@ class ResultTile {
 
     /** @returns Var tile. */
     Tile& var_tile() {
-      return var_tile_;
+      return var_tile_.value();
     }
 
     /** @returns Validity tile. */
     Tile& validity_tile() {
-      return validity_tile_;
+      return validity_tile_.value();
     }
 
     /** @returns Fixed tile. */
@@ -108,12 +119,12 @@ class ResultTile {
 
     /** @returns Var tile. */
     const Tile& var_tile() const {
-      return var_tile_;
+      return var_tile_.value();
     }
 
     /** @returns Validity tile. */
     const Tile& validity_tile() const {
-      return validity_tile_;
+      return validity_tile_.value();
     }
 
    private:
@@ -121,10 +132,10 @@ class ResultTile {
     Tile fixed_tile_;
 
     /** Stores the var data tile. */
-    Tile var_tile_;
+    optional<Tile> var_tile_;
 
     /** Stores the validity data tile. */
-    Tile validity_tile_;
+    optional<Tile> validity_tile_;
   };
 
   /* ********************************* */
@@ -185,10 +196,11 @@ class ResultTile {
   void erase_tile(const std::string& name);
 
   /** Initializes the result tile for the given attribute. */
-  void init_attr_tile(const std::string& name);
+  void init_attr_tile(const std::string& name, bool var_size, bool nullable);
 
   /** Initializes the result tile for the given dimension name and index. */
-  void init_coord_tile(const std::string& name, unsigned dim_idx);
+  void init_coord_tile(
+      const std::string& name, bool var_size, unsigned dim_idx);
 
   /** Returns the tile pair for the input attribute or dimension. */
   TileTuple* tile_tuple(const std::string& name);

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1311,11 +1311,9 @@ Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
             static_cast<uint64_t*>(query_buffer.buffer_) + dest_cell_offset;
 
         if (fragment_metadata_[rt->frag_idx()]->has_timestamps()) {
-          // Get source buffers.
+          // Copy tile.
           const auto tile_tuple = rt->tile_tuple(constants::timestamps);
           const auto t = &tile_tuple->fixed_tile();
-
-          // Copy tile.
           const auto src_buff = t->template data_as<uint8_t>();
           memcpy(
               buffer,

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1058,11 +1058,11 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
 
         // Get source buffers.
         const auto tile_tuple = rt->tile_tuple(name);
-        const auto t = &std::get<0>(*tile_tuple);
-        const auto t_var = &std::get<1>(*tile_tuple);
+        const auto t = &tile_tuple->fixed_tile();
+        const auto t_var = &tile_tuple->var_tile();
         const auto src_buff = t->template data_as<uint64_t>();
         const auto src_var_buff = t_var->template data_as<char>();
-        const auto t_val = &std::get<2>(*tile_tuple);
+        const auto t_val = &tile_tuple->validity_tile();
         const auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -1223,9 +1223,9 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
         const auto tile_tuple = stores_zipped_coords ?
                                     rt->tile_tuple(constants::coords) :
                                     rt->tile_tuple(name);
-        const auto t = &std::get<0>(*tile_tuple);
+        const auto t = &tile_tuple->fixed_tile();
         const auto src_buff = t->template data_as<uint8_t>();
-        const auto t_val = &std::get<2>(*tile_tuple);
+        const auto t_val = &tile_tuple->validity_tile();
 
         // Compute parallelization parameters.
         auto&& [min_pos, max_pos, dest_cell_offset, skip_copy] =
@@ -1313,7 +1313,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
         if (fragment_metadata_[rt->frag_idx()]->has_timestamps()) {
           // Get source buffers.
           const auto tile_tuple = rt->tile_tuple(constants::timestamps);
-          const auto t = &std::get<0>(*tile_tuple);
+          const auto t = &tile_tuple->fixed_tile();
 
           // Copy tile.
           const auto src_buff = t->template data_as<uint8_t>();

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1058,11 +1058,10 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
 
         // Get source buffers.
         const auto tile_tuple = rt->tile_tuple(name);
-        const auto t = &tile_tuple->fixed_tile();
-        const auto t_var = &tile_tuple->var_tile();
-        const auto src_buff = t->template data_as<uint64_t>();
-        const auto src_var_buff = t_var->template data_as<char>();
-        const auto t_val = &tile_tuple->validity_tile();
+        const auto& t = tile_tuple->fixed_tile();
+        const auto& t_var = tile_tuple->var_tile();
+        const auto src_buff = t.template data_as<uint64_t>();
+        const auto src_var_buff = t_var.template data_as<char>();
         const auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -1096,13 +1095,14 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         // Copy last cell.
         if (max_pos == cell_num) {
           *buffer =
-              (OffType)(t_var->size() - src_buff[max_pos - 1]) / offset_div;
+              (OffType)(t_var.size() - src_buff[max_pos - 1]) / offset_div;
           *var_data_buffer = src_var_buff + src_buff[max_pos - 1];
         }
 
         // Copy nullable values.
         if (nullable) {
-          const auto src_val_buff = t_val->template data_as<uint8_t>();
+          const auto& t_val = tile_tuple->validity_tile();
+          const auto src_val_buff = t_val.template data_as<uint8_t>();
           for (uint64_t c = min_pos; c < max_pos; c++) {
             *val_buffer = src_val_buff[c];
             val_buffer++;
@@ -1223,9 +1223,8 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
         const auto tile_tuple = stores_zipped_coords ?
                                     rt->tile_tuple(constants::coords) :
                                     rt->tile_tuple(name);
-        const auto t = &tile_tuple->fixed_tile();
-        const auto src_buff = t->template data_as<uint8_t>();
-        const auto t_val = &tile_tuple->validity_tile();
+        const auto& t = tile_tuple->fixed_tile();
+        const auto src_buff = t.template data_as<uint8_t>();
 
         // Compute parallelization parameters.
         auto&& [min_pos, max_pos, dest_cell_offset, skip_copy] =
@@ -1261,7 +1260,8 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
         }
 
         if (nullable) {
-          const auto src_val_buff = t_val->template data_as<uint8_t>();
+          const auto& t_val = tile_tuple->validity_tile();
+          const auto src_val_buff = t_val.template data_as<uint8_t>();
           memcpy(val_buffer, src_val_buff + min_pos, max_pos - min_pos);
         }
 

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -519,11 +519,10 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
     void** var_data) {
   // Get source buffers.
   const auto tile_tuple = rt->tile_tuple(name);
-  const auto t = &tile_tuple->fixed_tile();
-  const auto t_var = &tile_tuple->var_tile();
-  const auto src_buff = t->data_as<uint64_t>();
-  const auto src_var_buff = t_var->data_as<char>();
-  const auto t_val = &tile_tuple->validity_tile();
+  const auto& t = tile_tuple->fixed_tile();
+  const auto& t_var = tile_tuple->var_tile();
+  const auto src_buff = t.data_as<uint64_t>();
+  const auto src_var_buff = t_var.data_as<char>();
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -542,7 +541,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
   if (src_max_pos == cell_num) {
     for (uint64_t i = 0; i < rt->bitmap()[src_max_pos - 1]; i++) {
       *buffer =
-          (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
+          (OffType)(t_var.size() - src_buff[src_max_pos - 1]) / offset_div;
       buffer++;
       *var_data = src_var_buff + src_buff[src_max_pos - 1];
       var_data++;
@@ -551,7 +550,8 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
 
   // Copy nullable values.
   if (nullable) {
-    const auto src_val_buff = t_val->data_as<uint8_t>();
+    const auto& t_val = tile_tuple->validity_tile();
+    const auto src_val_buff = t_val.data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         *val_buffer = src_val_buff[c];
@@ -578,11 +578,10 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     void** var_data) {
   // Get source buffers.
   const auto tile_tuple = rt->tile_tuple(name);
-  const auto t = &tile_tuple->fixed_tile();
-  const auto t_var = &tile_tuple->var_tile();
-  const auto src_buff = t->data_as<uint64_t>();
-  const auto src_var_buff = t_var->data_as<char>();
-  const auto t_val = &tile_tuple->validity_tile();
+  const auto& t = tile_tuple->fixed_tile();
+  const auto& t_var = tile_tuple->var_tile();
+  const auto src_buff = t.data_as<uint64_t>();
+  const auto src_var_buff = t_var.data_as<char>();
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -601,13 +600,14 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     // Do last cell.
     if (src_max_pos == cell_num && rt->bitmap()[src_max_pos - 1]) {
       *buffer =
-          (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
+          (OffType)(t_var.size() - src_buff[src_max_pos - 1]) / offset_div;
       *var_data = src_var_buff + src_buff[src_max_pos - 1];
     }
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = t_val->data_as<uint8_t>();
+      const auto& t_val = tile_tuple->validity_tile();
+      const auto src_val_buff = t_val.data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         if (rt->bitmap()[c]) {
           *val_buffer = src_val_buff[c];
@@ -628,13 +628,14 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     // Copy last cell.
     if (src_max_pos == cell_num) {
       *buffer =
-          (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
+          (OffType)(t_var.size() - src_buff[src_max_pos - 1]) / offset_div;
       *var_data = src_var_buff + src_buff[src_max_pos - 1];
     }
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = t_val->data_as<uint8_t>();
+      const auto& t_val = tile_tuple->validity_tile();
+      const auto src_val_buff = t_val.data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         *val_buffer = src_val_buff[c];
         val_buffer++;
@@ -833,8 +834,8 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   const auto tile_tuple = stores_zipped_coords ?
                               rt->tile_tuple(constants::coords) :
                               rt->tile_tuple(name);
-  const auto t = &tile_tuple->fixed_tile();
-  const auto src_buff = t->data_as<uint8_t>();
+  const auto& t = tile_tuple->fixed_tile();
+  const auto src_buff = t.data_as<uint8_t>();
 
   // Copy values.
   if (!stores_zipped_coords) {
@@ -857,8 +858,8 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
 
   // Copy nullable values.
   if (nullable) {
-    const auto t_val = &tile_tuple->validity_tile();
-    const auto src_val_buff = t_val->data_as<uint8_t>();
+    const auto& t_val = tile_tuple->validity_tile();
+    const auto src_val_buff = t_val.data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
         *val_buffer = src_val_buff[c];
@@ -888,9 +889,8 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto tile_tuple = stores_zipped_coords ?
                               rt->tile_tuple(constants::coords) :
                               rt->tile_tuple(name);
-  const auto t = &tile_tuple->fixed_tile();
-  const auto src_buff = t->data_as<uint8_t>();
-  const auto t_val = &tile_tuple->validity_tile();
+  const auto& t = tile_tuple->fixed_tile();
+  const auto src_buff = t.data_as<uint8_t>();
 
   if (!rt->copy_full_tile()) {
     // Copy values.
@@ -933,9 +933,10 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
     if (nullable) {
       // Go through bitmap, when there is a hole in cell contiguity, do a
       // memcpy.
+      const auto& t_val = tile_tuple->validity_tile();
       uint64_t length = 0;
       uint64_t start = src_min_pos;
-      const auto src_val_buff = t_val->data_as<uint8_t>();
+      const auto src_val_buff = t_val.data_as<uint8_t>();
       for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
         if (rt->bitmap()[c]) {
           length++;
@@ -963,7 +964,8 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
         (src_max_pos - src_min_pos) * cell_size);
 
     if (nullable) {
-      const auto src_val_buff = t_val->data_as<uint8_t>();
+      const auto& t_val = tile_tuple->validity_tile();
+      const auto src_val_buff = t_val.data_as<uint8_t>();
       memcpy(val_buffer, src_val_buff + src_min_pos, src_max_pos - src_min_pos);
     }
   }

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -519,11 +519,11 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
     void** var_data) {
   // Get source buffers.
   const auto tile_tuple = rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
-  const auto t_var = &std::get<1>(*tile_tuple);
+  const auto t = &tile_tuple->fixed_tile();
+  const auto t_var = &tile_tuple->var_tile();
   const auto src_buff = t->data_as<uint64_t>();
   const auto src_var_buff = t_var->data_as<char>();
-  const auto t_val = &std::get<2>(*tile_tuple);
+  const auto t_val = &tile_tuple->validity_tile();
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -578,11 +578,11 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     void** var_data) {
   // Get source buffers.
   const auto tile_tuple = rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
-  const auto t_var = &std::get<1>(*tile_tuple);
+  const auto t = &tile_tuple->fixed_tile();
+  const auto t_var = &tile_tuple->var_tile();
   const auto src_buff = t->data_as<uint64_t>();
   const auto src_var_buff = t_var->data_as<char>();
-  const auto t_val = &std::get<2>(*tile_tuple);
+  const auto t_val = &tile_tuple->validity_tile();
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
@@ -833,7 +833,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   const auto tile_tuple = stores_zipped_coords ?
                               rt->tile_tuple(constants::coords) :
                               rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
+  const auto t = &tile_tuple->fixed_tile();
   const auto src_buff = t->data_as<uint8_t>();
 
   // Copy values.
@@ -857,7 +857,7 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
 
   // Copy nullable values.
   if (nullable) {
-    const auto t_val = &std::get<2>(*tile_tuple);
+    const auto t_val = &tile_tuple->validity_tile();
     const auto src_val_buff = t_val->data_as<uint8_t>();
     for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
       for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
@@ -888,9 +888,9 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto tile_tuple = stores_zipped_coords ?
                               rt->tile_tuple(constants::coords) :
                               rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
+  const auto t = &tile_tuple->fixed_tile();
   const auto src_buff = t->data_as<uint8_t>();
-  const auto t_val = &std::get<2>(*tile_tuple);
+  const auto t_val = &tile_tuple->validity_tile();
 
   if (!rt->copy_full_tile()) {
     // Copy values.
@@ -982,9 +982,10 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
   Tile* t = nullptr;
   uint8_t* src_buff = nullptr;
   if (tile_tuple != nullptr) {
-    t = &std::get<0>(*tile_tuple);
+    t = &tile_tuple->fixed_tile();
     src_buff = t->data_as<uint8_t>();
   }
+
   const uint64_t cell_size = constants::timestamp_size;
 
   if (fragment_metadata_[rt->frag_idx()]->has_timestamps()) {
@@ -1020,9 +1021,10 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_timestamp_data_tile(
   Tile* t = nullptr;
   uint8_t* src_buff = nullptr;
   if (tile_tuple != nullptr) {
-    t = &std::get<0>(*tile_tuple);
+    t = &tile_tuple->fixed_tile();
     src_buff = t->data_as<uint8_t>();
   }
+
   const uint64_t cell_size = constants::timestamp_size;
   auto frag_timestamp = fragment_timestamp(rt);
 

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1475,7 +1475,7 @@ void test_apply_tile<char*>(
   bool var_size = array_schema.attribute(field_name)->var_size();
   bool nullable = array_schema.attribute(field_name)->nullable();
   Tile* const tile =
-      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+      var_size ? &tile_tuple->var_tile() : &tile_tuple->fixed_tile();
 
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,
@@ -1493,7 +1493,7 @@ void test_apply_tile<char*>(
   REQUIRE(tile->write(values.data(), 0, 2 * cells * sizeof(char)).ok());
 
   if (var_size) {
-    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    Tile* const tile_offsets = &tile_tuple->fixed_tile();
     REQUIRE(tile_offsets
                 ->init_unfiltered(
                     constants::format_version,
@@ -1514,7 +1514,7 @@ void test_apply_tile<char*>(
   }
 
   if (nullable) {
-    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    Tile* const tile_validity = &tile_tuple->validity_tile();
     REQUIRE(tile_validity
                 ->init_unfiltered(
                     constants::format_version,
@@ -1551,7 +1551,7 @@ void test_apply_tile(
     const ArraySchema& array_schema,
     ResultTile* const result_tile) {
   ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
-  Tile* const tile = &std::get<0>(*tile_tuple);
+  Tile* const tile = &tile_tuple->fixed_tile();
 
   REQUIRE(
       tile->init_unfiltered(
@@ -1733,7 +1733,7 @@ TEST_CASE(
   var_size = array_schema.attribute(field_name)->var_size();
   nullable = array_schema.attribute(field_name)->nullable();
   Tile* const tile =
-      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+      var_size ? &tile_tuple->var_tile() : &tile_tuple->fixed_tile();
 
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,
@@ -1754,7 +1754,7 @@ TEST_CASE(
   REQUIRE(tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)).ok());
 
   if (var_size) {
-    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    Tile* const tile_offsets = &tile_tuple->fixed_tile();
     REQUIRE(tile_offsets
                 ->init_unfiltered(
                     constants::format_version,
@@ -1777,7 +1777,7 @@ TEST_CASE(
   }
 
   if (nullable) {
-    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    Tile* const tile_validity = &tile_tuple->validity_tile();
     REQUIRE(tile_validity
                 ->init_unfiltered(
                     constants::format_version,
@@ -2149,7 +2149,7 @@ void test_apply_tile_dense<char*>(
   bool var_size = array_schema.attribute(field_name)->var_size();
   bool nullable = array_schema.attribute(field_name)->nullable();
   Tile* const tile =
-      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+      var_size ? &tile_tuple->var_tile() : &tile_tuple->fixed_tile();
 
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,
@@ -2167,7 +2167,7 @@ void test_apply_tile_dense<char*>(
   REQUIRE(tile->write(values.data(), 0, 2 * cells * sizeof(char)).ok());
 
   if (var_size) {
-    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    Tile* const tile_offsets = &tile_tuple->fixed_tile();
     REQUIRE(tile_offsets
                 ->init_unfiltered(
                     constants::format_version,
@@ -2188,7 +2188,7 @@ void test_apply_tile_dense<char*>(
   }
 
   if (nullable) {
-    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    Tile* const tile_validity = &tile_tuple->validity_tile();
     REQUIRE(tile_validity
                 ->init_unfiltered(
                     constants::format_version,
@@ -2225,7 +2225,7 @@ void test_apply_tile_dense(
     const ArraySchema& array_schema,
     ResultTile* const result_tile) {
   ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
-  Tile* const tile = &std::get<0>(*tile_tuple);
+  Tile* const tile = &tile_tuple->fixed_tile();
 
   REQUIRE(
       tile->init_unfiltered(
@@ -2420,7 +2420,7 @@ TEST_CASE(
   var_size = array_schema.attribute(field_name)->var_size();
   nullable = array_schema.attribute(field_name)->nullable();
   Tile* const tile =
-      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+      var_size ? &tile_tuple->var_tile() : &tile_tuple->fixed_tile();
 
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,
@@ -2440,7 +2440,7 @@ TEST_CASE(
   REQUIRE(tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)).ok());
 
   if (var_size) {
-    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    Tile* const tile_offsets = &tile_tuple->fixed_tile();
     REQUIRE(tile_offsets
                 ->init_unfiltered(
                     constants::format_version,
@@ -2463,7 +2463,7 @@ TEST_CASE(
   }
 
   if (nullable) {
-    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    Tile* const tile_validity = &tile_tuple->validity_tile();
     REQUIRE(tile_validity
                 ->init_unfiltered(
                     constants::format_version,
@@ -2824,7 +2824,7 @@ void test_apply_tile_sparse<char*>(
   bool var_size = array_schema.attribute(field_name)->var_size();
   bool nullable = array_schema.attribute(field_name)->nullable();
   Tile* const tile =
-      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+      var_size ? &tile_tuple->var_tile() : &tile_tuple->fixed_tile();
 
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,
@@ -2842,7 +2842,7 @@ void test_apply_tile_sparse<char*>(
   REQUIRE(tile->write(values.data(), 0, 2 * cells * sizeof(char)).ok());
 
   if (var_size) {
-    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    Tile* const tile_offsets = &tile_tuple->fixed_tile();
     REQUIRE(tile_offsets
                 ->init_unfiltered(
                     constants::format_version,
@@ -2863,7 +2863,7 @@ void test_apply_tile_sparse<char*>(
   }
 
   if (nullable) {
-    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    Tile* const tile_validity = &tile_tuple->validity_tile();
     REQUIRE(tile_validity
                 ->init_unfiltered(
                     constants::format_version,
@@ -2900,7 +2900,7 @@ void test_apply_tile_sparse(
     const ArraySchema& array_schema,
     ResultTile* const result_tile) {
   ResultTile::TileTuple* const tile_tuple = result_tile->tile_tuple(field_name);
-  Tile* const tile = &std::get<0>(*tile_tuple);
+  Tile* const tile = &tile_tuple->fixed_tile();
 
   REQUIRE(
       tile->init_unfiltered(
@@ -3718,7 +3718,7 @@ TEST_CASE(
   ResultTile result_tile(0, 0, array_schema);
   result_tile.init_attr_tile(field_name);
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
-  Tile* const tile = &std::get<0>(*tile_tuple);
+  Tile* const tile = &tile_tuple->fixed_tile();
 
   // Initialize and populate the data tile.
   REQUIRE(tile->init_unfiltered(
@@ -4018,7 +4018,7 @@ TEST_CASE(
   result_tile.init_attr_tile(field_name);
 
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
-  Tile* const tile = &std::get<1>(*tile_tuple);
+  Tile* const tile = &tile_tuple->var_tile();
 
   std::string data = "alicebobcraigdaveerinfrankgraceheidiivanjudy";
   std::vector<uint64_t> offsets = {0, 5, 8, 13, 17, 21, 26, 31, 36, 40};
@@ -4034,7 +4034,7 @@ TEST_CASE(
   REQUIRE(tile->write(data.c_str(), 0, data.size()).ok());
 
   // Write the tile offsets.
-  Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+  Tile* const tile_offsets = &tile_tuple->fixed_tile();
   REQUIRE(tile_offsets
               ->init_unfiltered(
                   constants::format_version,
@@ -4301,7 +4301,7 @@ TEST_CASE(
   ResultTile result_tile(0, 0, array_schema);
   result_tile.init_attr_tile(field_name);
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
-  Tile* const tile = &std::get<0>(*tile_tuple);
+  Tile* const tile = &tile_tuple->fixed_tile();
 
   // Initialize and populate the data tile.
   REQUIRE(tile->init_unfiltered(
@@ -4316,7 +4316,7 @@ TEST_CASE(
       3.4, 1.3, 2.2, 4.5, 2.8, 2.1, 1.7, 3.3, 1.9, 4.2};
   REQUIRE(tile->write(values.data(), 0, cells * sizeof(float)).ok());
 
-  Tile* const tile_validity = &std::get<2>(*tile_tuple);
+  Tile* const tile_validity = &tile_tuple->validity_tile();
   REQUIRE(tile_validity
               ->init_unfiltered(
                   constants::format_version,
@@ -4399,7 +4399,7 @@ TEST_CASE(
   var_size = array_schema.attribute(field_name)->var_size();
   nullable = array_schema.attribute(field_name)->nullable();
   Tile* const tile =
-      var_size ? &std::get<1>(*tile_tuple) : &std::get<0>(*tile_tuple);
+      var_size ? &tile_tuple->var_tile() : &tile_tuple->fixed_tile();
 
   REQUIRE(tile->init_unfiltered(
                   constants::format_version,
@@ -4419,7 +4419,7 @@ TEST_CASE(
   REQUIRE(tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)).ok());
 
   if (var_size) {
-    Tile* const tile_offsets = &std::get<0>(*tile_tuple);
+    Tile* const tile_offsets = &tile_tuple->fixed_tile();
     REQUIRE(tile_offsets
                 ->init_unfiltered(
                     constants::format_version,
@@ -4442,7 +4442,7 @@ TEST_CASE(
   }
 
   if (nullable) {
-    Tile* const tile_validity = &std::get<2>(*tile_tuple);
+    Tile* const tile_validity = &tile_tuple->validity_tile();
     REQUIRE(tile_validity
                 ->init_unfiltered(
                     constants::format_version,

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1616,7 +1616,7 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   test_apply_tile<char*>(field_name, cells, type, array_schema, &result_tile);
 }
@@ -1649,7 +1649,7 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   test_apply_tile<T>(field_name, cells, type, array_schema, &result_tile);
 }
@@ -1726,7 +1726,7 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
 
@@ -2296,7 +2296,7 @@ void test_apply_dense<char*>(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   test_apply_tile_dense<char*>(
       field_name, cells, type, array_schema, &result_tile);
@@ -2335,7 +2335,7 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   test_apply_tile_dense<T>(field_name, cells, type, array_schema, &result_tile);
 }
@@ -2413,7 +2413,7 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
 
@@ -2972,7 +2972,7 @@ void test_apply_sparse<char*>(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   test_apply_tile_sparse<char*>(
       field_name, cells, type, array_schema, &result_tile);
@@ -3011,7 +3011,7 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   test_apply_tile_sparse<T>(
       field_name, cells, type, array_schema, &result_tile);
@@ -3716,7 +3716,7 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, false, false);
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
   Tile* const tile = &tile_tuple->fixed_tile();
 
@@ -4015,7 +4015,7 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, true, false);
 
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
   Tile* const tile = &tile_tuple->var_tile();
@@ -4299,7 +4299,7 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, false, true);
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
   Tile* const tile = &tile_tuple->fixed_tile();
 
@@ -4392,7 +4392,7 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile result_tile(0, 0, array_schema);
-  result_tile.init_attr_tile(field_name);
+  result_tile.init_attr_tile(field_name, var_size, nullable);
 
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
 


### PR DESCRIPTION
In preparation for future C.41 work, this implements a full class for
`TileTuple` and moves it from being a simple `std::tuple`. Having
constructors for TileTuple will allow in the future to create the
underlying tile objects with the proper size from the get go.

This also cleans up a few places where the default constructor for `Tile`
was used when clearing memory for a particular attribute.

---
TYPE: IMPROVEMENT
DESC: Implement class for TileTuple.
