### PR TITLE
Removes unused method from DimensionLabel

### DIFF
--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -136,18 +136,6 @@ void DimensionLabel::open(
   query_type_ = query_type;
 }
 
-void DimensionLabel::open_without_fragments(
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length) {
-  throw_if_not_ok(indexed_array_->open_without_fragments(
-      encryption_type, encryption_key, key_length));
-  throw_if_not_ok(labelled_array_->open_without_fragments(
-      encryption_type, encryption_key, key_length));
-  load_schema();
-  query_type_ = QueryType::READ;
-}
-
 void DimensionLabel::load_schema() {
   // Get dimension label schema metadata
   GroupV1 label_group{uri_, storage_manager_};

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -136,21 +136,6 @@ class DimensionLabel {
       const void* encryption_key,
       uint32_t key_length);
 
-  /**
-   * Opens the dimension label for reading without fragments.
-   *
-   * @param encryption_type The encryption type of the dimension label
-   * @param encryption_key If the dimension label is encrypted, the private
-   *     encryption key. For unencrypted axes, pass `nullptr`.
-   * @param key_length The length in bytes of the encryption key.
-   *
-   * @note Applicable only to reads.
-   */
-  void open_without_fragments(
-      EncryptionType encryption_type,
-      const void* encryption_key,
-      uint32_t key_length);
-
   /** Returns the query type the dimension label was opened with. */
   QueryType query_type() const;
 


### PR DESCRIPTION
The behavior of `open_without_fragments` is going to be modified in
the `Array` class. Rather than maintaining this method in
`DimensionLabel` as well, wait to add it back until there is a need for
it.


---
TYPE: NO_HISTORY
DESC: Remove unused method from DimensionLabel
