### PR TITLE
Clear orphan stats when deserializing.

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1101,7 +1101,10 @@ IQueryStrategy* Query::strategy(bool skip_checks_serialization) {
 Status Query::reset_strategy_with_layout(
     Layout layout, bool force_legacy_reader) {
   force_legacy_reader_ = force_legacy_reader;
-  strategy_ = nullptr;
+  if (strategy_ != nullptr) {
+    dynamic_cast<StrategyBase*>(strategy_.get())->stats()->reset();
+    strategy_ = nullptr;
+  }
   layout_ = layout;
   subarray_.set_layout(layout);
   RETURN_NOT_OK(create_strategy(true));


### PR DESCRIPTION
When deserialize a query from rest, the strategy gets cleared and the
associated stats are kept orphaned. The server then deserializes a new
stats structure, which will create duplication. This change clears the
stats before clearing the strategy.

---
TYPE: IMPROVEMENT
DESC: Clear orphan stats when deserializing.
