### PR TITLE
Deletes: disallow in middle of consolidated fragment with no timestamps.

### DIFF
--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -6743,6 +6743,7 @@ TEST_CASE_METHOD(
   remove_sparse_array();
 }
 
+// TODO: remove once tiledb_vfs_copy_dir is implemented for windows.
 #ifndef _WIN32
 TEST_CASE_METHOD(
     ConsolidationFx,

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -513,6 +513,7 @@ TEST_CASE_METHOD(
   remove_sparse_array();
 }
 
+// TODO: remove once tiledb_vfs_copy_dir is implemented for windows.
 #ifndef _WIN32
 TEST_CASE_METHOD(
     ConsolidationWithTimestampsFx,

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1490,6 +1490,7 @@ TEST_CASE_METHOD(
   remove_sparse_array();
 }
 
+// TODO: remove once tiledb_vfs_copy_dir is implemented for windows.
 #ifndef _WIN32
 TEST_CASE_METHOD(
     DeletesFx,

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -68,12 +68,14 @@ struct DeletesFx {
   void set_legacy();
   void set_purge_deleted_cells();
   void create_sparse_array(bool allows_dups = false, bool encrypt = false);
+  void create_sparse_array_v11();
   void write_sparse(
       std::vector<int> a1,
       std::vector<uint64_t> dim1,
       std::vector<uint64_t> dim2,
       uint64_t timestamp,
       bool encrypt = false);
+  void write_sparse_v11(uint64_t timestamp);
   void read_sparse(
       std::vector<int>& a1,
       std::vector<uint64_t>& dim1,
@@ -167,6 +169,18 @@ void DeletesFx::create_sparse_array(bool allows_dups, bool encrypt) {
   }
 }
 
+void DeletesFx::create_sparse_array_v11() {
+  // Get the v11 sparse array.
+  std::string v11_arrays_dir =
+      std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays/sparse_array_v11";
+  REQUIRE(
+      tiledb_vfs_copy_dir(
+          ctx_.ptr().get(),
+          vfs_.ptr().get(),
+          v11_arrays_dir.c_str(),
+          SPARSE_ARRAY_NAME) == TILEDB_OK);
+}
+
 void DeletesFx::write_sparse(
     std::vector<int> a1,
     std::vector<uint64_t> dim1,
@@ -201,6 +215,36 @@ void DeletesFx::write_sparse(
 
   // Close array.
   array->close();
+}
+void DeletesFx::write_sparse_v11(uint64_t timestamp) {
+  // Prepare cell buffers.
+  std::vector<int> buffer_a1{0, 1, 2, 3};
+  std::vector<uint64_t> buffer_a2{0, 1, 3, 6};
+  std::string buffer_var_a2("abbcccdddd");
+  std::vector<float> buffer_a3{0.1f, 0.2f, 1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f};
+  std::vector<uint64_t> buffer_coords_dim1{1, 1, 1, 2};
+  std::vector<uint64_t> buffer_coords_dim2{1, 2, 4, 3};
+
+  // Open array.
+  Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_WRITE, timestamp);
+
+  // Create query.
+  Query query(ctx_, array, TILEDB_WRITE);
+  query.set_layout(TILEDB_GLOBAL_ORDER);
+  query.set_data_buffer("a1", buffer_a1);
+  query.set_data_buffer(
+      "a2", (void*)buffer_var_a2.c_str(), buffer_var_a2.size());
+  query.set_offsets_buffer("a2", buffer_a2);
+  query.set_data_buffer("a3", buffer_a3);
+  query.set_data_buffer("d1", buffer_coords_dim1);
+  query.set_data_buffer("d2", buffer_coords_dim2);
+
+  // Submit/finalize the query.
+  query.submit();
+  query.finalize();
+
+  // Close array.
+  array.close();
 }
 
 void DeletesFx::read_sparse(
@@ -292,9 +336,13 @@ void DeletesFx::write_delete_condition(
     CHECK(error_expected);
   }
 
-  CHECK(
-      query.query_status() ==
-      (error_expected ? Query::Status::FAILED : Query::Status::COMPLETE));
+  if (error_expected) {
+    CHECK(
+        (query.query_status() == Query::Status::FAILED ||
+         query.query_status() == Query::Status::INPROGRESS));
+  } else {
+    CHECK(query.query_status() == Query::Status::COMPLETE);
+  }
 
   // Close array.
   array->close();
@@ -1456,3 +1504,39 @@ TEST_CASE_METHOD(
 
   remove_sparse_array();
 }
+
+#ifndef _WIN32
+TEST_CASE_METHOD(
+    DeletesFx,
+    "CPP API: Test writing delete in middle of fragment consolidated without "
+    "timestamps",
+    "[cppapi][deletes][write][old-consolidated-fragment]") {
+  if constexpr (is_experimental_build) {
+    return;
+  }
+
+  remove_sparse_array();
+  create_sparse_array_v11();
+  // Write first fragment.
+  write_sparse_v11(1);
+
+  // Write second fragment.
+  write_sparse_v11(3);
+
+  // Consolidate.
+  consolidate_sparse();
+
+  // Upgrade to latest version.
+  Array::upgrade_version(ctx_, SPARSE_ARRAY_NAME);
+
+  // Define query condition (d2 == 3).
+  QueryCondition qc2(ctx_);
+  uint64_t val2 = 3;
+  qc2.init("d2", &val2, sizeof(uint64_t), TILEDB_EQ);
+
+  // Write condition and specify an error is expected.
+  write_delete_condition(qc2, 2, false, true);
+
+  remove_sparse_array();
+}
+#endif

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -404,7 +404,9 @@ Status Array::open(
       array_schema_latest_ = array_schema_latest.value();
       array_schemas_all_ = array_schemas.value();
       fragment_metadata_ = fragment_metadata.value();
-    } else {
+    } else if (
+        query_type == QueryType::WRITE ||
+        query_type == QueryType::MODIFY_EXCLUSIVE) {
       array_dir_ = ArrayDirectory(
           storage_manager_->vfs(),
           storage_manager_->compute_tp(),
@@ -412,6 +414,27 @@ Status Array::open(
           timestamp_start_,
           timestamp_end_opened_at_,
           ArrayDirectoryMode::SCHEMA_ONLY);
+
+      auto&& [st, array_schema_latest, array_schemas] =
+          storage_manager_->array_open_for_writes(this);
+      if (!st.ok()) {
+        throw StatusException(st);
+      }
+
+      // Set schemas
+      array_schema_latest_ = array_schema_latest.value();
+      array_schemas_all_ = array_schemas.value();
+
+      metadata_.reset(timestamp_end_opened_at_);
+    } else if (
+        query_type == QueryType::DELETE || query_type == QueryType::UPDATE) {
+      array_dir_ = ArrayDirectory(
+          storage_manager_->vfs(),
+          storage_manager_->compute_tp(),
+          array_uri_,
+          timestamp_start_,
+          timestamp_end_opened_at_,
+          ArrayDirectoryMode::READ);
 
       auto&& [st, array_schema_latest, array_schemas] =
           storage_manager_->array_open_for_writes(this);
@@ -432,10 +455,9 @@ Status Array::open(
         err << ") is smaller than the minimum supported version (";
         err << constants::deletes_min_version << ").";
         return LOG_STATUS(Status_ArrayError(err.str()));
-      }
-
-      if (query_type == QueryType::UPDATE &&
-          version < constants::deletes_min_version) {
+      } else if (
+          query_type == QueryType::UPDATE &&
+          version < constants::updates_min_version) {
         std::stringstream err;
         err << "Cannot open array for updates; Array format version (";
         err << version;
@@ -445,6 +467,8 @@ Status Array::open(
       }
 
       metadata_.reset(timestamp_end_opened_at_);
+    } else {
+      throw Status_ArrayError("Cannot open array; Unsupported query type.");
     }
   } catch (std::exception& e) {
     set_array_closed();

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -417,9 +417,7 @@ Status Array::open(
 
       auto&& [st, array_schema_latest, array_schemas] =
           storage_manager_->array_open_for_writes(this);
-      if (!st.ok()) {
-        throw StatusException(st);
-      }
+      throw_if_not_ok(st);
 
       // Set schemas
       array_schema_latest_ = array_schema_latest.value();
@@ -438,9 +436,7 @@ Status Array::open(
 
       auto&& [st, array_schema_latest, array_schemas] =
           storage_manager_->array_open_for_writes(this);
-      if (!st.ok()) {
-        throw StatusException(st);
-      }
+      throw_if_not_ok(st);
 
       // Set schemas
       array_schema_latest_ = array_schema_latest.value();

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -84,6 +84,10 @@ const URI& ArrayDirectory::latest_array_schema_uri() const {
   return latest_array_schema_uri_;
 }
 
+const std::vector<URI>& ArrayDirectory::unfiltered_fragment_uris() const {
+  return unfiltered_fragment_uris_;
+}
+
 const std::vector<URI>& ArrayDirectory::array_meta_uris_to_vacuum() const {
   return array_meta_uris_to_vacuum_;
 }

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -271,6 +271,9 @@ class ArrayDirectory {
   /** Returns the latest array schema URI. */
   const URI& latest_array_schema_uri() const;
 
+  /** Returns the unfiltered fragment uris. */
+  const std::vector<URI>& unfiltered_fragment_uris() const;
+
   /** Returns the URIs of the array metadata files to vacuum. */
   const std::vector<URI>& array_meta_uris_to_vacuum() const;
 
@@ -320,6 +323,7 @@ class ArrayDirectory {
   /** Returns `true` if `load` has been run. */
   bool loaded() const;
 
+  /** Returns the filtered fragment URIs struct. */
   const FilteredFragmentUris filtered_fragment_uris(
       const bool full_overlap_only) const;
 


### PR DESCRIPTION
This change disallows deletion in the middle of a fragment consolidated
with no timestamps.

---
TYPE: IMPROVEMENT
DESC: Deletes: disallow in middle of consolidated fragment with no timestamps.
