### PR TITLE
Change to use Serializer in place of Buffer/ConstBuffer

### DIFF
--- a/test/external/src/crc32_link_test.cc
+++ b/test/external/src/crc32_link_test.cc
@@ -34,11 +34,12 @@
 
 #include <include/crc32c/crc32c.h>
 
-int main()
-{
+int main() {
   uint8_t buf[32];
 
-  printf("crc32 of indeterminate buffer is %u\n", crc32c::Crc32c(buf, sizeof(buf)));
+  printf(
+      "crc32 of indeterminate buffer is %u\n",
+      crc32c::Crc32c(buf, sizeof(buf)));
 
-  return 0 ;
+  return 0;
 }

--- a/tiledb/common/scoped_executor.h
+++ b/tiledb/common/scoped_executor.h
@@ -80,7 +80,7 @@ class ScopedExecutor final {
    * need to disable or modify a prior function that may have been
    * intended for premature/error exit cleanup and would cause problems
    * if exited at some point later than appropriate.
-   * 
+   *
    * @param fn the function to install
    */
   void set_fn(std::function<void()>&& fn) {

--- a/tiledb/common/scoped_executor.h
+++ b/tiledb/common/scoped_executor.h
@@ -74,6 +74,15 @@ class ScopedExecutor final {
   DISABLE_COPY_AND_COPY_ASSIGN(ScopedExecutor);
   DISABLE_MOVE_ASSIGN(ScopedExecutor);
 
+  /**
+   * Helper method to allow setting/changing function as needed.
+   * This can be used to change/disable a function should a routine
+   * need to disable or modify a prior function that may have been
+   * intended for premature/error exit cleanup and would cause problems
+   * if exited at some point later than appropriate.
+   * 
+   * @param fn the function to install
+   */
   void set_fn(std::function<void()>&& fn) {
     fn_ = fn;
   }

--- a/tiledb/common/scoped_executor.h
+++ b/tiledb/common/scoped_executor.h
@@ -74,6 +74,10 @@ class ScopedExecutor final {
   DISABLE_COPY_AND_COPY_ASSIGN(ScopedExecutor);
   DISABLE_MOVE_ASSIGN(ScopedExecutor);
 
+  void set_fn(std::function<void()>&& fn) {
+    fn_ = fn;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/common/scoped_executor.h
+++ b/tiledb/common/scoped_executor.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2021 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,19 +73,6 @@ class ScopedExecutor final {
 
   DISABLE_COPY_AND_COPY_ASSIGN(ScopedExecutor);
   DISABLE_MOVE_ASSIGN(ScopedExecutor);
-
-  /**
-   * Helper method to allow setting/changing function as needed.
-   * This can be used to change/disable a function should a routine
-   * need to disable or modify a prior function that may have been
-   * intended for premature/error exit cleanup and would cause problems
-   * if exited at some point later than appropriate.
-   *
-   * @param fn the function to install
-   */
-  void set_fn(std::function<void()>&& fn) {
-    fn_ = fn;
-  }
 
  private:
   /* ********************************* */

--- a/tiledb/common/scoped_executor.h
+++ b/tiledb/common/scoped_executor.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -855,11 +855,11 @@ void FragmentMetadata::store(const EncryptionKey& encryption_key) {
   }
   try {
     if (version_ <= 10) {
-      store_v7_v10(encryption_key);
+      throw_if_not_ok(store_v7_v10(encryption_key));
     } else if (version_ == 11) {
-      store_v11(encryption_key);
+      throw_if_not_ok(store_v11(encryption_key));
     } else if (version_ <= 14) {
-      store_v12_v14(encryption_key);
+      throw_if_not_ok(store_v12_v14(encryption_key));
     } else {
       store_v15_or_higher(encryption_key);
     }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1114,8 +1114,7 @@ Status FragmentMetadata::store_v15_or_higher(
   gt_offsets_.tile_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_offsets_[i] = offset;
-    RETURN_NOT_OK(
-        store_tile_offsets(i, encryption_key, &nbytes));
+    RETURN_NOT_OK(store_tile_offsets(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1123,8 +1122,7 @@ Status FragmentMetadata::store_v15_or_higher(
   gt_offsets_.tile_var_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_var_offsets_[i] = offset;
-    RETURN_NOT_OK(
-        store_tile_var_offsets(i, encryption_key, &nbytes));
+    RETURN_NOT_OK(store_tile_var_offsets(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1132,8 +1130,7 @@ Status FragmentMetadata::store_v15_or_higher(
   gt_offsets_.tile_var_sizes_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_var_sizes_[i] = offset;
-    RETURN_NOT_OK(
-        store_tile_var_sizes(i, encryption_key, &nbytes));
+    RETURN_NOT_OK(store_tile_var_sizes(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1141,8 +1138,7 @@ Status FragmentMetadata::store_v15_or_higher(
   gt_offsets_.tile_validity_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_validity_offsets_[i] = offset;
-    RETURN_NOT_OK(
-        store_tile_validity_offsets(i, encryption_key, &nbytes));
+    RETURN_NOT_OK(store_tile_validity_offsets(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1174,8 +1170,7 @@ Status FragmentMetadata::store_v15_or_higher(
   gt_offsets_.tile_null_count_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_null_count_offsets_[i] = offset;
-    RETURN_NOT_OK(
-        store_tile_null_counts(i, encryption_key, &nbytes));
+    RETURN_NOT_OK(store_tile_null_counts(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1194,7 +1189,7 @@ Status FragmentMetadata::store_v15_or_higher(
   RETURN_NOT_OK(store_footer(encryption_key));
 
   // disable the premature exit cleanup action (don't delete the fragment file)
-  premature_exit_cleanup.set_fn([]() {});  
+  premature_exit_cleanup.set_fn([]() {});
   // Close file
   return storage_manager_->close_file(fragment_metadata_uri);
 }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -4803,12 +4803,12 @@ Status FragmentMetadata::store_fragment_min_max_sum_null_count(
 Status FragmentMetadata::store_processed_conditions(
     const EncryptionKey& encryption_key, uint64_t* nbytes) {
   auto serialize_processed_conditions = [this](Serializer& serializer) {
-  // Store num conditions.
-  uint64_t num = processed_conditions_.size();
+    // Store num conditions.
+    uint64_t num = processed_conditions_.size();
     serializer.write<uint64_t>(num);
 
-  for (auto& processed_condition : processed_conditions_) {
-    uint64_t size = processed_condition.size();
+    for (auto& processed_condition : processed_conditions_) {
+      uint64_t size = processed_condition.size();
       serializer.write<uint64_t>(size);
 
       serializer.write(processed_condition.data(), processed_condition.size());

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -850,7 +850,8 @@ void FragmentMetadata::store(const EncryptionKey& encryption_key) {
         fragment_uri_.join_path(constants::fragment_metadata_filename);
     throw std::logic_error(
         "FragmentMetadata::store(), unexpected version_ " +
-        std::to_string(version_) + " storing " + fragment_metadata_uri.to_string());
+        std::to_string(version_) + " storing " +
+        fragment_metadata_uri.to_string());
   }
   try {
     if (version_ <= 10) {
@@ -867,8 +868,9 @@ void FragmentMetadata::store(const EncryptionKey& encryption_key) {
     clean_up();
     auto fragment_metadata_uri =
         fragment_uri_.join_path(constants::fragment_metadata_filename);
-    std::throw_with_nested(
-        std::runtime_error("FragmentMetadata::store() failed on " + fragment_metadata_uri.to_string()));
+    std::throw_with_nested(std::runtime_error(
+        "FragmentMetadata::store() failed on " +
+        fragment_metadata_uri.to_string()));
   }
 }
 

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -282,7 +282,7 @@ class FragmentMetadata {
       std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas);
 
   /** Stores all the metadata to storage. */
-  Status store(const EncryptionKey& encryption_key);
+  void store(const EncryptionKey& encryption_key);
 
   /**
    * Stores all the metadata to storage.

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1666,7 +1666,7 @@ class FragmentMetadata {
    * @param nbytes The total number of bytes written.
    * @return Status
    */
-  Status store_processed_conditions(
+  void store_processed_conditions(
       const EncryptionKey& encryption_key, uint64_t* nbytes);
 
   /**

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1426,7 +1426,7 @@ class FragmentMetadata {
   /**
    * Loads the processed conditions for the fragment.
    */
-  Status load_processed_conditions(ConstBuffer* buff);
+  Status load_processed_conditions(Deserializer& deserializer);
 
   /** Loads the format version from the buffer. */
   Status load_version(ConstBuffer* buff);

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -517,7 +517,12 @@ Status GlobalOrderWriter::finalize_global_write_state() {
       meta->compute_fragment_min_max_sum_null_count(), clean_up(uri));
 
   // Flush fragment metadata to storage
-  RETURN_NOT_OK_ELSE(meta->store(array_->get_encryption_key()), clean_up(uri));
+  try {
+    meta->store(array_->get_encryption_key());
+  } catch (...) {
+    clean_up(uri);
+    throw;
+  }
 
   // Add written fragment info
   RETURN_NOT_OK_ELSE(add_written_fragment_info(uri), clean_up(uri));

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -296,9 +296,12 @@ Status OrderedWriter::ordered_write() {
       storage_manager_->vfs()->remove_dir(uri));
 
   // Write the fragment metadata
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      frag_meta->store(array_->get_encryption_key()),
-      storage_manager_->vfs()->remove_dir(uri));
+  try {
+    frag_meta->store(array_->get_encryption_key());
+  } catch (...) {
+    storage_manager_->vfs()->remove_dir(uri);
+    throw;
+  }
 
   // Add written fragment info
   RETURN_NOT_OK_ELSE(

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -666,8 +666,12 @@ Status UnorderedWriter::unordered_write() {
       frag_meta->compute_fragment_min_max_sum_null_count(), clean_up(uri));
 
   // Write the fragment metadata
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      frag_meta->store(array_->get_encryption_key()), clean_up(uri));
+  try {
+    frag_meta->store(array_->get_encryption_key());
+  } catch (...) {
+    clean_up(uri);
+    throw;
+  }
 
   // Add written fragment info
   RETURN_NOT_OK_ELSE(add_written_fragment_info(uri), clean_up(uri));

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -42,6 +42,13 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+class TileStatusException : public StatusException {
+ public:
+  explicit TileStatusException(const std::string& message)
+      : StatusException("Tile", message) {
+  }
+};
+
 void nop_free(void* const) {
 }
 
@@ -76,6 +83,20 @@ Status Tile::compute_chunk_size(
 
 void Tile::set_max_tile_chunk_size(uint64_t max_tile_chunk_size) {
   max_tile_chunk_size_ = max_tile_chunk_size;
+}
+
+Tile Tile::from_generic(storage_size_t tile_size) {
+  Tile tile;
+  if (!tile.init_unfiltered(
+               0,
+               constants::generic_tile_datatype,
+               tile_size,
+               constants::generic_tile_cell_size,
+               0)
+           .ok()) {
+    throw TileStatusException("Cannot initialize tile");
+  }
+  return tile;
 }
 
 /* ****************************** */

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -75,6 +75,14 @@ class Tile {
    */
   static void set_max_tile_chunk_size(uint64_t max_tile_chunk_size);
 
+  /**
+   * returns a Tile initialized with parameters commonly used for
+   * generic data storage.
+   *
+   * @param tile_size to be provided to init_unfiltered call
+   */
+  static Tile from_generic(storage_size_t tile_size);
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */


### PR DESCRIPTION
Changes to use Serializer instead of Buffer/ConstBuffer for retrieval/storage of process conditions in FragmentMetadata.

---
TYPE: IMPROVEMENT
DESC: Change to use Serializer in place of Buffer/ConstBuffer
