### PR TITLE
Implement delete_fragments API

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -687,7 +687,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Deletion of sequential fragment writes",
     "[cppapi][fragments][delete]") {
-  /* Note: An array must be open, in WRITE_EXCLUSIVE mode to delete_fragments */
+  /* Note: An array must be open in MODIFY_EXCLUSIVE mode to delete_fragments */
   Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";
@@ -718,14 +718,14 @@ TEST_CASE(
     CHECK(tiledb::test::num_fragments(array_name) == 3);
     REQUIRE_THROWS_WITH(
         array.delete_fragments(array_name, timestamp_start, timestamp_end),
-        Catch::Contains("Query type must be WRITE_EXCLUSIVE"));
+        Catch::Contains("Query type must be MODIFY_EXCLUSIVE"));
     CHECK(tiledb::test::num_fragments(array_name) == 3);
     array.close();
   }
 
-  SECTION("WRITE_EXCLUSIVE") {
-    auto array = tiledb::Array(ctx, array_name, TILEDB_WRITE_EXCLUSIVE);
-    auto query = tiledb::Query(ctx, array, TILEDB_WRITE_EXCLUSIVE);
+  SECTION("MODIFY_EXCLUSIVE") {
+    auto array = tiledb::Array(ctx, array_name, TILEDB_MODIFY_EXCLUSIVE);
+    auto query = tiledb::Query(ctx, array, TILEDB_MODIFY_EXCLUSIVE);
     query.set_data_buffer("a", data).set_subarray({0, 1}).submit();
     query.set_data_buffer("a", data).set_subarray({2, 3}).submit();
     query.set_data_buffer("a", data).set_subarray({4, 5}).submit();
@@ -745,7 +745,7 @@ TEST_CASE(
       // Consolidate and reopen array
       Array::consolidate(ctx, array_name);
       CHECK(tiledb::test::num_fragments(array_name) == 4);
-      array.open(TILEDB_WRITE_EXCLUSIVE);
+      array.open(TILEDB_MODIFY_EXCLUSIVE);
       CHECK(tiledb::test::num_fragments(array_name) == 4);
 
       // Check commits directory after consolidation

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -229,19 +229,19 @@ Status Array::delete_fragments(
   // Check that query type is WRITE_EXCLUSIVE
   if (query_type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_ArrayError(
-        "Cannot delete fragments; Query type must be WRITE_EXCLUSIVE"));
+        "[Array::delete_fragments] Query type must be WRITE_EXCLUSIVE"));
   }
 
   // Check that array is open
   if (!is_open() && !controller().is_open(uri)) {
     return LOG_STATUS(
-        Status_ArrayError("Cannot delete fragments; Array is closed"));
+        Status_ArrayError("[Array::delete_fragments] Array is closed"));
   }
 
   // Check that array is not in the process of opening or closing
   if (is_opening_or_closing_) {
     return LOG_STATUS(Status_ArrayError(
-        "Cannot delete fragments; "
+        "[Array::delete_fragments] "
         "May not perform simultaneous open or close operations."));
   }
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -158,7 +158,7 @@ Status Array::open_without_fragments(
   /* Note: the open status MUST be exception safe. If anything interrupts the
    * opening process, it will throw and the array will be set as closed. */
   try {
-    set_array_open();
+    set_array_open(query_type_);
 
     // Copy the key bytes.
     st = encryption_key_->set_key(encryption_type, encryption_key, key_length);
@@ -224,6 +224,34 @@ Status Array::load_fragments(
   return Status::Ok();
 }
 
+Status Array::delete_fragments(
+    const URI& uri, uint64_t timestamp_start, uint64_t timestamp_end) {
+  // Check that query type is WRITE_EXCLUSIVE
+  if (query_type_ != QueryType::WRITE_EXCLUSIVE) {
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot delete fragments; Query type must be WRITE_EXCLUSIVE"));
+  }
+
+  // Check that array is open
+  if (!is_open() && !controller().is_open(uri)) {
+    return LOG_STATUS(
+        Status_ArrayError("Cannot delete fragments; Array is closed"));
+  }
+
+  // Check that array is not in the process of opening or closing
+  if (is_opening_or_closing_) {
+    return LOG_STATUS(Status_ArrayError(
+        "Cannot delete fragments; "
+        "May not perform simultaneous open or close operations."));
+  }
+
+  // Vacuum fragments for deletes
+  RETURN_NOT_OK(storage_manager_->fragments_vacuum(
+      uri.c_str(), timestamp_start, timestamp_end, true));
+
+  return Status::Ok();
+}
+
 void Array::set_delete_tiles_location(
     const std::vector<ArrayDirectory::DeleteTileLocation>&
         delete_tiles_location) {
@@ -253,7 +281,7 @@ Status Array::open(
     uint32_t key_length) {
   Status st;
   // Checks
-  if (is_open_) {
+  if (is_open()) {
     return LOG_STATUS(
         Status_ArrayError("Cannot open array; Array already open"));
   }
@@ -263,15 +291,12 @@ Status Array::open(
   non_empty_domain_computed_ = false;
   timestamp_start_ = timestamp_start;
   timestamp_end_opened_at_ = timestamp_end;
-
-  /* Note: query_type_ MUST be set before calling set_array_open()
-    because it will be examined by the ConsistencyController. */
   query_type_ = query_type;
 
   /* Note: the open status MUST be exception safe. If anything interrupts the
    * opening process, it will throw and the array will be set as closed. */
   try {
-    set_array_open();
+    set_array_open(query_type);
 
     // Get encryption key from config
     std::string encryption_key_from_cfg;
@@ -323,7 +348,9 @@ Status Array::open(
       if (query_type == QueryType::READ) {
         timestamp_end_opened_at_ = utils::time::timestamp_now_ms();
       } else if (
-          query_type == QueryType::WRITE || query_type == QueryType::DELETE) {
+          query_type == QueryType::WRITE ||
+          query_type == QueryType::WRITE_EXCLUSIVE ||
+          query_type == QueryType::DELETE) {
         timestamp_end_opened_at_ = 0;
       } else {
         throw Status_ArrayError("Cannot open array; Unsupported query type.");
@@ -427,7 +454,9 @@ Status Array::close() {
     if (remote_) {
       // Update array metadata for write queries if metadata was written by the
       // user
-      if (query_type_ == QueryType::WRITE && metadata_.num() > 0) {
+      if ((query_type_ == QueryType::WRITE ||
+           query_type_ == QueryType::WRITE_EXCLUSIVE) &&
+          metadata_.num() > 0) {
         // Set metadata loaded to be true so when serialization fetchs the
         // metadata it won't trigger a deadlock
         metadata_loaded_ = true;
@@ -449,7 +478,9 @@ Status Array::close() {
         st = storage_manager_->array_close_for_reads(this);
         if (!st.ok())
           throw StatusException(st);
-      } else if (query_type_ == QueryType::WRITE) {
+      } else if (
+          query_type_ == QueryType::WRITE ||
+          query_type_ == QueryType::WRITE_EXCLUSIVE) {
         st = storage_manager_->array_close_for_writes(this);
         if (!st.ok())
           throw StatusException(st);
@@ -503,16 +534,14 @@ tuple<Status, optional<shared_ptr<ArraySchema>>> Array::get_array_schema()
   return {Status::Ok(), array_schema_latest_};
 }
 
-Status Array::get_query_type(QueryType* query_type) const {
+QueryType Array::get_query_type() const {
   // Error if the array is not open
   if (!is_open_) {
-    return LOG_STATUS(
+    throw StatusException(
         Status_ArrayError("Cannot get query_type; Array is not open"));
   }
 
-  *query_type = query_type_;
-
-  return Status::Ok();
+  return query_type_;
 }
 
 Status Array::get_max_buffer_size(
@@ -757,7 +786,8 @@ Status Array::delete_metadata(const char* key) {
   }
 
   // Check mode
-  if (query_type_ != QueryType::WRITE) {
+  if (query_type_ != QueryType::WRITE &&
+      query_type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_ArrayError("Cannot delete metadata. Array was "
                           "not opened in write mode"));
@@ -786,7 +816,8 @@ Status Array::put_metadata(
   }
 
   // Check mode
-  if (query_type_ != QueryType::WRITE) {
+  if (query_type_ != QueryType::WRITE &&
+      query_type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_ArrayError("Cannot put metadata; Array was "
                           "not opened in write mode"));
@@ -1163,7 +1194,7 @@ Status Array::compute_non_empty_domain() {
   return Status::Ok();
 }
 
-void Array::set_array_open() {
+void Array::set_array_open(const QueryType& query_type) {
   std::lock_guard<std::mutex> lock(mtx_);
   if (is_opening_or_closing_) {
     is_opening_or_closing_ = false;
@@ -1177,7 +1208,7 @@ void Array::set_array_open() {
    * only the pointer value is used and nothing is called on the Array objects.
    */
   consistency_sentry_.emplace(
-      consistency_controller_.make_sentry(array_uri_, *this));
+      consistency_controller_.make_sentry(array_uri_, *this, query_type));
   is_open_ = true;
 }
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -226,10 +226,10 @@ Status Array::load_fragments(
 
 Status Array::delete_fragments(
     const URI& uri, uint64_t timestamp_start, uint64_t timestamp_end) {
-  // Check that query type is WRITE_EXCLUSIVE
-  if (query_type_ != QueryType::WRITE_EXCLUSIVE) {
+  // Check that query type is MODIFY_EXCLUSIVE
+  if (query_type_ != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(Status_ArrayError(
-        "[Array::delete_fragments] Query type must be WRITE_EXCLUSIVE"));
+        "[Array::delete_fragments] Query type must be MODIFY_EXCLUSIVE"));
   }
 
   // Check that array is open
@@ -349,7 +349,7 @@ Status Array::open(
         timestamp_end_opened_at_ = utils::time::timestamp_now_ms();
       } else if (
           query_type == QueryType::WRITE ||
-          query_type == QueryType::WRITE_EXCLUSIVE ||
+          query_type == QueryType::MODIFY_EXCLUSIVE ||
           query_type == QueryType::DELETE) {
         timestamp_end_opened_at_ = 0;
       } else {
@@ -455,7 +455,7 @@ Status Array::close() {
       // Update array metadata for write queries if metadata was written by the
       // user
       if ((query_type_ == QueryType::WRITE ||
-           query_type_ == QueryType::WRITE_EXCLUSIVE) &&
+           query_type_ == QueryType::MODIFY_EXCLUSIVE) &&
           metadata_.num() > 0) {
         // Set metadata loaded to be true so when serialization fetchs the
         // metadata it won't trigger a deadlock
@@ -480,7 +480,7 @@ Status Array::close() {
           throw StatusException(st);
       } else if (
           query_type_ == QueryType::WRITE ||
-          query_type_ == QueryType::WRITE_EXCLUSIVE) {
+          query_type_ == QueryType::MODIFY_EXCLUSIVE) {
         st = storage_manager_->array_close_for_writes(this);
         if (!st.ok())
           throw StatusException(st);
@@ -787,10 +787,10 @@ Status Array::delete_metadata(const char* key) {
 
   // Check mode
   if (query_type_ != QueryType::WRITE &&
-      query_type_ != QueryType::WRITE_EXCLUSIVE) {
+      query_type_ != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(
         Status_ArrayError("Cannot delete metadata. Array was "
-                          "not opened in write mode"));
+                          "not opened in write or modify_exclusive mode"));
   }
 
   // Check if key is null
@@ -817,10 +817,10 @@ Status Array::put_metadata(
 
   // Check mode
   if (query_type_ != QueryType::WRITE &&
-      query_type_ != QueryType::WRITE_EXCLUSIVE) {
+      query_type_ != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(
         Status_ArrayError("Cannot put metadata; Array was "
-                          "not opened in write mode"));
+                          "not opened in write or modify_exclusive mode"));
   }
 
   // Check if key is null

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -179,6 +179,19 @@ class Array {
   Status load_fragments(const std::vector<TimestampedURI>& fragments_to_load);
 
   /**
+   * Deletes the fragments from the Array with given URI.
+   *
+   * @param uri The uri of the Array whose fragments are to be deleted.
+   * @param timestamp_start The start timestamp at which to delete fragments.
+   * @param timestamp_end The end timestamp at which to delete fragments.
+   * @return Status
+   *
+   * @pre The Array must be open for exclusive writes
+   */
+  Status delete_fragments(
+      const URI& uri, uint64_t timestamp_start, uint64_t timstamp_end);
+
+  /**
    * Sets the delete tiles location.
    *
    * @param delete_tiles_location Location for the delete tiles.
@@ -237,8 +250,8 @@ class Array {
   /** Retrieves the array schema. Errors if the array is not open. */
   tuple<Status, optional<shared_ptr<ArraySchema>>> get_array_schema() const;
 
-  /** Retrieves the query type. Errors if the array is not open. */
-  Status get_query_type(QueryType* qyery_type) const;
+  /** Retrieves the query type. Throws if the array is not open. */
+  QueryType get_query_type() const;
 
   /**
    * Returns the max buffer size given a fixed-sized attribute/dimension and
@@ -587,8 +600,12 @@ class Array {
   /** Computes the non-empty domain of the array. */
   Status compute_non_empty_domain();
 
-  /** Sets the array state as open. */
-  void set_array_open();
+  /**
+   * Sets the array state as open.
+   *
+   * @param query_type The QueryType of the Array.
+   */
+  void set_array_open(const QueryType& query_type);
 
   /** Sets the array state as closed.
    *

--- a/tiledb/sm/array/consistency.cc
+++ b/tiledb/sm/array/consistency.cc
@@ -71,16 +71,17 @@ ConsistencyController::entry_type ConsistencyController::register_array(
 
   std::lock_guard<std::mutex> lock(mtx_);
   if (this->is_open(uri)) {
-    if (query_type == QueryType::WRITE_EXCLUSIVE) {
+    if (query_type == QueryType::MODIFY_EXCLUSIVE) {
       throw std::runtime_error(
           "[ConsistencyController::register_array] Array already open; must "
-          "close array before opening for exclusive write.");
+          "close array before opening for exclusive modification.");
     } else {
       auto iter = array_registry_.find(uri);
-      if (iter->second.get_query_type() == QueryType::WRITE_EXCLUSIVE) {
+      if (iter->second.get_query_type() == QueryType::MODIFY_EXCLUSIVE) {
         throw std::runtime_error(
             "[ConsistencyController::register_array] Must close array opened "
-            "for exclusive write before opening an array at the same address.");
+            "for exclusive modification before opening an array at the same "
+            "address.");
       }
     }
   }

--- a/tiledb/sm/array/consistency.h
+++ b/tiledb/sm/array/consistency.h
@@ -38,6 +38,7 @@
 
 #include "tiledb/common/common.h"
 #include "tiledb/common/logger.h"
+#include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/filesystem/uri.h"
 
 using namespace tiledb::common;
@@ -99,7 +100,8 @@ class ConsistencyController {
    *
    * @return Sentry object whose lifespan is the same as the registration.
    */
-  ConsistencySentry make_sentry(const URI uri, Array& array);
+  ConsistencySentry make_sentry(
+      const URI uri, Array& array, const QueryType& query_type);
 
   /** Returns true if the array is open, i.e. registered in the multimap. */
   bool is_open(const URI uri);
@@ -113,7 +115,8 @@ class ConsistencyController {
    *
    * @pre the given URI is the root directory of the Array and is not empty.
    */
-  entry_type register_array(const URI uri, Array& array);
+  entry_type register_array(
+      const URI uri, Array& array, const QueryType& query_type);
 
   /**
    * Wrapper around a multimap deregistration operation.

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -65,13 +65,14 @@ TEST_CASE(
   const URI uri_empty = URI();
   Array* array = nullptr;
 
-  REQUIRE_THROWS_AS(x.register_array(uri_empty, *array), std::exception);
+  REQUIRE_THROWS_AS(
+      x.register_array(uri_empty, *array, QueryType::READ), std::exception);
   REQUIRE(x.registry_size() == 0);
   REQUIRE(x.is_open(uri_empty) == false);
 
   // Register a non-empty URI
   const URI uri = URI("whitebox_null_array_direct_registration");
-  entry_type iter = x.register_array(uri, *array);
+  entry_type iter = x.register_array(uri, *array, QueryType::READ);
 
   // Check registration
   REQUIRE(x.registry_size() == 1);
@@ -91,7 +92,7 @@ TEST_CASE(
   REQUIRE(x.is_open(uri) == false);
 
   // Re-register uri and check registry
-  iter = x.register_array(uri, *array);
+  iter = x.register_array(uri, *array, QueryType::READ);
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
   REQUIRE(tiledb::sm::utils::parse::is_element_of(uri_empty, uri) == false);
@@ -110,13 +111,15 @@ TEST_CASE(
   // Try to register an empty URI
   const URI uri_empty = URI();
   Array* array = nullptr;
-  REQUIRE_THROWS_AS(x.make_sentry(uri_empty, *array), std::exception);
+  REQUIRE_THROWS_AS(
+      x.make_sentry(uri_empty, *array, QueryType::READ), std::exception);
   REQUIRE(x.registry_size() == 0);
   REQUIRE(x.is_open(uri_empty) == false);
 
   // Register a non-empty URI
   const URI uri = URI("whitebox_null_array_sentry_registration");
-  tiledb::sm::ConsistencySentry sentry_uri = x.make_sentry(uri, *array);
+  tiledb::sm::ConsistencySentry sentry_uri =
+      x.make_sentry(uri, *array, QueryType::READ);
 
   // Check registration
   REQUIRE(x.registry_size() == 1);
@@ -135,7 +138,8 @@ TEST_CASE(
   // Register a URI
   const URI uri = URI("whitebox_sentry");
   Array* array = nullptr;
-  tiledb::sm::ConsistencySentry sentry = x.make_sentry(uri, *array);
+  tiledb::sm::ConsistencySentry sentry =
+      x.make_sentry(uri, *array, QueryType::READ);
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
 
@@ -152,7 +156,7 @@ TEST_CASE(
   // Create an optional Sentry
   const URI uri_optional = URI("whitebox_optional_sentry");
   std::optional<tiledb::sm::ConsistencySentry> sentry_optional(
-      x.make_sentry(uri_optional, *array));
+      x.make_sentry(uri_optional, *array, QueryType::READ));
   REQUIRE(x.registry_size() == 2);
   REQUIRE(x.is_open(uri) == true);
 }
@@ -230,4 +234,60 @@ TEST_CASE(
   for (auto uri : uris) {
     sm.vfs()->remove_dir(uri);
   }
+}
+
+TEST_CASE(
+    "WhiteboxConsistencyController: Exclusive write",
+    "[ConsistencyController][write][exclusive]") {
+  WhiteboxConsistencyController x;
+  const URI uri = URI("whitebox_exclusive_write");
+
+  // Create a StorageManager
+  Config config;
+  ThreadPool tp_cpu(1);
+  ThreadPool tp_io(1);
+  stats::Stats stats("");
+  StorageManager sm(&tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""));
+  Status st = sm.init(config);
+  REQUIRE(st.ok());
+
+  // Create an array
+  tdb_unique_ptr<Array> array = x.create_array(uri, &sm);
+
+  // Open an array for exclusive write
+  st = array->open(
+      QueryType::WRITE_EXCLUSIVE, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+  REQUIRE(st.ok());
+  REQUIRE(x.registry_size() == 1);
+  REQUIRE(x.is_open(uri) == true);
+
+  // Try to register an array for read
+  REQUIRE_THROWS_WITH(
+      x.register_array(uri, *array.get(), QueryType::READ),
+      Catch::Contains("close array opened for exclusive write"));
+  REQUIRE(x.registry_size() == 1);
+  REQUIRE(x.is_open(uri) == true);
+
+  // Close exclusive write array
+  array.get()->close();
+  REQUIRE(x.registry_size() == 0);
+  REQUIRE(x.is_open(uri) == false);
+
+  // Open array for read
+  st = array->open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+  REQUIRE(st.ok());
+  REQUIRE(x.registry_size() == 1);
+  REQUIRE(x.is_open(uri) == true);
+
+  // Try to register an array for exclusive write
+  REQUIRE_THROWS_WITH(
+      x.register_array(uri, *array, QueryType::WRITE_EXCLUSIVE),
+      Catch::Contains("must close array before opening for exclusive write"));
+  REQUIRE(x.registry_size() == 1);
+
+  // Clean up
+  array.get()->close();
+  REQUIRE(x.registry_size() == 0);
+  REQUIRE(x.is_open(uri) == false);
+  sm.vfs()->remove_dir(uri);
 }

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -237,10 +237,10 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "WhiteboxConsistencyController: Exclusive write",
-    "[ConsistencyController][write][exclusive]") {
+    "WhiteboxConsistencyController: Exclusive modification",
+    "[ConsistencyController][modify][exclusive]") {
   WhiteboxConsistencyController x;
-  const URI uri = URI("whitebox_exclusive_write");
+  const URI uri = URI("whitebox_modify_exclusive");
 
   // Create a StorageManager
   Config config;
@@ -254,9 +254,9 @@ TEST_CASE(
   // Create an array
   tdb_unique_ptr<Array> array = x.create_array(uri, &sm);
 
-  // Open an array for exclusive write
+  // Open an array for exclusive modification
   st = array->open(
-      QueryType::WRITE_EXCLUSIVE, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+      QueryType::MODIFY_EXCLUSIVE, EncryptionType::NO_ENCRYPTION, nullptr, 0);
   REQUIRE(st.ok());
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
@@ -264,11 +264,11 @@ TEST_CASE(
   // Try to register an array for read
   REQUIRE_THROWS_WITH(
       x.register_array(uri, *array.get(), QueryType::READ),
-      Catch::Contains("close array opened for exclusive write"));
+      Catch::Contains("close array opened for exclusive modification"));
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
 
-  // Close exclusive write array
+  // Close exclusive modification array
   array.get()->close();
   REQUIRE(x.registry_size() == 0);
   REQUIRE(x.is_open(uri) == false);
@@ -279,10 +279,11 @@ TEST_CASE(
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
 
-  // Try to register an array for exclusive write
+  // Try to register an array for exclusive modification
   REQUIRE_THROWS_WITH(
-      x.register_array(uri, *array, QueryType::WRITE_EXCLUSIVE),
-      Catch::Contains("must close array before opening for exclusive write"));
+      x.register_array(uri, *array, QueryType::MODIFY_EXCLUSIVE),
+      Catch::Contains(
+          "must close array before opening for exclusive modification"));
   REQUIRE(x.registry_size() == 1);
 
   // Clean up

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2483,8 +2483,12 @@ int32_t tiledb_query_alloc(
 
   // Error if the query type and array query type do not match
   tiledb::sm::QueryType array_query_type;
-  if (SAVE_ERROR_CATCH(ctx, array->array_->get_query_type(&array_query_type)))
+  try {
+    array_query_type = array->array_->get_query_type();
+  } catch (StatusException& e) {
     return TILEDB_ERR;
+  }
+
   if (query_type != static_cast<tiledb_query_type_t>(array_query_type)) {
     std::stringstream errmsg;
     errmsg << "Cannot create query; "
@@ -3973,6 +3977,24 @@ int32_t tiledb_array_get_open_timestamp_end(
   return TILEDB_OK;
 }
 
+int32_t tiledb_array_delete_fragments(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* uri,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          array->array_->delete_fragments(
+              tiledb::sm::URI(uri), timestamp_start, timestamp_end)))
+    return TILEDB_ERR;
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_array_open(
     tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type) {
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
@@ -4202,8 +4224,11 @@ int32_t tiledb_array_get_query_type(
 
   // Get query_type
   tiledb::sm::QueryType type;
-  if (SAVE_ERROR_CATCH(ctx, array->array_->get_query_type(&type)))
+  try {
+    type = array->array_->get_query_type();
+  } catch (StatusException& e) {
     return TILEDB_ERR;
+  }
 
   *query_type = static_cast<tiledb_query_type_t>(type);
 
@@ -8969,6 +8994,16 @@ int32_t tiledb_array_get_open_timestamp_end(
     uint64_t* timestamp_end) noexcept {
   return api_entry<detail::tiledb_array_get_open_timestamp_end>(
       ctx, array, timestamp_end);
+}
+
+int32_t tiledb_array_delete_fragments(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* uri,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end) noexcept {
+  return api_entry<detail::tiledb_array_delete_fragments>(
+      ctx, array, uri, timestamp_start, timestamp_end);
 }
 
 int32_t tiledb_array_open(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5737,6 +5737,31 @@ TILEDB_EXPORT int32_t tiledb_array_get_open_timestamp_end(
     uint64_t* timestamp_end) TILEDB_NOEXCEPT;
 
 /**
+ * Deletes array fragments written between the input timestamps.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_vfs_delete_fragments(
+ *   ctx, vfs, "hdfs:///temp/my_array", 0, UINT64_MAX);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param array The array to delete the fragments from.
+ * @param uri The URI of the fragments' parent Array.
+ * @param timestamp_start The epoch timestamp in milliseconds.
+ * @param timestamp_end The epoch timestamp in milliseconds. Use UINT64_MAX for
+ *   the current timestamp.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_delete_fragments(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* uri,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end) TILEDB_NOEXCEPT;
+
+/**
  * Opens a TileDB array. The array is opened using a query type as input.
  * This is to indicate that queries created for this `tiledb_array_t`
  * object will inherit the query type. In other words, `tiledb_array_t`

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -37,8 +37,8 @@
     TILEDB_QUERY_TYPE_ENUM(WRITE) = 1,
     /** Delete query */
     TILEDB_QUERY_TYPE_ENUM(DELETE) = 2,
-    /** Exclusive Write query */
-    TILEDB_QUERY_TYPE_ENUM(WRITE_EXCLUSIVE) = 3,
+    /** Exclusive Modification query */
+    TILEDB_QUERY_TYPE_ENUM(MODIFY_EXCLUSIVE) = 3,
 #endif
 // clang-format on
 

--- a/tiledb/sm/c_api/tiledb_enum.h
+++ b/tiledb/sm/c_api/tiledb_enum.h
@@ -37,6 +37,8 @@
     TILEDB_QUERY_TYPE_ENUM(WRITE) = 1,
     /** Delete query */
     TILEDB_QUERY_TYPE_ENUM(DELETE) = 2,
+    /** Exclusive Write query */
+    TILEDB_QUERY_TYPE_ENUM(WRITE_EXCLUSIVE) = 3,
 #endif
 // clang-format on
 

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -317,14 +317,6 @@ Status FragmentConsolidator::vacuum(
     return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
   }
 
-  auto array_dir = ArrayDirectory(
-      vfs,
-      compute_tp,
-      URI(array_name),
-      0,
-      std::numeric_limits<uint64_t>::max(),
-      ArrayDirectoryMode::VACUUM_FRAGMENTS);
-
   auto filtered_fragment_uris = array_dir.filtered_fragment_uris(true);
   const auto& fragment_uris_to_vacuum =
       filtered_fragment_uris.fragment_uris_to_vacuum();

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -289,13 +289,33 @@ Status FragmentConsolidator::consolidate_fragments(
 }
 
 Status FragmentConsolidator::vacuum(const char* array_name) {
+  return vacuum(array_name, 0, std::numeric_limits<uint64_t>::max(), false);
+}
+
+Status FragmentConsolidator::vacuum(
+    const char* array_name,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    bool for_deletes) {
   if (array_name == nullptr)
     return logger_->status(Status_StorageManagerError(
         "Cannot vacuum fragments; Array name cannot be null"));
 
-  // Get the fragment URIs and vacuum file URIs to be vacuum
+  // Get the fragment URIs and vacuum file URIs to be vacuumed
   auto vfs = storage_manager_->vfs();
   auto compute_tp = storage_manager_->compute_tp();
+  ArrayDirectory array_dir;
+  try {
+    array_dir = ArrayDirectory(
+        vfs,
+        compute_tp,
+        URI(array_name),
+        timestamp_start,
+        timestamp_end,
+        ArrayDirectoryMode::VACUUM_FRAGMENTS);
+  } catch (const std::logic_error& le) {
+    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
+  }
 
   auto array_dir = ArrayDirectory(
       vfs,
@@ -363,6 +383,16 @@ Status FragmentConsolidator::vacuum(const char* array_name) {
         return Status::Ok();
       });
   RETURN_NOT_OK(status);
+
+  // Delete fragments if vacuuming for deletes
+  if (for_deletes) {
+    const auto& fragment_uris = filtered_fragment_uris.fragment_uris();
+    status = parallel_for(compute_tp, 0, fragment_uris.size(), [&](size_t i) {
+      RETURN_NOT_OK(vfs->remove_dir(fragment_uris[i].uri_));
+      return Status::Ok();
+    });
+    RETURN_NOT_OK(status);
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -304,18 +304,13 @@ Status FragmentConsolidator::vacuum(
   // Get the fragment URIs and vacuum file URIs to be vacuumed
   auto vfs = storage_manager_->vfs();
   auto compute_tp = storage_manager_->compute_tp();
-  ArrayDirectory array_dir;
-  try {
-    array_dir = ArrayDirectory(
-        vfs,
-        compute_tp,
-        URI(array_name),
-        timestamp_start,
-        timestamp_end,
-        ArrayDirectoryMode::VACUUM_FRAGMENTS);
-  } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
-  }
+  auto array_dir = ArrayDirectory(
+      vfs,
+      compute_tp,
+      URI(array_name),
+      timestamp_start,
+      timestamp_end,
+      ArrayDirectoryMode::VACUUM_FRAGMENTS);
 
   auto filtered_fragment_uris = array_dir.filtered_fragment_uris(true);
   const auto& fragment_uris_to_vacuum =

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -122,10 +122,25 @@ class FragmentConsolidator : public Consolidator {
   /**
    * Performs the vacuuming operation.
    *
-   * @param array_name URI of array to consolidate.
+   * @param array_name URI of array to vacuum.
    * @return Status
    */
   Status vacuum(const char* array_name);
+
+  /**
+   * Performs the vacuuming operation.
+   *
+   * @param array_name URI of array to vacuum.
+   * @param timestamp_start The start timestamp at which to vacuum.
+   * @param timestamp_end The end timestamp at which to vacuum.
+   * @param for_deletes True if vacuumuming for deletion of fragments.
+   * @return Status
+   */
+  Status vacuum(
+      const char* array_name,
+      uint64_t timestamp_start = 0,
+      uint64_t timestamp_end = std::numeric_limits<uint64_t>::max(),
+      bool for_deletes = false);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -393,6 +393,23 @@ class Array {
   }
 
   /**
+   * Deletes the fragments written between the input timestamps of an array
+   * with the input uri.
+   */
+  void delete_fragments(
+      const std::string& uri,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end) const {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_array_delete_fragments(
+        ctx.ptr().get(),
+        array_.get(),
+        uri.c_str(),
+        timestamp_start,
+        timestamp_end));
+  }
+
+  /**
    * @brief Opens the array. The array is opened using a query type as input.
    *
    * This is to indicate that queries created for this `Array`

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -2316,8 +2316,8 @@ class Query {
         return "READ";
       case TILEDB_WRITE:
         return "WRITE";
-      case TILEDB_WRITE_EXCLUSIVE:
-        return "WRITE_EXCLUSIVE";
+      case TILEDB_MODIFY_EXCLUSIVE:
+        return "MODIFY_EXCLUSIVE";
       case TILEDB_DELETE:
         return "DELETE";
     }

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -2316,6 +2316,8 @@ class Query {
         return "READ";
       case TILEDB_WRITE:
         return "WRITE";
+      case TILEDB_WRITE_EXCLUSIVE:
+        return "WRITE_EXCLUSIVE";
       case TILEDB_DELETE:
         return "DELETE";
     }

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -55,6 +55,8 @@ inline const std::string& query_type_str(QueryType query_type) {
       return constants::query_type_read_str;
     case QueryType::WRITE:
       return constants::query_type_write_str;
+    case QueryType::WRITE_EXCLUSIVE:
+      return constants::query_type_write_exclusive_str;
     case QueryType::DELETE:
       return constants::query_type_delete_str;
     default:
@@ -69,6 +71,8 @@ inline Status query_type_enum(
     *query_type = QueryType::READ;
   else if (query_type_str == constants::query_type_write_str)
     *query_type = QueryType::WRITE;
+  else if (query_type_str == constants::query_type_write_exclusive_str)
+    *query_type = QueryType::WRITE_EXCLUSIVE;
   else if (query_type_str == constants::query_type_delete_str)
     *query_type = QueryType::DELETE;
   else {

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -55,10 +55,10 @@ inline const std::string& query_type_str(QueryType query_type) {
       return constants::query_type_read_str;
     case QueryType::WRITE:
       return constants::query_type_write_str;
-    case QueryType::WRITE_EXCLUSIVE:
-      return constants::query_type_write_exclusive_str;
     case QueryType::DELETE:
       return constants::query_type_delete_str;
+    case QueryType::MODIFY_EXCLUSIVE:
+      return constants::query_type_modify_exclusive_str;
     default:
       return constants::empty_str;
   }
@@ -71,10 +71,10 @@ inline Status query_type_enum(
     *query_type = QueryType::READ;
   else if (query_type_str == constants::query_type_write_str)
     *query_type = QueryType::WRITE;
-  else if (query_type_str == constants::query_type_write_exclusive_str)
-    *query_type = QueryType::WRITE_EXCLUSIVE;
   else if (query_type_str == constants::query_type_delete_str)
     *query_type = QueryType::DELETE;
+  else if (query_type_str == constants::query_type_modify_exclusive_str)
+    *query_type = QueryType::MODIFY_EXCLUSIVE;
   else {
     return Status_Error("Invalid QueryType " + query_type_str);
   }

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -71,7 +71,8 @@ Status Group::open(
     return Status_GroupError("Cannot open group; Group already open");
   }
 
-  if (query_type != QueryType::READ && query_type != QueryType::WRITE) {
+  if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
+      query_type != QueryType::WRITE_EXCLUSIVE) {
     return Status_GroupError("Cannot open group; Unsupported query type");
   }
 
@@ -79,7 +80,9 @@ Status Group::open(
     if (query_type == QueryType::READ) {
       timestamp_end = utils::time::timestamp_now_ms();
     } else {
-      assert(query_type == QueryType::WRITE);
+      assert(
+          query_type == QueryType::WRITE ||
+          query_type == QueryType::WRITE_EXCLUSIVE);
       timestamp_end = 0;
     }
   }
@@ -230,7 +233,8 @@ Status Group::close() {
   if (remote_) {
     // Update group metadata for write queries if metadata was written by the
     // user
-    if (query_type_ == QueryType::WRITE) {
+    if (query_type_ == QueryType::WRITE ||
+        query_type_ == QueryType::WRITE_EXCLUSIVE) {
       if (metadata_.num() > 0) {
         // Set metadata loaded to be true so when serialization fetches the
         // metadata it won't trigger a deadlock
@@ -260,7 +264,9 @@ Status Group::close() {
   } else {
     if (query_type_ == QueryType::READ) {
       RETURN_NOT_OK(storage_manager_->group_close_for_reads(this));
-    } else if (query_type_ == QueryType::WRITE) {
+    } else if (
+        query_type_ == QueryType::WRITE ||
+        query_type_ == QueryType::WRITE_EXCLUSIVE) {
       // If changes haven't been applied, apply them
       if (!changes_applied_) {
         RETURN_NOT_OK(apply_pending_changes());
@@ -302,7 +308,8 @@ Status Group::delete_metadata(const char* key) {
     return Status_GroupError("Cannot delete metadata. Group is not open");
 
   // Check mode
-  if (query_type_ != QueryType::WRITE)
+  if (query_type_ != QueryType::WRITE &&
+      query_type_ != QueryType::WRITE_EXCLUSIVE)
     return Status_GroupError(
         "Cannot delete metadata. Group was "
         "not opened in write mode");
@@ -326,7 +333,8 @@ Status Group::put_metadata(
     return Status_GroupError("Cannot put metadata; Group is not open");
 
   // Check mode
-  if (query_type_ != QueryType::WRITE)
+  if (query_type_ != QueryType::WRITE &&
+      query_type_ != QueryType::WRITE_EXCLUSIVE)
     return Status_GroupError(
         "Cannot put metadata; Group was "
         "not opened in write mode");
@@ -518,7 +526,8 @@ Status Group::mark_member_for_addition(
   }
 
   // Check mode
-  if (query_type_ != QueryType::WRITE) {
+  if (query_type_ != QueryType::WRITE &&
+      query_type_ != QueryType::WRITE_EXCLUSIVE) {
     return Status_GroupError(
         "Cannot get member; Group was not opened in write mode");
   }
@@ -587,7 +596,8 @@ Status Group::mark_member_for_removal(const std::string& uri) {
   }
 
   // Check mode
-  if (query_type_ != QueryType::WRITE) {
+  if (query_type_ != QueryType::WRITE &&
+      query_type_ != QueryType::WRITE_EXCLUSIVE) {
     return Status_GroupError(
         "Cannot get member; Group was not opened in write mode");
   }

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -72,7 +72,7 @@ Status Group::open(
   }
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
-      query_type != QueryType::WRITE_EXCLUSIVE) {
+      query_type != QueryType::MODIFY_EXCLUSIVE) {
     return Status_GroupError("Cannot open group; Unsupported query type");
   }
 
@@ -82,7 +82,7 @@ Status Group::open(
     } else {
       assert(
           query_type == QueryType::WRITE ||
-          query_type == QueryType::WRITE_EXCLUSIVE);
+          query_type == QueryType::MODIFY_EXCLUSIVE);
       timestamp_end = 0;
     }
   }
@@ -234,7 +234,7 @@ Status Group::close() {
     // Update group metadata for write queries if metadata was written by the
     // user
     if (query_type_ == QueryType::WRITE ||
-        query_type_ == QueryType::WRITE_EXCLUSIVE) {
+        query_type_ == QueryType::MODIFY_EXCLUSIVE) {
       if (metadata_.num() > 0) {
         // Set metadata loaded to be true so when serialization fetches the
         // metadata it won't trigger a deadlock
@@ -266,7 +266,7 @@ Status Group::close() {
       RETURN_NOT_OK(storage_manager_->group_close_for_reads(this));
     } else if (
         query_type_ == QueryType::WRITE ||
-        query_type_ == QueryType::WRITE_EXCLUSIVE) {
+        query_type_ == QueryType::MODIFY_EXCLUSIVE) {
       // If changes haven't been applied, apply them
       if (!changes_applied_) {
         RETURN_NOT_OK(apply_pending_changes());
@@ -309,10 +309,10 @@ Status Group::delete_metadata(const char* key) {
 
   // Check mode
   if (query_type_ != QueryType::WRITE &&
-      query_type_ != QueryType::WRITE_EXCLUSIVE)
+      query_type_ != QueryType::MODIFY_EXCLUSIVE)
     return Status_GroupError(
         "Cannot delete metadata. Group was "
-        "not opened in write mode");
+        "not opened in write or modify_exclusive mode");
 
   // Check if key is null
   if (key == nullptr)
@@ -334,10 +334,10 @@ Status Group::put_metadata(
 
   // Check mode
   if (query_type_ != QueryType::WRITE &&
-      query_type_ != QueryType::WRITE_EXCLUSIVE)
+      query_type_ != QueryType::MODIFY_EXCLUSIVE)
     return Status_GroupError(
         "Cannot put metadata; Group was "
-        "not opened in write mode");
+        "not opened in write or modify_exclusive mode");
 
   // Check if key is null
   if (key == nullptr)
@@ -527,9 +527,10 @@ Status Group::mark_member_for_addition(
 
   // Check mode
   if (query_type_ != QueryType::WRITE &&
-      query_type_ != QueryType::WRITE_EXCLUSIVE) {
+      query_type_ != QueryType::MODIFY_EXCLUSIVE) {
     return Status_GroupError(
-        "Cannot get member; Group was not opened in write mode");
+        "Cannot get member; Group was not opened in write or modify_exclusive "
+        "mode");
   }
 
   const std::string& uri = group_member_uri.to_string();
@@ -597,9 +598,10 @@ Status Group::mark_member_for_removal(const std::string& uri) {
 
   // Check mode
   if (query_type_ != QueryType::WRITE &&
-      query_type_ != QueryType::WRITE_EXCLUSIVE) {
+      query_type_ != QueryType::MODIFY_EXCLUSIVE) {
     return Status_GroupError(
-        "Cannot get member; Group was not opened in write mode");
+        "Cannot get member; Group was not opened in write or modify_exclusive "
+        "mode");
   }
   if (members_to_add_.find(uri) != members_to_add_.end()) {
     return Status_GroupError(

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -281,6 +281,9 @@ const std::string query_type_read_str = "READ";
 /** TILEDB_WRITE Query String **/
 const std::string query_type_write_str = "WRITE";
 
+/** TILEDB_WRITE_EXCLUSIVE Query String **/
+const std::string query_type_write_exclusive_str = "WRITE_EXCLUSIVE";
+
 /** TILEDB_DELETE Query String **/
 const std::string query_type_delete_str = "DELETE";
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -281,11 +281,11 @@ const std::string query_type_read_str = "READ";
 /** TILEDB_WRITE Query String **/
 const std::string query_type_write_str = "WRITE";
 
-/** TILEDB_WRITE_EXCLUSIVE Query String **/
-const std::string query_type_write_exclusive_str = "WRITE_EXCLUSIVE";
-
 /** TILEDB_DELETE Query String **/
 const std::string query_type_delete_str = "DELETE";
+
+/** TILEDB_MODIFY_EXCLUSIVE Query String **/
+const std::string query_type_modify_exclusive_str = "MODIFY_EXCLUSIVE";
 
 /** TILEDB_FAILED Query String **/
 const std::string query_status_failed_str = "FAILED";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -266,6 +266,9 @@ extern const std::string query_type_read_str;
 /** TILEDB_WRITE Query String **/
 extern const std::string query_type_write_str;
 
+/** TILEDB_WRITE_EXCLUSIVE Query String **/
+extern const std::string query_type_write_exclusive_str;
+
 /** TILEDB_DELETE Query String **/
 extern const std::string query_type_delete_str;
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -266,11 +266,11 @@ extern const std::string query_type_read_str;
 /** TILEDB_WRITE Query String **/
 extern const std::string query_type_write_str;
 
-/** TILEDB_WRITE_EXCLUSIVE Query String **/
-extern const std::string query_type_write_exclusive_str;
-
 /** TILEDB_DELETE Query String **/
 extern const std::string query_type_delete_str;
+
+/** TILEDB_MODIFY_EXCLUSIVE Query String **/
+extern const std::string query_type_modify_exclusive_str;
 
 /** TILEDB_FAILED Query String **/
 extern const std::string query_status_failed_str;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1124,7 +1124,7 @@ Status Query::disable_checks_consolidation() {
         "Cannot disable checks for consolidation after initialization"));
   }
 
-  if (type_ != QueryType::WRITE) {
+  if (type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) {
     return logger_->status(Status_QueryError(
         "Cannot disable checks for consolidation; Applicable only to writes"));
   }
@@ -1155,7 +1155,7 @@ void Query::set_processed_conditions(
 }
 
 Status Query::check_buffer_names() {
-  if (type_ == QueryType::WRITE) {
+  if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) {
     // If the array is sparse, the coordinates must be provided
     if (!array_schema_->dense() && !coords_info_.has_coords_)
       return logger_->status(Status_WriterError(
@@ -1190,7 +1190,7 @@ Status Query::check_buffer_names() {
 }
 
 Status Query::create_strategy(bool skip_checks_serialization) {
-  if (type_ == QueryType::WRITE) {
+  if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) {
     if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           OrderedWriter,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -88,8 +88,7 @@ Query::Query(
     , fragment_uri_(fragment_uri)
     , force_legacy_reader_(false) {
   assert(array->is_open());
-  auto st = array->get_query_type(&type_);
-  assert(st.ok());
+  type_ = array->get_query_type();
 
   if (type_ != QueryType::READ) {
     subarray_ = Subarray(array_, stats_, logger_);
@@ -133,7 +132,8 @@ Query::~Query() {
 
 Status Query::add_range(
     unsigned dim_idx, const void* start, const void* end, const void* stride) {
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return logger_->status(
         Status_QueryError("Adding a range for an unsupported query type"));
   }
@@ -201,7 +201,8 @@ Status Query::add_range_var(
     uint64_t start_size,
     const void* end,
     uint64_t end_size) {
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return logger_->status(
         Status_QueryError("Adding a range for an unsupported query type"));
   }
@@ -219,7 +220,7 @@ Status Query::add_range_var(
     return logger_->status(
         Status_QueryError("Cannot add range; Range must be variable-sized"));
 
-  if (type_ == QueryType::WRITE)
+  if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)
     return logger_->status(Status_QueryError(
         "Cannot add range; Function applicable only to reads"));
 
@@ -240,7 +241,8 @@ Status Query::add_range_var(
 }
 
 Status Query::get_range_num(unsigned dim_idx, uint64_t* range_num) const {
-  if (type_ == QueryType::WRITE && !array_schema_->dense())
+  if ((type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      !array_schema_->dense())
     return logger_->status(
         Status_QueryError("Getting the number of ranges from a write query "
                           "is not applicable to sparse arrays"));
@@ -259,7 +261,8 @@ Status Query::get_range(
         "Getting a var range size only applicable to read queries"));
   }
 
-  if (type_ == QueryType::WRITE && !array_schema_->dense()) {
+  if ((type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      !array_schema_->dense()) {
     return logger_->status(
         Status_QueryError("Getting a range from a write query is not "
                           "applicable to sparse arrays"));
@@ -556,7 +559,7 @@ Query::get_max_mem_size_map() {
 }
 
 Status Query::get_written_fragment_num(uint32_t* num) const {
-  if (type_ != QueryType::WRITE) {
+  if (type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) {
     return logger_->status(Status_QueryError(
         "Cannot get number of fragments; Applicable only to WRITE mode"));
   }
@@ -567,7 +570,7 @@ Status Query::get_written_fragment_num(uint32_t* num) const {
 }
 
 Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
-  if (type_ != QueryType::WRITE) {
+  if (type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) {
     return logger_->status(Status_QueryError(
         "Cannot get fragment URI; Applicable only to WRITE mode"));
   }
@@ -584,7 +587,7 @@ Status Query::get_written_fragment_uri(uint32_t idx, const char** uri) const {
 
 Status Query::get_written_fragment_timestamp_range(
     uint32_t idx, uint64_t* t1, uint64_t* t2) const {
-  if (type_ != QueryType::WRITE) {
+  if (type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) {
     return logger_->status(Status_QueryError(
         "Cannot get fragment timestamp range; Applicable only to WRITE mode"));
   }
@@ -632,7 +635,8 @@ std::vector<std::string> Query::buffer_names() const {
 
 QueryBuffer Query::buffer(const std::string& name) const {
   // Special zipped coordinates
-  if (type_ == QueryType::WRITE && name == constants::coords) {
+  if ((type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      name == constants::coords) {
     return QueryBuffer(
         coords_info_.coords_buffer_,
         nullptr,
@@ -693,7 +697,8 @@ Status Query::get_buffer(
     void** buffer_val,
     uint64_t** buffer_val_size) const {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot get buffer; Unsupported query type."));
   }
@@ -736,7 +741,8 @@ Status Query::get_buffer(
 Status Query::get_offsets_buffer(
     const char* name, uint64_t** buffer_off, uint64_t** buffer_off_size) const {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot get buffer; Unsupported query type."));
   }
@@ -775,7 +781,8 @@ Status Query::get_offsets_buffer(
 Status Query::get_data_buffer(
     const char* name, void** buffer, uint64_t** buffer_size) const {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot get buffer; Unsupported query type."));
   }
@@ -790,7 +797,8 @@ Status Query::get_data_buffer(
   }
 
   // Special zipped coordinates
-  if (type_ == QueryType::WRITE && name == constants::coords) {
+  if ((type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      name == constants::coords) {
     *buffer = coords_info_.coords_buffer_;
     *buffer_size = coords_info_.coords_buffer_size_;
     return Status::Ok();
@@ -821,7 +829,8 @@ Status Query::get_validity_buffer(
     uint8_t** buffer_validity_bytemap,
     uint64_t** buffer_validity_bytemap_size) const {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot get buffer; Unsupported query type."));
   }
@@ -885,7 +894,8 @@ Status Query::get_buffer(
     uint64_t** buffer_size,
     const ValidityVector** validity_vector) const {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot get buffer; Unsupported query type."));
   }
@@ -930,7 +940,8 @@ Status Query::get_buffer(
     uint64_t** buffer_val_size,
     const ValidityVector** validity_vector) const {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot get buffer; Unsupported query type."));
   }
@@ -998,8 +1009,7 @@ Status Query::init() {
           "Cannot init query; The associated array is not open"));
 
     // Check if the array got re-opened with a different query type
-    QueryType array_query_type;
-    RETURN_NOT_OK(array_->get_query_type(&array_query_type));
+    QueryType array_query_type{array_->get_query_type()};
     if (array_query_type != type_) {
       std::stringstream errmsg;
       errmsg << "Cannot init query; "
@@ -1039,7 +1049,7 @@ Layout Query::layout() const {
 }
 
 const QueryCondition* Query::condition() const {
-  if (type_ == QueryType::WRITE) {
+  if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) {
     return nullptr;
   }
 
@@ -1066,7 +1076,8 @@ Status Query::process() {
     return st;
   }
 
-  if (type_ == QueryType::WRITE && layout_ == Layout::GLOBAL_ORDER) {
+  if ((type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      layout_ == Layout::GLOBAL_ORDER) {
     // reset coord buffer marker at end of global write
     // this will allow for the user to properly set the next write batch
     coord_buffer_is_set_ = false;
@@ -1368,7 +1379,8 @@ Status Query::create_strategy(bool skip_checks_serialization) {
 }
 
 Status Query::check_set_fixed_buffer(const std::string& name) {
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot set buffer; Unsupported query type."));
   }
@@ -1470,11 +1482,12 @@ Status Query::set_buffer(
     has_zipped_coords_buffer_ = true;
 
     // Set special function for zipped coordinates buffer
-    if (type_ == QueryType::WRITE)
+    if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)
       return set_coords_buffer(buffer, buffer_size);
   }
 
-  if (is_dim && type_ == QueryType::WRITE) {
+  if (is_dim &&
+      (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)) {
     // Check number of coordinates
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
     if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
@@ -1506,7 +1519,8 @@ Status Query::set_data_buffer(
 
   // Check buffer
   if (check_null_buffers && buffer == nullptr) {
-    if (type_ != QueryType::WRITE || *buffer_size != 0) {
+    if ((type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) ||
+        *buffer_size != 0) {
       return logger_->status(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
     }
@@ -1529,7 +1543,9 @@ Status Query::set_data_buffer(
         "'"));
   }
 
-  if (array_schema_->dense() && type_ == QueryType::WRITE && !is_attr) {
+  if (array_schema_->dense() &&
+      (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      !is_attr) {
     return logger_->status(Status_QueryError(
         std::string("Dense write queries cannot set dimension buffers")));
   }
@@ -1554,11 +1570,12 @@ Status Query::set_data_buffer(
     has_zipped_coords_buffer_ = true;
 
     // Set special function for zipped coordinates buffer
-    if (type_ == QueryType::WRITE)
+    if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)
       return set_coords_buffer(buffer, buffer_size);
   }
 
-  if (is_dim && type_ == QueryType::WRITE) {
+  if (is_dim &&
+      (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)) {
     // Check number of coordinates
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
     if (coord_data_buffer_is_set_ && coords_num != coords_info_.coords_num_ &&
@@ -1628,7 +1645,8 @@ Status Query::set_offsets_buffer(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
-  if (is_dim && type_ == QueryType::WRITE) {
+  if (is_dim &&
+      (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)) {
     // Check number of coordinates
     uint64_t coords_num =
         *buffer_offsets_size / constants::cell_var_offset_size;
@@ -1707,14 +1725,16 @@ Status Query::set_buffer(
     uint64_t* const buffer_val_size,
     const bool check_null_buffers) {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot set buffer; Unsupported query type."));
   }
 
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
-    if (type_ != QueryType::WRITE || *buffer_val_size != 0)
+    if ((type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) ||
+        *buffer_val_size != 0)
       return logger_->status(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
@@ -1762,7 +1782,8 @@ Status Query::set_buffer(
         std::string("Cannot set buffer for new attribute/dimension '") + name +
         "' after initialization"));
 
-  if (is_dim && type_ == QueryType::WRITE) {
+  if (is_dim &&
+      (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)) {
     // Check number of coordinates
     uint64_t coords_num = *buffer_off_size / constants::cell_var_offset_size;
     if (coord_buffer_is_set_ && coords_num != coords_info_.coords_num_)
@@ -1893,14 +1914,16 @@ Status Query::set_buffer(
     ValidityVector&& validity_vector,
     const bool check_null_buffers) {
   // Check query type
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot set layout; Unsupported query type."));
   }
 
   // Check buffer
   if (check_null_buffers && buffer_val == nullptr)
-    if (type_ != QueryType::WRITE || *buffer_val_size != 0)
+    if ((type_ != QueryType::WRITE && type_ != QueryType::WRITE_EXCLUSIVE) ||
+        *buffer_val_size != 0)
       return logger_->status(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
 
@@ -1975,7 +1998,8 @@ Status Query::set_est_result_size(
 }
 
 Status Query::set_layout(Layout layout) {
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot set layout; Unsupported query type."));
   }
@@ -1990,8 +2014,8 @@ Status Query::set_layout(Layout layout) {
         "Cannot set layout; Hilbert order is not applicable to queries"));
   }
 
-  if (type_ == QueryType::WRITE && array_schema_->dense() &&
-      layout == Layout::UNORDERED) {
+  if ((type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) &&
+      array_schema_->dense() && layout == Layout::UNORDERED) {
     return logger_->status(Status_QueryError(
         "Unordered writes are only possible for sparse arrays"));
   }
@@ -2002,7 +2026,7 @@ Status Query::set_layout(Layout layout) {
 }
 
 Status Query::set_condition(const QueryCondition& condition) {
-  if (type_ == QueryType::WRITE)
+  if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE)
     return logger_->status(Status_QueryError(
         "Cannot set query condition; Operation not applicable "
         "to write queries"));
@@ -2016,7 +2040,8 @@ void Query::set_status(QueryStatus status) {
 }
 
 Status Query::set_subarray(const void* subarray) {
-  if (type_ != QueryType::READ && type_ != QueryType::WRITE) {
+  if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
+      type_ != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot set subarray; Unsupported query type."));
   }
@@ -2061,7 +2086,7 @@ Status Query::set_subarray(const void* subarray) {
     }
   }
 
-  if (type_ == QueryType::WRITE) {
+  if (type_ == QueryType::WRITE || type_ == QueryType::WRITE_EXCLUSIVE) {
     // Not applicable to sparse arrays
     if (!array_schema_->dense())
       return logger_->status(Status_WriterError(
@@ -2136,7 +2161,7 @@ Status Query::set_subarray_unsafe(const NDRange& subarray) {
 
 Status Query::check_buffers_correctness() {
   if (type_ != QueryType::READ && type_ != QueryType::WRITE &&
-      type_ != QueryType::DELETE) {
+      type_ != QueryType::WRITE_EXCLUSIVE && type_ != QueryType::DELETE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot check buffers; Unsupported query type."));
   }

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1211,14 +1211,14 @@ Status query_to_capnp(
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
       query_type != QueryType::DELETE &&
-      query_type != QueryType::WRITE_EXCLUSIVE) {
+      query_type != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; Unsupported query type."));
   }
 
   if (layout == Layout::GLOBAL_ORDER &&
       (query_type == QueryType::WRITE ||
-       query_type == QueryType::WRITE_EXCLUSIVE)) {
+       query_type == QueryType::MODIFY_EXCLUSIVE)) {
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; global order "
                                   "serialization not supported for writes."));
@@ -1381,7 +1381,7 @@ Status query_from_capnp(
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
       query_type != QueryType::DELETE &&
-      query_type != QueryType::WRITE_EXCLUSIVE) {
+      query_type != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; Unsupported query type."));
   }
@@ -1960,7 +1960,7 @@ Status query_serialize(
     // Determine whether we should be serializing the buffer data.
     const bool serialize_buffers =
         (clientside && query->type() == QueryType::WRITE) ||
-        (clientside && query->type() == QueryType::WRITE_EXCLUSIVE) ||
+        (clientside && query->type() == QueryType::MODIFY_EXCLUSIVE) ||
         (!clientside && query->type() == QueryType::READ);
 
     switch (serialize_type) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1210,8 +1210,7 @@ Status query_to_capnp(
   auto query_type = query.type();
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
-      query_type != QueryType::DELETE) {
-  if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
+      query_type != QueryType::DELETE &&
       query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; Unsupported query type."));
@@ -1381,8 +1380,7 @@ Status query_from_capnp(
   }
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
-      query_type != QueryType::DELETE) {
-  if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
+      query_type != QueryType::DELETE &&
       query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; Unsupported query type."));

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1211,11 +1211,15 @@ Status query_to_capnp(
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
       query_type != QueryType::DELETE) {
+  if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
+      query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; Unsupported query type."));
   }
 
-  if (layout == Layout::GLOBAL_ORDER && query_type == QueryType::WRITE) {
+  if (layout == Layout::GLOBAL_ORDER &&
+      (query_type == QueryType::WRITE ||
+       query_type == QueryType::WRITE_EXCLUSIVE)) {
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; global order "
                                   "serialization not supported for writes."));
@@ -1378,6 +1382,8 @@ Status query_from_capnp(
 
   if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
       query_type != QueryType::DELETE) {
+  if (query_type != QueryType::READ && query_type != QueryType::WRITE &&
+      query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(Status_SerializationError(
         "Cannot deserialize; Unsupported query type."));
   }
@@ -1956,6 +1962,7 @@ Status query_serialize(
     // Determine whether we should be serializing the buffer data.
     const bool serialize_buffers =
         (clientside && query->type() == QueryType::WRITE) ||
+        (clientside && query->type() == QueryType::WRITE_EXCLUSIVE) ||
         (!clientside && query->type() == QueryType::READ);
 
     switch (serialize_type) {

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -552,6 +552,20 @@ Status StorageManager::fragments_consolidate(
       array_name, encryption_type, encryption_key, key_length, fragment_uris);
 }
 
+Status StorageManager::fragments_vacuum(
+    const char* array_name,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    bool for_deletes) {
+  // Vacuum
+  auto consolidator =
+      Consolidator::create(ConsolidationMode::FRAGMENT, &config_, this);
+  auto fragment_consolidator =
+      dynamic_cast<FragmentConsolidator*>(consolidator.get());
+  return fragment_consolidator->vacuum(
+      array_name, timestamp_start, timestamp_end, for_deletes);
+}
+
 Status StorageManager::array_vacuum(
     const char* array_name, const Config* config) {
   // If 'config' is unset, use the 'config_' that was set during initialization
@@ -888,8 +902,7 @@ Status StorageManager::array_get_non_empty_domain(
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array is not open"));
 
-  QueryType query_type;
-  RETURN_NOT_OK(array->get_query_type(&query_type));
+  QueryType query_type{array->get_query_type()};
   if (query_type != QueryType::READ)
     return logger_->status(Status_StorageManagerError(
         "Cannot get non-empty domain; Array not opened for reads"));

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -411,6 +411,21 @@ class StorageManager {
       const Config* config);
 
   /**
+   * Cleans up the array fragments.
+   *
+   * @param array_name The name of the array to be vacuumed.
+   * @param timestamp_start The start timestamp at which to vacuum.
+   * @param timestamp_end The end timestamp at which to vacuum.
+   * @param for_deletes True if vacuumuming for deletion of fragments.
+   * @return Status
+   */
+  Status fragments_vacuum(
+      const char* array_name,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
+      bool for_deletes);
+
+  /**
    * Cleans up the array, such as its consolidated fragments and array
    * metadata. Note that this will coarsen the granularity of time traveling
    * (see docs for more information).

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -355,10 +355,10 @@ Status Subarray::add_range(
 
   QueryType array_query_type{array_->get_query_type()};
   if (array_query_type == QueryType::WRITE ||
-      array_query_type == QueryType::WRITE_EXCLUSIVE) {
+      array_query_type == QueryType::MODIFY_EXCLUSIVE) {
     if (!array_->array_schema_latest().dense()) {
       return LOG_STATUS(Status_SubarrayError(
-          "Adding a subarray range to a write query is not "
+          "Adding a subarray range to a write or modify_exclusive query is not "
           "supported in sparse arrays"));
     }
     if (this->is_set(dim_idx)) {
@@ -370,7 +370,7 @@ Status Subarray::add_range(
 
   if (array_query_type != QueryType::READ &&
       array_query_type != QueryType::WRITE &&
-      array_query_type != QueryType::WRITE_EXCLUSIVE) {
+      array_query_type != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Unsupported query type"));
   }
@@ -411,10 +411,10 @@ Status Subarray::add_point_ranges(
 
   QueryType array_query_type{array_->get_query_type()};
   if (array_query_type == QueryType::WRITE ||
-      array_query_type == QueryType::WRITE_EXCLUSIVE) {
+      array_query_type == QueryType::MODIFY_EXCLUSIVE) {
     if (!array_->array_schema_latest().dense()) {
       return LOG_STATUS(Status_SubarrayError(
-          "Adding a subarray range to a write query is not "
+          "Adding a subarray range to a write or modify_exclsuive query is not "
           "supported in sparse arrays"));
     }
     if (this->is_set(dim_idx)) {
@@ -426,7 +426,7 @@ Status Subarray::add_point_ranges(
 
   if (array_query_type != QueryType::READ &&
       array_query_type != QueryType::WRITE &&
-      array_query_type != QueryType::WRITE_EXCLUSIVE) {
+      array_query_type != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Unsupported query type"));
   }
@@ -649,11 +649,11 @@ Status Subarray::get_range(
     const void** stride) const {
   QueryType array_query_type{array_->get_query_type()};
   if (array_query_type == QueryType::WRITE ||
-      array_query_type == QueryType::WRITE_EXCLUSIVE) {
+      array_query_type == QueryType::MODIFY_EXCLUSIVE) {
     if (!array_->array_schema_latest().dense())
-      return LOG_STATUS(
-          Status_SubarrayError("Getting a range from a write query is not "
-                               "applicable to sparse arrays"));
+      return LOG_STATUS(Status_SubarrayError(
+          "Getting a range from a write or modify_exclsuive query is not "
+          "applicable to sparse arrays"));
   }
 
   if (array_query_type != QueryType::READ &&
@@ -955,16 +955,16 @@ Status Subarray::get_range_num(uint32_t dim_idx, uint64_t* range_num) const {
 
   QueryType array_query_type{array_->get_query_type()};
   if ((array_query_type == QueryType::WRITE ||
-       array_query_type == QueryType::WRITE_EXCLUSIVE) &&
+       array_query_type == QueryType::MODIFY_EXCLUSIVE) &&
       !array_->array_schema_latest().dense()) {
-    return LOG_STATUS(
-        Status_SubarrayError("Getting the number of ranges from a write query "
-                             "is not applicable to sparse arrays"));
+    return LOG_STATUS(Status_SubarrayError(
+        "Getting the number of ranges from a write or modify_exclusive query "
+        "is not applicable to sparse arrays"));
   }
 
   if (array_query_type != QueryType::READ &&
       array_query_type != QueryType::WRITE &&
-      array_query_type != QueryType::WRITE_EXCLUSIVE) {
+      array_query_type != QueryType::MODIFY_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SubarrayError("Getting the number of ranges for an unsupported "
                              "query type"));

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -353,9 +353,9 @@ Status Subarray::add_range(
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Invalid dimension index"));
 
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
-  if (array_query_type == QueryType::WRITE) {
+  QueryType array_query_type{array_->get_query_type()};
+  if (array_query_type == QueryType::WRITE ||
+      array_query_type == QueryType::WRITE_EXCLUSIVE) {
     if (!array_->array_schema_latest().dense()) {
       return LOG_STATUS(Status_SubarrayError(
           "Adding a subarray range to a write query is not "
@@ -369,7 +369,8 @@ Status Subarray::add_range(
   }
 
   if (array_query_type != QueryType::READ &&
-      array_query_type != QueryType::WRITE) {
+      array_query_type != QueryType::WRITE &&
+      array_query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Unsupported query type"));
   }
@@ -408,9 +409,9 @@ Status Subarray::add_point_ranges(
         Status_SubarrayError("Cannot add range; Invalid dimension index"));
   }
 
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
-  if (array_query_type == QueryType::WRITE) {
+  QueryType array_query_type{array_->get_query_type()};
+  if (array_query_type == QueryType::WRITE ||
+      array_query_type == QueryType::WRITE_EXCLUSIVE) {
     if (!array_->array_schema_latest().dense()) {
       return LOG_STATUS(Status_SubarrayError(
           "Adding a subarray range to a write query is not "
@@ -424,7 +425,8 @@ Status Subarray::add_point_ranges(
   }
 
   if (array_query_type != QueryType::READ &&
-      array_query_type != QueryType::WRITE) {
+      array_query_type != QueryType::WRITE &&
+      array_query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SubarrayError("Cannot add range; Unsupported query type"));
   }
@@ -500,8 +502,7 @@ Status Subarray::add_range_var(
         Status_SubarrayError("Cannot add range; Range must be variable-sized"));
   }
 
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
+  QueryType array_query_type{array_->get_query_type()};
   if (array_query_type != QueryType::READ) {
     return LOG_STATUS(Status_SubarrayError(
         "Cannot add range; Function applicable only to reads"));
@@ -609,8 +610,7 @@ void Subarray::get_label_range_var_size(
 
 Status Subarray::get_range_var(
     unsigned dim_idx, uint64_t range_idx, void* start, void* end) const {
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
+  QueryType array_query_type{array_->get_query_type()};
   if (array_query_type != QueryType::READ) {
     return LOG_STATUS(Status_SubarrayError(
         "Getting a var range for an unsupported query type"));
@@ -647,9 +647,9 @@ Status Subarray::get_range(
     const void** start,
     const void** end,
     const void** stride) const {
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
-  if (array_query_type == QueryType::WRITE) {
+  QueryType array_query_type{array_->get_query_type()};
+  if (array_query_type == QueryType::WRITE ||
+      array_query_type == QueryType::WRITE_EXCLUSIVE) {
     if (!array_->array_schema_latest().dense())
       return LOG_STATUS(
           Status_SubarrayError("Getting a range from a write query is not "
@@ -862,12 +862,12 @@ bool Subarray::empty() const {
   return range_num() == 0;
 }
 
-Status Subarray::get_query_type(QueryType* type) const {
+QueryType Subarray::get_query_type() const {
   if (array_ == nullptr)
-    return logger_->status(Status_SubarrayError(
+    throw StatusException(Status_SubarrayError(
         "Cannot get query type from array; Invalid array"));
 
-  return array_->get_query_type(type);
+  return array_->get_query_type();
 }
 
 Status Subarray::get_range(
@@ -953,9 +953,9 @@ Status Subarray::get_range_num(uint32_t dim_idx, uint64_t* range_num) const {
     return LOG_STATUS(Status_SubarrayError(msg.str()));
   }
 
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
-  if (array_query_type == QueryType::WRITE &&
+  QueryType array_query_type{array_->get_query_type()};
+  if ((array_query_type == QueryType::WRITE ||
+       array_query_type == QueryType::WRITE_EXCLUSIVE) &&
       !array_->array_schema_latest().dense()) {
     return LOG_STATUS(
         Status_SubarrayError("Getting the number of ranges from a write query "
@@ -963,7 +963,8 @@ Status Subarray::get_range_num(uint32_t dim_idx, uint64_t* range_num) const {
   }
 
   if (array_query_type != QueryType::READ &&
-      array_query_type != QueryType::WRITE) {
+      array_query_type != QueryType::WRITE &&
+      array_query_type != QueryType::WRITE_EXCLUSIVE) {
     return LOG_STATUS(
         Status_SubarrayError("Getting the number of ranges for an unsupported "
                              "query type"));
@@ -1059,8 +1060,7 @@ void Subarray::set_layout(Layout layout) {
 Status Subarray::set_config(const Config& config) {
   config_ = config;
 
-  QueryType array_query_type;
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
+  QueryType array_query_type{array_->get_query_type()};
 
   if (array_query_type == QueryType::READ) {
     bool found = false;
@@ -1170,11 +1170,9 @@ Status Subarray::get_est_result_size_internal(
 
 Status Subarray::get_est_result_size(
     const char* name, uint64_t* size, StorageManager* storage_manager) {
-  QueryType array_query_type;
   // Note: various items below expect array open, get_query_type() providing
   // that audit.
-  RETURN_NOT_OK(array_->get_query_type(&array_query_type));
-
+  QueryType array_query_type{array_->get_query_type()};
   if (array_query_type != QueryType::READ) {
     return LOG_STATUS(Status_SubarrayError(
         "Cannot get estimated result size; unsupported query type"));

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -814,7 +814,7 @@ class Subarray {
       ThreadPool* compute_tp);
 
   /** Retrieves the query type of the subarray's array. */
-  Status get_query_type(QueryType* type) const;
+  QueryType get_query_type() const;
 
   /**
    * Returns the range coordinates (for all dimensions) given a flattened


### PR DESCRIPTION
Implement delete_fragments API.

This API uses the existing `FragmentConsolidator::vacuum` to:
1. vacuum fragments between specified timestamps
2. delete the vacuumed fragments

Note that this API can only be invoked on an array that is _open_ with the new `QueryType::WRITE_EXCLUSIVE`.

---
[sc-15852]

---
TYPE: FEATURE
DESC: Implement delete_fragments API
