### PR TITLE
Correct defect in source of keying material

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -828,10 +828,10 @@ Status StorageManager::array_upgrade_version(
   // Get encryption key from config
   bool found = false;
   std::string encryption_key_from_cfg =
-      config_.get("sm.encryption_key", &found);
+      config->get("sm.encryption_key", &found);
   assert(found);
   std::string encryption_type_from_cfg =
-      config_.get("sm.encryption_type", &found);
+      config->get("sm.encryption_type", &found);
   assert(found);
   auto [st1, etc] = encryption_type_enum(encryption_type_from_cfg);
   RETURN_NOT_OK(st1);


### PR DESCRIPTION
Correct a defect in `StorageManager::array_upgrade_version` where keying material was drawn from its member variable instead of its argument. The consequences of this is that the wrong keying material would be used for the operation.

---
TYPE: BUG
DESC: Correct defect in source of keying material