### PR TITLE
[capi] Add include policy for non-TileDB headers in the C API

### DIFF
--- a/tiledb/api/C_API_STRUCTURE.md
+++ b/tiledb/api/C_API_STRUCTURE.md
@@ -43,3 +43,11 @@ For each facade base class, there's an optional proxy class, that is, a `{0,1}` 
 
 A proxy class represent a C API object that is newly created by collecting constructor arguments through API `set_` calls.
 
+## Implementation restrictions
+
+* In order to facilitate correct SWIG wrapper generation, non-TileDB headers included by the external header files *must* be wrapped as follows:
+  ```
+  #ifndef TILEDB_CAPI_WRAPPING
+  #include <stdint.h>
+  #endif
+  ```

--- a/tiledb/api/c_api/api_external_common.h
+++ b/tiledb/api/c_api/api_external_common.h
@@ -36,7 +36,9 @@
 /*
  * Use C headers since we need to compile externally-visible headers as C
  */
+#ifndef TILEDB_CAPI_WRAPPING
 #include <stdint.h>
+#endif
 
 /*
  * Header "tiledb_export.h" is built by CMake `GenerateExportHeader` and appears


### PR DESCRIPTION
Non-TileDB includes in the external API must be wrapped by `ifndef
TILEDB_CAPI_WRAPPING` to facilitate correct SWIG wrapper generation.

x-ref https://github.com/TileDB-Inc/TileDB-Java/pull/270

---
TYPE: C_API
DESC: Add include policy for non-TileDB headers in the C API
