### PR TITLE
Fix reader serialization for old clients.

### DIFF
--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -907,6 +907,73 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     SerializationFx,
+    "Query serialization, sparse, old client",
+    "[query][sparse][serialization][old-client]") {
+  create_array(TILEDB_SPARSE);
+  write_sparse_array();
+
+  Config config;
+  config.set("sm.query.sparse_global_order.reader", "legacy");
+  config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  auto ctx_client = Context(config);
+
+  SECTION("- Read all") {
+    Array array(ctx_client, array_uri, TILEDB_READ);
+    Query query(ctx_client, array);
+    std::vector<int32_t> coords(1000);
+    std::vector<uint32_t> a1(1000);
+    std::vector<uint32_t> a2(1000);
+    std::vector<uint8_t> a2_nullable(1000);
+    std::vector<char> a3_data(1000 * 100);
+    std::vector<uint64_t> a3_offsets(1000);
+    std::vector<int32_t> subarray = {1, 10, 1, 10};
+
+    query.set_layout(TILEDB_GLOBAL_ORDER);
+    query.set_subarray(subarray);
+    query.set_coordinates(coords);
+    query.set_data_buffer("a1", a1);
+    query.set_data_buffer("a2", a2);
+    query.set_validity_buffer("a2", a2_nullable);
+    query.set_data_buffer("a3", a3_data);
+    query.set_offsets_buffer("a3", a3_offsets);
+
+    // Serialize into a copy and submit.
+    std::vector<uint8_t> serialized;
+    serialize_query(ctx_client, query, &serialized, true);
+
+    Array array2(ctx, array_uri, TILEDB_READ);
+    Query query2(ctx, array2);
+    deserialize_query(ctx, serialized, &query2, false);
+    auto to_free = allocate_query_buffers(ctx, array2, &query2);
+    query2.submit();
+    serialize_query(ctx, query2, &serialized, false);
+
+    // Make sure query2 has logged stats
+    check_read_stats(query2);
+
+    // Deserialize into original query
+    deserialize_query(ctx_client, serialized, &query, true);
+    REQUIRE(query.query_status() == Query::Status::COMPLETE);
+
+    // The deserialized query should also include the write stats
+    check_read_stats(query);
+
+    auto result_el = query.result_buffer_elements_nullable();
+    REQUIRE(std::get<1>(result_el["a1"]) == 10);
+    REQUIRE(std::get<1>(result_el["a2"]) == 20);
+    REQUIRE(std::get<2>(result_el["a2"]) == 10);
+    REQUIRE(std::get<0>(result_el["a3"]) == 10);
+    REQUIRE(std::get<1>(result_el["a3"]) == 55);
+
+    // TODO: check results
+
+    for (void* b : to_free)
+      std::free(b);
+  }
+}
+
+TEST_CASE_METHOD(
+    SerializationFx,
     "Query serialization, split coords, sparse",
     "[query][sparse][serialization][split-coords]") {
   create_array(TILEDB_SPARSE);

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -558,9 +558,11 @@ class Query {
    * Switch the strategy depending on layout. Used by serialization.
    *
    * @param layout New layout
+   * @param force_legacy_reader Force use of the legacy reader if the client
+   *    requested it.
    * @return Status
    */
-  Status reset_strategy_with_layout(Layout layout);
+  Status reset_strategy_with_layout(Layout layout, bool force_legacy_reader);
 
   /**
    * Disables checking the global order and coordinate duplicates. Applicable
@@ -1015,6 +1017,14 @@ class Query {
 
   /* Processed conditions, used for consolidation. */
   std::vector<std::string> processed_conditions_;
+
+  /**
+   * Flag to force legacy reader when strategy gets created. This is used by
+   * the serialization codebase if a query comes from an older version of the
+   * library that doesn't have the refactored readers, we need to run it with
+   * the legacy reader.
+   */
+  bool force_legacy_reader_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1334,7 +1334,11 @@ Status query_from_capnp(
   // Deserialize layout.
   Layout layout = Layout::UNORDERED;
   RETURN_NOT_OK(layout_enum(query_reader.getLayout().cStr(), &layout));
-  RETURN_NOT_OK(query->reset_strategy_with_layout(layout));
+
+  // Make sure we have the right query strategy in place.
+  bool force_legacy_reader =
+      query_type == QueryType::READ && query_reader.hasReader();
+  RETURN_NOT_OK(query->reset_strategy_with_layout(layout, force_legacy_reader));
 
   // Deserialize array instance.
   RETURN_NOT_OK(array_from_capnp(query_reader.getArray(), array));


### PR DESCRIPTION
Old clients might submit a query using the legacy reader when the server
would select the refactored ones. This causes au issue because the read
state gets deserialized by the client and used to determine query
completion. The server needs to serialize a read state that the client
will understand, so for now, if the client decides to use the legacy
reader, the server needs to process that query with the legacy reader.

Long term, we will want to serialize a member of the query to determine
completion, and the read state will be serialized as a blob not
deserialized by the client. That way, the server can decide to use
whatever reader it wants.

---
TYPE: IMPROVEMENT
DESC: Fix reader serialization for old clients.
