### PR TITLE
Enable building libcurl with zstd support

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -88,6 +88,9 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
         -DCURL_STATICLIB=ON
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DHTTP_ONLY=ON
+        # NOTE: as of Curl 7.74 there is no way to set ZSTD paths for cmake
+        # ZSTD is not enabled until curl support being able to point to superbuild
+        #-DCURL_ZSTD=ON
         "${WITH_SSL}"
         "-DCMAKE_C_FLAGS=${CFLAGS_DEF}"
       UPDATE_COMMAND ""
@@ -127,6 +130,18 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       message(WARNING "TileDB FindZlib_EP did not set TILEDB_ZLIB_DIR. Falling back to autotools detection.")
       # ensure that curl config errors out if SSL not available
       set(WITH_ZLIB "--with-zlib")
+    endif()
+
+    if (TARGET ep_zstd)
+      list(APPEND DEPENDS ep_zstd)
+      set(WITH_ZLIB "--with-zstd=${TILEDB_EP_INSTALL_PREFIX}")
+    elseif (TILEDB_ZSTD_DIR)
+      # ensure that curl links against the same libz
+      set(WITH_ZSTD "--with-zstd=${TILEDB_ZSTD_DIR}")
+    else()
+      message(WARNING "TileDB FindZstd_EP did not set TILEDB_ZSTD_DIR. Falling back to autotools detection.")
+      # ensure that curl config errors out if SSL not available
+      set(WITH_ZSTD "--with-zstd")
     endif()
 
     # Support cross compilation of MacOS
@@ -181,6 +196,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
           --disable-tftp
           ${WITH_SSL}
           ${WITH_ZLIB}
+          ${WITH_ZSTD}
           ${CURL_CROSS_COMPILATION_FLAGS}
       BUILD_IN_SOURCE TRUE
       BUILD_COMMAND $(MAKE)

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -98,6 +98,11 @@ if (NOT ZSTD_FOUND)
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
+	# Disable building ZSTD shared library as this is not used by superbuild
+	# When using superbuild for zstd + curl the shared library was being selected
+	# on some envs due to ordering of search paths.
+	# This caused linker errors for projects using libtiledb because of missing shared zstd library.
+	-DZSTD_BUILD_SHARED=OFF
         ${TILEDB_EP_BASE}/src/ep_zstd/build/cmake
       UPDATE_COMMAND ""
       LOG_DOWNLOAD TRUE

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -107,6 +107,7 @@ if (NOT ZSTD_FOUND)
       LOG_OUTPUT_ON_FAILURE ${TILEDB_LOG_OUTPUT_ON_FAILURE}
     )
     list(APPEND TILEDB_EXTERNAL_PROJECTS ep_zstd)
+    set(TILEDB_ZSTD_DIR "${TILEDB_EP_INSTALL_PREFIX}")
   else()
     message(FATAL_ERROR "Unable to find Zstd")
   endif()


### PR DESCRIPTION
This adds support for curl to enable zstd compression in linux/macos builds. Windows uses cmake for building and the curl cmake does not allow for setting the library paths for zstd. This means the windows superbuild is not supported. For now we just enable on linux/macos.

The goal of enable zstd to is to allow this as an option for http compression.

---
TYPE: IMPROVEMENT
DESC: Enable superbuild libcurl to support zstd
