### PR TITLE
[ci] Add GHA meta job to simplify branch protection status checks.

### DIFF
--- a/.github/workflows/full-ci-dummy.yml
+++ b/.github/workflows/full-ci-dummy.yml
@@ -1,0 +1,25 @@
+name: "Full CI"
+on:
+  pull_request:
+    branches:
+      - '*'  # must quote since "*" is a YAML reserved character; we want a string
+
+    ##############################################################################
+    #                                                                            #
+    #   This section must be synchronized with 'paths-ignore' in full-ci.yml     #
+    #                                                                            #
+    ##############################################################################
+
+    paths:
+      - '.github/workflows/quarto-render.yml'
+      - '_quarto.yml'
+      - 'quarto-materials/*'
+      - '**/.md'
+      - 'doc/source/conf.py'
+      - 'tiledb/sm/c_api/tiledb_version.h'
+
+jobs:
+  full_ci_passed:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -8,7 +8,7 @@ on:
 
     ##############################################################################
     #                                                                            #
-    #   These sections must be synchronized with 'paths-ignore' in full-ci.yml   #
+    #These sections must be synchronized with 'paths-ignore' in full-ci-dummy.yml#
     #                                                                            #
     ##############################################################################
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -5,6 +5,13 @@ on:
       - dev
       - release-*
       - refs/tags/*
+
+    ##############################################################################
+    #                                                                            #
+    #   These sections must be synchronized with 'paths-ignore' in full-ci.yml   #
+    #                                                                            #
+    ##############################################################################
+
     paths-ignore:
       - '.github/workflows/quarto-render.yml'
       - '_quarto.yml'

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -79,3 +79,11 @@ jobs:
 
   standalone:
     uses: ./.github/workflows/unit-test-runs.yml
+
+  # dummy job for branch protection check
+  full_ci_passed:
+    needs: [ci1, ci2, ci2, ci3, ci4, ci5, ci6, ci7, ci_msvc, standalone]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: ''
+        run: echo "Complete"

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -8,7 +8,7 @@ on:
 
     ##############################################################################
     #                                                                            #
-    #These sections must be synchronized with 'paths-ignore' in full-ci-dummy.yml#
+    #    These sections must be synchronized with 'paths' in full-ci-dummy.yml   #
     #                                                                            #
     ##############################################################################
 


### PR DESCRIPTION
1. [ci] Adds meta-job for CI workflow completion

    This PR adds a new github actions job called 'full_ci_passed', the
    purpose of which is to require preceding specified CI jobs to finish.
    This single job name will then be used for branch protection status checks,
    because GHA does not have a mechanism to only require status checks for
    jobs which have actually been triggered. In some cases we want to allow
    non-code changes (eg narrative docs) to be merged without invoking a
    full CI run.

2.  [ci] Add full-ci-dummy workflow

    This commit adds a no-op 'full_ci_passed' job which will run for PRs that only touch
    non-code paths (such as narrative docs in .md files). This allows CI
    branch protection to be used without blocking non-code PRs, as
    documented here:

      - https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

---

Example run of (2): https://github.com/ihnorton/TileDB/actions/runs/2853045094

---

TYPE: NO_HISTORY