### PR TITLE
Sparse refactored readers, mark empty fragments as fully loaded early.

### DIFF
--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -280,9 +280,14 @@ Status SparseIndexReaderBase::load_initial_data(bool include_coords) {
         read_state_.frag_idx_,
         &result_tile_ranges_));
 
-    for (auto frag_result_tile_ranges : result_tile_ranges_) {
-      memory_used_result_tile_ranges_ += frag_result_tile_ranges.size() *
-                                         sizeof(std::pair<uint64_t, uint64_t>);
+    // Compute the size of the tile ranges structure and mark empty fragments
+    // as fully loaded.
+    for (uint64_t i = 0; i < result_tile_ranges_.size(); i++) {
+      memory_used_result_tile_ranges_ +=
+          result_tile_ranges_[i].size() * sizeof(std::pair<uint64_t, uint64_t>);
+      if (result_tile_ranges_[i].size() == 0) {
+        all_tiles_loaded_[i] = true;
+      }
     }
 
     if (memory_used_result_tile_ranges_ >


### PR DESCRIPTION
This fixes an issue where the refactored readers would not mark a
fragment as fully loaded when the tile ranges for this fragment are
empty. This prevented queries with a large number of fragments but only
a few fragments in the results to run when they should have, with a low
memory budget.

---
TYPE: IMPROVEMENT
DESC: Sparse refactored readers, mark empty fragments as fully loaded early.