### PR TITLE
Change a low-information message in `FindCatch_EP.cmake` to `VERBOSE`

### DIFF
--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -34,7 +34,7 @@
 include(TileDBCommon)
 
 # Search the path set during the superbuild for the EP.
-message(STATUS "searching for catch in ${TILEDB_EP_SOURCE_DIR}")
+message(VERBOSE "searching for catch in ${TILEDB_EP_SOURCE_DIR}")
 set(CATCH_PATHS ${TILEDB_EP_SOURCE_DIR}/ep_catch/single_include)
 
 if (NOT TILEDB_FORCE_ALL_DEPS OR TILEDB_CATCH_EP_BUILT)


### PR DESCRIPTION
Change a low-information message in `FindCatch_EP.cmake` to `VERBOSE`. It no longer shows up by default.

---
TYPE: NO_HISTORY
DESC: Change a low-information message in `FindCatch_EP.cmake` to `VERBOSE`
