### PR TITLE
Ensuring that compile_all_filters target compiles/links correctly

### DIFF
--- a/tiledb/sm/filter/test/compile_all_filters_main.cc
+++ b/tiledb/sm/filter/test/compile_all_filters_main.cc
@@ -30,6 +30,14 @@
 
 int main() {
   (void)sizeof(tiledb::sm::FilterCreate);
-  (void)&tiledb::sm::FilterCreate::deserialize;
+  std::shared_ptr<tiledb::sm::Filter> (*fn_enc)(
+      tiledb::sm::Deserializer&,
+      const tiledb::sm::EncryptionKey&,
+      const uint32_t) = tiledb::sm::FilterCreate::deserialize;
+  (void)fn_enc;
+  std::shared_ptr<tiledb::sm::Filter> (*fn)(
+      tiledb::sm::Deserializer&, const uint32_t) =
+      tiledb::sm::FilterCreate::deserialize;
+  (void)fn;
   return 0;
 }


### PR DESCRIPTION
I noticed a compiler issue with compile_all_filters after the Deserializer object was implemented, so I changed `compile_all_filters.main` to ensure that the function overload in FilterCreate::deserialize is implemented correctly.

---
TYPE: BUG
DESC: Ensuring that compile_all_filters target compiles/links correctly
