### PR TITLE
Handle FilterType::NONE in filter_from_capnp

### DIFF
--- a/test/src/unit-filter-serialization.cc
+++ b/test/src/unit-filter-serialization.cc
@@ -49,6 +49,20 @@
 using namespace tiledb::sm;
 
 TEST_CASE(
+    "Filter serialization: Test noop filter", "[filter][noop][serialization]") {
+  Filter* f = FilterCreate::make(FilterType::FILTER_NONE);
+  ::capnp::MallocMessageBuilder message;
+  tiledb::sm::serialization::capnp::Filter::Builder filter_builder =
+      message.initRoot<tiledb::sm::serialization::capnp::Filter>();
+  REQUIRE(tiledb::sm::serialization::filter_to_capnp(f, &filter_builder).ok());
+
+  auto&& [st_f, filter_none]{
+      tiledb::sm::serialization::filter_from_capnp(filter_builder)};
+  REQUIRE(st_f.ok());
+  REQUIRE(filter_none == std::nullopt);
+}
+
+TEST_CASE(
     "Filter serialization: Test default float scaling filter",
     "[filter][float-scaling][serialization]") {
   Filter* f = FilterCreate::make(FilterType::FILTER_SCALE_FLOAT);

--- a/test/src/unit-filter-serialization.cc
+++ b/test/src/unit-filter-serialization.cc
@@ -56,10 +56,10 @@ TEST_CASE(
       message.initRoot<tiledb::sm::serialization::capnp::Filter>();
   REQUIRE(tiledb::sm::serialization::filter_to_capnp(f, &filter_builder).ok());
 
-  auto&& [st_f, filter_none]{
+  auto&& [st_f, filter_noop]{
       tiledb::sm::serialization::filter_from_capnp(filter_builder)};
   REQUIRE(st_f.ok());
-  REQUIRE(filter_none == std::nullopt);
+  REQUIRE(filter_noop.value()->type() == FilterType::FILTER_NONE);
 }
 
 TEST_CASE(

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -138,7 +138,7 @@ inline Status filter_type_enum(
   return Status::Ok();
 }
 
-/** Throws error if the input Filtertype enum is not between 0 and 15. */
+/** Throws error if the input Filtertype enum is not between 0 and 16. */
 inline void ensure_filtertype_is_valid(uint8_t type) {
   if (type > 16) {
     throw std::runtime_error(
@@ -146,7 +146,7 @@ inline void ensure_filtertype_is_valid(uint8_t type) {
   }
 }
 
-/** Throws error if the input Filtertype's enum is not between 0 and 14. */
+/** Throws error if the input Filtertype's enum is not between 0 and 16. */
 inline void ensure_filtertype_is_valid(FilterType type) {
   ensure_filtertype_is_valid(::stdx::to_underlying(type));
 }

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -58,6 +58,7 @@
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
 #include "tiledb/sm/filter/filter_create.h"
 #include "tiledb/sm/filter/float_scaling_filter.h"
+#include "tiledb/sm/filter/noop_filter.h"
 #include "tiledb/sm/filter/positive_delta_filter.h"
 #include "tiledb/sm/filter/xor_filter.h"
 #include "tiledb/sm/misc/constants.h"
@@ -205,8 +206,9 @@ tuple<Status, optional<shared_ptr<Filter>>> filter_from_capnp(
       return {Status::Ok(),
               tiledb::common::make_shared<FloatScalingFilter>(HERE())};
     }
-    case FilterType::FILTER_NONE:
-      return {Status::Ok(), std::nullopt};
+    case FilterType::FILTER_NONE: {
+      return {Status::Ok(), tiledb::common::make_shared<NoopFilter>(HERE())};
+    }
     case FilterType::FILTER_BITSHUFFLE: {
       return {Status::Ok(),
               tiledb::common::make_shared<BitshuffleFilter>(HERE())};

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -206,7 +206,7 @@ tuple<Status, optional<shared_ptr<Filter>>> filter_from_capnp(
               tiledb::common::make_shared<FloatScalingFilter>(HERE())};
     }
     case FilterType::FILTER_NONE:
-      break;
+      return {Status::Ok(), std::nullopt};
     case FilterType::FILTER_BITSHUFFLE: {
       return {Status::Ok(),
               tiledb::common::make_shared<BitshuffleFilter>(HERE())};


### PR DESCRIPTION
`filter_from_capnp` was incorrectly handling the `FilterType::NONE` case. Rather than break, we will return `{Status::Ok(), NoopFilter}`. A test has been added to verify this behavior. 

---
TYPE: BUG
DESC: Handle filter_from_capnp FilterType::NONE case
