### PR TITLE
Memory tracker: using the correct type for setting default budget.

### DIFF
--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -44,7 +44,7 @@ class MemoryTracker {
   /** Constructor. */
   MemoryTracker() {
     memory_usage_ = 0;
-    memory_budget_ = std::numeric_limits<uint32_t>::max();
+    memory_budget_ = std::numeric_limits<uint64_t>::max();
   };
 
   /** Destructor. */


### PR DESCRIPTION
For very large VCF queries using the legacy reader, the reader cannot load the tile offsets because we reach 4GB of memory consumption for the array data. The legacy reader does not set a budget for array data so really the default value for the memory tracker should be the max uint64 value, not uint32.

---
TYPE: IMPROVEMENT
DESC: Memory tracker: using the correct type for setting default budget.
