### PR TITLE
Update Metadata::deserialize constructor to current standards

### DIFF
--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -275,10 +275,7 @@ inline Status Status_ArraySchemaError(const std::string& msg) {
 inline Status Status_ArraySchemaEvolutionError(const std::string& msg) {
   return {"[TileDB::ArraySchemaEvolution] Error", msg};
 }
-/** Return a Metadata error class Status with a given message **/
-inline Status Status_MetadataError(const std::string& msg) {
-  return {"[TileDB::Metadata] Error", msg};
-}
+
 /** Return a IO error class Status with a given message **/
 inline Status Status_IOError(const std::string& msg) {
   return {"[TileDB::IO] Error", msg};

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -86,6 +86,7 @@ Array::Array(
     , storage_manager_(storage_manager)
     , config_(storage_manager_->config())
     , remote_(array_uri.is_tiledb())
+    , metadata_()
     , metadata_loaded_(false)
     , non_empty_domain_computed_(false)
     , consistency_controller_(cc)

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -120,11 +120,11 @@ Status Metadata::generate_uri(const URI& array_uri) {
   return Status::Ok();
 }
 
-shared_ptr<Metadata> Metadata::deserialize(
+Metadata Metadata::deserialize(
     const std::vector<shared_ptr<Buffer>>& metadata_buffs) {
-  std::map<std::string, MetadataValue> metadata_map;
   if (metadata_buffs.empty())
-    return make_shared<Metadata>(HERE(), metadata_map);
+    return Metadata();
+  std::map<std::string, MetadataValue> metadata_map;
 
   Status st;
   uint32_t key_len;
@@ -154,7 +154,8 @@ shared_ptr<Metadata> Metadata::deserialize(
         value_len = value_struct.num_ *
                     datatype_size(static_cast<Datatype>(value_struct.type_));
         value_struct.value_.resize(value_len);
-        throw_if_not_ok(buff->read((void*)value_struct.value_.data(), value_len));
+        throw_if_not_ok(
+            buff->read((void*)value_struct.value_.data(), value_len));
       }
 
       // Insert to metadata
@@ -162,7 +163,7 @@ shared_ptr<Metadata> Metadata::deserialize(
     }
   }
 
-  return make_shared<Metadata>(HERE(), metadata_map);
+  return Metadata(metadata_map);
 }
 
 Status Metadata::serialize(Buffer* buff) const {

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -45,6 +45,11 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+/** Return a Metadata error class Status with a given message **/
+inline Status Status_MetadataError(const std::string& msg) {
+  return {"[TileDB::Metadata] Error", msg};
+}
+
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
@@ -115,11 +120,11 @@ Status Metadata::generate_uri(const URI& array_uri) {
   return Status::Ok();
 }
 
-tuple<Status, optional<shared_ptr<Metadata>>> Metadata::deserialize(
+shared_ptr<Metadata> Metadata::deserialize(
     const std::vector<shared_ptr<Buffer>>& metadata_buffs) {
   std::map<std::string, MetadataValue> metadata_map;
   if (metadata_buffs.empty())
-    return {Status::Ok(), make_shared<Metadata>(HERE())};
+    return make_shared<Metadata>(HERE(), metadata_map);
 
   Status st;
   uint32_t key_len;
@@ -129,10 +134,10 @@ tuple<Status, optional<shared_ptr<Metadata>>> Metadata::deserialize(
     // Iterate over all items
     buff->reset_offset();
     while (buff->offset() != buff->size()) {
-      RETURN_NOT_OK_TUPLE(buff->read(&key_len, sizeof(uint32_t)), nullopt);
+      throw_if_not_ok(buff->read(&key_len, sizeof(uint32_t)));
       std::string key((const char*)buff->cur_data(), key_len);
       buff->advance_offset(key_len);
-      RETURN_NOT_OK_TUPLE(buff->read(&del, sizeof(char)), nullopt);
+      throw_if_not_ok(buff->read(&del, sizeof(char)));
 
       metadata_map.erase(key);
 
@@ -142,17 +147,14 @@ tuple<Status, optional<shared_ptr<Metadata>>> Metadata::deserialize(
 
       MetadataValue value_struct;
       value_struct.del_ = del;
-      RETURN_NOT_OK_TUPLE(
-          buff->read(&value_struct.type_, sizeof(char)), nullopt);
-      RETURN_NOT_OK_TUPLE(
-          buff->read(&value_struct.num_, sizeof(uint32_t)), nullopt);
+      throw_if_not_ok(buff->read(&value_struct.type_, sizeof(char)));
+      throw_if_not_ok(buff->read(&value_struct.num_, sizeof(uint32_t)));
 
       if (value_struct.num_) {
         value_len = value_struct.num_ *
                     datatype_size(static_cast<Datatype>(value_struct.type_));
         value_struct.value_.resize(value_len);
-        RETURN_NOT_OK_TUPLE(
-            buff->read((void*)value_struct.value_.data(), value_len), nullopt);
+        throw_if_not_ok(buff->read((void*)value_struct.value_.data(), value_len));
       }
 
       // Insert to metadata
@@ -160,7 +162,7 @@ tuple<Status, optional<shared_ptr<Metadata>>> Metadata::deserialize(
     }
   }
 
-  return {Status::Ok(), make_shared<Metadata>(HERE(), metadata_map)};
+  return make_shared<Metadata>(HERE(), metadata_map);
 }
 
 Status Metadata::serialize(Buffer* buff) const {

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -88,7 +88,7 @@ class Metadata {
   /* ********************************* */
 
   /** Constructor. */
-  Metadata();
+  explicit Metadata();
 
   /** Constructor. */
   Metadata(const std::map<std::string, MetadataValue>& metadata_map);
@@ -117,10 +117,10 @@ class Metadata {
 
   /**
    * Deserializes the input metadata buffers. Note that the buffers are
-   * assummed to be sorted on time. The function will take care of any
+   * assumed to be sorted on time. The function will take care of any
    * deleted or overwritten metadata items considering the order.
    */
-  static tuple<Status, optional<shared_ptr<Metadata>>> deserialize(
+  static shared_ptr<Metadata> deserialize(
       const std::vector<shared_ptr<Buffer>>& metadata_buffs);
 
   /** Serializes all key-value metadata items into the input buffer. */

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -120,7 +120,7 @@ class Metadata {
    * assumed to be sorted on time. The function will take care of any
    * deleted or overwritten metadata items considering the order.
    */
-  static shared_ptr<Metadata> deserialize(
+  static Metadata deserialize(
       const std::vector<shared_ptr<Buffer>>& metadata_buffs);
 
   /** Serializes all key-value metadata items into the input buffer. */

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -114,7 +114,7 @@ TEST_CASE(
 
   // Read key_1 metadata
   const int32_t* v_1;
-  meta->get("key1", &type, &v_num, (const void**)(&v_1));
+  meta.get("key1", &type, &v_num, (const void**)(&v_1));
   CHECK(type == Datatype::INT32);
   CHECK(v_num == (uint32_t)(value_1_vector.size()));
   CHECK(*(v_1) == 100);
@@ -122,14 +122,14 @@ TEST_CASE(
 
   // Read key_2 metadata
   const double* v_2;
-  meta->get("key2", &type, &v_num, (const void**)(&v_2));
+  meta.get("key2", &type, &v_num, (const void**)(&v_2));
   CHECK(type == Datatype::FLOAT64);
   CHECK(v_num == value_2_size);
   CHECK(*(v_2) == value_2);
 
   // Read key_3 metadata
   const char* v_3;
-  meta->get("key3", &type, &v_num, (const void**)(&v_3));
+  meta.get("key3", &type, &v_num, (const void**)(&v_3));
   CHECK(type == Datatype::STRING_ASCII);
   CHECK(v_num == value_3_size);
   CHECK(std::string(v_3, value_3_size) == value_3);

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -107,16 +107,14 @@ TEST_CASE(
   metadata_buffs.push_back(make_shared<Buffer>(
       HERE(), &serialized_buffer_3, sizeof(serialized_buffer_3)));
 
-  auto&& [st_meta, meta]{Metadata::deserialize(metadata_buffs)};
-
-  REQUIRE(st_meta.ok());
+  auto meta{Metadata::deserialize(metadata_buffs)};
 
   Datatype type;
   uint32_t v_num;
 
   // Read key_1 metadata
   const int32_t* v_1;
-  meta.value()->get("key1", &type, &v_num, (const void**)(&v_1));
+  meta->get("key1", &type, &v_num, (const void**)(&v_1));
   CHECK(type == Datatype::INT32);
   CHECK(v_num == (uint32_t)(value_1_vector.size()));
   CHECK(*(v_1) == 100);
@@ -124,14 +122,14 @@ TEST_CASE(
 
   // Read key_2 metadata
   const double* v_2;
-  meta.value()->get("key2", &type, &v_num, (const void**)(&v_2));
+  meta->get("key2", &type, &v_num, (const void**)(&v_2));
   CHECK(type == Datatype::FLOAT64);
   CHECK(v_num == value_2_size);
   CHECK(*(v_2) == value_2);
 
   // Read key_3 metadata
   const char* v_3;
-  meta.value()->get("key3", &type, &v_num, (const void**)(&v_3));
+  meta->get("key3", &type, &v_num, (const void**)(&v_3));
   CHECK(type == Datatype::STRING_ASCII);
   CHECK(v_num == value_3_size);
   CHECK(std::string(v_3, value_3_size) == value_3);

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1590,12 +1590,7 @@ Status StorageManager::load_array_metadata(
     meta_size += b->size();
   stats_->add_counter("read_array_meta_size", meta_size);
 
-  auto&& [st_metadata, deserialized_metadata]{
-      Metadata::deserialize(metadata_buffs)};
-  if (!st_metadata.ok()) {
-    return st_metadata;
-  }
-  *metadata = *(deserialized_metadata.value());
+  *metadata = *Metadata::deserialize(metadata_buffs);
 
   // Sets the loaded metadata URIs
   RETURN_NOT_OK(metadata->set_loaded_metadata_uris(array_metadata_to_load));
@@ -2186,14 +2181,8 @@ Status StorageManager::load_group_metadata(
     meta_size += b->size();
   stats_->add_counter("read_array_meta_size", meta_size);
 
-  // Deserialize metadata buffers
-  auto&& [st, deserialized_metadata] = metadata->deserialize(metadata_buffs);
-  if (!st.ok()) {
-    return st;
-  }
-
   // Copy the deserialized metadata into the original Metadata object
-  *metadata = *(deserialized_metadata.value());
+  *metadata = *Metadata::deserialize(metadata_buffs);
   RETURN_NOT_OK(metadata->set_loaded_metadata_uris(group_metadata_to_load));
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1590,7 +1590,7 @@ Status StorageManager::load_array_metadata(
     meta_size += b->size();
   stats_->add_counter("read_array_meta_size", meta_size);
 
-  *metadata = *Metadata::deserialize(metadata_buffs);
+  *metadata = Metadata::deserialize(metadata_buffs);
 
   // Sets the loaded metadata URIs
   RETURN_NOT_OK(metadata->set_loaded_metadata_uris(array_metadata_to_load));
@@ -2182,7 +2182,7 @@ Status StorageManager::load_group_metadata(
   stats_->add_counter("read_array_meta_size", meta_size);
 
   // Copy the deserialized metadata into the original Metadata object
-  *metadata = *Metadata::deserialize(metadata_buffs);
+  *metadata = Metadata::deserialize(metadata_buffs);
   RETURN_NOT_OK(metadata->set_loaded_metadata_uris(group_metadata_to_load));
 
   return Status::Ok();


### PR DESCRIPTION
`throw_if_not_ok` was used to handle exceptions thrown in `Metadata::deserialize`, but I also relocated `Status_MetadataError` following C.41 sync discussion.

---
TYPE: IMPROVEMENT
DESC: Update Metadata::deserialize to return a Metadata object and throw exceptions if/where necessary
