### PR TITLE
Fix reader serialization for old clients.

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -85,7 +85,8 @@ Query::Query(
     , offsets_buffer_name_("")
     , disable_checks_consolidation_(false)
     , consolidation_with_timestamps_(false)
-    , fragment_uri_(fragment_uri) {
+    , fragment_uri_(fragment_uri)
+    , force_legacy_reader_(false) {
   assert(array->is_open());
   auto st = array->get_query_type(&type_);
   assert(st.ok());
@@ -1094,7 +1095,9 @@ IQueryStrategy* Query::strategy(bool skip_checks_serialization) {
   return strategy_.get();
 }
 
-Status Query::reset_strategy_with_layout(Layout layout) {
+Status Query::reset_strategy_with_layout(
+    Layout layout, bool force_legacy_reader) {
+  force_legacy_reader_ = force_legacy_reader;
   strategy_ = nullptr;
   layout_ = layout;
   subarray_.set_layout(layout);
@@ -2244,6 +2247,12 @@ bool Query::use_refactored_dense_reader(
     const ArraySchema& array_schema, bool all_dense) {
   bool use_refactored_reader = false;
   bool found = false;
+
+  // If the query comes from a client using the legacy reader.
+  if (force_legacy_reader_) {
+    return false;
+  }
+
   // First check for legacy option
   config_.get<bool>(
       "sm.use_refactored_readers", &use_refactored_reader, &found);
@@ -2266,6 +2275,12 @@ bool Query::use_refactored_sparse_global_order_reader(
     Layout layout, const ArraySchema& array_schema) {
   bool use_refactored_reader = false;
   bool found = false;
+
+  // If the query comes from a client using the legacy reader.
+  if (force_legacy_reader_) {
+    return false;
+  }
+
   // First check for legacy option
   config_.get<bool>(
       "sm.use_refactored_readers", &use_refactored_reader, &found);
@@ -2290,6 +2305,11 @@ bool Query::use_refactored_sparse_unordered_with_dups_reader(
     Layout layout, const ArraySchema& array_schema) {
   bool use_refactored_reader = false;
   bool found = false;
+
+  // If the query comes from a client using the legacy reader.
+  if (force_legacy_reader_) {
+    return false;
+  }
 
   // First check for legacy option
   config_.get<bool>(

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -558,9 +558,11 @@ class Query {
    * Switch the strategy depending on layout. Used by serialization.
    *
    * @param layout New layout
+   * @param force_legacy_reader Force use of the legacy reader if the client
+   *    requested it.
    * @return Status
    */
-  Status reset_strategy_with_layout(Layout layout);
+  Status reset_strategy_with_layout(Layout layout, bool force_legacy_reader);
 
   /**
    * Disables checking the global order and coordinate duplicates. Applicable
@@ -1005,6 +1007,14 @@ class Query {
 
   /* Scratch space used for REST requests. */
   shared_ptr<Buffer> rest_scratch_;
+
+  /**
+   * Flag to force legacy reader when strategy gets created. This is used by
+   * the serialization codebase if a query comes from an older version of the
+   * library that doesn't have the refactored readers, we need to run it with
+   * the legacy reader.
+   */
+  bool force_legacy_reader_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1334,7 +1334,11 @@ Status query_from_capnp(
   // Deserialize layout.
   Layout layout = Layout::UNORDERED;
   RETURN_NOT_OK(layout_enum(query_reader.getLayout().cStr(), &layout));
-  RETURN_NOT_OK(query->reset_strategy_with_layout(layout));
+
+  // Make sure we have the right query strategy in place.
+  bool force_legacy_reader =
+      query_type == QueryType::READ && query_reader.hasReader();
+  RETURN_NOT_OK(query->reset_strategy_with_layout(layout, force_legacy_reader));
 
   // Deserialize array instance.
   RETURN_NOT_OK(array_from_capnp(query_reader.getArray(), array));


### PR DESCRIPTION
Old clients might submit a query using the legacy reader when the server
would select the refactored ones. This causes au issue because the read
state gets deserialized by the client and used to determine query
completion. The server needs to serialize a read state that the client
will understand, so for now, if the client decides to use the legacy
reader, the server needs to process that query with the legacy reader.

Long term, we will want to serialize a member of the query to determine
completion, and the read state will be serialized as a blob not
deserialized by the client. That way, the server can decide to use
whatever reader it wants.

---
TYPE: IMPROVEMENT
DESC: Fix reader serialization for old clients.
