### PR TITLE
clang-format for some files that the CI script doesn't check

### DIFF
--- a/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
@@ -299,7 +299,7 @@ void ConsolidationWithTimestampsFx::read_sparse(
   // Open array.
   Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_READ, timestamp);
 
-  if(!skip_query){
+  if (!skip_query) {
     // Create query.
     Query query(ctx_, array, TILEDB_READ);
     query.set_layout(layout);
@@ -397,7 +397,7 @@ TEST_CASE_METHOD(
   // Write fourth fragment.
   write_sparse({12, 13, 14, 15}, {4, 3, 3, 4}, {2, 3, 4, 4}, 6);
 
-  for(auto ux=0u; ux < consolidate_sparse_iters; ++ux) {
+  for (auto ux = 0u; ux < consolidate_sparse_iters; ++ux) {
     // Consolidate.
     consolidate_sparse(3, 7, vacuum);
   }
@@ -422,20 +422,25 @@ TEST_CASE_METHOD(
   SECTION("Read after all writes") {
     // Read after both writes - should see everything.
     tstamp = 7;
-    //read_sparse(a, dim1, dim2, stats, layout, 7, timestamps_ptr);
-
+    // read_sparse(a, dim1, dim2, stats, layout, 7, timestamps_ptr);
   }
 
   // Read with full coverage on first 2 consolidated, partial coverage on second
   // 2 consolidated.
   SECTION("Read between the 2 writes") {
     tstamp = 5;
-    //read_sparse(a, dim1, dim2, stats, layout, 5, timestamps_ptr);
-
+    // read_sparse(a, dim1, dim2, stats, layout, 5, timestamps_ptr);
   }
-  for(auto ux=0u ; ux < read_sparse_iters; ++ux)
-    read_sparse(a, dim1, dim2, stats, layout, tstamp, timestamps_ptr, perform_query == 0);
+  for (auto ux = 0u; ux < read_sparse_iters; ++ux)
+    read_sparse(
+        a,
+        dim1,
+        dim2,
+        stats,
+        layout,
+        tstamp,
+        timestamps_ptr,
+        perform_query == 0);
 
   remove_sparse_array();
 }
-

--- a/test/performance/msys_handle_leakage/unit.cc
+++ b/test/performance/msys_handle_leakage/unit.cc
@@ -1,32 +1,41 @@
-// cmake --build tiledb/test/performance --target tiledb_explore_msys_handle_leakage --config RelWithDebInfo
+// cmake --build tiledb/test/performance --target
+// tiledb_explore_msys_handle_leakage --config RelWithDebInfo
 
-/*
-(from                                                                                                                   
-* https://app.shortcut.com/tiledb-inc/story/19067/rtools40-msys-builds-of-tiledb-unit-leaking-handles)
-*                                                                                                                                             
-* (Event) Handle leakage in mingw builds (rtools40, rtools42) seems to be issue within
-* those cpp std libraries that tiledb usage aggravates, as visual studio builds are not exhibiting this leakage.
-* 
-* The leakage itself does not seem to be completely deterministic, as repeatedly running with the same parameters
-* (available with modified unit test) multiple times generally results in different numbers of handles leaked on
-* any given run.  Leakage can be demonstrated with tiledb_unit filtering on "CPP API: Test consolidation with timestamps, full and partial read with dups"
-* 
-* Modifications to unit-cppapi-consolidation-with-timestamps.cc which implements that TEST_CASE indicate that in
-* particular the activity of the .query .submit()d in read_sparse() routine seems to be at least the largest culprit,
-* without the query there seems little/no leakage.
-* 
-* The handle leakage may be causing some of the 32bit unit test failures in mingw, as some of the tests that fail in an
-* unfiltered run work acceptably when run individually, but it seems 32bit builds are not going to be supported with
-* rtools42 so this may not be important.
-* 
-* The ('recent') msys2 mingw versions I have installed of both gdb and lldb seem to have (differing) issues of their own
-* making it difficult to try and gather a complete picture of exactly what/where all may be involved in calls to the
-* CreateEventA (windows api) routine presumed to be at least responsible for the direct creation of the handles being 
-* leaked.
-* 
-* See notes on building this module and running some trials in the top of unit.cc along with some previously observed results.
-*/
+/* (from
+ * https://app.shortcut.com/tiledb-inc/story/19067/rtools40-msys-builds-of-tiledb-unit-leaking-handles)
+ *
+ * (Event) Handle leakage in mingw builds (rtools40, rtools42) seems to be issue
+ * within those cpp std libraries that tiledb usage aggravates, as visual studio
+ * builds are not exhibiting this leakage.
+ *
+ * The leakage itself does not seem to be completely deterministic, as
+ * repeatedly running with the same parameters (available with modified unit
+ * test) multiple times generally results in different numbers of handles leaked
+ * on any given run.  Leakage can be demonstrated with tiledb_unit filtering on
+ * "CPP API: Test consolidation with timestamps, full and partial read with
+ * dups"
+ *
+ * Modifications to unit-cppapi-consolidation-with-timestamps.cc which
+ * implements that TEST_CASE indicate that in particular the activity of the
+ * .query .submit()d in read_sparse() routine seems to be at least the largest
+ * culprit, without the query there seems little/no leakage.
+ *
+ * The handle leakage may be causing some of the 32bit unit test failures in
+ * mingw, as some of the tests that fail in an unfiltered run work acceptably
+ * when run individually, but it seems 32bit builds are not going to be
+ * supported with rtools42 so this may not be important.
+ *
+ * The ('recent') msys2 mingw versions I have installed of both gdb and lldb
+ * seem to have (differing) issues of their own making it difficult to try and
+ * gather a complete picture of exactly what/where all may be involved in calls
+ * to the CreateEventA (windows api) routine presumed to be at least responsible
+ * for the direct creation of the handles being leaked.
+ *
+ * See notes on building this module and running some trials in the top of
+ * unit.cc along with some previously observed results.
+ */
 
+// clang-format off
 //.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1 --wait-for-keypress both
 //./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-sparse-iters=1 --wait-for-keypress both
 
@@ -97,6 +106,7 @@ handle_count
 before 52
 after  70
   */
+// clang-format on
 
 #define CATCH_CONFIG_RUNNER
 #include <test/support/tdb_catch.h>
@@ -139,11 +149,16 @@ int main(const int argc, char** const argv) {
   Catch::clara::Parser cli =
       session.cli() |
       Catch::clara::Opt(vfs, vfs_fs_oss.str())["--vfs"](
-          "Override the VFS filesystem to use for generic tests")
-      | Catch::clara::Opt(read_sparse_iters, "read_sparse_iters")["--read-sparse-iters"]("specify read_sparse_iters (default 1)")
-      | Catch::clara::Opt(perform_query, "perform_query")["--perform-query"]("specify whether to perform query (default non-zero)")
-      | Catch::clara::Opt(consolidate_sparse_iters, "consolidate_sparse_iters")["--consolidate-sparse-iters"]("how many read_sparse iters to perform (default 1)")
-      ;
+          "Override the VFS filesystem to use for generic tests") |
+      Catch::clara::Opt(
+          read_sparse_iters, "read_sparse_iters")["--read-sparse-iters"](
+          "specify read_sparse_iters (default 1)") |
+      Catch::clara::Opt(perform_query, "perform_query")["--perform-query"](
+          "specify whether to perform query (default non-zero)") |
+      Catch::clara::Opt(
+          consolidate_sparse_iters,
+          "consolidate_sparse_iters")["--consolidate-sparse-iters"](
+          "how many read_sparse iters to perform (default 1)");
 
   session.cli(cli);
 
@@ -156,15 +171,15 @@ int main(const int argc, char** const argv) {
   if (rc != 0)
     return rc;
 
-  DWORD handle_count_before=0, handle_count_after;
+  DWORD handle_count_before = 0, handle_count_after;
   BOOL got_before, got_after;
-  got_before = GetProcessHandleCount(GetCurrentProcess(),&handle_count_before);
-  //return session.run();
-  auto retval =  session.run();
-  got_after = GetProcessHandleCount(GetCurrentProcess(),&handle_count_after);
+  got_before = GetProcessHandleCount(GetCurrentProcess(), &handle_count_before);
+  // return session.run();
+  auto retval = session.run();
+  got_after = GetProcessHandleCount(GetCurrentProcess(), &handle_count_after);
   std::cout << "handle_count" << std::endl
-      << "before " << handle_count_before << std::endl
-      << "after  " << handle_count_after << std::endl;
+            << "before " << handle_count_before << std::endl
+            << "after  " << handle_count_after << std::endl;
   return retval;
 }
 

--- a/test/regression/targets/sc-18836.cc
+++ b/test/regression/targets/sc-18836.cc
@@ -1,7 +1,7 @@
-#include <string>
-#include <iostream>
-#include <tiledb/tiledb>
 #include <future>
+#include <iostream>
+#include <string>
+#include <tiledb/tiledb>
 
 #include <test/support/tdb_catch.h>
 
@@ -10,15 +10,15 @@ using namespace tiledb;
 float a2_fill_value = 0.0f;
 const std::string array_name = "cpp_qc_nullable_array";
 
-void create_array(){
+void create_array() {
   Context ctx;
-  
+
   // Create dimension
   auto dim = tiledb::Dimension::create<int32_t>(ctx, "dim", {{1, 9}}, 2);
-  
+
   Domain domain(ctx);
   domain.add_dimension(dim);
-  
+
   Attribute a1(ctx, "a1", TILEDB_INT32);
   a1.set_nullable(true);
   Attribute a2(ctx, "a2", TILEDB_FLOAT32);
@@ -34,7 +34,8 @@ void create_array(){
   std::vector<int> data1 = {8, 9, 10, 11, 12, 13, 14, 15, 16};
   std::vector<uint8_t> a1_validity_buf = {0, 1, 1, 1, 1, 0, 1, 1, 0};
 
-  std::vector<float> data2 = {13.2f, 14.1f, 14.2f, 15.1f, 15.2f, 15.3f, 16.1f, 18.3f, 19.1f};
+  std::vector<float> data2 = {
+      13.2f, 14.1f, 14.2f, 15.1f, 15.2f, 15.3f, 16.1f, 18.3f, 19.1f};
 
   // Set the subarray to write into
   std::vector<int> subarray = {1, 9};
@@ -44,16 +45,19 @@ void create_array(){
 
   Query query(ctx, array);
   query.set_layout(TILEDB_ROW_MAJOR)
-    .set_buffer("a1", data1)
-    .set_validity_buffer("a1", a1_validity_buf)
-    .set_buffer("a2", data2)
-    .set_subarray(subarray);
+      .set_buffer("a1", data1)
+      .set_validity_buffer("a1", a1_validity_buf)
+      .set_buffer("a2", data2)
+      .set_subarray(subarray);
 
   query.submit();
   array.close();
 }
 
-TEST_CASE("Query Condition CPP API: Query Condition OR with nullable attributes (sc-18836)", "[QueryCondition]"){
+TEST_CASE(
+    "Query Condition CPP API: Query Condition OR with nullable attributes "
+    "(sc-18836)",
+    "[QueryCondition]") {
   Context ctx;
   VFS vfs(ctx);
 
@@ -70,45 +74,46 @@ TEST_CASE("Query Condition CPP API: Query Condition OR with nullable attributes 
   // Prepare the vectors that will hold the results
   std::vector<int> a1_buffer(9);
   std::vector<float> a2_buffer(9);
-  std::vector<uint8_t> a1_validity_buf(9);  
+  std::vector<uint8_t> a1_validity_buf(9);
 
   // Prepare the query
   Query query(ctx, array, TILEDB_READ);
   query.set_subarray(subarray)
-       .set_layout(TILEDB_ROW_MAJOR)
-       .set_buffer("a1", a1_buffer)
-       .set_validity_buffer("a1", a1_validity_buf)
-       .set_buffer("a2", a2_buffer); 
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_buffer("a1", a1_buffer)
+      .set_validity_buffer("a1", a1_validity_buf)
+      .set_buffer("a2", a2_buffer);
 
   QueryCondition qc1(ctx);
   float val = 15.1f;
-  qc1.init("a2", &val, sizeof(float), TILEDB_EQ);  
+  qc1.init("a2", &val, sizeof(float), TILEDB_EQ);
   QueryCondition qc2(ctx);
-  qc2.init("a1", nullptr, 0, TILEDB_EQ);  
+  qc2.init("a1", nullptr, 0, TILEDB_EQ);
   QueryCondition qc(ctx);
 
   SECTION("Ordering q1, q2") {
-      qc = qc1.combine(qc2, TILEDB_OR); 
-  }  
+    qc = qc1.combine(qc2, TILEDB_OR);
+  }
 
   SECTION("Ordering q2, q1") {
-      qc = qc2.combine(qc1, TILEDB_OR); 
-  }  
+    qc = qc2.combine(qc1, TILEDB_OR);
+  }
 
   query.set_condition(qc);
   query.submit();
-  array.close();  
+  array.close();
 
   // Print out the results.
   int m = std::numeric_limits<int>::min();
   std::vector<int> a1_expected = {8, m, m, 11, m, 13, m, m, 16};
-  std::vector<float> a2_expected = {13.2f, 0.0f, 0.0f, 15.1f, 0.0f, 15.3f, 0.0f, 0.0f, 19.1f};
-    auto result_num = (int)query.result_buffer_elements()["a1"].second;
-    for (int r = 0; r < result_num; r++) {
-      CHECK(a1_buffer[r] == a1_expected[r]);
-      CHECK(a2_buffer[r] == a2_expected[r]);
-  }  
-  
+  std::vector<float> a2_expected = {
+      13.2f, 0.0f, 0.0f, 15.1f, 0.0f, 15.3f, 0.0f, 0.0f, 19.1f};
+  auto result_num = (int)query.result_buffer_elements()["a1"].second;
+  for (int r = 0; r < result_num; r++) {
+    CHECK(a1_buffer[r] == a1_expected[r]);
+    CHECK(a2_buffer[r] == a2_expected[r]);
+  }
+
   if (vfs.is_dir(array_name))
-      vfs.remove_dir(array_name);
+    vfs.remove_dir(array_name);
 }


### PR DESCRIPTION
The CI script only check in `test/src`, not in all of the `test` directory. A few files have slipped in that clang-format wants to change.

---
TYPE: NO_HISTORY
DESC: clang-format for some files that the CI script doesn't check
