### PR TITLE
Backport 3528 to release 2.11

### DIFF
--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -432,6 +432,12 @@ TEST_CASE(
   using namespace tiledb;
   Context ctx;
   VFS vfs(ctx);
+  auto layout = GENERATE(
+      TILEDB_ROW_MAJOR,
+      TILEDB_COL_MAJOR,
+      TILEDB_UNORDERED,
+      TILEDB_GLOBAL_ORDER);
+  bool duplicates = GENERATE(true, false);
 
   std::string array_uri = "test_schema_evolution_array_read";
 
@@ -446,6 +452,8 @@ TEST_CASE(
 
     ArraySchema schema(ctx, TILEDB_SPARSE);
     schema.set_domain(domain);
+    schema.set_allows_dups(duplicates);
+    CHECK(duplicates == schema.allows_dups());
     schema.add_attribute(a);
     schema.set_cell_order(TILEDB_ROW_MAJOR);
     schema.set_tile_order(TILEDB_COL_MAJOR);
@@ -493,7 +501,7 @@ TEST_CASE(
     Query query(ctx, array, TILEDB_READ);
     query.add_range(0, 1, 4)
         .add_range(1, 1, 4)
-        .set_layout(TILEDB_ROW_MAJOR)
+        .set_layout(layout)
         .set_data_buffer("a", data)
         .set_data_buffer("d1", d1_data)
         .set_data_buffer("d2", d2_data);
@@ -505,6 +513,7 @@ TEST_CASE(
     // Compare the results.
     auto result_num = (int)query.result_buffer_elements()["a"].second;
     CHECK(result_num == 3);
+    // Same result buffers for all layouts
     CHECK_THAT(data, Catch::Matchers::Equals(std::vector<int>{1, 3, 2}));
     CHECK_THAT(d1_data, Catch::Matchers::Equals(std::vector<int>{1, 2, 2}));
     CHECK_THAT(d2_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 4}));
@@ -555,7 +564,7 @@ TEST_CASE(
 
   // Write again
   {
-    // Write some simple data to cells (1, 1), (2, 4) and (2, 3).
+    // Write some simple data to cell (3, 1)
     std::vector<int> d1_data = {3};
     std::vector<int> d2_data = {1};
     std::vector<int> a_data = {4};
@@ -613,7 +622,7 @@ TEST_CASE(
     Query query(ctx, array, TILEDB_READ);
     query.add_range(0, 1, 4)
         .add_range(1, 1, 4)
-        .set_layout(TILEDB_ROW_MAJOR)
+        .set_layout(layout)
         .set_data_buffer("a", a_data)
         .set_data_buffer("b", b_data)
         .set_data_buffer("c", c_data)
@@ -633,27 +642,310 @@ TEST_CASE(
     // Compare the results.
     auto result_num = (int)query.result_buffer_elements()["a"].second;
     CHECK(result_num == 4);
-    CHECK_THAT(a_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 2, 4}));
-    CHECK_THAT(
-        b_data, Catch::Matchers::Equals(std::vector<uint32_t>{1, 1, 1, 4}));
-    CHECK_THAT(
-        c_data, Catch::Matchers::Equals(std::vector<uint32_t>{2, 2, 2, 40}));
-    CHECK_THAT(
-        c_validity, Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
-    CHECK_THAT(
-        d_data,
-        Catch::Matchers::Equals(std::vector<char>{
-            't', 'e', 's', 't', 't', 'e', 's', 't', 't', 'e', 's', 't', 'd'}));
-    CHECK_THAT(
-        d_offsets, Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 8, 12}));
-    CHECK_THAT(
-        e_data, Catch::Matchers::Equals(std::vector<char>{'n', 'n', 'n', 'e'}));
-    CHECK_THAT(
-        e_offsets, Catch::Matchers::Equals(std::vector<uint64_t>{0, 1, 2, 3}));
-    CHECK_THAT(
-        e_validity, Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
-    CHECK_THAT(d1_data, Catch::Matchers::Equals(std::vector<int>{1, 2, 2, 3}));
-    CHECK_THAT(d2_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 4, 1}));
+    if (layout == TILEDB_COL_MAJOR) {
+      CHECK_THAT(a_data, Catch::Matchers::Equals(std::vector<int>{1, 4, 3, 2}));
+      CHECK_THAT(
+          b_data, Catch::Matchers::Equals(std::vector<uint32_t>{1, 4, 1, 1}));
+      CHECK_THAT(
+          c_data, Catch::Matchers::Equals(std::vector<uint32_t>{2, 40, 2, 2}));
+      CHECK_THAT(
+          c_validity,
+          Catch::Matchers::Equals(std::vector<uint8_t>{0, 1, 0, 0}));
+      CHECK_THAT(
+          d_data,
+          Catch::Matchers::Equals(std::vector<char>{
+              't',
+              'e',
+              's',
+              't',
+              'd',
+              't',
+              'e',
+              's',
+              't',
+              't',
+              'e',
+              's',
+              't'}));
+      CHECK_THAT(
+          d_offsets,
+          Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 5, 9}));
+      CHECK_THAT(
+          e_data,
+          Catch::Matchers::Equals(std::vector<char>{'n', 'e', 'n', 'n'}));
+      CHECK_THAT(
+          e_offsets,
+          Catch::Matchers::Equals(std::vector<uint64_t>{0, 1, 2, 3}));
+      CHECK_THAT(
+          e_validity,
+          Catch::Matchers::Equals(std::vector<uint8_t>{0, 1, 0, 0}));
+      CHECK_THAT(
+          d1_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 2, 2}));
+      CHECK_THAT(
+          d2_data, Catch::Matchers::Equals(std::vector<int>{1, 1, 3, 4}));
+    } else {
+      // Check values for unordered, global, and row-major
+      CHECK_THAT(a_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 2, 4}));
+      CHECK_THAT(
+          b_data, Catch::Matchers::Equals(std::vector<uint32_t>{1, 1, 1, 4}));
+      CHECK_THAT(
+          c_data, Catch::Matchers::Equals(std::vector<uint32_t>{2, 2, 2, 40}));
+      CHECK_THAT(
+          c_validity,
+          Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
+      CHECK_THAT(
+          d_data,
+          Catch::Matchers::Equals(std::vector<char>{
+              't',
+              'e',
+              's',
+              't',
+              't',
+              'e',
+              's',
+              't',
+              't',
+              'e',
+              's',
+              't',
+              'd'}));
+      CHECK_THAT(
+          d_offsets,
+          Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 8, 12}));
+      CHECK_THAT(
+          e_data,
+          Catch::Matchers::Equals(std::vector<char>{'n', 'n', 'n', 'e'}));
+      CHECK_THAT(
+          e_offsets,
+          Catch::Matchers::Equals(std::vector<uint64_t>{0, 1, 2, 3}));
+      CHECK_THAT(
+          e_validity,
+          Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
+      CHECK_THAT(
+          d1_data, Catch::Matchers::Equals(std::vector<int>{1, 2, 2, 3}));
+      CHECK_THAT(
+          d2_data, Catch::Matchers::Equals(std::vector<int>{1, 3, 4, 1}));
+    }
+  }
+
+  // Read using overlapping multi-range query
+  // + Global order does not support multi-range subarrays
+  if (layout != TILEDB_GLOBAL_ORDER) {
+    Array array(ctx, array_uri, TILEDB_READ);
+
+    std::vector<int> a_data(8);
+    std::vector<uint32_t> b_data(8);
+    std::vector<uint32_t> c_data(8);
+    std::vector<uint8_t> c_validity(8);
+    std::vector<char> d_data(26);
+    std::vector<uint64_t> d_offsets(8);
+    std::vector<char> e_data(8);
+    std::vector<uint8_t> e_validity(8);
+    std::vector<uint64_t> e_offsets(8);
+    std::vector<int> d1_data(8);
+    std::vector<int> d2_data(8);
+
+    // Resize buffers for multi-range unordered read
+    if (layout == TILEDB_UNORDERED) {
+      a_data.resize(16);
+      b_data.resize(16);
+      c_data.resize(16);
+      c_validity.resize(16);
+      d_data.resize(52);
+      d_offsets.resize(16);
+      e_data.resize(16);
+      e_validity.resize(16);
+      e_offsets.resize(16);
+      d1_data.resize(16);
+      d2_data.resize(16);
+    }
+
+    // Prepare the query
+    Query query(ctx, array, TILEDB_READ);
+    query.add_range(0, 1, 4)
+        .add_range(0, 1, 4)
+        .add_range(1, 1, 4)
+        .add_range(1, 1, 4)
+        .set_layout(layout)
+        .set_data_buffer("a", a_data)
+        .set_data_buffer("b", b_data)
+        .set_data_buffer("c", c_data)
+        .set_validity_buffer("c", c_validity)
+        .set_data_buffer("d", d_data)
+        .set_offsets_buffer("d", d_offsets)
+        .set_data_buffer("e", e_data)
+        .set_offsets_buffer("e", e_offsets)
+        .set_validity_buffer("e", e_validity)
+        .set_data_buffer("d1", d1_data)
+        .set_data_buffer("d2", d2_data);
+
+    // Submit the query and close the array.
+    query.submit();
+    array.close();
+
+    // Compare the results.
+    if (layout == TILEDB_COL_MAJOR) {
+      auto result_num = (int)query.result_buffer_elements()["a"].second;
+      CHECK(result_num == 8);
+
+      CHECK_THAT(
+          a_data,
+          Catch::Matchers::Equals(std::vector<int>{1, 1, 4, 4, 3, 3, 2, 2}));
+      CHECK_THAT(
+          b_data,
+          Catch::Matchers::Equals(
+              std::vector<uint32_t>{1, 1, 4, 4, 1, 1, 1, 1}));
+      CHECK_THAT(
+          c_data,
+          Catch::Matchers::Equals(
+              std::vector<uint32_t>{2, 2, 40, 40, 2, 2, 2, 2}));
+      CHECK_THAT(
+          c_validity,
+          Catch::Matchers::Equals(
+              std::vector<uint8_t>{0, 0, 1, 1, 0, 0, 0, 0}));
+      CHECK_THAT(
+          d_data,
+          Catch::Matchers::Equals(
+              std::vector<char>{'t', 'e', 's', 't', 't', 'e', 's', 't', 'd',
+                                'd', 't', 'e', 's', 't', 't', 'e', 's', 't',
+                                't', 'e', 's', 't', 't', 'e', 's', 't'}));
+      CHECK_THAT(
+          d_offsets,
+          Catch::Matchers::Equals(
+              std::vector<uint64_t>{0, 4, 8, 9, 10, 14, 18, 22}));
+      CHECK_THAT(
+          e_data,
+          Catch::Matchers::Equals(
+              std::vector<char>{'n', 'n', 'e', 'e', 'n', 'n', 'n', 'n'}));
+      CHECK_THAT(
+          e_offsets,
+          Catch::Matchers::Equals(
+              std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7}));
+      CHECK_THAT(
+          e_validity,
+          Catch::Matchers::Equals(
+              std::vector<uint8_t>{0, 0, 1, 1, 0, 0, 0, 0}));
+      CHECK_THAT(
+          d1_data,
+          Catch::Matchers::Equals(std::vector<int>{1, 1, 3, 3, 2, 2, 2, 2}));
+      CHECK_THAT(
+          d2_data,
+          Catch::Matchers::Equals(std::vector<int>{1, 1, 1, 1, 3, 3, 4, 4}));
+    } else if (layout == TILEDB_ROW_MAJOR) {
+      auto result_num = (int)query.result_buffer_elements()["a"].second;
+      CHECK(result_num == 8);
+
+      CHECK_THAT(
+          a_data,
+          Catch::Matchers::Equals(std::vector<int>{1, 1, 3, 3, 2, 2, 4, 4}));
+      CHECK_THAT(
+          b_data,
+          Catch::Matchers::Equals(
+              std::vector<uint32_t>{1, 1, 1, 1, 1, 1, 4, 4}));
+      CHECK_THAT(
+          c_data,
+          Catch::Matchers::Equals(
+              std::vector<uint32_t>{2, 2, 2, 2, 2, 2, 40, 40}));
+      CHECK_THAT(
+          c_validity,
+          Catch::Matchers::Equals(
+              std::vector<uint8_t>{0, 0, 0, 0, 0, 0, 1, 1}));
+      CHECK_THAT(
+          d_data,
+          Catch::Matchers::Equals(
+              std::vector<char>{'t', 'e', 's', 't', 't', 'e', 's', 't', 't',
+                                'e', 's', 't', 't', 'e', 's', 't', 't', 'e',
+                                's', 't', 't', 'e', 's', 't', 'd', 'd'}));
+      CHECK_THAT(
+          d_offsets,
+          Catch::Matchers::Equals(
+              std::vector<uint64_t>{0, 4, 8, 12, 16, 20, 24, 25}));
+      CHECK_THAT(
+          e_data,
+          Catch::Matchers::Equals(
+              std::vector<char>{'n', 'n', 'n', 'n', 'n', 'n', 'e', 'e'}));
+      CHECK_THAT(
+          e_offsets,
+          Catch::Matchers::Equals(
+              std::vector<uint64_t>{0, 1, 2, 3, 4, 5, 6, 7}));
+      CHECK_THAT(
+          e_validity,
+          Catch::Matchers::Equals(
+              std::vector<uint8_t>{0, 0, 0, 0, 0, 0, 1, 1}));
+      CHECK_THAT(
+          d1_data,
+          Catch::Matchers::Equals(std::vector<int>{1, 1, 2, 2, 2, 2, 3, 3}));
+      CHECK_THAT(
+          d2_data,
+          Catch::Matchers::Equals(std::vector<int>{1, 1, 3, 3, 4, 4, 1, 1}));
+    } else if (layout == TILEDB_UNORDERED) {
+      auto result_num = (int)query.result_buffer_elements()["a"].second;
+      CHECK(result_num == 16);
+
+      CHECK_THAT(
+          a_data,
+          Catch::Matchers::Equals(std::vector<int>{
+              1, 1, 1, 1, 3, 3, 3, 3, 2, 2, 2, 2, 4, 4, 4, 4}));
+      CHECK_THAT(
+          b_data,
+          Catch::Matchers::Equals(std::vector<uint32_t>{
+              1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 4, 4, 4, 4}));
+      CHECK_THAT(
+          c_data,
+          Catch::Matchers::Equals(std::vector<uint32_t>{
+              2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 40, 40, 40, 40}));
+      CHECK_THAT(
+          c_validity,
+          Catch::Matchers::Equals(std::vector<uint8_t>{
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1}));
+      CHECK_THAT(
+          d_data,
+          Catch::Matchers::Equals(std::vector<char>{
+              't', 'e', 's', 't', 't', 'e', 's', 't', 't', 'e', 's',
+              't', 't', 'e', 's', 't', 't', 'e', 's', 't', 't', 'e',
+              's', 't', 't', 'e', 's', 't', 't', 'e', 's', 't', 't',
+              'e', 's', 't', 't', 'e', 's', 't', 't', 'e', 's', 't',
+              't', 'e', 's', 't', 'd', 'd', 'd', 'd'}));
+      CHECK_THAT(
+          d_offsets,
+          Catch::Matchers::Equals(std::vector<uint64_t>{
+              0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 49, 50, 51}));
+      CHECK_THAT(
+          e_data,
+          Catch::Matchers::Equals(std::vector<char>{
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'n',
+              'e',
+              'e',
+              'e',
+              'e'}));
+      CHECK_THAT(
+          e_offsets,
+          Catch::Matchers::Equals(std::vector<uint64_t>{
+              0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}));
+      CHECK_THAT(
+          e_validity,
+          Catch::Matchers::Equals(std::vector<uint8_t>{
+              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1}));
+      CHECK_THAT(
+          d1_data,
+          Catch::Matchers::Equals(std::vector<int>{
+              1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3}));
+      CHECK_THAT(
+          d2_data,
+          Catch::Matchers::Equals(std::vector<int>{
+              1, 1, 1, 1, 3, 3, 3, 3, 4, 4, 4, 4, 1, 1, 1, 1}));
+    }
   }
 
   // Clean up

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -653,20 +653,19 @@ TEST_CASE(
           Catch::Matchers::Equals(std::vector<uint8_t>{0, 1, 0, 0}));
       CHECK_THAT(
           d_data,
-          Catch::Matchers::Equals(std::vector<char>{
-              't',
-              'e',
-              's',
-              't',
-              'd',
-              't',
-              'e',
-              's',
-              't',
-              't',
-              'e',
-              's',
-              't'}));
+          Catch::Matchers::Equals(std::vector<char>{'t',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    'd',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't'}));
       CHECK_THAT(
           d_offsets,
           Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 5, 9}));
