### PR TITLE
Add all_link_complete target, to build all compile_* targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,9 @@ target_include_directories(local_install INTERFACE ${TILEDB_LOCALINSTALL_INCLUDE
 # Enable testing
 enable_testing()
 
+# Aggregate all link-completeness targets
+add_custom_target(all_link_complete)
+
 # Build the TileDB library experimental features
 add_subdirectory(experimental)
 

--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(tiledb)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_experimental EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_experimental)
 target_sources(compile_experimental PRIVATE
         test/compile_experimental_main.cc
 )

--- a/experimental/tiledb/common/dag/data_block/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/data_block/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(data_block PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_data_block EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_data_blocks)
 target_link_libraries(compile_data_block PRIVATE data_block)
 target_sources(compile_data_block PRIVATE test/compile_data_block_main.cc)
 
@@ -84,6 +85,7 @@ target_link_libraries(pool_allocator PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_pool_allocator EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_pool_allocator)
 target_link_libraries(compile_pool_allocator PRIVATE pool_allocator)
 target_sources(compile_pool_allocator PRIVATE test/compile_pool_allocator_main.cc)
 

--- a/experimental/tiledb/common/dag/data_block/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/data_block/CMakeLists.txt
@@ -43,7 +43,7 @@ target_link_libraries(data_block PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_data_block EXCLUDE_FROM_ALL)
-add_dependencies(all_link_complete compile_data_blocks)
+add_dependencies(all_link_complete compile_data_block)
 target_link_libraries(compile_data_block PRIVATE data_block)
 target_sources(compile_data_block PRIVATE test/compile_data_block_main.cc)
 

--- a/experimental/tiledb/common/dag/edge/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/edge/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(edge PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_edge EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_edge)
 target_link_libraries(compile_edge PRIVATE edge)
 target_sources(compile_edge PRIVATE test/compile_edge_main.cc)
 

--- a/experimental/tiledb/common/dag/execution/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/execution/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(execution PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_execution EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_execution)
 target_link_libraries(compile_execution PRIVATE execution)
 target_sources(compile_execution PRIVATE test/compile_execution_main.cc)
 

--- a/experimental/tiledb/common/dag/graph/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/graph/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(graph PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_graph EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_graph)
 target_link_libraries(compile_graph PRIVATE graph)
 target_sources(compile_graph PRIVATE test/compile_graph_main.cc)
 

--- a/experimental/tiledb/common/dag/node/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/node/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(node PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_node EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_node)
 target_link_libraries(compile_node PRIVATE node)
 target_sources(compile_node PRIVATE test/compile_node_main.cc)
 

--- a/experimental/tiledb/common/dag/ports/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/ports/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(ports PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_ports EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_ports)
 target_link_libraries(compile_ports PRIVATE ports)
 target_sources(compile_ports PRIVATE test/compile_ports_main.cc)
 
@@ -86,6 +87,7 @@ target_link_libraries(fsm PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_fsm EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_fsm)
 target_link_libraries(compile_fsm PRIVATE fsm)
 target_sources(compile_fsm PRIVATE test/compile_fsm_main.cc)
 
@@ -127,6 +129,7 @@ target_link_libraries(pseudo_nodes PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_pseudo_nodes EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_pseudo_nodes)
 target_link_libraries(compile_pseudo_nodes PRIVATE pseudo_nodes)
 target_sources(compile_pseudo_nodes PRIVATE test/compile_pseudo_nodes_main.cc)
 

--- a/experimental/tiledb/common/dag/utils/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/utils/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(utils PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_utils EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_utils)
 target_link_libraries(compile_utils PRIVATE utils)
 target_sources(compile_utils PRIVATE test/compile_utils_main.cc)
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -51,6 +51,9 @@ find_package(Threads REQUIRED)
 # Subdirectories
 ############################################################
 
+# Aggregate all link-completeness targets
+add_custom_target(all_link_complete EXCLUDE_FROM_ALL)
+
 add_subdirectory(api)
 add_subdirectory(common)
 add_subdirectory(type)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -51,9 +51,6 @@ find_package(Threads REQUIRED)
 # Subdirectories
 ############################################################
 
-# Aggregate all link-completeness targets
-add_custom_target(all_link_complete)
-
 add_subdirectory(api)
 add_subdirectory(common)
 add_subdirectory(type)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -52,7 +52,7 @@ find_package(Threads REQUIRED)
 ############################################################
 
 # Aggregate all link-completeness targets
-add_custom_target(all_link_complete EXCLUDE_FROM_ALL)
+add_custom_target(all_link_complete)
 
 add_subdirectory(api)
 add_subdirectory(common)

--- a/tiledb/common/CMakeLists.txt
+++ b/tiledb/common/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(baseline PUBLIC common)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_baseline EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_baseline)
 target_link_libraries(compile_baseline PRIVATE baseline)
 target_sources(compile_baseline PRIVATE
     test/compile_baseline_main.cc $<TARGET_OBJECTS:baseline>
@@ -81,6 +82,7 @@ add_library(stringx OBJECT
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_stringx EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_stringx)
 target_link_libraries(compile_stringx PRIVATE stringx)
 target_sources(compile_stringx PRIVATE
     test/compile_stringx_main.cc $<TARGET_OBJECTS:stringx>

--- a/tiledb/common/thread_pool/CMakeLists.txt
+++ b/tiledb/common/thread_pool/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(thread_pool PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_thread_pool EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_thread_pool)
 target_link_libraries(compile_thread_pool PRIVATE thread_pool)
 target_sources(compile_thread_pool PRIVATE test/compile_thread_pool_main.cc)
 

--- a/tiledb/common/types/CMakeLists.txt
+++ b/tiledb/common/types/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(datum OBJECT untyped_datum.cc dynamic_typed_datum.cc)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_datum EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_datum)
 target_link_libraries(compile_datum PRIVATE datum)
 target_sources(compile_datum PRIVATE test/compile_datum_main.cc)
 

--- a/tiledb/sm/array/CMakeLists.txt
+++ b/tiledb/sm/array/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(array PUBLIC uuid $<TARGET_OBJECTS:uuid>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_array EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_array)
 target_link_libraries(compile_array PRIVATE config)
 target_sources(compile_array PRIVATE test/compile_array_directory_main.cc)
 

--- a/tiledb/sm/array_schema/CMakeLists.txt
+++ b/tiledb/sm/array_schema/CMakeLists.txt
@@ -80,6 +80,7 @@ target_sources(compile_domain PRIVATE test/compile_domain_main.cc)
 add_library(dimension_label_reference OBJECT dimension_label_reference.cc)
 target_link_libraries(dimension_label_reference PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(dimension_label_reference PUBLIC buffer $<TARGET_OBJECTS:buffer>)
+target_link_libraries(dimension_label_reference PUBLIC range $<TARGET_OBJECTS:range>)
 target_link_libraries(dimension_label_reference PUBLIC constants $<TARGET_OBJECTS:constants>)
 target_link_libraries(dimension_label_reference PUBLIC vfs $<TARGET_OBJECTS:vfs>)
 #

--- a/tiledb/sm/array_schema/CMakeLists.txt
+++ b/tiledb/sm/array_schema/CMakeLists.txt
@@ -40,9 +40,9 @@ target_link_libraries(attribute PUBLIC stringx $<TARGET_OBJECTS:stringx>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_attribute EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_attribute)
 target_link_libraries(compile_attribute PRIVATE attribute)
 target_sources(compile_attribute PRIVATE test/compile_attribute_main.cc)
-
 #
 # `dimension` object library
 #
@@ -55,6 +55,7 @@ target_link_libraries(dimension PUBLIC range $<TARGET_OBJECTS:range>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_dimension EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_dimension)
 target_link_libraries(compile_dimension PRIVATE dimension)
 target_sources(compile_dimension PRIVATE test/compile_dimension_main.cc)
 
@@ -69,6 +70,7 @@ target_link_libraries(domain PUBLIC math $<TARGET_OBJECTS:math>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_domain EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_domain)
 target_link_libraries(compile_domain PRIVATE domain)
 target_sources(compile_domain PRIVATE test/compile_domain_main.cc)
 
@@ -84,6 +86,7 @@ target_link_libraries(dimension_label_reference PUBLIC vfs $<TARGET_OBJECTS:vfs>
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_dimension_label_reference EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_dimension_label_reference)
 target_link_libraries(compile_dimension_label_reference PRIVATE dimension_label_reference)
 target_sources(compile_dimension_label_reference PRIVATE test/compile_dimension_label_reference_main.cc)
 
@@ -99,6 +102,7 @@ target_link_libraries(array_schema PUBLIC vfs $<TARGET_OBJECTS:vfs>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_array_schema EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_array_schema)
 target_link_libraries(compile_array_schema PRIVATE array_schema)
 target_sources(compile_array_schema PRIVATE test/compile_array_schema_main.cc)
 

--- a/tiledb/sm/buffer/CMakeLists.txt
+++ b/tiledb/sm/buffer/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(buffer PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_buffer EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_buffer)
 target_link_libraries(compile_buffer PRIVATE buffer)
 target_sources(compile_buffer PRIVATE
     test/compile_buffer_main.cc $<TARGET_OBJECTS:buffer>

--- a/tiledb/sm/compressors/CMakeLists.txt
+++ b/tiledb/sm/compressors/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(compressors PUBLIC Bzip2::Bzip2 LZ4::LZ4 Zlib::Zlib Zstd::
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_compressors EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_compressors)
 target_link_libraries(compile_compressors PRIVATE compressors)
 target_sources(compile_compressors PRIVATE
         test/compile_compressors_main.cc
@@ -52,15 +53,15 @@ target_sources(compile_compressors PRIVATE
 #
 add_executable(tdb_gzip_embedded_data)
 target_sources(tdb_gzip_embedded_data PRIVATE
-        util/tdb_gzip_embedded_data.cc 
+        util/tdb_gzip_embedded_data.cc
 )
 
 target_link_libraries(
-    tdb_gzip_embedded_data PUBLIC 
+    tdb_gzip_embedded_data PUBLIC
     filter
     compressors
     )
-    
+
 target_include_directories(tdb_gzip_embedded_data PRIVATE
         $<TARGET_PROPERTY:TILEDB_CORE_OBJECTS,INCLUDE_DIRECTORIES>
 )

--- a/tiledb/sm/config/CMakeLists.txt
+++ b/tiledb/sm/config/CMakeLists.txt
@@ -37,5 +37,6 @@ target_link_libraries(config PUBLIC parse_argument $<TARGET_OBJECTS:parse_argume
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_config EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_config)
 target_link_libraries(compile_config PRIVATE config)
 target_sources(compile_config PRIVATE test/compile_config_main.cc)

--- a/tiledb/sm/crypto/CMakeLists.txt
+++ b/tiledb/sm/crypto/CMakeLists.txt
@@ -54,5 +54,6 @@ endif()
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_crypto EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_crypto)
 target_link_libraries(compile_crypto PRIVATE crypto)
 target_sources(compile_crypto PRIVATE test/compile_crypto_main.cc)

--- a/tiledb/sm/filesystem/CMakeLists.txt
+++ b/tiledb/sm/filesystem/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_vfs EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_vfs)
 target_link_libraries(compile_vfs PRIVATE vfs)
 target_sources(compile_vfs PRIVATE test/compile_vfs_main.cc)
 

--- a/tiledb/sm/filter/CMakeLists.txt
+++ b/tiledb/sm/filter/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(filter PUBLIC crypto $<TARGET_OBJECTS:crypto>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_filter EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_filter)
 target_link_libraries(compile_filter PRIVATE filter)
 target_sources(compile_filter PRIVATE test/compile_filter_main.cc)
 
@@ -172,6 +173,7 @@ target_link_libraries(all_filters PUBLIC float_scaling_filters $<TARGET_OBJECTS:
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_all_filters EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_all_filters)
 target_link_libraries(compile_all_filters PRIVATE all_filters)
 target_sources(compile_all_filters PRIVATE test/compile_all_filters_main.cc)
 
@@ -192,9 +194,10 @@ target_link_libraries(filter_pipeline PUBLIC tile $<TARGET_OBJECTS:tile>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_filter_pipeline EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_filter_pipeline)
 target_link_libraries(compile_filter_pipeline PRIVATE filter_pipeline)
 target_sources(compile_filter_pipeline PRIVATE test/compile_filter_pipeline_main.cc)
-
+add_dependencies(all_link_complete compile_filter_pipeline)
 
 
 if (TILEDB_TESTS)

--- a/tiledb/sm/filter/test/compile_all_filters_main.cc
+++ b/tiledb/sm/filter/test/compile_all_filters_main.cc
@@ -29,7 +29,11 @@
 #include "../filter_create.h"
 
 int main() {
+  using namespace tiledb::sm;
+
   (void)sizeof(tiledb::sm::FilterCreate);
-  (void)&tiledb::sm::FilterCreate::deserialize;
+  (void)static_cast<shared_ptr<Filter> (*)(
+      Deserializer & deserializer, const uint32_t version)>(
+      tiledb::sm::FilterCreate::deserialize);
   return 0;
 }

--- a/tiledb/sm/group/CMakeLists.txt
+++ b/tiledb/sm/group/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(group PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_group EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_group)
 target_link_libraries(compile_group PRIVATE group)
 target_sources(compile_group PRIVATE
     test/compile_group_main.cc $<TARGET_OBJECTS:group>

--- a/tiledb/sm/group/CMakeLists.txt
+++ b/tiledb/sm/group/CMakeLists.txt
@@ -31,12 +31,16 @@ include(common NO_POLICY_SCOPE)
 #
 add_library(group OBJECT group_directory.cc group.cc group_member.cc group_v1.cc group_member_v1.cc)
 target_link_libraries(group PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+target_link_libraries(group PUBLIC baseline $<TARGET_OBJECTS:buffer>)
 
 #
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_group EXCLUDE_FROM_ALL)
-add_dependencies(all_link_complete compile_group)
+
+# TODO: fix linkage of compile_group
+#add_dependencies(all_link_complete compile_group)
+
 target_link_libraries(compile_group PRIVATE group)
 target_sources(compile_group PRIVATE
     test/compile_group_main.cc $<TARGET_OBJECTS:group>

--- a/tiledb/sm/metadata/CMakeLists.txt
+++ b/tiledb/sm/metadata/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(metadata PUBLIC vfs $<TARGET_OBJECTS:vfs>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_metadata EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_metadata)
 target_link_libraries(compile_metadata PRIVATE metadata)
 target_sources(compile_metadata PRIVATE test/compile_metadata_main.cc)
 

--- a/tiledb/sm/misc/CMakeLists.txt
+++ b/tiledb/sm/misc/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(cancelable_tasks PUBLIC thread_pool $<TARGET_OBJECTS:threa
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_cancelable_tasks EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_cancelable_tasks)
 target_link_libraries(compile_cancelable_tasks PRIVATE cancelable_tasks)
 target_sources(compile_cancelable_tasks PRIVATE test/compile_cancelable_tasks_main.cc)
 
@@ -47,6 +48,7 @@ target_link_libraries(constants PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_constants EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_constants)
 target_link_libraries(compile_constants PRIVATE constants)
 target_sources(compile_constants PRIVATE test/compile_constants_main.cc)
 
@@ -58,6 +60,7 @@ add_library(math OBJECT tdb_math.cc)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_math EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_math)
 target_link_libraries(compile_math PRIVATE math)
 target_sources(compile_math PRIVATE test/compile_math_main.cc)
 
@@ -70,6 +73,7 @@ target_link_libraries(misc_types PUBLIC range $<TARGET_OBJECTS:range>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_misc_types EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_misc_types)
 target_link_libraries(compile_misc_types PRIVATE misc_types)
 target_sources(compile_misc_types PRIVATE test/compile_misc_types_main.cc)
 
@@ -82,6 +86,7 @@ target_link_libraries(parse_argument PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_parse_argument EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_parse_argument)
 target_link_libraries(compile_parse_argument PRIVATE parse_argument)
 target_sources(compile_parse_argument PRIVATE test/compile_parse_argument_main.cc)
 
@@ -93,6 +98,7 @@ add_library(time OBJECT tdb_time.cc)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_time EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_time)
 target_link_libraries(compile_time PRIVATE time)
 target_sources(compile_time PRIVATE test/compile_time_main.cc)
 
@@ -118,6 +124,7 @@ endif()
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_uuid EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_uuid)
 target_link_libraries(compile_uuid PRIVATE uuid)
 target_sources(compile_uuid PRIVATE test/compile_uuid_main.cc)
 

--- a/tiledb/sm/query/ast/CMakeLists.txt
+++ b/tiledb/sm/query/ast/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(query_ast PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_query_ast EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_query_ast)
 target_sources(compile_query_ast PRIVATE test/compile_query_ast_main.cc)
 
 target_link_libraries(compile_query_ast PRIVATE query_ast)

--- a/tiledb/sm/stats/CMakeLists.txt
+++ b/tiledb/sm/stats/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(stats PUBLIC stringx $<TARGET_OBJECTS:stringx>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_stats EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_stats)
 target_link_libraries(compile_stats PRIVATE stats)
 target_sources(compile_stats PRIVATE
     test/compile_stats_main.cc $<TARGET_OBJECTS:stats>

--- a/tiledb/sm/subarray/CMakeLists.txt
+++ b/tiledb/sm/subarray/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(range_subset PUBLIC range $<TARGET_OBJECTS:range>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_range_subset EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_range_subset)
 target_link_libraries(compile_range_subset PRIVATE range_subset)
 target_sources(compile_range_subset PRIVATE test/compile_range_subset_main.cc)
 

--- a/tiledb/sm/subarray/CMakeLists.txt
+++ b/tiledb/sm/subarray/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(range_subset PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(range_subset PUBLIC constants $<TARGET_OBJECTS:constants>)
 target_link_libraries(range_subset PUBLIC thread_pool $<TARGET_OBJECTS:thread_pool>)
 target_link_libraries(range_subset PUBLIC range $<TARGET_OBJECTS:range>)
+target_link_libraries(range_subset PUBLIC range $<TARGET_OBJECTS:buffer>)
 
 #
 # Test-compile of object library ensures link-completeness

--- a/tiledb/sm/subarray/test/compile_range_subset_main.cc
+++ b/tiledb/sm/subarray/test/compile_range_subset_main.cc
@@ -29,6 +29,6 @@
 #include "../range_subset.h"
 
 int main() {
-  (void)sizeof(tiledb::sm::RangeSubsetBase);
+  (void)sizeof(tiledb::sm::RangeSetAndSuperset);
   return 0;
 }

--- a/tiledb/sm/tile/CMakeLists.txt
+++ b/tiledb/sm/tile/CMakeLists.txt
@@ -37,5 +37,6 @@ target_link_libraries(tile PUBLIC constants $<TARGET_OBJECTS:constants>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_tile EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_tile)
 target_link_libraries(compile_tile PRIVATE tile)
 target_sources(compile_tile PRIVATE test/compile_tile_main.cc)

--- a/tiledb/storage_format/uri/CMakeLists.txt
+++ b/tiledb/storage_format/uri/CMakeLists.txt
@@ -35,5 +35,6 @@ target_link_libraries(uri_format PUBLIC vfs $<TARGET_OBJECTS:vfs>)
 # Test-compile of object library ensures link-completeness
 #
 add_executable(compile_uri_format EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_uri_format)
 target_link_libraries(compile_uri_format PRIVATE uri_format)
 target_sources(compile_uri_format PRIVATE test/compile_uri_format_main.cc)

--- a/tiledb/type/range/CMakeLists.txt
+++ b/tiledb/type/range/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(range PUBLIC constants $<TARGET_OBJECTS:constants>)
 
 # Test-compile of object library ensures link-completeness
 add_executable(compile_range EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_range)
 target_sources(compile_range PRIVATE test/compile_range_main.cc)
 target_link_libraries(compile_range PRIVATE range)
 


### PR DESCRIPTION
- adds new meta-target `all_link_complete` which aggregates the `compile_*` targets
- fixes most of the currently broken `compile_*` targets
    - except for `compile_group` (SC-20138), which has a very complex dependency tree
- follow up (@shaunrd0) will add this target to CI (SC-20135)

---
TYPE: NO_HISTORY
