### PR TITLE
Remove buffer usage from Array Schema on disk serialization.

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -134,7 +134,8 @@ TEST_CASE(
   std::string array_uri(arrays_dir + "/dense_array_v1_3_0");
   REQUIRE_THROWS_WITH(
       Array(ctx, array_uri, TILEDB_READ),
-      Catch::Contains("Failed to load maximum tile chunk size"));
+      "[TileDB::Array] Error: [TileDB::StorageManager] Error: Reading data "
+      "past end of serialized data size.");
 }
 
 template <typename T>

--- a/test/src/unit-domain.cc
+++ b/test/src/unit-domain.cc
@@ -113,19 +113,18 @@ TEST_CASE("Domain: Test deserialization", "[domain][deserialize") {
   dom_buffer_offset<uint64_t, 63>(p) = domain_size2;
   dom_buffer_offset<uint8_t, 71>(p) = null_tile_extent2;
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
-  auto&& [st_dom, dom]{Domain::deserialize(
-      &constbuffer, 10, Layout::ROW_MAJOR, Layout::ROW_MAJOR)};
-  REQUIRE(st_dom.ok());
-  CHECK(dom.value()->dim_num() == dim_num);
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
+  auto dom{Domain::deserialize(
+      deserializer, 10, Layout::ROW_MAJOR, Layout::ROW_MAJOR)};
+  CHECK(dom->dim_num() == dim_num);
 
-  auto dim1{dom.value()->dimension_ptr("d1")};
+  auto dim1{dom->dimension_ptr("d1")};
   CHECK(dim1->name() == dimension_name1);
   CHECK(dim1->type() == type1);
   CHECK(dim1->cell_val_num() == cell_val_num1);
   CHECK(dim1->filters().size() == num_filters1);
 
-  auto dim2{dom.value()->dimension_ptr("d2")};
+  auto dim2{dom->dimension_ptr("d2")};
   CHECK(dim2->name() == dimension_name2);
   CHECK(dim2->type() == type2);
   CHECK(dim2->cell_val_num() == cell_val_num2);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -557,23 +557,23 @@ void ArraySchema::serialize(Serializer& serializer) const {
   // the in-memory `version_`, we will serialize every array schema
   // as the latest version.
   const uint32_t version = constants::format_version;
-  serializer.write(version);
+  serializer.write<uint32_t>(version);
 
   // Write allows_dups
-  serializer.write(allows_dups_);
+  serializer.write<uint8_t>(allows_dups_);
 
   // Write array type
   auto array_type = (uint8_t)array_type_;
-  serializer.write(array_type);
+  serializer.write<uint8_t>(array_type);
 
   // Write tile and cell order
   auto tile_order = (uint8_t)tile_order_;
-  serializer.write(tile_order);
+  serializer.write<uint8_t>(tile_order);
   auto cell_order = (uint8_t)cell_order_;
-  serializer.write(cell_order);
+  serializer.write<uint8_t>(cell_order);
 
   // Write capacity
-  serializer.write(capacity_);
+  serializer.write<uint64_t>(capacity_);
 
   // Write coords filters
   coords_filters_.serialize(serializer);
@@ -589,7 +589,7 @@ void ArraySchema::serialize(Serializer& serializer) const {
 
   // Write attributes
   auto attribute_num = (uint32_t)attributes_.size();
-  serializer.write(attribute_num);
+  serializer.write<uint32_t>(attribute_num);
   for (auto& attr : attributes_) {
     attr->serialize(serializer, version);
   }
@@ -601,7 +601,7 @@ void ArraySchema::serialize(Serializer& serializer) const {
       throw StatusException(Status_ArraySchemaError(
           "Overflow when attempting to serialize label number."));
     }
-    serializer.write(label_num);
+    serializer.write<uint32_t>(label_num);
     for (auto& label : dimension_labels_) {
       label->serialize(serializer, version);
     }

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -597,10 +597,11 @@ void ArraySchema::serialize(Serializer& serializer) const {
   // Experimental: Write dimension labels
   if constexpr (is_experimental_build) {
     auto label_num = static_cast<uint32_t>(dimension_labels_.size());
-    if (label_num != dimension_labels_.size())
+    if (label_num != dimension_labels_.size()) {
       throw StatusException(Status_ArraySchemaError(
           "Overflow when attempting to serialize label number."));
-    serializer.write(&label_num);
+    }
+    serializer.write(label_num);
     for (auto& label : dimension_labels_) {
       label->serialize(serializer, version);
     }

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -286,10 +286,10 @@ class ArraySchema {
   /**
    * Serializes the array schema object into a buffer.
    *
-   * @param buff The buffer the array schema is serialized into.
+   * @param serializer The object the array schema is serialized into.
    * @return Status
    */
-  Status serialize(Buffer* buff) const;
+  void serialize(Serializer& serializer) const;
 
   /** Returns the tile order. */
   Layout tile_order() const;
@@ -349,11 +349,11 @@ class ArraySchema {
   /**
    * It assigns values to the members of the object from the input buffer.
    *
-   * @param buff The binary representation of the object to read from.
+   * @param deserializer The deserializer to deserialize from.
    * @param uri The uri of the Array.
    * @return A new ArraySchema.
    */
-  static ArraySchema deserialize(ConstBuffer* buff, const URI& uri);
+  static ArraySchema deserialize(Deserializer& deserializer, const URI& uri);
 
   /** Returns the array domain. */
   inline const Domain& domain() const {

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -208,15 +208,15 @@ void Attribute::serialize(
     Serializer& serializer, const uint32_t version) const {
   // Write attribute name
   auto attribute_name_size = (uint32_t)name_.size();
-  serializer.write(attribute_name_size);
+  serializer.write<uint32_t>(attribute_name_size);
   serializer.write(name_.data(), attribute_name_size);
 
   // Write type
   auto type = (uint8_t)type_;
-  serializer.write(type);
+  serializer.write<uint8_t>(type);
 
   // Write cell_val_num_
-  serializer.write(cell_val_num_);
+  serializer.write<uint32_t>(cell_val_num_);
 
   // Write filter pipeline
   filters_.serialize(serializer);
@@ -225,18 +225,18 @@ void Attribute::serialize(
   if (version >= 6) {
     auto fill_value_size = (uint64_t)fill_value_.size();
     assert(fill_value_size != 0);
-    serializer.write(fill_value_size);
+    serializer.write<uint64_t>(fill_value_size);
     serializer.write(fill_value_.data(), fill_value_.size());
   }
 
   // Write nullable
   if (version >= 7) {
-    serializer.write(nullable_);
+    serializer.write<uint8_t>(nullable_);
   }
 
   // Write validity fill value
   if (version >= 7) {
-    serializer.write(fill_value_validity_);
+    serializer.write<uint8_t>(fill_value_validity_);
   }
 }
 

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -134,12 +134,11 @@ class Attribute {
   /**
    * Populates the object members from the data in the input binary buffer.
    *
-   * @param buff The buffer to deserialize from.
+   * @param deserializer The deserializer to deserialize from.
    * @param version The format spec version.
-   * @return Status and Attribute
+   * @return Attribute
    */
-  static tuple<Status, optional<Attribute>> deserialize(
-      ConstBuffer* buff, uint32_t version);
+  static Attribute deserialize(Deserializer& deserializer, uint32_t version);
 
   /** Dumps the attribute contents in ASCII form in the selected output. */
   void dump(FILE* out) const;
@@ -153,11 +152,11 @@ class Attribute {
   /**
    * Serializes the object members into a binary buffer.
    *
-   * @param buff The buffer to serialize the data into.
+   * @param serializer The object the attribute is serialized into.
    * @param version The format spec version.
    * @return Status
    */
-  const Status serialize(Buffer* buff, uint32_t version) const;
+  void serialize(Serializer& serializer, uint32_t version) const;
 
   /**
    * Sets the attribute number of values per cell. Note that if the attribute

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1305,17 +1305,17 @@ void Dimension::serialize(Serializer& serializer, uint32_t version) const {
 
   // Write dimension name
   auto dimension_name_size = (uint32_t)name_.size();
-  serializer.write(dimension_name_size);
+  serializer.write<uint32_t>(dimension_name_size);
   serializer.write(name_.data(), dimension_name_size);
 
   // Applicable only to version >= 5
   if (version >= 5) {
     // Write type
     auto type = (uint8_t)type_;
-    serializer.write(type);
+    serializer.write<uint8_t>(type);
 
     // Write cell_val_num_
-    serializer.write(cell_val_num_);
+    serializer.write<uint32_t>(cell_val_num_);
 
     // Write filter pipeline
     filters_.serialize(serializer);
@@ -1323,11 +1323,11 @@ void Dimension::serialize(Serializer& serializer, uint32_t version) const {
 
   // Write domain and tile extent
   uint64_t domain_size = (is_str) ? 0 : 2 * coord_size();
-  serializer.write(domain_size);
+  serializer.write<uint64_t>(domain_size);
   serializer.write(domain_.data(), domain_size);
 
   auto null_tile_extent = (uint8_t)(tile_extent_ ? 0 : 1);
-  serializer.write(null_tile_extent);
+  serializer.write<uint8_t>(null_tile_extent);
   if (tile_extent_) {
     serializer.write(tile_extent_.data(), tile_extent_.size());
   }

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -175,19 +175,13 @@ Status Dimension::set_cell_val_num(unsigned int cell_val_num) {
   return Status::Ok();
 }
 
-tuple<Status, optional<shared_ptr<Dimension>>> Dimension::deserialize(
-    ConstBuffer* buff, uint32_t version, Datatype type) {
+shared_ptr<Dimension> Dimension::deserialize(
+    Deserializer& deserializer, uint32_t version, Datatype type) {
   Status st;
   // Load dimension name
-  uint32_t dimension_name_size;
-  st = buff->read(&dimension_name_size, sizeof(uint32_t));
-  if (!st.ok())
-    return {st, nullopt};
-  std::string name;
-  name.resize(dimension_name_size);
-  st = buff->read(&name[0], dimension_name_size);
-  if (!st.ok())
-    return {st, nullopt};
+  auto dimension_name_size = deserializer.read<uint32_t>();
+  std::string name(
+      deserializer.get_ptr<char>(dimension_name_size), dimension_name_size);
 
   Datatype datatype;
   uint32_t cell_val_num;
@@ -195,21 +189,14 @@ tuple<Status, optional<shared_ptr<Dimension>>> Dimension::deserialize(
   // Applicable only to version >= 5
   if (version >= 5) {
     // Load type
-    uint8_t type;
-    st = buff->read(&type, sizeof(uint8_t));
-    if (!st.ok())
-      return {st, nullopt};
+    auto type = deserializer.read<uint8_t>();
     datatype = (Datatype)type;
 
     // Load cell_val_num_
-    st = buff->read(&cell_val_num, sizeof(uint32_t));
-    if (!st.ok())
-      return {st, nullopt};
+    cell_val_num = deserializer.read<uint32_t>();
 
     // Load filter pipeline
-    // Note: Security validation delegated to invoked API
-    auto filterpipeline{FilterPipeline::deserialize(buff, version)};
-    filter_pipeline = filterpipeline;
+    filter_pipeline = FilterPipeline::deserialize(deserializer, version);
   } else {
     datatype = type;
     cell_val_num = (datatype_is_string(datatype)) ? constants::var_num : 1;
@@ -218,44 +205,32 @@ tuple<Status, optional<shared_ptr<Dimension>>> Dimension::deserialize(
   // Load domain
   uint64_t domain_size = 0;
   if (version >= 5) {
-    st = buff->read(&domain_size, sizeof(uint64_t));
-    if (!st.ok())
-      return {st, nullopt};
+    domain_size = deserializer.read<uint64_t>();
   } else {
     domain_size = 2 * datatype_size(datatype);
   }
   Range domain;
   if (domain_size != 0) {
-    std::vector<uint8_t> tmp(domain_size);
-    st = buff->read(&tmp[0], domain_size);
-    if (!st.ok())
-      return {st, nullopt};
-    domain = Range(&tmp[0], domain_size);
+    domain = Range(deserializer.get_ptr<uint8_t>(domain_size), domain_size);
   }
 
   ByteVecValue tile_extent;
   // Load tile extent
   tile_extent.assign_as_void();
-  uint8_t null_tile_extent;
-  st = buff->read(&null_tile_extent, sizeof(uint8_t));
-  if (!st.ok())
-    return {st, nullopt};
+  auto null_tile_extent = deserializer.read<uint8_t>();
   if (null_tile_extent == 0) {
     tile_extent.resize(datatype_size(datatype));
-    st = buff->read(tile_extent.data(), datatype_size(datatype));
-    if (!st.ok())
-      return {st, nullopt};
+    deserializer.read(tile_extent.data(), datatype_size(datatype));
   }
 
-  return {Status::Ok(),
-          tiledb::common::make_shared<Dimension>(
-              HERE(),
-              name,
-              datatype,
-              cell_val_num,
-              domain,
-              filter_pipeline,
-              tile_extent)};
+  return tiledb::common::make_shared<Dimension>(
+      HERE(),
+      name,
+      datatype,
+      cell_val_num,
+      domain,
+      filter_pipeline,
+      tile_extent);
 }
 
 const Range& Dimension::domain() const {
@@ -1323,40 +1298,39 @@ bool Dimension::smaller_than<char>(
 // domain (void* - domain_size)
 // null_tile_extent (uint8_t)
 // tile_extent (void* - type_size)
-Status Dimension::serialize(Buffer* buff, uint32_t version) {
+void Dimension::serialize(Serializer& serializer, uint32_t version) const {
   // Sanity check
   auto is_str = datatype_is_string(type_);
   assert(is_str || !domain_.empty());
 
   // Write dimension name
   auto dimension_name_size = (uint32_t)name_.size();
-  RETURN_NOT_OK(buff->write(&dimension_name_size, sizeof(uint32_t)));
-  RETURN_NOT_OK(buff->write(name_.c_str(), dimension_name_size));
+  serializer.write(dimension_name_size);
+  serializer.write(name_.data(), dimension_name_size);
 
   // Applicable only to version >= 5
   if (version >= 5) {
     // Write type
     auto type = (uint8_t)type_;
-    RETURN_NOT_OK(buff->write(&type, sizeof(uint8_t)));
+    serializer.write(type);
 
     // Write cell_val_num_
-    RETURN_NOT_OK(buff->write(&cell_val_num_, sizeof(uint32_t)));
+    serializer.write(cell_val_num_);
 
     // Write filter pipeline
-    RETURN_NOT_OK(filters_.serialize(buff));
+    filters_.serialize(serializer);
   }
 
   // Write domain and tile extent
   uint64_t domain_size = (is_str) ? 0 : 2 * coord_size();
-  RETURN_NOT_OK(buff->write(&domain_size, sizeof(uint64_t)));
-  RETURN_NOT_OK(buff->write(domain_.data(), domain_size));
+  serializer.write(domain_size);
+  serializer.write(domain_.data(), domain_size);
 
   auto null_tile_extent = (uint8_t)(tile_extent_ ? 0 : 1);
-  RETURN_NOT_OK(buff->write(&null_tile_extent, sizeof(uint8_t)));
-  if (tile_extent_)
-    RETURN_NOT_OK(buff->write(tile_extent_.data(), tile_extent_.size()));
-
-  return Status::Ok();
+  serializer.write(null_tile_extent);
+  if (tile_extent_) {
+    serializer.write(tile_extent_.data(), tile_extent_.size());
+  }
 }
 
 Status Dimension::set_domain(const void* domain) {

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -142,13 +142,13 @@ class Dimension {
   /**
    * Populates the object members from the data in the input binary buffer.
    *
-   * @param buff The buffer to deserialize from.
+   * @param deserializer The deserializer to deserialize from.
    * @param type The type of the dimension.
    * @param version The array schema version.
-   * @return Status and Dimension
+   * @return Dimension
    */
-  static tuple<Status, optional<shared_ptr<Dimension>>> deserialize(
-      ConstBuffer* buff, uint32_t version, Datatype type);
+  static shared_ptr<Dimension> deserialize(
+      Deserializer& deserializer, uint32_t version, Datatype type);
 
   /** Returns the domain. */
   const Range& domain() const;
@@ -686,11 +686,11 @@ class Dimension {
   /**
    * Serializes the object members into a binary buffer.
    *
-   * @param buff The buffer to serialize the data into.
+   * @param serializer The object the dimension is serialized into.
    * @param version The array schema version
    * @return Status
    */
-  Status serialize(Buffer* buff, uint32_t version);
+  void serialize(Serializer& serializer, uint32_t version) const;
 
   /** Sets the domain. */
   Status set_domain(const void* domain);

--- a/tiledb/sm/array_schema/dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/dimension_label_reference.cc
@@ -231,23 +231,23 @@ void DimensionLabelReference::dump(FILE* out) const {
 //| URI                       | `char []`  |
 void DimensionLabelReference::serialize(
     Serializer& serializer, uint32_t) const {
-  serializer.write(dim_id_);
+  serializer.write<uint32_t>(dim_id_);
   auto label_order_int = static_cast<uint8_t>(label_order_);
-  serializer.write(label_order_int);
+  serializer.write<uint8_t>(label_order_int);
   auto label_type_int = static_cast<uint8_t>(label_type_);
-  serializer.write(label_type_int);
-  serializer.write(label_cell_val_num_);
+  serializer.write<uint8_t>(label_type_int);
+  serializer.write<uint32_t>(label_cell_val_num_);
   auto is_external_int = static_cast<uint8_t>(is_external_);
-  serializer.write(is_external_int);
+  serializer.write<uint8_t>(is_external_int);
   auto relative_uri_int = static_cast<uint8_t>(relative_uri_);
-  serializer.write(relative_uri_int);
+  serializer.write<uint8_t>(relative_uri_int);
   uint64_t label_domain_size =
       datatype_is_string(label_type_) ? 0 : 2 * datatype_size(label_type_);
-  serializer.write(label_domain_size);
+  serializer.write<uint64_t>(label_domain_size);
   uint64_t name_size{name_.size()};
-  serializer.write(name_size);
+  serializer.write<uint64_t>(name_size);
   uint64_t uri_size{uri_.to_string().size()};
-  serializer.write(uri_size);
+  serializer.write<uint64_t>(uri_size);
   serializer.write(label_domain_.data(), label_domain_size);
   serializer.write(name_.c_str(), name_size);
   serializer.write(uri_.c_str(), uri_size);

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/common.h"
 #include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 #include "tiledb/type/range/range.h"
 
 using namespace tiledb::common;
@@ -123,12 +124,12 @@ class DimensionLabelReference {
   /**
    * Populates the object members from the data in the input binary buffer.
    *
-   * @param buff The buffer to deserialize from.
+   * @param deserializer The deserializer to deserialize from.
    * @param version The array schema version.
    * @return DimensionLabelReference
    */
   static shared_ptr<DimensionLabelReference> deserialize(
-      ConstBuffer* buff, uint32_t version);
+      Deserializer& deserializer, uint32_t version);
 
   /** Index of the dimension the label is attached to. */
   inline dimension_size_type dimension_id() const {
@@ -192,10 +193,10 @@ class DimensionLabelReference {
   /**
    * Serializes the dimension label object into a buffer.
    *
-   * @param buff The buffer the array schema is serialized into.
+   * @param serializer The object the dimension is serialized into.
    * @param version The array schema version.
    */
-  void serialize(Buffer* buff, uint32_t version) const;
+  void serialize(Serializer& serializer, uint32_t version) const;
 
   /** Returns the URI of the dimension label. */
   inline const URI& uri() const {

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -588,7 +588,7 @@ bool Domain::null_tile_extents() const {
 // ...
 void Domain::serialize(Serializer& serializer, uint32_t version) const {
   // Write dimensions
-  serializer.write(dim_num_);
+  serializer.write<uint32_t>(dim_num_);
   for (const auto& dim : dimensions_) {
     dim->serialize(serializer, version);
   }

--- a/tiledb/sm/array_schema/domain.h
+++ b/tiledb/sm/array_schema/domain.h
@@ -39,6 +39,7 @@
 #include "tiledb/common/types/dynamic_typed_datum.h"
 #include "tiledb/common/types/untyped_datum.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 #include <vector>
 
@@ -186,12 +187,12 @@ class Domain {
   /**
    * Populates the object members from the data in the input binary buffer.
    *
-   * @param buff The buffer to deserialize from.
+   * @param deserializer The deserializer to deserialize from.
    * @param version The array schema version.
    * @return Status and Domain
    */
-  static tuple<Status, optional<shared_ptr<Domain>>> deserialize(
-      ConstBuffer* buff,
+  static shared_ptr<Domain> deserialize(
+      Deserializer& deserializer,
       uint32_t version,
       Layout cell_order,
       Layout tile_order);
@@ -392,11 +393,11 @@ class Domain {
   /**
    * Serializes the object members into a binary buffer.
    *
-   * @param buff The buffer to serialize the data into.
+   * @param serializer The object the array schema is serialized into.
    * @param version The array schema version.
    * @return Status
    */
-  Status serialize(Buffer* buff, uint32_t version);
+  void serialize(Serializer& serializer, uint32_t version) const;
 
   /**
    * For every dimension that has a null tile extent, it sets

--- a/tiledb/sm/array_schema/test/unit_dimension.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension.cc
@@ -134,20 +134,17 @@ TEST_CASE("Dimension: Test deserialize,int32", "[dimension][deserialize]") {
   dim_buffer_offset<uint8_t, 35>(p) = null_tile_extent;
   dim_buffer_offset<int32_t, 36>(p) = tile_extent;
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
-  auto&& [st_dim, dim]{
-      Dimension::deserialize(&constbuffer, 10, Datatype::INT32)};
-
-  REQUIRE(st_dim.ok());
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
+  auto dim = Dimension::deserialize(deserializer, 10, Datatype::INT32);
 
   // Check name
-  CHECK(dim.value()->name() == dimension_name);
+  CHECK(dim->name() == dimension_name);
 
   // Check type
-  CHECK(dim.value()->type() == Datatype::INT32);
+  CHECK(dim->type() == Datatype::INT32);
 
-  CHECK(dim.value()->cell_val_num() == 1);
-  CHECK(dim.value()->var_size() == false);
+  CHECK(dim->cell_val_num() == 1);
+  CHECK(dim->var_size() == false);
 }
 
 TEST_CASE("Dimension: Test deserialize,string", "[dimension][deserialize]") {
@@ -176,16 +173,14 @@ TEST_CASE("Dimension: Test deserialize,string", "[dimension][deserialize]") {
   dim_buffer_offset<uint64_t, 19>(p) = domain_size;
   dim_buffer_offset<uint8_t, 27>(p) = null_tile_extent;
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
-  auto&& [st_dim, dim]{
-      Dimension::deserialize(&constbuffer, 10, Datatype::INT32)};
-  REQUIRE(st_dim.ok());
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
+  auto dim = Dimension::deserialize(deserializer, 10, Datatype::INT32);
   // Check name
-  CHECK(dim.value()->name() == dimension_name);
+  CHECK(dim->name() == dimension_name);
   // Check type
-  CHECK(dim.value()->type() == type);
-  CHECK(dim.value()->cell_val_num() == constants::var_num);
-  CHECK(dim.value()->var_size() == true);
+  CHECK(dim->type() == type);
+  CHECK(dim->cell_val_num() == constants::var_num);
+  CHECK(dim->var_size() == true);
 }
 
 typedef tuple<

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -572,9 +572,8 @@ BitWidthReductionFilter* BitWidthReductionFilter::clone_impl() const {
   return clone;
 }
 
-Status BitWidthReductionFilter::serialize_impl(Buffer* buff) const {
-  RETURN_NOT_OK(buff->write(&max_window_size_, sizeof(uint32_t)));
-  return Status::Ok();
+void BitWidthReductionFilter::serialize_impl(Serializer& serializer) const {
+  serializer.write(max_window_size_);
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -573,7 +573,7 @@ BitWidthReductionFilter* BitWidthReductionFilter::clone_impl() const {
 }
 
 void BitWidthReductionFilter::serialize_impl(Serializer& serializer) const {
-  serializer.write(max_window_size_);
+  serializer.write<uint32_t>(max_window_size_);
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -201,7 +201,7 @@ class BitWidthReductionFilter : public Filter {
   Status set_option_impl(FilterOption option, const void* value) override;
 
   /** Serializes this filter's metadata to the given buffer. */
-  Status serialize_impl(Buffer* buff) const override;
+  void serialize_impl(Serializer& serializer) const override;
 
   /**
    * Writes the given value of type T to the given buffer after compressing

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -649,8 +649,8 @@ void CompressionFilter::serialize_impl(Serializer& serializer) const {
     return;
   }
   auto compressor_char = static_cast<uint8_t>(compressor_);
-  serializer.write(compressor_char);
-  serializer.write(level_);
+  serializer.write<uint8_t>(compressor_char);
+  serializer.write<int32_t>(level_);
 }
 
 void CompressionFilter::init_compression_resource_pool(uint64_t size) {

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -644,15 +644,13 @@ uint64_t CompressionFilter::overhead(const Tile& tile, uint64_t nbytes) const {
   }
 }
 
-Status CompressionFilter::serialize_impl(Buffer* buff) const {
+void CompressionFilter::serialize_impl(Serializer& serializer) const {
   if (compressor_ == Compressor::NO_COMPRESSION) {
-    return Status::Ok();
+    return;
   }
   auto compressor_char = static_cast<uint8_t>(compressor_);
-  RETURN_NOT_OK(buff->write(&compressor_char, sizeof(uint8_t)));
-  RETURN_NOT_OK(buff->write(&level_, sizeof(int32_t)));
-
-  return Status::Ok();
+  serializer.write(compressor_char);
+  serializer.write(level_);
 }
 
 void CompressionFilter::init_compression_resource_pool(uint64_t size) {

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -230,7 +230,7 @@ class CompressionFilter : public Filter {
   Status set_option_impl(FilterOption option, const void* value) override;
 
   /** Serializes this filter's metadata to the given buffer. */
-  Status serialize_impl(Buffer* buff) const override;
+  void serialize_impl(Serializer& serializer) const override;
 
   /** Initializes the compression resource pool */
   void init_compression_resource_pool(uint64_t size) override;

--- a/tiledb/sm/filter/filter.cc
+++ b/tiledb/sm/filter/filter.cc
@@ -68,13 +68,13 @@ Status Filter::set_option(FilterOption option, const void* value) {
 // filter metadata (char[])
 void Filter::serialize(Serializer& serializer) const {
   auto type = static_cast<uint8_t>(type_);
-  serializer.write(type);
+  serializer.write<uint8_t>(type);
 
   // Compute and write metadata length
   SizeComputationSerializer size_computation_serializer;
   serialize_impl(size_computation_serializer);
   uint32_t md_length = size_computation_serializer.size();
-  serializer.write(md_length);
+  serializer.write<uint32_t>(md_length);
 
   // Filter-specific serialization
   serialize_impl(serializer);

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -36,6 +36,7 @@
 #include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 using namespace tiledb::common;
 
@@ -164,10 +165,10 @@ class Filter {
   /**
    * Serializes the filter metadata into a binary buffer.
    *
-   * @param buff The buffer to serialize the data into.
+   * @param serializer The object to serialized into.
    * @return Status
    */
-  Status serialize(Buffer* buff) const;
+  void serialize(Serializer& serializer) const;
 
   /** Returns the filter type. */
   FilterType type() const;
@@ -197,9 +198,8 @@ class Filter {
    * implement this method.
    *
    * @param buff The buffer to serialize the data into.
-   * @return Status
    */
-  virtual Status serialize_impl(Buffer* buff) const;
+  virtual void serialize_impl(Serializer& serializer) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter_create.cc
+++ b/tiledb/sm/filter/filter_create.cc
@@ -86,34 +86,17 @@ tiledb::sm::Filter* tiledb::sm::FilterCreate::make(FilterType type) {
 }
 
 shared_ptr<tiledb::sm::Filter> tiledb::sm::FilterCreate::deserialize(
-    ConstBuffer* buff,
+    Deserializer& deserializer,
     const EncryptionKey& encryption_key,
     const uint32_t version) {
   Status st;
-
-  uint8_t type;
-  st = buff->read(&type, sizeof(uint8_t));
-  if (!st.ok()) {
-    throw std::runtime_error(
-        "[FilterCreate::deserialize] Failed to load filter type");
-  }
-  try {
-    ensure_filtertype_is_valid(type);
-  } catch (const std::exception& e) {
-    std::throw_with_nested(std::runtime_error("[FilterCreate::deserialize] "));
-  }
+  uint8_t type = deserializer.read<uint8_t>();
   FilterType filtertype = static_cast<FilterType>(type);
-
-  uint32_t filter_metadata_len;
-  st = buff->read(&filter_metadata_len, sizeof(uint32_t));
-  if (!st.ok()) {
-    throw std::runtime_error(
-        "[FilterCreate::deserialize] Failed to load filter metadata length");
-  }
-  auto offset = buff->offset();
-  if ((buff->size() - offset) < filter_metadata_len) {
-    throw StatusException(Status_FilterError(
-        "Deserialization error; not enough data in buffer for metadata"));
+  uint32_t filter_metadata_len = deserializer.read<uint32_t>();
+  if (deserializer.size() < filter_metadata_len) {
+    throw StatusException(
+        "FilterCreate",
+        "Deserialization error; not enough data in buffer for metadata");
   }
 
   switch (filtertype) {
@@ -126,40 +109,14 @@ shared_ptr<tiledb::sm::Filter> tiledb::sm::FilterCreate::deserialize(
     case FilterType::FILTER_BZIP2:
     case FilterType::FILTER_DOUBLE_DELTA:
     case FilterType::FILTER_DICTIONARY: {
-      uint8_t compressor_char;
-      int compression_level;
-      st = (buff->read(&compressor_char, sizeof(uint8_t)));
-      if (!st.ok()) {
-        throw std::runtime_error(
-            "[FilterCreate::deserialize] Failed to load compressor");
-      }
-      try {
-        ensure_compressor_is_valid(compressor_char);
-      } catch (const std::exception& e) {
-        std::throw_with_nested(
-            std::runtime_error("[FilterCreate::deserialize] "));
-      }
-
-      /* Note: compression level is directly handled by the Compressor
-        and thus needn't be validated here. */
+      uint8_t compressor_char = deserializer.read<uint8_t>();
+      int compression_level = deserializer.read<int32_t>();
       Compressor compressor = static_cast<Compressor>(compressor_char);
-      st = buff->read(&compression_level, sizeof(int32_t));
-      if (!st.ok()) {
-        throw std::runtime_error(
-            "[FilterCreate::deserialize] Failed to load compression level");
-      }
       return make_shared<CompressionFilter>(
           HERE(), compressor, compression_level, version);
     }
     case FilterType::FILTER_BIT_WIDTH_REDUCTION: {
-      /* Note: No validation is possible on max_window_size;
-        no actual limit, though usable limit is likely in the low 1000s. */
-      uint32_t max_window_size;
-      st = buff->read(&max_window_size, sizeof(uint32_t));
-      if (!st.ok()) {
-        throw std::runtime_error(
-            "[FilterCreate::deserialize] Failed to load maximum window size");
-      }
+      uint32_t max_window_size = deserializer.read<uint32_t>();
       return make_shared<BitWidthReductionFilter>(HERE(), max_window_size);
     }
     case FilterType::FILTER_BITSHUFFLE:
@@ -167,14 +124,8 @@ shared_ptr<tiledb::sm::Filter> tiledb::sm::FilterCreate::deserialize(
     case FilterType::FILTER_BYTESHUFFLE:
       return make_shared<ByteshuffleFilter>(HERE());
     case FilterType::FILTER_POSITIVE_DELTA: {
-      uint32_t max_window_size;
-      st = buff->read(&max_window_size, sizeof(uint32_t));
-      if (!st.ok()) {
-        throw std::runtime_error(
-            "[FilterCreate::deserialize] Failed to load maximum window size");
-      } else {
-        return make_shared<PositiveDeltaFilter>(HERE(), max_window_size);
-      }
+      uint32_t max_window_size = deserializer.read<uint32_t>();
+      return make_shared<PositiveDeltaFilter>(HERE(), max_window_size);
     }
     case FilterType::INTERNAL_FILTER_AES_256_GCM:
       if (encryption_key.encryption_type() ==
@@ -188,28 +139,22 @@ shared_ptr<tiledb::sm::Filter> tiledb::sm::FilterCreate::deserialize(
     case FilterType::FILTER_CHECKSUM_SHA256:
       return make_shared<ChecksumSHA256Filter>(HERE());
     case FilterType::FILTER_SCALE_FLOAT: {
-      FloatScalingFilter::FilterConfig filter_config;
-      st = buff->read(&filter_config, sizeof(FloatScalingFilter::FilterConfig));
-      if (!st.ok()) {
-        throw std::runtime_error(
-            "[FilterCreate::deserialize] Failed to load FloatScaling metadata");
-      } else {
-        return make_shared<FloatScalingFilter>(
-            HERE(),
-            filter_config.byte_width,
-            filter_config.scale,
-            filter_config.offset);
-      }
+      auto filter_config =
+          deserializer.read<FloatScalingFilter::FilterConfig>();
+      return make_shared<FloatScalingFilter>(
+          HERE(),
+          filter_config.byte_width,
+          filter_config.scale,
+          filter_config.offset);
     };
     default:
-      assert(false);
       throw StatusException(
-          Status_FilterError("Deserialization error; unknown type"));
+          "FilterCreate", "Deserialization error; unknown type");
   }
 }
-
 shared_ptr<tiledb::sm::Filter> tiledb::sm::FilterCreate::deserialize(
-    ConstBuffer* buff, const uint32_t version) {
+    Deserializer& deserializer, const uint32_t version) {
   EncryptionKey encryption_key;
-  return tiledb::sm::FilterCreate::deserialize(buff, encryption_key, version);
+  return tiledb::sm::FilterCreate::deserialize(
+      deserializer, encryption_key, version);
 }

--- a/tiledb/sm/filter/filter_create.h
+++ b/tiledb/sm/filter/filter_create.h
@@ -53,15 +53,13 @@ class FilterCreate {
   /**
    * Deserializes a new Filter instance from the data in the given buffer.
    *
-   * @param buff The buffer to deserialize from.
+   * @param deserializer The deserializer to deserialize from.
    * @param encryption_key.
    * @param version Array schema version
    * @return Filter
-   *
-   * @pre version has been validated by ArraySchema::deserialize
    */
   static shared_ptr<Filter> deserialize(
-      ConstBuffer* buff,
+      Deserializer& deserializer,
       const EncryptionKey& encryption_key,
       const uint32_t version);
 
@@ -71,11 +69,9 @@ class FilterCreate {
    * @param buff The buffer to deserialize from.
    * @param version Array schema version
    * @return Filter
-   *
-   * @pre version has been validated by ArraySchema::deserialize
    */
   static shared_ptr<Filter> deserialize(
-      ConstBuffer* buff, const uint32_t version);
+      Deserializer& deserializer, const uint32_t version);
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -639,9 +639,9 @@ Status FilterPipeline::run_reverse_internal(
 // filter0 metadata (see Filter::serialize)
 // filter1...
 void FilterPipeline::serialize(Serializer& serializer) const {
-  serializer.write(max_chunk_size_);
+  serializer.write<uint32_t>(max_chunk_size_);
   auto num_filters = static_cast<uint32_t>(filters_.size());
-  serializer.write(num_filters);
+  serializer.write<uint32_t>(num_filters);
 
   for (const auto& f : filters_) {
     // For compatibility with the old attribute compressor API: if the filter

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -638,10 +638,10 @@ Status FilterPipeline::run_reverse_internal(
 // num_filters (uint32_t)
 // filter0 metadata (see Filter::serialize)
 // filter1...
-Status FilterPipeline::serialize(Buffer* buff) const {
-  RETURN_NOT_OK(buff->write(&max_chunk_size_, sizeof(uint32_t)));
+void FilterPipeline::serialize(Serializer& serializer) const {
+  serializer.write(max_chunk_size_);
   auto num_filters = static_cast<uint32_t>(filters_.size());
-  RETURN_NOT_OK(buff->write(&num_filters, sizeof(uint32_t)));
+  serializer.write(num_filters);
 
   for (const auto& f : filters_) {
     // For compatibility with the old attribute compressor API: if the filter
@@ -650,44 +650,21 @@ Status FilterPipeline::serialize(Buffer* buff) const {
     auto as_compression = dynamic_cast<CompressionFilter*>(f.get());
     if (as_compression != nullptr && f->type() == FilterType::FILTER_NONE) {
       auto noop = tdb_unique_ptr<NoopFilter>(new NoopFilter);
-      RETURN_NOT_OK(noop->serialize(buff));
+      noop->serialize(serializer);
     } else {
-      RETURN_NOT_OK(f->serialize(buff));
+      f->serialize(serializer);
     }
   }
-
-  return Status::Ok();
 }
 
 FilterPipeline FilterPipeline::deserialize(
-    ConstBuffer* buff, const uint32_t version) {
-  Status st;
-  uint32_t max_chunk_size;
+    Deserializer& deserializer, const uint32_t version) {
+  auto max_chunk_size = deserializer.read<uint32_t>();
+  auto num_filters = deserializer.read<uint32_t>();
   std::vector<shared_ptr<Filter>> filters;
 
-  st = buff->read(&max_chunk_size, sizeof(uint32_t));
-  if (!st.ok()) {
-    throw std::runtime_error(
-        "[FilterPipeline::deserialize] Failed to load maximum tile chunk size");
-  }
-  if (max_chunk_size > constants::max_tile_chunk_size) {
-    throw std::logic_error(
-        "[FilterPipeline::deserialize] " + std::to_string(max_chunk_size) +
-        " is invalid as a maximum tile chunk size; too large");
-  }
-
-  // Note: No security validation is possible.
-  // Note: A FilterPipeline may have 0 filters.
-  uint32_t num_filters;
-  st = buff->read(&num_filters, sizeof(uint32_t));
-  if (!st.ok()) {
-    throw std::runtime_error(
-        "[FilterPipeline::deserialize] Failed to load number of filters");
-  }
-
-  // Note: Security validation delegated to invoked API
   for (uint32_t i = 0; i < num_filters; i++) {
-    auto filter{FilterCreate::deserialize(buff, version)};
+    auto filter{FilterCreate::deserialize(deserializer, version)};
     filters.push_back(std::move(filter));
   }
 

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -104,13 +104,12 @@ class FilterPipeline {
   /**
    * Populates the filter pipeline from the data in the input binary buffer.
    *
-   * @param buff The buffer to deserialize from.
+   * @param deserializer The deserializer to deserialize from.
    * @param version Array schema version
    * @return FilterPipeline
-   *
-   * @pre version has been validated by ArraySchema::deserialize
    */
-  static FilterPipeline deserialize(ConstBuffer* buff, const uint32_t version);
+  static FilterPipeline deserialize(
+      Deserializer& deserializer, const uint32_t version);
 
   /**
    * Dumps the filter pipeline details in ASCII format in the selected
@@ -279,10 +278,10 @@ class FilterPipeline {
   /**
    * Serializes the pipeline metadata into a binary buffer.
    *
-   * @param buff The buffer to serialize the data into.
+   * @param serializer The object the filter pipeline is serialized into.
    * @return Status
    */
-  Status serialize(Buffer* buff) const;
+  void serialize(Serializer& serializer) const;
 
   /** Sets the maximum tile chunk size. */
   void set_max_chunk_size(uint32_t max_chunk_size);

--- a/tiledb/sm/filter/float_scaling_filter.cc
+++ b/tiledb/sm/filter/float_scaling_filter.cc
@@ -55,10 +55,9 @@ void FloatScalingFilter::dump(FILE* out) const {
       offset_);
 }
 
-Status FloatScalingFilter::serialize_impl(Buffer* buff) const {
+void FloatScalingFilter::serialize_impl(Serializer& serializer) const {
   FilterConfig buffer_struct = {scale_, offset_, byte_width_};
-  RETURN_NOT_OK(buff->write(&buffer_struct, sizeof(FilterConfig)));
-  return Status::Ok();
+  serializer.write(buffer_struct);
 }
 
 template <typename T, typename W>

--- a/tiledb/sm/filter/float_scaling_filter.h
+++ b/tiledb/sm/filter/float_scaling_filter.h
@@ -92,7 +92,7 @@ class FloatScalingFilter : public Filter {
   void dump(FILE* out) const override;
 
   /** Serializes this filter's metadata to the given buffer. */
-  Status serialize_impl(Buffer* buff) const override;
+  void serialize_impl(Serializer& serializer) const override;
 
   /**
    * Run forward. Takes input data in floating point representation and

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -411,9 +411,8 @@ PositiveDeltaFilter* PositiveDeltaFilter::clone_impl() const {
   return clone;
 }
 
-Status PositiveDeltaFilter::serialize_impl(Buffer* buff) const {
-  RETURN_NOT_OK(buff->write(&max_window_size_, sizeof(uint32_t)));
-  return Status::Ok();
+void PositiveDeltaFilter::serialize_impl(Serializer& serializer) const {
+  serializer.write(max_window_size_);
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -412,7 +412,7 @@ PositiveDeltaFilter* PositiveDeltaFilter::clone_impl() const {
 }
 
 void PositiveDeltaFilter::serialize_impl(Serializer& serializer) const {
-  serializer.write(max_window_size_);
+  serializer.write<uint32_t>(max_window_size_);
 }
 
 }  // namespace sm

--- a/tiledb/sm/filter/positive_delta_filter.h
+++ b/tiledb/sm/filter/positive_delta_filter.h
@@ -163,7 +163,7 @@ class PositiveDeltaFilter : public Filter {
   Status set_option_impl(FilterOption option, const void* value) override;
 
   /** Serializes this filter's metadata to the given buffer. */
-  Status serialize_impl(Buffer* buff) const override;
+  void serialize_impl(Serializer& serializer) const override;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/test/unit_filter_create.cc
+++ b/tiledb/sm/filter/test/unit_filter_create.cc
@@ -70,9 +70,9 @@ TEST_CASE(
   buffer_offset<uint32_t, 1>(p) = sizeof(uint32_t);  // metadata_length
   buffer_offset<uint32_t, 5>(p) = max_window_size0;
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -93,9 +93,9 @@ TEST_CASE(
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = 0;  // metadata_length
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -110,9 +110,9 @@ TEST_CASE(
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = 0;  // metadata_length
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -127,9 +127,9 @@ TEST_CASE(
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = 0;  // metadata_length
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -144,9 +144,9 @@ TEST_CASE(
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = 0;  // metadata_length
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -161,9 +161,9 @@ TEST_CASE(
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = 0;  // metadata_length
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -195,9 +195,9 @@ TEST_CASE(
         sizeof(uint8_t) + sizeof(int32_t);  // metadata_length
     buffer_offset<uint8_t, 5>(p) = static_cast<uint8_t>(compressor0);
 
-    ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+    Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
     auto filter1{
-        FilterCreate::deserialize(&constbuffer, constants::format_version)};
+        FilterCreate::deserialize(deserializer, constants::format_version)};
 
     // Check type
     CHECK(filter1->type() == filtertype0);
@@ -216,9 +216,9 @@ TEST_CASE(
     buffer_offset<uint8_t, 5>(p) = static_cast<uint8_t>(compressor0);
     buffer_offset<int32_t, 6>(p) = level0;
 
-    ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+    Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
     auto filter1{
-        FilterCreate::deserialize(&constbuffer, constants::format_version)};
+        FilterCreate::deserialize(deserializer, constants::format_version)};
 
     // Check type
     CHECK(filter1->type() == filtertype0);
@@ -244,9 +244,9 @@ TEST_CASE(
     buffer_offset<uint8_t, 5>(p) = static_cast<uint8_t>(compressor0);
     buffer_offset<int32_t, 6>(p) = level0;
 
-    ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+    Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
     auto filter1{
-        FilterCreate::deserialize(&constbuffer, constants::format_version)};
+        FilterCreate::deserialize(deserializer, constants::format_version)};
 
     // Check type
     CHECK(filter1->type() == filtertype0);
@@ -272,9 +272,9 @@ TEST_CASE(
     buffer_offset<uint8_t, 5>(p) = static_cast<uint8_t>(compressor0);
     buffer_offset<int32_t, 6>(p) = level0;
 
-    ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+    Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
     auto filter1{
-        FilterCreate::deserialize(&constbuffer, constants::format_version)};
+        FilterCreate::deserialize(deserializer, constants::format_version)};
 
     // Check type
     CHECK(filter1->type() == filtertype0);
@@ -300,9 +300,9 @@ TEST_CASE(
     buffer_offset<uint8_t, 5>(p) = static_cast<uint8_t>(compressor0);
     buffer_offset<int32_t, 6>(p) = level0;
 
-    ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+    Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
     auto filter1{
-        FilterCreate::deserialize(&constbuffer, constants::format_version)};
+        FilterCreate::deserialize(deserializer, constants::format_version)};
 
     // Check type
     CHECK(filter1->type() == filtertype0);
@@ -323,9 +323,9 @@ TEST_CASE("Filter: Test noop filter deserialization", "[filter][noop]") {
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = 0;  // metadata_length
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -341,9 +341,9 @@ TEST_CASE(
   buffer_offset<uint8_t, 0>(p) = static_cast<uint8_t>(filtertype0);
   buffer_offset<uint32_t, 1>(p) = sizeof(uint32_t);  // metadata_length
   buffer_offset<uint32_t, 5>(p) = max_window_size0;
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
 
   // Check type
   CHECK(filter1->type() == filtertype0);
@@ -375,9 +375,9 @@ TEST_CASE(
   buffer_offset<double, 13>(p) = offset0;
   buffer_offset<uint64_t, 21>(p) = byte_width0;
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filter1{
-      FilterCreate::deserialize(&constbuffer, constants::format_version)};
+      FilterCreate::deserialize(deserializer, constants::format_version)};
   CHECK(filter1->type() == filtertype0);
   double scale1 = 0.0;
   REQUIRE(filter1->get_option(FilterOption::SCALE_FLOAT_FACTOR, &scale1).ok());

--- a/tiledb/sm/filter/test/unit_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_filter_pipeline.cc
@@ -102,9 +102,9 @@ TEST_CASE(
   filters_buffer_offset<uint8_t, 33>(p) = static_cast<uint8_t>(compressor3);
   filters_buffer_offset<int32_t, 34>(p) = compressor_level3;
 
-  ConstBuffer constbuffer(&serialized_buffer, sizeof(serialized_buffer));
+  Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto filters{
-      FilterPipeline::deserialize(&constbuffer, constants::format_version)};
+      FilterPipeline::deserialize(deserializer, constants::format_version)};
 
   CHECK(filters.max_chunk_size() == max_chunk_size);
   CHECK(filters.size() == num_filters);

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -44,7 +44,7 @@ void serialize_condition_impl(
   // Serialize is_expr.
   const auto node_type =
       node->is_expr() ? NodeType::EXPRESSION : NodeType::VALUE;
-  serializer.write(static_cast<uint8_t>(node_type));
+  serializer.write<uint8_t>(static_cast<uint8_t>(node_type));
   if (!node->is_expr()) {
     // Get values.
     const auto op = node->get_op();
@@ -54,14 +54,14 @@ void serialize_condition_impl(
     const auto& value = node->get_condition_value_view();
     const storage_size_t value_length = value.size();
     // Serialize op.
-    serializer.write(op);
+    serializer.write<uint8_t>(static_cast<uint8_t>(op));
 
     // Serialize field name.
-    serializer.write(field_name_length);
+    serializer.write<uint32_t>(field_name_length);
     serializer.write(field_name.data(), field_name_length);
 
     // Serialize value.
-    serializer.write(value_length);
+    serializer.write<uint64_t>(value_length);
     serializer.write(value.content(), value.size());
   } else {
     // Get values.
@@ -70,10 +70,10 @@ void serialize_condition_impl(
     const auto combinatin_op = node->get_combination_op();
 
     // Serialize combination op.
-    serializer.write(combinatin_op);
+    serializer.write<uint8_t>(static_cast<uint8_t>(combinatin_op));
 
     // Serialize children num.
-    serializer.write(nodes_size);
+    serializer.write<size_t>(nodes_size);
 
     for (storage_size_t i = 0; i < nodes.size(); i++) {
       serialize_condition_impl(nodes[i], serializer);

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -259,14 +259,14 @@ uint64_t RTree::subtree_leaf_num(uint64_t level) const {
 }
 
 void RTree::serialize(Serializer& serializer) const {
-  serializer.write(fanout_);
+  serializer.write<uint32_t>(fanout_);
   auto level_num = (unsigned)levels_.size();
-  serializer.write(level_num);
+  serializer.write<uint32_t>(level_num);
   auto dim_num = domain_->dim_num();
 
   for (unsigned l = 0; l < level_num; ++l) {
     auto mbr_num = (uint64_t)levels_[l].size();
-    serializer.write(mbr_num);
+    serializer.write<uint64_t>(mbr_num);
     for (uint64_t m = 0; m < mbr_num; ++m) {
       for (unsigned d = 0; d < dim_num; ++d) {
         const auto& r = levels_[l][m][d];
@@ -275,8 +275,8 @@ void RTree::serialize(Serializer& serializer) const {
           serializer.write(r.data(), r.size());
         } else {  // Var-sized
           // range_size | start_size | range
-          serializer.write(r.size());
-          serializer.write(r.start_size());
+          serializer.write<uint64_t>(r.size());
+          serializer.write<uint64_t>(r.start_size());
           serializer.write(r.data(), r.size());
         }
       }

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -984,6 +984,17 @@ class StorageManager {
       const URI& uri,
       const EncryptionKey& encryption_key);
 
+  /**
+   * Stores data into persistent storage.
+   *
+   * @param tile Tile to store.
+   * @param uri The object URI.
+   * @param encryption_key The encryption key to use.
+   * @return Status
+   */
+  Status store_data_to_generic_tile(
+      Tile& tile, const URI& uri, const EncryptionKey& encryption_key);
+
   /** Closes a file, flushing its contents to persistent storage. */
   Status close_file(const URI& uri);
 
@@ -1007,15 +1018,6 @@ class StorageManager {
    */
   Status write_to_cache(
       const URI& uri, uint64_t offset, const FilteredBuffer& buffer) const;
-
-  /**
-   * Writes the contents of a buffer into a URI file.
-   *
-   * @param uri The file to write into.
-   * @param buffer The buffer to write.
-   * @return Status.
-   */
-  Status write(const URI& uri, Buffer* buffer) const;
 
   /**
    * Writes the input data into a URI file.

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -160,6 +160,15 @@ class GenericTileIO {
       Tile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes);
 
   /**
+   * Serialize a generic tile header.
+   *
+   * @param serializer The serializer.
+   * @param header The header to serialize.
+   */
+  template <class T>
+  void serialize_generic_tile_header(T& serializer, GenericTileHeader& header);
+
+  /**
    * Writes the generic tile header to the file.
    *
    * @param header The header to write

--- a/tiledb/storage_format/serialization/serializers.h
+++ b/tiledb/storage_format/serialization/serializers.h
@@ -169,6 +169,22 @@ class Deserializer {
   }
 
   /**
+   * Deserialize a buffer.
+   *
+   * @param data data to read.
+   * @param size size of the data.
+   */
+  void read(void* data, storage_size_t size) {
+    if (size > size_) {
+      throw std::logic_error("Reading data past end of serialized data size.");
+    }
+
+    memcpy(data, ptr_, size);
+    ptr_ += size;
+    size_ -= size;
+  }
+
+  /**
    * Return a pointer to serialized data.
    *
    * @tparam T Type of the data.


### PR DESCRIPTION
This removes the usage of the `Buffer` class when doing serialization/
deserialization for the array schema to/from disk.

---
TYPE: IMPROVEMENT
DESC: Remove buffer usage from Array Schema on disk serialization.
