### PR TITLE
Use const reference in DictEncoding::decompress

### DIFF
--- a/tiledb/sm/compressors/dict_compressor.h
+++ b/tiledb/sm/compressors/dict_compressor.h
@@ -237,11 +237,13 @@ class DictEncoding {
 
     std::vector<std::string> dict;
     dict.reserve(serialized_dict.size());
+    // T is uint{8,16,32,64} specified at the call-site
     T str_len = 0;
 
     size_t in_index = 0;
     while (in_index < serialized_dict.size()) {
       str_len = utils::endianness::decode_be<T>(&serialized_dict[in_index]);
+      // increment past the size element to the per-word data block
       in_index += sizeof(T);
       // construct string in place
       dict.emplace_back(

--- a/tiledb/sm/compressors/dict_compressor.h
+++ b/tiledb/sm/compressors/dict_compressor.h
@@ -195,7 +195,7 @@ class DictEncoding {
       word_id = utils::endianness::decode_be<T>(&input[in_index]);
       in_index += sizeof(T);
       assert(word_id < dict.size());
-      auto word = dict[word_id];
+      const auto& word = dict[word_id];
       memcpy(&output[out_index], word.data(), word.size());
       output_offsets[offset_index++] = out_index;
       out_index += word.size();


### PR DESCRIPTION
This can save a significant amount of time (measured at 25% in one case) and memory by avoiding transient copies of the dictionary strings when decoding.



---
TYPE: IMPROVEMENT
DESC: Avoid string copy in Dictionary Encoding decompression.
