### PR TITLE
Add new versions of `Config::get` that return optional and do not have output-arguments.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,8 @@ set(TILEDB_EP_INSTALL_PREFIX "${TILEDB_EP_BASE}/install")
 
 # Set compiler flags
 if (MSVC)
+  # Turn on standards-conformance mode
+  add_compile_options("/permissive-")
   # We disable some warnings that are not present in gcc/clang -Wall:
   #   C4101: unreferenced local variable
   #   C4146: unary minus operator applied to unsigned type
@@ -213,12 +215,18 @@ if (MSVC)
   #   C4457: local variable hiding function parameter
   #   C4702: unreachable code
   #   C4800: warning implicit cast int to bool
-  #   C4996: deprecation warning about e.g. sscanf.
-  add_compile_options(/W4 /wd4101 /wd4146 /wd4244 /wd4251 /wd4456 /wd4457 /wd4702 /wd4800 /wd4996)
+  add_compile_options(/W4 /wd4101 /wd4146 /wd4244 /wd4251 /wd4456 /wd4457 /wd4702 /wd4800)
   # Warnings as errors:
   if (TILEDB_WERROR)
     add_compile_options(/WX)
   endif()
+  # Turn off MSVC deprecation of certain standard library functions. This allows
+  # other deprecations to remain visible.
+  add_compile_definitions("_CRT_SECURE_NO_WARNINGS")
+  # We currently need to suppress warnings about deprecation (C4996) for two cases:
+  #   1. C++ API functions that call deprecated C API functions
+  #   2. two warnings in `test/src/helpers.cc` that call deprecated C API functions
+  add_compile_options(/wd4996)
   # Disable GDI (which we don't need, and causes some macro
   # re-definition issues if wingdi.h is included)
   add_compile_options(/DNOGDI)
@@ -424,6 +432,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_exception unit_interval unit_thread_pool unit_experimental)
   add_dependencies(tests unit_array_schema unit_filter_create unit_filter_pipeline unit_metadata)
   add_dependencies(tests unit_compressors unit_query unit_misc unit_vfs unit_array)
+  add_dependencies(tests unit_config)
   add_dependencies(tests unit_range_subset)
   add_dependencies(tests unit_consistency)
   add_dependencies(tests unit_range)

