### PR TITLE
Adding experimental API for getting relevant fragments.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -108,6 +108,7 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/object_iter.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query_condition.h
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/schema_base.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/stats.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/subarray.h

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3401,6 +3401,19 @@ int32_t tiledb_query_get_subarray_t(
   return TILEDB_OK;
 }
 
+int32_t tiledb_query_get_relevant_fragment_num(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint64_t* relevant_fragment_num) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  *relevant_fragment_num =
+      query->query_->subarray()->relevant_fragments()->size();
+
+  return TILEDB_OK;
+}
+
 /* ****************************** */
 /*         SUBARRAY               */
 /* ****************************** */
@@ -8593,6 +8606,14 @@ int32_t tiledb_query_get_subarray_t(
     const tiledb_query_t* query,
     tiledb_subarray_t** subarray) noexcept {
   return api_entry<detail::tiledb_query_get_subarray_t>(ctx, query, subarray);
+}
+
+int32_t tiledb_query_get_relevant_fragment_num(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint64_t* relevant_fragment_num) noexcept {
+  return api_entry<detail::tiledb_query_get_relevant_fragment_num>(
+      ctx, query, relevant_fragment_num);
 }
 
 /* ****************************** */

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -275,6 +275,23 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_query_add_point_ranges(
     const void* start,
     uint64_t count) TILEDB_NOEXCEPT;
 
+/**
+ * Get the number of relevant fragments from the subarray. Should only be
+ * called after size estimation was asked for.
+ *
+ * @param ctx The TileDB context.
+ * @param query The query to get the data fron.
+ * @param relevant_fragment_num Variable to receive the number of relevant
+ * fragments.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note Should only be called after size estimation was run.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_relevant_fragment_num(
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint64_t* relevant_fragment_num) TILEDB_NOEXCEPT;
+
 /* ********************************* */
 /*        QUERY STATUS DETAILS       */
 /* ********************************* */

--- a/tiledb/sm/cpp_api/query_experimental.h
+++ b/tiledb/sm/cpp_api/query_experimental.h
@@ -1,11 +1,11 @@
 /**
- * @file   tiledb_experimental
+ * @file   query_experimental.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,14 +27,32 @@
  *
  * @section DESCRIPTION
  *
- * This file declares the experimental C++ API for TileDB.
+ * This file declares the C++ experimental API for the query.
  */
 
-#ifndef TILEDB_EXPERIMENTAL_CPP_H
-#define TILEDB_EXPERIMENTAL_CPP_H
+#ifndef TILEDB_CPP_API_QUERY_EXPERIMENTAL_H
+#define TILEDB_CPP_API_QUERY_EXPERIMENTAL_H
+#include "context.h"
+#include "tiledb.h"
 
-#include "array_schema_evolution.h"
-#include "group_experimental.h"
-#include "query_experimental.h"
+namespace tiledb {
+class QueryExperimental {
+ public:
+  /**
+   * Get the number of relevant fragments from the subarray. Should only be
+   * called after size estimation was asked for.
+   *
+   * @param ctx TileDB context.
+   * @param query Query object.
+   * @return Number of relevant fragments.
+   */
+  static uint64_t get_relevant_fragment_num(Context& ctx, const Query& query) {
+    uint64_t relevant_fragment_num = 0;
+    ctx.handle_error(tiledb_query_get_relevant_fragment_num(
+        ctx.ptr().get(), query.ptr().get(), &relevant_fragment_num));
+    return relevant_fragment_num;
+  }
+};
+}  // namespace tiledb
 
-#endif  // TILEDB_EXPERIMENTAL_CPP_H
+#endif  // TILEDB_CPP_API_QUERY_EXPERIMENTAL_H

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -350,12 +350,12 @@ SparseGlobalOrderReader<BitmapType>::add_result_tile(
   // Adjust total memory used.
   {
     std::unique_lock<std::mutex> lck(mem_budget_mtx_);
-    memory_used_for_coords_total_ += tiles_size + sizeof(ResultTile);
+    memory_used_for_coords_total_ += tiles_size;
     memory_used_qc_tiles_total_ += tiles_size_qc;
   }
 
   // Adjust per fragment memory used.
-  memory_used_for_coords_[f] += tiles_size + sizeof(ResultTile);
+  memory_used_for_coords_[f] += tiles_size;
   memory_used_for_qc_tiles_[f] += tiles_size_qc;
 
   // Add the tile.
@@ -375,8 +375,9 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
 
   // Get the number of fragments to process.
   unsigned num_fragments_to_process = 0;
-  for (auto all_loaded : all_tiles_loaded_)
+  for (auto all_loaded : all_tiles_loaded_) {
     num_fragments_to_process += !all_loaded;
+  }
 
   per_fragment_memory_ =
       memory_budget_ * memory_budget_ratio_coords_ / num_fragments_to_process;
@@ -411,10 +412,18 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                     f,
                     t);
 
-                if (result_tiles_[f].empty())
+                if (result_tiles_[f].empty()) {
+                  auto&& [st, tile_sizes] = get_coord_tiles_size(dim_num, f, t);
                   return logger_->status(Status_SparseGlobalOrderReaderError(
                       "Cannot load a single tile for fragment, increase memory "
-                      "budget"));
+                      "budget, tile size : " +
+                      std::to_string(tile_sizes.value().first) +
+                      ", per fragment memory " +
+                      std::to_string(per_fragment_memory_) + ", total budget " +
+                      std::to_string(memory_budget_) +
+                      " , num fragments to process " +
+                      std::to_string(num_fragments_to_process)));
+                }
                 return Status::Ok();
               }
 
@@ -458,10 +467,18 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                   f,
                   t);
 
-              if (result_tiles_[f].empty())
+              if (result_tiles_[f].empty()) {
+                auto&& [st, tile_sizes] = get_coord_tiles_size(dim_num, f, t);
                 return logger_->status(Status_SparseGlobalOrderReaderError(
                     "Cannot load a single tile for fragment, increase memory "
-                    "budget"));
+                    "budget, tile size : " +
+                    std::to_string(tile_sizes.value().first) +
+                    ", per fragment memory " +
+                    std::to_string(per_fragment_memory_) + ", total budget " +
+                    std::to_string(memory_budget_) +
+                    " , num fragments to process " +
+                    std::to_string(num_fragments_to_process)));
+              }
               return Status::Ok();
             }
           }
@@ -1671,13 +1688,13 @@ Status SparseGlobalOrderReader<BitmapType>::remove_result_tile(
   }
 
   // Adjust per fragment memory usage.
-  memory_used_for_coords_[frag_idx] -= tiles_size + sizeof(ResultTile);
+  memory_used_for_coords_[frag_idx] -= tiles_size;
   memory_used_for_qc_tiles_[frag_idx] -= tiles_size_qc;
 
   // Adjust total memory usage.
   {
     std::unique_lock<std::mutex> lck(mem_budget_mtx_);
-    memory_used_for_coords_total_ -= tiles_size + sizeof(ResultTile);
+    memory_used_for_coords_total_ -= tiles_size;
     memory_used_qc_tiles_total_ -= tiles_size_qc;
   }
 


### PR DESCRIPTION
This is adding an API to retrieve the number of relevant fragments after
size estimation was run. It will be used by the cloud to determine the
minimum size of the memory budget for some sparse global order queries.

---
TYPE: IMPROVEMENT
DESC: Adding experimental API for getting relevant fragments.
