### PR TITLE
Fix empty metadata after array open/query submit

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2363,5 +2363,6 @@ TEST_CASE_METHOD(
   tiledb_array_schema_free(&array_schema);
   tiledb_config_free(&config);
   tiledb_ctx_free(&ctx);
+  remove_temp_dir(array_name);
 #endif
 }

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -64,6 +64,8 @@
 #include <thread>
 
 using namespace tiledb::test;
+using namespace tiledb::common;
+using namespace tiledb::sm;
 
 struct ArrayFx {
   // TileDB context
@@ -89,7 +91,7 @@ struct ArrayFx {
   static std::string random_name(const std::string& prefix);
   static int get_fragment_timestamps(const char* path, void* data);
   void array_serialize_wrapper(
-      tiledb_array_t* array, tiledb_array_t* new_array);
+      tiledb_array_t* array, tiledb_array_t** new_array);
 };
 
 static const std::string test_ca_path =
@@ -363,7 +365,7 @@ void ArrayFx::create_dense_array(const std::string& path) {
 }
 
 void ArrayFx::array_serialize_wrapper(
-    tiledb_array_t* array, tiledb_array_t* new_array) {
+    tiledb_array_t* array, tiledb_array_t** new_array) {
   // Serialize the array
   tiledb_buffer_t* buff;
   REQUIRE(
@@ -381,7 +383,7 @@ void ArrayFx::array_serialize_wrapper(
           buff,
           (tiledb_serialization_type_t)tiledb::sm::SerializationType::CAPNP,
           0,
-          &new_array) == TILEDB_OK);
+          new_array) == TILEDB_OK);
 
   // Clean up.
   tiledb_buffer_free(&buff);
