### PR TITLE
Deletes consolidation: switch from marker hashes to condition indexes.

### DIFF
--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -26,7 +26,7 @@ my_array                                    # array folder
          |      |_ ...  
          |      |_ dt.tdb                   # delete timestamp attribute
          |      |_ ...  
-         |      |_ dcmh.tdb                 # delete condition marker hash attribute
+         |      |_ dci.tdb                  # delete condition index attribute
          |      |_ ...  
         |_ ...  
 ```
@@ -43,7 +43,7 @@ There can be any number of fragments in an array. The fragment folder contains:
 * The names of the data files are not dependent on the names of the attributes/dimensions. The file names are determined by the order of the attributes and dimensions in the array schema.
 * The timestamp fixed attribute (`t.tdb`) is, for fragments consolidated with timestamps, the time at which a cell was added.
 * The delete timestamp fixed attribute (`dt.tdb`) is, for fragments consolidated with delete conditions, the time at which a cell was deleted.
-* The delete condition marker hash fixed attribute (`dcmh.tdb`) is, for fragments consolidated with delete conditions, the hash of the delete condition marker that deleted the cell. The delete condition marker is the file path of the delete condition relative to the array URI.
+* The delete condition index fixed attribute (`dci.tdb`) is, for fragments consolidated with delete conditions, the index of the delete condition (inside of [Tile Processed Conditions](#tile-processed-conditions)) that deleted the cell.
 
 ## Fragment Metadata File 
 
@@ -203,7 +203,7 @@ The fragment min max sum null count is a [generic tile](./generic_tile.md) with 
 
 ### Tile Processed Conditions
 
-The processed conditions is a [generic tile](./generic_tile.md) and is the list of delete/update conditions that have already been applied for this fragment and don't need to be applied again, in no particular order, with the following internal format:
+The processed conditions is a [generic tile](./generic_tile.md) and is the list of delete/update conditions that have already been applied for this fragment and don't need to be applied again, sorted by filename, with the following internal format:
 
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |

--- a/format_spec/fragment.md
+++ b/format_spec/fragment.md
@@ -43,7 +43,7 @@ There can be any number of fragments in an array. The fragment folder contains:
 * The names of the data files are not dependent on the names of the attributes/dimensions. The file names are determined by the order of the attributes and dimensions in the array schema.
 * The timestamp fixed attribute (`t.tdb`) is, for fragments consolidated with timestamps, the time at which a cell was added.
 * The delete timestamp fixed attribute (`dt.tdb`) is, for fragments consolidated with delete conditions, the time at which a cell was deleted.
-* The delete condition index fixed attribute (`dci.tdb`) is, for fragments consolidated with delete conditions, the index of the delete condition (inside of [Tile Processed Conditions](#tile-processed-conditions)) that deleted the cell.
+* The delete condition [Delete commit file](./delete_commit_file.md) index fixed attribute (`dci.tdb`) is, for fragments consolidated with delete conditions, the index of the delete condition (inside of [Tile Processed Conditions](#tile-processed-conditions)) that deleted the cell.
 
 ## Fragment Metadata File 
 

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -260,8 +260,8 @@ uint64_t ArraySchema::cell_size(const std::string& name) const {
     return constants::timestamp_size;
   }
 
-  if (name == constants::delete_condition_marker_hash) {
-    return sizeof(size_t);
+  if (name == constants::delete_condition_index) {
+    return sizeof(uint64_t);
   }
 
   // Attribute
@@ -626,8 +626,8 @@ Datatype ArraySchema::type(const std::string& name) const {
     return constants::timestamp_type;
   }
 
-  if (name == constants::delete_condition_marker_hash) {
-    return constants::delete_condition_marker_hash_type;
+  if (name == constants::delete_condition_index) {
+    return constants::delete_condition_index_type;
   }
 
   // Attribute

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -152,7 +152,7 @@ class ArraySchema {
   static inline bool is_special_attribute(const std::string& name) {
     return name == constants::coords || name == constants::timestamps ||
            name == constants::delete_timestamps ||
-           name == constants::delete_condition_marker_hash;
+           name == constants::delete_condition_index;
   }
 
   /**

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -569,7 +569,7 @@ Status FragmentConsolidator::create_buffers(
   }
 
   // Adding buffers for delete meta, one for timestamp and one for condition
-  // marker hash.
+  // index.
   if (config_.with_delete_meta_) {
     buffer_num += 2;
   }
@@ -852,7 +852,7 @@ Status FragmentConsolidator::set_query_buffers(
         &(*buffer_sizes)[bid]));
     ++bid;
     RETURN_NOT_OK(query->set_data_buffer(
-        constants::delete_condition_marker_hash,
+        constants::delete_condition_index,
         (void*)&(*buffers)[bid][0],
         &(*buffer_sizes)[bid]));
     ++bid;

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -728,7 +728,16 @@ class FragmentMetadata {
    *
    * @return Processed conditions.
    */
-  std::unordered_set<std::string>& get_processed_conditions();
+  std::vector<std::string>& get_processed_conditions();
+
+  /**
+   * Retrieves the processed conditions set. The processed conditions is the
+   * list of delete/update conditions that have already been applied for this
+   * fragment and don't need to be applied again.
+   *
+   * @return Processed conditions set.
+   */
+  std::unordered_set<std::string>& get_processed_conditions_set();
 
   /** Returns the first timestamp of the fragment timestamp range. */
   uint64_t first_timestamp() const;
@@ -1085,7 +1094,13 @@ class FragmentMetadata {
   URI array_uri_;
 
   /** Set of already processed delete/update conditions for this fragment. */
-  std::unordered_set<std::string> processed_conditions_;
+  std::unordered_set<std::string> processed_conditions_set_;
+
+  /**
+   * Ordered list of already processed delete/update conditions for this
+   * fragment.
+   */
+  std::vector<std::string> processed_conditions_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -132,9 +132,8 @@ const std::string timestamps = "__timestamps";
 /** Special name reserved for the delete timestamp attribute. */
 const std::string delete_timestamps = "__delete_timestamps";
 
-/** Special name reserved for the delete condition marker hash attribute. */
-const std::string delete_condition_marker_hash =
-    "__delete_condition_marker_hash";
+/** Special name reserved for the delete condition index attribute. */
+const std::string delete_condition_index = "__delete_condition_index";
 
 /** The size of a timestamp cell. */
 const uint64_t timestamp_size = sizeof(uint64_t);
@@ -142,8 +141,8 @@ const uint64_t timestamp_size = sizeof(uint64_t);
 /** The type of a timestamp cell. */
 extern const Datatype timestamp_type = Datatype::UINT64;
 
-/** The type of a delete condition marker hash cell. */
-extern const Datatype delete_condition_marker_hash_type = Datatype::UINT64;
+/** The type of a delete condition index cell. */
+extern const Datatype delete_condition_index_type = Datatype::UINT64;
 
 /** The default compressor for the coordinates. */
 Compressor coords_compression = Compressor::ZSTD;

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -128,8 +128,8 @@ extern const std::string timestamps;
 /** Special name reserved for the delete timestamp attribute. */
 extern const std::string delete_timestamps;
 
-/** Special name reserved for the delete condition marker hash attribute. */
-extern const std::string delete_condition_marker_hash;
+/** Special name reserved for the delete condition index attribute. */
+extern const std::string delete_condition_index;
 
 /** The size of a timestamp cell. */
 extern const uint64_t timestamp_size;
@@ -137,8 +137,8 @@ extern const uint64_t timestamp_size;
 /** The type of a timestamp cell. */
 extern const Datatype timestamp_type;
 
-/** The type of a delete condition marker hash cell. */
-extern const Datatype delete_condition_marker_hash_type;
+/** The type of a delete condition index cell. */
+extern const Datatype delete_condition_index_type;
 
 /** The special value for an empty int32. */
 extern const int empty_int32;

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -144,12 +144,15 @@ tdb_unique_ptr<ASTNode> deserialize_condition_impl(Deserializer& deserializer) {
 }
 
 QueryCondition deserialize_condition(
+    const uint64_t condition_index,
     const std::string& condition_marker,
     const void* buff,
     const storage_size_t size) {
   Deserializer deserializer(buff, size);
   return QueryCondition(
-      condition_marker, deserialize_condition_impl(deserializer));
+      condition_index,
+      condition_marker,
+      deserialize_condition_impl(deserializer));
 }
 
 }  // namespace tiledb::sm::deletes_and_updates::serialization

--- a/tiledb/sm/query/deletes_and_updates/serialization.h
+++ b/tiledb/sm/query/deletes_and_updates/serialization.h
@@ -52,6 +52,7 @@ std::vector<uint8_t> serialize_condition(const QueryCondition& query_condition);
 /**
  * Deserializes the condition.
  *
+ * @param condition_index Index for this condition.
  * @param condition_marker Marker used to know which file the condition came
  * from.
  * @param buff Pointer to the serialized data.
@@ -59,6 +60,7 @@ std::vector<uint8_t> serialize_condition(const QueryCondition& query_condition);
  * @return Deserialized query condition.
  */
 QueryCondition deserialize_condition(
+    const uint64_t condition_index,
     const std::string& condition_marker,
     const void* buff,
     const storage_size_t size);

--- a/tiledb/sm/query/deletes_and_updates/test/unit_delete_condition.cc
+++ b/tiledb/sm/query/deletes_and_updates/test/unit_delete_condition.cc
@@ -48,7 +48,7 @@ using namespace tiledb::sm::deletes_and_updates::serialization;
 void serialize_deserialize_check(QueryCondition& query_condition) {
   auto serialized = serialize_condition(query_condition);
   auto deserialized =
-      deserialize_condition("", serialized.data(), serialized.size());
+      deserialize_condition(0, "", serialized.data(), serialized.size());
 
   CHECK(tiledb::test::ast_equal(query_condition.ast(), deserialized.ast()));
 }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1164,7 +1164,7 @@ Status Query::check_buffer_names() {
     expected_num += static_cast<decltype(expected_num)>(
         buffers_.count(constants::delete_timestamps));
     expected_num += static_cast<decltype(expected_num)>(
-        buffers_.count(constants::delete_condition_marker_hash));
+        buffers_.count(constants::delete_condition_index));
     expected_num += (coord_buffer_is_set_ || coord_data_buffer_is_set_ ||
                      coord_offsets_buffer_is_set_) ?
                         array_schema_->dim_num() :

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -70,6 +70,7 @@ class QueryCondition {
 
   /** Constructor from a tree and marker. */
   QueryCondition(
+      const uint64_t condition_index,
       const std::string& condition_marker,
       tdb_unique_ptr<tiledb::sm::ASTNode>&& tree);
 
@@ -228,9 +229,9 @@ class QueryCondition {
   const std::string& condition_marker() const;
 
   /**
-   * Returns the condition marker hash.
+   * Returns the condition index.
    */
-  size_t condition_marker_hash() const;
+  uint64_t condition_index() const;
 
  private:
   /* ********************************* */
@@ -262,8 +263,8 @@ class QueryCondition {
   /** Marker used to reference which file the condition came from. */
   std::string condition_marker_;
 
-  /** Hash of `condition_marker_`. */
-  size_t condition_marker_hash_;
+  /** Index for the condition. */
+  size_t condition_index_;
 
   /** AST Tree structure representing the condition. **/
   tdb_unique_ptr<tiledb::sm::ASTNode> tree_{};

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -286,7 +286,7 @@ class ReaderBase : public StrategyBase {
   inline bool delete_meta_not_present(
       const std::string& name, const unsigned f) const {
     return (name == constants::delete_timestamps ||
-            name == constants::delete_condition_marker_hash) &&
+            name == constants::delete_condition_index) &&
            !fragment_metadata_[f]->has_delete_meta();
   }
 

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -922,14 +922,14 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   }
 
   /**
-   * Returns the delete hash for the cell at `cell_idx`. If there was not any
-   * delete condition that deleted this cell, the hash is going to be size_t
-   * max.
+   * Returns the delete condition index for the cell at `cell_idx`. If there
+   * was not any delete condition that deleted this cell, the value is going
+   * to be uint64_t max.
    */
-  inline size_t delete_hash(uint64_t cell_idx) {
+  inline size_t delete_condition_index(uint64_t cell_idx) {
     auto ptr = per_cell_delete_condition_[cell_idx];
-    return ptr == nullptr ? std::numeric_limits<size_t>::max() :
-                            ptr->condition_marker_hash();
+    return ptr == nullptr ? std::numeric_limits<uint64_t>::max() :
+                            ptr->condition_index();
   }
 
  private:

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -644,7 +644,7 @@ Status SparseIndexReaderBase::apply_query_condition(
 
             for (uint64_t i = 0; i < delete_conditions_.size(); i++) {
               if (!frag_meta->has_delete_meta() ||
-                  frag_meta->get_processed_conditions().count(
+                  frag_meta->get_processed_conditions_set().count(
                       delete_conditions_[i].condition_marker()) == 0) {
                 auto delete_timestamp =
                     delete_conditions_[i].condition_timestamp();

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1619,6 +1619,7 @@ StorageManager::load_delete_conditions(const Array& array) {
 
     delete_conditions[i] =
         tiledb::sm::deletes_and_updates::serialization::deserialize_condition(
+            i,
             locations[i].condition_marker(),
             tile_opt->data(),
             tile_opt->size());


### PR DESCRIPTION
std::hash is not guaranteed to give consistent results on different
platforms so it cannot be used to store on disk data. It was used to
hash the delete condition marker to know which delete condition deleted
a specific cell. Fortunately, as we already store the processed
conditions in the fragment metadata, we can store an index to the
processed conditions and that will allow to retrieve the same
information. The only complexity comes from when a previous fragment
consolidated with deletes gets processed by consolidation, we need to
convert the index into the original fragment processed condition to the
new fragment processed conditions. This can be done by building a hash
table with a key of the condition marker and a value of the index into
the new processed condition array for constant time conversion.

---
TYPE: IMPROVEMENT
DESC: Deletes consolidation: switch from marker hashes to condition indexes.
