### PR TITLE
Update run-clang-format.sh

### DIFF
--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -193,15 +193,6 @@ if (${CLANG_FORMAT_FOUND})
   message(STATUS "clang hunt, found ${CLANG_FORMAT_BIN}")
   # runs clang format and updates files in place.
 
-  # This section must be updated with `scripts/ci/check_formatting_linux.sh`
-  set(CLANG_FORMAT_FIND_FILES
-      `find ${CMAKE_CURRENT_SOURCE_DIR}/tiledb
-      ${CMAKE_CURRENT_SOURCE_DIR}/test/src
-      ${CMAKE_CURRENT_SOURCE_DIR}/examples
-      ${CMAKE_CURRENT_SOURCE_DIR}/tools
-      ${CMAKE_CURRENT_SOURCE_DIR}/experimental
-      -name \\*.cc -or -name \\*.c -or -name \\*.h`)
-
   add_custom_target(format ${SCRIPTS_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_BIN} 1
                     ${CLANG_FORMAT_FIND_FILES})
 

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -192,20 +192,22 @@ endif()
 if (${CLANG_FORMAT_FOUND})
   message(STATUS "clang hunt, found ${CLANG_FORMAT_BIN}")
   # runs clang format and updates files in place.
+
+  # This section must be updated with `scripts/ci/check_formatting_linux.sh`
+  set(CLANG_FORMAT_FIND_FILES
+      `find ${CMAKE_CURRENT_SOURCE_DIR}/tiledb
+      ${CMAKE_CURRENT_SOURCE_DIR}/test/src
+      ${CMAKE_CURRENT_SOURCE_DIR}/examples
+      ${CMAKE_CURRENT_SOURCE_DIR}/tools
+      ${CMAKE_CURRENT_SOURCE_DIR}/experimental
+      -name \\*.cc -or -name \\*.c -or -name \\*.h`)
+
   add_custom_target(format ${SCRIPTS_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_BIN} 1
-    `find ${CMAKE_CURRENT_SOURCE_DIR}/tiledb
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples
-    ${CMAKE_CURRENT_SOURCE_DIR}/tools
-    -name \\*.cc -or -name \\*.c -or -name \\*.h`)
+                    ${CLANG_FORMAT_FIND_FILES})
 
   # runs clang format and exits with a non-zero exit code if any files need to be reformatted
   add_custom_target(check-format ${SCRIPTS_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_BIN} 0
-    `find ${CMAKE_CURRENT_SOURCE_DIR}/tiledb
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/src
-    ${CMAKE_CURRENT_SOURCE_DIR}/examples
-    ${CMAKE_CURRENT_SOURCE_DIR}/tools
-    -name \\*.cc -or -name \\*.c -or -name \\*.h`)
+                    ${CLANG_FORMAT_FIND_FILES})
 else()
   message(STATUS "was unable to find clang-format")
 endif()

--- a/scripts/ci/check_formatting_linux.sh
+++ b/scripts/ci/check_formatting_linux.sh
@@ -35,7 +35,4 @@ sudo ./scripts/install-clangformat.sh
 src=$GITHUB_WORKSPACE
 cd $src
 
-files=$(find $src/tiledb $src/test $src/examples $src/tools $src/experimental \
-        -name "*.cc" -or -name "*.c" -or -name "*.h")
-set -x
 $src/scripts/run-clang-format.sh $src clang-format-9 0

--- a/scripts/ci/check_formatting_linux.sh
+++ b/scripts/ci/check_formatting_linux.sh
@@ -25,12 +25,17 @@
 #
 
 # Check test formatting - linux ONLY
+
 set -e pipefail
+
 # Install clang-format (v9)
 ls -la
 sudo ./scripts/install-clangformat.sh
+
 src=$GITHUB_WORKSPACE
 cd $src
-$src/scripts/run-clang-format.sh $src clang-format-9 0 \
-  $(find $src/tiledb $src/test $src/examples $src/tools $src/experimental \
-    -name "*.cc" -or -name "*.c" -or -name "*.h")
+
+files=$(find $src/tiledb $src/test $src/examples $src/tools $src/experimental \
+        -name "*.cc" -or -name "*.c" -or -name "*.h")
+set -x
+$src/scripts/run-clang-format.sh $src clang-format-9 0

--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -27,20 +27,35 @@ shift
 APPLY_FIXES=$1
 shift
 
-# clang format will only find its configuration if we are in 
+# clang format will only find its configuration if we are in
 # the source tree or in a path relative to the source tree
 pushd $SOURCE_DIR
+
+src=$SOURCE_DIR
+SOURCE_PATHS=($src/tiledb $src/test $src/examples $src/tools $src/experimental)
+FIND_FILES=(-name "*.cc" -or -name "*.c" -or -name "*.h")
 
 if [ "$APPLY_FIXES" == "1" ]; then
   $CLANG_FORMAT -i $@
 
 else
+  NUM_CORRECTIONS=`find "${SOURCE_PATHS[@]}" "${FIND_FILES[@]}" -print0 | xargs -0 -P8 $CLANG_FORMAT -output-replacements-xml | grep offset | wc -l`
 
-  NUM_CORRECTIONS=`$CLANG_FORMAT -output-replacements-xml  $@ | grep offset | wc -l`
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
     echo "clang-format suggested changes, please run 'make format'!!!!"
+
+    # If running on CI, print out the change-set
+    if [ "$CI" = true ]; then
+      echo "-------- see list of files to update below --------"
+      find "${SOURCE_PATHS[@]}" "${FIND_FILES[@]}" -print0 | xargs -P8 -0 $CLANG_FORMAT -i
+      git diff --name-only
+
+      echo "-------- see diff below --------"
+      git diff
+    fi
+
+    # Fail the job
     exit 1
   fi
-
-fi 
+fi
 popd


### PR DESCRIPTION
This PR makes the following changes:
  - centralize the search logic for which files are checked by
    clang-format into run-clang-format.sh
    (previously duplicated in cmake target which just calls the script)
  - use xargs to avoid argument length limits when applying (due to
    recent path additions)
  - add printout of the files-to-be-changed and the actual diff when
    running on CI.

---
TYPE: NO_HISTORY
