### PR TITLE
VFS: Adding option to disable batching for `read_tiles`.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -289,6 +289,7 @@ void check_save_to_file() {
      << "\n";
   ss << "vfs.azure.use_block_list_upload true\n";
   ss << "vfs.azure.use_https true\n";
+  ss << "vfs.disable_batching false\n";
   ss << "vfs.file.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.file.posix_directory_permissions 755\n";
@@ -635,6 +636,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.var_offsets.mode"] = "elements";
   all_param_values["sm.max_tile_overlap_size"] = "314572800";
 
+  all_param_values["vfs.disable_batching"] = "false";
   all_param_values["vfs.max_batch_size"] = std::to_string(UINT64_MAX);
   all_param_values["vfs.min_batch_gap"] = "512000";
   all_param_values["vfs.min_batch_size"] = "20971520";
@@ -703,6 +705,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["min_batch_gap"] = "512000";
   vfs_param_values["min_batch_size"] = "20971520";
   vfs_param_values["min_parallel_size"] = "10485760";
+  vfs_param_values["disable_batching"] = "false";
   vfs_param_values["read_ahead_size"] = "102400";
   vfs_param_values["read_ahead_cache_size"] = "10485760";
   vfs_param_values["gcs.project_id"] = "";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -67,7 +67,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 58);
+  CHECK(names.size() == 59);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1094,6 +1094,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `vfs.min_batch_gap` <br>
  *    The minimum number of bytes between two VFS read batches.<br>
  *    **Default**: 500KB
+ * - `vfs.disable_batching` <br>
+ *    **Experimental** <br>
+ *    Disables tile batching from VFS, making direct reads.<br>
+ *    **Default**: false
  * - `vfs.file.posix_file_permissions` <br>
  *    Permissions to use for posix file system with file creation.<br>
  *    **Default**: 644

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -128,6 +128,7 @@ const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MAX_BATCH_SIZE = std::to_string(UINT64_MAX);
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
 const std::string Config::VFS_MIN_BATCH_SIZE = "20971520";
+const std::string Config::VFS_DISABLE_BATCHING = "false";
 const std::string Config::VFS_FILE_POSIX_FILE_PERMISSIONS = "644";
 const std::string Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS = "755";
 const std::string Config::VFS_FILE_MAX_PARALLEL_OPS =
@@ -303,6 +304,7 @@ Config::Config() {
   param_values_["vfs.max_batch_size"] = VFS_MAX_BATCH_SIZE;
   param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
+  param_values_["vfs.disable_batching"] = VFS_DISABLE_BATCHING;
   param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
   param_values_["vfs.read_ahead_cache_size"] = VFS_READ_AHEAD_CACHE_SIZE;
   param_values_["vfs.file.posix_file_permissions"] =
@@ -663,6 +665,8 @@ Status Config::unset(const std::string& param) {
     param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
   } else if (param == "vfs.min_batch_size") {
     param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
+  } else if (param == "vfs.disable_batching") {
+    param_values_["vfs.disable_batching"] = VFS_DISABLE_BATCHING;
   } else if (param == "vfs.read_ahead_size") {
     param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
   } else if (param == "vfs.read_ahead_cache_size") {
@@ -886,6 +890,8 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.min_batch_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
+  } else if (param == "vfs.disable_batching") {
+    RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "vfs.read_ahead_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "vfs.read_ahead_cache_size") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -341,6 +341,9 @@ class Config {
   /** The default minimum number of bytes in a batched VFS read operation. */
   static const std::string VFS_MIN_BATCH_SIZE;
 
+  /** Disable batching from VFS, making direct reads from storage. */
+  static const std::string VFS_DISABLE_BATCHING;
+
   /** The default posix permissions for file creations */
   static const std::string VFS_FILE_POSIX_FILE_PERMISSIONS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -463,6 +463,10 @@ class Config {
    * - `vfs.min_batch_gap` <br>
    *    The minimum number of bytes between two VFS read batches.<br>
    *    **Default**: 500KB
+   * - `vfs.disable_batching` <br>
+   *    **Experimental** <br>
+   *    Disables tile batching from VFS, making direct reads.<br>
+   *    **Default**: false
    * - `vfs.file.posix_file_permissions` <br>
    *    permissions to use for posix file system with file or dir creation.<br>
    *    **Default**: 644

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -359,6 +359,24 @@ class VFS {
       std::vector<ThreadPool::Task>* tasks,
       bool use_read_ahead = true);
 
+  /**
+   * Reads multiple regions from a file with no batching.
+   *
+   * @param uri The URI of the file.
+   * @param regions The list of regions to read. Each region is a tuple
+   *    `(file_offset, dest_buffer, nbytes)`.
+   * @param thread_pool Thread pool to execute async read tasks to.
+   * @param tasks Vector to which new async read tasks are pushed.
+   * @param use_read_ahead Whether to use the read-ahead cache.
+   * @return Status
+   */
+  Status read_all_no_batching(
+      const URI& uri,
+      const std::vector<tuple<uint64_t, Tile*, uint64_t>>& regions,
+      ThreadPool* thread_pool,
+      std::vector<ThreadPool::Task>* tasks,
+      bool use_read_ahead = true);
+
   /** Checks if a given filesystem is supported. */
   bool supports_fs(Filesystem fs) const;
 

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -178,6 +178,9 @@ class ReaderBase : public StrategyBase {
   /** Disable the tile cache or not. */
   bool disable_cache_;
 
+  /** Read directly from storage without batching. */
+  bool disable_batching_;
+
   /**
    * The condition to apply on results when there is partial time overlap
    * with at least one fragment


### PR DESCRIPTION
This adds an option so that VFS does reads directly from storage
without performing any batching. For applications with large tiles and
a very small number of tiles per requests, it eliminates a costly buffer
allocation and memcpy in VFS.

The option is exposed in the vfs.disable_batching setting, which is
experimental and can be removed at any time.

---
TYPE: IMPROVEMENT
DESC: VFS: Adding option to disable batching for `read_tiles`.