--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -335,10 +335,6 @@ inline Status Status_ConsolidatorError(const std::string& msg) {
 inline Status Status_LRUCacheError(const std::string& msg) {
   return {"[TileDB::LRUCache] Error", msg};
 }
-/** Return a Config error class Status with a given message **/
-inline Status Status_ConfigError(const std::string& msg) {
-  return {"[TileDB::Config] Error", msg};
-}
 /** Return a Utils error class Status with a given message **/
 inline Status Status_UtilsError(const std::string& msg) {
   return {"[TileDB::Utils] Error", msg};

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -694,15 +694,13 @@ class Config {
 
 /**
  * An explicit specialization for `std::string`. It does not call a conversion
- * function and it thus the same as the non-template `get`.
+ * function and it is thus the same as the non-template `get`.
  */
 template <>
 [[nodiscard]] inline optional<std::string> Config::get<std::string>(
     const std::string& key) const {
   return get(key);
 }
-
-
 
 }  // namespace tiledb::sm
 

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -577,16 +577,6 @@ class Config {
   [[nodiscard]] optional<T> get(const std::string& key) const;
 
   /**
-   * An explicit specialization for `std::string`. It does not call a conversion
-   * function and it thus the same as the non-template `get`.
-   */
-  template <>
-  [[nodiscard]] inline optional<std::string> get<std::string>(
-      const std::string& key) const {
-    return get(key);
-  }
-
-  /**
    * Returns the string representation of a config parameter value.
    * Sets `found` to `true` if found and `false` otherwise.
    */
@@ -701,6 +691,18 @@ class Config {
   const char* get_from_config_or_env(
       const std::string& param, bool* found) const;
 };
+
+/**
+ * An explicit specialization for `std::string`. It does not call a conversion
+ * function and it thus the same as the non-template `get`.
+ */
+template <>
+[[nodiscard]] inline optional<std::string> Config::get<std::string>(
+    const std::string& key) const {
+  return get(key);
+}
+
+
 
 }  // namespace tiledb::sm
 

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -581,7 +581,8 @@ class Config {
    * function and it thus the same as the non-template `get`.
    */
   template <>
-  [[nodiscard]] inline optional<std::string> get<std::string>(const std::string& key) const {
+  [[nodiscard]] inline optional<std::string> get<std::string>(
+      const std::string& key) const {
     return get(key);
   }
 

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,10 +40,26 @@
 #include <string>
 #include <vector>
 
+/*
+ * C++14 introduced the attribute [[deprecated]], but no conditional syntax
+ * for it. In order to turn it on only when we want it, we have to use the
+ * preprocessor.
+ */
+#if defined(TILEDB_DEPRECATE_OLD_CONFIG_GET)
+/*
+ * Old versions of `Config::get` don't obey the "outputs on the left" principle,
+ * or return `Status`, or both.
+ */
+#define TILEDB_DEPRECATE_CONFIG \
+  [[deprecated(                 \
+      "Instead use the single-argument version that returns `optional`")]]
+#else
+#define TILEDB_DEPRECATE_CONFIG
+#endif
+
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /**
  * This class manages the TileDB configuration options.
@@ -543,18 +559,48 @@ class Config {
   Status set(const std::string& param, const std::string& value);
 
   /**
+   * Retrieve the string value of a configuration parameter.
+   *
+   * @param key The name of the configuration parameter
+   * @return If a configuration item is present, its value. If not, `nullopt`.
+   */
+  [[nodiscard]] optional<std::string> get(const std::string& key) const;
+
+  /**
+   * Retrieve the string value of a configuration parameter and convert it to
+   * a designated type.
+   *
+   * @param key The name of the configuration parameter
+   * @return If a configuration item is present, its value. If not, `nullopt`.
+   */
+  template <class T>
+  [[nodiscard]] optional<T> get(const std::string& key) const;
+
+  /**
+   * An explicit specialization for `std::string`. It does not call a conversion
+   * function and it thus the same as the non-template `get`.
+   */
+  template <>
+  [[nodiscard]] inline optional<std::string> get(const std::string& key) const {
+    return get(key);
+  }
+
+  /**
    * Returns the string representation of a config parameter value.
    * Sets `found` to `true` if found and `false` otherwise.
    */
+  TILEDB_DEPRECATE_CONFIG
   std::string get(const std::string& param, bool* found) const;
 
   /** Gets a config parameter value (`nullptr` if `param` does not exist). */
+  TILEDB_DEPRECATE_CONFIG
   Status get(const std::string& param, const char** value) const;
 
   /**
    * Retrieves the value of the given parameter in the templated type.
    * Sets `found` to `true` if found and `false` otherwise.
    */
+  TILEDB_DEPRECATE_CONFIG
   template <class T>
   Status get(const std::string& param, T* value, bool* found) const;
 
@@ -655,7 +701,10 @@ class Config {
       const std::string& param, bool* found) const;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
+
+#ifdef TILEDB_DEPRECATE_CONFIG
+#undef TILEDB_DEPRECATE_CONFIG
+#endif
 
 #endif  // TILEDB_CONFIG_H

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -581,7 +581,7 @@ class Config {
    * function and it thus the same as the non-template `get`.
    */
   template <>
-  [[nodiscard]] inline optional<std::string> get(const std::string& key) const {
+  [[nodiscard]] inline optional<std::string> get<std::string>(const std::string& key) const {
     return get(key);
   }
 

--- a/tiledb/sm/config/test/CMakeLists.txt
+++ b/tiledb/sm/config/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/sm/config/CMakeLists.txt
+# tiledb/sm/config/test/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021-2022 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,22 +23,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-
 include(common NO_POLICY_SCOPE)
 
-#
-# `config` object library
-#
-add_library(config OBJECT config.cc)
-target_link_libraries(config PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-target_link_libraries(config PUBLIC constants $<TARGET_OBJECTS:constants>)
-target_link_libraries(config PUBLIC parse_argument $<TARGET_OBJECTS:parse_argument>)
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_config EXCLUDE_FROM_ALL)
-add_dependencies(all_link_complete compile_config)
-target_link_libraries(compile_config PRIVATE config)
-target_sources(compile_config PRIVATE test/compile_config_main.cc)
-
-add_test_subdirectory()
+add_executable(unit_config EXCLUDE_FROM_ALL)
+find_package(Catch_EP REQUIRED)
+target_link_libraries(unit_config PUBLIC Catch2::Catch2)
+target_link_libraries(unit_config PUBLIC config)
+target_sources(unit_config PUBLIC unit_config.cc)
+add_test(
+    NAME "unit_config"
+    COMMAND $<TARGET_FILE:unit_config>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tiledb/sm/config/test/unit_config.cc
+++ b/tiledb/sm/config/test/unit_config.cc
@@ -1,0 +1,107 @@
+/**
+ * @file tiledb/sm/config/test/unit_config.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <test/support/tdb_catch.h>
+#include "../config.h"
+
+using tiledb::sm::Config;
+
+/*
+ * These are the types for which `Config::get` is explicitly specialized.
+ */
+using config_types = std::
+    tuple<bool, int, uint32_t, int64_t, uint64_t, float, double, std::string>;
+using config_types_integral = std::tuple<int, uint32_t, int64_t, uint64_t>;
+using config_types_floating = std::tuple<float, double>;
+
+TEST_CASE("Config::get - not found", "[config]") {
+  Config c{};  // empty
+  std::string key{"this_key_is_not_present"};
+  auto x{c.get(key)};
+  CHECK(!x.has_value());
+}
+
+TEMPLATE_LIST_TEST_CASE("Config::get - not found", "[config]", config_types) {
+  Config c{};  // empty
+  std::string key{"this_key_is_not_present"};
+  auto x{c.get<TestType>(key)};
+  CHECK(!x.has_value());
+}
+
+TEST_CASE("Config::get<bool> - found true", "[config]") {
+  Config c{};
+  std::string key{"the_key"};
+  c.set(key, "true");
+  auto x{c.get<bool>(key)};
+  REQUIRE(x.has_value());
+  CHECK(x.value());
+}
+
+TEST_CASE("Config::get<bool> - found false", "[config]") {
+  Config c{};
+  std::string key{"the_key"};
+  c.set(key, "false");
+  auto x{c.get<bool>(key)};
+  REQUIRE(x.has_value());
+  CHECK(!x.value());
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Config::get<T> - found 1", "[config]", config_types_integral) {
+  Config c{};
+  std::string key{"the_key"};
+  c.set(key, "1");
+  auto x{c.get<TestType>(key)};
+  REQUIRE(x.has_value());
+  CHECK(x.value() == 1);
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "Config::get<T> - found 1.0", "[config]", config_types_floating) {
+  Config c{};
+  std::string key{"the_key"};
+  c.set(key, "1.0");
+  auto x{c.get<TestType>(key)};
+  REQUIRE(x.has_value());
+  CHECK(x.value() == 1.0);
+}
+
+TEST_CASE("Config::get<std::string> - found and matched", "[config]") {
+  Config c{};
+  std::string key{"the_key"};
+  std::string value{"xyzzy"};
+  c.set(key, value);
+  auto x{c.get<std::string>(key)};
+  REQUIRE(x.has_value());
+  CHECK(x.value() == value);
+}


### PR DESCRIPTION
Add new versions of `Config::get` that return optional and do not have output-arguments.
Add unit tests for `Config::get`. There were none before, not even in `tiledb_unit`. Only tests for the new functions were added.
Make it easier to turn on deprecation for old versions of `Config::get`.

---
TYPE: NO_HISTORY
DESC: Add new versions of `Config::get` that return optional and do not have output-arguments.