### PR TITLE
Fixes bug in strategy creation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ set(TILEDB_TEST_SUPPORT_SOURCES
 set(TILEDB_UNIT_TEST_SOURCES
   src/helpers.h
   src/helpers-dimension.h
+  src/test-capi-query-error-handling.cc
   src/unit-azure.cc
   src/unit-backwards_compat.cc
   src/unit-bufferlist.cc

--- a/test/src/test-capi-query-error-handling.cc
+++ b/test/src/test-capi-query-error-handling.cc
@@ -98,11 +98,13 @@ TEST_CASE_METHOD(
       ctx, query, "a", input_attr_data.data(), &attr_data_size));
 
   // Submit write query.
-  require_tiledb_ok(tiledb_query_submit(ctx, query));
-  tiledb_query_status_t query_status;
-  require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
-  REQUIRE(query_status == TILEDB_COMPLETED);
-
+  auto rc = tiledb_query_submit(ctx, query);
+  REQUIRE(rc != TILEDB_OK);
+  /**
+   tiledb_query_status_t query_status;
+   require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+   REQUIRE(query_status == TILEDB_COMPLETED);
+ */
   // Clean-up.
   tiledb_query_free(&query);
   tiledb_array_free(&array);

--- a/test/src/test-capi-query-error-handling.cc
+++ b/test/src/test-capi-query-error-handling.cc
@@ -1,0 +1,168 @@
+/**
+ * @file test-capi-query-error-handling.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests catching errors for queries with invalid options set.
+ */
+
+#include "test/src/helpers.h"
+#include "test/src/vfs_helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/enums/encryption_type.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <test/support/tdb_catch.h>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+TEST_CASE_METHOD(
+    TemporaryDirectoryFixture,
+    "Write sparse array without setting layout",
+    "[capi][query]") {
+  // Create the array.
+  uint64_t domain[2]{0, 3};
+  uint64_t x_tile_extent{4};
+  auto array_schema = create_array_schema(
+      ctx,
+      TILEDB_SPARSE,
+      {"x"},
+      {TILEDB_UINT64},
+      {&domain[0]},
+      {&x_tile_extent},
+      {"a"},
+      {TILEDB_FLOAT64},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      4096,
+      false);
+  auto array_name = create_temporary_array("sparse_array1", array_schema);
+  tiledb_array_schema_free(&array_schema);
+
+  // Open array for writing.
+  tiledb_array_t* array;
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+  // Define input data and write.
+  std::vector<uint64_t> input_dim_data{0, 1, 2, 3};
+  std::vector<double> input_attr_data{0.5, 1.0, 1.5, 2.0};
+  uint64_t dim_data_size{input_dim_data.size() * sizeof(uint64_t)};
+  uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+
+  // Create write query.
+  tiledb_query_t* query;
+  require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+  require_tiledb_ok(tiledb_query_set_data_buffer(
+      ctx, query, "x", input_dim_data.data(), &dim_data_size));
+  require_tiledb_ok(tiledb_query_set_data_buffer(
+      ctx, query, "a", input_attr_data.data(), &attr_data_size));
+
+  // Submit write query.
+  require_tiledb_ok(tiledb_query_submit(ctx, query));
+  tiledb_query_status_t query_status;
+  require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+  REQUIRE(query_status == TILEDB_COMPLETED);
+
+  // Clean-up.
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    TemporaryDirectoryFixture,
+    "Write dense array without setting layout",
+    "[capi][query]") {
+  // Create the array.
+  uint64_t x_tile_extent{4};
+  uint64_t domain[2]{0, 3};
+  auto array_schema = create_array_schema(
+      ctx,
+      TILEDB_DENSE,
+      {"x"},
+      {TILEDB_UINT64},
+      {&domain[0]},
+      {&x_tile_extent},
+      {"a"},
+      {TILEDB_FLOAT64},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      4096,
+      false);
+  auto array_name = create_temporary_array("dense_array_1", array_schema);
+  tiledb_array_schema_free(&array_schema);
+
+  // Open array for writing.
+  tiledb_array_t* array;
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+  // Create subarray.
+  tiledb_subarray_t* subarray;
+  require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+  require_tiledb_ok(tiledb_subarray_add_range(
+      ctx, subarray, 0, &domain[0], &domain[1], nullptr));
+
+  // Define data for writing.
+  std::vector<double> input_attr_data{0.5, 1.0, 1.5, 2.0};
+  uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+
+  // Create write query.
+  tiledb_query_t* query;
+  require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+  require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+  if (attr_data_size != 0) {
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "a", input_attr_data.data(), &attr_data_size));
+  }
+
+  // Submit write query.
+  require_tiledb_ok(tiledb_query_submit(ctx, query));
+  tiledb_query_status_t query_status;
+  require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+  REQUIRE(query_status == TILEDB_COMPLETED);
+
+  // Clean-up.
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
+}

