### PR TITLE
cross-platform issue with experimental version numbers

### DIFF
--- a/tiledb/storage_format/uri/parse_uri.cc
+++ b/tiledb/storage_format/uri/parse_uri.cc
@@ -88,7 +88,7 @@ Status get_fragment_name_version(const std::string& name, uint32_t* version) {
     // version is greater than or equal to 7, we have a footer version of 4.
     // Otherwise, it is version 3.
     const uint32_t frag_version =
-        std::stol(name.substr(name.find_last_of('_') + 1));
+        std::stoul(name.substr(name.find_last_of('_') + 1));
     if (frag_version >= 10)
       *version = 5;
     else if (frag_version >= 7)


### PR DESCRIPTION
change stol() to stoul() for correct cross-platform operations with experimental version numbers

---
TYPE: BUG
DESC: use stoul() to correctly parse (32bit unsigned values) experimental version numbers cross-platform
