### PR TITLE
Updates group serial/deserial to use sizeof only on types

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -660,7 +660,7 @@ Status Group::apply_and_serialize(Buffer* buff) {
 std::tuple<Status, std::optional<tdb_shared_ptr<Group>>> Group::deserialize(
     ConstBuffer* buff, const URI& group_uri, StorageManager* storage_manager) {
   uint32_t version = 0;
-  RETURN_NOT_OK_TUPLE(buff->read(&version, sizeof(version)), std::nullopt);
+  RETURN_NOT_OK_TUPLE(buff->read(&version, sizeof(uint32_t)), std::nullopt);
   if (version == 1) {
     return GroupV1::deserialize(buff, group_uri, storage_manager);
   }

--- a/tiledb/sm/group/group_member.cc
+++ b/tiledb/sm/group/group_member.cc
@@ -73,7 +73,7 @@ Status GroupMember::serialize(Buffer*) {
 std::tuple<Status, std::optional<tdb_shared_ptr<GroupMember>>>
 GroupMember::deserialize(ConstBuffer* buff) {
   uint32_t version = 0;
-  RETURN_NOT_OK_TUPLE(buff->read(&version, sizeof(version)), std::nullopt);
+  RETURN_NOT_OK_TUPLE(buff->read(&version, sizeof(uint32_t)), std::nullopt);
   if (version == 1) {
     return GroupMemberV1::deserialize(buff);
   }

--- a/tiledb/sm/group/group_v1.cc
+++ b/tiledb/sm/group/group_v1.cc
@@ -48,10 +48,9 @@ GroupV1::GroupV1(const URI& group_uri, StorageManager* storage_manager)
 //   group_member #2
 //   ...
 Status GroupV1::serialize(Buffer* buff) {
-  RETURN_NOT_OK(
-      buff->write(&GroupV1::format_version_, sizeof(GroupV1::format_version_)));
+  RETURN_NOT_OK(buff->write(&GroupV1::format_version_, sizeof(uint32_t)));
   uint64_t group_member_num = members_.size();
-  RETURN_NOT_OK(buff->write(&group_member_num, sizeof(group_member_num)));
+  RETURN_NOT_OK(buff->write(&group_member_num, sizeof(uint64_t)));
   for (auto& it : members_) {
     RETURN_NOT_OK(it.second->serialize(buff));
   }
@@ -65,7 +64,7 @@ std::tuple<Status, std::optional<tdb_shared_ptr<Group>>> GroupV1::deserialize(
 
   uint64_t member_count = 0;
   RETURN_NOT_OK_TUPLE(
-      buff->read(&member_count, sizeof(member_count)), std::nullopt);
+      buff->read(&member_count, sizeof(uint64_t)), std::nullopt);
 
   for (uint64_t i = 0; i < member_count; i++) {
     auto&& [st, member] = GroupMember::deserialize(buff);


### PR DESCRIPTION
Fixes groups to only use `sizeof` on types instead of variables.

---
TYPE:  BUG
DESC: Prevent possible compiler dependent errors serializing groups