@@ -695,20 +694,19 @@ TEST_CASE(
           Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
       CHECK_THAT(
           d_data,
-          Catch::Matchers::Equals(std::vector<char>{
-              't',
-              'e',
-              's',
-              't',
-              't',
-              'e',
-              's',
-              't',
-              't',
-              'e',
-              's',
-              't',
-              'd'}));
+          Catch::Matchers::Equals(std::vector<char>{'t',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    'd'}));
       CHECK_THAT(
           d_offsets,
           Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 8, 12}));
@@ -912,23 +910,22 @@ TEST_CASE(
               0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 49, 50, 51}));
       CHECK_THAT(
           e_data,
-          Catch::Matchers::Equals(std::vector<char>{
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'e',
-              'e',
-              'e',
-              'e'}));
+          Catch::Matchers::Equals(std::vector<char>{'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'e',
+                                                    'e',
+                                                    'e',
+                                                    'e'}));
       CHECK_THAT(
           e_offsets,
           Catch::Matchers::Equals(std::vector<uint64_t>{

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1138,7 +1138,6 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
 
         // Copy last cell.
         if (max_pos == cell_num && !use_fill_value) {
-          if (t_var_size == 0) throw std::runtime_error("Unexpected zero size");
           *buffer = (OffType)(t_var_size - src_buff[max_pos - 1]) / offset_div;
           *var_data_buffer = src_var_buff + src_buff[max_pos - 1];
         }
@@ -1459,7 +1458,8 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
             accounted_tiles.emplace(id);
 
             // Skip for fields added in schema evolution.
-            if (!fragment_metadata_[rt->frag_idx()]->array_schema()->is_field(name)) {
+            if (!fragment_metadata_[rt->frag_idx()]->array_schema()->is_field(
+                    name)) {
               continue;
             }
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1058,7 +1058,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
     const std::vector<ResultCellSlab>& result_cell_slabs,
     const std::vector<uint64_t>& cell_offsets,
     QueryBuffer& query_buffer,
-    std::vector<void*>& var_data) {
+    std::vector<const void*>& var_data) {
   auto timer_se = stats_->start_timer("copy_offsets_tiles");
 
   // Process all tiles/cells in parallel.
@@ -1075,14 +1075,29 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
             result_cell_slabs[i].tile_);
 
         // Get source buffers.
-        const auto tile_tuple = rt->tile_tuple(name);
-        const auto t = &std::get<0>(*tile_tuple);
-        const auto t_var = &std::get<1>(*tile_tuple);
-        const auto src_buff = t->template data_as<uint64_t>();
-        const auto src_var_buff = t_var->template data_as<char>();
-        const auto t_val = &std::get<2>(*tile_tuple);
         const auto cell_num =
             fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
+        const auto tile_tuple = rt->tile_tuple(name);
+
+        // If the tile_tuple is null, this is a field added in schema
+        // evolution. Use the fill value.
+        const uint64_t* src_buff = nullptr;
+        const uint8_t* src_var_buff = nullptr;
+        bool use_fill_value = false;
+        OffType fill_value_size = 0;
+        uint64_t t_var_size = 0;
+        if (tile_tuple == nullptr) {
+          use_fill_value = true;
+          fill_value_size = static_cast<OffType>(
+              array_schema_.attribute(name)->fill_value().size());
+          src_var_buff = array_schema_.attribute(name)->fill_value().data();
+        } else {
+          const auto& t = tile_tuple->fixed_tile();
+          const auto& t_var = tile_tuple->var_tile();
+          t_var_size = t_var.size();
+          src_buff = t.template data_as<uint64_t>();
+          src_var_buff = t_var.template data_as<uint8_t>();
+        }
 
         // Compute parallelization parameters.
         auto&& [min_pos, max_pos, dest_cell_offset, skip_copy] =
@@ -1103,27 +1118,45 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         auto var_data_buffer = &var_data[dest_cell_offset - cell_offsets[0]];
 
         // Copy full tile. Last cell might be taken out for vectorization.
-        uint64_t end = (max_pos == cell_num) ? max_pos - 1 : max_pos;
-        for (uint64_t c = min_pos; c < end; c++) {
-          *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
-          buffer++;
-          *var_data_buffer = src_var_buff + src_buff[c];
-          var_data_buffer++;
+        uint64_t end =
+            (max_pos == cell_num && !use_fill_value) ? max_pos - 1 : max_pos;
+        if (!use_fill_value) {
+          for (uint64_t c = min_pos; c < end; c++) {
+            *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
+            buffer++;
+            *var_data_buffer = src_var_buff + src_buff[c];
+            var_data_buffer++;
+          }
+        } else {
+          for (uint64_t c = min_pos; c < end; c++) {
+            *buffer = fill_value_size / offset_div;
+            buffer++;
+            *var_data_buffer = src_var_buff;
+            var_data_buffer++;
+          }
         }
 
         // Copy last cell.
-        if (max_pos == cell_num) {
-          *buffer =
-              (OffType)(t_var->size() - src_buff[max_pos - 1]) / offset_div;
+        if (max_pos == cell_num && !use_fill_value) {
+          *buffer = (OffType)(t_var_size - src_buff[max_pos - 1]) / offset_div;
           *var_data_buffer = src_var_buff + src_buff[max_pos - 1];
         }
 
         // Copy nullable values.
         if (nullable) {
-          const auto src_val_buff = t_val->template data_as<uint8_t>();
-          for (uint64_t c = min_pos; c < max_pos; c++) {
-            *val_buffer = src_val_buff[c];
-            val_buffer++;
+          if (!use_fill_value) {
+            const auto& t_val = tile_tuple->validity_tile();
+            const auto src_val_buff = t_val.template data_as<uint8_t>();
+            for (uint64_t c = min_pos; c < max_pos; c++) {
+              *val_buffer = src_val_buff[c];
+              val_buffer++;
+            }
+          } else {
+            uint8_t v = array_schema_.attribute(name)->fill_value_validity();
+            for (uint64_t c = min_pos; c < max_pos; c++) {
+              *val_buffer = v;
+              val_buffer++;
+            }
           }
         }
 
@@ -1143,7 +1176,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
     const std::vector<ResultCellSlab>& result_cell_slabs,
     const std::vector<uint64_t>& cell_offsets,
     QueryBuffer& query_buffer,
-    const std::vector<void*>& var_data) {
+    std::vector<const void*>& var_data) {
   auto timer_se = stats_->start_timer("copy_var_tiles");
 
   // For easy reference.
@@ -1241,9 +1274,18 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
         const auto tile_tuple = stores_zipped_coords ?
                                     rt->tile_tuple(constants::coords) :
                                     rt->tile_tuple(name);
-        const auto t = &std::get<0>(*tile_tuple);
-        const auto src_buff = t->template data_as<uint8_t>();
-        const auto t_val = &std::get<2>(*tile_tuple);
+
+        // If the tile_tuple is null, this is a field added in schema
+        // evolution. Use the fill value.
+        const uint8_t* src_buff = nullptr;
+        bool use_fill_value = false;
+        if (tile_tuple == nullptr) {
+          use_fill_value = true;
+          src_buff = array_schema_.attribute(name)->fill_value().data();
+        } else {
+          const auto& t = tile_tuple->fixed_tile();
+          src_buff = t.template data_as<uint8_t>();
+        }
 
         // Compute parallelization parameters.
         auto&& [min_pos, max_pos, dest_cell_offset, skip_copy] =
@@ -1264,11 +1306,19 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
             query_buffer.validity_vector_.buffer() + dest_cell_offset;
 
         if (!stores_zipped_coords) {
-          // Copy tile.
-          memcpy(
-              buffer,
-              src_buff + min_pos * cell_size,
-              (max_pos - min_pos) * cell_size);
+          if (!use_fill_value) {
+            // Copy tile.
+            memcpy(
+                buffer,
+                src_buff + min_pos * cell_size,
+                (max_pos - min_pos) * cell_size);
+          } else {
+            // Copy tile using the fill value.
+            for (uint64_t i = 0; i < max_pos - min_pos; i++) {
+              memcpy(buffer, src_buff, cell_size);
+              buffer += cell_size;
+            }
+          }
         } else {  // Copy for zipped coords.
           const auto dim_num = rt->domain()->dim_num();
           for (uint64_t c = min_pos; c < max_pos; c++) {
@@ -1279,8 +1329,19 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
         }
 
         if (nullable) {
-          const auto src_val_buff = t_val->template data_as<uint8_t>();
-          memcpy(val_buffer, src_val_buff + min_pos, max_pos - min_pos);
+          if (!use_fill_value) {
+            // Copy validity values from tile.
+            const auto& t_val = tile_tuple->validity_tile();
+            const auto src_val_buff = t_val.template data_as<uint8_t>();
+            memcpy(val_buffer, src_val_buff + min_pos, max_pos - min_pos);
+          } else {
+            // Copy the fill value for validity.
+            uint8_t v = array_schema_.attribute(name)->fill_value_validity();
+            for (uint64_t i = 0; i < max_pos - min_pos; i++) {
+              *val_buffer = v;
+              val_buffer++;
+            }
+          }
         }
 
         return Status::Ok();
@@ -1395,6 +1456,11 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
 
           if (accounted_tiles.count(id) == 0) {
             accounted_tiles.emplace(id);
+
+            // Skip for fields added in schema evolution.
+            if (!fragment_metadata_[f]->array_schema()->is_field(name)) {
+              continue;
+            }
 
             // Size of the tile in memory.
             auto&& [st, tile_size] =
@@ -1596,7 +1662,7 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
       auto& query_buffer = buffers_[name];
 
       // Pointers to var size data, generated when offsets are processed.
-      std::vector<void*> var_data;
+      std::vector<const void*> var_data;
       if (var_sized) {
         var_data.resize(
             cell_offsets[result_cell_slabs.size()] - cell_offsets[0]);

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -360,7 +360,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       const std::vector<ResultCellSlab>& result_cell_slabs,
       const std::vector<uint64_t>& cell_offsets,
       QueryBuffer& query_buffer,
-      std::vector<void*>& var_data);
+      std::vector<const void*>& var_data);
 
   /**
    * Copy var data tiles.
@@ -383,7 +383,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       const std::vector<ResultCellSlab>& result_cell_slabs,
       const std::vector<uint64_t>& cell_offsets,
       QueryBuffer& query_buffer,
-      const std::vector<void*>& var_data);
+      std::vector<const void*>& var_data);
 
   /**
    * Copy fixed size data tiles.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -509,46 +509,85 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
     uint64_t src_max_pos,
     OffType* buffer,
     uint8_t* val_buffer,
-    void** var_data) {
+    const void** var_data) {
   // Get source buffers.
   const auto tile_tuple = rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
-  const auto t_var = &std::get<1>(*tile_tuple);
-  const auto src_buff = t->data_as<uint64_t>();
-  const auto src_var_buff = t_var->data_as<char>();
-  const auto t_val = &std::get<2>(*tile_tuple);
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
-  // Process all cells. Last cell might be taken out for vectorization.
-  uint64_t end = (src_max_pos == cell_num) ? src_max_pos - 1 : src_max_pos;
-  for (uint64_t c = src_min_pos; c < end; c++) {
-    for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
-      *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
-      buffer++;
-      *var_data = src_var_buff + src_buff[c];
-      var_data++;
-    }
+  // If the tile_tuple is null, this is a field added in schema
+  // evolution. Use the fill value.
+  const uint64_t* src_buff = nullptr;
+  const uint8_t* src_var_buff = nullptr;
+  bool use_fill_value = false;
+  OffType fill_value_size = 0;
+  uint64_t t_var_size = 0;
+  if (tile_tuple == nullptr) {
+    use_fill_value = true;
+    fill_value_size = static_cast<OffType>(
+        array_schema_.attribute(name)->fill_value().size());
+    src_var_buff = array_schema_.attribute(name)->fill_value().data();
+  } else {
+    const auto& t = tile_tuple->fixed_tile();
+    const auto& t_var = tile_tuple->var_tile();
+    t_var_size = t_var.size();
+    src_buff = t.template data_as<uint64_t>();
+    src_var_buff = t_var.template data_as<uint8_t>();
   }
 
-  // Do last cell.
-  if (src_max_pos == cell_num) {
-    for (uint64_t i = 0; i < rt->bitmap_[src_max_pos - 1]; i++) {
-      *buffer =
-          (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
-      buffer++;
-      *var_data = src_var_buff + src_buff[src_max_pos - 1];
-      var_data++;
+  // Process all cells. Last cell might be taken out for vectorization.
+  uint64_t end = (src_max_pos == cell_num && !use_fill_value) ?
+                     src_max_pos - 1 :
+                     src_max_pos;
+  if (!use_fill_value) {
+    for (uint64_t c = src_min_pos; c < end; c++) {
+      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+        *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
+        buffer++;
+        *var_data = src_var_buff + src_buff[c];
+        var_data++;
+      }
+    }
+
+    // Do last cell.
+    if (src_max_pos == cell_num) {
+      for (uint64_t i = 0; i < rt->bitmap_[src_max_pos - 1]; i++) {
+        *buffer =
+            (OffType)(t_var_size - src_buff[src_max_pos - 1]) / offset_div;
+        buffer++;
+        *var_data = src_var_buff + src_buff[src_max_pos - 1];
+        var_data++;
+      }
+    }
+  } else {
+    for (uint64_t c = src_min_pos; c < end; c++) {
+      for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
+        *buffer = fill_value_size / offset_div;
+        buffer++;
+        *var_data = src_var_buff;
+        var_data++;
+      }
     }
   }
 
   // Copy nullable values.
   if (nullable) {
-    const auto src_val_buff = t_val->data_as<uint8_t>();
-    for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
-        *val_buffer = src_val_buff[c];
-        val_buffer++;
+    if (!use_fill_value) {
+      const auto& t_val = tile_tuple->validity_tile();
+      const auto src_val_buff = t_val.data_as<uint8_t>();
+      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+        for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+          *val_buffer = src_val_buff[c];
+          val_buffer++;
+        }
+      }
+    } else {
+      uint8_t v = array_schema_.attribute(name)->fill_value_validity();
+      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+        for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+          *val_buffer = v;
+          val_buffer++;
+        }
       }
     }
   }
@@ -568,44 +607,82 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     const uint64_t src_max_pos,
     OffType* buffer,
     uint8_t* val_buffer,
-    void** var_data) {
+    const void** var_data) {
   // Get source buffers.
-  const auto tile_tuple = rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
-  const auto t_var = &std::get<1>(*tile_tuple);
-  const auto src_buff = t->data_as<uint64_t>();
-  const auto src_var_buff = t_var->data_as<char>();
-  const auto t_val = &std::get<2>(*tile_tuple);
   const auto cell_num =
       fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
+  const auto tile_tuple = rt->tile_tuple(name);
 
-  // 0 sized bitmap means full tile, full tile copy done below.
-  if (rt->has_bmp()) {
+  // If the tile_tuple is null, this is a field added in schema
+  // evolution. Use the fill value.
+  const uint64_t* src_buff = nullptr;
+  const uint8_t* src_var_buff = nullptr;
+  bool use_fill_value = false;
+  OffType fill_value_size = 0;
+  uint64_t t_var_size = 0;
+  if (tile_tuple == nullptr) {
+    use_fill_value = true;
+    fill_value_size = static_cast<OffType>(
+        array_schema_.attribute(name)->fill_value().size());
+    src_var_buff = array_schema_.attribute(name)->fill_value().data();
+  } else {
+    const auto& t = tile_tuple->fixed_tile();
+    const auto& t_var = tile_tuple->var_tile();
+    t_var_size = t_var.size();
+    src_buff = t.template data_as<uint64_t>();
+    src_var_buff = t_var.template data_as<uint8_t>();
+  }
+
+  if (!rt->has_bmp() || use_fill_value) {
     // Process all cells. Last cell might be taken out for vectorization.
-    uint64_t end = (src_max_pos == cell_num) ? src_max_pos - 1 : src_max_pos;
-    for (uint64_t c = src_min_pos; c < end; c++) {
-      if (rt->bitmap_[c]) {
-        *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
-        buffer++;
-        *var_data = src_var_buff + src_buff[c];
-        var_data++;
+    uint64_t end = (src_max_pos == cell_num && !use_fill_value) ?
+                       src_max_pos - 1 :
+                       src_max_pos;
+    if (!use_fill_value) {
+      for (uint64_t c = src_min_pos; c < end; c++) {
+        if (rt->bitmap_[c]) {
+          *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
+          buffer++;
+          *var_data = src_var_buff + src_buff[c];
+          var_data++;
+        }
       }
-    }
 
-    // Do last cell.
-    if (src_max_pos == cell_num && rt->bitmap_[src_max_pos - 1]) {
-      *buffer =
-          (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
-      *var_data = src_var_buff + src_buff[src_max_pos - 1];
+      // Do last cell.
+      if (src_max_pos == cell_num && rt->bitmap_[src_max_pos - 1]) {
+        *buffer =
+            (OffType)(t_var_size - src_buff[src_max_pos - 1]) / offset_div;
+        *var_data = src_var_buff + src_buff[src_max_pos - 1];
+      }
+    } else {
+      for (uint64_t c = src_min_pos; c < end; c++) {
+        if (!rt->has_bmp() || rt->bitmap_[c]) {
+          *buffer = fill_value_size / offset_div;
+          buffer++;
+          *var_data = src_var_buff;
+          var_data++;
+        }
+      }
     }
 
     // Copy nullable values.
     if (nullable) {
-      const auto src_val_buff = t_val->data_as<uint8_t>();
-      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
-          *val_buffer = src_val_buff[c];
-          val_buffer++;
+      if (!use_fill_value) {
+        const auto& t_val = tile_tuple->validity_tile();
+        const auto src_val_buff = t_val.data_as<uint8_t>();
+        for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+          if (rt->bitmap_[c]) {
+            *val_buffer = src_val_buff[c];
+            val_buffer++;
+          }
+        }
+      } else {
+        uint8_t v = array_schema_.attribute(name)->fill_value_validity();
+        for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+          if (rt->bitmap_[c]) {
+            *val_buffer = v;
+            val_buffer++;
+          }
         }
       }
     }
@@ -621,8 +698,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
 
     // Copy last cell.
     if (src_max_pos == cell_num) {
-      *buffer =
-          (OffType)(t_var->size() - src_buff[src_max_pos - 1]) / offset_div;
+      *buffer = (OffType)(t_var_size - src_buff[src_max_pos - 1]) / offset_div;
       *var_data = src_var_buff + src_buff[src_max_pos - 1];
     }
 
@@ -649,7 +725,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
     const std::vector<ResultTile*>& result_tiles,
     const std::vector<uint64_t>& cell_offsets,
     QueryBuffer& query_buffer,
-    std::vector<void*>& var_data) {
+    std::vector<const void*>& var_data) {
   auto timer_se = stats_->start_timer("copy_offsets_tiles");
 
   // For easy reference.
@@ -767,7 +843,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
     const std::vector<ResultTile*>& result_tiles,
     const std::vector<uint64_t>& cell_offsets,
     QueryBuffer& query_buffer,
-    std::vector<void*>& var_data) {
+    std::vector<const void*>& var_data) {
   auto timer_se = stats_->start_timer("copy_var_tiles");
 
   // For easy reference.
@@ -834,15 +910,34 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
   const auto tile_tuple = stores_zipped_coords ?
                               rt->tile_tuple(constants::coords) :
                               rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
-  const auto src_buff = t->data_as<uint8_t>();
+
+  // If the tile_tuple is null, this is a field added in schema
+  // evolution. Use the fill value.
+  const uint8_t* src_buff = nullptr;
+  bool use_fill_value = false;
+  if (tile_tuple == nullptr) {
+    use_fill_value = true;
+    src_buff = array_schema_.attribute(name)->fill_value().data();
+  } else {
+    const auto& t = tile_tuple->fixed_tile();
+    src_buff = t.template data_as<uint8_t>();
+  }
 
   // Copy values.
   if (!stores_zipped_coords) {
-    for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
-        memcpy(buffer, src_buff + c * cell_size, cell_size);
-        buffer += cell_size;
+    if (!use_fill_value) {
+      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+        for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+          memcpy(buffer, src_buff + c * cell_size, cell_size);
+          buffer += cell_size;
+        }
+      }
+    } else {
+      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+        for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+          memcpy(buffer, src_buff, cell_size);
+          buffer += cell_size;
+        }
       }
     }
   } else {  // Copy for zipped coords.
@@ -858,12 +953,22 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
 
   // Copy nullable values.
   if (nullable) {
-    const auto t_val = &std::get<2>(*tile_tuple);
-    const auto src_val_buff = t_val->data_as<uint8_t>();
-    for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-      for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
-        *val_buffer = src_val_buff[c];
-        val_buffer++;
+    if (!use_fill_value) {
+      const auto& t_val = tile_tuple->validity_tile();
+      const auto src_val_buff = t_val.data_as<uint8_t>();
+      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+        for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+          *val_buffer = src_val_buff[c];
+          val_buffer++;
+        }
+      }
+    } else {
+      uint8_t v = array_schema_.attribute(name)->fill_value_validity();
+      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+        for (uint64_t i = 0; i < rt->bitmap_[c]; i++) {
+          *val_buffer = v;
+          val_buffer++;
+        }
       }
     }
   }
@@ -889,36 +994,53 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
   const auto tile_tuple = stores_zipped_coords ?
                               rt->tile_tuple(constants::coords) :
                               rt->tile_tuple(name);
-  const auto t = &std::get<0>(*tile_tuple);
-  const auto src_buff = t->data_as<uint8_t>();
-  const auto t_val = &std::get<2>(*tile_tuple);
 
-  // Partial tile copy, full tile copy done below.
-  if (rt->has_bmp()) {
+  // If the tile_tuple is null, this is a field added in schema
+  // evolution. Use the fill value.
+  const uint8_t* src_buff = nullptr;
+  bool use_fill_value = false;
+  if (tile_tuple == nullptr) {
+    use_fill_value = true;
+    src_buff = array_schema_.attribute(name)->fill_value().data();
+  } else {
+    const auto& t = tile_tuple->fixed_tile();
+    src_buff = t.template data_as<uint8_t>();
+  }
+
+  if (!rt->has_bmp() || use_fill_value) {
     // Copy values.
     if (!stores_zipped_coords) {
-      // Go through bitmap, when there is a hole in cell contiguity, do a
-      // memcpy.
-      uint64_t length = 0;
-      uint64_t start = src_min_pos;
-      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
-          length++;
-        } else {
-          if (length != 0) {
-            memcpy(buffer, src_buff + start * cell_size, length * cell_size);
-            buffer += length * cell_size;
-            length = 0;
+      if (!use_fill_value) {
+        // Go through bitmap, when there is a hole in cell contiguity, do a
+        // memcpy.
+        uint64_t length = 0;
+        uint64_t start = src_min_pos;
+        for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+          if (rt->bitmap_[c]) {
+            length++;
+          } else {
+            if (length != 0) {
+              memcpy(buffer, src_buff + start * cell_size, length * cell_size);
+              buffer += length * cell_size;
+              length = 0;
+            }
+
+            start = c + 1;
           }
-
-          start = c + 1;
         }
-      }
 
-      // Do last memcpy.
-      if (length != 0) {
-        memcpy(buffer, src_buff + start * cell_size, length * cell_size);
-        buffer += length * cell_size;
+        // Do last memcpy.
+        if (length != 0) {
+          memcpy(buffer, src_buff + start * cell_size, length * cell_size);
+          buffer += length * cell_size;
+        }
+      } else {
+        for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+          if (!rt->has_bmp() || rt->bitmap()[c]) {
+            memcpy(buffer, src_buff, cell_size);
+            buffer += cell_size;
+          }
+        }
       }
     } else {  // Copy for zipped coords.
       const auto dim_num = rt->domain()->dim_num();
@@ -933,29 +1055,40 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
 
     // Copy nullable values.
     if (nullable) {
-      // Go through bitmap, when there is a hole in cell contiguity, do a
-      // memcpy.
-      uint64_t length = 0;
-      uint64_t start = src_min_pos;
-      const auto src_val_buff = t_val->data_as<uint8_t>();
-      for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
-        if (rt->bitmap_[c]) {
-          length++;
-        } else {
-          if (length != 0) {
-            memcpy(val_buffer, src_val_buff + start, length);
-            val_buffer += length;
-            length = 0;
+      if (!use_fill_value) {
+        // Go through bitmap, when there is a hole in cell contiguity, do a
+        // memcpy.
+        const auto& t_val = tile_tuple->validity_tile();
+        uint64_t length = 0;
+        uint64_t start = src_min_pos;
+        const auto src_val_buff = t_val.data_as<uint8_t>();
+        for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+          if (rt->bitmap_[c]) {
+            length++;
+          } else {
+            if (length != 0) {
+              memcpy(val_buffer, src_val_buff + start, length);
+              val_buffer += length;
+              length = 0;
+            }
+
+            start = c + 1;
           }
-
-          start = c + 1;
         }
-      }
 
-      // Do last memcpy.
-      if (length != 0) {
-        memcpy(val_buffer, src_val_buff + start, length);
-        val_buffer += length;
+        // Do last memcpy.
+        if (length != 0) {
+          memcpy(val_buffer, src_val_buff + start, length);
+          val_buffer += length;
+        }
+      } else {
+        uint8_t v = array_schema_.attribute(name)->fill_value_validity();
+        for (uint64_t c = src_min_pos; c < src_max_pos; c++) {
+          for (uint64_t i = 0; i < rt->bitmap()[c]; i++) {
+            *val_buffer = v;
+            val_buffer++;
+          }
+        }
       }
     }
   } else {  // Copy full tile.
@@ -1284,6 +1417,12 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
           // Size of the tile in memory.
           auto rt = (UnorderedWithDupsResultTile<BitmapType>*)result_tiles[idx];
 
+          // Skip for fields added in schema evolution.
+          if (!fragment_metadata_[rt->frag_idx()]->array_schema()->is_field(
+                  name)) {
+            continue;
+          }
+
           auto&& [st, tile_size] =
               get_attribute_tile_size(name, rt->frag_idx(), rt->tile_idx());
           RETURN_NOT_OK(st);
@@ -1462,7 +1601,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
       }
 
       // Pointers to var size data, generated when offsets are processed.
-      std::vector<void*> var_data;
+      std::vector<const void*> var_data;
       if (var_sized) {
         var_data.resize(cell_offsets[result_tiles.size()] - cell_offsets[0]);
       }

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -633,7 +633,7 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     src_var_buff = t_var->template data_as<uint8_t>();
   }
 
-  if (!rt->has_bmp() || use_fill_value) {
+  if (rt->has_bmp() || use_fill_value) {
     // Process all cells. Last cell might be taken out for vectorization.
     uint64_t end = (src_max_pos == cell_num && !use_fill_value) ?
                        src_max_pos - 1 :
@@ -1004,11 +1004,11 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
     use_fill_value = true;
     src_buff = array_schema_.attribute(name)->fill_value().data();
   } else {
-    const auto& t = std::get<0>(*tile_tuple);;
+    const auto& t = std::get<0>(*tile_tuple);
     src_buff = t.template data_as<uint8_t>();
   }
 
-  if (!rt->has_bmp() || use_fill_value) {
+  if (rt->has_bmp() || use_fill_value) {
     // Copy values.
     if (!stores_zipped_coords) {
       if (!use_fill_value) {

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -260,7 +260,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const uint64_t src_max_pos,
       OffType* buffer,
       uint8_t* val_buffer,
-      void** var_data);
+      const void** var_data);
 
   /**
    * Copy offsets tiles.
@@ -285,7 +285,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const std::vector<ResultTile*>& result_tiles,
       const std::vector<uint64_t>& cell_offsets,
       QueryBuffer& query_buffer,
-      std::vector<void*>& var_data);
+      std::vector<const void*>& var_data);
 
   /**
    * Copy var data tile.
@@ -335,7 +335,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const std::vector<ResultTile*>& result_tiles,
       const std::vector<uint64_t>& cell_offsets,
       QueryBuffer& query_buffer,
-      std::vector<void*>& var_data);
+      std::vector<const void*>& var_data);
 
   /**
    * Copy fixed size data tile.


### PR DESCRIPTION

---
TYPE: BUG
DESC: Fix segfault after schema evolution when reading using TILEDB_UNORDERED (#3528)
