### PR TITLE
Fix SC-21741, array evolve via REST

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4902,33 +4902,11 @@ int32_t tiledb_array_evolve(
               0)))
     return TILEDB_ERR;
 
-  // For easy reference
-  auto storage_manager = ctx->storage_manager();
-  auto vfs = storage_manager->vfs();
-  auto tp = storage_manager->compute_tp();
-
-  // Load URIs from the array directory
-  tiledb::sm::ArrayDirectory array_dir;
-  try {
-    array_dir = tiledb::sm::ArrayDirectory(
-        vfs,
-        tp,
-        uri,
-        0,
-        UINT64_MAX,
-        tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY);
-  } catch (const std::logic_error& le) {
-    auto st = Status_ArrayDirectoryError(le.what());
-    LOG_STATUS(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
-  }
-
   // Evolve schema
   if (SAVE_ERROR_CATCH(
           ctx,
           ctx->storage_manager()->array_evolve_schema(
-              array_dir, array_schema_evolution->array_schema_evolution_, key)))
+              uri, array_schema_evolution->array_schema_evolution_, key)))
     return TILEDB_ERR;
 
   // Success
@@ -4950,33 +4928,11 @@ int32_t tiledb_array_upgrade_version(
     return TILEDB_ERR;
   }
 
-  // For easy reference
-  auto storage_manager = ctx->storage_manager();
-  auto vfs = storage_manager->vfs();
-  auto tp = storage_manager->compute_tp();
-
-  // Load URIs from the array directory
-  tiledb::sm::ArrayDirectory array_dir;
-  try {
-    array_dir = tiledb::sm::ArrayDirectory(
-        vfs,
-        tp,
-        uri,
-        0,
-        UINT64_MAX,
-        tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY);
-  } catch (const std::logic_error& le) {
-    auto st = Status_ArrayDirectoryError(le.what());
-    LOG_STATUS(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
-  }
-
   // Upgrade version
   if (SAVE_ERROR_CATCH(
           ctx,
           ctx->storage_manager()->array_upgrade_version(
-              array_dir,
+              uri,
               (config == nullptr) ? &ctx->storage_manager()->config() :
                                     config->config_)))
     return TILEDB_ERR;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -669,8 +669,7 @@ Status StorageManager::array_create(
   }
 
   // Check if array exists
-  bool exists = false;
-  RETURN_NOT_OK(is_array(array_uri, &exists));
+  bool exists = is_array(array_uri);
   if (exists)
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot create array; Array '") + array_uri.c_str() +
@@ -764,11 +763,9 @@ Status StorageManager::array_create(
 }
 
 Status StorageManager::array_evolve_schema(
-    const ArrayDirectory& array_dir,
+    const URI& array_uri,
     ArraySchemaEvolution* schema_evolution,
     const EncryptionKey& encryption_key) {
-  const URI& array_uri = array_dir.uri();
-
   // Check array schema
   if (schema_evolution == nullptr) {
     return logger_->status(Status_StorageManagerError(
@@ -780,13 +777,21 @@ Status StorageManager::array_evolve_schema(
         array_uri, schema_evolution);
   }
 
+  // Load URIs from the array directory
+  tiledb::sm::ArrayDirectory array_dir{
+      this->vfs(),
+      this->io_tp(),
+      array_uri,
+      0,
+      UINT64_MAX,
+      tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY};
+
   // Check if array exists
-  bool exists = false;
-  RETURN_NOT_OK(is_array(array_uri, &exists));
-  if (!exists)
+  if (!is_array(array_uri)) {
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot evolve array; Array '") + array_uri.c_str() +
         "' not exists"));
+  }
 
   auto&& [st1, array_schema] =
       load_array_schema_latest(array_dir, encryption_key);
@@ -808,16 +813,21 @@ Status StorageManager::array_evolve_schema(
 }
 
 Status StorageManager::array_upgrade_version(
-    const ArrayDirectory& array_dir, const Config* config) {
-  const URI& array_uri = array_dir.uri();
-
+    const URI& array_uri, const Config* config) {
   // Check if array exists
-  bool exists = false;
-  RETURN_NOT_OK(is_array(array_uri, &exists));
-  if (!exists)
+  if (!is_array(array_uri))
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot upgrade array; Array '") + array_uri.c_str() +
         "' does not exist"));
+
+  // Load URIs from the array directory
+  tiledb::sm::ArrayDirectory array_dir{
+      this->vfs(),
+      this->io_tp(),
+      array_uri,
+      0,
+      UINT64_MAX,
+      tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY};
 
   // If 'config' is unset, use the 'config_' that was set during initialization
   // of this StorageManager instance.
@@ -1409,29 +1419,31 @@ void StorageManager::increment_in_progress() {
   queries_in_progress_cv_.notify_all();
 }
 
-Status StorageManager::is_array(const URI& uri, bool* is_array) const {
+bool StorageManager::is_array(const URI& uri) const {
   // Handle remote array
   if (uri.is_tiledb()) {
     auto&& [st, exists] = rest_client_->check_array_exists_from_rest(uri);
-    RETURN_NOT_OK(st);
-    *is_array = *exists;
+    throw_if_not_ok(st);
+    assert(exists.has_value());
+    return exists.value();
   } else {
     // Check if the schema directory exists or not
-    bool is_dir = false;
-    // Since is_dir could return NOT Ok status, we will not use RETURN_NOT_OK
-    // here
-    Status st =
-        vfs_->is_dir(uri.join_path(constants::array_schema_dir_name), &is_dir);
-    if (st.ok() && is_dir) {
-      *is_array = true;
-      return Status::Ok();
+    bool dir_exists = false;
+    throw_if_not_ok(vfs_->is_dir(
+        uri.join_path(constants::array_schema_dir_name), &dir_exists));
+
+    if (dir_exists) {
+      return true;
     }
 
+    bool schema_exists = false;
     // If there is no schema directory, we check schema file
-    RETURN_NOT_OK(vfs_->is_file(
-        uri.join_path(constants::array_schema_filename), is_array));
+    throw_if_not_ok(vfs_->is_file(
+        uri.join_path(constants::array_schema_filename), &schema_exists));
+    return schema_exists;
   }
-  return Status::Ok();
+
+  // TODO: mark unreachable
 }
 
 Status StorageManager::is_file(const URI& uri, bool* is_file) const {
@@ -1668,8 +1680,7 @@ Status StorageManager::object_type(const URI& uri, ObjectType* type) const {
       return Status::Ok();
     }
   }
-  bool exists = false;
-  RETURN_NOT_OK(is_array(uri, &exists));
+  bool exists = is_array(uri);
   if (exists) {
     *type = ObjectType::ARRAY;
     return Status::Ok();
@@ -1909,7 +1920,6 @@ Status StorageManager::store_group_detail(
   Serializer serializer(tile.data(), tile.size());
   group->serialize(serializer);
 
-
   stats_->add_counter("write_group_size", tile.size());
 
   // Check if the array schema directory exists
@@ -2097,7 +2107,6 @@ tuple<Status, optional<shared_ptr<Group>>> StorageManager::load_group_from_uri(
   Deserializer deserializer(tile.data(), tile.size());
   auto opt_group = Group::deserialize(deserializer, group_uri, this);
   return {Status::Ok(), opt_group};
-
 }
 
 tuple<Status, optional<shared_ptr<Group>>> StorageManager::load_group_details(

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -488,7 +488,7 @@ class StorageManager {
    * @return Status
    */
   Status array_evolve_schema(
-      const ArrayDirectory& array_dir,
+      const URI& array_uri,
       ArraySchemaEvolution* array_schema,
       const EncryptionKey& encryption_key);
 
@@ -502,8 +502,7 @@ class StorageManager {
    *      this instance).
    * @return Status
    */
-  Status array_upgrade_version(
-      const ArrayDirectory& array_dir, const Config* config);
+  Status array_upgrade_version(const URI& array_uri, const Config* config);
 
   /**
    * Retrieves the non-empty domain from an array. This is the union of the
@@ -702,7 +701,7 @@ class StorageManager {
    * @param is_array Set to `true` if the URI is an array and `false` otherwise.
    * @return Status
    */
-  Status is_array(const URI& uri, bool* is_array) const;
+  bool is_array(const URI& uri) const;
 
   /**
    * Checks if the input URI represents a directory.


### PR DESCRIPTION
Move array directory calls into storage manager implementation functions, after the switch on URI type. ArrayDirectory does not support REST URIs.

Also minor refactor of `StorageManager::is_array` usage to return bool rather than Status.

---
TYPE: BUG
DESC: Fix SC-21741, array evolve via REST
