### PR TITLE
Update HISTORY for 2.11.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -64,7 +64,8 @@
 ## API additions
 
 ### C API
-* New: `tiledb_fragment_info_get_total_cell_num` [#3234](https://github.com/TileDB-Inc/TileDB/pull/3273)
+* New (experimental): `tiledb_fragment_info_get_total_cell_num` [#3234](https://github.com/TileDB-Inc/TileDB/pull/3273)
+* New (experimental): `tiledb_query_get_relevant_fragment_num` [#3413](https://github.com/TileDB-Inc/TileDB/pull/3413)
 * Remove incorrect noexcept annotations from C API implementations in filestore API. [#3273](https://github.com/TileDB-Inc/TileDB/pull/3273)
 
 ## Test only changes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,11 @@
   due to format changes.
   *Backward read-compatibility is unaffected, and is tested for each release.*
 
+## Potential change
+* **If you have a use-case with tiles larger than 64 MB (in-memory), please get in touch.**
+  In order to facilitate improved memory usage and i/o processing performance, we are
+  considering a default upper-bound on tile size in a future version.
+
 ## New features
 * Floating point scaling filter
  ([#3243](https://github.com/TileDB-Inc/TileDB/pull/3243),

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,7 @@
 * Use sparse global ordered reader for unordered queries with no dups. [#3207](https://github.com/TileDB-Inc/TileDB/pull/3207)
 * compute_results_count_sparse_string: using cached ranges properly. [#3314](https://github.com/TileDB-Inc/TileDB/pull/3314)
 * GCS/AWS: remove unnecessary classA operations. [#3323](https://github.com/TileDB-Inc/TileDB/pull/3323)
+* Reduce the number of requests in dir_size [#3382](https://github.com/TileDB-Inc/TileDB/pull/3382)
 
 ### Internal
 * Add DataBlocks, port finite state machine, and other DAG infrastructure [#3328](https://github.com/TileDB-Inc/TileDB/pull/3328)
@@ -38,7 +39,9 @@
 * Replace unnecessary uses of `std::unique_lock` and `std::scope_lock` with `std::lock_guard`. [#3340](https://github.com/TileDB-Inc/TileDB/pull/3340)
 * Deletes: implement negate for query condition. [#3299](https://github.com/TileDB-Inc/TileDB/pull/3299)
 * Deletes: adding configuration parameter for purging deleted cells. [#3334](https://github.com/TileDB-Inc/TileDB/pull/3334)
+
 ## Defects removed
+* Sparse refactored readers, mark empty fragments as fully loaded early. [#3394](https://github.com/TileDB-Inc/TileDB/pull/3394)
 * Fix printing of TILEDB_BOOL attributes in `Attribute::Dump`. [#3251](https://github.com/TileDB-Inc/TileDB/pull/3251)
 * Store compression filter's version as uint32. [#3341](https://github.com/TileDB-Inc/TileDB/pull/3341)
 * Sparse global order reader: consider qc results after deduplication. [#3350](https://github.com/TileDB-Inc/TileDB/pull/3350)


### PR DESCRIPTION
- [Add release note on potential tile size maximum](https://github.com/TileDB-Inc/TileDB/commit/a6f54820273fc531cea8033e9f2688c5dcba2160)
- Several backports (including #3413 - pending)

---
TYPE: NO_HISTORY