### PR TITLE
Read only matching fragments in dimension label

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -251,6 +251,8 @@ endif()
 if (TILEDB_EXPERIMENTAL_FEATURES)
   list(APPEND TILEDB_UNIT_TEST_SOURCES
     src/test-capi-dimension_labels.cc
+    src/test-dimension_labels-read-consistency.cc
+    src/unit_intersect_fragments.cc
   )
 endif()
 

--- a/test/src/test-dimension_labels-read-consistency.cc
+++ b/test/src/test-dimension_labels-read-consistency.cc
@@ -1,0 +1,380 @@
+/**
+ * @file test-dimension_labels-read-consistency.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests dimension labels only read fragments that exist in both labelled and
+ * indexed array.
+ */
+
+#include <algorithm>
+
+#include "test/src/helpers.h"
+#include "test/src/vfs_helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/array_schema/dimension_label_schema.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/encryption_type.h"
+#include "tiledb/sm/enums/label_order.h"
+#include "tiledb/sm/enums/query_status.h"
+#include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/query/query.h"
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/storage_format/uri/generate_uri.h"
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/**
+ * Example dimension label with fixed-sized labels.
+ *
+ * Dimension label summary:
+ * * Order: Increasing
+ * * Index dimension: type=uint64_t, domain=[1, 4]
+ * * Label dimesnion: type=uint64_t, domain=[0, 400]
+ *
+ */
+class ExampleFixedDimensionLabel : public TemporaryDirectoryFixture {
+ public:
+  ExampleFixedDimensionLabel()
+      : uri_{URI(fullpath("fixed_label"))} {
+    uint64_t index_tile_extent{4};
+    uint64_t label_tile_extent{401};
+    DimensionLabelSchema dim_label_schema{
+        tiledb::sm::LabelOrder::INCREASING_LABELS,
+        tiledb::sm::Datatype::UINT64,
+        index_domain,
+        &index_tile_extent,
+        tiledb::sm::Datatype::UINT64,
+        label_domain,
+        &label_tile_extent};
+    create_dimension_label(uri_, *ctx->storage_manager(), dim_label_schema);
+  }
+
+  /**
+   * Returns true if no valid fragments exist in the dimension label.
+   */
+  bool dimension_label_is_empty() {
+    DimensionLabel dimension_label{uri_, ctx->storage_manager()};
+    dimension_label.open(
+        QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+    return dimension_label.indexed_array()->is_empty() &&
+           dimension_label.labelled_array()->is_empty();
+  }
+
+  /**
+   * Reads and returns all data in the indexed array.
+   *
+   * @returns A vector of the label values read from the indexed array.
+   **/
+  std::vector<uint64_t> read_indexed_array() {
+    // Open dimension label.
+    DimensionLabel dimension_label{uri_, ctx->storage_manager()};
+    dimension_label.open(
+        QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+
+    // Create label query buffer.
+    std::vector<uint64_t> label_data(ncells_, 0);
+    uint64_t label_data_size{label_data.size() * sizeof(uint64_t)};
+    tiledb::sm::QueryBuffer label_data_buffer{
+        label_data.data(), nullptr, &label_data_size, nullptr};
+
+    // Create subarray.
+    Subarray subarray(
+        dimension_label.indexed_array().get(),
+        (tiledb::sm::stats::Stats*)nullptr,
+        ctx->storage_manager()->logger(),
+        true,
+        ctx->storage_manager());
+    subarray.add_range(0, &index_domain[0], &index_domain[1], nullptr);
+
+    // Create and submit query.
+    Query query{ctx->storage_manager(), dimension_label.indexed_array()};
+    REQUIRE_TILEDB_STATUS_OK(query.set_subarray(subarray));
+    REQUIRE_TILEDB_STATUS_OK(query.set_layout(Layout::ROW_MAJOR));
+    REQUIRE_TILEDB_STATUS_OK(query.set_data_buffer(
+        dimension_label.label_dimension()->name(),
+        label_data_buffer.buffer_,
+        label_data_buffer.buffer_size_,
+        true));
+    REQUIRE_TILEDB_STATUS_OK(query.submit());
+    REQUIRE(query.status() == QueryStatus::COMPLETED);
+
+    // Return results
+    return label_data;
+  }
+
+  /**
+   * Returns the index and label data from the labelled array.
+   *
+   * @returns index_data, label_data
+   **/
+  tuple<std::vector<uint64_t>, std::vector<uint64_t>> read_labelled_array() {
+    // Open dimension label.
+    DimensionLabel dimension_label{uri_, ctx->storage_manager()};
+    dimension_label.open(
+        QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+
+    // Create index query buffer.
+    std::vector<uint64_t> index_data(ncells_, 0);
+    uint64_t index_data_size{index_data.size() * sizeof(uint64_t)};
+    tiledb::sm::QueryBuffer index_data_buffer{
+        index_data.data(), nullptr, &index_data_size, nullptr};
+
+    // Create label query buffer.
+    std::vector<uint64_t> label_data(ncells_, 0);
+    uint64_t label_data_size{label_data.size() * sizeof(uint64_t)};
+    tiledb::sm::QueryBuffer label_data_buffer{
+        label_data.data(), nullptr, &label_data_size, nullptr};
+
+    // Create and submit query.
+    Query query{ctx->storage_manager(), dimension_label.labelled_array()};
+    REQUIRE_TILEDB_STATUS_OK(query.set_layout(Layout::ROW_MAJOR));
+    REQUIRE_TILEDB_STATUS_OK(query.set_data_buffer(
+        dimension_label.label_dimension()->name(),
+        label_data_buffer.buffer_,
+        label_data_buffer.buffer_size_,
+        true));
+    REQUIRE_TILEDB_STATUS_OK(query.set_data_buffer(
+        dimension_label.index_attribute()->name(),
+        index_data_buffer.buffer_,
+        index_data_buffer.buffer_size_,
+        true));
+    REQUIRE_TILEDB_STATUS_OK(query.submit());
+    REQUIRE(query.status() == QueryStatus::COMPLETED);
+
+    // Return results.
+    return {index_data, label_data};
+  }
+
+  /**
+   * Write the entire dimension label.
+   *
+   * @param label_data Label data for the entire label array.
+   * @param enable_indexed_array_write If true, write to the indexed array.
+   * @param enable_labelled_array_write If true, write to the lablled array.
+   */
+  void write_dimension_label(
+      std::vector<uint64_t> label_data,
+      bool enable_indexed_array_write = true,
+      bool enable_labelled_array_write = true) {
+    // Open dimension label for writing.
+    DimensionLabel dimension_label{uri_, ctx->storage_manager()};
+    dimension_label.open(
+        QueryType::WRITE, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+
+    // Generate single fragment name for queries.
+    auto timestamp = dimension_label.indexed_array()->timestamp_end_opened_at();
+    auto timestamp2 =
+        dimension_label.labelled_array()->timestamp_end_opened_at();
+    REQUIRE(timestamp == timestamp2);
+    auto fragment_name = tiledb::storage_format::generate_fragment_name(
+        timestamp, constants::format_version);
+
+    // Create label query buffer.
+    uint64_t label_data_size{label_data.size() * sizeof(uint64_t)};
+    tiledb::sm::QueryBuffer label_buffer{
+        label_data.data(), nullptr, &label_data_size, nullptr};
+    // Write indexed array.
+    if (enable_indexed_array_write) {
+      write_indexed_array(dimension_label, label_buffer, fragment_name);
+    }
+
+    // Read labelled array.
+    if (enable_labelled_array_write) {
+      write_labelled_array(dimension_label, label_buffer, fragment_name);
+    }
+  }
+
+  /**
+   * Write only to the indexed array.
+   *
+   * @param label_data Label data to write for the indexed array.
+   */
+  inline void write_indexed_array_only(std::vector<uint64_t> label_data) {
+    write_dimension_label(label_data, true, false);
+  }
+
+  /**
+   * Write the entire dimension label.
+   *
+   * @param label_data Label data for the entire label array.
+   */
+  inline void write_labelled_array_only(std::vector<uint64_t> label_data) {
+    write_dimension_label(label_data, false, true);
+  }
+
+ protected:
+  /** Number of cells in the index. */
+  const uint64_t ncells_{4};
+
+  /** Valid range for the index. */
+  constexpr static uint64_t index_domain[2]{1, 4};
+
+  /** Valid range for the label. */
+  constexpr static uint64_t label_domain[2]{0, 400};
+
+  /** URI of the dimension label. */
+  URI uri_;
+
+ private:
+  /** Write data to the indexed array. */
+  void write_indexed_array(
+      const DimensionLabel& dimension_label,
+      const tiledb::sm::QueryBuffer& label_data_buffer,
+      const std::string& fragment_name) {
+    Query query{
+        ctx->storage_manager(), dimension_label.indexed_array(), fragment_name};
+    REQUIRE_TILEDB_STATUS_OK(query.set_data_buffer(
+        dimension_label.label_attribute()->name(),
+        label_data_buffer.buffer_,
+        label_data_buffer.buffer_size_,
+        true));
+    auto st = query.submit();
+    INFO(st.to_string());
+    REQUIRE_TILEDB_STATUS_OK(st);
+    REQUIRE(query.status() == QueryStatus::COMPLETED);
+  }
+
+  /** Write data to the labelled array. */
+  void write_labelled_array(
+      const DimensionLabel& dimension_label,
+      const tiledb::sm::QueryBuffer& label_data_buffer,
+      const std::string& fragment_name) {
+    Query query{ctx->storage_manager(),
+                dimension_label.labelled_array(),
+                fragment_name};
+
+    // Create index query buffer.
+    std::vector<uint64_t> index_data(ncells_, 0);
+    for (uint64_t ii{0}; ii < ncells_; ++ii) {
+      index_data[ii] = ii + index_domain[0];
+    }
+    uint64_t index_data_size{index_data.size() * sizeof(uint64_t)};
+    tiledb::sm::QueryBuffer index_data_buffer{
+        index_data.data(), nullptr, &index_data_size, nullptr};
+
+    // Create the query.
+    REQUIRE_TILEDB_STATUS_OK(query.set_layout(Layout::UNORDERED));
+    REQUIRE_TILEDB_STATUS_OK(query.set_data_buffer(
+        dimension_label.label_dimension()->name(),
+        label_data_buffer.buffer_,
+        label_data_buffer.buffer_size_,
+        true));
+    REQUIRE_TILEDB_STATUS_OK(query.set_data_buffer(
+        dimension_label.index_attribute()->name(),
+        index_data_buffer.buffer_,
+        index_data_buffer.buffer_size_,
+        true));
+    REQUIRE_TILEDB_STATUS_OK(query.submit());
+    REQUIRE(query.status() == QueryStatus::COMPLETED);
+  }
+};
+
+TEST_CASE_METHOD(
+    ExampleFixedDimensionLabel,
+    "Read from dimension label with matching fragments",
+    "[DimensionLabel][Query]") {
+  // Write data to the dimension label.
+  std::vector<uint64_t> input_label_data{10, 20, 30, 40};
+  write_dimension_label(input_label_data);
+
+  // Verify labelled array data is as expected.
+  {
+    auto&& [output_index_data, output_label_data] = read_labelled_array();
+
+    // Check label data.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(output_label_data[ii] == input_label_data[ii]);
+    }
+
+    // Check index data.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(output_index_data[ii] == ii + 1);
+    }
+  }
+
+  // Verify indexed array data is as expected.
+  {
+    auto output_label_data = read_indexed_array();
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(output_label_data[ii] == input_label_data[ii]);
+    }
+  }
+}
+
+TEST_CASE_METHOD(
+    ExampleFixedDimensionLabel,
+    "Read from dimension label with inconsistent fragments",
+    "[DimensionLabel][Query]") {
+  // Write good, matching fragment.
+  std::vector<uint64_t> input_label_data{10, 20, 30, 40};
+  write_dimension_label(input_label_data);
+
+  // Write bad, non-matching fragments.
+  std::vector<uint64_t> extra_data1{0, 100, 200, 300};
+  write_labelled_array_only(extra_data1);
+  std::vector<uint64_t> extra_data2{0, 1, 2, 3};
+  write_indexed_array_only(extra_data2);
+
+  // Verify labelled array only returns matched fragment data.
+  {
+    auto&& [output_index_data, output_label_data] = read_labelled_array();
+
+    // Check label data.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(output_label_data[ii] == input_label_data[ii]);
+    }
+
+    // Check index data.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(output_index_data[ii] == ii + 1);
+    }
+  }
+
+  // Verify indexed array data is as expected.
+  {
+    auto output_label_data = read_indexed_array();
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(output_label_data[ii] == input_label_data[ii]);
+    }
+  }
+}
+
+TEST_CASE_METHOD(
+    ExampleFixedDimensionLabel,
+    "Read from dimension label with disjoint fragments",
+    "[DimensionLabel][Query]") {
+  // Write bad, non-matching fragments.
+  std::vector<uint64_t> extra_data1{0, 100, 200, 300};
+  write_labelled_array_only(extra_data1);
+  std::vector<uint64_t> extra_data2{0, 1, 2, 3};
+  write_indexed_array_only(extra_data2);
+
+  // Verify dimension label opens no fragments.
+  REQUIRE(dimension_label_is_empty());
+}