@@ -2047,41 +2049,29 @@ TEST_CASE_METHOD(
       local_fs.file_prefix() + local_fs.temp_dir() + "array_serialization";
   create_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
 
-  create_dense_array(array_name);
+  create_dense_vector(array_name);
 
-  // Open array
+  // Test for both versions of array open
+  bool array_v2 = GENERATE(true, false);
+  if (array_v2) {
+    // Set the needed config variables
+    tiledb_ctx_free(&ctx_);
+    tiledb_config_t* config;
+    tiledb_error_t* error;
+    tiledb_config_alloc(&config, &error);
+    tiledb_config_set(config, "rest.use_refactored_array_open", "true", &error);
+    tiledb_config_set(
+        config, "rest.load_metadata_on_array_open", "true", &error);
+    tiledb_config_set(
+        config, "rest.load_non_empty_domain_on_array_open", "true", &error);
+    tiledb_ctx_alloc(config, &ctx_);
+  }
+
+  // Open array to WRITE metadata
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
-  REQUIRE(rc == TILEDB_OK);
 
-  auto all_arrays = array->array_->array_schemas_all();
-
-  int32_t a[4];
-  uint64_t a_size = sizeof(a);
-
-  // Prepare query
-  tiledb_query_t* query;
-  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", a, &a_size);
-  CHECK(rc == TILEDB_OK);
-
-  int64_t subarray[] = {2, 3, 4, 5};
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
-  CHECK(rc == TILEDB_OK);
-
-  rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_submit(ctx_, query);
-  CHECK(rc == TILEDB_OK);
-
-  // Close array
-  rc = tiledb_array_close(ctx_, array);
-  REQUIRE(rc == TILEDB_OK);
-
-  // Reopen array in WRITE mode
   rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
@@ -2093,9 +2083,45 @@ TEST_CASE_METHOD(
   rc = tiledb_array_put_metadata(ctx_, array, "bb", TILEDB_FLOAT32, 2, f);
   CHECK(rc == TILEDB_OK);
 
+  // Write some data so that non empty domain is not empty
+  int buffer_a1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  uint64_t buffer_a1_size = sizeof(buffer_a1);
+
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(
+      ctx_, query, "a", buffer_a1, &buffer_a1_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_finalize(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Get a reference value to check against after deserialization
+  auto all_arrays = array->array_->array_schemas_all();
+
+  // Close array
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Open array to test serialization
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Metadata are not loaded automatically in array open v1
+  // but with a separate request, so we simulate this here
+  // by forcing metadata loading
+  if (!array_v2) {
+    Metadata* metadata = nullptr;
+    array->array_->metadata(&metadata);
+  }
+
   // Serialize array and deserialize into new_array
   tiledb_array_t* new_array = nullptr;
-  array_serialize_wrapper(array, new_array);
+  array_serialize_wrapper(array, &new_array);
 
   // Close array and clean up
   rc = tiledb_array_close(ctx_, array);
@@ -2103,44 +2129,22 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
   tiledb_query_free(&query);
 
-  rc = tiledb_array_alloc(ctx_, array_name.c_str(), &new_array);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_array_open(ctx_, new_array, TILEDB_READ);
-  REQUIRE(rc == TILEDB_OK);
-
   // Check the retrieved array schema
-  tiledb_array_schema_t* new_array_schema;
-  rc = tiledb_array_schema_load(ctx_, array_name.c_str(), &new_array_schema);
-  CHECK(rc == TILEDB_OK);
+  auto& new_array_schema = new_array->array_->array_schema_latest();
 
-  rc = tiledb_array_schema_check(ctx_, new_array_schema);
-  REQUIRE(rc == TILEDB_OK);
+  auto cell_order = new_array_schema.cell_order();
+  CHECK(cell_order == Layout::ROW_MAJOR);
 
-  tiledb_layout_t cell_order;
-  rc = tiledb_array_schema_get_cell_order(ctx_, new_array_schema, &cell_order);
-  REQUIRE(rc == TILEDB_OK);
-  CHECK(cell_order == TILEDB_ROW_MAJOR);
+  auto tile_order = new_array_schema.tile_order();
+  CHECK(tile_order == Layout::ROW_MAJOR);
 
-  tiledb_layout_t tile_order;
-  rc = tiledb_array_schema_get_tile_order(ctx_, new_array_schema, &tile_order);
-  REQUIRE(rc == TILEDB_OK);
-  CHECK(tile_order == TILEDB_ROW_MAJOR);
-
-  unsigned int num_attributes = 0;
-  rc = tiledb_array_schema_get_attribute_num(
-      ctx_, new_array_schema, &num_attributes);
-  REQUIRE(rc == TILEDB_OK);
+  auto num_attributes = new_array_schema.attribute_num();
   CHECK(num_attributes == 1);
 
-  tiledb_domain_t* dom;
-  rc = tiledb_array_schema_get_domain(ctx_, new_array_schema, &dom);
-  REQUIRE(rc == TILEDB_OK);
+  auto ndim = new_array_schema.dim_num();
+  CHECK(ndim == 1);
 
-  unsigned int ndim = 0;
-  rc = tiledb_domain_get_ndim(ctx_, dom, &ndim);
-  REQUIRE(rc == TILEDB_OK);
-  CHECK(ndim == 2);
-
+  // Check all the retrieved arrays
   auto all_arrays_new = new_array->array_->array_schemas_all();
   CHECK(all_arrays.size() == all_arrays_new.size());
   CHECK(std::equal(
@@ -2150,58 +2154,29 @@ TEST_CASE_METHOD(
       [](auto a, auto b) { return a.first == b.first; }));
 
   // Check the retrieved non empty domain
-  int is_empty;
-  uint64_t domain[4];
-  rc = tiledb_array_get_non_empty_domain(ctx_, new_array, domain, &is_empty);
-  CHECK(rc == TILEDB_OK);
-  CHECK(is_empty == 1);
+  auto non_empty_domain = new_array->array_->loaded_non_empty_domain();
+  CHECK(non_empty_domain->empty() == false);
 
   // Check the retrieved metadata
+  Datatype type;
   const void* v_r;
-  tiledb_datatype_t v_type;
   uint32_t v_num;
-  rc = tiledb_array_get_metadata(ctx_, new_array, "aaa", &v_type, &v_num, &v_r);
-  CHECK(rc == TILEDB_OK);
-  CHECK(v_type == TILEDB_INT32);
+  auto new_metadata = new_array->array_->unsafe_metadata();
+  Status st = new_metadata->get("aaa", &type, &v_num, &v_r);
+  CHECK(static_cast<tiledb_datatype_t>(type) == TILEDB_INT32);
   CHECK(v_num == 1);
   CHECK(*((const int32_t*)v_r) == 5);
 
-  rc = tiledb_array_get_metadata(ctx_, new_array, "bb", &v_type, &v_num, &v_r);
-  CHECK(rc == TILEDB_OK);
-  CHECK(v_type == TILEDB_FLOAT32);
+  st = new_metadata->get("bb", &type, &v_num, &v_r);
+  CHECK(static_cast<tiledb_datatype_t>(type) == TILEDB_FLOAT32);
   CHECK(v_num == 2);
   CHECK(((const float*)v_r)[0] == 1.1f);
   CHECK(((const float*)v_r)[1] == 1.2f);
 
-  uint64_t num = 0;
-  rc = tiledb_array_get_metadata_num(ctx_, new_array, &num);
-  CHECK(rc == TILEDB_OK);
+  auto num = new_metadata->num();
   CHECK(num == 2);
 
-  const char* key;
-  uint32_t key_len;
-  rc = tiledb_array_get_metadata_from_index(
-      ctx_, new_array, 1, &key, &key_len, &v_type, &v_num, &v_r);
-  CHECK(rc == TILEDB_OK);
-  CHECK(v_type == TILEDB_FLOAT32);
-  CHECK(v_num == 2);
-  CHECK(((const float*)v_r)[0] == 1.1f);
-  CHECK(((const float*)v_r)[1] == 1.2f);
-  CHECK(key_len == strlen("bb"));
-  CHECK(!strncmp(key, "bb", strlen("bb")));
-
-  // Check has_key
-  int32_t has_key = 0;
-  rc = tiledb_array_has_metadata_key(ctx_, new_array, "bb", &v_type, &has_key);
-  CHECK(rc == TILEDB_OK);
-  CHECK(v_type == TILEDB_FLOAT32);
-  CHECK(has_key == 1);
-
-  // Close array
-  rc = tiledb_array_close(ctx_, new_array);
-  REQUIRE(rc == TILEDB_OK);
   tiledb_array_free(&new_array);
-
   remove_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
 #endif
 }

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2111,12 +2111,13 @@ TEST_CASE_METHOD(
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
 
-  // Metadata are not loaded automatically in array open v1
-  // but with a separate request, so we simulate this here
-  // by forcing metadata loading
+  // Metadata and non empty domain are not loaded automatically
+  // in array open v1 but with separate requests, so we simulate
+  // this here by forcing metadata loading
   if (!array_v2) {
     Metadata* metadata = nullptr;
     array->array_->metadata(&metadata);
+    array->array_->non_empty_domain();
   }
 
   // Serialize array and deserialize into new_array

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1000,6 +1000,10 @@ Status Array::metadata(Metadata** metadata) {
   return Status::Ok();
 }
 
+NDRange* Array::loaded_non_empty_domain() {
+  return &non_empty_domain_;
+}
+
 tuple<Status, optional<const NDRange>> Array::non_empty_domain() {
   if (!non_empty_domain_computed_) {
     // Compute non-empty domain

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -407,6 +407,12 @@ class Array {
    * */
   tuple<Status, optional<const NDRange>> non_empty_domain();
 
+  /**
+   * Retrieves the array metadata object that is already loadad.
+   * If it's not yet loaded it will be empty.
+   */
+  NDRange* loaded_non_empty_domain();
+
   /** Returns the non-empty domain of the opened array. */
   void set_non_empty_domain(const NDRange& non_empty_domain);
 

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -401,6 +401,16 @@ class Array {
     metadata_loaded_ = is_loaded;
   }
 
+  /** Check if array metadata is loaded already for this array or not */
+  inline bool& metadata_loaded() {
+    return metadata_loaded_;
+  }
+
+  /** Check if non emtpy domain is loaded already for this array or not */
+  inline bool& non_empty_domain_computed() {
+    return non_empty_domain_computed_;
+  }
+
   /** Returns the non-empty domain of the opened array.
    *  If the non_empty_domain has not been computed or loaded
    *  it will be loaded first

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -426,6 +426,9 @@ class Array {
    */
   bool serialize_metadata() const;
 
+  /** Checks the config to see if refactored array open should be used. */
+  bool use_refactored_array_open() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -603,9 +606,6 @@ class Array {
    * Note: the Sentry object will also be released upon Array destruction.
    **/
   void set_array_closed();
-
-  /** Checks the config to see if refactored array open should be used. */
-  bool use_refactored_array_open() const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -200,6 +200,7 @@ Status Metadata::del(const char* key) {
   MetadataValue value;
   value.del_ = 1;
   metadata_map_.emplace(std::make_pair(std::string(key), std::move(value)));
+  build_metadata_index();
 
   return Status::Ok();
 }
@@ -229,6 +230,7 @@ Status Metadata::put(
   metadata_map_.erase(std::string(key));
   metadata_map_.emplace(
       std::make_pair(std::string(key), std::move(value_struct)));
+  build_metadata_index();
 
   return Status::Ok();
 }

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -213,40 +213,20 @@ Status array_from_capnp(
         make_shared<ArraySchema>(HERE(), array_schema_latest));
   }
 
-  if (array->use_refactored_array_open()) {
-    if (array->serialize_non_empty_domain()) {
-      if (array_reader.hasNonEmptyDomain()) {
-        const auto& nonempty_domain_reader = array_reader.getNonEmptyDomain();
-        // Deserialize
-        RETURN_NOT_OK(
-            utils::deserialize_non_empty_domain(nonempty_domain_reader, array));
-        array->set_non_empty_domain_computed(true);
-      }
-    }
+  if (array_reader.hasNonEmptyDomain()) {
+    const auto& nonempty_domain_reader = array_reader.getNonEmptyDomain();
+    // Deserialize
+    RETURN_NOT_OK(
+        utils::deserialize_non_empty_domain(nonempty_domain_reader, array));
+    array->set_non_empty_domain_computed(true);
+  }
 
-    if (array->serialize_metadata()) {
-      if (array_reader.hasArrayMetadata()) {
-        const auto& array_metadata_reader = array_reader.getArrayMetadata();
-        // Deserialize
-        RETURN_NOT_OK(metadata_from_capnp(
-            array_metadata_reader, array->unsafe_metadata()));
-        array->set_metadata_loaded(true);
-      }
-    }
-  } else {
-    if (array_reader.hasNonEmptyDomain()) {
-      const auto& nonempty_domain_reader = array_reader.getNonEmptyDomain();
-      // Deserialize
-      RETURN_NOT_OK(
-          utils::deserialize_non_empty_domain(nonempty_domain_reader, array));
-    }
-
-    if (array_reader.hasArrayMetadata()) {
-      const auto& array_metadata_reader = array_reader.getArrayMetadata();
-      // Deserialize
-      RETURN_NOT_OK(
-          metadata_from_capnp(array_metadata_reader, array->unsafe_metadata()));
-    }
+  if (array_reader.hasArrayMetadata()) {
+    const auto& array_metadata_reader = array_reader.getArrayMetadata();
+    // Deserialize
+    RETURN_NOT_OK(
+        metadata_from_capnp(array_metadata_reader, array->unsafe_metadata()));
+    array->set_metadata_loaded(true);
   }
 
   return Status::Ok();

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -147,13 +147,28 @@ Status array_to_capnp(
         *(schema.second.get()), &schema_builder, client_side));
   }
 
-  if (array->serialize_non_empty_domain()) {
+  if (array->use_refactored_array_open()) {
+    if (array->serialize_non_empty_domain()) {
+      auto nonempty_domain_builder = array_builder->initNonEmptyDomain();
+      RETURN_NOT_OK(
+          utils::serialize_non_empty_domain(nonempty_domain_builder, array));
+    }
+
+    if (array->serialize_metadata()) {
+      auto array_metadata_builder = array_builder->initArrayMetadata();
+      // If this is the Cloud server, it should load and serialize metadata
+      // If this is the client, it should have previously received the array
+      // metadata from the Cloud server, so it should just serialize it
+      Metadata* metadata = nullptr;
+      // Get metadata. If not loaded, load it first.
+      RETURN_NOT_OK(array->metadata(&metadata));
+      RETURN_NOT_OK(metadata_to_capnp(metadata, &array_metadata_builder));
+    }
+  } else {
     auto nonempty_domain_builder = array_builder->initNonEmptyDomain();
     RETURN_NOT_OK(
         utils::serialize_non_empty_domain(nonempty_domain_builder, array));
-  }
 
-  if (array->serialize_metadata()) {
     auto array_metadata_builder = array_builder->initArrayMetadata();
     RETURN_NOT_OK(
         metadata_to_capnp(array->unsafe_metadata(), &array_metadata_builder));
@@ -198,23 +213,39 @@ Status array_from_capnp(
         make_shared<ArraySchema>(HERE(), array_schema_latest));
   }
 
-  if (array->serialize_non_empty_domain()) {
+  if (array->use_refactored_array_open()) {
+    if (array->serialize_non_empty_domain()) {
+      if (array_reader.hasNonEmptyDomain()) {
+        const auto& nonempty_domain_reader = array_reader.getNonEmptyDomain();
+        // Deserialize
+        RETURN_NOT_OK(
+            utils::deserialize_non_empty_domain(nonempty_domain_reader, array));
+        array->set_non_empty_domain_computed(true);
+      }
+    }
+
+    if (array->serialize_metadata()) {
+      if (array_reader.hasArrayMetadata()) {
+        const auto& array_metadata_reader = array_reader.getArrayMetadata();
+        // Deserialize
+        RETURN_NOT_OK(metadata_from_capnp(
+            array_metadata_reader, array->unsafe_metadata()));
+        array->set_metadata_loaded(true);
+      }
+    }
+  } else {
     if (array_reader.hasNonEmptyDomain()) {
       const auto& nonempty_domain_reader = array_reader.getNonEmptyDomain();
       // Deserialize
       RETURN_NOT_OK(
           utils::deserialize_non_empty_domain(nonempty_domain_reader, array));
-      array->set_non_empty_domain_computed(true);
     }
-  }
 
-  if (array->serialize_metadata()) {
     if (array_reader.hasArrayMetadata()) {
       const auto& array_metadata_reader = array_reader.getArrayMetadata();
       // Deserialize
       RETURN_NOT_OK(
           metadata_from_capnp(array_metadata_reader, array->unsafe_metadata()));
-      array->set_metadata_loaded(true);
     }
   }
 

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -165,13 +165,17 @@ Status array_to_capnp(
       RETURN_NOT_OK(metadata_to_capnp(metadata, &array_metadata_builder));
     }
   } else {
-    auto nonempty_domain_builder = array_builder->initNonEmptyDomain();
-    RETURN_NOT_OK(
-        utils::serialize_non_empty_domain(nonempty_domain_builder, array));
+    if (array->non_empty_domain_computed()) {
+      auto nonempty_domain_builder = array_builder->initNonEmptyDomain();
+      RETURN_NOT_OK(
+          utils::serialize_non_empty_domain(nonempty_domain_builder, array));
+    }
 
-    auto array_metadata_builder = array_builder->initArrayMetadata();
-    RETURN_NOT_OK(
-        metadata_to_capnp(array->unsafe_metadata(), &array_metadata_builder));
+    if (array->metadata_loaded()) {
+      auto array_metadata_builder = array_builder->initArrayMetadata();
+      RETURN_NOT_OK(
+          metadata_to_capnp(array->unsafe_metadata(), &array_metadata_builder));
+    }
   }
 
   return Status::Ok();


### PR DESCRIPTION
This PR addresses 3 different issues:
- A regression introduced by #3339  to array open v1 , that made array metadata disappear after a query submit when serialization was included (TileDB Cloud use case). This was fixed by restoring the old behavior in `array_to/from_capnp` in case we are using _array open v1._
- Incorrect population of array metadata in _array open v2_ that resulted in empty metadata for that case too. This was fixed by forcing loading the array metadata before including them in the serialized array object.
- Incorrect UT for `array_to/from_capnp` that existed before array v2 changes but was not actually testing by comparing the serialized to the deserialized object, thus it failed to detect the regressions. Fixed the test that now works as a regression test for both of the above issues.

---
TYPE: BUG
DESC: Fix empty metadata after array open/query submit
