### PR TITLE
Adjust dockerfile so layers can be cached better

### DIFF
--- a/examples/Dockerfile/Dockerfile
+++ b/examples/Dockerfile/Dockerfile
@@ -19,9 +19,6 @@ RUN useradd tiledb \
     && chown tiledb /home/tiledb
 ENV HOME /home/tiledb
 
-# Copy TileDB source files from the build context.
-COPY . /home/tiledb/TileDB
-
 # Install dependencies, accepting prompts with their default value.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
@@ -37,6 +34,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     && rm -rf /var/lib/apt/lists* \
     && pip3 install cmake
 
+# Copy TileDB source files from the build context.
+COPY . /home/tiledb/TileDB
+
 # Build and install TileDB.
 RUN cd /home/tiledb/TileDB \
     && mkdir build \
@@ -49,8 +49,8 @@ RUN cd /home/tiledb/TileDB \
         --enable-serialization \
         --enable-tools \
         --enable=${enable} \
-    && make -j2 \
-    && make -j2 examples \
+    && make -j$(nproc) \
+    && make -j$(nproc) examples \
     && make install-tiledb \
 # Update shared library links/cache.
     && ldconfig \


### PR DESCRIPTION
Adjust dockerfile so layers can be cached better. Also compile TileDB with all cores available.

---
TYPE: IMPROVEMENT
DESC: Adjust example dockerfile so layers can be cached better