--- a/test/src/unit_intersect_fragments.cc
+++ b/test/src/unit_intersect_fragments.cc
@@ -1,0 +1,230 @@
+/**
+ * @file unit_intersect_fragments.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file tests the ``intersect_fragments`` function.
+ */
+
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <catch.hpp>
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/storage_format/uri/generate_uri.h"
+
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+const uint32_t test_format_version{16};
+
+/**
+ * Create example fragment timestamps.
+ *
+ * Note: uses subsequent timestamps to guarantee order of URIs.
+ */
+tuple<std::vector<std::string>, std::vector<std::pair<uint64_t, uint64_t>>>
+fragment_uri_components(uint64_t num_components) {
+  std::vector<std::string> frag_names;
+  std::vector<std::pair<uint64_t, uint64_t>> times;
+  for (uint64_t ii{1}; ii <= num_components; ++ii) {
+    frag_names.push_back(tiledb::storage_format::generate_fragment_name(
+        ii, test_format_version));
+    uint64_t timestamp_start{ii};
+    uint64_t timestamp_stop{ii};
+    times.emplace_back(std::move(timestamp_start), std::move(timestamp_stop));
+  }
+  return {frag_names, times};
+}
+
+TEST_CASE("Intersect fragments", "[uri]") {
+  // Initialize fragment lists.
+  std::vector<TimestampedURI> list1;
+  std::vector<TimestampedURI> list2;
+  std::set<URI> expected_values;
+
+  SECTION("Both lists empty") {
+    // No data to add.
+  }
+
+  SECTION("Comparison list is empty") {
+    // Add timestamped URIs to list 1 only.
+    auto path2 = URI("base2", false);
+    auto&& [names, times] = fragment_uri_components(2);
+    list2.emplace_back(path2.join_path(names[0]), times[0]);
+    list2.emplace_back(path2.join_path(names[1]), times[1]);
+
+    // No data in result - expect empty vector.
+  }
+
+  SECTION("Fragment list is empty") {
+    // Add timestamped URIs to list 2 only.
+    auto path1 = URI("base1", false);
+    auto&& [names, times] = fragment_uri_components(2);
+    list1.emplace_back(path1.join_path(names[0]), times[0]);
+    list1.emplace_back(path1.join_path(names[1]), times[1]);
+
+    // No data in result - expect empty vector.
+  }
+
+  SECTION("Disjoint fragment lists") {
+    // Create fragment names.
+    auto&& [names, times] = fragment_uri_components(6);
+
+    // Add fragment URIs to fragment list 1.
+    auto path1 = URI("base1", false);
+    list1.emplace_back(path1.join_path(names[0]), times[0]);
+    list1.emplace_back(path1.join_path(names[4]), times[4]);
+
+    // Add fragment URIS to fragment list 2.
+    auto path2 = URI("base2", false);
+    list2.emplace_back(path2.join_path(names[1]), times[1]);
+    list2.emplace_back(path2.join_path(names[2]), times[2]);
+    list2.emplace_back(path2.join_path(names[3]), times[3]);
+    list2.emplace_back(path2.join_path(names[5]), times[5]);
+
+    // No data in result - expect empty vector.
+  }
+
+  SECTION("Indentical fragment lists") {
+    // Create fragment names.
+    auto&& [names, times] = fragment_uri_components(3);
+
+    // Add fragment URIs to fragment list 1.
+    auto path1 = URI("base1", false);
+    list1.emplace_back(path1.join_path(names[0]), times[0]);
+    list1.emplace_back(path1.join_path(names[1]), times[1]);
+    list1.emplace_back(path1.join_path(names[2]), times[2]);
+
+    // Add fragment URIS to fragment list 2.
+    auto path2 = URI("base2", false);
+    list2.emplace_back(path2.join_path(names[2]), times[2]);
+    list2.emplace_back(path2.join_path(names[1]), times[1]);
+    list2.emplace_back(path2.join_path(names[0]), times[0]);
+
+    // Update expected result names.
+    expected_values.insert(path2.join_path(names[0]));
+    expected_values.insert(path2.join_path(names[1]));
+    expected_values.insert(path2.join_path(names[2]));
+  }
+
+  SECTION("Extra values in comparison list") {
+    // Create fragment names.
+    auto&& [names, times] = fragment_uri_components(6);
+
+    // Add fragment URIs to fragment list 1.
+    auto path1 = URI("base1", false);
+    list1.emplace_back(path1.join_path(names[0]), times[0]);
+    list1.emplace_back(path1.join_path(names[1]), times[1]);
+    list1.emplace_back(path1.join_path(names[2]), times[2]);
+    list1.emplace_back(path1.join_path(names[3]), times[3]);
+    list1.emplace_back(path1.join_path(names[4]), times[4]);
+    list1.emplace_back(path1.join_path(names[5]), times[5]);
+
+    // Add fragment URIS to fragment list 2.
+    auto path2 = URI("base2", false);
+    list2.emplace_back(path2.join_path(names[4]), times[4]);
+    list2.emplace_back(path2.join_path(names[2]), times[2]);
+    list2.emplace_back(path2.join_path(names[1]), times[1]);
+
+    // Update expected result names.
+    expected_values.insert(path2.join_path(names[1]));
+    expected_values.insert(path2.join_path(names[2]));
+    expected_values.insert(path2.join_path(names[4]));
+  }
+
+  SECTION("Extra values in fragment list") {
+    // Create fragment names.
+    auto&& [names, times] = fragment_uri_components(6);
+
+    // Add fragment URIs to fragment list 1.
+    auto path1 = URI("base1", false);
+    list1.emplace_back(path1.join_path(names[4]), times[4]);
+    list1.emplace_back(path1.join_path(names[2]), times[2]);
+    list1.emplace_back(path1.join_path(names[1]), times[1]);
+
+    // Add fragment URIS to fragment list 2.
+    auto path2 = URI("base2", false);
+    list2.emplace_back(path2.join_path(names[0]), times[0]);
+    list2.emplace_back(path2.join_path(names[1]), times[1]);
+    list2.emplace_back(path2.join_path(names[2]), times[2]);
+    list2.emplace_back(path2.join_path(names[3]), times[3]);
+    list2.emplace_back(path2.join_path(names[4]), times[4]);
+    list2.emplace_back(path2.join_path(names[5]), times[5]);
+
+    // Update expected result names.
+    expected_values.insert(path2.join_path(names[1]));
+    expected_values.insert(path2.join_path(names[2]));
+    expected_values.insert(path2.join_path(names[4]));
+  }
+
+  SECTION("Extra values in both lists") {
+    // Create fragment names.
+    auto&& [names, times] = fragment_uri_components(8);
+
+    // Add fragment URIs to fragment list 1.
+    auto path1 = URI("base1", false);
+    list1.emplace_back(path1.join_path(names[4]), times[4]);
+    list1.emplace_back(path1.join_path(names[2]), times[2]);
+    list1.emplace_back(path1.join_path(names[1]), times[1]);
+    list1.emplace_back(path1.join_path(names[5]), times[5]);
+    list1.emplace_back(path1.join_path(names[7]), times[7]);
+
+    // Add fragment URIS to fragment list 2.
+    auto path2 = URI("base2", false);
+    list2.emplace_back(path2.join_path(names[0]), times[0]);
+    list2.emplace_back(path2.join_path(names[1]), times[1]);
+    list2.emplace_back(path2.join_path(names[2]), times[2]);
+    list2.emplace_back(path2.join_path(names[3]), times[3]);
+    list2.emplace_back(path2.join_path(names[4]), times[4]);
+    list2.emplace_back(path2.join_path(names[6]), times[6]);
+
+    // Update expected result names.
+    expected_values.insert(path2.join_path(names[1]));
+    expected_values.insert(path2.join_path(names[2]));
+    expected_values.insert(path2.join_path(names[4]));
+  }
+
+  // Remove fragments.
+  intersect_fragments(list1, list2);
+
+  // Check fragments in list2.
+  {
+    INFO(
+        "List2 missing fragments. Expected " +
+        std::to_string(expected_values.size()) + "fragments, but found " +
+        std::to_string(list2.size()) + " framgents.");
+    CHECK(list2.size() >= expected_values.size());
+  }
+  for (const auto& frag_uri : list2) {
+    auto search = expected_values.find(frag_uri.uri_);
+    INFO("Extra fragment found in list2: " + frag_uri.uri_.to_string());
+    CHECK(search != expected_values.end());
+  }
+}

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -268,6 +268,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/generic_tile_io.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile_metadata_generator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/writer_tile.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/storage_format/uri/generate_uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/storage_format/uri/parse_uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/type/range/range.cc
 )

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -351,7 +351,7 @@ tuple<Status, optional<URI>> ArrayDirectory::get_commit_uri(
           URI(temp_uri.to_string() + constants::write_file_suffix)};
 }
 
