### PR TITLE
Fragment info: allow to pass in an array directory.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -195,7 +195,7 @@ Status Array::open_without_fragments(
           array_uri_,
           0,
           UINT64_MAX,
-          ArrayDirectoryMode::SCHEMA_ONLY);
+          ArrayDirectoryMode::READ);
 
       auto&& [st, array_schema, array_schemas] =
           storage_manager_->array_open_for_reads_without_fragments(this);
@@ -251,12 +251,6 @@ Status Array::delete_fragments(
       uri.c_str(), timestamp_start, timestamp_end, true));
 
   return Status::Ok();
-}
-
-void Array::set_delete_tiles_location(
-    const std::vector<ArrayDirectory::DeleteTileLocation>&
-        delete_tiles_location) {
-  array_dir_.set_delete_tiles_location(delete_tiles_location);
 }
 
 Status Array::open(

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -192,15 +192,6 @@ class Array {
       const URI& uri, uint64_t timestamp_start, uint64_t timstamp_end);
 
   /**
-   * Sets the delete tiles location.
-   *
-   * @param delete_tiles_location Location for the delete tiles.
-   */
-  void set_delete_tiles_location(
-      const std::vector<ArrayDirectory::DeleteTileLocation>&
-          delete_tiles_location);
-
-  /**
    * Opens the array for reading.
    *
    * @param query_type The query type. This should always be READ. It

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -304,11 +304,6 @@ ArrayDirectory::delete_tiles_location() const {
   return delete_tiles_location_;
 }
 
-void ArrayDirectory::set_delete_tiles_location(
-    const std::vector<DeleteTileLocation>& delete_tiles_location) {
-  delete_tiles_location_ = delete_tiles_location;
-}
-
 URI ArrayDirectory::get_fragments_dir(uint32_t write_version) const {
   if (write_version < 12) {
     return uri_;

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -295,10 +295,6 @@ class ArrayDirectory {
   /** Returns the location of delete tiles. */
   const std::vector<DeleteTileLocation>& delete_tiles_location() const;
 
-  /** Set the location of delete tiles, used by consolidation */
-  void set_delete_tiles_location(
-      const std::vector<DeleteTileLocation>& delete_tiles_location);
-
   /** Returns the URI to store fragments. */
   URI get_fragments_dir(uint32_t write_version) const;
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -6510,15 +6510,7 @@ int32_t tiledb_fragment_info_load(
     return TILEDB_ERR;
 
   // Load fragment info
-  bool set_timestamp_range_from_config = true;
-  bool set_enc_key_from_config = true;
-  bool compute_anterior = false;
-  if (SAVE_ERROR_CATCH(
-          ctx,
-          fragment_info->fragment_info_->load(
-              set_timestamp_range_from_config,
-              set_enc_key_from_config,
-              compute_anterior)))
+  if (SAVE_ERROR_CATCH(ctx, fragment_info->fragment_info_->load()))
     return TILEDB_ERR;
 
   return TILEDB_OK;

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -100,21 +100,17 @@ Status FragmentConsolidator::consolidate(
   // which dense fragments are consolidatable.
   FragmentInfo fragment_info(URI(array_name), storage_manager_);
   auto st = fragment_info.load(
+      array_for_reads->array_directory(),
       config_.timestamp_start_,
       config_.timestamp_end_,
       encryption_type,
       encryption_key,
-      key_length,
-      array_for_reads->array_schema_latest().dense());
+      key_length);
   if (!st.ok()) {
     array_for_reads->close();
     array_for_writes->close();
     return st;
   }
-
-  // Set the delete tiles location in the open array.
-  array_for_reads->set_delete_tiles_location(
-      fragment_info.delete_tiles_location());
 
   uint32_t step = 0;
   std::vector<TimestampedURI> to_consolidate;
@@ -212,21 +208,17 @@ Status FragmentConsolidator::consolidate_fragments(
   // Get all fragment info
   FragmentInfo fragment_info(URI(array_name), storage_manager_);
   auto st = fragment_info.load(
+      array_for_reads->array_directory(),
       0,
       utils::time::timestamp_now_ms(),
       encryption_type,
       encryption_key,
-      key_length,
-      false);
+      key_length);
   if (!st.ok()) {
     array_for_reads->close();
     array_for_writes->close();
     return st;
   }
-
-  // Set the delete tiles location in the open array.
-  array_for_reads->set_delete_tiles_location(
-      fragment_info.delete_tiles_location());
 
   // Make a set of the uris to consolidate
   NDRange union_non_empty_domains;

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -864,8 +864,8 @@ Status FragmentInfo::load(const ArrayDirectory& array_dir) {
       0,
       fragment_num,
       [this, &fragment_metadata_value, &sizes](uint64_t i) {
-        // Get fragment size. Applicable only to relevant fragments, excluding
-        // those potentially loaded in a passed in an array directory.
+        // Get fragment size. Applicable only to relevant fragments, including
+        // fragments that are in the range [timestamp_start_, timestamp_end_].
         auto meta = fragment_metadata_value[i];
         if (meta->timestamp_range().first >= timestamp_start_ &&
             meta->timestamp_range().second <= timestamp_end_) {

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -796,83 +796,66 @@ Status FragmentInfo::has_consolidated_metadata(
 
   return Status::Ok();
 }
-Status FragmentInfo::load(
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length) {
-  RETURN_NOT_OK(enc_key_.set_key(encryption_type, encryption_key, key_length));
-  auto set_timestamp_range_from_config = true;
-  auto set_key_from_config = false;  // Key set explicitly above
-  auto compute_anterior = false;
-  return load(
-      set_timestamp_range_from_config, set_key_from_config, compute_anterior);
-}
 
-Status FragmentInfo::load(
-    uint64_t timestamp_start,
-    uint64_t timestamp_end,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    bool compute_anterior) {
-  timestamp_start_ = timestamp_start;
-  timestamp_end_ = timestamp_end;
-  RETURN_NOT_OK(enc_key_.set_key(encryption_type, encryption_key, key_length));
-  auto set_timestamp_range_from_config =
-      false;                         // Timestamps set explicitly above
-  auto set_key_from_config = false;  // Key set explicitly above
-  return load(
-      set_timestamp_range_from_config, set_key_from_config, compute_anterior);
-}
-
-Status FragmentInfo::load(
-    bool set_timestamp_range_from_config,
-    bool set_key_from_config,
-    bool compute_anterior) {
-  bool is_array;
-  RETURN_NOT_OK(storage_manager_->is_array(array_uri_, &is_array));
-  if (!is_array) {
-    auto msg = std::string("Cannot load fragment info; Array '") +
-               array_uri_.to_string() + "' does not exist";
-    return LOG_STATUS(Status_FragmentInfoError(msg));
-  }
-
-  if (array_uri_.is_tiledb()) {
-    auto msg = std::string(
-                   "FragmentInfo not supported in TileDB Cloud arrays; "
-                   "FragmentInfo for array '") +
-               array_uri_.to_string() + "' cannot be loaded";
-    return LOG_STATUS(Status_FragmentInfoError(msg));
-  }
-
-  // Set the timestamp range
-  if (set_timestamp_range_from_config) {
-    RETURN_NOT_OK(this->set_timestamp_range_from_config());
-  }
-
-  // Get the encryption key (if not already set)
-  if (set_key_from_config) {
-    RETURN_NOT_OK(this->set_enc_key_from_config());
-  }
+Status FragmentInfo::load() {
+  RETURN_NOT_OK(check_array_uri());
+  RETURN_NOT_OK(set_enc_key_from_config());
+  RETURN_NOT_OK(set_timestamp_range_from_config());
 
   // Create an ArrayDirectory object and load
-  auto timestamp_start = compute_anterior ? 0 : timestamp_start_;
   auto array_dir = ArrayDirectory(
       storage_manager_->vfs(),
       storage_manager_->compute_tp(),
       array_uri_,
-      timestamp_start,
+      timestamp_start_,
       timestamp_end_);
 
+  return load(array_dir);
+}
+
+Status FragmentInfo::load(
+    EncryptionType encryption_type,
+    const void* encryption_key,
+    uint32_t key_length) {
+  RETURN_NOT_OK(check_array_uri());
+
+  RETURN_NOT_OK(enc_key_.set_key(encryption_type, encryption_key, key_length));
+  RETURN_NOT_OK(set_timestamp_range_from_config());
+
+  // Create an ArrayDirectory object and load
+  auto array_dir = ArrayDirectory(
+      storage_manager_->vfs(),
+      storage_manager_->compute_tp(),
+      array_uri_,
+      timestamp_start_,
+      timestamp_end_);
+  return load(array_dir);
+}
+
+Status FragmentInfo::load(
+    const ArrayDirectory& array_dir,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    EncryptionType encryption_type,
+    const void* encryption_key,
+    uint32_t key_length) {
+  RETURN_NOT_OK(check_array_uri());
+  timestamp_start_ = timestamp_start;
+  timestamp_end_ = timestamp_end;
+
+  RETURN_NOT_OK(enc_key_.set_key(encryption_type, encryption_key, key_length));
+  return load(array_dir);
+}
+
+Status FragmentInfo::load(const ArrayDirectory& array_dir) {
   // Get the array schemas and fragment metadata.
-  auto&& [st_schemas, array_schema_latest, array_schemas_all, fragment_metadata] =
+  auto&& [st_schemas, array_schema_latest, array_schemas_all, fragment_metadata_opt] =
       storage_manager_->load_array_schemas_and_fragment_metadata(
           array_dir, nullptr, enc_key_);
   RETURN_NOT_OK(st_schemas);
-  (void)array_schema_latest;  // Not needed here
+  const auto& fragment_metadata = fragment_metadata_opt.value();
   array_schemas_all_ = std::move(array_schemas_all.value());
-  auto fragment_num = (uint32_t)fragment_metadata.value().size();
-  const auto& fragment_metadata_v = fragment_metadata.value();
+  auto fragment_num = (uint32_t)fragment_metadata.size();
 
   // Get fragment sizes
   std::vector<uint64_t> sizes(fragment_num, 0);
@@ -880,11 +863,12 @@ Status FragmentInfo::load(
       storage_manager_->compute_tp(),
       0,
       fragment_num,
-      [this, &fragment_metadata_v, &sizes](uint64_t i) {
-        // Get fragment size. Applicable only to relevant fragments,
-        // excluding those potentially used to compute anterior_ndrange_.
-        auto meta = fragment_metadata_v[i];
-        if (meta->timestamp_range().first >= timestamp_start_) {
+      [this, &fragment_metadata, &sizes](uint64_t i) {
+        // Get fragment size. Applicable only to relevant fragments, excluding
+        // those potentially loaded in a passed in an array directory.
+        auto meta = fragment_metadata[i];
+        if (meta->timestamp_range().first >= timestamp_start_ &&
+            meta->timestamp_range().second <= timestamp_end_) {
           uint64_t size;
           RETURN_NOT_OK(meta->fragment_size(&size));
           sizes[i] = size;
@@ -899,13 +883,13 @@ Status FragmentInfo::load(
 
   // Create the vector that will store the SingleFragmentInfo objects
   for (uint64_t fid = 0; fid < fragment_num; fid++) {
-    const auto meta = fragment_metadata_v[fid];
+    const auto meta = fragment_metadata[fid];
     const auto& array_schema = meta->array_schema();
     const auto& non_empty_domain = meta->non_empty_domain();
 
     if (meta->timestamp_range().first < timestamp_start_) {
       expand_anterior_ndrange(array_schema->domain(), non_empty_domain);
-    } else {
+    } else if (meta->timestamp_range().second <= timestamp_end_) {
       const auto& uri = meta->fragment_uri();
       bool sparse = !meta->dense();
 
@@ -935,9 +919,6 @@ Status FragmentInfo::load(
   for (const auto& f : single_fragment_info_vec_) {
     unconsolidated_metadata_num_ += (uint32_t)!f.has_consolidated_footer();
   }
-
-  // Store the delete tile locations
-  delete_tiles_location_ = array_dir.delete_tiles_location();
 
   return Status::Ok();
 }
@@ -973,14 +954,21 @@ uint32_t FragmentInfo::unconsolidated_metadata_num() const {
   return unconsolidated_metadata_num_;
 }
 
-const std::vector<ArrayDirectory::DeleteTileLocation>&
-FragmentInfo::delete_tiles_location() const {
-  return delete_tiles_location_;
-}
-
 /* ********************************* */
 /*          PRIVATE METHODS          */
 /* ********************************* */
+
+Status FragmentInfo::check_array_uri() {
+  if (array_uri_.is_tiledb()) {
+    auto msg = std::string(
+                   "FragmentInfo not supported in TileDB Cloud arrays; "
+                   "FragmentInfo for array '") +
+               array_uri_.to_string() + "' cannot be loaded";
+    return LOG_STATUS(Status_FragmentInfoError(msg));
+  }
+
+  return Status::Ok();
+}
 
 Status FragmentInfo::set_enc_key_from_config() {
   std::string enc_key_str, enc_type_str;

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -362,10 +362,9 @@ class FragmentInfo {
   Status set_enc_key_from_config();
 
   /**
-   * Sets the timestamp range from config_. If not present, the timestamp
-   * range is set to [0, now].
+   * Sets the timestamp range to [0, now].
    */
-  Status set_timestamp_range_from_config();
+  Status set_default_timestamp_range();
 
   /**
    * Loads the fragment info from an array using the array directory.

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -242,19 +242,9 @@ class FragmentInfo {
   /**
    * Loads the fragment info from an array.
    *
-   * @param set_timestamp_range_from_config If `true` the timestamps
-   *     will be set by reading them from `config_`.
-   * @param set_key_from_cfg If `true`, the encryption key and type
-   *     will be set by reading them from `config_`.
-   * @param compute_anterior If `true`, all fragments
-   *     will be loaded and `anterior_ndrange` will be computed for
-   *     those that have a start timestamp smaller than `timestamp_start_`.
    * @return Status
    */
-  Status load(
-      bool set_timestamp_range_from_config,
-      bool set_key_from_config,
-      bool compute_anterior);
+  Status load();
 
   /**
    * Loads the fragment info from an array using the input key.
@@ -273,6 +263,7 @@ class FragmentInfo {
    * Loads the fragment info from an array using the input key
    * and timestamps.
    *
+   * @param array_dir The array directory to load the fragments.
    * @param timestamp_start This function will load fragments with
    *      whose timestamps are within [timestamp_start, timestamp_end].
    * @param timestamp_end This function will load fragments with
@@ -280,18 +271,15 @@ class FragmentInfo {
    * @param encryption_type The encryption type.
    * @param encryption_key The encryption key.
    * @param key_length The length of `encryption_key`.
-   * @param compute_anterior If `true`, all fragments
-   *     will be loaded and `anterior_ndrange` will be computed for
-   *     those that have a start timestamp smaller than `timestamp_start_`.
    * @return Status
    */
   Status load(
+      const ArrayDirectory& array_dir,
       uint64_t timestamp_start,
       uint64_t timestamp_end,
       EncryptionType encryption_type,
       const void* encryption_key,
-      uint32_t key_length,
-      bool compute_anterior);
+      uint32_t key_length);
 
   /**
    * It replaces a sequence of SingleFragmentInfo elements in
@@ -321,10 +309,6 @@ class FragmentInfo {
 
   /** Returns the number of fragments with unconsolidated metadata. */
   uint32_t unconsolidated_metadata_num() const;
-
-  /** Returns the location of delete tiles. */
-  const std::vector<ArrayDirectory::DeleteTileLocation>& delete_tiles_location()
-      const;
 
  private:
   /* ********************************* */
@@ -367,12 +351,12 @@ class FragmentInfo {
   /** Timestamp end used in load. */
   uint64_t timestamp_end_;
 
-  /** Delete tile locations. */
-  std::vector<ArrayDirectory::DeleteTileLocation> delete_tiles_location_;
-
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
+
+  /** Checks the array URI is valid. */
+  Status check_array_uri();
 
   /** Sets the encryption key (if present) from config_. */
   Status set_enc_key_from_config();
@@ -382,6 +366,11 @@ class FragmentInfo {
    * range is set to [0, now].
    */
   Status set_timestamp_range_from_config();
+
+  /**
+   * Loads the fragment info from an array using the array directory.
+   */
+  Status load(const ArrayDirectory& array_directory);
 
   /**
    * Loads the fragment metadata of the input URI and returns a


### PR DESCRIPTION
This changes `FragmentInfo` so that it can take in an already loaded array directory. This is useful for the consolidation path where the array is opened without fragments, we get information with about the fragments with the `FragmentInfo` APIs, then load fragments to be consolidated on the opened array. This also changes `open_without_fragments` so that array directory lists everything it will need. That way, we can pass in the `ArrayDirectory` from the opened array. A side effect of this refactor is that we could get rid of the hack to pass in the delete tile locations from the fragment info APIs to the array opened without fragments.

---
TYPE: IMPROVEMENT
DESC: Fragment info: allow to pass in an array directory.
