### PR TITLE
Remove buffer from fragment_min_max_sum_null_count serialization/deserialization.

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -4227,16 +4227,6 @@ Tile FragmentMetadata::write_rtree() {
   SizeComputationSerializer size_computation_serializer;
   rtree_.serialize(size_computation_serializer);
 
-  // Tile tile;
-  // if (!tile.init_unfiltered(
-  //              0,
-  //              constants::generic_tile_datatype,
-  //              size_computation_serializer.size(),
-  //              constants::generic_tile_cell_size,
-  //              0)
-  //          .ok()) {
-  //   throw FragmentMetadataStatusException("Cannot initialize tile");
-  // }
   Tile tile{Tile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -861,7 +861,7 @@ void FragmentMetadata::store(const EncryptionKey& encryption_key) {
     } else if (version_ <= 14) {
       throw_if_not_ok(store_v12_v14(encryption_key));
     } else {
-      store_v15_or_higher(encryption_key);
+      throw_if_not_ok(store_v15_or_higher(encryption_key));
     }
     return;
   } catch (...) {
@@ -1023,15 +1023,15 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
 
   // Store R-Tree
   gt_offsets_.rtree_ = offset;
-  RETURN_NOT_OK_ELSE(store_rtree(encryption_key, &nbytes), clean_up());
+  throw_if_not_ok(store_rtree(encryption_key, &nbytes));
   offset += nbytes;
 
   // Store tile offsets
   gt_offsets_.tile_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(
-        store_tile_offsets(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(
+        store_tile_offsets(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1039,8 +1039,8 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_var_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_var_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(
-        store_tile_var_offsets(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(
+        store_tile_var_offsets(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1048,8 +1048,8 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_var_sizes_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_var_sizes_[i] = offset;
-    RETURN_NOT_OK_ELSE(
-        store_tile_var_sizes(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(
+        store_tile_var_sizes(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1057,8 +1057,8 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_validity_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_validity_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(
-        store_tile_validity_offsets(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(
+        store_tile_validity_offsets(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1066,7 +1066,7 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_min_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_min_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(store_tile_mins(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(store_tile_mins(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1074,7 +1074,7 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_max_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_max_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(store_tile_maxs(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(store_tile_maxs(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1082,7 +1082,7 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_sum_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_sum_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(store_tile_sums(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(store_tile_sums(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
@@ -1090,20 +1090,18 @@ Status FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   gt_offsets_.tile_null_count_offsets_.resize(num);
   for (unsigned int i = 0; i < num; ++i) {
     gt_offsets_.tile_null_count_offsets_[i] = offset;
-    RETURN_NOT_OK_ELSE(
-        store_tile_null_counts(i, encryption_key, &nbytes), clean_up());
+    throw_if_not_ok(
+        store_tile_null_counts(i, encryption_key, &nbytes));
     offset += nbytes;
   }
 
   // Store fragment min, max, sum and null count
   gt_offsets_.fragment_min_max_sum_null_count_offset_ = offset;
-  RETURN_NOT_OK_ELSE(
-      store_fragment_min_max_sum_null_count(num, encryption_key, &nbytes),
-      clean_up());
+  store_fragment_min_max_sum_null_count(num, encryption_key, &nbytes);
   offset += nbytes;
 
   // Store footer
-  RETURN_NOT_OK_ELSE(store_footer(encryption_key), clean_up());
+  throw_if_not_ok(store_footer(encryption_key));
 
   // Close file
   return storage_manager_->close_file(fragment_metadata_uri);
@@ -1187,8 +1185,7 @@ Status FragmentMetadata::store_v15_or_higher(
 
   // Store fragment min, max, sum and null count
   gt_offsets_.fragment_min_max_sum_null_count_offset_ = offset;
-  throw_if_not_ok(
-      store_fragment_min_max_sum_null_count(num, encryption_key, &nbytes));
+  store_fragment_min_max_sum_null_count(num, encryption_key, &nbytes);
   offset += nbytes;
 
   // Store processed condition
@@ -1534,8 +1531,9 @@ Status FragmentMetadata::load_fragment_min_max_sum_null_count(
   storage_manager_->stats()->add_counter(
       "read_fragment_min_max_sum_null_count_size", tile.size());
 
-  ConstBuffer cbuff(tile.data(), tile.size());
-  RETURN_NOT_OK(load_fragment_min_max_sum_null_count(&cbuff));
+  Deserializer deserializer(tile.data(), tile.size());
+
+  load_fragment_min_max_sum_null_count(deserializer);
 
   loaded_metadata_.fragment_min_max_sum_null_count_ = true;
 
@@ -1563,7 +1561,7 @@ Status FragmentMetadata::load_processed_conditions(
       "read_processed_conditions_size", tile.size());
 
   Deserializer deserializer(tile.data(), tile.size());
-  RETURN_NOT_OK(load_processed_conditions(deserializer));
+  load_processed_conditions(deserializer);
 
   loaded_metadata_.processed_conditions_ = true;
 
@@ -3450,64 +3448,31 @@ Status FragmentMetadata::load_tile_null_count_values(
 // fragment_max_attr#<attribute_num-1> (max_size)
 // fragment_sum_attr#<attribute_num-1> (uint64_t)
 // fragment_null_count_attr#<attribute_num-1> (uint64_t)
-Status FragmentMetadata::load_fragment_min_max_sum_null_count(
-    ConstBuffer* buff) {
-  Status st;
+void FragmentMetadata::load_fragment_min_max_sum_null_count(
+    Deserializer& deserializer) {
   auto num = num_dims_and_attrs();
 
   for (unsigned int i = 0; i < num; ++i) {
     // Get min.
     uint64_t min_size;
-    st = buff->read(&min_size, sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
-                                       " fragment min size failed"));
-    }
+    min_size = deserializer.read<uint64_t>();
 
     fragment_mins_[i].resize(min_size);
-    st = buff->read(fragment_mins_[i].data(), min_size);
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
-                                       " fragment min failed"));
-    }
+    deserializer.read(fragment_mins_[i].data(), min_size);
 
     // Get max.
     uint64_t max_size;
-    st = buff->read(&max_size, sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
-                                       " fragment max size failed"));
-    }
+    max_size = deserializer.read<uint64_t>();
 
     fragment_maxs_[i].resize(max_size);
-    st = buff->read(fragment_maxs_[i].data(), max_size);
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
-                                       " fragment max failed"));
-    }
+    deserializer.read(fragment_maxs_[i].data(), max_size);
 
     // Get sum.
-    st = buff->read(&fragment_sums_[i], sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
-                                       " sum failed"));
-    }
+    fragment_sums_[i] = deserializer.read<uint64_t>();
 
     // Get null count.
-    st = buff->read(&fragment_null_counts_[i], sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot load fragment metadata; Reading"
-                                       " null count failed"));
-    }
+    fragment_null_counts_[i] = deserializer.read<uint64_t>();
   }
-
-  return Status::Ok();
 }
 
 // ===== FORMAT =====
@@ -3517,7 +3482,7 @@ Status FragmentMetadata::load_fragment_min_max_sum_null_count(
 // ...
 // processed_condition_size#<condition_num-1> (uint64_t)
 // processed_condition#<condition_num-1>
-Status FragmentMetadata::load_processed_conditions(Deserializer& deserializer) {
+void FragmentMetadata::load_processed_conditions(Deserializer& deserializer) {
   // Get num conditions.
   uint64_t num;
   num = deserializer.read<uint64_t>();
@@ -3536,8 +3501,6 @@ Status FragmentMetadata::load_processed_conditions(Deserializer& deserializer) {
 
   processed_conditions_set_ = std::unordered_set<std::string>(
       processed_conditions_.begin(), processed_conditions_.end());
-
-  return Status::Ok();
 }
 
 Status FragmentMetadata::load_version(ConstBuffer* buff) {
@@ -4744,67 +4707,45 @@ Status FragmentMetadata::write_tile_null_counts(unsigned idx, Buffer* buff) {
   return Status::Ok();
 }
 
-Status FragmentMetadata::store_fragment_min_max_sum_null_count(
+void FragmentMetadata::store_fragment_min_max_sum_null_count(
     uint64_t num, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   Status st;
   Buffer buff;
 
-  // Store all attributes.
-  for (unsigned int i = 0; i < num; ++i) {
-    // Store min.
-    uint64_t min_size = fragment_mins_[i].size();
-    st = buff.write(&min_size, sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
-                                       "Writing fragment min size failed"));
-    }
+  auto serialize_data = [&](Serializer& serializer) {
+    // Store all attributes.
+    for (unsigned int i = 0; i < num; ++i) {
+      // Store min.
+      uint64_t min_size = fragment_mins_[i].size();
+      serializer.write<uint64_t>(min_size);
 
-    st = buff.write(fragment_mins_[i].data(), min_size);
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
-                                       "Writing fragment min failed"));
-    }
+      serializer.write(fragment_mins_[i].data(), min_size);
 
-    // Store max.
-    uint64_t max_size = fragment_maxs_[i].size();
-    st = buff.write(&max_size, sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
-                                       "Writing fragment max size failed"));
-    }
+      // Store max.
+      uint64_t max_size = fragment_maxs_[i].size();
+      serializer.write<uint64_t>(max_size);
 
-    st = buff.write(fragment_maxs_[i].data(), max_size);
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
-                                       "Writing fragment max failed"));
-    }
+      serializer.write(fragment_maxs_[i].data(), max_size);
 
-    // Store sum.
-    st = buff.write(&fragment_sums_[i], sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
-                                       "Writing fragment sum failed"));
-    }
+      // Store sum.
+      serializer.write<uint64_t>(fragment_sums_[i]);
 
-    // Store null count.
-    st = buff.write(&fragment_null_counts_[i], sizeof(uint64_t));
-    if (!st.ok()) {
-      return LOG_STATUS(
-          Status_FragmentMetadataError("Cannot serialize fragment metadata; "
-                                       "Writing fragment null count failed"));
+      // Store null count.
+      serializer.write<uint64_t>(fragment_null_counts_[i]);
     }
-  }
+  };
 
-  RETURN_NOT_OK(write_generic_tile_to_file(encryption_key, buff, nbytes));
+  SizeComputationSerializer size_computation_serializer;
+  serialize_data(size_computation_serializer);
+
+  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+
+  Serializer serializer(tile.data(), tile.size());
+  serialize_data(serializer);
+
+  throw_if_not_ok(write_generic_tile_to_file(encryption_key, tile, nbytes));
 
   storage_manager_->stats()->add_counter("write_null_counts_size", *nbytes);
-
-  return Status::Ok();
 }
 
 void FragmentMetadata::store_processed_conditions(

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1532,7 +1532,6 @@ Status FragmentMetadata::load_fragment_min_max_sum_null_count(
       "read_fragment_min_max_sum_null_count_size", tile.size());
 
   Deserializer deserializer(tile.data(), tile.size());
-
   load_fragment_min_max_sum_null_count(deserializer);
 
   loaded_metadata_.fragment_min_max_sum_null_count_ = true;
@@ -4228,16 +4227,17 @@ Tile FragmentMetadata::write_rtree() {
   SizeComputationSerializer size_computation_serializer;
   rtree_.serialize(size_computation_serializer);
 
-  Tile tile;
-  if (!tile.init_unfiltered(
-               0,
-               constants::generic_tile_datatype,
-               size_computation_serializer.size(),
-               constants::generic_tile_cell_size,
-               0)
-           .ok()) {
-    throw FragmentMetadataStatusException("Cannot initialize tile");
-  }
+  // Tile tile;
+  // if (!tile.init_unfiltered(
+  //              0,
+  //              constants::generic_tile_datatype,
+  //              size_computation_serializer.size(),
+  //              constants::generic_tile_cell_size,
+  //              0)
+  //          .ok()) {
+  //   throw FragmentMetadataStatusException("Cannot initialize tile");
+  // }
+  Tile tile{Tile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   rtree_.serialize(serializer);

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1421,12 +1421,12 @@ class FragmentMetadata {
   /**
    * Loads the min max sum null count values for the fragment.
    */
-  Status load_fragment_min_max_sum_null_count(ConstBuffer* buff);
+  void load_fragment_min_max_sum_null_count(Deserializer& deserializer);
 
   /**
    * Loads the processed conditions for the fragment.
    */
-  Status load_processed_conditions(Deserializer& deserializer);
+  void load_processed_conditions(Deserializer& deserializer);
 
   /** Loads the format version from the buffer. */
   Status load_version(ConstBuffer* buff);
@@ -1654,9 +1654,8 @@ class FragmentMetadata {
    * @param num The number of attributes.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written.
-   * @return Status
    */
-  Status store_fragment_min_max_sum_null_count(
+  void store_fragment_min_max_sum_null_count(
       uint64_t num, const EncryptionKey& encryption_key, uint64_t* nbytes);
 
   /**

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1928,17 +1928,7 @@ Status StorageManager::store_array_schema(
   SizeComputationSerializer size_computation_serializer;
   array_schema->serialize(size_computation_serializer);
 
-  Tile tile;
-  if (!tile.init_unfiltered(
-               0,
-               constants::generic_tile_datatype,
-               size_computation_serializer.size(),
-               constants::generic_tile_cell_size,
-               0)
-           .ok()) {
-    throw StatusException("StorageManager", "Cannot initialize tile");
-  }
-
+  Tile tile{Tile::from_generic(size_computation_serializer.size())};
   Serializer serializer(tile.data(), tile.size());
   array_schema->serialize(serializer);
 


### PR DESCRIPTION
Remove buffer from fragment_min_max_sum_null_count serialization/deserialization.

plus some missed changes in earlier similar effort for store/load processed conditions.

---
TYPE: IMPROVEMENT
DESC: Remove buffer from fragment_min_max_sum_null_count serialization/deserialization.
