### PR TITLE
Class VFS C.41 compliance, Part 1

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5140,7 +5140,7 @@ int32_t tiledb_vfs_alloc(
   if (config)
     ctx_config.inherit(*(config->config_));
   if (SAVE_ERROR_CATCH(
-          ctx, (*vfs)->vfs_->init(stats, compute_tp, io_tp, &ctx_config))) {
+          ctx, (*vfs)->vfs_->init(stats, compute_tp, io_tp, ctx_config))) {
     delete (*vfs)->vfs_;
     delete vfs;
     return TILEDB_ERR;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -5136,12 +5136,11 @@ int32_t tiledb_vfs_alloc(
   auto stats = ctx->storage_manager()->stats();
   auto compute_tp = ctx->storage_manager()->compute_tp();
   auto io_tp = ctx->storage_manager()->io_tp();
-  auto vfs_config = config ? config->config_ : nullptr;
   auto ctx_config = ctx->storage_manager()->config();
+  if (config)
+    ctx_config.inherit(*(config->config_));
   if (SAVE_ERROR_CATCH(
-          ctx,
-          (*vfs)->vfs_->init(
-              stats, compute_tp, io_tp, &ctx_config, vfs_config))) {
+          ctx, (*vfs)->vfs_->init(stats, compute_tp, io_tp, &ctx_config))) {
     delete (*vfs)->vfs_;
     delete vfs;
     return TILEDB_ERR;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5121,7 +5121,14 @@ int32_t tiledb_vfs_alloc(
   }
 
   // Create VFS object
-  (*vfs)->vfs_ = new (std::nothrow) tiledb::sm::VFS();
+  auto stats = ctx->storage_manager()->stats();
+  auto compute_tp = ctx->storage_manager()->compute_tp();
+  auto io_tp = ctx->storage_manager()->io_tp();
+  auto ctx_config = ctx->storage_manager()->config();
+  if (config)
+    ctx_config.inherit(*(config->config_));
+  (*vfs)->vfs_ =
+      new (std::nothrow) tiledb::sm::VFS(stats, compute_tp, io_tp, ctx_config);
   if ((*vfs)->vfs_ == nullptr) {
     auto st =
         Status_Error("Failed to allocate TileDB virtual filesystem object");
@@ -5132,30 +5139,11 @@ int32_t tiledb_vfs_alloc(
     return TILEDB_OOM;
   }
 
-  // Initialize VFS object
-  auto stats = ctx->storage_manager()->stats();
-  auto compute_tp = ctx->storage_manager()->compute_tp();
-  auto io_tp = ctx->storage_manager()->io_tp();
-  auto ctx_config = ctx->storage_manager()->config();
-  if (config)
-    ctx_config.inherit(*(config->config_));
-  if (SAVE_ERROR_CATCH(
-          ctx, (*vfs)->vfs_->init(stats, compute_tp, io_tp, ctx_config))) {
-    delete (*vfs)->vfs_;
-    delete vfs;
-    return TILEDB_ERR;
-  }
-
   // Success
   return TILEDB_OK;
 }
 
 void tiledb_vfs_free(tiledb_vfs_t** vfs) {
-  const auto st = (*vfs)->vfs_->terminate();
-  if (!st.ok()) {
-    LOG_STATUS(st);
-  }
-
   if (vfs != nullptr && *vfs != nullptr) {
     delete (*vfs)->vfs_;
     delete *vfs;

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -199,9 +199,21 @@ S3::S3()
 }
 
 S3::~S3() {
-  assert(state_ == State::DISCONNECTED);
-  for (auto& buff : file_buffers_)
-    tdb_delete(buff.second);
+  /**
+   * Note: if s3 fails to disconnect, the Status must be logged.
+   * Right now, there aren't means to adjust s3 issues that may cause
+   * disconnection failure.
+   * In the future, the Governor class may be invoked here as a means of
+   * handling s3 connection issues.
+   */
+  Status st = disconnect();
+  if (!st.ok()) {
+    LOG_STATUS(st);
+  } else {
+    assert(state_ == State::DISCONNECTED);
+    for (auto& buff : file_buffers_)
+      tdb_delete(buff.second);
+  }
 }
 
 /* ********************************* */

--- a/tiledb/sm/filesystem/test/compile_vfs_main.cc
+++ b/tiledb/sm/filesystem/test/compile_vfs_main.cc
@@ -29,6 +29,9 @@
 #include "../vfs.h"
 
 int main() {
-  tiledb::sm::VFS x{};
+  static tiledb::sm::stats::Stats stats("test");
+  ThreadPool compute_tp(4);
+  ThreadPool io_tp(4);
+  tiledb::sm::VFS x{&stats, &compute_tp, &io_tp, tiledb::sm::Config{}};
   return 0;
 }

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -123,22 +123,6 @@ VFS::VFS(
   supported_fs_.insert(Filesystem::MEMFS);
 }
 
-VFS::~VFS() {
-  /**
-   * Note: if s3 fails to disconnect, the Status must be logged.
-   * Right now, there aren't means to adjust s3 issues that may cause
-   * disconnection failure.
-   * In the future, the Governor class may be invoked here as a means of
-   * handling s3 connection issues.
-   */
-  Status st;
-#ifdef HAVE_S3
-  st = s3_.disconnect();
-#endif
-  if (!st.ok())
-    LOG_STATUS(st);
-}
-
 /* ********************************* */
 /*                API                */
 /* ********************************* */

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -162,7 +162,7 @@ class VFS {
       const Config& config);
 
   /** Destructor. */
-  ~VFS();
+  ~VFS() = default;
 
   DISABLE_COPY_AND_COPY_ASSIGN(VFS);
   DISABLE_MOVE_AND_MOVE_ASSIGN(VFS);

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -162,7 +162,7 @@ class VFS {
   VFS(stats::Stats* parent_stats,
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
-      const Config* config);
+      const Config& config);
 
   /** Destructor. */
   ~VFS() = default;
@@ -326,7 +326,7 @@ class VFS {
       stats::Stats* parent_stats,
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
-      const Config* config);
+      const Config& config);
 
   /**
    * Terminates the virtual system. Must only be called if init() returned

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -150,9 +150,6 @@ class VFS {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Constructor. */
-  VFS();
-
   /** Constructor.
    * @param parent_stats The parent stats to inherit from.
    * @param compute_tp Thread pool for compute-bound tasks.
@@ -165,7 +162,7 @@ class VFS {
       const Config& config);
 
   /** Destructor. */
-  ~VFS() = default;
+  ~VFS();
 
   DISABLE_COPY_AND_COPY_ASSIGN(VFS);
   DISABLE_MOVE_AND_MOVE_ASSIGN(VFS);
@@ -314,28 +311,6 @@ class VFS {
    * @param is_empty Set to `true` if the bucket is empty and `false` otherwise.
    */
   Status is_empty_bucket(const URI& uri, bool* is_empty) const;
-
-  /**
-   * Initializes the virtual filesystem with the given configuration.
-   *
-   * @param parent_stats The parent stats to inherit from.
-   * @param config Configuration parameters
-   * @return Status
-   */
-  Status init(
-      stats::Stats* parent_stats,
-      ThreadPool* compute_tp,
-      ThreadPool* io_tp,
-      const Config& config);
-
-  /**
-   * Terminates the virtual system. Must only be called if init() returned
-   * successfully. The behavior is undefined if not successfully invoked prior
-   * to destructing this object.
-   *
-   * @return Status
-   */
-  Status terminate();
 
   /**
    * Retrieves all the URIs that have the first input as parent.
@@ -750,9 +725,6 @@ class VFS {
    * pass-by-reference initialization of filesystems' config_ member variables.
    **/
   Config config_;
-
-  /** `true` if the VFS object has been initialized. */
-  bool init_;
 
   /** The set with the supported filesystems. */
   std::set<Filesystem> supported_fs_;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -104,11 +104,6 @@ StorageManager::~StorageManager() {
 
   if (vfs_ != nullptr) {
     cancel_all_tasks();
-    const Status st = vfs_->terminate();
-    if (!st.ok()) {
-      logger_->status(Status_StorageManagerError("Failed to terminate VFS."));
-    }
-
     tdb_delete(vfs_);
   }
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1447,7 +1447,7 @@ Status StorageManager::init(const Config& config) {
   auto& global_state = global_state::GlobalState::GetGlobalState();
   RETURN_NOT_OK(global_state.init(config));
 
-  vfs_ = tdb_new(VFS, stats_, compute_tp_, io_tp_, &config_);
+  vfs_ = tdb_new(VFS, stats_, compute_tp_, io_tp_, config_);
 #ifdef TILEDB_SERIALIZATION
   RETURN_NOT_OK(init_rest_client());
 #endif

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1442,13 +1442,12 @@ Status StorageManager::init(const Config& config) {
   tile_cache_ =
       tdb_unique_ptr<BufferLRUCache>(tdb_new(BufferLRUCache, tile_cache_size));
 
-  // GlobalState must be initialized before `vfs->init` because S3::init calls
-  // GetGlobalState
+  // GlobalState must be initialized before initializing the VFS
+  // because S3::init calls GetGlobalState
   auto& global_state = global_state::GlobalState::GetGlobalState();
   RETURN_NOT_OK(global_state.init(config));
 
-  vfs_ = tdb_new(VFS);
-  RETURN_NOT_OK(vfs_->init(stats_, compute_tp_, io_tp_, &config_, nullptr));
+  vfs_ = tdb_new(VFS, stats_, compute_tp_, io_tp_, &config_);
 #ifdef TILEDB_SERIALIZATION
   RETURN_NOT_OK(init_rest_client());
 #endif


### PR DESCRIPTION
Part 1 of 2 for Class `VFS` C.41 conversion. Noteworthy changes include:
- Addition of C.41 constructor, to replace default constructor and `VFS::init`
- New struct, `VFSParameters`, which contains the VFS-relevant configuration parameters

---
TYPE: IMPROVEMENT
DESC: Class VFS C.41 compliance, Part 1