### PR TITLE
[build] Update libmagic tag (fix for arm64 mac in conda-forge feedstock)

### DIFF
--- a/cmake/Modules/FindMagic_EP.cmake
+++ b/cmake/Modules/FindMagic_EP.cmake
@@ -90,7 +90,7 @@ if(NOT TILEDB_LIBMAGIC_EP_BUILT)
     ExternalProject_Add(ep_magic
       PREFIX "externals"
       GIT_REPOSITORY "https://github.com/TileDB-Inc/file-windows.git"
-      GIT_TAG "5.38.1.tiledb"
+      GIT_TAG "5.38.2.tiledb"
       GIT_SUBMODULES_RECURSE TRUE
       UPDATE_COMMAND ""
       CMAKE_ARGS


### PR DESCRIPTION
Update the libmagic tag to include a work-around fix for build issues in a mac arm64 cross-compile conda environment (for the tiledb feedstock): https://github.com/TileDB-Inc/file-windows/releases/tag/5.38.2.tiledb

---
TYPE: NO_HISTORY
