### PR TITLE
Sparse GO reader: issue when no tile progress because user buffers full.

### DIFF
--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -446,8 +446,8 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
   const auto dim_num = array_schema_.dim_num();
   const auto cell_order = array_schema_.cell_order();
 
-  // No subarray set, return.
-  if (!subarray_.is_set()) {
+  // No subarray set or empry result tiles, return.
+  if (!subarray_.is_set() || result_tiles.empty()) {
     return Status::Ok();
   }
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -446,7 +446,7 @@ Status SparseIndexReaderBase::compute_tile_bitmaps(
   const auto dim_num = array_schema_.dim_num();
   const auto cell_order = array_schema_.cell_order();
 
-  // No subarray set or empry result tiles, return.
+  // No subarray set or empty result tiles, return.
   if (!subarray_.is_set() || result_tiles.empty()) {
     return Status::Ok();
   }


### PR DESCRIPTION
This fixes an issue when the `sparse global order reader` didn't make any tile progress since the last iteration because the user buffers were full. The new iteration will not find new coordinate tiles to read/unfilter so the `tmp_result_tiles` is empty. This caused a SIGFPE in `compute_result_tiles` as it divides a value by the size of the passed in result tile which is 0. The fix is to simply exit the function early when the list of result tiles is empty.

---
TYPE: IMPROVEMENT
DESC: Sparse GO reader: issue when no tile progress because user buffers full.