-tuple<Status, optional<URI>> ArrayDirectory::get_vaccum_uri(
+tuple<Status, optional<URI>> ArrayDirectory::get_vacuum_uri(
     const URI& fragment_uri) const {
   auto name = fragment_uri.remove_trailing_slash().last_path_part();
   uint32_t version;

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -312,7 +312,7 @@ class ArrayDirectory {
   tuple<Status, optional<URI>> get_commit_uri(const URI& fragment_uri) const;
 
   /** Returns the URI for a vacuum file. */
-  tuple<Status, optional<URI>> get_vaccum_uri(const URI& fragment_uri) const;
+  tuple<Status, optional<URI>> get_vacuum_uri(const URI& fragment_uri) const;
 
   /**
    * The new fragment name is computed

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -30,6 +30,7 @@
 #include "tiledb/sm/dimension_label/dimension_label.h"
 #include "tiledb/common/common.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array/array_directory.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/dimension_label_schema.h"
@@ -118,6 +119,7 @@ void DimensionLabel::open(
     EncryptionType encryption_type,
     const void* encryption_key,
     uint32_t key_length) {
+  // Open indexed array and get schema
   throw_if_not_ok(indexed_array_->open(
       query_type,
       timestamp_start,
@@ -125,6 +127,11 @@ void DimensionLabel::open(
       encryption_type,
       encryption_key,
       key_length));
+  auto&& [index_status, indexed_array_schema] =
+      indexed_array_->get_array_schema();
+  throw_if_not_ok(index_status);
+
+  // Open labelled array and get schema
   throw_if_not_ok(labelled_array_->open(
       query_type,
       timestamp_start,
@@ -132,17 +139,43 @@ void DimensionLabel::open(
       encryption_type,
       encryption_key,
       key_length));
-  load_schema();
+  auto&& [label_status, labelled_array_schema] =
+      labelled_array_->get_array_schema();
+  throw_if_not_ok(label_status);
+  load_schema(indexed_array_schema.value(), labelled_array_schema.value());
   query_type_ = query_type;
+
+  // Restrict reading to only shared fragments.
+  if (query_type_ == QueryType::READ) {
+    // Get label names
+    std::vector<TimestampedURI> indexed_frag_uris{
+        indexed_array_->array_directory()
+            .filtered_fragment_uris(false)
+            .fragment_uris()};
+    std::vector<TimestampedURI> labelled_frag_uris{
+        labelled_array_->array_directory()
+            .filtered_fragment_uris(false)
+            .fragment_uris()};
+
+    // Remove mismatched fragments.
+    intersect_fragments(indexed_frag_uris, labelled_frag_uris);
+    intersect_fragments(labelled_frag_uris, indexed_frag_uris);
+
+    // Reload with only shared fragments.
+    indexed_array_->load_fragments(indexed_frag_uris);
+    labelled_array_->load_fragments(labelled_frag_uris);
+  }
 }
 
-void DimensionLabel::load_schema() {
+void DimensionLabel::load_schema(
+    shared_ptr<ArraySchema> indexed_array_schema,
+    shared_ptr<ArraySchema> labelled_array_schema) {
   // Get dimension label schema metadata
   GroupV1 label_group{uri_, storage_manager_};
   throw_if_not_ok(label_group.open(QueryType::READ));
-
   Datatype datatype;
   uint32_t value_num;
+
   // - Read format version.
   const void* format_version_value;
   throw_if_not_ok(label_group.get_metadata(
@@ -168,6 +201,7 @@ void DimensionLabel::load_schema() {
         "DimensionLabel",
         "Cannot load dimension label schema. Version is newer than current "
         "library version.");
+
   // - Read label order
   const void* label_order_value;
   throw_if_not_ok(label_group.get_metadata(
@@ -186,15 +220,13 @@ void DimensionLabel::load_schema() {
         "Unexpected number of values for the index attribute id.");
   auto label_order =
       label_order_from_int(*static_cast<const uint8_t*>(label_order_value));
+
   // - Close group
   throw_if_not_ok(label_group.close());
+
   // Get array schemas
-  auto&& [label_status, label_schema] = labelled_array_->get_array_schema();
-  throw_if_not_ok(label_status);
-  auto&& [index_status, index_schema] = indexed_array_->get_array_schema();
-  throw_if_not_ok(index_status);
   schema_ = make_shared<DimensionLabelSchema>(
-      HERE(), label_order, index_schema.value(), label_schema.value());
+      HERE(), label_order, indexed_array_schema, labelled_array_schema);
 }
 
 QueryType DimensionLabel::query_type() const {
@@ -211,6 +243,7 @@ void create_dimension_label(
     const DimensionLabelSchema& schema) {
   // Create the group for the dimension label.
   storage_manager.group_create(uri.to_string());
+
   // Create the arrays inside the group.
   EncryptionKey key;
   key.set_key(EncryptionType::NO_ENCRYPTION, nullptr, 0);
@@ -226,9 +259,11 @@ void create_dimension_label(
       uri.join_path(labelled_array_name.value()),
       schema.labelled_array_schema(),
       key);
+
   // Open dimension label group.
   GroupV1 label_group{uri, &storage_manager};
   label_group.open(QueryType::WRITE);
+
   // Add metadata to group.
   const uint32_t format_version{1};
   label_group.put_metadata(
@@ -236,13 +271,47 @@ void create_dimension_label(
   uint8_t label_order_int{static_cast<uint8_t>(schema.label_order())};
   label_group.put_metadata(
       "__label_order", Datatype::UINT8, 1, &label_order_int);
+
   // Add arrays to group.
   label_group.mark_member_for_addition(
       URI(indexed_array_name.value(), false), true, indexed_array_name);
   label_group.mark_member_for_addition(
       URI(labelled_array_name.value(), false), true, labelled_array_name);
+
   // Close group.
   label_group.close();
+}
+
+void intersect_fragments(
+    const std::vector<TimestampedURI>& comparison_fragment_list,
+    std::vector<TimestampedURI>& fragment_list) {
+  // If the comparison list is empty, clear the fragment list and return.
+  if (comparison_fragment_list.empty()) {
+    fragment_list.clear();
+    return;
+  }
+
+  // Create a set of fragment names from the comparison fragment list.
+  std::set<std::string> allowed_fragment_names;
+  for (const auto& frag_uri : comparison_fragment_list) {
+    allowed_fragment_names.insert(
+        frag_uri.uri_.remove_trailing_slash().last_path_part());
+  }
+
+  // Iterate over fragment list removing any fragments that are not in the
+  // comparison list.
+  for (auto iter = fragment_list.rbegin(); iter != fragment_list.rend();
+       ++iter) {
+    auto search = allowed_fragment_names.find(
+        iter->uri_.remove_trailing_slash().last_path_part());
+    if (search == allowed_fragment_names.end()) {
+      // Swap & pop the fragment: Replace the value at this iterator with the
+      // last element in the vector, then remove the final element for the
+      // vector.
+      *iter = fragment_list.back();
+      fragment_list.pop_back();
+    }
+  }
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -159,14 +159,22 @@ class DimensionLabel {
   /** Latest dimension label schema  */
   shared_ptr<DimensionLabelSchema> schema_;
 
+  /** The query type the dimension label is opened as. */
   optional<QueryType> query_type_;
 
   /*******************/
   /* Private methods */
   /*******************/
 
-  /** Loads and checks the dimension label schema. */
-  void load_schema();
+  /**
+   * Loads and checks the dimension label schema.
+   *
+   * @param indexed_array_schema Array schema for the indexed array
+   * @param labelled_array_schema Array schema for the labelled array
+   **/
+  void load_schema(
+      shared_ptr<ArraySchema> indexed_array_schema,
+      shared_ptr<ArraySchema> labelled_array_schema);
 };
 
 /**
@@ -181,6 +189,20 @@ void create_dimension_label(
     const URI& uri,
     StorageManager& storage_manager,
     const DimensionLabelSchema& schema);
+
+/**
+ * Removes all fragments URIs from a fragment list that do not have a similarly
+ * named fragment in a comparison fragments list.
+ *
+ * The comparison here is only on the base name of the fragment URIs. Fragments
+ * may be re-ordered upon return.
+ *
+ * @param comparison_fragment_uris The list of fragment URIs to check against.
+ * @param fragment_list The list of fragment URIs to prune.
+ */
+void intersect_fragments(
+    const std::vector<TimestampedURI>& comparison_fragment_list,
+    std::vector<TimestampedURI>& fragment_list);
 
 }  // namespace tiledb::sm
 

--- a/tiledb/sm/query/deletes_and_updates/deletes.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/query/deletes_and_updates/serialization.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
+#include "tiledb/storage_format/uri/generate_uri.h"
 
 using namespace tiledb;
 using namespace tiledb::common;
@@ -125,11 +126,9 @@ Status Deletes::dowork() {
   // Get a new fragment name for the delete.
   uint64_t timestamp = array_->timestamp_end_opened_at();
   auto write_version = array_->array_schema_latest().write_version();
-  auto&& [st, new_fragment_name_opt] =
-      new_fragment_name(timestamp, write_version);
-  RETURN_NOT_OK(st);
-  std::string new_fragment_str =
-      *new_fragment_name_opt + constants::delete_file_suffix;
+  auto new_fragment_str =
+      storage_format::generate_fragment_name(timestamp, write_version) +
+      constants::delete_file_suffix;
 
   // Get the delete URI.
   auto& array_dir = array_->array_directory();

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -68,7 +68,9 @@ namespace sm {
 /* ****************************** */
 
 Query::Query(
-    StorageManager* storage_manager, shared_ptr<Array> array, URI fragment_uri)
+    StorageManager* storage_manager,
+    shared_ptr<Array> array,
+    optional<std::string> fragment_name)
     : array_shared_(array)
     , array_(array_shared_.get())
     , array_schema_(array->array_schema_latest_ptr())
@@ -85,8 +87,8 @@ Query::Query(
     , offsets_buffer_name_("")
     , disable_checks_consolidation_(false)
     , consolidation_with_timestamps_(false)
-    , fragment_uri_(fragment_uri)
-    , force_legacy_reader_(false) {
+    , force_legacy_reader_(false)
+    , fragment_name_(fragment_name) {
   assert(array->is_open());
   auto st = array->get_query_type(&type_);
   assert(st.ok());
@@ -1193,7 +1195,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           layout_,
           written_fragment_info_,
           coords_info_,
-          fragment_uri_,
+          fragment_name_,
           skip_checks_serialization));
     } else if (layout_ == Layout::UNORDERED) {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
@@ -1208,7 +1210,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           layout_,
           written_fragment_info_,
           coords_info_,
-          fragment_uri_,
+          fragment_name_,
           skip_checks_serialization));
     } else if (layout_ == Layout::GLOBAL_ORDER) {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
@@ -1225,7 +1227,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           disable_checks_consolidation_,
           processed_conditions_,
           coords_info_,
-          fragment_uri_,
+          fragment_name_,
           skip_checks_serialization));
     } else {
       assert(false);

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -135,11 +135,17 @@ class Query {
    * for the name of the new fragment to be created.
    *
    * @note Array must be a properly opened array.
+   *
+   * @param array The array that is being queried.
+   * @param fragment_uri The full URI for the new fragment. Only used for
+   * writes.
+   * @param fragment_base_uri Optional base name for new fragment. Only used for
+   *     writes and only if fragment_uri is empty.
    */
   Query(
       StorageManager* storage_manager,
       shared_ptr<Array> array,
-      URI fragment_uri = URI(""));
+      optional<std::string> fragment_name = nullopt);
 
   /** Destructor. */
   ~Query();
@@ -1009,9 +1015,6 @@ class Query {
    */
   bool consolidation_with_timestamps_;
 
-  /** The name of the new fragment to be created for writes. */
-  URI fragment_uri_;
-
   /* Scratch space used for REST requests. */
   shared_ptr<Buffer> rest_scratch_;
 
@@ -1025,6 +1028,14 @@ class Query {
    * the legacy reader.
    */
   bool force_legacy_reader_;
+
+  /**
+   * The name of the new fragment to be created for writes.
+   *
+   * If not set, the fragment name will be created using the latest array
+   * timestamp and a generated UUID.
+   */
+  optional<std::string> fragment_name_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -105,19 +105,6 @@ void StrategyBase::get_dim_attr_stats() const {
   }
 }
 
-tuple<Status, optional<std::string>> StrategyBase::new_fragment_name(
-    uint64_t timestamp, uint32_t format_version) const {
-  timestamp = (timestamp != 0) ? timestamp : utils::time::timestamp_now_ms();
-
-  std::string uuid;
-  RETURN_NOT_OK_TUPLE(uuid::generate_uuid(&uuid, false), nullopt);
-  std::stringstream ss;
-  ss << "/__" << timestamp << "_" << timestamp << "_" << uuid << "_"
-     << format_version;
-
-  return {Status::Ok(), ss.str()};
-}
-
 std::string StrategyBase::offsets_mode() const {
   return offsets_format_mode_;
 }

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -152,23 +152,6 @@ class StrategyBase {
    * the query.
    */
   void get_dim_attr_stats() const;
-
-  /**
-   * Generates a new fragment name, which is in the form: <br>
-   * `__t_t_uuid_v`, where `t` is the input timestamp and `v` is the current
-   * format version. For instance,
-   * `__1458759561320_1458759561320_6ba7b8129dad11d180b400c04fd430c8_3`.
-   *
-   * If `timestamp` is 0, then it is set to the current time.
-   *
-   * @param timestamp The timestamp of when the array got opened for writes. It
-   *     is in ms since 1970-01-01 00:00:00 +0000 (UTC).
-   * @param format_version The write version.
-   *
-   * @return Status, new fragment name.
-   */
-  tuple<Status, optional<std::string>> new_fragment_name(
-      uint64_t timestamp, uint32_t format_version) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -78,7 +78,7 @@ GlobalOrderWriter::GlobalOrderWriter(
     bool disable_checks_consolidation,
     std::vector<std::string>& processed_conditions,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri,
+    optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : WriterBase(
           stats,
@@ -92,7 +92,7 @@ GlobalOrderWriter::GlobalOrderWriter(
           written_fragment_info,
           disable_checks_consolidation,
           coords_info,
-          fragment_uri,
+          fragment_name,
           skip_checks_serialization)
     , processed_conditions_(processed_conditions) {
 }

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -110,7 +110,7 @@ class GlobalOrderWriter : public WriterBase {
       bool disable_checks_consolidation,
       std::vector<std::string>& processed_conditions,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""),
+      optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -76,7 +76,7 @@ OrderedWriter::OrderedWriter(
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri,
+    optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : WriterBase(
           stats,
@@ -90,7 +90,7 @@ OrderedWriter::OrderedWriter(
           written_fragment_info,
           false,
           coords_info,
-          fragment_uri,
+          fragment_name,
           skip_checks_serialization) {
 }
 

--- a/tiledb/sm/query/writers/ordered_writer.h
+++ b/tiledb/sm/query/writers/ordered_writer.h
@@ -63,7 +63,7 @@ class OrderedWriter : public WriterBase {
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""),
+      optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -76,7 +76,7 @@ UnorderedWriter::UnorderedWriter(
     Layout layout,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
-    URI fragment_uri,
+    optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : WriterBase(
           stats,
@@ -90,7 +90,7 @@ UnorderedWriter::UnorderedWriter(
           written_fragment_info,
           false,
           coords_info,
-          fragment_uri,
+          fragment_name,
           skip_checks_serialization) {
 }
 

--- a/tiledb/sm/query/writers/unordered_writer.h
+++ b/tiledb/sm/query/writers/unordered_writer.h
@@ -63,7 +63,7 @@ class UnorderedWriter : public WriterBase {
       Layout layout,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""),
+      optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -79,7 +79,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
-      URI fragment_uri = URI(""),
+      optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 
   /** Destructor. */
@@ -258,12 +258,14 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   /**
    * Creates a new fragment.
    *
+   * This will create the fragment directory, fragment URI directory, and commit
+   * directory (if they do not already exist) the first time it is called.
+   *
    * @param dense Whether the fragment is dense or not.
    * @param frag_meta The fragment metadata to be generated.
    * @return Status
    */
-  Status create_fragment(
-      bool dense, shared_ptr<FragmentMetadata>& frag_meta) const;
+  Status create_fragment(bool dense, shared_ptr<FragmentMetadata>& frag_meta);
 
   /**
    * Runs the input coordinate and attribute tiles through their

--- a/tiledb/storage_format/uri/CMakeLists.txt
+++ b/tiledb/storage_format/uri/CMakeLists.txt
@@ -31,6 +31,8 @@ include(common NO_POLICY_SCOPE)
 add_library(uri_format OBJECT parse_uri.cc)
 target_link_libraries(uri_format PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(uri_format PUBLIC vfs $<TARGET_OBJECTS:vfs>)
+target_link_libraries(uri_format PUBLIC uuid $<TARGET_OBJECTS:uuid>)
+target_link_libraries(uri_format PUBLIC time $<TARGET_OBJECTS:time>)
 #
 # Test-compile of object library ensures link-completeness
 #

--- a/tiledb/storage_format/uri/generate_uri.cc
+++ b/tiledb/storage_format/uri/generate_uri.cc
@@ -1,0 +1,57 @@
+/**
+ * @file generate_uri.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "tiledb/storage_format/uri/generate_uri.h"
+#include "tiledb/sm/misc/tdb_time.h"
+#include "tiledb/sm/misc/uuid.h"
+
+#include <sstream>
+
+using namespace tiledb::common;
+
+namespace tiledb::storage_format {
+
+std::string generate_uri(
+    uint64_t timestamp_start, uint64_t timestamp_end, uint32_t version) {
+  std::string uuid;
+  throw_if_not_ok(sm::uuid::generate_uuid(&uuid, false));
+  std::stringstream ss;
+  ss << "/__" << timestamp_start << "_" << timestamp_end << "_" << uuid << "_"
+     << version;
+
+  return ss.str();
+}
+
+std::string generate_fragment_name(
+    uint64_t timestamp, uint32_t format_version) {
+  timestamp =
+      (timestamp != 0) ? timestamp : sm::utils::time::timestamp_now_ms();
+  return generate_uri(timestamp, timestamp, format_version);
+}
+
+}  // namespace tiledb::storage_format

--- a/tiledb/storage_format/uri/generate_uri.h
+++ b/tiledb/storage_format/uri/generate_uri.h
@@ -1,0 +1,80 @@
+/**
+ * @file generate_uri.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Functions for generating TileDB URIs.
+ */
+
+#ifndef TILEDB_GENERATE_URI_H
+#define TILEDB_GENERATE_URI_H
+
+#include "tiledb/common/common.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::storage_format {
+
+/**
+ * Generates a new URI.
+ *
+ * Generate a new URI in the form `__t1_t2_uuid_v`, where `t1` is the starting
+ * timestamp, `t2` is the ending timestamp,  and `v` is the current format
+ * version. For instance,
+ * `__1458759561320_1458759561480_6ba7b8129dad11d180b400c04fd430c8_3`.
+ *
+ * @param timestamp_start The staring timestamp. It is in ms since
+ *     1970-01-01 00:00:00 +0000 (UTC).
+ * @param timestamp_end The ending timestamp. It is in ms since
+ *     1970-01-01 00:00:00 +0000 (UTC).
+ * @param version Version number to append to the URI.
+ *
+ * @return The new URI.
+ */
+std::string generate_uri(
+    uint64_t timestamp_start, uint64_t timestamp_end, uint32_t version);
+
+/**
+ * Generates a new fragment name.
+ *
+ * Generates a fragment name in the form `__t_t_uuid_v`, where `t` is the input
+ * timestamp and `v` is the current format version. For instance,
+ * `__1458759561320_1458759561320_6ba7b8129dad11d180b400c04fd430c8_3`.
+ *
+ * If `timestamp` is 0, then it is set to the current time.
+ *
+ * @param timestamp The timestamp of when the array got opened for writes. It
+ *     is in ms since 1970-01-01 00:00:00 +0000 (UTC).
+ * @param format_version The write version.
+ *
+ * @return new fragment name.
+ */
+std::string generate_fragment_name(uint64_t timestamp, uint32_t format_version);
+
+}  // namespace tiledb::storage_format
+
+#endif


### PR DESCRIPTION
Adds dimension label read consistency

Adds the ability to write to a specified fragment name and updates the dimension label open to only open array fragments that exist in both the labelled and indexed arrays.

---
TYPE: FEATURE
DESC: Adds dimension label read consistency
