### PR TITLE
Update C examples to use non-deprecated functions

### DIFF
--- a/examples/c_api/async.c
+++ b/examples/c_api/async.c
@@ -147,7 +147,7 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   uint64_t subarray_v[] = {1, 4, 1, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/async.c
+++ b/examples/c_api/async.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -147,7 +147,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  uint64_t subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t coords_size = 16;
@@ -161,7 +164,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -194,6 +197,7 @@ void read_array() {
   free((void*)coords_rows);
   free((void*)coords_cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/axes_labels.c
+++ b/examples/c_api/axes_labels.c
@@ -247,10 +247,11 @@ void read_data_array_with_label(
   tiledb_query_alloc(ctx, label_array, TILEDB_READ, &label_query);
 
   // Slice only the label passed in
-  tiledb_subarray_t *label_subarray;
+  tiledb_subarray_t* label_subarray;
   tiledb_subarray_alloc(ctx, label_array, &label_subarray);
   uint64_t label_size = strlen(label);
-  tiledb_subarray_add_range_var(ctx, label_subarray, 0, label, label_size, label, label_size);
+  tiledb_subarray_add_range_var(
+      ctx, label_subarray, 0, label, label_size, label, label_size);
   tiledb_query_set_subarray_t(ctx, label_query, label_subarray);
 
   // Prepare the vector that will hold the result.
@@ -272,7 +273,7 @@ void read_data_array_with_label(
   // Close array
   tiledb_array_close(ctx, label_array);
 
-  tiledb_subarray_t *data_subarray;
+  tiledb_subarray_t* data_subarray;
   tiledb_subarray_alloc(ctx, data_array, &data_subarray);
   tiledb_query_set_subarray_t(ctx, data_query, data_subarray);
 
@@ -281,8 +282,8 @@ void read_data_array_with_label(
     int32_t i = ids_coords[r];
     int64_t j = timestamps_coords[r];
     printf("Adding range for point ( %d, %" PRId64 ")\n", i, j);
-    tiledb_subarray_add_range(ctx, data_subarray, 0,  &i, &i, NULL);
-    tiledb_subarray_add_range(ctx, data_subarray, 1,  &j, &j, NULL);
+    tiledb_subarray_add_range(ctx, data_subarray, 0, &i, &i, NULL);
+    tiledb_subarray_add_range(ctx, data_subarray, 1, &j, &j, NULL);
   }
 
   // Setup the data query's buffers

--- a/examples/c_api/encryption.c
+++ b/examples/c_api/encryption.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -151,7 +151,10 @@ void read_array() {
   tiledb_config_free(&cfg);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int32_t subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 6 elements)
   int data[6];
@@ -160,7 +163,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -176,6 +179,7 @@ void read_array() {
   printf("\n");
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/encryption.c
+++ b/examples/c_api/encryption.c
@@ -153,7 +153,7 @@ void read_array() {
   // Slice only rows 1, 2 and cols 2, 3, 4
   tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
-  int32_t subarray_v[] = {1, 2, 2, 4};
+  int subarray_v[] = {1, 2, 2, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 6 elements)

--- a/examples/c_api/encryption.c
+++ b/examples/c_api/encryption.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <tiledb/tiledb.h>
-#if 0
+
 // Name of array.
 const char* array_name = "encrypted_array";
 
@@ -105,7 +105,7 @@ void write_array() {
   tiledb_config_t* cfg;
   tiledb_error_t* err;
   tiledb_config_alloc(&cfg, &err);
-  tiledb_config_set(cfg, "sm.encryption_type", "TILEDB_AES_256_GCS", &err);
+  tiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM", &err);
   tiledb_config_set(cfg, "sm.encryption_key", encryption_key, &err);
   tiledb_array_set_config(ctx, array, cfg);
   tiledb_array_open(ctx, array, TILEDB_WRITE);
@@ -144,7 +144,7 @@ void read_array() {
   tiledb_config_t* cfg;
   tiledb_error_t* err;
   tiledb_config_alloc(&cfg, &err);
-  tiledb_config_set(cfg, "sm.encryption_type", "TILEDB_AES_256_GCM", &err);
+  tiledb_config_set(cfg, "sm.encryption_type", "AES_256_GCM", &err);
   tiledb_config_set(cfg, "sm.encryption_key", encryption_key, &err);
   tiledb_array_set_config(ctx, array, cfg);
   tiledb_array_open(ctx, array, TILEDB_READ);
@@ -202,8 +202,3 @@ int main() {
 
   return 0;
 }
-#else
-int main() {
-  return 0;
-}
-#endif

--- a/examples/c_api/encryption.c
+++ b/examples/c_api/encryption.c
@@ -151,7 +151,7 @@ void read_array() {
   tiledb_config_free(&cfg);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int32_t subarray_v[] = {1, 2, 2, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/encryption.c
+++ b/examples/c_api/encryption.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <tiledb/tiledb.h>
-
+#if 0
 // Name of array.
 const char* array_name = "encrypted_array";
 
@@ -202,3 +202,8 @@ int main() {
 
   return 0;
 }
+#else
+int main() {
+  return 0;
+}
+#endif

--- a/examples/c_api/filters.c
+++ b/examples/c_api/filters.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -163,7 +163,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t coords_size = 12;
@@ -177,7 +180,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a1", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -202,6 +205,7 @@ void read_array() {
   free((void*)coords_rows);
   free((void*)coords_cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/filters.c
+++ b/examples/c_api/filters.c
@@ -163,7 +163,7 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 2, 2, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/fragment_info.c
+++ b/examples/c_api/fragment_info.c
@@ -98,7 +98,7 @@ void write_array() {
   uint64_t data_size = sizeof(data);
 
   // Write in subarray [1,2], [1,4]
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 2, 1, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/fragment_info.c
+++ b/examples/c_api/fragment_info.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -98,12 +98,15 @@ void write_array() {
   uint64_t data_size = sizeof(data);
 
   // Write in subarray [1,2], [1,4]
-  int subarray[] = {1, 2, 1, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -114,6 +117,7 @@ void write_array() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/fragments_consolidation.c
+++ b/examples/c_api/fragments_consolidation.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -99,12 +99,15 @@ void write_array_1() {
   uint64_t data_size = sizeof(data);
 
   // Write in subarray [1,2], [1,4]
-  int subarray[] = {1, 2, 1, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -115,6 +118,7 @@ void write_array_1() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -135,12 +139,15 @@ void write_array_2() {
   uint64_t data_size = sizeof(data);
 
   // Write in subarray [2,3], [2,3]
-  int subarray[] = {2, 3, 2, 3};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {2, 3, 2, 3};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -151,6 +158,7 @@ void write_array_2() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -204,7 +212,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t coords_size = 64;
@@ -218,7 +229,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -240,6 +251,7 @@ void read_array() {
   }
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/fragments_consolidation.c
+++ b/examples/c_api/fragments_consolidation.c
@@ -99,7 +99,7 @@ void write_array_1() {
   uint64_t data_size = sizeof(data);
 
   // Write in subarray [1,2], [1,4]
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 2, 1, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
@@ -139,7 +139,7 @@ void write_array_2() {
   uint64_t data_size = sizeof(data);
 
   // Write in subarray [2,3], [2,3]
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {2, 3, 2, 3};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
@@ -212,7 +212,7 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 4, 1, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/multi_attribute.c
+++ b/examples/c_api/multi_attribute.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -153,7 +153,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vectors that will hold the results
   char a1[6];
@@ -164,7 +167,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a1", a1, &a1_size);
   tiledb_query_set_data_buffer(ctx, query, "a2", a2, &a2_size);
@@ -182,6 +185,7 @@ void read_array() {
   printf("\n");
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -198,7 +202,10 @@ void read_array_subselect() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the results
   char a1[6];
@@ -207,7 +214,7 @@ void read_array_subselect() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a1", a1, &a1_size);
 
@@ -223,6 +230,7 @@ void read_array_subselect() {
     printf("a1: %c\n", a1[i]);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/multi_attribute.c
+++ b/examples/c_api/multi_attribute.c
@@ -153,7 +153,7 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 2, 2, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
@@ -202,7 +202,7 @@ void read_array_subselect() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 2, 2, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/multi_range_subarray.c
+++ b/examples/c_api/multi_range_subarray.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -138,13 +138,18 @@ void read_array() {
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
+  // Create subarray
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
+
   // Set multi-range subarray to query
   int row_0_start = 1, row_0_end = 2;
   int row_1_start = 4, row_1_end = 4;
   int col_0_start = 1, col_0_end = 4;
-  tiledb_query_add_range(ctx, query, 0, &row_0_start, &row_0_end, NULL);
-  tiledb_query_add_range(ctx, query, 0, &row_1_start, &row_1_end, NULL);
-  tiledb_query_add_range(ctx, query, 1, &col_0_start, &col_0_end, NULL);
+  tiledb_subarray_add_range(ctx, subarray, 0, &row_0_start, &row_0_end, NULL);
+  tiledb_subarray_add_range(ctx, subarray, 0, &row_1_start, &row_1_end, NULL);
+  tiledb_subarray_add_range(ctx, subarray, 1, &col_0_start, &col_0_end, NULL);
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -158,6 +163,7 @@ void read_array() {
   printf("\n");
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/multi_range_subarray.c
+++ b/examples/c_api/multi_range_subarray.c
@@ -139,7 +139,7 @@ void read_array() {
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Create subarray
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   tiledb_query_set_subarray_t(ctx, query, subarray);
 

--- a/examples/c_api/nullable_attribute.c
+++ b/examples/c_api/nullable_attribute.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -158,7 +158,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read the full array
-  int subarray_full[] = {1, 2, 1, 2};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 1, 2};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t a1_data_size = 16;
@@ -180,7 +183,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray_full);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
 
   // Set the query buffers specifying the validity for each data
@@ -226,6 +229,7 @@ void read_array() {
   free((void*)a2_data);
   free((void*)a2_off);
   free((void*)a2_validity_buf);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/query_condition_dense.c
+++ b/examples/c_api/query_condition_dense.c
@@ -214,6 +214,11 @@ void read_array_with_qc(tiledb_ctx_t* ctx, tiledb_query_condition_t* qc) {
   tiledb_array_alloc(ctx, array_name, &array);
   tiledb_array_open(ctx, array, TILEDB_READ);
 
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {0, num_elems - 1};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
+
   // Execute the read query.
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
@@ -226,8 +231,7 @@ void read_array_with_qc(tiledb_ctx_t* ctx, tiledb_query_condition_t* qc) {
       ctx, query, "b", b_data_offsets, &b_offsets_size);
   tiledb_query_set_data_buffer(ctx, query, "c", c_data, &c_size);
   tiledb_query_set_data_buffer(ctx, query, "d", d_data, &d_size);
-  int dims[] = {0, num_elems - 1};
-  tiledb_query_set_subarray(ctx, query, dims);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
 
   if (qc) {
     tiledb_query_set_condition(ctx, query, qc);
@@ -260,6 +264,7 @@ void read_array_with_qc(tiledb_ctx_t* ctx, tiledb_query_condition_t* qc) {
   tiledb_query_finalize(ctx, query);
   tiledb_array_close(ctx, array);
 
+  tiledb_subarray_free(&subarray);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
 }

--- a/examples/c_api/quickstart_dense.c
+++ b/examples/c_api/quickstart_dense.c
@@ -125,7 +125,7 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  tiledb_subarray_t *subarray;
+  tiledb_subarray_t* subarray;
   tiledb_subarray_alloc(ctx, array, &subarray);
   int subarray_v[] = {1, 2, 2, 4};
   tiledb_subarray_set_subarray(ctx, subarray, subarray_v);

--- a/examples/c_api/quickstart_dense.c
+++ b/examples/c_api/quickstart_dense.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -125,7 +125,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t *subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 6 elements)
   int data[6];
@@ -134,7 +137,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -150,6 +153,7 @@ void read_array() {
   printf("\n");
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/quickstart_sparse.c
+++ b/examples/c_api/quickstart_sparse.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -131,7 +131,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t coords_size = 12;
@@ -145,7 +148,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -170,6 +173,7 @@ void read_array() {
   free((void*)coords_rows);
   free((void*)coords_cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/quickstart_sparse_heter.c
+++ b/examples/c_api/quickstart_sparse_heter.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -160,13 +160,17 @@ void read_array() {
   tiledb_query_set_data_buffer(ctx, query, "rows", rows, &row_coords_size);
   tiledb_query_set_data_buffer(ctx, query, "cols", cols, &cols_coords_size);
 
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
+
   int row_start = 1, row_end = 2;
   float cols_start = 1,
         cols_end = 2;  // note 'float', type needs to match for item being added
-  tiledb_query_add_range(
-      ctx, query, 0, &row_start, &row_end, NULL);  //'0' dimension, rows
-  tiledb_query_add_range(
-      ctx, query, 1, &cols_start, &cols_end, NULL);  //'1' dimension, cols
+  tiledb_subarray_add_range(
+      ctx, subarray, 0, &row_start, &row_end, NULL);  //'0' dimension, rows
+  tiledb_subarray_add_range(
+      ctx, subarray, 1, &cols_start, &cols_end, NULL);  //'1' dimension, cols
 
   // Submit query
   tiledb_query_submit(ctx, query);
@@ -187,6 +191,7 @@ void read_array() {
   free((void*)rows);
   free((void*)cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/quickstart_sparse_string.c
+++ b/examples/c_api/quickstart_sparse_string.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -156,11 +156,16 @@ void read_array() {
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
 
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+
   // Slice only rows "bb", "c" and cols 3, 4
   int cols_start = 2, cols_end = 4;
-  tiledb_query_add_range_var(ctx, query, 0, "a", strlen("a"), "c", strlen("c"));
-  tiledb_query_add_range(
-      ctx, query, 1, &cols_start, &cols_end, NULL);  //'1', cols
+  tiledb_subarray_add_range_var(
+      ctx, subarray, 0, "a", strlen("a"), "c", strlen("c"));
+  tiledb_subarray_add_range(
+      ctx, subarray, 1, &cols_start, &cols_end, NULL);  //'1', cols
+  tiledb_query_set_subarray_t(ctx, query, subarray);
 
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
@@ -194,6 +199,7 @@ void read_array() {
   free((void*)rows);
   free((void*)cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/reading_dense_layouts.c
+++ b/examples/c_api/reading_dense_layouts.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -141,7 +141,10 @@ void read_array(tiledb_layout_t layout) {
       domain[3]);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vectors that will hold the results
   int coords_rows[6];
@@ -153,7 +156,7 @@ void read_array(tiledb_layout_t layout) {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, layout);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -175,6 +178,7 @@ void read_array(tiledb_layout_t layout) {
   }
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/reading_incomplete.c
+++ b/examples/c_api/reading_incomplete.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -200,7 +200,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare buffers such that the results **cannot** fit
   int* coords_rows = (int*)malloc(sizeof(int));
@@ -222,7 +225,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a1", a1_data, &a1_data_size);
   tiledb_query_set_data_buffer(ctx, query, "a2", a2_data, &a2_data_size);
@@ -288,6 +291,7 @@ void read_array() {
   free((void*)a1_data);
   free((void*)a2_data);
   free((void*)a2_off);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/reading_sparse_layouts.c
+++ b/examples/c_api/reading_sparse_layouts.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -147,7 +147,10 @@ void read_array(tiledb_layout_t layout) {
       domain[3]);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t coords_size = 24;
@@ -161,7 +164,7 @@ void read_array(tiledb_layout_t layout) {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, layout);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -186,6 +189,7 @@ void read_array(tiledb_layout_t layout) {
   free((void*)coords_rows);
   free((void*)coords_cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/using_tiledb_stats.c
+++ b/examples/c_api/using_tiledb_stats.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -130,7 +130,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read a slice of 3,000 rows.
-  int subarray[] = {1, 3000, 1, 12000};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 3000, 1, 12000};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result.
   uint64_t num_cells = 3000 * 12000;
@@ -140,7 +143,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -155,6 +158,7 @@ void read_array() {
 
   // Clean up
   free(data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/variable_length.c
+++ b/examples/c_api/variable_length.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -149,7 +149,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Slice only rows 1, 2 and cols 2, 3, 4
-  int subarray[] = {1, 2, 2, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 2, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Set maximum buffer sizes
   uint64_t a1_data_size = 34;
@@ -166,7 +169,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a1", (void*)a1_data, &a1_data_size);
   tiledb_query_set_offsets_buffer(ctx, query, "a1", a1_off, &a1_off_size);
@@ -205,6 +208,7 @@ void read_array() {
   free((void*)a1_off);
   free((void*)a2_data);
   free((void*)a2_off);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/writing_dense_global.c
+++ b/examples/c_api/writing_dense_global.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -97,13 +97,16 @@ void write_array() {
   int data[] = {1, 2, 3, 4, 5, 6, 7, 8};
   uint64_t data_size = 4 * sizeof(int);  // We will write 4 cells at a time
 
-  int subarray[] = {1, 4, 1, 2};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 2};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Submit first query
@@ -122,6 +125,7 @@ void write_array() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -138,7 +142,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 16 elements)
   int data[16];
@@ -147,7 +154,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -162,6 +169,7 @@ void read_array() {
     printf("%d\n", data[i]);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/writing_dense_global_expansion.c
+++ b/examples/c_api/writing_dense_global_expansion.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -100,13 +100,16 @@ void write_array_global() {
   int data[] = {1, 2, 3, 4, 5, 6, 7, 8};
   uint64_t data_size = sizeof(data);
 
-  int subarray[] = {1, 4, 1, 2};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 2};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Submit query
@@ -119,6 +122,7 @@ void write_array_global() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -138,13 +142,16 @@ void write_array_row_major() {
   int data[] = {9, 10, 11, 12};
   uint64_t data_size = sizeof(data);
 
-  int subarray[] = {1, 4, 3, 3};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 3, 3};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Submit query
@@ -154,6 +161,7 @@ void write_array_row_major() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -170,7 +178,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read the entire array
-  int subarray[] = {1, 4, 1, 3};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 3};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 6 elements)
   int data[12];
@@ -179,7 +190,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -194,6 +205,7 @@ void read_array() {
     printf("%d\n", data[i]);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/writing_dense_multiple.c
+++ b/examples/c_api/writing_dense_multiple.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -97,13 +97,16 @@ void write_array_1() {
   int data[] = {1, 2, 3, 4};
   uint64_t data_size = sizeof(data);
 
-  int subarray[] = {1, 2, 1, 2};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 2, 1, 2};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Submit query
@@ -113,6 +116,7 @@ void write_array_1() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -132,13 +136,16 @@ void write_array_2() {
   int data[] = {5, 6, 7, 8, 9, 10, 11, 12};
   uint64_t data_size = sizeof(data);
 
-  int subarray[] = {2, 3, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {2, 3, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Submit query
@@ -148,6 +155,7 @@ void write_array_2() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -164,7 +172,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 16 elements)
   int data[16];
@@ -173,7 +184,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -188,6 +199,7 @@ void read_array() {
     printf("%d\n", data[i]);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/writing_dense_padding.c
+++ b/examples/c_api/writing_dense_padding.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -97,13 +97,16 @@ void write_array() {
   int data[] = {1, 2, 3, 4};
   uint64_t data_size = sizeof(data);
 
-  int subarray[] = {2, 3, 1, 2};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {2, 3, 1, 2};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Create the query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
   // Submit query
@@ -113,6 +116,7 @@ void write_array() {
   tiledb_array_close(ctx, array);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);
@@ -129,7 +133,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Prepare the vector that will hold the result (of size 16 elements)
   int data[16];
@@ -138,7 +145,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
 
@@ -153,6 +160,7 @@ void read_array() {
     printf("%d\n", data[i]);
 
   // Clean up
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/writing_sparse_global.c
+++ b/examples/c_api/writing_sparse_global.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -153,7 +153,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Calculate maximum buffer sizes
   uint64_t coords_size = 12;
@@ -167,7 +170,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -192,6 +195,7 @@ void read_array() {
   free((void*)coords_rows);
   free((void*)coords_cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);

--- a/examples/c_api/writing_sparse_multiple.c
+++ b/examples/c_api/writing_sparse_multiple.c
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -154,7 +154,10 @@ void read_array() {
   tiledb_array_open(ctx, array, TILEDB_READ);
 
   // Read the entire array
-  int subarray[] = {1, 4, 1, 4};
+  tiledb_subarray_t* subarray;
+  tiledb_subarray_alloc(ctx, array, &subarray);
+  int subarray_v[] = {1, 4, 1, 4};
+  tiledb_subarray_set_subarray(ctx, subarray, subarray_v);
 
   // Calculate maximum buffer sizes
   uint64_t coords_size = 20;
@@ -168,7 +171,7 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-  tiledb_query_set_subarray(ctx, query, subarray);
+  tiledb_query_set_subarray_t(ctx, query, subarray);
   tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
   tiledb_query_set_data_buffer(ctx, query, "a", data, &data_size);
   tiledb_query_set_data_buffer(ctx, query, "rows", coords_rows, &coords_size);
@@ -193,6 +196,7 @@ void read_array() {
   free((void*)coords_rows);
   free((void*)coords_cols);
   free((void*)data);
+  tiledb_subarray_free(&subarray);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
   tiledb_ctx_free(&ctx);


### PR DESCRIPTION
This PR updates the C examples to use current, non-deprecated functions similar to how #3380 updated the C++ examples.

It currently updates only the range setting to `subarray` use.  Three examples still use a deprecated group creation function.  The examples still run as before. No actual code changes in the library, the current Windows CI failure is likely unrelated and may go away under a re-run (as it did in #3380 too).

---
TYPE: IMPROVEMENT 
DESC: Update C examples