--- a/test/src/test-capi-query-error-handling.cc
+++ b/test/src/test-capi-query-error-handling.cc
@@ -91,7 +91,6 @@ TEST_CASE_METHOD(
   // Create write query.
   tiledb_query_t* query;
   require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
-  //  require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
   require_tiledb_ok(tiledb_query_set_data_buffer(
       ctx, query, "x", input_dim_data.data(), &dim_data_size));
   require_tiledb_ok(tiledb_query_set_data_buffer(
@@ -100,11 +99,7 @@ TEST_CASE_METHOD(
   // Submit write query.
   auto rc = tiledb_query_submit(ctx, query);
   REQUIRE(rc != TILEDB_OK);
-  /**
-   tiledb_query_status_t query_status;
-   require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
-   REQUIRE(query_status == TILEDB_COMPLETED);
- */
+
   // Clean-up.
   tiledb_query_free(&query);
   tiledb_array_free(&array);

--- a/test/src/test-capi-query-error-handling.cc
+++ b/test/src/test-capi-query-error-handling.cc
@@ -91,70 +91,11 @@ TEST_CASE_METHOD(
   // Create write query.
   tiledb_query_t* query;
   require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+  //  require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
   require_tiledb_ok(tiledb_query_set_data_buffer(
       ctx, query, "x", input_dim_data.data(), &dim_data_size));
   require_tiledb_ok(tiledb_query_set_data_buffer(
       ctx, query, "a", input_attr_data.data(), &attr_data_size));
-
-  // Submit write query.
-  require_tiledb_ok(tiledb_query_submit(ctx, query));
-  tiledb_query_status_t query_status;
-  require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
-  REQUIRE(query_status == TILEDB_COMPLETED);
-
-  // Clean-up.
-  tiledb_query_free(&query);
-  tiledb_array_free(&array);
-}
-
-TEST_CASE_METHOD(
-    TemporaryDirectoryFixture,
-    "Write dense array without setting layout",
-    "[capi][query]") {
-  // Create the array.
-  uint64_t x_tile_extent{4};
-  uint64_t domain[2]{0, 3};
-  auto array_schema = create_array_schema(
-      ctx,
-      TILEDB_DENSE,
-      {"x"},
-      {TILEDB_UINT64},
-      {&domain[0]},
-      {&x_tile_extent},
-      {"a"},
-      {TILEDB_FLOAT64},
-      {1},
-      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
-      TILEDB_ROW_MAJOR,
-      TILEDB_ROW_MAJOR,
-      4096,
-      false);
-  auto array_name = create_temporary_array("dense_array_1", array_schema);
-  tiledb_array_schema_free(&array_schema);
-
-  // Open array for writing.
-  tiledb_array_t* array;
-  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
-  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
-
-  // Create subarray.
-  tiledb_subarray_t* subarray;
-  require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
-  require_tiledb_ok(tiledb_subarray_add_range(
-      ctx, subarray, 0, &domain[0], &domain[1], nullptr));
-
-  // Define data for writing.
-  std::vector<double> input_attr_data{0.5, 1.0, 1.5, 2.0};
-  uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
-
-  // Create write query.
-  tiledb_query_t* query;
-  require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
-  require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
-  if (attr_data_size != 0) {
-    require_tiledb_ok(tiledb_query_set_data_buffer(
-        ctx, query, "a", input_attr_data.data(), &attr_data_size));
-  }
 
   // Submit write query.
   require_tiledb_ok(tiledb_query_submit(ctx, query));

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -5302,6 +5302,7 @@ TEST_CASE_METHOD(
   REQUIRE(query_status == TILEDB_COMPLETED);
 
   // Clean-up.
+  tiledb_subarray_free(&subarray);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
 }

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -1266,10 +1266,11 @@ void DenseArrayFx::check_simultaneous_writes(const std::string& path) {
 
   // Pre-generate buffers to write
   for (int i = 0; i < nthreads; i++) {
-    subarrays.push_back({{domain_0_lo,
-                          domain_0_lo + tile_extent_0 - 1,
-                          domain_1_lo,
-                          domain_1_lo + tile_extent_1 - 1}});
+    subarrays.push_back(
+        {{domain_0_lo,
+          domain_0_lo + tile_extent_0 - 1,
+          domain_1_lo,
+          domain_1_lo + tile_extent_1 - 1}});
     buffer_sizes.push_back({{tile_extent_0 * tile_extent_1 * sizeof(int)}});
     buffers.push_back(new int[buffer_sizes.back()[0] / sizeof(int)]);
   }
@@ -1327,16 +1328,17 @@ void DenseArrayFx::check_cancel_and_retry_writes(const std::string& path) {
       cell_order,
       tile_order);
 
-  int64_t subarray[] = {domain_0_lo,
-                        domain_0_lo + tile_extent_0 - 1,
-                        domain_1_lo,
-                        domain_1_lo + tile_extent_1 - 1};
+  int64_t subarray[] = {
+      domain_0_lo,
+      domain_0_lo + tile_extent_0 - 1,
+      domain_1_lo,
+      domain_1_lo + tile_extent_1 - 1};
   uint64_t buffer_sizes[] = {tile_extent_0 * tile_extent_1 * sizeof(int)};
   auto buffer = new int[buffer_sizes[0] / sizeof(int)];
 
   // Prepare buffer
-  int64_t subarray_length[2] = {subarray[1] - subarray[0] + 1,
-                                subarray[3] - subarray[2] + 1};
+  int64_t subarray_length[2] = {
+      subarray[1] - subarray[0] + 1, subarray[3] - subarray[2] + 1};
   int64_t cell_num_in_subarray = subarray_length[0] * subarray_length[1];
   int64_t index = 0;
   for (int64_t r = 0; r < subarray_length[0]; ++r)
@@ -2592,18 +2594,19 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_row(
   int c_buffer_a1[] = {9, 12, 13, 11, 14, 15};
   uint64_t c_buffer_a2_off[] = {0, 2, 3, 5, 9, 12};
   char c_buffer_a2_val[] = "jjmnnllllooopppp";
-  float c_buffer_a3[] = {9.1f,
-                         9.2f,
-                         12.1f,
-                         12.2f,
-                         13.1f,
-                         13.2f,
-                         11.1f,
-                         11.2f,
-                         14.1f,
-                         14.2f,
-                         15.1f,
-                         15.2f};
+  float c_buffer_a3[] = {
+      9.1f,
+      9.2f,
+      12.1f,
+      12.2f,
+      13.1f,
+      13.2f,
+      11.1f,
+      11.2f,
+      14.1f,
+      14.2f,
+      15.1f,
+      15.2f};
   uint64_t c_buffer_coords_dim1[] = {3, 3, 3, 4, 4, 4};
   uint64_t c_buffer_coords_dim2[] = {2, 3, 4, 2, 3, 4};
   uint64_t c_buffer_d1[] = {3, 3, 3, 4, 4, 4};
@@ -2736,18 +2739,19 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_col(
   int c_buffer_a1[] = {9, 11, 12, 14, 13, 15};
   uint64_t c_buffer_a2_off[] = {0, 2, 6, 7, 10, 12};
   char c_buffer_a2_val[] = "jjllllmooonnpppp";
-  float c_buffer_a3[] = {9.1f,
-                         9.2f,
-                         11.1f,
-                         11.2f,
-                         12.1f,
-                         12.2f,
-                         14.1f,
-                         14.2f,
-                         13.1f,
-                         13.2f,
-                         15.1f,
-                         15.2f};
+  float c_buffer_a3[] = {
+      9.1f,
+      9.2f,
+      11.1f,
+      11.2f,
+      12.1f,
+      12.2f,
+      14.1f,
+      14.2f,
+      13.1f,
+      13.2f,
+      15.1f,
+      15.2f};
   uint64_t c_buffer_coords_dim1[] = {3, 4, 3, 4, 3, 4};
   uint64_t c_buffer_coords_dim2[] = {2, 2, 3, 3, 4, 4};
   uint64_t c_buffer_d1[] = {3, 4, 3, 4, 3, 4};
@@ -3976,22 +3980,23 @@ TEST_CASE_METHOD(
 
   // Read whole array
   uint64_t subarray_read[] = {1, 4, 1, 4};
-  int c_a1[] = {INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                1,
-                2,
-                INT_MIN,
-                INT_MIN,
-                3,
-                4,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN};
+  int c_a1[] = {
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      1,
+      2,
+      INT_MIN,
+      INT_MIN,
+      3,
+      4,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN};
   int read_a1[16];
   uint64_t read_a1_size = sizeof(read_a1);
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
@@ -4067,22 +4072,23 @@ TEST_CASE_METHOD(
 
   // Read whole array
   uint64_t subarray_read[] = {1, 4, 1, 4};
-  int c_a1[] = {INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                1,
-                2,
-                INT_MIN,
-                INT_MIN,
-                3,
-                4,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN,
-                INT_MIN};
+  int c_a1[] = {
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      1,
+      2,
+      INT_MIN,
+      INT_MIN,
+      3,
+      4,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN};
   int read_a1[16];
   uint64_t read_a1_size = sizeof(read_a1);
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
@@ -4180,22 +4186,23 @@ TEST_CASE_METHOD(
 
   // Read whole array
   uint64_t subarray_read[] = {1, 4, 1, 4};
-  int c_a[] = {1,
-               2,
-               3,
-               4,
-               5,
-               101,
-               102,
-               8,
-               INT_MIN,
-               103,
-               104,
-               INT_MIN,
-               INT_MIN,
-               INT_MIN,
-               INT_MIN,
-               INT_MIN};
+  int c_a[] = {
+      1,
+      2,
+      3,
+      4,
+      5,
+      101,
+      102,
+      8,
+      INT_MIN,
+      103,
+      104,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN,
+      INT_MIN};
   int read_a[16];
   uint64_t read_a_size = sizeof(read_a);
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
@@ -5244,4 +5251,64 @@ TEST_CASE_METHOD(
   CHECK(!memcmp(c_a1, a1.data(), sizeof(c_a1)));
 
   remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    TemporaryDirectoryFixture,
+    "C API: Test dense array write without setting layout",
+    "[capi][query]") {
+  // Create the array.
+  uint64_t x_tile_extent{4};
+  uint64_t domain[2]{0, 3};
+  auto array_schema = create_array_schema(
+      ctx,
+      TILEDB_DENSE,
+      {"x"},
+      {TILEDB_UINT64},
+      {&domain[0]},
+      {&x_tile_extent},
+      {"a"},
+      {TILEDB_FLOAT64},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      4096,
+      false);
+  auto array_name = create_temporary_array("dense_array_1", array_schema);
+  tiledb_array_schema_free(&array_schema);
+
+  // Open array for writing.
+  tiledb_array_t* array;
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+  // Create subarray.
+  tiledb_subarray_t* subarray;
+  require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+  require_tiledb_ok(tiledb_subarray_add_range(
+      ctx, subarray, 0, &domain[0], &domain[1], nullptr));
+
+  // Define data for writing.
+  std::vector<double> input_attr_data{0.5, 1.0, 1.5, 2.0};
+  uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+
+  // Create write query.
+  tiledb_query_t* query;
+  require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+  require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+  if (attr_data_size != 0) {
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "a", input_attr_data.data(), &attr_data_size));
+  }
+
+  // Submit write query.
+  require_tiledb_ok(tiledb_query_submit(ctx, query));
+  tiledb_query_status_t query_status;
+  require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+  REQUIRE(query_status == TILEDB_COMPLETED);
+
+  // Clean-up.
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
 }

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -1266,11 +1266,10 @@ void DenseArrayFx::check_simultaneous_writes(const std::string& path) {
 
   // Pre-generate buffers to write
   for (int i = 0; i < nthreads; i++) {
-    subarrays.push_back(
-        {{domain_0_lo,
-          domain_0_lo + tile_extent_0 - 1,
-          domain_1_lo,
-          domain_1_lo + tile_extent_1 - 1}});
+    subarrays.push_back({{domain_0_lo,
+                          domain_0_lo + tile_extent_0 - 1,
+                          domain_1_lo,
+                          domain_1_lo + tile_extent_1 - 1}});
     buffer_sizes.push_back({{tile_extent_0 * tile_extent_1 * sizeof(int)}});
     buffers.push_back(new int[buffer_sizes.back()[0] / sizeof(int)]);
   }
@@ -1328,17 +1327,16 @@ void DenseArrayFx::check_cancel_and_retry_writes(const std::string& path) {
       cell_order,
       tile_order);
 
-  int64_t subarray[] = {
-      domain_0_lo,
-      domain_0_lo + tile_extent_0 - 1,
-      domain_1_lo,
-      domain_1_lo + tile_extent_1 - 1};
+  int64_t subarray[] = {domain_0_lo,
+                        domain_0_lo + tile_extent_0 - 1,
+                        domain_1_lo,
+                        domain_1_lo + tile_extent_1 - 1};
   uint64_t buffer_sizes[] = {tile_extent_0 * tile_extent_1 * sizeof(int)};
   auto buffer = new int[buffer_sizes[0] / sizeof(int)];
 
   // Prepare buffer
-  int64_t subarray_length[2] = {
-      subarray[1] - subarray[0] + 1, subarray[3] - subarray[2] + 1};
+  int64_t subarray_length[2] = {subarray[1] - subarray[0] + 1,
+                                subarray[3] - subarray[2] + 1};
   int64_t cell_num_in_subarray = subarray_length[0] * subarray_length[1];
   int64_t index = 0;
   for (int64_t r = 0; r < subarray_length[0]; ++r)
@@ -2594,19 +2592,18 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_row(
   int c_buffer_a1[] = {9, 12, 13, 11, 14, 15};
   uint64_t c_buffer_a2_off[] = {0, 2, 3, 5, 9, 12};
   char c_buffer_a2_val[] = "jjmnnllllooopppp";
-  float c_buffer_a3[] = {
-      9.1f,
-      9.2f,
-      12.1f,
-      12.2f,
-      13.1f,
-      13.2f,
-      11.1f,
-      11.2f,
-      14.1f,
-      14.2f,
-      15.1f,
-      15.2f};
+  float c_buffer_a3[] = {9.1f,
+                         9.2f,
+                         12.1f,
+                         12.2f,
+                         13.1f,
+                         13.2f,
+                         11.1f,
+                         11.2f,
+                         14.1f,
+                         14.2f,
+                         15.1f,
+                         15.2f};
   uint64_t c_buffer_coords_dim1[] = {3, 3, 3, 4, 4, 4};
   uint64_t c_buffer_coords_dim2[] = {2, 3, 4, 2, 3, 4};
   uint64_t c_buffer_d1[] = {3, 3, 3, 4, 4, 4};
@@ -2739,19 +2736,18 @@ void DenseArrayFx::read_dense_array_with_coords_subarray_col(
   int c_buffer_a1[] = {9, 11, 12, 14, 13, 15};
   uint64_t c_buffer_a2_off[] = {0, 2, 6, 7, 10, 12};
   char c_buffer_a2_val[] = "jjllllmooonnpppp";
-  float c_buffer_a3[] = {
-      9.1f,
-      9.2f,
-      11.1f,
-      11.2f,
-      12.1f,
-      12.2f,
-      14.1f,
-      14.2f,
-      13.1f,
-      13.2f,
-      15.1f,
-      15.2f};
+  float c_buffer_a3[] = {9.1f,
+                         9.2f,
+                         11.1f,
+                         11.2f,
+                         12.1f,
+                         12.2f,
+                         14.1f,
+                         14.2f,
+                         13.1f,
+                         13.2f,
+                         15.1f,
+                         15.2f};
   uint64_t c_buffer_coords_dim1[] = {3, 4, 3, 4, 3, 4};
   uint64_t c_buffer_coords_dim2[] = {2, 2, 3, 3, 4, 4};
   uint64_t c_buffer_d1[] = {3, 4, 3, 4, 3, 4};
@@ -3980,23 +3976,22 @@ TEST_CASE_METHOD(
 
   // Read whole array
   uint64_t subarray_read[] = {1, 4, 1, 4};
-  int c_a1[] = {
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      1,
-      2,
-      INT_MIN,
-      INT_MIN,
-      3,
-      4,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN};
+  int c_a1[] = {INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                1,
+                2,
+                INT_MIN,
+                INT_MIN,
+                3,
+                4,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN};
   int read_a1[16];
   uint64_t read_a1_size = sizeof(read_a1);
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
@@ -4072,23 +4067,22 @@ TEST_CASE_METHOD(
 
   // Read whole array
   uint64_t subarray_read[] = {1, 4, 1, 4};
-  int c_a1[] = {
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      1,
-      2,
-      INT_MIN,
-      INT_MIN,
-      3,
-      4,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN};
+  int c_a1[] = {INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                1,
+                2,
+                INT_MIN,
+                INT_MIN,
+                3,
+                4,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN,
+                INT_MIN};
   int read_a1[16];
   uint64_t read_a1_size = sizeof(read_a1);
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);
@@ -4186,23 +4180,22 @@ TEST_CASE_METHOD(
 
   // Read whole array
   uint64_t subarray_read[] = {1, 4, 1, 4};
-  int c_a[] = {
-      1,
-      2,
-      3,
-      4,
-      5,
-      101,
-      102,
-      8,
-      INT_MIN,
-      103,
-      104,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN,
-      INT_MIN};
+  int c_a[] = {1,
+               2,
+               3,
+               4,
+               5,
+               101,
+               102,
+               8,
+               INT_MIN,
+               103,
+               104,
+               INT_MIN,
+               INT_MIN,
+               INT_MIN,
+               INT_MIN,
+               INT_MIN};
   int read_a[16];
   uint64_t read_a_size = sizeof(read_a);
   rc = tiledb_array_alloc(ctx_, array_name.c_str(), &array);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -6997,3 +6997,55 @@ TEST_CASE_METHOD(
   tiledb_array_free(&array);
   tiledb_query_free(&query);
 }
+
+TEST_CASE_METHOD(
+    TemporaryDirectoryFixture,
+    "Write sparse array without setting layout",
+    "[capi][query]") {
+  // Create the array.
+  uint64_t domain[2]{0, 3};
+  uint64_t x_tile_extent{4};
+  auto array_schema = create_array_schema(
+      ctx,
+      TILEDB_SPARSE,
+      {"x"},
+      {TILEDB_UINT64},
+      {&domain[0]},
+      {&x_tile_extent},
+      {"a"},
+      {TILEDB_FLOAT64},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      4096,
+      false);
+  auto array_name = create_temporary_array("sparse_array1", array_schema);
+  tiledb_array_schema_free(&array_schema);
+
+  // Open array for writing.
+  tiledb_array_t* array;
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+  // Define input data and write.
+  std::vector<uint64_t> input_dim_data{0, 1, 2, 3};
+  std::vector<double> input_attr_data{0.5, 1.0, 1.5, 2.0};
+  uint64_t dim_data_size{input_dim_data.size() * sizeof(uint64_t)};
+  uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+
+  // Create write query.
+  tiledb_query_t* query;
+  require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+  require_tiledb_ok(tiledb_query_set_data_buffer(
+      ctx, query, "x", input_dim_data.data(), &dim_data_size));
+  require_tiledb_ok(tiledb_query_set_data_buffer(
+      ctx, query, "a", input_attr_data.data(), &attr_data_size));
+
+  // Submit write query.
+  require_tiledb_ok(tiledb_query_submit(ctx, query));
+
+  // Clean-up.
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
+}

--- a/test/src/vfs_helpers.cc
+++ b/test/src/vfs_helpers.cc
@@ -360,6 +360,28 @@ std::string SupportedFsMem::temp_dir() {
   return temp_dir_;
 }
 
+void TemporaryDirectoryFixture::check_tiledb_ok(int rc) {
+  if (rc != TILEDB_OK) {
+    tiledb_error_t* err = NULL;
+    tiledb_ctx_get_last_error(ctx, &err);
+    const char* msg;
+    tiledb_error_message(err, &msg);
+    UNSCOPED_INFO(msg);
+  }
+  CHECK(rc == TILEDB_OK);
+}
+
+void TemporaryDirectoryFixture::require_tiledb_ok(int rc) {
+  if (rc != TILEDB_OK) {
+    tiledb_error_t* err = NULL;
+    tiledb_ctx_get_last_error(ctx, &err);
+    const char* msg;
+    tiledb_error_message(err, &msg);
+    UNSCOPED_INFO(msg);
+  }
+  REQUIRE(rc == TILEDB_OK);
+}
+
 }  // End of namespace test
 
 }  // End of namespace tiledb

--- a/test/src/vfs_helpers.h
+++ b/test/src/vfs_helpers.h
@@ -594,6 +594,24 @@ struct TemporaryDirectoryFixture {
     return array_uri;
   };
 
+  /**
+   * Checks the return code for a TileDB C-API function is TILEDB_OK. If not,
+   * if will add a failed assert to the Catch2 test and print the last error
+   * message from the local TileDB context.
+   *
+   * @param rc Return code from a TileDB C-API function.
+   */
+  void check_tiledb_ok(int rc);
+
+  /**
+   * Requires the return code for a TileDB C-API function is TILEDB_OK. If not,
+   * it will end the Catch2 test and print the last error message from the local
+   * TileDB context.
+   *
+   * @param rc Return code from a TileDB C-API function.
+   */
+  void require_tiledb_ok(int rc);
+
  protected:
   /** TileDB context */
   tiledb_ctx_t* ctx;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1250,7 +1250,8 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           fragment_name_,
           skip_checks_serialization));
     } else {
-      assert(false);
+      return Status_QueryError(
+          "Cannot create strategy; unsupported layout " + layout_str(layout_));
     }
   } else if (type_ == QueryType::READ) {
     bool use_default = true;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -92,11 +92,7 @@ Query::Query(
   assert(array->is_open());
   type_ = array->get_query_type();
 
-  if (type_ != QueryType::READ) {
-    subarray_ = Subarray(array_, stats_, logger_);
-  } else {
-    subarray_ = Subarray(array_, Layout::ROW_MAJOR, stats_, logger_);
-  }
+  subarray_ = Subarray(array_, layout_, stats_, logger_);
 
   fragment_metadata_ = array->fragment_metadata();
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -954,6 +954,9 @@ class Query {
   /** The data input to the callback function. */
   void* callback_data_;
 
+  /** The query type. */
+  QueryType type_;
+
   /** The layout of the cells in the result of the subarray. */
   Layout layout_;
 
@@ -965,9 +968,6 @@ class Query {
 
   /** The storage manager. */
   StorageManager* storage_manager_;
-
-  /** The query type. */
-  QueryType type_;
 
   /** The query strategy. */
   tdb_unique_ptr<IQueryStrategy> strategy_;

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -95,6 +95,11 @@ GlobalOrderWriter::GlobalOrderWriter(
           fragment_name,
           skip_checks_serialization)
     , processed_conditions_(processed_conditions) {
+  if (layout != Layout::GLOBAL_ORDER) {
+    throw StatusException(Status_WriterError(
+        "Failed to initialize global order writer. Layout " +
+        layout_str(layout) + " is not global order."));
+  }
 }
 
 GlobalOrderWriter::~GlobalOrderWriter() {
@@ -249,8 +254,8 @@ Status GlobalOrderWriter::check_global_order() const {
   auto& domain{array_schema_.domain()};
   DomainBuffersView domain_buffs{array_schema_, buffers_};
   if (global_write_state_->cells_written_.begin()->second > 0) {
-    DomainBuffersView last_cell_buffs{array_schema_,
-                                      *global_write_state_->last_cell_coords_};
+    DomainBuffersView last_cell_buffs{
+        array_schema_, *global_write_state_->last_cell_coords_};
     auto left{last_cell_buffs.domain_ref_at(domain, 0)};
     auto right{domain_buffs.domain_ref_at(domain, 0)};
 

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -254,8 +254,8 @@ Status GlobalOrderWriter::check_global_order() const {
   auto& domain{array_schema_.domain()};
   DomainBuffersView domain_buffs{array_schema_, buffers_};
   if (global_write_state_->cells_written_.begin()->second > 0) {
-    DomainBuffersView last_cell_buffs{
-        array_schema_, *global_write_state_->last_cell_coords_};
+    DomainBuffersView last_cell_buffs{array_schema_,
+                                      *global_write_state_->last_cell_coords_};
     auto left{last_cell_buffs.domain_ref_at(domain, 0)};
     auto right{domain_buffs.domain_ref_at(domain, 0)};
 

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -98,6 +98,7 @@ OrderedWriter::OrderedWriter(
         "support layout " +
         layout_str(layout)));
   }
+
   if (!array_schema_.dense()) {
     throw StatusException(
         Status_WriterError("Failed to initialize OrderedWriter; The ordered "

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -92,6 +92,17 @@ OrderedWriter::OrderedWriter(
           coords_info,
           fragment_name,
           skip_checks_serialization) {
+  if (layout != Layout::ROW_MAJOR && layout != Layout::COL_MAJOR) {
+    throw StatusException(Status_WriterError(
+        "Failed to initialize OrderedWriter; The ordered writer does not "
+        "support layout " +
+        layout_str(layout)));
+  }
+  if (!array_schema_.dense()) {
+    throw StatusException(
+        Status_WriterError("Failed to initialize OrderedWriter; The ordered "
+                           "writer does not support sparse arrays."));
+  }
 }
 
 OrderedWriter::~OrderedWriter() {

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -92,6 +92,17 @@ UnorderedWriter::UnorderedWriter(
           coords_info,
           fragment_name,
           skip_checks_serialization) {
+  if (layout != Layout::UNORDERED) {
+    throw StatusException(Status_WriterError(
+        "Failed to initialize UnorderedWriter; The unordered writer does not "
+        "support layout " +
+        layout_str(layout)));
+  }
+  if (array_schema_.dense()) {
+    throw StatusException(Status_WriterError(
+        "Failed to initialize UnorderedWriter; The unordered "
+        "writer does not support dense arrays."));
+  }
 }
 
 UnorderedWriter::~UnorderedWriter() {

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -98,6 +98,7 @@ UnorderedWriter::UnorderedWriter(
         "support layout " +
         layout_str(layout)));
   }
+
   if (array_schema_.dense()) {
     throw StatusException(Status_WriterError(
         "Failed to initialize UnorderedWriter; The unordered "


### PR DESCRIPTION
This PR fixes two bugs:

1. Sparse writes for ROW_MAJOR/COL_MAJOR were using a dense writer strategy
2. For non-read Queries, the Query layout and Subarray layout were initialized to different values.

Additional status errors were added to supplement and/or replace assert statements.

---
TYPE: BUG
DESC: Fixes silent failure for mismatched layout and bad layout/array combos on query
