### PR TITLE
Change to use Serializer in place of Buffer/ConstBuffer

### DIFF
--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -38,6 +38,7 @@ else
 
   NUM_CORRECTIONS=`$CLANG_FORMAT -output-replacements-xml  $@ | grep offset | wc -l`
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
+    $CLANG_FORMAT -output-replacements-xml  $@
     echo "clang-format suggested changes, please run 'make format'!!!!"
     $CLANG_FORMAT --version
     exit 1

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -39,6 +39,7 @@ else
   NUM_CORRECTIONS=`$CLANG_FORMAT -output-replacements-xml  $@ | grep offset | wc -l`
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
     echo "clang-format suggested changes, please run 'make format'!!!!"
+    $CLANG_FORMAT --version
     exit 1
   fi
 

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -38,7 +38,7 @@ else
 
   NUM_CORRECTIONS=`$CLANG_FORMAT -output-replacements-xml  $@ | grep offset | wc -l`
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
-    $CLANG_FORMAT -output-replacements-xml  $@
+    $CLANG_FORMAT  $@
     echo "clang-format suggested changes, please run 'make format'!!!!"
     $CLANG_FORMAT --version
     exit 1

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -38,7 +38,7 @@ else
 
   NUM_CORRECTIONS=`$CLANG_FORMAT -output-replacements-xml  $@ | grep offset | wc -l`
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
-    $CLANG_FORMAT  $@
+    $CLANG_FORMAT --verbose $@
     echo "clang-format suggested changes, please run 'make format'!!!!"
     $CLANG_FORMAT --version
     exit 1

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3510,7 +3510,7 @@ Status FragmentMetadata::load_fragment_min_max_sum_null_count(
 // ...
 // processed_condition_size#<condition_num-1> (uint64_t)
 // processed_condition#<condition_num-1>
-Status FragmentMetadata::load_processed_conditions(Deserializer &deserializer) {
+Status FragmentMetadata::load_processed_conditions(Deserializer& deserializer) {
   // Get num conditions.
   uint64_t num;
   num = deserializer.read<uint64_t>();
@@ -4802,7 +4802,6 @@ Status FragmentMetadata::store_fragment_min_max_sum_null_count(
 
 Status FragmentMetadata::store_processed_conditions(
     const EncryptionKey& encryption_key, uint64_t* nbytes) {
-
   auto serialize_processed_conditions = [this](Serializer& serializer) {
     // Store num conditions.
     uint64_t num = processed_conditions_.size();

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1426,7 +1426,7 @@ class FragmentMetadata {
   /**
    * Loads the processed conditions for the fragment.
    */
-  Status load_processed_conditions(Deserializer &deserializer);
+  Status load_processed_conditions(Deserializer& deserializer);
 
   /** Loads the format version from the buffer. */
   Status load_version(ConstBuffer* buff);

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1426,7 +1426,7 @@ class FragmentMetadata {
   /**
    * Loads the processed conditions for the fragment.
    */
-  Status load_processed_conditions(ConstBuffer* buff);
+  Status load_processed_conditions(Deserializer &deserializer);
 
   /** Loads the format version from the buffer. */
   Status load_version(ConstBuffer* buff);


### PR DESCRIPTION
Changes to use Serializer instead of Buffer/ConstBuffer for retrieval/storage of process conditions in FragmentMetadata.

---
TYPE: IMPROVEMENT
DESC: Change to use Serializer in place of Buffer/ConstBuffer
