### PR TITLE
Tile metadata: fixing for ordered writes.

### DIFF
--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -288,7 +288,7 @@ TEST_CASE(
   uint64_t size;
   rc = tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 1, &size);
   CHECK(rc == TILEDB_OK);
-  CHECK(size == 3193);
+  CHECK(size == 3202);
 
   // Get dense / sparse
   int32_t dense;
@@ -539,7 +539,7 @@ TEST_CASE(
   uint64_t size;
   rc = tiledb_fragment_info_get_fragment_size(ctx, fragment_info, 1, &size);
   CHECK(rc == TILEDB_OK);
-  CHECK(size == 5576);
+  CHECK(size == 5585);
 
   // Get dense / sparse
   int32_t dense;
@@ -1376,16 +1376,16 @@ TEST_CASE("C API: Test fragment info, dump", "[capi][fragment_info][dump]") {
       "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
       "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
       "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
-      "  > Size: 3193\n" + "  > Cell num: 10\n" +
+      "  > Size: 3202\n" + "  > Cell num: 10\n" +
       "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
       "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [1, 4]\n" + "  > Size: 3142\n" +
+      "  > Non-empty domain: [1, 4]\n" + "  > Size: 3151\n" +
       "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
       "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [5, 6]\n" + "  > Size: 3190\n" +
+      "  > Non-empty domain: [5, 6]\n" + "  > Size: 3202\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -227,7 +227,7 @@ TEST_CASE(
 
     // Get fragment size
     auto size = fragment_info.fragment_size(1);
-    CHECK(size == 3193);
+    CHECK(size == 3202);
 
     // Get dense / sparse
     auto dense = fragment_info.dense(0);
@@ -851,16 +851,16 @@ TEST_CASE(
         "- Unconsolidated metadata num: 3\n" + "- To vacuum num: 0\n" +
         "- Fragment #1:\n" + "  > URI: " + written_frag_uri_1 + "\n" +
         "  > Type: dense\n" + "  > Non-empty domain: [1, 6]\n" +
-        "  > Size: 3193\n" + "  > Cell num: 10\n" +
+        "  > Size: 3202\n" + "  > Cell num: 10\n" +
         "  > Timestamp range: [1, 1]\n" + "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #2:\n" +
         "  > URI: " + written_frag_uri_2 + "\n" + "  > Type: dense\n" +
-        "  > Non-empty domain: [1, 4]\n" + "  > Size: 3142\n" +
+        "  > Non-empty domain: [1, 4]\n" + "  > Size: 3151\n" +
         "  > Cell num: 5\n" + "  > Timestamp range: [2, 2]\n" +
         "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n" + "- Fragment #3:\n" +
         "  > URI: " + written_frag_uri_3 + "\n" + "  > Type: dense\n" +
-        "  > Non-empty domain: [5, 6]\n" + "  > Size: 3190\n" +
+        "  > Non-empty domain: [5, 6]\n" + "  > Size: 3202\n" +
         "  > Cell num: 10\n" + "  > Timestamp range: [3, 3]\n" +
         "  > Format version: " + ver + "\n" +
         "  > Has consolidated metadata: no\n";

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -185,13 +185,9 @@ TEMPLATE_LIST_TEST_CASE(
 
   // Call the tile metadata generator.
   TileMetadataGenerator md_generator(
-      writer_tile,
-      tiledb_type,
-      false,
-      false,
-      cell_val_num * sizeof(T),
-      cell_val_num);
-  md_generator.process_full_tile();
+      tiledb_type, false, false, cell_val_num * sizeof(T), cell_val_num);
+  md_generator.process_full_tile(writer_tile);
+  md_generator.set_tile_metadata(writer_tile);
 
   // Compare the metadata to what's expected.
   if constexpr (std::is_same<T, char>::value) {
@@ -273,9 +269,9 @@ TEMPLATE_LIST_TEST_CASE(
   tile_buff[3] = std::numeric_limits<T>::lowest();
 
   // Call the tile metadata generator.
-  TileMetadataGenerator md_generator(
-      writer_tile, tiledb_type, false, false, sizeof(T), 1);
-  md_generator.process_full_tile();
+  TileMetadataGenerator md_generator(tiledb_type, false, false, sizeof(T), 1);
+  md_generator.process_full_tile(writer_tile);
+  md_generator.set_tile_metadata(writer_tile);
 
   // Compare the metadata to what's expected.
   if constexpr (std::is_integral_v<T>) {
@@ -298,9 +294,9 @@ TEMPLATE_LIST_TEST_CASE(
     tile_buff[3] = std::numeric_limits<T>::max();
 
     // Call the tile metadata generator.
-    TileMetadataGenerator md_generator(
-        writer_tile, tiledb_type, false, false, sizeof(T), 1);
-    md_generator.process_full_tile();
+    TileMetadataGenerator md_generator(tiledb_type, false, false, sizeof(T), 1);
+    md_generator.process_full_tile(writer_tile);
+    md_generator.set_tile_metadata(writer_tile);
 
     // Compare the metadata to what's expected.
     if constexpr (std::is_integral_v<T>) {
@@ -394,8 +390,9 @@ TEST_CASE(
 
   // Call the tile metadata generator.
   TileMetadataGenerator md_generator(
-      writer_tile, Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
-  md_generator.process_full_tile();
+      Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
+  md_generator.process_full_tile(writer_tile);
+  md_generator.set_tile_metadata(writer_tile);
 
   // Compare the metadata to what's expected.
   if (all_null || empty_tile) {
@@ -446,8 +443,9 @@ TEST_CASE(
 
   // Call the tile metadata generator.
   TileMetadataGenerator md_generator(
-      writer_tile, Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
-  md_generator.process_full_tile();
+      Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
+  md_generator.process_full_tile(writer_tile);
+  md_generator.set_tile_metadata(writer_tile);
 
   // Compare the metadata to what's expected.
   CHECK(0 == strncmp((const char*)writer_tile.min().data(), "12", 2));

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -185,8 +185,13 @@ TEMPLATE_LIST_TEST_CASE(
 
   // Call the tile metadata generator.
   TileMetadataGenerator md_generator(
-      tiledb_type, false, false, cell_val_num * sizeof(T), cell_val_num);
-  md_generator.process_tile(writer_tile);
+      writer_tile,
+      tiledb_type,
+      false,
+      false,
+      cell_val_num * sizeof(T),
+      cell_val_num);
+  md_generator.process_full_tile();
 
   // Compare the metadata to what's expected.
   if constexpr (std::is_same<T, char>::value) {
@@ -268,8 +273,9 @@ TEMPLATE_LIST_TEST_CASE(
   tile_buff[3] = std::numeric_limits<T>::lowest();
 
   // Call the tile metadata generator.
-  TileMetadataGenerator md_generator(tiledb_type, false, false, sizeof(T), 1);
-  md_generator.process_tile(writer_tile);
+  TileMetadataGenerator md_generator(
+      writer_tile, tiledb_type, false, false, sizeof(T), 1);
+  md_generator.process_full_tile();
 
   // Compare the metadata to what's expected.
   if constexpr (std::is_integral_v<T>) {
@@ -292,8 +298,9 @@ TEMPLATE_LIST_TEST_CASE(
     tile_buff[3] = std::numeric_limits<T>::max();
 
     // Call the tile metadata generator.
-    TileMetadataGenerator md_generator(tiledb_type, false, false, sizeof(T), 1);
-    md_generator.process_tile(writer_tile);
+    TileMetadataGenerator md_generator(
+        writer_tile, tiledb_type, false, false, sizeof(T), 1);
+    md_generator.process_full_tile();
 
     // Compare the metadata to what's expected.
     if constexpr (std::is_integral_v<T>) {
@@ -387,8 +394,8 @@ TEST_CASE(
 
   // Call the tile metadata generator.
   TileMetadataGenerator md_generator(
-      Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
-  md_generator.process_tile(writer_tile);
+      writer_tile, Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
+  md_generator.process_full_tile();
 
   // Compare the metadata to what's expected.
   if (all_null || empty_tile) {
@@ -439,8 +446,8 @@ TEST_CASE(
 
   // Call the tile metadata generator.
   TileMetadataGenerator md_generator(
-      Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
-  md_generator.process_tile(writer_tile);
+      writer_tile, Datatype::STRING_ASCII, false, true, TILEDB_VAR_NUM, 1);
+  md_generator.process_full_tile();
 
   // Compare the metadata to what's expected.
   CHECK(0 == strncmp((const char*)writer_tile.min().data(), "12", 2));

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -65,7 +65,7 @@ struct CPPFixedTileMetadataFx {
     tiledb_ctx_alloc(NULL, &ctx);
 
     // The array will be one dimension "d", with domain [0,999].
-    uint32_t dim_domain[] = {0, 999};
+    uint32_t dim_domain[]{0, 999};
     tiledb_dimension_t* d;
     tiledb_dimension_alloc(
         ctx, "d", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d);
@@ -1069,7 +1069,7 @@ struct CPPFixedTileMetadataPartialFx {
     tiledb_ctx_alloc(NULL, &ctx);
 
     // The array will be two dimension "d1" and "d2", with domain [1,8].
-    uint32_t dim_domain[] = {1, 8};
+    uint32_t dim_domain[]{1, 8};
     tiledb_dimension_t* d1;
     tiledb_dimension_alloc(
         ctx, "d1", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d1);
@@ -1115,27 +1115,27 @@ struct CPPFixedTileMetadataPartialFx {
     // Write a 4x4 square intersecting the 4 tiles of the array. Writting a 2x2
     // square to each tile.
     Subarray subarray(ctx_, array);
-    uint32_t r[2] = {3, 6};
+    uint32_t r[2]{3, 6};
     subarray.add_range(0, r[0], r[1]);
     subarray.add_range(1, r[0], r[1]);
     query.set_subarray(subarray);
 
-    std::vector<double> a = {1.7,
-                             1.1,
-                             2.2,
-                             2.5,
-                             1.5,
-                             1.3,
-                             2.1,
-                             2.6,
-                             3.4,
-                             3.8,
-                             4.1,
-                             4.2,
-                             3.5,
-                             3.2,
-                             4.9,
-                             4.6};
+    std::vector<double> a{1.7,
+                          1.1,
+                          2.2,
+                          2.5,
+                          1.5,
+                          1.3,
+                          2.1,
+                          2.6,
+                          3.4,
+                          3.8,
+                          4.1,
+                          4.2,
+                          3.5,
+                          3.2,
+                          4.9,
+                          4.6};
     query.set_layout(TILEDB_ROW_MAJOR);
     query.set_data_buffer("a", a);
 
@@ -1209,9 +1209,9 @@ struct CPPFixedTileMetadataPartialFx {
         enc_key, std::move(names_null_count));
     CHECK(st.ok());
 
-    std::vector<double> correct_tile_mins = {1.1, 2.1, 3.2, 4.1};
-    std::vector<double> correct_tile_maxs = {1.7, 2.6, 3.8, 4.9};
-    std::vector<double> correct_tile_sums = {5.6, 9.4, 13.9, 17.8};
+    std::vector<double> correct_tile_mins{1.1, 2.1, 3.2, 4.1};
+    std::vector<double> correct_tile_maxs{1.7, 2.6, 3.8, 4.9};
+    std::vector<double> correct_tile_sums{5.6, 9.4, 13.9, 17.8};
 
     // Validate attribute metadta.
     for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
@@ -1284,7 +1284,7 @@ struct CPPVarTileMetadataPartialFx {
     tiledb_ctx_alloc(NULL, &ctx);
 
     // The array will be two dimension "d1" and "d2", with domain [1,8].
-    uint32_t dim_domain[] = {1, 8};
+    uint32_t dim_domain[]{1, 8};
     tiledb_dimension_t* d1;
     tiledb_dimension_alloc(
         ctx, "d1", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d1);
@@ -1331,13 +1331,13 @@ struct CPPVarTileMetadataPartialFx {
     // Write a 4x4 square intersecting the 4 tiles of the array. Writting a 2x2
     // square to each tile.
     Subarray subarray(ctx_, array);
-    uint32_t r[2] = {3, 6};
+    uint32_t r[2]{3, 6};
     subarray.add_range(0, r[0], r[1]);
     subarray.add_range(1, r[0], r[1]);
     query.set_subarray(subarray);
 
     std::string a = "1.71.12.22.51.51.32.12.63.43.84.14.23.53.24.94.6";
-    std::vector<uint64_t> offsets = {
+    std::vector<uint64_t> offsets{
         0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45};
     query.set_layout(TILEDB_ROW_MAJOR);
     query.set_data_buffer("a", a).set_offsets_buffer("a", offsets);
@@ -1402,8 +1402,8 @@ struct CPPVarTileMetadataPartialFx {
         enc_key, std::move(names_null_count));
     CHECK(st.ok());
 
-    std::vector<std::string> correct_tile_mins = {"1.1", "2.1", "3.2", "4.1"};
-    std::vector<std::string> correct_tile_maxs = {"1.7", "2.6", "3.8", "4.9"};
+    std::vector<std::string> correct_tile_mins{"1.1", "2.1", "3.2", "4.1"};
+    std::vector<std::string> correct_tile_maxs{"1.7", "2.6", "3.8", "4.9"};
 
     // Validate attribute metadta.
     for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -64,8 +64,7 @@ struct CPPFixedTileMetadataFx {
     tiledb_ctx_t* ctx;
     tiledb_ctx_alloc(NULL, &ctx);
 
-    // The array will be 4x4 with dimensions "rows" and "cols", with domain
-    // [1,4].
+    // The array will be one dimension "d", with domain [0,999].
     uint32_t dim_domain[] = {0, 999};
     tiledb_dimension_t* d;
     tiledb_dimension_alloc(
@@ -1050,4 +1049,404 @@ TEST_CASE_METHOD(
     // Check metadata.
     CPPVarTileMetadataFx::check_metadata(f, layout, nullable, all_null);
   }
+}
+
+struct CPPFixedTileMetadataPartialFx {
+  CPPFixedTileMetadataPartialFx()
+      : vfs_(ctx_) {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  ~CPPFixedTileMetadataPartialFx() {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  void create_array() {
+    // Create TileDB context
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+
+    // The array will be two dimension "d1" and "d2", with domain [1,8].
+    uint32_t dim_domain[] = {1, 8};
+    tiledb_dimension_t* d1;
+    tiledb_dimension_alloc(
+        ctx, "d1", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d1);
+    tiledb_dimension_t* d2;
+    tiledb_dimension_alloc(
+        ctx, "d2", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d2);
+
+    // Create domain
+    tiledb_domain_t* domain;
+    tiledb_domain_alloc(ctx, &domain);
+    tiledb_domain_add_dimension(ctx, domain, d1);
+    tiledb_domain_add_dimension(ctx, domain, d2);
+
+    // Create a single attribute "a" so each (i,j) cell can store a double.
+    tiledb_attribute_t* a;
+    tiledb_attribute_alloc(ctx, "a", TILEDB_FLOAT64, &a);
+
+    // Create array schema
+    tiledb_array_schema_t* array_schema;
+    tiledb_array_schema_alloc(ctx, TILEDB_DENSE, &array_schema);
+    tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+    tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+    tiledb_array_schema_set_domain(ctx, array_schema, domain);
+    tiledb_array_schema_add_attribute(ctx, array_schema, a);
+
+    // Create array
+    tiledb_array_create(ctx, ARRAY_NAME, array_schema);
+
+    // Clean up
+    tiledb_attribute_free(&a);
+    tiledb_dimension_free(&d1);
+    tiledb_dimension_free(&d2);
+    tiledb_domain_free(&domain);
+    tiledb_array_schema_free(&array_schema);
+    tiledb_ctx_free(&ctx);
+  }
+
+  void write_fragment() {
+    // Write to the array.
+    auto array = tiledb::Array(ctx_, ARRAY_NAME, TILEDB_WRITE);
+    auto query = tiledb::Query(ctx_, array, TILEDB_WRITE);
+
+    // Write a 4x4 square intersecting the 4 tiles of the array. Writting a 2x2
+    // square to each tile.
+    Subarray subarray(ctx_, array);
+    uint32_t r[2] = {3, 6};
+    subarray.add_range(0, r[0], r[1]);
+    subarray.add_range(1, r[0], r[1]);
+    query.set_subarray(subarray);
+
+    std::vector<double> a = {1.7,
+                             1.1,
+                             2.2,
+                             2.5,
+                             1.5,
+                             1.3,
+                             2.1,
+                             2.6,
+                             3.4,
+                             3.8,
+                             4.1,
+                             4.2,
+                             3.5,
+                             3.2,
+                             4.9,
+                             4.6};
+    query.set_layout(TILEDB_ROW_MAJOR);
+    query.set_data_buffer("a", a);
+
+    query.submit();
+    query.finalize();
+    array.close();
+  }
+
+  void check_metadata() {
+    // Open array.
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+    tiledb_array_t* array;
+    int rc = tiledb_array_alloc(ctx, ARRAY_NAME, &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx, array, TILEDB_READ);
+    CHECK(rc == TILEDB_OK);
+
+    // Load fragment metadata.
+    auto frag_meta = array->array_->fragment_metadata();
+    auto& enc_key = array->array_->get_encryption_key();
+    auto st = frag_meta[0]->load_fragment_min_max_sum_null_count(enc_key);
+    CHECK(st.ok());
+
+    // Do fragment metadata first for attribute.
+    {
+      // Validate min.
+      auto&& [st_min, min] = frag_meta[0]->get_min("a");
+      CHECK(st_min.ok());
+      if (st_min.ok()) {
+        CHECK((*min).size() == sizeof(double));
+
+        double correct_min = 1.1;
+        CHECK(0 == memcmp((*min).data(), &correct_min, (*min).size()));
+      }
+
+      // Validate max.
+      auto&& [st_max, max] = frag_meta[0]->get_max("a");
+      CHECK(st_max.ok());
+      if (st_max.ok()) {
+        CHECK((*max).size() == sizeof(double));
+
+        double correct_max = 4.9;
+        CHECK(0 == memcmp((*max).data(), &correct_max, (*max).size()));
+      }
+
+      // Validate sum.
+      auto&& [st_sum, sum] = frag_meta[0]->get_sum("a");
+      CHECK(st_sum.ok());
+      if (st_sum.ok()) {
+        double correct_sum = 46.7;
+        CHECK(*(double*)*sum - correct_sum < 0.0001);
+      }
+    }
+
+    // Load attribute metadata.
+    std::vector<std::string> names_min{"a"};
+    st = frag_meta[0]->load_tile_min_values(enc_key, std::move(names_min));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_max{"a"};
+    st = frag_meta[0]->load_tile_max_values(enc_key, std::move(names_max));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_sum{"a"};
+    st = frag_meta[0]->load_tile_sum_values(enc_key, std::move(names_sum));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_null_count{"a"};
+    st = frag_meta[0]->load_tile_null_count_values(
+        enc_key, std::move(names_null_count));
+    CHECK(st.ok());
+
+    std::vector<double> correct_tile_mins = {1.1, 2.1, 3.2, 4.1};
+    std::vector<double> correct_tile_maxs = {1.7, 2.6, 3.8, 4.9};
+    std::vector<double> correct_tile_sums = {5.6, 9.4, 13.9, 17.8};
+
+    // Validate attribute metadta.
+    for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
+      // Validate min.
+      auto&& [st_min, min, min_size] =
+          frag_meta[0]->get_tile_min("a", tile_idx);
+      CHECK(st_min.ok());
+      if (st_min.ok()) {
+        CHECK(*min_size == sizeof(double));
+        CHECK(0 == memcmp(*min, &correct_tile_mins[tile_idx], *min_size));
+      }
+
+      // Validate max.
+      auto&& [st_max, max, max_size] =
+          frag_meta[0]->get_tile_max("a", tile_idx);
+      CHECK(st_max.ok());
+      if (st_max.ok()) {
+        CHECK(*max_size == sizeof(double));
+        CHECK(0 == memcmp(*max, &correct_tile_maxs[tile_idx], *max_size));
+      }
+
+      // Validate sum.
+      auto&& [st_sum, sum] = frag_meta[0]->get_tile_sum("a", tile_idx);
+      CHECK(st_sum.ok());
+      if (st_sum.ok()) {
+        CHECK(*(double*)*sum - correct_tile_sums[tile_idx] < 0.0001);
+      }
+    }
+
+    // Close array.
+    rc = tiledb_array_close(ctx, array);
+    CHECK(rc == TILEDB_OK);
+
+    // Clean up.
+    tiledb_array_free(&array);
+    tiledb_ctx_free(&ctx);
+  }
+
+  const char* ARRAY_NAME = "tile_metadata_unit_array";
+  const uint64_t tile_extent_ = 4;
+  tiledb::Context ctx_;
+  tiledb::VFS vfs_;
+};
+
+TEST_CASE_METHOD(
+    CPPFixedTileMetadataPartialFx,
+    "TileMetadata: partial tile fixed",
+    "[tile-metadata][fixed][partial]") {
+  // Create the array.
+  create_array();
+  write_fragment();
+  check_metadata();
+}
+
+struct CPPVarTileMetadataPartialFx {
+  CPPVarTileMetadataPartialFx()
+      : vfs_(ctx_) {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  ~CPPVarTileMetadataPartialFx() {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  void create_array() {
+    // Create TileDB context
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+
+    // The array will be two dimension "d1" and "d2", with domain [1,8].
+    uint32_t dim_domain[] = {1, 8};
+    tiledb_dimension_t* d1;
+    tiledb_dimension_alloc(
+        ctx, "d1", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d1);
+    tiledb_dimension_t* d2;
+    tiledb_dimension_alloc(
+        ctx, "d2", TILEDB_UINT32, &dim_domain[0], &tile_extent_, &d2);
+
+    // Create domain
+    tiledb_domain_t* domain;
+    tiledb_domain_alloc(ctx, &domain);
+    tiledb_domain_add_dimension(ctx, domain, d1);
+    tiledb_domain_add_dimension(ctx, domain, d2);
+
+    // Create a single attribute "a" so each (i,j) cell can store an integer
+    tiledb_attribute_t* a;
+    tiledb_attribute_alloc(ctx, "a", TILEDB_STRING_ASCII, &a);
+    tiledb_attribute_set_cell_val_num(ctx, a, TILEDB_VAR_NUM);
+
+    // Create array schema
+    tiledb_array_schema_t* array_schema;
+    tiledb_array_schema_alloc(ctx, TILEDB_DENSE, &array_schema);
+    tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+    tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+    tiledb_array_schema_set_domain(ctx, array_schema, domain);
+    tiledb_array_schema_add_attribute(ctx, array_schema, a);
+
+    // Create array
+    tiledb_array_create(ctx, ARRAY_NAME, array_schema);
+
+    // Clean up
+    tiledb_attribute_free(&a);
+    tiledb_dimension_free(&d1);
+    tiledb_dimension_free(&d2);
+    tiledb_domain_free(&domain);
+    tiledb_array_schema_free(&array_schema);
+    tiledb_ctx_free(&ctx);
+  }
+
+  void write_fragment() {
+    // Write to the array.
+    auto array = tiledb::Array(ctx_, ARRAY_NAME, TILEDB_WRITE);
+    auto query = tiledb::Query(ctx_, array, TILEDB_WRITE);
+
+    // Write a 4x4 square intersecting the 4 tiles of the array. Writting a 2x2
+    // square to each tile.
+    Subarray subarray(ctx_, array);
+    uint32_t r[2] = {3, 6};
+    subarray.add_range(0, r[0], r[1]);
+    subarray.add_range(1, r[0], r[1]);
+    query.set_subarray(subarray);
+
+    std::string a = "1.71.12.22.51.51.32.12.63.43.84.14.23.53.24.94.6";
+    std::vector<uint64_t> offsets = {
+        0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45};
+    query.set_layout(TILEDB_ROW_MAJOR);
+    query.set_data_buffer("a", a).set_offsets_buffer("a", offsets);
+
+    query.submit();
+    query.finalize();
+    array.close();
+  }
+
+  void check_metadata() {
+    // Open array.
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+    tiledb_array_t* array;
+    int rc = tiledb_array_alloc(ctx, ARRAY_NAME, &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx, array, TILEDB_READ);
+    CHECK(rc == TILEDB_OK);
+
+    // Load fragment metadata.
+    auto frag_meta = array->array_->fragment_metadata();
+    auto& enc_key = array->array_->get_encryption_key();
+    auto st = frag_meta[0]->load_fragment_min_max_sum_null_count(enc_key);
+    CHECK(st.ok());
+
+    // Do fragment metadata first for attribute.
+    {
+      // Validate min.
+      auto&& [st_min, min] = frag_meta[0]->get_min("a");
+      CHECK(st_min.ok());
+      if (st_min.ok()) {
+        std::string correct_min = "1.1";
+        CHECK((*min).size() == correct_min.size());
+        CHECK(0 == memcmp((*min).data(), correct_min.data(), (*min).size()));
+      }
+
+      // Validate max.
+      auto&& [st_max, max] = frag_meta[0]->get_max("a");
+      CHECK(st_max.ok());
+      if (st_max.ok()) {
+        std::string correct_max = "4.9";
+        CHECK((*max).size() == correct_max.size());
+        CHECK(0 == memcmp((*max).data(), correct_max.data(), (*max).size()));
+      }
+    }
+
+    // Load attribute metadata.
+    std::vector<std::string> names_min{"a"};
+    st = frag_meta[0]->load_tile_min_values(enc_key, std::move(names_min));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_max{"a"};
+    st = frag_meta[0]->load_tile_max_values(enc_key, std::move(names_max));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_sum{"a"};
+    st = frag_meta[0]->load_tile_sum_values(enc_key, std::move(names_sum));
+    CHECK(st.ok());
+
+    std::vector<std::string> names_null_count{"a"};
+    st = frag_meta[0]->load_tile_null_count_values(
+        enc_key, std::move(names_null_count));
+    CHECK(st.ok());
+
+    std::vector<std::string> correct_tile_mins = {"1.1", "2.1", "3.2", "4.1"};
+    std::vector<std::string> correct_tile_maxs = {"1.7", "2.6", "3.8", "4.9"};
+
+    // Validate attribute metadta.
+    for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
+      // Validate min.
+      auto&& [st_min, min, min_size] =
+          frag_meta[0]->get_tile_min("a", tile_idx);
+      CHECK(st_min.ok());
+      if (st_min.ok()) {
+        CHECK(*min_size == correct_tile_mins[tile_idx].size());
+        CHECK(0 == memcmp(*min, correct_tile_mins[tile_idx].data(), *min_size));
+      }
+
+      // Validate max.
+      auto&& [st_max, max, max_size] =
+          frag_meta[0]->get_tile_max("a", tile_idx);
+      CHECK(st_max.ok());
+      if (st_max.ok()) {
+        CHECK(*max_size == correct_tile_maxs[tile_idx].size());
+        CHECK(0 == memcmp(*max, correct_tile_maxs[tile_idx].data(), *max_size));
+      }
+    }
+
+    // Close array.
+    rc = tiledb_array_close(ctx, array);
+    CHECK(rc == TILEDB_OK);
+
+    // Clean up.
+    tiledb_array_free(&array);
+    tiledb_ctx_free(&ctx);
+  }
+
+  const char* ARRAY_NAME = "tile_metadata_unit_array";
+  const uint64_t tile_extent_ = 4;
+  tiledb::Context ctx_;
+  tiledb::VFS vfs_;
+};
+
+TEST_CASE_METHOD(
+    CPPVarTileMetadataPartialFx,
+    "TileMetadata: partial tile var",
+    "[tile-metadata][var][partial]") {
+  // Create the array.
+  create_array();
+  write_fragment();
+  check_metadata();
 }

--- a/tiledb/sm/query/writers/dense_tiler.cc
+++ b/tiledb/sm/query/writers/dense_tiler.cc
@@ -483,8 +483,9 @@ std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
 
   // Get the tile coordinates in the array tile domain
   std::vector<uint64_t> tile_coords_in_dom(dim_num);
-  for (unsigned d = 0; d < dim_num; ++d)
+  for (unsigned d = 0; d < dim_num; ++d) {
     tile_coords_in_dom[d] = tile_coords_in_sub[d] + first_sub_tile_coords_[d];
+  }
 
   // Calculate tile subarray based on the tile coordinates in the domain
   std::vector<std::array<T, 2>> ret(dim_num);
@@ -511,11 +512,13 @@ Status DenseTiler<T>::copy_tile(
   auto tile_offset = copy_plan.tile_start_el_ * cell_size;
   auto copy_nbytes = copy_plan.copy_el_ * cell_size;
   auto sub_strides_nbytes = copy_plan.sub_strides_el_;
-  for (auto& bsn : sub_strides_nbytes)
+  for (auto& bsn : sub_strides_nbytes) {
     bsn *= cell_size;
+  }
   auto tile_strides_nbytes = copy_plan.tile_strides_el_;
-  for (auto& tsn : tile_strides_nbytes)
+  for (auto& tsn : tile_strides_nbytes) {
     tsn *= cell_size;
+  }
   const auto& dim_ranges = copy_plan.dim_ranges_;
   auto first_d = copy_plan.first_d_;
   auto dim_num = (int64_t)dim_ranges.size();
@@ -523,14 +526,17 @@ Status DenseTiler<T>::copy_tile(
 
   // Auxiliary information needed in the copy loop
   std::vector<uint64_t> tile_offsets(dim_num);
-  for (int64_t i = 0; i < dim_num; ++i)
+  for (int64_t i = 0; i < dim_num; ++i) {
     tile_offsets[i] = tile_offset;
+  }
   std::vector<uint64_t> sub_offsets(dim_num);
-  for (int64_t i = 0; i < dim_num; ++i)
+  for (int64_t i = 0; i < dim_num; ++i) {
     sub_offsets[i] = sub_offset;
+  }
   std::vector<uint64_t> cell_coords(dim_num);
-  for (int64_t i = 0; i < dim_num; ++i)
+  for (int64_t i = 0; i < dim_num; ++i) {
     cell_coords[i] = dim_ranges[i][0];
+  }
 
   // Perform the tile copy (always in row-major order)
   auto d = dim_num - 1;
@@ -543,15 +549,17 @@ Status DenseTiler<T>::copy_tile(
     auto last_dim_changed = d;
     for (; last_dim_changed >= 0; --last_dim_changed) {
       ++cell_coords[last_dim_changed];
-      if (cell_coords[last_dim_changed] > dim_ranges[last_dim_changed][1])
+      if (cell_coords[last_dim_changed] > dim_ranges[last_dim_changed][1]) {
         cell_coords[last_dim_changed] = dim_ranges[last_dim_changed][0];
-      else
+      } else {
         break;
+      }
     }
 
     // Check if copy loop is done
-    if (last_dim_changed < 0)
+    if (last_dim_changed < 0) {
       break;
+    }
 
     // Update the offsets
     tile_offsets[last_dim_changed] +=
@@ -592,11 +600,13 @@ Status DenseTiler<T>::compute_tile_metadata(
 
   // Auxiliary information needed in the copy loop
   std::vector<uint64_t> tile_offsets(dim_num);
-  for (int64_t i = 0; i < dim_num; ++i)
+  for (int64_t i = 0; i < dim_num; ++i) {
     tile_offsets[i] = tile_offset;
+  }
   std::vector<uint64_t> cell_coords(dim_num);
-  for (int64_t i = 0; i < dim_num; ++i)
+  for (int64_t i = 0; i < dim_num; ++i) {
     cell_coords[i] = dim_ranges[i][0];
+  }
 
   // Perform the tile copy (always in row-major order)
   auto d = dim_num - 1;
@@ -609,15 +619,17 @@ Status DenseTiler<T>::compute_tile_metadata(
     auto last_dim_changed = d;
     for (; last_dim_changed >= 0; --last_dim_changed) {
       ++cell_coords[last_dim_changed];
-      if (cell_coords[last_dim_changed] > dim_ranges[last_dim_changed][1])
+      if (cell_coords[last_dim_changed] > dim_ranges[last_dim_changed][1]) {
         cell_coords[last_dim_changed] = dim_ranges[last_dim_changed][0];
-      else
+      } else {
         break;
+      }
     }
 
     // Check if copy loop is done
-    if (last_dim_changed < 0)
+    if (last_dim_changed < 0) {
       break;
+    }
 
     // Update the offsets
     tile_offsets[last_dim_changed] +=
@@ -627,7 +639,7 @@ Status DenseTiler<T>::compute_tile_metadata(
     }
   }
 
-  md_generator.finalize();
+  md_generator.set_tile_metadata();
   return Status::Ok();
 }
 

--- a/tiledb/sm/query/writers/dense_tiler.cc
+++ b/tiledb/sm/query/writers/dense_tiler.cc
@@ -587,7 +587,7 @@ Status DenseTiler<T>::compute_tile_metadata(
   const auto cell_size = array_schema_.cell_size(name);
   const auto cell_val_num = array_schema_.cell_val_num(name);
   TileMetadataGenerator md_generator(
-      tile, type, is_dim, var, cell_size, cell_val_num);
+      type, is_dim, var, cell_size, cell_val_num);
 
   // For easy reference
   auto tile_offset = copy_plan.tile_start_el_;
@@ -613,7 +613,7 @@ Status DenseTiler<T>::compute_tile_metadata(
   while (true) {
     // Copy a slab
     md_generator.process_cell_slab(
-        tile_offsets[d], tile_offsets[d] + copy_plan.copy_el_);
+        tile, tile_offsets[d], tile_offsets[d] + copy_plan.copy_el_);
 
     // Advance cell coordinates, tile and buffer offsets
     auto last_dim_changed = d;
@@ -639,7 +639,7 @@ Status DenseTiler<T>::compute_tile_metadata(
     }
   }
 
-  md_generator.set_tile_metadata();
+  md_generator.set_tile_metadata(tile);
   return Status::Ok();
 }
 

--- a/tiledb/sm/query/writers/dense_tiler.h
+++ b/tiledb/sm/query/writers/dense_tiler.h
@@ -319,6 +319,19 @@ class DenseTiler {
    */
   Status copy_tile(
       uint64_t id, uint64_t cell_size, uint8_t* buff, Tile& tile) const;
+
+  /**
+   * Computes the tile metadata according to the copy plan.
+   *
+   * @param name The name of the dimension/attribute.
+   * @param id The id of the tile within the subarray to be retrieved. The id
+   *    is serialied in the tile order of the array domain.
+   * @param tile The tile to compute the metadata for. The tile needs to be
+   *    filled in.
+   * @return Status
+   */
+  Status compute_tile_metadata(
+      const std::string& name, uint64_t id, WriterTile& tile) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -328,10 +328,8 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
 
   // For easy reference
   const auto type = array_schema_.type(name);
-  const auto is_dim = array_schema_.is_dim(name);
   const bool var = array_schema_.var_size(name);
   const auto cell_size = array_schema_.cell_size(name);
-  const auto cell_val_num = array_schema_.cell_val_num(name);
   const bool nullable = array_schema_.is_nullable(name);
 
   // Initialization
@@ -363,12 +361,8 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
         storage_manager_->compute_tp(), 0, batch_size, [&](uint64_t i) {
           // Prepare and filter tiles
           auto& writer_tile = tile_batches[b][i];
-          TileMetadataGenerator md_generator(
-              type, is_dim, var, cell_size, cell_val_num);
-
           RETURN_NOT_OK(
               dense_tiler->get_tile(frag_tile_id + i, name, writer_tile));
-          md_generator.process_tile(writer_tile);
 
           if (!var) {
             RETURN_NOT_OK(filter_tile(

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -587,8 +587,9 @@ Status WriterBase::compute_tiles_metadata(
       const auto cell_val_num = array_schema_.cell_val_num(attr);
       for (auto& tile : attr_tiles) {
         TileMetadataGenerator md_generator(
-            tile, type, is_dim, var_size, cell_size, cell_val_num);
-        md_generator.process_full_tile();
+            type, is_dim, var_size, cell_size, cell_val_num);
+        md_generator.process_full_tile(tile);
+        md_generator.set_tile_metadata(tile);
       }
 
       return Status::Ok();
@@ -605,8 +606,9 @@ Status WriterBase::compute_tiles_metadata(
       const auto cell_val_num = array_schema_.cell_val_num(attr);
       auto st = parallel_for(compute_tp, 0, tile_num, [&](uint64_t t) {
         TileMetadataGenerator md_generator(
-            attr_tiles[t], type, is_dim, var_size, cell_size, cell_val_num);
-        md_generator.process_full_tile();
+            type, is_dim, var_size, cell_size, cell_val_num);
+        md_generator.process_full_tile(attr_tiles[t]);
+        md_generator.set_tile_metadata(attr_tiles[t]);
 
         return Status::Ok();
       });

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -585,10 +585,10 @@ Status WriterBase::compute_tiles_metadata(
       const auto var_size = array_schema_.var_size(attr);
       const auto cell_size = array_schema_.cell_size(attr);
       const auto cell_val_num = array_schema_.cell_val_num(attr);
-      TileMetadataGenerator md_generator(
-          type, is_dim, var_size, cell_size, cell_val_num);
       for (auto& tile : attr_tiles) {
-        md_generator.process_tile(tile);
+        TileMetadataGenerator md_generator(
+            tile, type, is_dim, var_size, cell_size, cell_val_num);
+        md_generator.process_full_tile();
       }
 
       return Status::Ok();
@@ -605,8 +605,8 @@ Status WriterBase::compute_tiles_metadata(
       const auto cell_val_num = array_schema_.cell_val_num(attr);
       auto st = parallel_for(compute_tp, 0, tile_num, [&](uint64_t t) {
         TileMetadataGenerator md_generator(
-            type, is_dim, var_size, cell_size, cell_val_num);
-        md_generator.process_tile(attr_tiles[t]);
+            attr_tiles[t], type, is_dim, var_size, cell_size, cell_val_num);
+        md_generator.process_full_tile();
 
         return Status::Ok();
       });

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -104,7 +104,7 @@ Subarray::Subarray(
     StorageManager* storage_manager)
     : stats_(
           parent_stats ? parent_stats->create_child("Subarray") :
-          storage_manager ?
+                         storage_manager ?
                          storage_manager->stats()->create_child("subSubarray") :
                          nullptr)
     , logger_(logger->clone("Subarray", ++logger_id_))
@@ -2740,6 +2740,7 @@ Subarray Subarray::clone() const {
   clone.is_default_ = is_default_;
   clone.range_offsets_ = range_offsets_;
   clone.label_range_subset_ = label_range_subset_;
+  clone.attr_range_subset_ = attr_range_subset_;
   clone.tile_overlap_ = tile_overlap_;
   clone.est_result_size_computed_ = est_result_size_computed_;
   clone.coalesce_ranges_ = coalesce_ranges_;
@@ -2885,6 +2886,7 @@ void Subarray::swap(Subarray& subarray) {
   std::swap(cell_order_, subarray.cell_order_);
   std::swap(range_subset_, subarray.range_subset_);
   std::swap(label_range_subset_, subarray.label_range_subset_);
+  std::swap(attr_range_subset_, subarray.attr_range_subset_);
   std::swap(is_default_, subarray.is_default_);
   std::swap(range_offsets_, subarray.range_offsets_);
   std::swap(tile_overlap_, subarray.tile_overlap_);

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -43,17 +43,14 @@ namespace sm {
 /* ****************************** */
 
 template <typename T>
-ByteVec Sum<T, int64_t>::sum(const Tile& tile) {
-  // Zero sum.
-  ByteVec ret(8, 0);
-
+void Sum<T, int64_t>::sum(
+    const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
-  auto cell_num = tile.size_as<T>();
-  auto sum_data = reinterpret_cast<int64_t*>(ret.data());
+  auto sum_data = reinterpret_cast<int64_t*>(sum.data());
 
   // Process cell by cell, swallowing overflow exception.
-  for (uint64_t c = 0; c < cell_num; c++) {
+  for (uint64_t c = start; c < end; c++) {
     auto value = static_cast<int64_t>(values[c]);
     if (*sum_data > 0 && value > 0 &&
         (*sum_data > std::numeric_limits<int64_t>::max() - value)) {
@@ -69,22 +66,17 @@ ByteVec Sum<T, int64_t>::sum(const Tile& tile) {
 
     *sum_data += value;
   }
-
-  return ret;
 }
 
 template <typename T>
-ByteVec Sum<T, uint64_t>::sum(const Tile& tile) {
-  // Zero sum.
-  ByteVec ret(8, 0);
-
+void Sum<T, uint64_t>::sum(
+    const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
-  auto cell_num = tile.size_as<T>();
-  auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
+  auto sum_data = reinterpret_cast<uint64_t*>(sum.data());
 
   // Process cell by cell, swallowing overflow exception.
-  for (uint64_t c = 0; c < cell_num; c++) {
+  for (uint64_t c = start; c < end; c++) {
     auto value = static_cast<uint64_t>(values[c]);
     if (*sum_data > std::numeric_limits<uint64_t>::max() - value) {
       *sum_data = std::numeric_limits<uint64_t>::max();
@@ -93,22 +85,17 @@ ByteVec Sum<T, uint64_t>::sum(const Tile& tile) {
 
     *sum_data += value;
   }
-
-  return ret;
 }
 
 template <typename T>
-ByteVec Sum<T, double>::sum(const Tile& tile) {
-  // Zero sum.
-  ByteVec ret(8, 0);
-
+void Sum<T, double>::sum(
+    const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
-  auto cell_num = tile.size_as<T>();
-  auto sum_data = reinterpret_cast<double*>(ret.data());
+  auto sum_data = reinterpret_cast<double*>(sum.data());
 
   // Process cell by cell, swallowing overflow exception.
-  for (uint64_t c = 0; c < cell_num; c++) {
+  for (uint64_t c = start; c < end; c++) {
     auto value = static_cast<double>(values[c]);
     if ((*sum_data < 0.0) == (value < 0.0) &&
         std::abs(*sum_data) >
@@ -120,24 +107,22 @@ ByteVec Sum<T, double>::sum(const Tile& tile) {
 
     *sum_data += value;
   }
-
-  return ret;
 }
 
 template <typename T>
-ByteVec Sum<T, int64_t>::sum_nullable(
-    const Tile& tile, const Tile& validity_tile) {
-  // Zero sum.
-  ByteVec ret(8, 0);
-
+void Sum<T, int64_t>::sum_nullable(
+    const Tile& tile,
+    const Tile& validity_tile,
+    uint64_t start,
+    uint64_t end,
+    ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
   auto validity_values = validity_tile.data_as<uint8_t>();
-  auto cell_num = tile.size_as<T>();
-  auto sum_data = reinterpret_cast<int64_t*>(ret.data());
+  auto sum_data = reinterpret_cast<int64_t*>(sum.data());
 
   // Process cell by cell, swallowing overflow exception.
-  for (uint64_t c = 0; c < cell_num; c++) {
+  for (uint64_t c = start; c < end; c++) {
     if (validity_values[c] != 0) {
       auto value = static_cast<int64_t>(values[c]);
       if (*sum_data > 0 && value > 0 &&
@@ -155,24 +140,22 @@ ByteVec Sum<T, int64_t>::sum_nullable(
       *sum_data += value;
     }
   }
-
-  return ret;
 }
 
 template <typename T>
-ByteVec Sum<T, uint64_t>::sum_nullable(
-    const Tile& tile, const Tile& validity_tile) {
-  // Zero sum.
-  ByteVec ret(8, 0);
-
+void Sum<T, uint64_t>::sum_nullable(
+    const Tile& tile,
+    const Tile& validity_tile,
+    uint64_t start,
+    uint64_t end,
+    ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
   auto validity_values = validity_tile.data_as<uint8_t>();
-  auto cell_num = tile.size_as<T>();
-  auto sum_data = reinterpret_cast<uint64_t*>(ret.data());
+  auto sum_data = reinterpret_cast<uint64_t*>(sum.data());
 
   // Process cell by cell, swallowing overflow exception.
-  for (uint64_t c = 0; c < cell_num; c++) {
+  for (uint64_t c = start; c < end; c++) {
     if (validity_values[c] != 0) {
       auto value = static_cast<uint64_t>(values[c]);
       if (*sum_data > std::numeric_limits<uint64_t>::max() - value) {
@@ -183,24 +166,22 @@ ByteVec Sum<T, uint64_t>::sum_nullable(
       *sum_data += value;
     }
   }
-
-  return ret;
 }
 
 template <typename T>
-ByteVec Sum<T, double>::sum_nullable(
-    const Tile& tile, const Tile& validity_tile) {
-  // Zero sum.
-  ByteVec ret(8, 0);
-
+void Sum<T, double>::sum_nullable(
+    const Tile& tile,
+    const Tile& validity_tile,
+    uint64_t start,
+    uint64_t end,
+    ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
   auto validity_values = validity_tile.data_as<uint8_t>();
-  auto cell_num = tile.size_as<T>();
-  auto sum_data = reinterpret_cast<double*>(ret.data());
+  auto sum_data = reinterpret_cast<double*>(sum.data());
 
   // Process cell by cell, swallowing overflow exception.
-  for (uint64_t c = 0; c < cell_num; c++) {
+  for (uint64_t c = start; c < end; c++) {
     if (validity_values[c] != 0) {
       auto value = static_cast<double>(values[c]);
       if ((*sum_data < 0.0) == (value < 0.0) &&
@@ -214,8 +195,6 @@ ByteVec Sum<T, double>::sum_nullable(
       *sum_data += value;
     }
   }
-
-  return ret;
 }
 
 /* ****************************** */
@@ -282,178 +261,76 @@ bool TileMetadataGenerator::has_sum_metadata(
   }
 }
 
-template <class T>
-const tuple<void*, void*> TileMetadataGenerator::min_max(
-    const Tile& tile, const uint64_t cell_size) {
-  // Initialize defaults.
-  void* min = (void*)&metadata_generator_type_data<T>::min;
-  void* max = (void*)&metadata_generator_type_data<T>::max;
-
-  // Get pointer to the data and cell num.
-  auto values = tile.data_as<T>();
-  auto cell_num = tile.size() / cell_size;
-
-  // Process cell by cell.
-  for (uint64_t c = 0; c < cell_num; c++) {
-    min = *static_cast<T*>(min) < values[c] ? min : &values[c];
-    max = *static_cast<T*>(max) > values[c] ? max : &values[c];
-  }
-
-  return {min, max};
-}
-
-template <>
-const tuple<void*, void*> TileMetadataGenerator::min_max<char>(
-    const Tile& tile, const uint64_t cell_size) {
-  // For strings, return null for empty tiles.
-  auto size = tile.size();
-  if (size == 0)
-    return {nullptr, nullptr};
-
-  // Get pointer to the data, set the min max to the first value.
-  auto data = tile.data_as<char>();
-  void* min = data;
-  void* max = data;
-
-  // Process all cells, starting at the second value.
-  auto value = data + cell_size;
-  auto cell_num = size / cell_size;
-  for (uint64_t c = 1; c < cell_num; c++) {
-    min = strncmp((const char*)min, (const char*)value, size) > 0 ? value : min;
-    max = strncmp((const char*)max, (const char*)value, size) < 0 ? value : max;
-    value += cell_size;
-  }
-
-  return {min, max};
-}
-
-template <class T>
-const tuple<void*, void*, uint64_t> TileMetadataGenerator::min_max_nullable(
-    const Tile& tile, const Tile& validity_tile, const uint64_t cell_size) {
-  // Initialize defaults.
-  void* min = (void*)&metadata_generator_type_data<T>::min;
-  void* max = (void*)&metadata_generator_type_data<T>::max;
-  uint64_t null_count = 0;
-
-  // Get pointers to the data and cell num.
-  auto values = tile.data_as<T>();
-  auto validity_values = validity_tile.data_as<uint8_t>();
-  auto cell_num = tile.size() / cell_size;
-
-  // Process cell by cell.
-  for (uint64_t c = 0; c < cell_num; c++) {
-    const bool is_null = validity_values[c] == 0;
-    min = (is_null || (*static_cast<T*>(min) < values[c])) ? min : &values[c];
-    max = (is_null || (*static_cast<T*>(max) > values[c])) ? max : &values[c];
-    null_count += is_null;
-  }
-
-  return {min, max, null_count};
-}
-
-template <>
-const tuple<void*, void*, uint64_t>
-TileMetadataGenerator::min_max_nullable<char>(
-    const Tile& tile, const Tile& validity_tile, const uint64_t cell_size) {
-  // Initialize to null.
-  void* min = nullptr;
-  void* max = nullptr;
-  uint64_t null_count = 0;
-
-  // Get pointers to the data and cell num.
-  auto value = tile.data_as<char>();
-  auto validity_values = validity_tile.data_as<uint8_t>();
-  auto cell_num = tile.size() / cell_size;
-
-  // Process cell by cell.
-  for (uint64_t c = 0; c < cell_num; c++) {
-    const bool is_null = validity_values[c] == 0;
-    min =
-        !is_null &&
-                (min == nullptr ||
-                 strncmp((const char*)min, (const char*)value, cell_size) > 0) ?
-            value :
-            min;
-    max =
-        !is_null &&
-                (max == nullptr ||
-                 strncmp((const char*)max, (const char*)value, cell_size) < 0) ?
-            value :
-            max;
-    value += cell_size;
-    null_count += is_null;
-  }
-
-  return {min, max, null_count};
-}
-
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
 TileMetadataGenerator::TileMetadataGenerator(
+    WriterTile& tile,
     const Datatype type,
     const bool is_dim,
     const bool var_size,
     const uint64_t cell_size,
     const uint64_t cell_val_num)
-    : type_(type)
+    : tile_(tile)
+    , var_size_(var_size)
+    , nullable_(tile.nullable())
+    , type_(type)
     , min_(nullptr)
     , min_size_(0)
     , max_(nullptr)
     , max_size_(0)
+    , sum_(sizeof(uint64_t))
     , null_count_(0)
-    , cell_size_(cell_size) {
-  has_min_max_ = has_min_max_metadata(type, is_dim, var_size, cell_val_num);
-  has_sum_ = has_sum_metadata(type, var_size, cell_val_num);
-
-  sum_.resize(sizeof(uint64_t));
+    , cell_size_(cell_size)
+    , has_min_max_(has_min_max_metadata(type, is_dim, var_size, cell_val_num))
+    , has_sum_(has_sum_metadata(type, var_size, cell_val_num)) {
 }
 
 /* ****************************** */
 /*               API              */
 /* ****************************** */
 
-void TileMetadataGenerator::process_tile(WriterTile& tile) {
-  min_ = nullptr;
-  min_size_ = 0;
-  max_ = nullptr;
-  max_size_ = 0;
-  null_count_ = 0;
+void TileMetadataGenerator::process_full_tile() {
+  uint64_t cell_num = tile_.cell_num();
+  process_cell_slab(0, cell_num);
+  finalize();
+}
 
-  if (!tile.var_size()) {
+void TileMetadataGenerator::process_cell_slab(uint64_t start, uint64_t end) {
+  if (!var_size_) {
     // Switch depending on datatype.
     switch (type_) {
       case Datatype::INT8:
-        process_tile<int8_t>(tile);
+        process_cell_range<int8_t>(start, end);
         break;
       case Datatype::INT16:
-        process_tile<int16_t>(tile);
+        process_cell_range<int16_t>(start, end);
         break;
       case Datatype::INT32:
-        process_tile<int32_t>(tile);
+        process_cell_range<int32_t>(start, end);
         break;
       case Datatype::INT64:
-        process_tile<int64_t>(tile);
+        process_cell_range<int64_t>(start, end);
         break;
       case Datatype::BOOL:
       case Datatype::UINT8:
-        process_tile<uint8_t>(tile);
+        process_cell_range<uint8_t>(start, end);
         break;
       case Datatype::UINT16:
-        process_tile<uint16_t>(tile);
+        process_cell_range<uint16_t>(start, end);
         break;
       case Datatype::UINT32:
-        process_tile<uint32_t>(tile);
+        process_cell_range<uint32_t>(start, end);
         break;
       case Datatype::UINT64:
-        process_tile<uint64_t>(tile);
+        process_cell_range<uint64_t>(start, end);
         break;
       case Datatype::FLOAT32:
-        process_tile<float>(tile);
+        process_cell_range<float>(start, end);
         break;
       case Datatype::FLOAT64:
-        process_tile<double>(tile);
+        process_cell_range<double>(start, end);
         break;
       case Datatype::DATETIME_YEAR:
       case Datatype::DATETIME_MONTH:
@@ -477,21 +354,25 @@ void TileMetadataGenerator::process_tile(WriterTile& tile) {
       case Datatype::TIME_PS:
       case Datatype::TIME_FS:
       case Datatype::TIME_AS:
-        process_tile<int64_t>(tile);
+        process_cell_range<int64_t>(start, end);
         break;
       case Datatype::STRING_ASCII:
       case Datatype::CHAR:
-        process_tile<char>(tile);
+        process_cell_range<char>(start, end);
         break;
       case Datatype::BLOB:
-        process_tile<std::byte>(tile);
+        process_cell_range<std::byte>(start, end);
         break;
       default:
         break;
     }
   } else {
-    process_tile_var(tile);
+    process_cell_range_var(start, end);
   }
+}
+
+void TileMetadataGenerator::finalize() {
+  tile_.set_metadata(min_, min_size_, max_, max_size_, sum_, null_count_);
 }
 
 /* ****************************** */
@@ -499,33 +380,123 @@ void TileMetadataGenerator::process_tile(WriterTile& tile) {
 /* ****************************** */
 
 template <class T>
-void TileMetadataGenerator::process_tile(WriterTile& tile) {
+void TileMetadataGenerator::min_max(
+    const Tile& tile, uint64_t start, uint64_t end) {
+  // Get pointer to the data and cell num.
+  auto values = tile.data_as<T>();
+
+  // Initialize defaults.
+  if (min_ == nullptr) {
+    min_ = static_cast<const void*>(&metadata_generator_type_data<T>::min);
+    max_ = static_cast<const void*>(&metadata_generator_type_data<T>::max);
+  }
+
+  // Process cell by cell.
+  for (uint64_t c = start; c < end; c++) {
+    min_ = *static_cast<const T*>(min_) < values[c] ? min_ : &values[c];
+    max_ = *static_cast<const T*>(max_) > values[c] ? max_ : &values[c];
+  }
+}
+
+template <>
+void TileMetadataGenerator::min_max<char>(
+    const Tile& tile, uint64_t start, uint64_t end) {
+  // For strings, return null for empty tiles.
+  auto size = tile.size();
+  if (size == 0) {
+    return;
+  }
+
+  // Get pointer to the data, set the min max to the first value.
+  auto data = tile.data_as<char>();
+  if (min_ == nullptr) {
+    min_ = data + start * cell_size_;
+    max_ = data + start * cell_size_;
+  }
+
+  // Process all cells, starting at the second value.
+  auto value = data + start * cell_size_;
+  for (uint64_t c = start; c < end; c++) {
+    min_ =
+        strncmp((const char*)min_, (const char*)value, size) > 0 ? value : min_;
+    max_ =
+        strncmp((const char*)max_, (const char*)value, size) < 0 ? value : max_;
+    value += cell_size_;
+  }
+}
+
+template <class T>
+void TileMetadataGenerator::min_max_nullable(
+    const Tile& tile, const Tile& validity_tile, uint64_t start, uint64_t end) {
+  auto values = tile.data_as<T>();
+  auto validity_values = validity_tile.data_as<uint8_t>();
+
+  // Initialize defaults.
+  if (min_ == nullptr) {
+    min_ = (void*)&metadata_generator_type_data<T>::min;
+    max_ = (void*)&metadata_generator_type_data<T>::max;
+  }
+
+  // Process cell by cell.
+  for (uint64_t c = start; c < end; c++) {
+    const bool is_null = validity_values[c] == 0;
+    min_ = (is_null || (*static_cast<const T*>(min_) < values[c])) ? min_ :
+                                                                     &values[c];
+    max_ = (is_null || (*static_cast<const T*>(max_) > values[c])) ? max_ :
+                                                                     &values[c];
+    null_count_ += is_null;
+  }
+}
+
+template <>
+void TileMetadataGenerator::min_max_nullable<char>(
+    const Tile& tile, const Tile& validity_tile, uint64_t start, uint64_t end) {
+  // Get pointers to the data and cell num.
+  auto value = tile.data_as<char>();
+  auto validity_values = validity_tile.data_as<uint8_t>();
+
+  // Process cell by cell.
+  for (uint64_t c = start; c < end; c++) {
+    const bool is_null = validity_values[c] == 0;
+    min_ = !is_null &&
+                   (min_ == nullptr ||
+                    strncmp((const char*)min_, (const char*)value, cell_size_) >
+                        0) ?
+               value :
+               min_;
+    max_ = !is_null &&
+                   (max_ == nullptr ||
+                    strncmp((const char*)max_, (const char*)value, cell_size_) <
+                        0) ?
+               value :
+               max_;
+    value += cell_size_;
+    null_count_ += is_null;
+  }
+}
+
+template <class T>
+void TileMetadataGenerator::process_cell_range(uint64_t start, uint64_t end) {
   min_size_ = max_size_ = cell_size_;
-  const auto& fixed_tile = tile.fixed_tile();
+  const auto& fixed_tile = tile_.fixed_tile();
 
   // Fixed size attribute, non nullable
-  if (!tile.nullable()) {
+  if (!nullable_) {
     if (has_min_max_) {
-      auto&& [min, max] = min_max<T>(fixed_tile, cell_size_);
-      min_ = min;
-      max_ = max;
+      min_max<T>(fixed_tile, start, end);
     }
 
     if (has_sum_) {
-      sum_ = Sum<T, typename metadata_generator_type_data<T>::sum_type>::sum(
-          fixed_tile);
+      Sum<T, typename metadata_generator_type_data<T>::sum_type>::sum(
+          fixed_tile, start, end, sum_);
     }
   } else {  // Fixed size attribute, nullable.
-    const auto& validity_tile = tile.validity_tile();
+    const auto& validity_tile = tile_.validity_tile();
     auto validity_value = validity_tile.data_as<uint8_t>();
     if (has_min_max_) {
-      auto&& [min, max, nc] =
-          min_max_nullable<T>(fixed_tile, validity_tile, cell_size_);
-      min_ = min;
-      max_ = max;
-      null_count_ = nc;
+      min_max_nullable<T>(fixed_tile, validity_tile, start, end);
     } else {
-      auto cell_num = tile.cell_num();
+      auto cell_num = tile_.cell_num();
       for (uint64_t c = 0; c < cell_num; c++) {
         auto is_null = *validity_value == 0;
         null_count_ += (uint64_t)is_null;
@@ -534,39 +505,42 @@ void TileMetadataGenerator::process_tile(WriterTile& tile) {
     }
 
     if (has_sum_) {
-      sum_ = Sum<T, typename metadata_generator_type_data<T>::sum_type>::
-          sum_nullable(fixed_tile, validity_tile);
+      Sum<T, typename metadata_generator_type_data<T>::sum_type>::sum_nullable(
+          fixed_tile, validity_tile, start, end, sum_);
     }
   }
-
-  tile.set_metadata(min_, min_size_, max_, max_size_, sum_, null_count_);
 }
 
-void TileMetadataGenerator::process_tile_var(WriterTile& tile) {
-  assert(tile.var_size());
+void TileMetadataGenerator::process_cell_range_var(
+    uint64_t start, uint64_t end) {
+  assert(tile_.var_size());
 
-  const auto& offset_tile = tile.offset_tile();
-  const auto& var_tile = tile.var_tile();
+  const auto& offset_tile = tile_.offset_tile();
+  const auto& var_tile = tile_.var_tile();
 
   // Handle empty tile.
   if (!has_min_max_ || offset_tile.size() == 0) {
-    tile.set_metadata(min_, min_size_, max_, max_size_, sum_, null_count_);
     return;
   }
 
   // Get pointers to the data and cell num.
-  auto offset_value = offset_tile.data_as<uint64_t>();
+  auto offset_value = offset_tile.data_as<uint64_t>() + start;
   auto var_data = var_tile.data_as<char>();
-  auto cell_num = tile.cell_num();
+  auto cell_num = tile_.cell_num();
 
   // Var size attribute, non nullable.
-  if (!tile.nullable()) {
-    offset_value++;
-    min_ = var_data;
-    max_ = var_data;
-    min_size_ = max_size_ = cell_num == 1 ? var_tile.size() : *offset_value;
+  if (!nullable_) {
+    if (min_ == nullptr) {
+      min_ = &var_data[*offset_value];
+      max_ = &var_data[*offset_value];
+      min_size_ = max_size_ = start == cell_num - 1 ?
+                                  var_tile.size() - *offset_value :
+                                  offset_value[1] - *offset_value;
+      offset_value++;
+      start++;
+    }
 
-    for (uint64_t c = 1; c < cell_num; c++) {
+    for (uint64_t c = start; c < end; c++) {
       auto value = var_data + *offset_value;
       auto size = c == cell_num - 1 ? var_tile.size() - *offset_value :
                                       offset_value[1] - *offset_value;
@@ -574,10 +548,10 @@ void TileMetadataGenerator::process_tile_var(WriterTile& tile) {
       offset_value++;
     }
   } else {  // Var size attribute, nullable.
-    const auto& validity_tile = tile.validity_tile();
+    const auto& validity_tile = tile_.validity_tile();
     auto validity_value = validity_tile.data_as<uint8_t>();
 
-    for (uint64_t c = 0; c < cell_num; c++) {
+    for (uint64_t c = start; c < end; c++) {
       auto is_null = *validity_value == 0;
       if (!is_null) {
         auto value = var_data + *offset_value;
@@ -598,8 +572,6 @@ void TileMetadataGenerator::process_tile_var(WriterTile& tile) {
       validity_value++;
     }
   }
-
-  tile.set_metadata(min_, min_size_, max_, max_size_, sum_, null_count_);
 }
 
 inline void TileMetadataGenerator::min_max_var(

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -294,7 +294,7 @@ TileMetadataGenerator::TileMetadataGenerator(
 void TileMetadataGenerator::process_full_tile() {
   uint64_t cell_num = tile_.cell_num();
   process_cell_slab(0, cell_num);
-  finalize();
+  set_tile_metadata();
 }
 
 void TileMetadataGenerator::process_cell_slab(uint64_t start, uint64_t end) {
@@ -371,7 +371,7 @@ void TileMetadataGenerator::process_cell_slab(uint64_t start, uint64_t end) {
   }
 }
 
-void TileMetadataGenerator::finalize() {
+void TileMetadataGenerator::set_tile_metadata() {
   tile_.set_metadata(min_, min_size_, max_, max_size_, sum_, null_count_);
 }
 
@@ -412,6 +412,7 @@ void TileMetadataGenerator::min_max<char>(
   if (min_ == nullptr) {
     min_ = data + start * cell_size_;
     max_ = data + start * cell_size_;
+    start++;
   }
 
   // Process all cells, starting at the second value.

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -53,7 +53,7 @@ class WriterTile;
 template <typename T, typename SUM_T>
 struct Sum {
   /**
-   * Compute the sum of a tile.
+   * Add the cells from [start, end[ to the current sum.
    *
    * @param tile Fixed data tile.
    * @param start Start cell index.
@@ -63,7 +63,7 @@ struct Sum {
   static void sum(Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
 
   /**
-   * Compute the sum of a nullable tile.
+   * Add the cells from [start, end[ to the current sum for a nullable tile.
    *
    * @param tile Fixed data tile.
    * @param tile_validity Validity tile.
@@ -222,7 +222,7 @@ class TileMetadataGenerator {
   /**
    * Copies the metadata to the tile once done processing slabs.
    */
-  void finalize();
+  void set_tile_metadata();
 
  private:
   /* ********************************* */

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -63,7 +63,8 @@ struct Sum {
   static void sum(Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
 
   /**
-   * Add the sum cells of from [start, end] to the current sum for a nullable tile.
+   * Add the sum cells of from [start, end] to the current sum for a nullable
+   * tile.
    *
    * @param tile Fixed data tile.
    * @param tile_validity Validity tile.
@@ -282,14 +283,12 @@ class TileMetadataGenerator {
   void min_max(const Tile& tile, uint64_t start, uint64_t end);
 
   /**
-   * Returns the min and max of a fixed data tile with nullable values.
+   * Updates the min and max of a fixed data tile with nullable values.
    *
    * @param tile Tile to process.
    * @param tile_validity Validity tile.
    * @param start Start cell index.
    * @param end End cell index.
-   *
-   * @return minimum, maximum, null count.
    */
   template <class T>
   void min_max_nullable(

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -56,16 +56,27 @@ struct Sum {
    * Compute the sum of a tile.
    *
    * @param tile Fixed data tile.
+   * @param start Start cell index.
+   * @param end End cell index.
+   * @param sum The current sum.
    */
-  static ByteVec sum(Tile& tile);
+  static void sum(Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
 
   /**
    * Compute the sum of a nullable tile.
    *
    * @param tile Fixed data tile.
    * @param tile_validity Validity tile.
+   * @param start Start cell index.
+   * @param end End cell index.
+   * @param sum The current sum.
    */
-  static ByteVec sum_nullable(const Tile& tile, const Tile& tile_validity);
+  static void sum_nullable(
+      const Tile& tile,
+      const Tile& tile_validity,
+      uint64_t start,
+      uint64_t end,
+      ByteVec& sum);
 };
 
 /**
@@ -73,8 +84,13 @@ struct Sum {
  */
 template <typename T>
 struct Sum<T, int64_t> {
-  static ByteVec sum(const Tile& tile);
-  static ByteVec sum_nullable(const Tile& tile, const Tile& tile_validity);
+  static void sum(const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum_nullable(
+      const Tile& tile,
+      const Tile& tile_validity,
+      uint64_t start,
+      uint64_t end,
+      ByteVec& sum);
 };
 
 /**
@@ -82,8 +98,13 @@ struct Sum<T, int64_t> {
  */
 template <typename T>
 struct Sum<T, uint64_t> {
-  static ByteVec sum(const Tile& tile);
-  static ByteVec sum_nullable(const Tile& tile, const Tile& tile_validity);
+  static void sum(const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum_nullable(
+      const Tile& tile,
+      const Tile& tile_validity,
+      uint64_t start,
+      uint64_t end,
+      ByteVec& sum);
 };
 
 /**
@@ -91,8 +112,13 @@ struct Sum<T, uint64_t> {
  */
 template <typename T>
 struct Sum<T, double> {
-  static ByteVec sum(const Tile& tile);
-  static ByteVec sum_nullable(const Tile& tile, const Tile& tile_validity);
+  static void sum(const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum_nullable(
+      const Tile& tile,
+      const Tile& tile_validity,
+      uint64_t start,
+      uint64_t end,
+      ByteVec& sum);
 };
 
 // Declare static values to point to min/max default values.
@@ -158,38 +184,12 @@ class TileMetadataGenerator {
   static bool has_sum_metadata(
       const Datatype type, const bool var_size, const uint64_t cell_val_num);
 
-  /**
-   * Returns the min and max of a fixed data tile.
-   *
-   * @param type_data Type data struct.
-   * @param tile Tile to process.
-   * @param cell_size Cell size.
-   *
-   * @return minimum, maximum.
-   */
-  template <class T>
-  static const tuple<void*, void*> min_max(
-      const Tile& tile, const uint64_t cell_size);
-
-  /**
-   * Returns the min and max of a fixed data tile with nullable values.
-   *
-   * @param type_data Type data struct.
-   * @param tile Tile to process.
-   * @param tile_validity Validity tile.
-   * @param cell_size Cell size.
-   *
-   * @return minimum, maximum, null count.
-   */
-  template <class T>
-  static const tuple<void*, void*, uint64_t> min_max_nullable(
-      const Tile& tile, const Tile& tile_validity, const uint64_t cell_size);
-
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
   /**
+   * @param tile Writer tile.
    * @param type Data type.
    * @param is_dim Is it a dimension.
    * @param var_size Is the attribute/dimension var size?
@@ -197,6 +197,7 @@ class TileMetadataGenerator {
    * @param cell_val_num Number of values per cell.
    */
   TileMetadataGenerator(
+      WriterTile& tile,
       const Datatype type,
       const bool is_dim,
       const bool var_size,
@@ -207,17 +208,35 @@ class TileMetadataGenerator {
   /*                API                */
   /* ********************************* */
 
+  /** Compute metatada for full tile. */
+  void process_full_tile();
+
   /**
-   * Compute metatada.
+   * Compute metatada for a slab.
    *
-   * @param tile The tile.
+   * @param start Start cell index.
+   * @param end End cell index.
    */
-  void process_tile(WriterTile& tile);
+  void process_cell_slab(uint64_t start, uint64_t end);
+
+  /**
+   * Copies the metadata to the tile once done processing slabs.
+   */
+  void finalize();
 
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** Fixed tile. */
+  WriterTile& tile_;
+
+  /** Is this a var tile. */
+  bool var_size_;
+
+  /** Is this a nullable tile. */
+  bool nullable_;
 
   /** The data type. */
   Datatype type_;
@@ -254,21 +273,50 @@ class TileMetadataGenerator {
   /* ********************************* */
 
   /**
-   * Process var size attribute.
+   * Returns the min and max of a fixed data tile.
    *
-   * @param tile The tile.
-   */
-
-  void process_tile_var(WriterTile& tile);
-
-  /**
-   * Process fixed size attribute.
+   * @param tile Tile to process.
+   * @param start Start cell index.
+   * @param end End cell index.
    *
-   * @param tile The fixed size tile.
-   * @param tile_validity The validity tile.
+   * @return minimum, maximum.
    */
   template <class T>
-  void process_tile(WriterTile& tile);
+  void min_max(const Tile& tile, uint64_t start, uint64_t end);
+
+  /**
+   * Returns the min and max of a fixed data tile with nullable values.
+   *
+   * @param tile Tile to process.
+   * @param tile_validity Validity tile.
+   * @param start Start cell index.
+   * @param end End cell index.
+   *
+   * @return minimum, maximum, null count.
+   */
+  template <class T>
+  void min_max_nullable(
+      const Tile& tile,
+      const Tile& tile_validity,
+      uint64_t start,
+      uint64_t end);
+
+  /**
+   * Process cell range for var size attribute.
+   *
+   * @param start Start index.
+   * @param end End index.
+   */
+  void process_cell_range_var(uint64_t start, uint64_t end);
+
+  /**
+   * Process cell range for fixed size attribute.
+   *
+   * @param start Start index.
+   * @param end End index.
+   */
+  template <class T>
+  void process_cell_range(uint64_t start, uint64_t end);
 
   /**
    * Min max function for var sized attributes.

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -53,7 +53,7 @@ class WriterTile;
 template <typename T, typename SUM_T>
 struct Sum {
   /**
-   * Add the cells from [start, end[ to the current sum.
+   * Add the sum of cells from [start, end] to the current sum.
    *
    * @param tile Fixed data tile.
    * @param start Start cell index.

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -272,13 +272,11 @@ class TileMetadataGenerator {
   /* ********************************* */
 
   /**
-   * Returns the min and max of a fixed data tile.
+   * Updates the min and max of a fixed data tile.
    *
    * @param tile Tile to process.
    * @param start Start cell index.
    * @param end End cell index.
-   *
-   * @return minimum, maximum.
    */
   template <class T>
   void min_max(const Tile& tile, uint64_t start, uint64_t end);

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -189,7 +189,6 @@ class TileMetadataGenerator {
   /* ********************************* */
 
   /**
-   * @param tile Writer tile.
    * @param type Data type.
    * @param is_dim Is it a dimension.
    * @param var_size Is the attribute/dimension var size?
@@ -197,7 +196,6 @@ class TileMetadataGenerator {
    * @param cell_val_num Number of values per cell.
    */
   TileMetadataGenerator(
-      WriterTile& tile,
       const Datatype type,
       const bool is_dim,
       const bool var_size,
@@ -208,35 +206,36 @@ class TileMetadataGenerator {
   /*                API                */
   /* ********************************* */
 
-  /** Compute metatada for full tile. */
-  void process_full_tile();
+  /**
+   * Compute metatada for full tile.
+   *
+   * @param tile Writer tile that contains the data.
+   */
+  void process_full_tile(const WriterTile& tile);
 
   /**
    * Compute metatada for a slab.
    *
+   * @param tile Writer tile that contains the data.
    * @param start Start cell index.
    * @param end End cell index.
    */
-  void process_cell_slab(uint64_t start, uint64_t end);
+  void process_cell_slab(const WriterTile& tile, uint64_t start, uint64_t end);
 
   /**
    * Copies the metadata to the tile once done processing slabs.
+   *
+   * @param tile Writer tile to copy the metadata to.
    */
-  void set_tile_metadata();
+  void set_tile_metadata(WriterTile& tile);
 
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** Fixed tile. */
-  WriterTile& tile_;
-
   /** Is this a var tile. */
   bool var_size_;
-
-  /** Is this a nullable tile. */
-  bool nullable_;
 
   /** The data type. */
   Datatype type_;
@@ -304,19 +303,22 @@ class TileMetadataGenerator {
   /**
    * Process cell range for var size attribute.
    *
+   * @param tile Writer tile that contains the data.
    * @param start Start index.
    * @param end End index.
    */
-  void process_cell_range_var(uint64_t start, uint64_t end);
+  void process_cell_range_var(
+      const WriterTile& tile, uint64_t start, uint64_t end);
 
   /**
    * Process cell range for fixed size attribute.
    *
+   * @param tile Writer tile that contains the data.
    * @param start Start index.
    * @param end End index.
    */
   template <class T>
-  void process_cell_range(uint64_t start, uint64_t end);
+  void process_cell_range(const WriterTile& tile, uint64_t start, uint64_t end);
 
   /**
    * Min max function for var sized attributes.

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -63,7 +63,7 @@ struct Sum {
   static void sum(Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
 
   /**
-   * Add the cells from [start, end[ to the current sum for a nullable tile.
+   * Add the sum cells of from [start, end] to the current sum for a nullable tile.
    *
    * @param tile Fixed data tile.
    * @param tile_validity Validity tile.


### PR DESCRIPTION
For ordered writes, it is possible to write incomplete tiles. The tile written to disk will add non written cells but with empty data. Unfortunately, the empty cells were considered by the tile metadata generator. To fix this, the tile metadata generator was modified to allow the processing of only a portion of the cells, then the dense tiler can run the generator only on the cells that are actually written.

---
TYPE: IMPROVEMENT
DESC: Tile metadata: fixing for ordered writes.
