### PR TITLE
Avoid creating second string_view in compute_results_count_sparse_string_range

### DIFF
--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -790,7 +790,7 @@ void ResultTile::compute_results_count_sparse_string_range(
     uint64_t c_size = (pos < cell_num - 1) ? buff_off[pos + 1] - c_offset :
                                              buff_str_size - c_offset;
 
-    std::string_view str(buff_str + c_offset, c_size);
+    const std::string_view str(buff_str + c_offset, c_size);
 
     // Binary search to find the first range containing the cell.
     auto it = std::lower_bound(
@@ -830,9 +830,8 @@ void ResultTile::compute_results_count_sparse_string_range(
     // dim.
     uint64_t count = 0;
     for (uint64_t j = start_range_idx; j < end_range_idx; ++j) {
-      auto& range = cached_ranges[j];
-      count += str_coord_intersects(
-          c_offset, c_size, buff_str, range.first, range.second);
+      const auto& range = cached_ranges[j];
+      count += str >= range.first && str <= range.second;
     }
 
     // Multiply the past count by this dimension's count.


### PR DESCRIPTION
We avoid creating second string_view in `compute_results_count_sparse_string_range`. We also declare the string view a const. This can speedup the for loop for the comparison when there is a large number of comparisons. This can save about 2s when there is 700 million cells being compared. Intel V-Tune called out the string object creation inside the for loop.


---
TYPE: IMPROVEMENT
DESC: Avoid duplicate string_view creation in `compute_results_count_sparse_string_range`
