### PR TITLE
Deletes: adding purge option for consolidation.

### DIFF
--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -590,12 +590,12 @@ TEST_CASE_METHOD(
   CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
 
-  // Reading after delete condition timestamp.
+  // Reading at delete condition timestamp.
   buffer_size = legacy ? 100 : 2;
   std::vector<int> a1_2(buffer_size);
   std::vector<uint64_t> dim1_2(buffer_size);
   std::vector<uint64_t> dim2_2(buffer_size);
-  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 4);
+  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 3);
 
   std::vector<int> c_a1_2 = {2, 3};
   std::vector<uint64_t> c_dim1_2 = {1, 2};
@@ -606,76 +606,92 @@ TEST_CASE_METHOD(
   CHECK(!memcmp(
       c_dim2_2.data(), dim2_2.data(), c_dim2_2.size() * sizeof(uint64_t)));
 
-  // Reading after new fragment.
-  buffer_size = legacy ? 100 : 3;
+  // Reading after delete condition timestamp.
+  buffer_size = legacy ? 100 : 2;
   std::vector<int> a1_3(buffer_size);
   std::vector<uint64_t> dim1_3(buffer_size);
   std::vector<uint64_t> dim2_3(buffer_size);
-  read_sparse(a1_3, dim1_3, dim2_3, stats, read_layout, 6);
+  read_sparse(a1_3, dim1_3, dim2_3, stats, read_layout, 4);
 
-  std::vector<int> c_a1_3 = {2, 3, 1};
-  std::vector<uint64_t> c_dim1_3 = {1, 2, 4};
-  std::vector<uint64_t> c_dim2_3 = {4, 3, 4};
+  std::vector<int> c_a1_3 = {2, 3};
+  std::vector<uint64_t> c_dim1_3 = {1, 2};
+  std::vector<uint64_t> c_dim2_3 = {4, 3};
   CHECK(!memcmp(c_a1_3.data(), a1_3.data(), c_a1_3.size() * sizeof(int)));
   CHECK(!memcmp(
       c_dim1_3.data(), dim1_3.data(), c_dim1_3.size() * sizeof(uint64_t)));
   CHECK(!memcmp(
       c_dim2_3.data(), dim2_3.data(), c_dim2_3.size() * sizeof(uint64_t)));
 
-  // Reading after adding deleted cells.
-  buffer_size = legacy ? 100 : 5;
+  // Reading after new fragment.
+  buffer_size = legacy ? 100 : 3;
   std::vector<int> a1_4(buffer_size);
   std::vector<uint64_t> dim1_4(buffer_size);
   std::vector<uint64_t> dim2_4(buffer_size);
-  read_sparse(a1_4, dim1_4, dim2_4, stats, read_layout, 8);
+  read_sparse(a1_4, dim1_4, dim2_4, stats, read_layout, 6);
 
-  std::vector<int> c_a1_4_ordered = {0, 1, 2, 3, 1};
-  std::vector<uint64_t> c_dim1_4_ordered = {1, 1, 1, 2, 4};
-  std::vector<uint64_t> c_dim2_4_ordered = {1, 2, 4, 3, 4};
-  std::vector<int> c_a1_4_unordered = {2, 3, 1, 0, 1};
-  std::vector<uint64_t> c_dim1_4_unordered = {1, 2, 4, 1, 1};
-  std::vector<uint64_t> c_dim2_4_unordered = {4, 3, 4, 1, 2};
+  std::vector<int> c_a1_4 = {2, 3, 1};
+  std::vector<uint64_t> c_dim1_4 = {1, 2, 4};
+  std::vector<uint64_t> c_dim2_4 = {4, 3, 4};
+  CHECK(!memcmp(c_a1_4.data(), a1_4.data(), c_a1_4.size() * sizeof(int)));
+  CHECK(!memcmp(
+      c_dim1_4.data(), dim1_4.data(), c_dim1_4.size() * sizeof(uint64_t)));
+  CHECK(!memcmp(
+      c_dim2_4.data(), dim2_4.data(), c_dim2_4.size() * sizeof(uint64_t)));
+
+  // Reading after adding deleted cells.
+  buffer_size = legacy ? 100 : 5;
+  std::vector<int> a1_5(buffer_size);
+  std::vector<uint64_t> dim1_5(buffer_size);
+  std::vector<uint64_t> dim2_5(buffer_size);
+  read_sparse(a1_5, dim1_5, dim2_5, stats, read_layout, 8);
+
+  std::vector<int> c_a1_5_ordered = {0, 1, 2, 3, 1};
+  std::vector<uint64_t> c_dim1_5_ordered = {1, 1, 1, 2, 4};
+  std::vector<uint64_t> c_dim2_5_ordered = {1, 2, 4, 3, 4};
+  std::vector<int> c_a1_5_unordered = {2, 3, 1, 0, 1};
+  std::vector<uint64_t> c_dim1_5_unordered = {1, 2, 4, 1, 1};
+  std::vector<uint64_t> c_dim2_5_unordered = {4, 3, 4, 1, 2};
   if (read_layout == TILEDB_GLOBAL_ORDER) {
     CHECK(!memcmp(
-        c_a1_4_ordered.data(),
-        a1_4.data(),
-        c_a1_4_ordered.size() * sizeof(int)));
+        c_a1_5_ordered.data(),
+        a1_5.data(),
+        c_a1_5_ordered.size() * sizeof(int)));
     CHECK(!memcmp(
-        c_dim1_4_ordered.data(),
-        dim1_4.data(),
-        c_dim1_4_ordered.size() * sizeof(uint64_t)));
+        c_dim1_5_ordered.data(),
+        dim1_5.data(),
+        c_dim1_5_ordered.size() * sizeof(uint64_t)));
     CHECK(!memcmp(
-        c_dim2_4_ordered.data(),
-        dim2_4.data(),
-        c_dim2_4_ordered.size() * sizeof(uint64_t)));
+        c_dim2_5_ordered.data(),
+        dim2_5.data(),
+        c_dim2_5_ordered.size() * sizeof(uint64_t)));
   } else {
     CHECK(
         (!memcmp(
-             c_a1_4_ordered.data(),
-             a1_4.data(),
-             c_a1_4_ordered.size() * sizeof(int)) ||
+             c_a1_5_ordered.data(),
+             a1_5.data(),
+             c_a1_5_ordered.size() * sizeof(int)) ||
          !memcmp(
-             c_a1_4_unordered.data(),
-             a1_4.data(),
-             c_a1_4_unordered.size() * sizeof(int))));
+             c_a1_5_unordered.data(),
+             a1_5.data(),
+             c_a1_5_unordered.size() * sizeof(int))));
     CHECK(
         (!memcmp(
-             c_dim1_4_ordered.data(),
-             dim1_4.data(),
-             c_dim1_4_ordered.size() * sizeof(uint64_t)) ||
+             c_dim1_5_ordered.data(),
+             dim1_5.data(),
+             c_dim1_5_ordered.size() * sizeof(uint64_t)) ||
          !memcmp(
-             c_dim1_4_unordered.data(),
-             dim1_4.data(),
-             c_dim1_4_unordered.size() * sizeof(uint64_t))));
+             c_dim1_5_unordered.data(),
+             dim1_5.data(),
+             c_dim1_5_unordered.size() * sizeof(uint64_t))));
     CHECK(
         (!memcmp(
-             c_dim2_4_ordered.data(),
-             dim2_4.data(),
-             c_dim2_4_ordered.size() * sizeof(uint64_t)) ||
+             c_dim2_5_ordered.data(),
+             dim2_5.data(),
+             c_dim2_5_ordered.size() * sizeof(uint64_t)) ||
          !memcmp(
-             c_dim2_4_unordered.data(),
-             dim2_4.data(),
-             c_dim2_4_unordered.size() * sizeof(uint64_t))));
+             c_dim2_5_unordered.data(),
+             dim2_5.data(),
+             c_dim2_5_unordered.size() * sizeof(uint64_t))));
   }
 
   remove_sparse_array();

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -66,6 +66,7 @@ struct DeletesFx {
 
   // Functions.
   void set_legacy();
+  void set_purge_deleted_cells();
   void create_sparse_array(bool allows_dups = false, bool encrypt = false);
   void write_sparse(
       std::vector<int> a1,
@@ -107,6 +108,16 @@ DeletesFx::DeletesFx()
 }
 
 DeletesFx::~DeletesFx() {
+}
+
+void DeletesFx::set_purge_deleted_cells() {
+  Config config;
+  config.set("sm.consolidation.buffer_size", "1000");
+  config.set("sm.consolidation.purge_deleted_cells", "true");
+
+  ctx_ = Context(config);
+  sm_ = ctx_.ptr().get()->storage_manager();
+  vfs_ = VFS(ctx_);
 }
 
 void DeletesFx::set_legacy() {
@@ -412,11 +423,12 @@ TEST_CASE_METHOD(
   remove_sparse_array();
 
   bool consolidate = GENERATE(true, false);
+  bool purge_deleted_cells = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-  if (!consolidate && vacuum) {
+  if (!consolidate && (vacuum || purge_deleted_cells)) {
     return;
   }
 
@@ -435,6 +447,11 @@ TEST_CASE_METHOD(
   // Write another fragment that will not be affected by the condition.
   write_sparse({1}, {4}, {4}, 5);
 
+  // Set purge consolidation config, if needed.
+  if (purge_deleted_cells) {
+    set_purge_deleted_cells();
+  }
+
   // Consolidate with delete.
   if (consolidate) {
     consolidate_sparse(vacuum);
@@ -446,7 +463,7 @@ TEST_CASE_METHOD(
   }
 
   // Reading before the delete condition timestamp.
-  uint64_t buffer_size = legacy ? 100 : 4;
+  uint64_t buffer_size = legacy ? 100 : purge_deleted_cells ? 2 : 4;
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);
@@ -456,6 +473,11 @@ TEST_CASE_METHOD(
   std::vector<int> c_a1 = {0, 1, 2, 3};
   std::vector<uint64_t> c_dim1 = {1, 1, 1, 2};
   std::vector<uint64_t> c_dim2 = {1, 2, 4, 3};
+  if (purge_deleted_cells) {
+    c_a1 = {2, 3};
+    c_dim1 = {1, 2};
+    c_dim2 = {4, 3};
+  }
   CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
   CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
@@ -503,11 +525,12 @@ TEST_CASE_METHOD(
   remove_sparse_array();
 
   bool consolidate = GENERATE(true, false);
+  bool purge_deleted_cells = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-  if (!consolidate && vacuum) {
+  if (!consolidate && (vacuum || purge_deleted_cells)) {
     return;
   }
 
@@ -529,6 +552,13 @@ TEST_CASE_METHOD(
 
   // Write condition.
   write_delete_condition(qc, 3);
+  // Write another fragment that will rewrite deleted cells.
+  write_sparse({0, 1}, {1, 1}, {1, 2}, 7);
+
+  // Set purge consolidation config, if needed.
+  if (purge_deleted_cells) {
+    set_purge_deleted_cells();
+  }
 
   // Consolidate with delete.
   if (consolidate) {
@@ -541,7 +571,7 @@ TEST_CASE_METHOD(
   }
 
   // Reading before the delete condition timestamp.
-  uint64_t buffer_size = legacy ? 100 : 4;
+  uint64_t buffer_size = legacy ? 100 : purge_deleted_cells ? 2 : 4;
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);
@@ -551,6 +581,11 @@ TEST_CASE_METHOD(
   std::vector<int> c_a1 = {0, 1, 2, 3};
   std::vector<uint64_t> c_dim1 = {1, 1, 1, 2};
   std::vector<uint64_t> c_dim2 = {1, 2, 4, 3};
+  if (purge_deleted_cells) {
+    c_a1 = {2, 3};
+    c_dim1 = {1, 2};
+    c_dim2 = {4, 3};
+  }
   CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
   CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
@@ -587,6 +622,62 @@ TEST_CASE_METHOD(
   CHECK(!memcmp(
       c_dim2_3.data(), dim2_3.data(), c_dim2_3.size() * sizeof(uint64_t)));
 
+  // Reading after adding deleted cells.
+  buffer_size = legacy ? 100 : 5;
+  std::vector<int> a1_4(buffer_size);
+  std::vector<uint64_t> dim1_4(buffer_size);
+  std::vector<uint64_t> dim2_4(buffer_size);
+  read_sparse(a1_4, dim1_4, dim2_4, stats, read_layout, 8);
+
+  std::vector<int> c_a1_4_ordered = {0, 1, 2, 3, 1};
+  std::vector<uint64_t> c_dim1_4_ordered = {1, 1, 1, 2, 4};
+  std::vector<uint64_t> c_dim2_4_ordered = {1, 2, 4, 3, 4};
+  std::vector<int> c_a1_4_unordered = {2, 3, 1, 0, 1};
+  std::vector<uint64_t> c_dim1_4_unordered = {1, 2, 4, 1, 1};
+  std::vector<uint64_t> c_dim2_4_unordered = {4, 3, 4, 1, 2};
+  if (read_layout == TILEDB_GLOBAL_ORDER) {
+    CHECK(!memcmp(
+        c_a1_4_ordered.data(),
+        a1_4.data(),
+        c_a1_4_ordered.size() * sizeof(int)));
+    CHECK(!memcmp(
+        c_dim1_4_ordered.data(),
+        dim1_4.data(),
+        c_dim1_4_ordered.size() * sizeof(uint64_t)));
+    CHECK(!memcmp(
+        c_dim2_4_ordered.data(),
+        dim2_4.data(),
+        c_dim2_4_ordered.size() * sizeof(uint64_t)));
+  } else {
+    CHECK(
+        (!memcmp(
+             c_a1_4_ordered.data(),
+             a1_4.data(),
+             c_a1_4_ordered.size() * sizeof(int)) ||
+         !memcmp(
+             c_a1_4_unordered.data(),
+             a1_4.data(),
+             c_a1_4_unordered.size() * sizeof(int))));
+    CHECK(
+        (!memcmp(
+             c_dim1_4_ordered.data(),
+             dim1_4.data(),
+             c_dim1_4_ordered.size() * sizeof(uint64_t)) ||
+         !memcmp(
+             c_dim1_4_unordered.data(),
+             dim1_4.data(),
+             c_dim1_4_unordered.size() * sizeof(uint64_t))));
+    CHECK(
+        (!memcmp(
+             c_dim2_4_ordered.data(),
+             dim2_4.data(),
+             c_dim2_4_ordered.size() * sizeof(uint64_t)) ||
+         !memcmp(
+             c_dim2_4_unordered.data(),
+             dim2_4.data(),
+             c_dim2_4_unordered.size() * sizeof(uint64_t))));
+  }
+
   remove_sparse_array();
 }
 
@@ -597,12 +688,13 @@ TEST_CASE_METHOD(
     "[cppapi][deletes][duplicates]") {
   remove_sparse_array();
 
+  bool purge_deleted_cells = GENERATE(true, false);
   bool consolidate = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-  if (!consolidate && vacuum) {
+  if (!consolidate && (vacuum || purge_deleted_cells)) {
     return;
   }
 
@@ -622,6 +714,11 @@ TEST_CASE_METHOD(
   // Write condition.
   write_delete_condition(qc, 5);
 
+  // Set purge consolidation config, if needed.
+  if (purge_deleted_cells) {
+    set_purge_deleted_cells();
+  }
+
   // Consolidate with delete.
   if (consolidate) {
     consolidate_sparse(vacuum);
@@ -640,25 +737,17 @@ TEST_CASE_METHOD(
   std::vector<uint64_t> dim2(buffer_size);
   read_sparse(a1, dim1, dim2, stats, read_layout, 7);
 
-  if (allows_dups) {
-    std::vector<int> c_a1 = {0, 1, 2, 3};
-    std::vector<uint64_t> c_dim1 = {1, 1, 1, 2};
-    std::vector<uint64_t> c_dim2 = {1, 2, 4, 3};
-    CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
-    CHECK(
-        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
-    CHECK(
-        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
-  } else {
-    std::vector<int> c_a1 = {1, 2, 3};
-    std::vector<uint64_t> c_dim1 = {1, 1, 2};
-    std::vector<uint64_t> c_dim2 = {2, 4, 3};
-    CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
-    CHECK(
-        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
-    CHECK(
-        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  std::vector<int> c_a1 = {0, 1, 2, 3};
+  std::vector<uint64_t> c_dim1 = {1, 1, 1, 2};
+  std::vector<uint64_t> c_dim2 = {1, 2, 4, 3};
+  if (!allows_dups) {
+    c_a1 = {1, 2, 3};
+    c_dim1 = {1, 1, 2};
+    c_dim2 = {2, 4, 3};
   }
+  CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
+  CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+  CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
 
   remove_sparse_array();
 }
@@ -723,6 +812,7 @@ TEST_CASE_METHOD(
 
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
+  bool vacuum = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
 
   create_sparse_array(allows_dups);
@@ -730,38 +820,41 @@ TEST_CASE_METHOD(
   // Write fragment with one cell.
   write_sparse({3}, {1}, {1}, 1);
 
+  // Write another fragment with one cell.
+  write_sparse({3}, {2}, {2}, 3);
+
   // Define query condition (a1 < 4).
   QueryCondition qc(ctx_);
   int32_t val = 4;
   qc.init("a1", &val, sizeof(int32_t), TILEDB_LT);
 
   // Write condition.
-  write_delete_condition(qc, 5);
+  write_delete_condition(qc, 7);
 
   // Consolidate.
-  consolidate_sparse(true);
+  consolidate_sparse(vacuum);
 
   // Reading before the delete condition timestamp.
-  uint64_t buffer_size = 1;
+  uint64_t buffer_size = 2;
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);
   std::vector<uint64_t> dim2(buffer_size);
-  read_sparse(a1, dim1, dim2, stats, read_layout, 4);
+  read_sparse(a1, dim1, dim2, stats, read_layout, 6);
 
-  std::vector<int> c_a1 = {3};
-  std::vector<uint64_t> c_dim1 = {1};
-  std::vector<uint64_t> c_dim2 = {1};
+  std::vector<int> c_a1 = {3, 3};
+  std::vector<uint64_t> c_dim1 = {1, 2};
+  std::vector<uint64_t> c_dim2 = {1, 2};
   CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
   CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
 
   // Reading after delete condition timestamp.
-  buffer_size = 1;
+  buffer_size = 2;
   std::vector<int> a1_empty(buffer_size);
   std::vector<uint64_t> dim1_empty(buffer_size);
   std::vector<uint64_t> dim2_empty(buffer_size);
-  read_sparse(a1_empty, dim1_empty, dim2_empty, stats, read_layout, 6);
+  read_sparse(a1_empty, dim1_empty, dim2_empty, stats, read_layout, 8);
 
   std::vector<int> c_a1_empty = {0};
   std::vector<uint64_t> c_dim1_empty = {0};
@@ -783,10 +876,13 @@ TEST_CASE_METHOD(
   qc2.init("a1", &val2, sizeof(int32_t), TILEDB_LT);
 
   // Write condition, but earlier.
-  write_delete_condition(qc2, 3);
+  write_delete_condition(qc2, 5);
+
+  // Write another fragment with one cell.
+  write_sparse({3}, {3}, {3}, 9);
 
   // Consolidate.
-  consolidate_sparse(true);
+  consolidate_sparse(vacuum);
 
   // Test read for both refactored and legacy.
   if (legacy) {
@@ -794,15 +890,15 @@ TEST_CASE_METHOD(
   }
 
   // Reading before new delete condition timestamp.
-  buffer_size = legacy ? 100 : 1;
+  buffer_size = legacy ? 100 : 2;
   std::vector<int> a1_2(buffer_size);
   std::vector<uint64_t> dim1_2(buffer_size);
   std::vector<uint64_t> dim2_2(buffer_size);
-  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 2);
+  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 4);
 
-  std::vector<int> c_a1_2 = {3};
-  std::vector<uint64_t> c_dim1_2 = {1};
-  std::vector<uint64_t> c_dim2_2 = {1};
+  std::vector<int> c_a1_2 = {3, 3};
+  std::vector<uint64_t> c_dim1_2 = {1, 2};
+  std::vector<uint64_t> c_dim2_2 = {1, 2};
   CHECK(!memcmp(c_a1_2.data(), a1_2.data(), c_a1_2.size() * sizeof(int)));
   CHECK(!memcmp(
       c_dim1_2.data(), dim1_2.data(), c_dim1_2.size() * sizeof(uint64_t)));
@@ -834,14 +930,18 @@ TEST_CASE_METHOD(
     "[cppapi][deletes][consolidation][multiple]") {
   remove_sparse_array();
 
+  bool purge_deleted_cells = GENERATE(true, false);
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
+  bool vacuum = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
 
   create_sparse_array(allows_dups);
 
   // Write fragment.
-  write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
+  write_sparse({0, 1}, {1, 1}, {1, 2}, 1);
+
+  write_sparse({2, 3}, {1, 2}, {4, 3}, 3);
 
   // Define query condition (a1 < 2).
   QueryCondition qc(ctx_);
@@ -849,13 +949,18 @@ TEST_CASE_METHOD(
   qc.init("a1", &val, sizeof(int32_t), TILEDB_LT);
 
   // Write condition.
-  write_delete_condition(qc, 3);
+  write_delete_condition(qc, 5);
+
+  // Set purge consolidation config, if needed.
+  if (purge_deleted_cells) {
+    set_purge_deleted_cells();
+  }
 
   // Consolidate.
-  consolidate_sparse(true);
+  consolidate_sparse(vacuum);
 
   // Write fragment.
-  write_sparse({4, 5, 6, 7}, {3, 3, 4, 4}, {3, 4, 3, 4}, 5);
+  write_sparse({4, 5, 6, 7}, {3, 3, 4, 4}, {3, 4, 3, 4}, 7);
 
   // Define query condition (d2 == 3).
   QueryCondition qc2(ctx_);
@@ -863,41 +968,51 @@ TEST_CASE_METHOD(
   qc2.init("d2", &val2, sizeof(uint64_t), TILEDB_EQ);
 
   // Write condition.
-  write_delete_condition(qc2, 7);
+  write_delete_condition(qc2, 9);
 
   // Consolidate.
-  consolidate_sparse(true);
+  consolidate_sparse(vacuum);
 
   // Test read for both refactored and legacy.
   if (legacy) {
     set_legacy();
   }
 
-  // Read at time 4.
+  // Read at time 6.
   uint64_t buffer_size = legacy ? 100 : 2;
   std::string stats;
   std::vector<int> a1(buffer_size);
   std::vector<uint64_t> dim1(buffer_size);
   std::vector<uint64_t> dim2(buffer_size);
-  read_sparse(a1, dim1, dim2, stats, read_layout, 4);
+  read_sparse(a1, dim1, dim2, stats, read_layout, 6);
 
   std::vector<int> c_a1 = {2, 3};
   std::vector<uint64_t> c_dim1 = {1, 2};
   std::vector<uint64_t> c_dim2 = {4, 3};
+  if (purge_deleted_cells) {
+    c_a1 = {2};
+    c_dim1 = {1};
+    c_dim2 = {4};
+  }
   CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
   CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
   CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
 
-  // Read at time 6.
+  // Read at time 8.
   buffer_size = legacy ? 100 : 6;
   std::vector<int> a1_2(buffer_size);
   std::vector<uint64_t> dim1_2(buffer_size);
   std::vector<uint64_t> dim2_2(buffer_size);
-  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 6);
+  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 8);
 
   std::vector<int> c_a1_2 = {2, 3, 4, 5, 6, 7};
   std::vector<uint64_t> c_dim1_2 = {1, 2, 3, 3, 4, 4};
   std::vector<uint64_t> c_dim2_2 = {4, 3, 3, 4, 3, 4};
+  if (purge_deleted_cells) {
+    c_a1_2 = {2, 5, 7};
+    c_dim1_2 = {1, 3, 4};
+    c_dim2_2 = {4, 4, 4};
+  }
   CHECK(!memcmp(c_a1_2.data(), a1_2.data(), c_a1_2.size() * sizeof(int)));
   CHECK(!memcmp(
       c_dim1_2.data(), dim1_2.data(), c_dim1_2.size() * sizeof(uint64_t)));
@@ -919,6 +1034,364 @@ TEST_CASE_METHOD(
       c_dim1_3.data(), dim1_3.data(), c_dim1_3.size() * sizeof(uint64_t)));
   CHECK(!memcmp(
       c_dim2_3.data(), dim2_3.data(), c_dim2_3.size() * sizeof(uint64_t)));
+
+  remove_sparse_array();
+}
+
+TEST_CASE_METHOD(
+    DeletesFx,
+    "CPP API: Test deletes, multiple cells with same coords in same fragment",
+    "[cppapi][deletes][consolidation][multiple-cells-same-coords]") {
+  remove_sparse_array();
+
+  bool purge_deleted_cells = GENERATE(true, false);
+  bool allows_dups = GENERATE(true, false);
+  bool legacy = GENERATE(true, false);
+  bool vacuum = GENERATE(true, false);
+  tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
+
+  create_sparse_array(allows_dups);
+
+  // Write fragment.
+  write_sparse({1, 2}, {1, 1}, {1, 2}, 1);
+
+  // Write fragment with same coords.
+  write_sparse({3, 4}, {1, 1}, {1, 2}, 3);
+
+  // Consolidate.
+  consolidate_sparse(vacuum);
+
+  // Write fragment, again with same coords.
+  write_sparse({5, 6}, {1, 1}, {1, 2}, 5);
+
+  // Define query condition (a1 == 3).
+  QueryCondition qc(ctx_);
+  int val = 3;
+  qc.init("a1", &val, sizeof(int), TILEDB_EQ);
+
+  // Write condition.
+  write_delete_condition(qc, 7);
+
+  // Set purge consolidation config, if needed.
+  if (purge_deleted_cells) {
+    set_purge_deleted_cells();
+  }
+
+  // Consolidate.
+  consolidate_sparse(vacuum);
+
+  // Test read for both refactored and legacy.
+  if (legacy) {
+    set_legacy();
+  }
+
+  // Read at time 6.
+  uint64_t buffer_size = 100;
+  if (!legacy) {
+    if (purge_deleted_cells) {
+      if (allows_dups) {
+        buffer_size = 5;
+      } else {
+        buffer_size = 2;
+      }
+    } else {
+      if (allows_dups) {
+        buffer_size = 6;
+      } else {
+        buffer_size = 2;
+      }
+    }
+  }
+  std::string stats;
+  std::vector<int> a1(buffer_size);
+  std::vector<uint64_t> dim1(buffer_size);
+  std::vector<uint64_t> dim2(buffer_size);
+  read_sparse(a1, dim1, dim2, stats, read_layout, 6);
+
+  std::vector<int> c_a1;
+  std::vector<uint64_t> c_dim1;
+  std::vector<uint64_t> c_dim2;
+  if (purge_deleted_cells) {
+    if (allows_dups) {
+      c_a1 = {};
+
+      // First two numbers for a1 should be 1 and 5.
+      CHECK((a1[0] == 1 || a1[1] == 1));
+      CHECK((a1[0] == 5 || a1[1] == 5));
+      CHECK(a1[0] != a1[1]);
+
+      // Last three numbers for a1 should be 2, 4, 6.
+      CHECK((a1[2] == 2 || a1[2] == 4 || a1[2] == 6));
+      CHECK((a1[3] == 2 || a1[3] == 4 || a1[3] == 6));
+      CHECK((a1[4] == 2 || a1[4] == 4 || a1[4] == 6));
+      CHECK(a1[2] != a1[3]);
+      CHECK(a1[3] != a1[4]);
+      CHECK(a1[4] != a1[2]);
+      c_dim1 = {1, 1, 1, 1, 1};
+      c_dim2 = {1, 1, 2, 2, 2};
+    } else {
+      c_a1 = {5, 6};
+      c_dim1 = {1, 1};
+      c_dim2 = {1, 2};
+    }
+  } else {
+    if (allows_dups) {
+      c_a1 = {};
+
+      // First three numbers for a1 should be 1, 3, 5.
+      CHECK((a1[0] == 1 || a1[0] == 3 || a1[0] == 5));
+      CHECK((a1[1] == 1 || a1[1] == 3 || a1[1] == 5));
+      CHECK((a1[2] == 1 || a1[2] == 3 || a1[2] == 5));
+      CHECK(a1[0] != a1[1]);
+      CHECK(a1[1] != a1[2]);
+      CHECK(a1[2] != a1[0]);
+
+      // Last three numbers for a1 should be 2, 4, 6.
+      CHECK((a1[3] == 2 || a1[3] == 4 || a1[3] == 6));
+      CHECK((a1[4] == 2 || a1[4] == 4 || a1[4] == 6));
+      CHECK((a1[5] == 2 || a1[5] == 4 || a1[5] == 6));
+      CHECK(a1[3] != a1[4]);
+      CHECK(a1[4] != a1[5]);
+      CHECK(a1[5] != a1[3]);
+
+      c_dim1 = {1, 1, 1, 1, 1, 1};
+      c_dim2 = {1, 1, 1, 2, 2, 2};
+    } else {
+      c_a1 = {5, 6};
+      c_dim1 = {1, 1};
+      c_dim2 = {1, 2};
+    }
+  }
+
+  CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
+  CHECK(!memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+  CHECK(!memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+
+  // Read at time 8.
+  buffer_size = 100;
+  if (!legacy) {
+    if (allows_dups) {
+      buffer_size = 5;
+    } else {
+      buffer_size = 2;
+    }
+  }
+  std::vector<int> a1_2(buffer_size);
+  std::vector<uint64_t> dim1_2(buffer_size);
+  std::vector<uint64_t> dim2_2(buffer_size);
+  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 8);
+
+  std::vector<int> c_a1_2;
+  std::vector<uint64_t> c_dim1_2;
+  std::vector<uint64_t> c_dim2_2;
+  if (allows_dups) {
+    c_a1_2 = {};
+
+    // First two numbers for a1 should be 1 and 5.
+    CHECK((a1_2[0] == 1 || a1_2[1] == 1));
+    CHECK((a1_2[0] == 5 || a1_2[1] == 5));
+    CHECK(a1_2[0] != a1_2[1]);
+
+    // Last three numbers for a1 should be 2, 4, 6.
+    CHECK((a1_2[2] == 2 || a1_2[2] == 4 || a1_2[2] == 6));
+    CHECK((a1_2[3] == 2 || a1_2[3] == 4 || a1_2[3] == 6));
+    CHECK((a1_2[4] == 2 || a1_2[4] == 4 || a1_2[4] == 6));
+    CHECK(a1_2[2] != a1_2[3]);
+    CHECK(a1_2[3] != a1_2[4]);
+    CHECK(a1_2[4] != a1_2[2]);
+    c_dim1_2 = {1, 1, 1, 1, 1};
+    c_dim2_2 = {1, 1, 2, 2, 2};
+  } else {
+    c_a1_2 = {5, 6};
+    c_dim1_2 = {1, 1};
+    c_dim2_2 = {1, 2};
+  }
+
+  CHECK(!memcmp(c_a1_2.data(), a1_2.data(), c_a1_2.size() * sizeof(int)));
+  CHECK(!memcmp(
+      c_dim1_2.data(), dim1_2.data(), c_dim1_2.size() * sizeof(uint64_t)));
+  CHECK(!memcmp(
+      c_dim2_2.data(), dim2_2.data(), c_dim2_2.size() * sizeof(uint64_t)));
+
+  remove_sparse_array();
+}
+
+TEST_CASE_METHOD(
+    DeletesFx,
+    "CPP API: Test deletes, multiple cells with same coords in same fragment, "
+    "across tiles",
+    "[cppapi][deletes][consolidation][multiple-cells-same-coords][across-"
+    "tiles]") {
+  remove_sparse_array();
+
+  bool purge_deleted_cells = GENERATE(true, false);
+  bool allows_dups = GENERATE(true, false);
+  bool legacy = GENERATE(true, false);
+  bool vacuum = GENERATE(true, false);
+  tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
+
+  create_sparse_array(allows_dups);
+
+  // Write fragments.
+  // We write 8 cells per fragments for 6 fragments. Then it gets consolidated
+  // into one. So we'll get in order 6xcell1, 6xcell2... total 48 cells. Tile
+  // capacity is 20 so we'll end up with 3 tiles. First break in the tiles will
+  // be in the middle of cell3, second will be in the middle of the cells7.
+  for (uint64_t i = 0; i < 5; i++) {
+    write_sparse(
+        {1, 2, 3, 4, 5, 6, 7, 8},
+        {1, 1, 2, 2, 1, 1, 2, 2},
+        {1, 2, 1, 2, 3, 4, 3, 4},
+        i + 1);
+  }
+
+  // Consolidate.
+  consolidate_sparse(vacuum);
+
+  // Write one more fragment.
+  write_sparse(
+      {1, 2, 3, 4, 5, 6, 7, 8},
+      {1, 1, 2, 2, 1, 1, 2, 2},
+      {1, 2, 1, 2, 3, 4, 3, 4},
+      6);
+
+  // Define query condition (a1 == 3).
+  QueryCondition qc(ctx_);
+  int val = 3;
+  qc.init("a1", &val, sizeof(int), TILEDB_EQ);
+
+  // Write condition.
+  write_delete_condition(qc, 2);
+
+  // Set purge consolidation config, if needed.
+  if (purge_deleted_cells) {
+    set_purge_deleted_cells();
+  }
+
+  // Consolidate.
+  consolidate_sparse(vacuum);
+
+  // Test read for both refactored and legacy.
+  if (legacy) {
+    set_legacy();
+  }
+
+  // Read at time 1.
+  uint64_t buffer_size = 100;
+  uint64_t expected_elements = 0;
+  if (purge_deleted_cells) {
+    expected_elements = 7;
+  } else {
+    expected_elements = 8;
+  }
+  if (!legacy) {
+    buffer_size = expected_elements;
+  }
+  std::string stats;
+  std::vector<int> a1(buffer_size);
+  std::vector<uint64_t> dim1(buffer_size);
+  std::vector<uint64_t> dim2(buffer_size);
+  read_sparse(a1, dim1, dim2, stats, read_layout, 1);
+
+  if (read_layout == TILEDB_UNORDERED) {
+    // For unordered, count the number of elements.
+    std::vector<int> count(8);
+    std::vector<int> expected;
+    for (uint64_t i = 0; i < expected_elements; i++) {
+      if ((a1[i] - 1) < 8) {
+        count[a1[i] - 1]++;
+      }
+    }
+
+    if (purge_deleted_cells) {
+      expected = {1, 1, 0, 1, 1, 1, 1, 1};
+    } else {
+      expected = {1, 1, 1, 1, 1, 1, 1, 1};
+    }
+
+    CHECK(!memcmp(count.data(), expected.data(), 8 * sizeof(int)));
+  } else {
+    // For ordered, check the exact results.
+    std::vector<int> c_a1;
+    std::vector<uint64_t> c_dim1;
+    std::vector<uint64_t> c_dim2;
+    if (purge_deleted_cells) {
+      c_a1 = {1, 2, 4, 5, 6, 7, 8};
+      c_dim1 = {1, 1, 2, 1, 1, 2, 2};
+      c_dim2 = {1, 2, 2, 3, 4, 3, 4};
+    } else {
+      c_a1 = {1, 2, 3, 4, 5, 6, 7, 8};
+      c_dim1 = {1, 1, 2, 2, 1, 1, 2, 2};
+      c_dim2 = {1, 2, 1, 2, 3, 4, 3, 4};
+    }
+
+    CHECK(!memcmp(c_a1.data(), a1.data(), c_a1.size() * sizeof(int)));
+    CHECK(
+        !memcmp(c_dim1.data(), dim1.data(), c_dim1.size() * sizeof(uint64_t)));
+    CHECK(
+        !memcmp(c_dim2.data(), dim2.data(), c_dim2.size() * sizeof(uint64_t)));
+  }
+
+  // Read at time 10.
+  buffer_size = 100;
+  expected_elements = 0;
+  if (allows_dups) {
+    expected_elements = 46;
+  } else {
+    expected_elements = 8;
+  }
+  if (!legacy) {
+    buffer_size = expected_elements;
+  }
+  std::vector<int> a1_2(buffer_size);
+  std::vector<uint64_t> dim1_2(buffer_size);
+  std::vector<uint64_t> dim2_2(buffer_size);
+  read_sparse(a1_2, dim1_2, dim2_2, stats, read_layout, 10);
+
+  if (read_layout == TILEDB_UNORDERED) {
+    // For unordered, count the number of elements.
+    std::vector<int> count(8);
+    std::vector<int> expected;
+    for (uint64_t i = 0; i < expected_elements; i++) {
+      if ((a1_2[i] - 1) < 8) {
+        count[a1_2[i] - 1]++;
+      }
+    }
+
+    if (allows_dups) {
+      expected = {6, 6, 4, 6, 6, 6, 6, 6};
+    } else {
+      expected = {1, 1, 1, 1, 1, 1, 1, 1};
+    }
+
+    CHECK(!memcmp(count.data(), expected.data(), 8 * sizeof(int)));
+  } else {
+    // For ordered, check the exact results.
+    std::vector<int> c_a1_2;
+    std::vector<uint64_t> c_dim1_2;
+    std::vector<uint64_t> c_dim2_2;
+    if (allows_dups) {
+      c_a1_2 = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3,
+                4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6,
+                6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8};
+      c_dim1_2 = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2,
+                  2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                  1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+      c_dim2_2 = {1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 1, 1, 1, 1,
+                  2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4,
+                  4, 4, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4};
+    } else {
+      c_a1_2 = {1, 2, 3, 4, 5, 6, 7, 8};
+      c_dim1_2 = {1, 1, 2, 2, 1, 1, 2, 2};
+      c_dim2_2 = {1, 2, 1, 2, 3, 4, 3, 4};
+    }
+
+    CHECK(!memcmp(c_a1_2.data(), a1_2.data(), c_a1_2.size() * sizeof(int)));
+    CHECK(!memcmp(
+        c_dim1_2.data(), dim1_2.data(), c_dim1_2.size() * sizeof(uint64_t)));
+    CHECK(!memcmp(
+        c_dim2_2.data(), dim2_2.data(), c_dim2_2.size() * sizeof(uint64_t)));
+  }
 
   remove_sparse_array();
 }

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -421,10 +421,10 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords, &coords_size, data, &data_size);
   }
 
-  // Two result tile (2 * (~504 + 8) will be bigger than the per fragment budget
-  // (1000).
+  // Two result tile (2 * (~1200 + 8) will be bigger than the per fragment
+  // budget (1000).
   total_budget_ = "10000";
-  ratio_coords_ = "0.21";
+  ratio_coords_ = "0.30";
   update_config();
 
   tiledb_array_t* array = nullptr;

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -770,9 +770,9 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords, &coords_size, data, &data_size);
   }
 
-  // Two result tile (2 * ~888) will be bigger than the budget (1000).
+  // Two result tile (2 * ~1208) will be bigger than the budget (1500).
   total_budget_ = "10000";
-  ratio_coords_ = "0.1";
+  ratio_coords_ = "0.15";
   update_config();
 
   tiledb_array_t* array = nullptr;

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -526,8 +526,7 @@ bool ArraySchema::is_dim_label(const std::string& name) const {
 }
 
 bool ArraySchema::is_field(const std::string& name) const {
-  return is_attr(name) || is_dim(name) || name == constants::coords ||
-         name == constants::timestamps || name == constants::delete_timestamps;
+  return is_attr(name) || is_dim(name) || is_special_attribute(name);
 }
 
 bool ArraySchema::is_nullable(const std::string& name) const {

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -429,7 +429,8 @@ Status FragmentConsolidator::consolidate_internal(
   // If there are any delete conditions coming after the first fragment or if
   // there are any fragments with delete meta, the new fragment will include
   // delete meta.
-  if (array_schema.write_version() >= constants::deletes_min_version) {
+  if (!config_.purge_deleted_cells_ &&
+      array_schema.write_version() >= constants::deletes_min_version) {
     // Get the first fragment first timestamp.
     std::pair<uint64_t, uint64_t> timestamps;
     RETURN_NOT_OK(

--- a/tiledb/sm/misc/comparators.h
+++ b/tiledb/sm/misc/comparators.h
@@ -65,10 +65,11 @@ class CellCmpBase {
  public:
   explicit CellCmpBase(
       const Domain& domain,
+      const bool use_timestamps = false,
       const std::vector<shared_ptr<FragmentMetadata>>* frag_md = nullptr)
       : domain_(domain)
       , dim_num_(domain.dim_num())
-      , use_timestamps_(false)
+      , use_timestamps_(use_timestamps)
       , frag_md_(frag_md) {
   }
 
@@ -165,8 +166,9 @@ class HilbertCmp : public CellCmpBase {
   /** Constructor. */
   HilbertCmp(
       const Domain& domain,
+      const bool use_timestamps = false,
       const std::vector<shared_ptr<FragmentMetadata>>* frag_md = nullptr)
-      : CellCmpBase(domain, frag_md) {
+      : CellCmpBase(domain, use_timestamps, frag_md) {
   }
 
   /**
@@ -217,12 +219,14 @@ class HilbertCmpReverse {
    * Constructor.
    *
    * @param domain The array domain.
+   * @param use_timestamps Use timestamps or not for this comparator.
    * @param frag_md Pointer to the fragment metadata.
    */
   HilbertCmpReverse(
       const Domain& domain,
+      const bool use_timestamps = false,
       const std::vector<shared_ptr<FragmentMetadata>>* frag_md = nullptr)
-      : cmp_(domain, frag_md) {
+      : cmp_(domain, use_timestamps, frag_md) {
   }
 
   /**
@@ -312,8 +316,9 @@ class GlobalCmp : public CellCmpBase {
    */
   explicit GlobalCmp(
       const Domain& domain,
+      const bool use_timestamps = false,
       const std::vector<shared_ptr<FragmentMetadata>>* frag_md = nullptr)
-      : CellCmpBase(domain, frag_md) {
+      : CellCmpBase(domain, use_timestamps, frag_md) {
     tile_order_ = domain.tile_order();
     cell_order_ = domain.cell_order();
   }
@@ -407,12 +412,14 @@ class GlobalCmpReverse {
    * Constructor.
    *
    * @param domain The array domain.
+   * @param use_timestamps Use timestamps or not for this comparator.
    * @param frag_md Pointer to the fragment metadata.
    */
   explicit GlobalCmpReverse(
       const Domain& domain,
+      const bool use_timestamps = false,
       const std::vector<shared_ptr<FragmentMetadata>>* frag_md = nullptr)
-      : cmp_(domain, frag_md) {
+      : cmp_(domain, use_timestamps, frag_md) {
   }
 
   /**

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -362,7 +362,7 @@ Status ReaderBase::add_delete_timestamps_condition() {
         std::string(constants::delete_timestamps),
         &open_ts,
         sizeof(uint64_t),
-        QueryConditionOp::GE));
+        QueryConditionOp::GT));
   }
 
   return Status::Ok();

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -362,7 +362,9 @@ Status ReaderBase::add_delete_timestamps_condition() {
         std::string(constants::delete_timestamps),
         &open_ts,
         sizeof(uint64_t),
-        QueryConditionOp::GT));
+        open_ts == std::numeric_limits<uint64_t>::max() ?
+            QueryConditionOp::GE :
+            QueryConditionOp::GT));
   }
 
   return Status::Ok();

--- a/tiledb/sm/query/readers/result_coords.h
+++ b/tiledb/sm/query/readers/result_coords.h
@@ -222,8 +222,8 @@ struct GlobalOrderResultCoords
     uint64_t ret = 1;
     uint64_t cell_num = base::tile_->cell_num();
     uint64_t next_pos = base::pos_ + 1;
-    if (base::tile_->has_post_qc_bmp()) {
-      auto& bitmap = base::tile_->bitmap_with_qc();
+    if (base::tile_->has_post_dedup_bmp()) {
+      auto& bitmap = base::tile_->post_dedup_bitmap();
 
       // Current cell is not in the bitmap.
       if (!bitmap[base::pos_]) {
@@ -283,8 +283,8 @@ struct GlobalOrderResultCoords
     // until we find a cell that isn't in the bitmap. This will tell us the
     // maximum slab that can be merged for this bitmap, next we'll look at
     // next.
-    if (base::tile_->has_post_qc_bmp()) {
-      auto& bitmap = base::tile_->bitmap_with_qc();
+    if (base::tile_->has_post_dedup_bmp()) {
+      auto& bitmap = base::tile_->post_dedup_bitmap();
       // Current cell is not in the bitmap.
       if (!bitmap[base::pos_]) {
         return 0;

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -184,6 +184,11 @@ void ResultTile::init_attr_tile(
     return;
   }
 
+  if (name == constants::delete_condition_index) {
+    delete_condition_index_tile_ = TileTuple(false, false);
+    return;
+  }
+
   // Handle attributes
   for (auto& at : attr_tiles_) {
     if (at.first == name && at.second == nullopt) {
@@ -218,6 +223,11 @@ ResultTile::TileTuple* ResultTile::tile_tuple(const std::string& name) {
   if (delete_timestamps_tile_.has_value() &&
       name == constants::delete_timestamps) {
     return &delete_timestamps_tile_.value();
+  }
+
+  if (delete_condition_index_tile_.has_value() &&
+      name == constants::delete_condition_index) {
+    return &delete_condition_index_tile_.value();
   }
 
   // Handle attribute tile

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -459,6 +459,9 @@ class ResultTile {
   /** The delete timestamp attribute tile. */
   optional<TileTuple> delete_timestamps_tile_;
 
+  /** The delete condition marker hash attribute tile. */
+  optional<TileTuple> delete_condition_index_tile_;
+
   /** The zipped coordinates tile. */
   optional<TileTuple> coords_tile_;
 
@@ -628,17 +631,6 @@ class ResultTileWithBitmap : public ResultTile {
    */
   inline uint64_t result_num() {
     return result_num_;
-  }
-
-  /**
-   * Clear a cell in the bitmap.
-   *
-   * @param cell_idx Cell index to clear.
-   */
-  void clear_cell(uint64_t cell_idx) {
-    assert(cell_idx < bitmap_.size());
-    result_num_ -= bitmap_[cell_idx];
-    bitmap_[cell_idx] = 0;
   }
 
   /**
@@ -854,6 +846,22 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
   inline std::vector<BitmapType>& bitmap_with_qc() {
     return extra_bitmap_.size() > 0 ? extra_bitmap_ :
                                       ResultTileWithBitmap<BitmapType>::bitmap_;
+  }
+
+  /**
+   * Clear a cell in the bitmap.
+   *
+   * @param cell_idx Cell index to clear.
+   */
+  void clear_cell(uint64_t cell_idx) {
+    assert(cell_idx < ResultTileWithBitmap<BitmapType>::bitmap_.size());
+    ResultTileWithBitmap<BitmapType>::result_num_ -=
+        ResultTileWithBitmap<BitmapType>::bitmap_[cell_idx];
+    ResultTileWithBitmap<BitmapType>::bitmap_[cell_idx] = 0;
+
+    if (extra_bitmap_.size() > 0) {
+      extra_bitmap_[cell_idx] = 0;
+    }
   }
 
   /** Allocate space for the hilbert values vector. */

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -159,7 +159,8 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
   auto fragment_num = fragment_metadata_.size();
 
   // Set the boolean to include delete meta, if required.
-  deletes_consolidation_ = buffers_.count(constants::delete_timestamps) != 0;
+  deletes_consolidation_no_purge_ =
+      buffers_.count(constants::delete_timestamps) != 0;
 
   // Check that the query condition is valid.
   RETURN_NOT_OK(condition_.check(array_schema_));
@@ -312,7 +313,7 @@ SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
   // We will also create the bitmap as a temporay bitmap to compute delete
   // condition results.
   if ((!dups && has_post_deduplication_conditions(*frag_meta)) ||
-      deletes_consolidation_) {
+      deletes_consolidation_no_purge_) {
     tiles_sizes->first += frag_meta->cell_num(t) * sizeof(BitmapType);
   }
 
@@ -362,7 +363,11 @@ SparseGlobalOrderReader<BitmapType>::add_result_tile(
 
   // Add the tile.
   result_tiles_[f].emplace_back(
-      f, t, array_schema_.allows_dups(), deletes_consolidation_, frag_md);
+      f,
+      t,
+      array_schema_.allows_dups(),
+      deletes_consolidation_no_purge_,
+      frag_md);
 
   return {Status::Ok(), false};
 }
@@ -556,12 +561,12 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
                   // If the current cell has a bigger timestamp, clear the old
                   // max in the bitmap and save the new max.
                   if (current_timestamp > max_timestamp) {
-                    rt->bitmap()[max] = 0;
+                    rt->clear_cell(max);
                     max_timestamp = current_timestamp;
                     max = c;
                   } else {
                     // Clear this cell from the bitmap.
-                    rt->bitmap()[c] = 0;
+                    rt->clear_cell(c);
                   }
                 }
 
@@ -702,93 +707,152 @@ SparseGlobalOrderReader<BitmapType>::compute_result_cell_slab() {
 
   if (array_schema_.cell_order() == Layout::HILBERT) {
     return merge_result_cell_slabs(
-        num_cells, HilbertCmpReverse(array_schema_.domain()));
+        num_cells,
+        HilbertCmpReverse(array_schema_.domain(), &fragment_metadata_));
   } else {
     return merge_result_cell_slabs(
-        num_cells, GlobalCmpReverse(array_schema_.domain()));
+        num_cells,
+        GlobalCmpReverse(array_schema_.domain(), &fragment_metadata_));
   }
 }
 
 template <class BitmapType>
 template <class CompType>
-tuple<Status, optional<bool>>
-SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
-    bool dups,
+bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
     GlobalOrderResultCoords<BitmapType>& rc,
     std::vector<TileListIt>& result_tiles_it,
     TileMinHeap<CompType>& tile_queue) {
   auto frag_idx = rc.tile_->frag_idx();
+  auto dups = array_schema_.allows_dups();
+  uint64_t last_cell_pos;
+  if (rc.tile_->has_bmp()) {
+    last_cell_pos = rc.tile_->last_cell_in_bitmap();
+  } else {
+    last_cell_pos =
+        fragment_metadata_[frag_idx]->cell_num(rc.tile_->tile_idx()) - 1;
+  }
+
+  while (rc.next_cell_same_coords()) {
+    // Construct a new result coords that specifies it has no next cell.
+    // A cell will be added after this one so we don't want to process it
+    // twice.
+    tile_queue.emplace(rc.tile_, rc.pos_, false);
+    rc.advance_to_next_cell();
+
+    // For arrays with no duplicates, we cannot use the last cell of a
+    // fragment with timestamps if not all tiles are loaded.
+    if (!dups && last_in_memory_cell_of_consolidated_fragment(frag_idx, rc)) {
+      return true;
+    }
+
+    // If we are at the last cell of this tile, check the next tile.
+    if (rc.pos_ == last_cell_pos) {
+      auto next_tile = result_tiles_it[frag_idx];
+      next_tile++;
+      if (next_tile != result_tiles_[frag_idx].end()) {
+        tile_queue.emplace(rc.tile_, rc.pos_, false);
+        GlobalOrderResultCoords rc2(&*next_tile, 0);
+
+        // All tiles should at least have one cell available.
+        if (!rc2.advance_to_next_cell()) {
+          throw std::logic_error("All tiles should have at least one cell.");
+        }
+
+        // Next tile starts with the same coords, switch to it.
+        if (rc.same_coords(rc2)) {
+          // Remove the current tile if not used.
+          if (!rc.tile_->used()) {
+            remove_result_tile(frag_idx, result_tiles_it[frag_idx]);
+          }
+
+          result_tiles_it[frag_idx] = next_tile;
+          rc = rc2;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+template <class BitmapType>
+template <class CompType>
+bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
+    const bool purge_deletes_no_dups_mode,
+    GlobalOrderResultCoords<BitmapType>& rc,
+    std::vector<TileListIt>& result_tiles_it,
+    TileMinHeap<CompType>& tile_queue) {
+  auto frag_idx = rc.tile_->frag_idx();
+  auto dups = array_schema_.allows_dups();
+
+  // Exit early if the result coords specifies it has no next cell to process.
+  // This would be because a cell after this one in the fragment was added to
+  // the queue as it had the same coordinates as this one.
+  if (!rc.has_next_) {
+    return false;
+  }
 
   // Try the next cell in the same tile.
-  if (rc.advance_to_next_cell()) {
-    // Update the fragment index, add the cell to the queue and return.
-    read_state_.frag_idx_[frag_idx] = FragIdx(rc.tile_->tile_idx(), rc.pos_);
+  if (!rc.advance_to_next_cell()) {
+    // Save the potential tile to delete and increment the tile iterator.
+    auto to_delete = result_tiles_it[frag_idx];
+    result_tiles_it[frag_idx]++;
 
-    // For arrays with no duplicates and when not in consolidation mode, we
-    // cannot use the last cell of a fragment with timestamps if not all tiles
-    // are loaded.
-    if (!dups && last_in_memory_cell_of_consolidated_fragment(frag_idx, rc)) {
-      return {Status::Ok(), true};
+    // Remove the tile from result tiles if it wasn't used at all.
+    if (!rc.tile_->used()) {
+      remove_result_tile(frag_idx, to_delete);
     }
 
-    {
-      std::unique_lock<std::mutex> ul(tile_queue_mutex_);
-      tile_queue.emplace(std::move(rc));
-    }
+    // Try to find a new tile.
+    if (result_tiles_it[frag_idx] != result_tiles_[frag_idx].end()) {
+      // Find a cell in the current result tile.
+      rc = GlobalOrderResultCoords(&*result_tiles_it[frag_idx], 0);
 
-    return {Status::Ok(), false};
+      // All tiles should at least have one cell available.
+      if (!rc.advance_to_next_cell()) {
+        throw std::logic_error("All tiles should have at least one cell.");
+      }
+    } else {
+      // Increment the tile index, which should clear all tiles in
+      // end_iteration.
+      if (!result_tiles_[frag_idx].empty()) {
+        read_state_.frag_idx_[frag_idx].tile_idx_++;
+        read_state_.frag_idx_[frag_idx].cell_idx_ = 0;
+      }
+
+      // This fragment has more tiles potentially.
+      if (!all_tiles_loaded_[frag_idx]) {
+        // Return we need more tiles.
+        return true;
+      }
+
+      // All tiles processed, done.
+      return false;
+    }
   }
 
-  // Save the potential tile to delete and increment the tile iterator.
-  auto to_delete = result_tiles_it[frag_idx];
-  result_tiles_it[frag_idx]++;
-
-  // Remove the tile from result tiles if it wasn't used at all.
-  if (!rc.tile_->used()) {
-    remove_result_tile(frag_idx, to_delete);
-  }
-
-  // Try to find a new tile.
-  if (result_tiles_it[frag_idx] != result_tiles_[frag_idx].end()) {
-    // Find a cell in the current result tile.
-    GlobalOrderResultCoords rc(&*result_tiles_it[frag_idx], 0);
-
-    // All tiles should at least have one cell available.
-    if (!rc.advance_to_next_cell()) {
-      throw std::logic_error("All tiles should have at least one cell.");
-    }
-
-    // Update the fragment index.
-    read_state_.frag_idx_[frag_idx] = FragIdx(rc.tile_->tile_idx(), rc.pos_);
-
-    // For arrays with no duplicates and when not in consolidation mode, we
-    // cannot use the last cell of a fragment with timestamps if not all tiles
-    // are loaded.
+  // We have a cell, add it to the list.
+  {
+    // For arrays with no duplicates, we cannot use the last cell of a fragment
+    //  with timestamps if not all tiles are loaded.
     if (!dups && last_in_memory_cell_of_consolidated_fragment(frag_idx, rc)) {
-      return {Status::Ok(), true};
+      return true;
     }
+    std::unique_lock<std::mutex> ul(tile_queue_mutex_);
 
-    // Insert the cell in the queue.
-    {
-      std::unique_lock<std::mutex> ul(tile_queue_mutex_);
-      tile_queue.emplace(std::move(rc));
+    // Add all the cells in this tile with the same coordinates as this cell
+    // for purge deletes with no dups mode.
+    if (purge_deletes_no_dups_mode &&
+        fragment_metadata_[frag_idx]->has_timestamps()) {
+      if (add_all_dups_to_queue(rc, result_tiles_it, tile_queue)) {
+        return true;
+      }
     }
-  } else {
-    // Increment the tile index, which should clear all tiles in end_iteration.
-    if (!result_tiles_[frag_idx].empty()) {
-      read_state_.frag_idx_[frag_idx].tile_idx_++;
-      read_state_.frag_idx_[frag_idx].cell_idx_ = 0;
-    }
-
-    // This fragment has more tiles potentially.
-    if (!all_tiles_loaded_[frag_idx]) {
-      // Return we need more tiles.
-      return {Status::Ok(), true};
-    }
+    tile_queue.emplace(std::move(rc));
   }
 
   // We don't need more tiles as a tile was found.
-  return {Status::Ok(), false};
+  return false;
 }
 
 template <class BitmapType>
@@ -838,13 +902,13 @@ Status SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
 }
 
 template <class BitmapType>
-uint64_t SparseGlobalOrderReader<BitmapType>::get_timestamp(
-    const GlobalOrderResultCoords<BitmapType>& rc) const {
-  const auto f = rc.tile_->frag_idx();
-  if (fragment_metadata_[f]->has_timestamps()) {
-    return rc.tile_->timestamp(rc.pos_);
-  } else {
-    return fragment_timestamp(rc.tile_);
+void SparseGlobalOrderReader<BitmapType>::update_frag_idx(
+    GlobalOrderResultTile<BitmapType>* tile, uint64_t c) {
+  auto& frag_idx = read_state_.frag_idx_[tile->frag_idx()];
+  auto t = tile->tile_idx();
+  if ((t == frag_idx.tile_idx_ && c > frag_idx.cell_idx_) ||
+      t > frag_idx.tile_idx_) {
+    frag_idx = FragIdx(t, c);
   }
 }
 
@@ -855,15 +919,37 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
     uint64_t num_cells, CompType cmp) {
   auto timer_se = stats_->start_timer("merge_result_cell_slabs");
   std::vector<ResultCellSlab> result_cell_slabs;
+  auto cmp_no_timestamps = cmp;
 
   // TODO Parallelize.
 
   // For easy reference.
-  auto dups = array_schema_.allows_dups() || consolidation_with_timestamps_;
+  const bool dups =
+      array_schema_.allows_dups() || consolidation_with_timestamps_;
+
+  // Are we doing purge deletes consolidation. The consolidation with
+  // timestamps flag will be set and we will have a post query condition
+  // bitmap. The later is only true in consolidation when delete conditions
+  // are present.
+  const bool purge_deletes_consolidation = !deletes_consolidation_no_purge_ &&
+                                           consolidation_with_timestamps_ &&
+                                           !delete_conditions_.empty();
+
+  // For purge deletes consolidation and no duplicates, we read in a different
+  // mode. We will first sort cells in the tile queue with the same coordinates
+  // using timestamps (where the cell with the greater timestamp comes first).
+  // Then when adding cells for a fragment consolidated with timestamps, we
+  // will add all the dups at once. Finally, when creating cell slabs, we will
+  // stop creating cell slabs once a cell is deleted. This will enable cells
+  // created after the last delete time to go through, but the cells created
+  // before to be purged.
+  const bool purge_deletes_no_dups_mode =
+      !array_schema_.allows_dups() && purge_deletes_consolidation;
 
   // A tile min heap, contains one GlobalOrderResultCoords per fragment.
   std::vector<GlobalOrderResultCoords<BitmapType>> container;
   container.reserve(result_tiles_.size());
+  cmp.use_timestamps(!array_schema_.allows_dups());
   TileMinHeap<CompType> tile_queue(cmp, std::move(container));
 
   // If any fragments needs to load more tiles.
@@ -885,13 +971,8 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
                   read_state_.frag_idx_[f].cell_idx_ :
                   0;
           GlobalOrderResultCoords rc(&*(rt_it[f]), cell_idx);
-          auto&& [st, more_tiles] =
-              add_next_cell_to_queue(dups, rc, rt_it, tile_queue);
-          RETURN_NOT_OK(st);
-
-          if (*more_tiles) {
-            need_more_tiles = true;
-          }
+          need_more_tiles |= add_next_cell_to_queue(
+              purge_deletes_no_dups_mode, rc, rt_it, tile_queue);
         }
 
         return Status::Ok();
@@ -903,34 +984,45 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
   // Process all elements.
   while (!tile_queue.empty() && !need_more_tiles && num_cells > 0) {
     auto to_process = tile_queue.top();
+    auto tile = to_process.tile_;
     tile_queue.pop();
+
+    // Used only for purge delete condolidation.
+    bool stop_creating_slabs = false;
 
     // Process all cells with the same coordinates at once.
     while (!tile_queue.empty() && to_process.same_coords(tile_queue.top()) &&
            num_cells > 0) {
-      // Potentially the next cell.
-      auto to_process_dup = tile_queue.top();
-      tile_queue.pop();
+      // For consolidation with deletes, check if the cell was deleted and
+      // stop copying if it is. All cells after this in the queue have a
+      // smaller timestamp so they should be deleted.
+      if (purge_deletes_no_dups_mode) {
+        stop_creating_slabs |= tile->bitmap_with_qc()[to_process.pos_] == 0;
+      }
 
-      // If we return duplicates, create one slab for all the dups.
-      auto tile = to_process_dup.tile_;
-      if (dups) {
-        tile->set_used();
+      if (dups && !stop_creating_slabs) {
+        // If we return duplicates, create one slab for all the dups.
         if (non_overlapping_ranges) {
-          result_cell_slabs.emplace_back(
-              to_process_dup.tile_, to_process_dup.pos_, 1);
-          num_cells--;
+          if (!purge_deletes_no_dups_mode ||
+              tile->bitmap_with_qc()[to_process.pos_] != 0) {
+            tile->set_used();
+            result_cell_slabs.emplace_back(tile, to_process.pos_, 1);
+            num_cells--;
+          }
         } else {
           // For overlapping ranges, create as many slabs as there are counts.
-          auto num = to_process_dup.tile_->bitmap()[to_process_dup.pos_];
+          auto num = tile->bitmap_with_qc()[to_process.pos_];
           if (num_cells < num) {
             num_cells = 0;
             break;
           }
 
+          if (num > 0) {
+            tile->set_used();
+          }
+
           for (uint64_t i = 0; i < num; i++) {
-            result_cell_slabs.emplace_back(
-                to_process_dup.tile_, to_process_dup.pos_, 1);
+            result_cell_slabs.emplace_back(tile, to_process.pos_, 1);
             num_cells--;
           }
         }
@@ -938,81 +1030,101 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
         if (num_cells == 0) {
           break;
         }
-      } else {
-        // Take the cell with the highest timestamp.
-        if (get_timestamp(to_process) < get_timestamp(to_process_dup)) {
-          std::swap(to_process, to_process_dup);
-        }
       }
 
-      // Put the next cell in the queue.
-      auto&& [st, more_tiles] =
-          add_next_cell_to_queue(dups, to_process_dup, rt_it, tile_queue);
-      RETURN_NOT_OK_TUPLE(st, nullopt);
-      need_more_tiles = *more_tiles;
+      update_frag_idx(tile, to_process.pos_ + 1);
+
+      // For no dups, we just remove the cells from the queue as the one with
+      // the higher timestamp is already in `to_process` and will be processed
+      // below. For dups, `to_process` was already added above, replace it with
+      // the top of the queue.
+      if (!dups) {
+        auto to_remove = tile_queue.top();
+        tile_queue.pop();
+
+        // Put the next cell from the processed tile in the queue.
+        need_more_tiles = add_next_cell_to_queue(
+            purge_deletes_no_dups_mode, to_remove, rt_it, tile_queue);
+      } else {
+        // Put the next cell from the processed tile in the queue.
+        need_more_tiles = add_next_cell_to_queue(
+            purge_deletes_no_dups_mode, to_process, rt_it, tile_queue);
+
+        to_process = tile_queue.top();
+        tile_queue.pop();
+        tile = to_process.tile_;
+      }
     }
 
     if (num_cells == 0) {
       break;
     }
 
-    // Get data from the result coord.
-    auto tile = to_process.tile_;
-    auto start = to_process.pos_;
-    const auto tile_idx = tile->tile_idx();
-    const auto frag_idx = tile->frag_idx();
+    if (!stop_creating_slabs) {
+      // Get data from the result coord.
+      auto start = to_process.pos_;
+      const auto frag_idx = tile->frag_idx();
 
-    // Flag the tile as used.
-    to_process.tile_->set_used();
+      // For purge delete no dups mode, we cannot merge more than one cell at
+      // time as we don't know if any cells in the generated slab are
+      // duplicates.
+      bool single_cell_only = purge_deletes_no_dups_mode &&
+                              fragment_metadata_[frag_idx]->has_timestamps();
 
-    // Compute the length of the cell slab.
-    uint64_t length = std::numeric_limits<uint64_t>::max();
-    if (tile_queue.empty()) {
-      length = to_process.max_slab_length();
-    } else {
-      length = to_process.max_slab_length(tile_queue.top(), cmp);
-    }
-
-    if (length != 0) {
-      // Make sure we don't merge more cells than the buffers.
-      length = std::min(length, num_cells);
-
-      // Update the position in the result coord.
-      to_process.pos_ += length - 1;
-
-      // Make sure we don't process the last loaded cell of a consolidated
-      // with timestamps fragment if there are more tiles for that fragment.
-      if (last_in_memory_cell_of_consolidated_fragment(frag_idx, to_process)) {
-        length--;
-        to_process.pos_--;
+      // Compute the length of the cell slab.
+      uint64_t length = 1;
+      if (to_process.has_next_ || single_cell_only) {
+        if (tile_queue.empty()) {
+          length = to_process.max_slab_length();
+        } else {
+          length =
+              to_process.max_slab_length(tile_queue.top(), cmp_no_timestamps);
+        }
       }
 
-      // Generate the result cell slabs.
-      if (non_overlapping_ranges) {
-        result_cell_slabs.emplace_back(tile, start, length);
-        read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
-        num_cells -= length;
-      } else {
-        auto num = to_process.tile_->bitmap()[to_process.pos_];
-        if (num > num_cells) {
-          num_cells = 0;
-          break;
+      if (length != 0) {
+        // Flag the tile as used.
+        to_process.tile_->set_used();
+
+        // Make sure we don't merge more cells than the buffers.
+        length = std::min(length, num_cells);
+
+        // Update the position in the result coord.
+        to_process.pos_ += length - 1;
+
+        // Make sure we don't process the last in memory cell of a consolidated
+        // with timestamps fragment if there are more tiles for that fragment.
+        if (last_in_memory_cell_of_consolidated_fragment(
+                frag_idx, to_process)) {
+          length--;
+          to_process.pos_--;
         }
 
-        for (uint64_t i = 0; i < num; i++) {
+        // Generate the result cell slabs.
+        if (non_overlapping_ranges) {
           result_cell_slabs.emplace_back(tile, start, length);
+          update_frag_idx(tile, start + length);
           num_cells -= length;
-        }
+        } else {
+          auto num = to_process.tile_->bitmap()[to_process.pos_];
+          if (num > num_cells) {
+            num_cells = 0;
+            break;
+          }
 
-        read_state_.frag_idx_[frag_idx] = FragIdx(tile_idx, start + length);
+          for (uint64_t i = 0; i < num; i++) {
+            result_cell_slabs.emplace_back(tile, start, length);
+            num_cells -= length;
+          }
+
+          update_frag_idx(tile, start + length);
+        }
       }
     }
 
     // Put the next cell in the queue.
-    auto&& [st, more_tiles] =
-        add_next_cell_to_queue(dups, to_process, rt_it, tile_queue);
-    RETURN_NOT_OK_TUPLE(st, nullopt);
-    need_more_tiles = *more_tiles;
+    need_more_tiles = add_next_cell_to_queue(
+        purge_deletes_no_dups_mode, to_process, rt_it, tile_queue);
   }
 
   buffers_full_ = num_cells == 0;
@@ -1023,7 +1135,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
       buffers_full_);
 
   return {Status::Ok(), std::move(result_cell_slabs)};
-};
+};  // namespace sm
 
 template <class BitmapType>
 tuple<uint64_t, uint64_t, uint64_t, bool>
@@ -1432,11 +1544,15 @@ Status SparseGlobalOrderReader<BitmapType>::copy_delete_meta_tiles(
 
               // Convert the source condition index to this fragment's
               // processed condition index.
-              auto& condition_marker =
-                  fragment_metadata_[rt->frag_idx()]
-                      ->get_processed_conditions()[*src_buff_condition_indexes];
-              uint64_t converted_index =
-                  condition_marker_to_index_map[condition_marker];
+              uint64_t converted_index = std::numeric_limits<uint64_t>::max();
+              if (*src_buff_condition_indexes !=
+                  std::numeric_limits<uint64_t>::max()) {
+                auto& condition_marker = fragment_metadata_[rt->frag_idx()]
+                                             ->get_processed_conditions()
+                                                 [*src_buff_condition_indexes];
+                converted_index =
+                    condition_marker_to_index_map[condition_marker];
+              }
               *buffer_condition_indexes = converted_index;
             } else {
               *buffer_delete_ts = delete_condition_ts;

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -635,7 +635,9 @@ Status SparseIndexReaderBase::apply_query_condition(
                 *(frag_meta->array_schema().get()),
                 *rt,
                 rt->post_dedup_bitmap()));
-            rt->count_cells();
+            if (array_schema_.allows_dups()) {
+              rt->count_cells();
+            }
           }
 
           // Compute the result of the query condition for this tile

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -301,8 +301,8 @@ class SparseIndexReaderBase : public ReaderBase {
   /** List of tiles to ignore. */
   std::unordered_set<IgnoredTile, ignored_tile_hash> ignored_tiles_;
 
-  /** Are we doing deletes consolidation. */
-  bool deletes_consolidation_;
+  /** Are we doing deletes consolidation (without purge option). */
+  bool deletes_consolidation_no_purge_;
 
   /* ********************************* */
   /*         PROTECTED METHODS         */


### PR DESCRIPTION
This adds the ability to purge deleted cells when running consolidation with deletes. When this is done, the cells that were deleted are fully removed from the fragment, unless they get added again after the deletion. This will also not write the delete metadata columns for this fragment as there is no delete times for the cells.

The harder problem to solve for this PR was for the no duplicates array, when a cell gets deleted, deduplication needs to delete only the cells that were added before a certain cell was deleted. For fragments with timestamps, as we still want to write every cells with their appropriate timestamps, this means that a fragment could have more than one cell with the same coordinate to process. The solution is to add all cells with the same coordinate to the sorting tile queue, and to add the timestamp dimension to the sorting (with the greater timestamp coming first). That way we can merge all cells until a deleted cell gets hit, at which point we stop and get rid of the cells that came in before the delete.

This also fixed a few tests that actually didn't run consolidation, and fixes consolidating a fragment consolidated with deletes, as the delete condition index tiles were not getting loaded properly.

---
TYPE: IMPROVEMENT
DESC: Deletes: adding purge option for consolidation.
