### PR TITLE
[ci] Make full-ci workflow use cancel-in-progress for PRs

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -1,17 +1,11 @@
 name: Build-Dockerfile
 
 on:
-  pull_request:
-    paths-ignore:
-      - '_quarto.yml'
-      - 'quarto-materials/*'
-      - '**/.md'
-      - 'doc/source/conf.py'
-      - 'tiledb/sm/c_api/tiledb_version.h'
+  workflow_call:
 
 jobs:
   build-dockerfile:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -30,6 +30,10 @@ on:
       - 'doc/source/conf.py'
       - 'tiledb/sm/c_api/tiledb_version.h'
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 ## NOTE: the job names below must be unique!
 jobs:
   ci1:
@@ -87,9 +91,12 @@ jobs:
   standalone:
     uses: ./.github/workflows/unit-test-runs.yml
 
+  ci_docker:
+    uses: ./.github/workflows/build-dockerfile.yml
+
   # dummy job for branch protection check
   full_ci_passed:
-    needs: [ci1, ci2, ci2, ci3, ci4, ci5, ci6, ci7, ci_msvc, standalone]
+    needs: [ci1, ci2, ci2, ci3, ci4, ci5, ci6, ci7, ci_msvc, backward_compatibility, standalone]
     runs-on: ubuntu-22.04
     steps:
       - name: ''


### PR DESCRIPTION
This change will ensure only one instance of the full-ci GHA workflow is running per PR, in order to reduce wasted CI load. If new commits are pushed to a PR branch which is already running jobs for this workflow, the jobs for prior commits will be canceled.

Also move the docker job to full-ci so that it is triggered under the
same rule set.

---
TYPE: NO_HISTORY