### PR TITLE
Dense reader: adding num tiles to stats.

### DIFF
--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -285,6 +285,7 @@ Status DenseReader::dense_read() {
 
   // Compute subarrays for each tile.
   const auto& tile_coords = subarray.tile_coords();
+  stats_->add_counter("num_tiles", tile_coords.size());
   TileSubarrays tile_subarrays{tile_coords.size()};
   const auto& layout =
       layout_ == Layout::GLOBAL_ORDER ? array_schema_.cell_order() : layout_;


### PR DESCRIPTION
Per @stavrospapadopoulos's request, adding number of tiles to the stats
for dense reads.

---
TYPE: IMPROVEMENT
DESC: Dense reader: adding num tiles to stats.
