### PR TITLE
Experimental dimension label data query

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -256,7 +256,10 @@ endif()
 
 if (TILEDB_EXPERIMENTAL_FEATURES)
   list(APPEND TILEDB_UNIT_TEST_SOURCES
+    src/experimental_helpers.cc
     src/test-capi-dimension_labels.cc
+    src/test-capi-dense-array-dimension-label.cc
+    src/test-capi-sparse-array-dimension-label.cc
     src/test-dimension_labels-read-consistency.cc
     src/unit_intersect_fragments.cc
   )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -257,6 +257,7 @@ endif()
 if (TILEDB_EXPERIMENTAL_FEATURES)
   list(APPEND TILEDB_UNIT_TEST_SOURCES
     src/experimental_helpers.cc
+    src/test-capi-array-many-dimension-labels.cc
     src/test-capi-dimension_labels.cc
     src/test-capi-dense-array-dimension-label.cc
     src/test-capi-dense-array-dimension-label-var.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -259,6 +259,7 @@ if (TILEDB_EXPERIMENTAL_FEATURES)
     src/experimental_helpers.cc
     src/test-capi-dimension_labels.cc
     src/test-capi-dense-array-dimension-label.cc
+    src/test-capi-dense-array-dimension-label-var.cc
     src/test-capi-sparse-array-dimension-label.cc
     src/test-dimension_labels-read-consistency.cc
     src/unit_intersect_fragments.cc

--- a/test/src/experimental_helpers.cc
+++ b/test/src/experimental_helpers.cc
@@ -1,0 +1,85 @@
+/**
+ * @file experimental_helpers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "experimental_helpers.h"
+
+namespace tiledb::test {
+
+void add_dimension_label(
+    tiledb_ctx_t* ctx,
+    tiledb_array_schema_t* array_schema,
+    const std::string& label_name,
+    const uint32_t dim_idx,
+    tiledb_label_order_t label_order,
+    tiledb_datatype_t label_datatype,
+    const void* label_domain,
+    const void* label_tile_extent,
+    const void* index_tile_extent,
+    optional<uint32_t> label_cell_val_num,
+    optional<std::pair<tiledb_filter_type_t, int>> label_filters,
+    optional<std::pair<tiledb_filter_type_t, int>> index_filters,
+    optional<uint64_t> capacity,
+    optional<bool> allows_dups) {
+  // Get definition of the dimension the label is being added to.
+  const auto* dim = array_schema->array_schema_->dimension_ptr(dim_idx);
+  auto dim_type = dim->type();
+  const auto& dim_domain = dim->domain();
+
+  // Create the dimension label.
+  tiledb_dimension_label_schema_t* dim_label_schema;
+  REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
+      ctx,
+      label_order,
+      static_cast<tiledb_datatype_t>(dim_type),
+      dim_domain.data(),
+      index_tile_extent,
+      label_datatype,
+      label_domain,
+      label_tile_extent,
+      &dim_label_schema));
+
+  // Update the proprerties of the dimension label.
+  UNSCOPED_INFO("API for adding label cell value number not yet implemented.");
+  REQUIRE(!label_cell_val_num.has_value());
+  UNSCOPED_INFO("API for adding label filters not yet implemented.");
+  REQUIRE(!label_filters.has_value());
+  UNSCOPED_INFO("API for adding index filters not yet implemented.");
+  REQUIRE(!index_filters.has_value());
+  UNSCOPED_INFO("API for adding capacity not yet implemented.");
+  REQUIRE(!capacity.has_value());
+  UNSCOPED_INFO("API for allowing duplicates not yet implemented.");
+  REQUIRE(!allows_dups.has_value());
+
+  // Add the dimension label to the array schema.
+  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
+      ctx, array_schema, dim_idx, label_name.c_str(), dim_label_schema));
+  tiledb_dimension_label_schema_free(&dim_label_schema);
+}
+
+}  // namespace tiledb::test

--- a/test/src/experimental_helpers.cc
+++ b/test/src/experimental_helpers.cc
@@ -25,6 +25,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
+ * This file declares some test suite helper functions for experimental
+ * features.
  */
 
 #include "experimental_helpers.h"

--- a/test/src/experimental_helpers.cc
+++ b/test/src/experimental_helpers.cc
@@ -40,13 +40,8 @@ void add_dimension_label(
     tiledb_datatype_t label_datatype,
     const void* label_domain,
     const void* label_tile_extent,
-    const void* index_tile_extent,
-    optional<uint32_t> label_cell_val_num,
-    optional<std::pair<tiledb_filter_type_t, int>> label_filters,
-    optional<std::pair<tiledb_filter_type_t, int>> index_filters,
-    optional<uint64_t> capacity,
-    optional<bool> allows_dups) {
-  // Get definition of the dimension the label is being added to.
+    const void* index_tile_extent) {
+  // Get the dimension type and domain from the array schema.
   const auto* dim = array_schema->array_schema_->dimension_ptr(dim_idx);
   auto dim_type = dim->type();
   const auto& dim_domain = dim->domain();
@@ -63,18 +58,6 @@ void add_dimension_label(
       label_domain,
       label_tile_extent,
       &dim_label_schema));
-
-  // Update the proprerties of the dimension label.
-  UNSCOPED_INFO("API for adding label cell value number not yet implemented.");
-  REQUIRE(!label_cell_val_num.has_value());
-  UNSCOPED_INFO("API for adding label filters not yet implemented.");
-  REQUIRE(!label_filters.has_value());
-  UNSCOPED_INFO("API for adding index filters not yet implemented.");
-  REQUIRE(!index_filters.has_value());
-  UNSCOPED_INFO("API for adding capacity not yet implemented.");
-  REQUIRE(!capacity.has_value());
-  UNSCOPED_INFO("API for allowing duplicates not yet implemented.");
-  REQUIRE(!allows_dups.has_value());
 
   // Add the dimension label to the array schema.
   REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(

--- a/test/src/experimental_helpers.h
+++ b/test/src/experimental_helpers.h
@@ -57,13 +57,6 @@ namespace tiledb::test {
  * @param label_domain The dimension label domain.
  * @param label_tile_extent The dimension tile extent for the label.
  * @param index_tile_extent The dimension label tile extent for the index.
- * @param label_cell_val_num Optional label cell vall num.
- * @param label_filters Optional filters for the label attr/dim on the dimension
- *     label.
- * @param index_filters Optional filters for the index attr/dim on the dimension
- *     label.
- * @param capacity Optional capacity size for the dimension label.
- * @param allow_dups Optional allow dups for the dimension label.
  */
 void add_dimension_label(
     tiledb_ctx_t* ctx,
@@ -74,12 +67,7 @@ void add_dimension_label(
     tiledb_datatype_t label_datatype,
     const void* label_domain,
     const void* label_tile_extent,
-    const void* index_tile_extent,
-    optional<uint32_t> label_cell_val_num = nullopt,
-    optional<std::pair<tiledb_filter_type_t, int>> label_filters = nullopt,
-    optional<std::pair<tiledb_filter_type_t, int>> index_filters = nullopt,
-    optional<uint64_t> capacity = nullopt,
-    optional<bool> allows_dups = nullopt);
+    const void* index_tile_extent);
 
 /**
  * Extension of the TemporaryDirectoryFixture that adds helper functions for

--- a/test/src/experimental_helpers.h
+++ b/test/src/experimental_helpers.h
@@ -49,7 +49,21 @@ namespace tiledb::test {
 /**
  * Helper method for adding an internal dimension label to an array schema.
  *
- * TODO: Add param docs
+ * @param ctx TileDB context.
+ * @param array_schema The array schema to add the dimension label to.
+ * @param label_name The name of the dimension label.
+ * @param dim_idx The dimension index to add the label on.
+ * @param label_order The label order for the dimension label.
+ * @param label_domain The dimension label domain.
+ * @param label_tile_extent The dimension tile extent for the label.
+ * @param index_tile_extent The dimension label tile extent for the index.
+ * @param label_cell_val_num Optional label cell vall num.
+ * @param label_filters Optional filters for the label attr/dim on the dimension
+ *     label.
+ * @param index_filters Optional filters for the index attr/dim on the dimension
+ *     label.
+ * @param capacity Optional capacity size for the dimension label.
+ * @param allow_dups Optional allow dups for the dimension label.
  */
 void add_dimension_label(
     tiledb_ctx_t* ctx,
@@ -74,7 +88,16 @@ void add_dimension_label(
 class DimensionLabelFixture : public TemporaryDirectoryFixture {
  public:
   /**
-   * TODO docs.
+   * Read data from the indexed array.
+   *
+   * Temporary hard-coded method for checking array data in the dimension label
+   * until update dimension label readers/writers are implemented.
+   *
+   * @param dim_label_uri URI of the dimension label.
+   * @param ncells The number of cells to read.
+   * @param start Starting index range value.
+   * @param end Ending index range value.
+   * @returns Vector of label values read from index array.
    */
   template <typename label_data_type>
   std::vector<label_data_type> read_indexed_array(
@@ -120,7 +143,17 @@ class DimensionLabelFixture : public TemporaryDirectoryFixture {
   }
 
   /**
-   * TODO: add docs
+   * Read data from the labelled array.
+   *
+   * Temporary hard-coded method for checking array data in the dimension label
+   * until update dimension label readers/writers are implemented.
+   *
+   * @param dim_label_uri URI of the dimension label.
+   * @param ncells The number of cells to read.
+   * @param start Starting label range value.
+   * @param end Ending label range value.
+   * @returns Vector of index values and vector of label values read from the
+   *     labelled array.
    */
   template <typename index_data_type, typename label_data_type>
   std::tuple<std::vector<index_data_type>, std::vector<label_data_type>>

--- a/test/src/experimental_helpers.h
+++ b/test/src/experimental_helpers.h
@@ -1,0 +1,176 @@
+/**
+ * @file   experimental_helpers.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares some test suite helper functions for experimental
+ * features.
+ */
+
+#ifndef TILEDB_TEST_EXPERIMENTAL_HELPERS_H
+#define TILEDB_TEST_EXPERIMENTAL_HELPERS_H
+
+#include "catch.hpp"
+#include "helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"
+#include "tiledb/sm/c_api/experimental/tiledb_struct_def.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "vfs_helpers.h"
+
+namespace tiledb::test {
+
+/**
+ * Helper method for adding an internal dimension label to an array schema.
+ *
+ * TODO: Add param docs
+ */
+void add_dimension_label(
+    tiledb_ctx_t* ctx,
+    tiledb_array_schema_t* array_schema,
+    const std::string& label_name,
+    const uint32_t dim_idx,
+    tiledb_label_order_t label_order,
+    tiledb_datatype_t label_datatype,
+    const void* label_domain,
+    const void* label_tile_extent,
+    const void* index_tile_extent,
+    optional<uint32_t> label_cell_val_num = nullopt,
+    optional<std::pair<tiledb_filter_type_t, int>> label_filters = nullopt,
+    optional<std::pair<tiledb_filter_type_t, int>> index_filters = nullopt,
+    optional<uint64_t> capacity = nullopt,
+    optional<bool> allows_dups = nullopt);
+
+/**
+ * Extension of the TemporaryDirectoryFixture that adds helper functions for
+ * testing dimension labels.
+ */
+class DimensionLabelFixture : public TemporaryDirectoryFixture {
+ public:
+  /**
+   * TODO docs.
+   */
+  template <typename label_data_type>
+  std::vector<label_data_type> read_indexed_array(
+      const sm::URI& dim_label_uri,
+      const uint64_t ncells,
+      void* start,
+      void* end) {
+    // Define output data.
+    std::vector<label_data_type> label_data(ncells);
+    uint64_t label_data_size{label_data.size() * sizeof(label_data_type)};
+
+    // Open array.
+    tiledb_array_t* array;
+    auto uri = dim_label_uri.join_path("indexed");
+    require_tiledb_ok(tiledb_array_alloc(ctx, uri.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(
+        tiledb_subarray_add_range(ctx, subarray, 0, start, end, nullptr));
+
+    // Create query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "label", label_data.data(), &label_data_size));
+
+    // Submit query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_query_free(&query);
+    tiledb_subarray_free(&subarray);
+    tiledb_array_free(&array);
+
+    return label_data;
+  }
+
+  /**
+   * TODO: add docs
+   */
+  template <typename index_data_type, typename label_data_type>
+  std::tuple<std::vector<index_data_type>, std::vector<label_data_type>>
+  read_labelled_array(
+      const sm::URI& dim_label_uri,
+      const uint64_t ncells,
+      void* start,
+      void* end) {
+    // Define output data.
+    std::vector<index_data_type> index_data(ncells);
+    uint64_t index_data_size{index_data.size() * sizeof(index_data_type)};
+    std::vector<label_data_type> label_data(ncells);
+    uint64_t label_data_size{label_data.size() * sizeof(label_data_type)};
+
+    // Open array.
+    tiledb_array_t* array;
+    auto uri = dim_label_uri.join_path("labelled");
+    require_tiledb_ok(tiledb_array_alloc(ctx, uri.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(
+        tiledb_subarray_add_range(ctx, subarray, 0, start, end, nullptr));
+
+    // Create query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "label", label_data.data(), &label_data_size));
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "index", index_data.data(), &index_data_size));
+
+    // Submit query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_query_free(&query);
+    tiledb_subarray_free(&subarray);
+    tiledb_array_free(&array);
+
+    return {index_data, label_data};
+  }
+};
+
+}  // namespace tiledb::test
+
+#endif

--- a/test/src/helpers.h
+++ b/test/src/helpers.h
@@ -77,18 +77,18 @@ extern std::mutex catch2_macro_mutex;
   { REQUIRE(a == TILEDB_OK); }
 
 // A variant of the CHECK macro for checking a Status object is okay.
-#define CHECK_TILEDB_STATUS_OK(status) \
-  {                                    \
-    if (!status.ok())                  \
-      INFO(status.to_string());        \
-    CHECK(status.ok());                \
+#define CHECK_TILEDB_STATUS_OK(status)   \
+  {                                      \
+    if (!status.ok())                    \
+      UNSCOPED_INFO(status.to_string()); \
+    CHECK(status.ok());                  \
   }
 
 // A variant of the REQUIRE macro for checking a Status objects is okay.
 #define REQUIRE_TILEDB_STATUS_OK(status) \
   {                                      \
     if (!status.ok())                    \
-      INFO(status.to_string());          \
+      UNSCOPED_INFO(status.to_string()); \
     REQUIRE(status.ok());                \
   }
 namespace tiledb {

--- a/test/src/test-capi-array-many-dimension-labels.cc
+++ b/test/src/test-capi-array-many-dimension-labels.cc
@@ -27,7 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * Tests the DimensionLabel API
+ * Test the dimension label API by writing many dimension labels to a dense
+ * array.
  */
 
 #include "test/src/experimental_helpers.h"
@@ -185,6 +186,18 @@ class ExampleArray : public DimensionLabelFixture {
     tiledb_array_schema_free(&array_schema);
   }
 
+  /**
+   * Write data to the array and all of the dimensions.
+   *
+   * @param a1 Data for the array attribute.
+   * @param x1 Data for the first x label.
+   * @param x2 Data for the second x label.
+   * @param y1 Data for the first y label.
+   * @param y2 Data for the second y label.
+   * @param z1 Data for the first z label.
+   * @param z2 Data for the second z label.
+   * @param time Data for the time data.
+   */
   void write_array_with_labels(
       std::vector<double>& a1,
       std::vector<double>& x1,
@@ -381,10 +394,19 @@ class ExampleArray : public DimensionLabelFixture {
   std::string array_name;
 
  private:
+  /** Domain for dimensions x, y, and z. */
   uint64_t domain_[2];
+
+  /** Domain for dimension t. */
   uint64_t t_domain_[2];
+
+  /** Domain for the dimension label on dimension t. */
   int64_t temporal_label_domain_[2];
+
+  /** Domain for the dimension labels x, y, and z. */
   double spatial_label1_domain_[2];
+
+  /** Domain for the dimension labels x_shifted, y_shifted, and z_shifted. */
   double spatial_label2_domain_[2];
 };
 

--- a/test/src/test-capi-array-many-dimension-labels.cc
+++ b/test/src/test-capi-array-many-dimension-labels.cc
@@ -1,0 +1,430 @@
+/**
+ * @file test-capi-array-many-dimension-labels.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the DimensionLabel API
+ */
+
+#include "test/src/experimental_helpers.h"
+#include "test/src/helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/array_schema/dimension_label_reference.h"
+#include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"
+#include "tiledb/sm/c_api/experimental/tiledb_struct_def.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/encryption_type.h"
+
+#include <test/support/tdb_catch.h>
+#include <iostream>
+#include <string>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/**
+ * Create a multi-dimensional array with multiple dimension labels.
+ *
+ * Array Summary:
+ *  * Array Type: Dense
+ *  * Dimensions:
+ *    - x: (type=UINT64, domain=[1, 4], tile=4)
+ *    - y: (type=UINT64, domain=[1, 4], tile=4)
+ *    - z: (type=UINT64, domain=[1, 4], tile=4)
+ *    - t: (type=UINT64, domain=[1, 8], tile=4)
+ *  * Attributes:
+ *    - a: (type=FLOAT64)
+ *  * Dimension labels:
+ *    - t: (label_order=INCREASING, dim_idx=3, type=DATETIME_SEC)
+ *    - x: (label_order=INCREASING, dim_idx=0, type=FLOAT64)
+ *    - y: (label_order=INCREASING, dim_idx=1, type=FLOAT64)
+ *    - z: (label_order=INCREASING, dim_idx=2, type=FLOAT64)
+ *    - alpha: (label_order=DECREASING, dim_idx=0, type=FLOAT64)
+ *    - beta:  (label_order=DECREASING, dim_idx=1, type=FLOAT64)
+ *    - gamma: (label_order=DEACRESING, dim_idx=2, type=FLOAT64)
+ *
+ */
+class ExampleArray : public DimensionLabelFixture {
+ public:
+  ExampleArray()
+      : domain_{1, 4}
+      , t_domain_{1, 8}
+      , temporal_label_domain_{0, 100}
+      , spatial_label1_domain_{-10.0, 10.0}
+      , spatial_label2_domain_{0.0, 100.0} {
+    // Create an array schema
+    uint64_t tile_extent{4};
+    auto array_schema = create_array_schema(
+        ctx,
+        TILEDB_DENSE,
+        {"x", "y", "z", "t"},
+        {TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64, TILEDB_UINT64},
+        {&domain_[0], &domain_[0], &domain_[0], &t_domain_[0]},
+        {&tile_extent, &tile_extent, &tile_extent, &tile_extent},
+        {"a"},
+        {TILEDB_FLOAT64},
+        {1},
+        {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+        TILEDB_ROW_MAJOR,
+        TILEDB_ROW_MAJOR,
+        4096,
+        false);
+
+    // Add dimension labels.
+    double spatial_label1_tile = 20.0;
+    double spatial_label2_tile = 100.0;
+    int64_t temporal_tile = 101;
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "t",
+        3,
+        TILEDB_INCREASING_LABELS,
+        TILEDB_DATETIME_SEC,
+        &temporal_label_domain_[0],
+        &temporal_tile,
+        &tile_extent);
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "x",
+        0,
+        TILEDB_INCREASING_LABELS,
+        TILEDB_FLOAT64,
+        &spatial_label1_domain_[0],
+        &spatial_label1_tile,
+        &tile_extent);
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "y",
+        1,
+        TILEDB_INCREASING_LABELS,
+        TILEDB_FLOAT64,
+        &spatial_label1_domain_[0],
+        &spatial_label1_tile,
+        &tile_extent);
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "z",
+        2,
+        TILEDB_INCREASING_LABELS,
+        TILEDB_FLOAT64,
+        &spatial_label1_domain_[0],
+        &spatial_label1_tile,
+        &tile_extent);
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "x_shifted",
+        0,
+        TILEDB_DECREASING_LABELS,
+        TILEDB_FLOAT64,
+        &spatial_label2_domain_[0],
+        &spatial_label2_tile,
+        &tile_extent);
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "y_shifted",
+        1,
+        TILEDB_DECREASING_LABELS,
+        TILEDB_FLOAT64,
+        &spatial_label2_domain_[0],
+        &spatial_label2_tile,
+        &tile_extent);
+
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "z_shifted",
+        2,
+        TILEDB_DECREASING_LABELS,
+        TILEDB_FLOAT64,
+        &spatial_label2_domain_[0],
+        &spatial_label2_tile,
+        &tile_extent);
+
+    // Create array
+    array_name =
+        create_temporary_array("array_with_multiple_labels", array_schema);
+    tiledb_array_schema_free(&array_schema);
+  }
+
+  void write_array_with_labels(
+      std::vector<double>& a1,
+      std::vector<double>& x1,
+      std::vector<double>& x2,
+      std::vector<double>& y1,
+      std::vector<double>& y2,
+      std::vector<double>& z1,
+      std::vector<double>& z2,
+      std::vector<int64_t>& time) {
+    // Open array for writing.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+    // Define sizes for setting buffers.
+    uint64_t a1_size{a1.size() * sizeof(double)};
+    uint64_t x1_size{x1.size() * sizeof(double)};
+    uint64_t x2_size{x2.size() * sizeof(double)};
+    uint64_t y1_size{y1.size() * sizeof(double)};
+    uint64_t y2_size{y2.size() * sizeof(double)};
+    uint64_t z1_size{z1.size() * sizeof(double)};
+    uint64_t z2_size{z2.size() * sizeof(double)};
+    uint64_t time_size{time.size() * sizeof(double)};
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &domain_[0], &domain_[1], nullptr));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 1, &domain_[0], &domain_[1], nullptr));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 2, &domain_[0], &domain_[1], nullptr));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 3, &t_domain_[0], &t_domain_[1], nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(
+        tiledb_query_set_data_buffer(ctx, query, "a", a1.data(), &a1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x", x1.data(), &x1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x_shifted", x2.data(), &x2_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "y", y1.data(), &y1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "y_shifted", y2.data(), &y2_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "z", z1.data(), &z1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "z_shifted", z2.data(), &z2_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "t", time.data(), &time_size));
+
+    // Submit write query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /**
+   * Read back and check label values in a data query.
+   *
+   * @param expected_x1 Expected values for the first x label.
+   * @param expected_x2 Expected values for the second x label.
+   * @param expected_y1 Expected values for the first y label.
+   * @param expected_y2 Expected values for the second y label.
+   * @param expected_z1 Expected values for the first z label.
+   * @param expected_z2 Expected values for the second z label.
+   * @param expected_time Excepted values for the time data.
+   */
+  void check_values_from_data_reader(
+      const std::vector<double>& expected_x1,
+      const std::vector<double>& expected_x2,
+      const std::vector<double>& expected_y1,
+      const std::vector<double>& expected_y2,
+      const std::vector<double>& expected_z1,
+      const std::vector<double>& expected_z2,
+      const std::vector<int64_t>& expected_time) {
+    // Open array for reading.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &domain_[0], &domain_[1], nullptr));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 1, &domain_[0], &domain_[1], nullptr));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 2, &domain_[0], &domain_[1], nullptr));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 3, &t_domain_[0], &t_domain_[1], nullptr));
+
+    // Define label data buffers.
+    std::vector<double> x1(4);
+    std::vector<double> x2(4);
+    std::vector<double> y1(4);
+    std::vector<double> y2(4);
+    std::vector<double> z1(4);
+    std::vector<double> z2(4);
+    std::vector<int64_t> time(8);
+
+    // Define sizes for setting buffers.
+    uint64_t x1_size{x1.size() * sizeof(double)};
+    uint64_t x2_size{x2.size() * sizeof(double)};
+    uint64_t y1_size{y1.size() * sizeof(double)};
+    uint64_t y2_size{y2.size() * sizeof(double)};
+    uint64_t z1_size{z1.size() * sizeof(double)};
+    uint64_t z2_size{z2.size() * sizeof(double)};
+    uint64_t time_size{time.size() * sizeof(double)};
+
+    // Create read query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x", x1.data(), &x1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x_shifted", x2.data(), &x2_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "y", y1.data(), &y1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "y_shifted", y2.data(), &y2_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "z", z1.data(), &z1_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "z_shifted", z2.data(), &z2_size));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "t", time.data(), &time_size));
+
+    // Submit read query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+
+    // Check results.
+    for (uint64_t index{0}; index < 4; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(x1[index] == expected_x1[index]);
+    }
+
+    for (uint64_t index{0}; index < 4; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(x2[index] == expected_x2[index]);
+    }
+
+    for (uint64_t index{0}; index < 4; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(y1[index] == expected_y1[index]);
+    }
+
+    for (uint64_t index{0}; index < 4; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(y2[index] == expected_y2[index]);
+    }
+
+    for (uint64_t index{0}; index < 4; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(z1[index] == expected_z1[index]);
+    }
+
+    for (uint64_t index{0}; index < 4; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(z2[index] == expected_z2[index]);
+    }
+
+    for (uint64_t index{0}; index < 8; ++index) {
+      UNSCOPED_INFO("index = " + std::to_string(index));
+      CHECK(time[index] == expected_time[index]);
+    }
+  }
+
+ protected:
+  /** Name of the example array. */
+  std::string array_name;
+
+ private:
+  uint64_t domain_[2];
+  uint64_t t_domain_[2];
+  int64_t temporal_label_domain_[2];
+  double spatial_label1_domain_[2];
+  double spatial_label2_domain_[2];
+};
+
+TEST_CASE_METHOD(
+    ExampleArray,
+    "Test writing to array with many dimension labels",
+    "[capi][query][DimensionLabel]") {
+  // Input attribute data.
+  std::vector<double> input_a(512);
+  for (uint64_t index{0}; index < 512; ++index) {
+    input_a[index] = 0.1 * index;
+  }
+
+  // Data for x labels.
+  std::vector<double> input_x1{-10.0, -4.0, -2.0, 8.0};
+  std::vector<double> input_x2{100.0, 70.0, 60.0, 30.0};
+
+  // Data for y labels.
+  std::vector<double> input_y1{-9.0, 2.0, 6.0, 10.0};
+  std::vector<double> input_y2{95.0, 40.0, 20.0, 0.0};
+
+  // Data for z labels.
+  std::vector<double> input_z1{-10.0, -5.0, 5.0, 10.0};
+  std::vector<double> input_z2{100, 75, 25, 0};
+
+  // Data for t label.
+  std::vector<int64_t> input_t{0, 4, 9, 11, 14, 15, 18, 20};
+
+  // Write data.
+  write_array_with_labels(
+      input_a,
+      input_x1,
+      input_x2,
+      input_y1,
+      input_y2,
+      input_z1,
+      input_z2,
+      input_t);
+
+  // Check the data.
+  check_values_from_data_reader(
+      input_x1, input_x2, input_y1, input_y2, input_z1, input_z2, input_t);
+}

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -55,7 +55,7 @@ using namespace tiledb::test;
  * Array Summary:
  *  * Array Type: Dense
  *  * Dimensions:
- *    - x: (type=UINT64, domain=[1, 4], tile=4)
+ *    - x: (type=UINT64, domain=[0, 3], tile=4)
  *  * Attributes:
  *    - a: (type=FLOAT64)
  *  * Dimension labels:
@@ -101,7 +101,7 @@ class ArrayExample : public DimensionLabelFixture {
 
   void write_array_with_label(
       std::vector<double>& input_attr_data,
-      std::vector<char>& input_label_data,
+      std::string& input_label_data,
       std::vector<uint64_t>& input_label_offsets) {
     // Open array for writing.
     tiledb_array_t* array;
@@ -152,7 +152,7 @@ class ArrayExample : public DimensionLabelFixture {
    * @param expected_label_data A vector of the expected label values.
    */
   void check_values_from_data_reader(
-      const std::vector<char>& expected_label_data,
+      const std::string& expected_label_data,
       const std::vector<uint64_t>& expected_label_offsets) {
     // Open array for reading.
     tiledb_array_t* array;
@@ -219,24 +219,7 @@ TEST_CASE_METHOD(
     "[capi][query][DimensionLabel]") {
   // Define the input data values.
   std::vector<double> input_attr_data{1.0, 2.5, -1.0, 0.0};
-  std::vector<char> input_label_data{'r',
-                                     'e',
-                                     'd',
-                                     'y',
-                                     'e',
-                                     'l',
-                                     'l',
-                                     'o',
-                                     'w',
-                                     'g',
-                                     'r',
-                                     'e',
-                                     'e',
-                                     'n',
-                                     'b',
-                                     'l',
-                                     'u',
-                                     'e'};
+  std::string input_label_data{"redyellowgreenblue"};
   std::vector<uint64_t> input_label_offsets{0, 4, 10, 15};
 
   // Write the array.

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -1,0 +1,253 @@
+/**
+ * @file test-capi-sparse-array-dimension-label.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the DimensionLabel API
+ */
+
+#include "test/src/experimental_helpers.h"
+#include "test/src/helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/array_schema/dimension_label_reference.h"
+#include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"
+#include "tiledb/sm/c_api/experimental/tiledb_struct_def.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/encryption_type.h"
+
+#include <test/support/tdb_catch.h>
+#include <iostream>
+#include <string>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/**
+ * Create a small dense array with a dimension label.
+ *
+ * Array Summary:
+ *  * Array Type: Dense
+ *  * Dimensions:
+ *    - x: (type=UINT64, domain=[1, 4], tile=4)
+ *  * Attributes:
+ *    - a: (type=FLOAT64)
+ *  * Dimension labels:
+ *    - x: (label_order=UNORDERED_LABELS, dim_idx=0, type=STRING_ASCII)
+ */
+class ArrayExample : public DimensionLabelFixture {
+ public:
+  ArrayExample()
+      : index_domain_{0, 3} {
+    // Create an array schema
+    uint64_t x_tile_extent{4};
+    auto array_schema = create_array_schema(
+        ctx,
+        TILEDB_DENSE,
+        {"x"},
+        {TILEDB_UINT64},
+        {&index_domain_[0]},
+        {&x_tile_extent},
+        {"a"},
+        {TILEDB_FLOAT64},
+        {1},
+        {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+        TILEDB_ROW_MAJOR,
+        TILEDB_ROW_MAJOR,
+        4096,
+        false);
+
+    // Add dimension label.
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "x",
+        0,
+        TILEDB_UNORDERED_LABELS,
+        TILEDB_STRING_ASCII,
+        nullptr,
+        nullptr,
+        &x_tile_extent);
+    // Create array
+    array_name = create_temporary_array("array_with_label_1", array_schema);
+    tiledb_array_schema_free(&array_schema);
+  }
+
+  void write_array_with_label(
+      std::vector<double>& input_attr_data,
+      std::vector<char>& input_label_data,
+      std::vector<uint64_t>& input_label_offsets) {
+    // Open array for writing.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+    // Define sizes for setting buffers.
+    uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+    uint64_t label_data_size{input_label_data.size() * sizeof(char)};
+    uint64_t label_offsets_size{input_label_offsets.size() * sizeof(uint64_t)};
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &index_domain_[0], &index_domain_[1], nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    if (attr_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_data_buffer(
+          ctx, query, "a", input_attr_data.data(), &attr_data_size));
+    }
+    if (label_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_label_data_buffer(
+          ctx, query, "x", input_label_data.data(), &label_data_size));
+      require_tiledb_ok(tiledb_query_set_label_offsets_buffer(
+          ctx, query, "x", input_label_offsets.data(), &label_offsets_size));
+    }
+
+    // Submit write query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /**
+   * Read back full array with a data query and check the values.
+   *
+   * @param expected_label_data A vector of the expected label values.
+   */
+  void check_values_from_data_reader(
+      const std::vector<char>& expected_label_data,
+      const std::vector<uint64_t>& expected_label_offsets) {
+    // Open array for reading.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &index_domain_[0], &index_domain_[1], nullptr));
+
+    // Define label buffers and size.
+    std::vector<char> label_data(20);
+    std::vector<uint64_t> label_offsets(4);
+    uint64_t label_data_size{label_data.size() * sizeof(char)};
+    uint64_t label_offsets_size{label_offsets.size() * sizeof(uint64_t)};
+
+    // Create read query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x", label_data.data(), &label_data_size));
+    require_tiledb_ok(tiledb_query_set_label_offsets_buffer(
+        ctx, query, "x", label_offsets.data(), &label_offsets_size));
+
+    // Submit read query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+
+    // Check results.
+    CHECK(label_data_size == sizeof(char) * expected_label_data.size());
+    CHECK(
+        label_offsets_size == sizeof(uint64_t) * expected_label_offsets.size());
+    for (uint64_t ii{0}; ii < expected_label_data.size(); ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_offsets[ii] == expected_label_offsets[ii]);
+    }
+  }
+
+ protected:
+  /** Name of the example array. */
+  std::string array_name;
+
+ private:
+  /** Valid range for the index. */
+  uint64_t index_domain_[2];
+};
+
+TEST_CASE_METHOD(
+    ArrayExample,
+    "Round trip dimension label and array data for dense 1d array",
+    "[capi][query][DimensionLabel]") {
+  // Define the input data values.
+  std::vector<double> input_attr_data{1.0, 2.5, -1.0, 0.0};
+  std::vector<char> input_label_data{'r',
+                                     'e',
+                                     'd',
+                                     'y',
+                                     'e',
+                                     'l',
+                                     'l',
+                                     'o',
+                                     'w',
+                                     'g',
+                                     'r',
+                                     'e',
+                                     'e',
+                                     'n',
+                                     'b',
+                                     'l',
+                                     'u',
+                                     'e'};
+  std::vector<uint64_t> input_label_offsets{0, 4, 10, 15};
+
+  // Write the array.
+  write_array_with_label(
+      input_attr_data, input_label_data, input_label_offsets);
+  /**
+  // Check the dimension label arrays have the correct data.
+  check_indexed_array_data(input_label_data);
+  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+
+  // Check data reader.
+  check_values_from_data_reader(input_label_data);
+  **/
+}

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -27,7 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * Tests the DimensionLabel API
+ * Test the dimension label API with a dense array using variable size dimension
+ * labels.
  */
 
 #include "test/src/experimental_helpers.h"
@@ -99,6 +100,16 @@ class ArrayExample : public DimensionLabelFixture {
     tiledb_array_schema_free(&array_schema);
   }
 
+  /**
+   * Write data to the array and its dimension label.
+   *
+   * @param input_attr_data Data to write to the array attribute. If empty, the
+   *     attribute is not written to.
+   * @param input_label_data Data to write to the dimension label. If empty, the
+   *     dimension label is not written to.
+   * @param input_label_offsets Data to write to the dimension label. If
+   *     `input_label_data` is emtpy, this data is not set.
+   */
   void write_array_with_label(
       std::vector<double>& input_attr_data,
       std::string& input_label_data,
@@ -150,6 +161,7 @@ class ArrayExample : public DimensionLabelFixture {
    * Read back full array with a data query and check the values.
    *
    * @param expected_label_data A vector of the expected label values.
+   * @param expected_label_offsets A vector of the expected label offsets.
    */
   void check_values_from_data_reader(
       const std::string& expected_label_data,
@@ -225,12 +237,7 @@ TEST_CASE_METHOD(
   // Write the array.
   write_array_with_label(
       input_attr_data, input_label_data, input_label_offsets);
-  /**
-  // Check the dimension label arrays have the correct data.
-  check_indexed_array_data(input_label_data);
-  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
 
   // Check data reader.
-  check_values_from_data_reader(input_label_data);
-  **/
+  check_values_from_data_reader(input_label_data, input_label_offsets);
 }

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -59,6 +59,14 @@ using namespace tiledb::test;
 /**
  * Create a small dense array with a dimension label.
  *
+ * Array Summary:
+ *  * Array Type: Dense
+ *  * Dimensions:
+ *    - x: (type=UINT64, domain=[1, 4], tile=4)
+ *  * Attributes:
+ *    - a: (type=FLOAT64)
+ *  * Dimension labels:
+ *    - x: (label_order=label_order_t, dim_idx=0, type=FLOAT64)
  */
 class DenseArrayExample1 : public DimensionLabelFixture {
  public:

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -55,7 +55,7 @@ using namespace tiledb::test;
  * Array Summary:
  *  * Array Type: Dense
  *  * Dimensions:
- *    - x: (type=UINT64, domain=[1, 4], tile=4)
+ *    - x: (type=UINT64, domain=[0, 3], tile=4)
  *  * Attributes:
  *    - a: (type=FLOAT64)
  *  * Dimension labels:

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -251,122 +251,112 @@ class DenseArrayExample1 : public DimensionLabelFixture {
 
 TEST_CASE_METHOD(
     DenseArrayExample1,
-    "Round trip dimension label and array data for dense 1d array",
-    "[capi][query][DimensionLabel]") {
-  // Define the input data values.
-  std::vector<double> input_label_data{};
-  std::vector<double> input_attr_data{};
-
-  // Define the expected output values.
-  std::vector<double> expected_label_data_sorted{};
-  std::vector<uint64_t> expected_index_data{};
-
-  SECTION("Write increasing labels", "[IncreasingLabels]") {
-    // Create the array.
-    create_example(TILEDB_INCREASING_LABELS);
-
-    // Set the input  values.
-    input_label_data = {-1.0, 0.0, 0.5, 1.0};
-    input_attr_data = {0.5, 1.0, 1.5, 2.0};
-
-    // Define expected output data.
-    expected_label_data_sorted = input_label_data;
-    expected_index_data = {0, 1, 2, 3};
-  }
-
-  SECTION("Write decreasing labels", "[DecreasingLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
-
-    // Set the data values.
-    input_label_data = {1.0, 0.0, -0.5, -1.0};
-    input_attr_data = {0.5, 1.0, 1.5, 2.0};
-
-    // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {3, 2, 1, 0};
-  }
-
-  SECTION("Write unordered labels", "[UnorderedLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
-
-    // Set the data values.
-    input_label_data = {-0.5, 1.0, 0.0, -1.0};
-    input_attr_data = {0.5, 1.0, 1.5, 2.0};
-
-    // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {3, 0, 2, 1};
-  }
-
-  // Write the array.
-  write_array_with_label(input_attr_data, input_label_data);
-
-  // Check the dimension label arrays have the correct data.
-  check_indexed_array_data(input_label_data);
-  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
-
-  // Check data reader.
-  check_values_from_data_reader(input_label_data);
-}
-
-TEST_CASE_METHOD(
-    DenseArrayExample1,
     "Round trip dimension label data for dense 1d array",
     "[capi][query][DimensionLabel]") {
-  // Define the input data values.
+  // Vectors for input data.
   std::vector<double> input_label_data{};
   std::vector<double> input_attr_data{};
 
-  // Define the expected output values.
-  std::vector<double> expected_label_data_sorted{};
-  std::vector<uint64_t> expected_index_data{};
+  // Vectors for expected output data.
+  std::vector<double> label_data_sorted_by_label{};
+  std::vector<uint64_t> index_data_sorted_by_label{};
 
-  SECTION("Write increasing labels", "[IncreasingLabels]") {
-    // Create the array.
-    create_example(TILEDB_INCREASING_LABELS);
+  // Dimension label parameters.
+  tiledb_label_order_t label_order;
+
+  SECTION("Write increasing labels and array", "[IncreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_INCREASING_LABELS;
+
+    // Set the data values.
+    input_label_data = {-1.0, 0.0, 0.5, 1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    label_data_sorted_by_label = input_label_data;
+    index_data_sorted_by_label = {0, 1, 2, 3};
+  }
+
+  SECTION("Write increasing labels only", "[IncreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_INCREASING_LABELS;
 
     // Set the data values.
     input_label_data = {-1.0, 0.0, 0.5, 1.0};
 
     // Define expected output data.
-    expected_label_data_sorted = input_label_data;
-    expected_index_data = {0, 1, 2, 3};
+    label_data_sorted_by_label = input_label_data;
+    index_data_sorted_by_label = {0, 1, 2, 3};
   }
 
   SECTION("Write decreasing labels", "[DecreasingLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
+    // Set the label order.
+    label_order = TILEDB_DECREASING_LABELS;
+
+    // Set the data values.
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {3, 2, 1, 0};
+  }
+
+  SECTION("Write decreasing labels only", "[DecreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_DECREASING_LABELS;
 
     // Set the data values.
     input_label_data = {1.0, 0.0, -0.5, -1.0};
 
     // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {3, 2, 1, 0};
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {3, 2, 1, 0};
   }
 
-  SECTION("Write unordered labels", "[UnorderedLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
+  SECTION("Write unordered labels and array", "[UnorderedLabels]") {
+    // Set the label order.
+    label_order = TILEDB_UNORDERED_LABELS;
 
     // Set the data values.
     input_label_data = {-0.5, 1.0, 0.0, -1.0};
     input_attr_data = {0.5, 1.0, 1.5, 2.0};
 
     // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {3, 0, 2, 1};
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {3, 0, 2, 1};
   }
 
-  // Write the array.
+  SECTION("Write unordered labels only", "[UnorderedLabels]") {
+    // Set the label order.
+    label_order = TILEDB_UNORDERED_LABELS;
+
+    // Set the data values.
+    input_label_data = {-0.5, 1.0, 0.0, -1.0};
+
+    // Define expected output data.
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {3, 0, 2, 1};
+  }
+
+  // Create and write the array.
+  create_example(label_order);
   write_array_with_label(input_attr_data, input_label_data);
 
   // Check the dimension label arrays have the correct data.
-  check_indexed_array_data(input_label_data);
-  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+  {
+    INFO("Check indexed array data");
+    check_indexed_array_data(input_label_data);
+  }
+  {
+    INFO("Check labelled array data");
+    check_labelled_array_data(
+        index_data_sorted_by_label, label_data_sorted_by_label);
+  }
 
   // Check data reader.
-  check_values_from_data_reader(input_label_data);
+  {
+    INFO("Check data readed value");
+    check_values_from_data_reader(input_label_data);
+  }
 }

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -1,0 +1,364 @@
+/**
+ * @file test-capi-sparse-array-dimension-label.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the DimensionLabel API
+ */
+
+#include "test/src/experimental_helpers.h"
+#include "test/src/helpers.h"
+#include "test/src/vfs_helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/array_schema/dimension_label_reference.h"
+#include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"
+#include "tiledb/sm/c_api/experimental/tiledb_struct_def.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/encryption_type.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <test/support/tdb_catch.h>
+#include <iostream>
+#include <string>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/**
+ * Create a small dense array with a dimension label.
+ *
+ */
+class DenseArrayExample1 : public DimensionLabelFixture {
+ public:
+  DenseArrayExample1()
+      : array_name{}
+      , index_domain_{0, 3}
+      , label_domain_{-1, 1} {
+  }
+
+  void create_example(tiledb_label_order_t label_order) {
+    // Create an array schema
+    uint64_t x_tile_extent{4};
+    auto array_schema = create_array_schema(
+        ctx,
+        TILEDB_DENSE,
+        {"x"},
+        {TILEDB_UINT64},
+        {&index_domain_[0]},
+        {&x_tile_extent},
+        {"a"},
+        {TILEDB_FLOAT64},
+        {1},
+        {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+        TILEDB_ROW_MAJOR,
+        TILEDB_ROW_MAJOR,
+        4096,
+        false);
+
+    // Add dimension label.
+    double label_tile_extent = 2.0;
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "x",
+        0,
+        label_order,
+        TILEDB_FLOAT64,
+        &label_domain_[0],
+        &label_tile_extent,
+        &x_tile_extent);
+    // Create array
+    array_name = create_temporary_array("array_with_label_1", array_schema);
+    tiledb_array_schema_free(&array_schema);
+  }
+
+  void write_array_with_label(
+      std::vector<double>& input_attr_data,
+      std::vector<double>& input_label_data) {
+    // Open array for writing.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+    // Define sizes for setting buffers.
+    uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+    uint64_t label_data_size{input_label_data.size() * sizeof(double)};
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &index_domain_[0], &index_domain_[1], nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    if (attr_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_data_buffer(
+          ctx, query, "a", input_attr_data.data(), &attr_data_size));
+    }
+    if (label_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_label_data_buffer(
+          ctx, query, "x", input_label_data.data(), &label_data_size));
+    }
+
+    // Submit write query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  void check_indexed_array_data(
+      const std::vector<double>& expected_label_data) {
+    // Read back the data.
+    auto label_data = DimensionLabelFixture::read_indexed_array<double>(
+        URI(array_name).join_path("__labels/l0"),
+        4,
+        &index_domain_[0],
+        &index_domain_[1]);
+
+    // Check results.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+  }
+
+  void check_labelled_array_data(
+      const std::vector<uint64_t>& expected_index_data,
+      const std::vector<double>& expected_label_data) {
+    // Read back the data.
+    auto [index_data, label_data] =
+        DimensionLabelFixture::read_labelled_array<uint64_t, double>(
+            URI(array_name).join_path("__labels/l0"),
+            4,
+            &label_domain_[0],
+            &label_domain_[1]);
+
+    // Check the results.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(index_data[ii] == expected_index_data[ii]);
+    }
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+  }
+
+  /**
+   * Read back full array with a data query and check the values.
+   *
+   * @param expected_label_data A vector of the expected label values.
+   */
+  void check_values_from_data_reader(
+      const std::vector<double>& expected_label_data) {
+    // Open array for reading.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &index_domain_[0], &index_domain_[1], nullptr));
+
+    // Define label buffer and size.
+    std::vector<double> label_data(4);
+    uint64_t label_data_size{label_data.size() * sizeof(double)};
+
+    // Create read query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x", label_data.data(), &label_data_size));
+
+    // Submit read query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+
+    // Check results.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+  }
+
+ protected:
+  /** Name of the example array. */
+  std::string array_name;
+
+ private:
+  /** Valid range for the index. */
+  uint64_t index_domain_[2];
+
+  /** Valid range for the label. */
+  double label_domain_[2];
+};
+
+TEST_CASE_METHOD(
+    DenseArrayExample1,
+    "Round trip dimension label and array data for dense 1d array",
+    "[capi][query][DimensionLabel]") {
+  // Define the input data values.
+  std::vector<double> input_label_data{};
+  std::vector<double> input_attr_data{};
+
+  // Define the expected output values.
+  std::vector<double> expected_label_data_sorted{};
+  std::vector<uint64_t> expected_index_data{};
+
+  SECTION("Write increasing labels", "[IncreasingLabels]") {
+    // Create the array.
+    create_example(TILEDB_INCREASING_LABELS);
+
+    // Set the input  values.
+    input_label_data = {-1.0, 0.0, 0.5, 1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = input_label_data;
+    expected_index_data = {0, 1, 2, 3};
+  }
+
+  SECTION("Write decreasing labels", "[DecreasingLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {3, 2, 1, 0};
+  }
+
+  SECTION("Write unordered labels", "[UnorderedLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_label_data = {-0.5, 1.0, 0.0, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {3, 0, 2, 1};
+  }
+
+  // Write the array.
+  write_array_with_label(input_attr_data, input_label_data);
+
+  // Check the dimension label arrays have the correct data.
+  check_indexed_array_data(input_label_data);
+  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+
+  // Check data reader.
+  check_values_from_data_reader(input_label_data);
+}
+
+TEST_CASE_METHOD(
+    DenseArrayExample1,
+    "Round trip dimension label data for dense 1d array",
+    "[capi][query][DimensionLabel]") {
+  // Define the input data values.
+  std::vector<double> input_label_data{};
+  std::vector<double> input_attr_data{};
+
+  // Define the expected output values.
+  std::vector<double> expected_label_data_sorted{};
+  std::vector<uint64_t> expected_index_data{};
+
+  SECTION("Write increasing labels", "[IncreasingLabels]") {
+    // Create the array.
+    create_example(TILEDB_INCREASING_LABELS);
+
+    // Set the data values.
+    input_label_data = {-1.0, 0.0, 0.5, 1.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = input_label_data;
+    expected_index_data = {0, 1, 2, 3};
+  }
+
+  SECTION("Write decreasing labels", "[DecreasingLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {3, 2, 1, 0};
+  }
+
+  SECTION("Write unordered labels", "[UnorderedLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_label_data = {-0.5, 1.0, 0.0, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {3, 0, 2, 1};
+  }
+
+  // Write the array.
+  write_array_with_label(input_attr_data, input_label_data);
+
+  // Check the dimension label arrays have the correct data.
+  check_indexed_array_data(input_label_data);
+  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+
+  // Check data reader.
+  check_values_from_data_reader(input_label_data);
+}

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -32,7 +32,6 @@
 
 #include "test/src/experimental_helpers.h"
 #include "test/src/helpers.h"
-#include "test/src/vfs_helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/array_schema/dimension_label_reference.h"
 #include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"
@@ -42,12 +41,6 @@
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/dimension_label/dimension_label.h"
 #include "tiledb/sm/enums/encryption_type.h"
-
-#ifdef _WIN32
-#include "tiledb/sm/filesystem/win.h"
-#else
-#include "tiledb/sm/filesystem/posix.h"
-#endif
 
 #include <test/support/tdb_catch.h>
 #include <iostream>
@@ -114,7 +107,8 @@ class DenseArrayExample1 : public DimensionLabelFixture {
 
   void write_array_with_label(
       std::vector<double>& input_attr_data,
-      std::vector<double>& input_label_data) {
+      std::vector<double>& input_label_data,
+      bool error_on_write = false) {
     // Open array for writing.
     tiledb_array_t* array;
     require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
@@ -145,10 +139,15 @@ class DenseArrayExample1 : public DimensionLabelFixture {
     }
 
     // Submit write query.
-    require_tiledb_ok(tiledb_query_submit(ctx, query));
-    tiledb_query_status_t query_status;
-    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
-    REQUIRE(query_status == TILEDB_COMPLETED);
+    if (error_on_write) {
+      auto rc = tiledb_query_submit(ctx, query);
+      REQUIRE(rc != TILEDB_OK);
+    } else {
+      require_tiledb_ok(tiledb_query_submit(ctx, query));
+      tiledb_query_status_t query_status;
+      require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+      REQUIRE(query_status == TILEDB_COMPLETED);
+    }
 
     // Clean-up.
     tiledb_query_free(&query);
@@ -359,4 +358,44 @@ TEST_CASE_METHOD(
     INFO("Check data readed value");
     check_values_from_data_reader(input_label_data);
   }
+}
+
+TEST_CASE_METHOD(
+    DenseArrayExample1,
+    "Test error on bad dimension label order for dense array",
+    "[capi][query][DimensionLabel]") {
+  // Vectors for input data.
+  std::vector<double> input_label_data{};
+  std::vector<double> input_attr_data{};
+
+  // Dimension label parameters.
+  tiledb_label_order_t label_order;
+
+  SECTION("Increasing labels with bad order", "[IncreasingLabels]") {
+    label_order = TILEDB_INCREASING_LABELS;
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+  }
+
+  SECTION("Increasing labels with duplicate values", "[IncreasingLabels]") {
+    label_order = TILEDB_INCREASING_LABELS;
+    input_label_data = {-1.0, 0.0, 0.0, 1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+  }
+
+  SECTION("Decreasing labels with bad order", "[IncreasingLabels]") {
+    label_order = TILEDB_DECREASING_LABELS;
+    input_label_data = {-1.0, -0.5, 0.0, 1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+  }
+
+  SECTION("Decreasing labels with duplicate values", "[IncreasingLabels]") {
+    label_order = TILEDB_DECREASING_LABELS;
+    input_label_data = {1.0, 0.0, 0.0, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+  }
+
+  // Create the array.
+  create_example(label_order);
+  write_array_with_label(input_attr_data, input_label_data, true);
 }

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -27,7 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * Tests the DimensionLabel API
+ * Test the dimension label API with a dense array using fixed size dimension
+ * labels.
  */
 
 #include "test/src/experimental_helpers.h"
@@ -69,6 +70,11 @@ class DenseArrayExample1 : public DimensionLabelFixture {
       , label_domain_{-1, 1} {
   }
 
+  /**
+   * Create the example array with a dimension label.
+   *
+   * @param label_order Label order for the dimension label.
+   */
   void create_example(tiledb_label_order_t label_order) {
     // Create an array schema
     uint64_t x_tile_extent{4};
@@ -100,11 +106,21 @@ class DenseArrayExample1 : public DimensionLabelFixture {
         &label_domain_[0],
         &label_tile_extent,
         &x_tile_extent);
+
     // Create array
     array_name = create_temporary_array("array_with_label_1", array_schema);
     tiledb_array_schema_free(&array_schema);
   }
 
+  /**
+   * Write data to the array and dimension label.
+   *
+   * @param input_attr_data Data to write to the array attribute. If empty, the
+   *     attribute data is not added to the query.
+   * @param input_label_data Data to write to the dimension label. If empty, the
+   *     dimension label data is not added to the query.
+   * @param error_on_write If true, require the query returns a failed status.
+   */
   void write_array_with_label(
       std::vector<double>& input_attr_data,
       std::vector<double>& input_label_data,
@@ -154,6 +170,11 @@ class DenseArrayExample1 : public DimensionLabelFixture {
     tiledb_array_free(&array);
   }
 
+  /**
+   * Check the value in the indexed array is correct.
+   *
+   * @param expected_label_data The expected label data in the indexed array.
+   */
   void check_indexed_array_data(
       const std::vector<double>& expected_label_data) {
     // Read back the data.
@@ -169,6 +190,12 @@ class DenseArrayExample1 : public DimensionLabelFixture {
     }
   }
 
+  /**
+   * Check the value in the labelled array is correct.
+   *
+   * @param expected_index_data The expected index data in the labelled array.
+   * @param expected_label_data The expected label data in the labelled array.
+   */
   void check_labelled_array_data(
       const std::vector<uint64_t>& expected_index_data,
       const std::vector<double>& expected_label_data) {

--- a/test/src/test-capi-dimension_labels.cc
+++ b/test/src/test-capi-dimension_labels.cc
@@ -140,7 +140,7 @@ std::string DimensionLabelTestFixture::create_single_label_array(
   tiledb_dimension_label_schema_t* dim_label_schema;
   REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
       ctx,
-      TILEDB_INCREASING_LABELS,
+      TILEDB_UNORDERED_LABELS,
       TILEDB_UINT64,
       x_domain,
       &x_tile_extent,

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -1,0 +1,372 @@
+/**
+ * @file test-capi-sparse-array-dimension-label.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the DimensionLabel API
+ */
+
+#include "test/src/experimental_helpers.h"
+#include "test/src/helpers.h"
+#include "test/src/vfs_helpers.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
+#include "tiledb/sm/array_schema/dimension_label_reference.h"
+#include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"
+#include "tiledb/sm/c_api/experimental/tiledb_struct_def.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/encryption_type.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <test/support/tdb_catch.h>
+#include <iostream>
+#include <string>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/**
+ * Create a small sparse array with a dimension label.
+ *
+ *  TODO: Add array summary
+ */
+class SparseArrayExample1 : public DimensionLabelFixture {
+ public:
+  SparseArrayExample1()
+      : array_name{}
+      , index_domain_{0, 3}
+      , label_domain_{-1, 1} {
+  }
+
+  void create_example(tiledb_label_order_t label_order) {
+    // Create an array schema
+    uint64_t x_tile_extent{4};
+    auto array_schema = create_array_schema(
+        ctx,
+        TILEDB_SPARSE,
+        {"x"},
+        {TILEDB_UINT64},
+        {&index_domain_[0]},
+        {&x_tile_extent},
+        {"a"},
+        {TILEDB_FLOAT64},
+        {1},
+        {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+        TILEDB_ROW_MAJOR,
+        TILEDB_ROW_MAJOR,
+        4096,
+        false);
+
+    // Add dimension label.
+    double label_tile_extent = 2.0;
+    add_dimension_label(
+        ctx,
+        array_schema,
+        "x",
+        0,
+        label_order,
+        TILEDB_FLOAT64,
+        &label_domain_[0],
+        &label_tile_extent,
+        &x_tile_extent);
+    // Create array
+    array_name = create_temporary_array("array_with_label_1", array_schema);
+    tiledb_array_schema_free(&array_schema);
+  }
+
+  void write_array_with_label(
+      std::vector<uint64_t>& input_index_data,
+      std::vector<double>& input_attr_data,
+      std::vector<double>& input_label_data) {
+    // Open array for writing.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+    // Define sizes for setting buffers.
+    uint64_t index_data_size{input_index_data.size() * sizeof(uint64_t)};
+    uint64_t attr_data_size{input_attr_data.size() * sizeof(double)};
+    uint64_t label_data_size{input_label_data.size() * sizeof(double)};
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
+    if (index_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_data_buffer(
+          ctx, query, "x", input_index_data.data(), &index_data_size));
+    }
+    if (attr_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_data_buffer(
+          ctx, query, "a", input_attr_data.data(), &attr_data_size));
+    }
+    if (label_data_size != 0) {
+      require_tiledb_ok(tiledb_query_set_label_data_buffer(
+          ctx, query, "x", input_label_data.data(), &label_data_size));
+    }
+
+    // Submit write query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /**
+   * Read back full array with a data query and check the values.
+   *
+   * @param expected_label_data A vector of the expected label values.
+   */
+  void check_values_from_data_reader(
+      const std::vector<double>& expected_label_data) {
+    // Open array for reading.
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &index_domain_[0], &index_domain_[1], nullptr));
+
+    // Define label buffer and size.
+    std::vector<double> label_data(4);
+    uint64_t label_data_size{label_data.size() * sizeof(double)};
+
+    // Create read query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
+    require_tiledb_ok(tiledb_query_set_label_data_buffer(
+        ctx, query, "x", label_data.data(), &label_data_size));
+
+    // Submit read query.
+    require_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    require_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    REQUIRE(query_status == TILEDB_COMPLETED);
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+
+    // Check results.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+  }
+
+  void check_indexed_array_data(
+      const std::vector<double>& expected_label_data) {
+    // Read back the data.
+    auto label_data = DimensionLabelFixture::read_indexed_array<double>(
+        URI(array_name).join_path("__labels/l0"),
+        4,
+        &index_domain_[0],
+        &index_domain_[1]);
+
+    // Check results.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+  }
+
+  void check_labelled_array_data(
+      const std::vector<uint64_t>& expected_index_data,
+      const std::vector<double>& expected_label_data) {
+    // Read back the data.
+    auto [index_data, label_data] =
+        DimensionLabelFixture::read_labelled_array<uint64_t, double>(
+            URI(array_name).join_path("__labels/l0"),
+            4,
+            &label_domain_[0],
+            &label_domain_[1]);
+
+    // Check the results.
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(index_data[ii] == expected_index_data[ii]);
+    }
+    for (uint64_t ii{0}; ii < 4; ++ii) {
+      CHECK(label_data[ii] == expected_label_data[ii]);
+    }
+  }
+
+ protected:
+  /** Name of the example array. */
+  std::string array_name;
+
+ private:
+  /** Valid range for the index. */
+  uint64_t index_domain_[2];
+
+  /** Valid range for the label. */
+  double label_domain_[2];
+};
+
+TEST_CASE_METHOD(
+    SparseArrayExample1,
+    "Round trip dimension label and array data for sparse 1D array",
+    "[capi][query][DimensionLabel]") {
+  // Define the input data values.
+  std::vector<uint64_t> input_index_data{};
+  std::vector<double> input_label_data{};
+  std::vector<double> input_attr_data{};
+
+  // Define the expected output values for the labelled array.
+  std::vector<double> expected_label_data_sorted{};
+  std::vector<uint64_t> expected_index_data{};
+
+  SECTION("Write increasing labels", "[IncreasingLabels]") {
+    // Create array.
+    create_example(TILEDB_INCREASING_LABELS);
+
+    // Set input values.
+    input_index_data = {0, 1, 2, 3};
+    input_label_data = {-1.0, 0.0, 0.5, 1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Set expected output values.
+    expected_label_data_sorted = input_label_data;
+    expected_index_data = input_index_data;
+  }
+
+  SECTION("Write decreasing labels", "[DecreasingLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_index_data = {0, 1, 2, 3};
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {3, 2, 1, 0};
+  }
+
+  SECTION("Write unordered labels", "[UnorderedLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_index_data = {0, 3, 2, 1};
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {1, 2, 3, 0};
+  }
+
+  // Write the array and label.
+  write_array_with_label(input_index_data, input_attr_data, input_label_data);
+
+  // Check the dimension label arrays have the correct data.
+  check_indexed_array_data(input_label_data);
+  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+
+  // Check data reader.
+  check_values_from_data_reader(input_label_data);
+}
+
+TEST_CASE_METHOD(
+    SparseArrayExample1,
+    "Round trip dimension label data for sparse 1D array",
+    "[capi][query][DimensionLabel]") {
+  // Define the input data values.
+  std::vector<uint64_t> input_index_data{};
+  std::vector<double> input_label_data{};
+  std::vector<double> input_attr_data{};
+
+  // Define the expected output values for the labelled array.
+  std::vector<double> expected_label_data_sorted{};
+  std::vector<uint64_t> expected_index_data{};
+
+  SECTION("Write increasing labels", "[IncreasingLabels]") {
+    // Create array.
+    create_example(TILEDB_INCREASING_LABELS);
+
+    // Set input values.
+    input_index_data = {0, 1, 2, 3};
+    input_label_data = {-1.0, 0.0, 0.5, 1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Set expected_output values.
+    expected_label_data_sorted = input_label_data;
+    expected_index_data = input_index_data;
+  }
+
+  SECTION("Write decreasing labels", "[DecreasingLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_index_data = {0, 1, 2, 3};
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {3, 2, 1, 0};
+  }
+
+  SECTION("Write unordered labels", "[UnorderedLabels]") {
+    // Create the array.
+    create_example(TILEDB_DECREASING_LABELS);
+
+    // Set the data values.
+    input_index_data = {0, 3, 2, 1};
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+
+    // Define expected output data.
+    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
+    expected_index_data = {1, 2, 3, 0};
+  }
+
+  // Write the array and label.
+  write_array_with_label(input_index_data, input_attr_data, input_label_data);
+
+  // Check the dimension label arrays have the correct data.
+  check_indexed_array_data(input_label_data);
+  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+
+  // Check data reader.
+  check_values_from_data_reader(input_label_data);
+}

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -27,7 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * Tests the DimensionLabel API
+ * Test the dimension label API with a sparse array using fixed size dimension
+ * labels.
  */
 
 #include "test/src/experimental_helpers.h"
@@ -69,6 +70,11 @@ class SparseArrayExample1 : public DimensionLabelFixture {
       , label_domain_{-1, 1} {
   }
 
+  /**
+   * Create the example array with a dimension label.
+   *
+   * @param label_order Label order for the dimension label.
+   */
   void create_example(tiledb_label_order_t label_order) {
     // Create an array schema
     uint64_t x_tile_extent{4};
@@ -105,6 +111,17 @@ class SparseArrayExample1 : public DimensionLabelFixture {
     tiledb_array_schema_free(&array_schema);
   }
 
+  /**
+   * Write data to the array and dimension label.
+   *
+   * @param input_index_data Coordinate data for the array. If empty, the
+   *     coordinate data is not added to the query.
+   * @param input_attr_data Data to write to the array attribute. If empty, the
+   *     attribute data is not added to the query..
+   * @param input_label_data Data to write to the dimension label. If empty, the
+   *     dimension label dadta is not added to the query.
+   * @param error_on_write If true, require the query returns a failed status.
+   */
   void write_array_with_label(
       std::vector<uint64_t>& input_index_data,
       std::vector<double>& input_attr_data,
@@ -201,6 +218,11 @@ class SparseArrayExample1 : public DimensionLabelFixture {
     }
   }
 
+  /**
+   * Check the value in the indexed array is correct.
+   *
+   * @param expected_label_data The expected label data in the indexed array.
+   */
   void check_indexed_array_data(
       const std::vector<double>& expected_label_data) {
     // Read back the data.
@@ -217,6 +239,12 @@ class SparseArrayExample1 : public DimensionLabelFixture {
     }
   }
 
+  /**
+   * Check the value in the labelled array is correct.
+   *
+   * @param expected_index_data The expected index data in the labelled array.
+   * @param expected_label_data The expected label data in the labelled array.
+   */
   void check_labelled_array_data(
       const std::vector<uint64_t>& expected_index_data,
       const std::vector<double>& expected_label_data) {

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -59,7 +59,14 @@ using namespace tiledb::test;
 /**
  * Create a small sparse array with a dimension label.
  *
- *  TODO: Add array summary
+ * Array Summary:
+ *  * Array Type: Sparse
+ *  * Dimensions:
+ *    - x: (type=UINT64, domain=[1, 4], tile=4)
+ *  * Attributes:
+ *    - a: (type=FLOAT64)
+ *  * Dimension labels:
+ *    - x: (label_order=label_order_t, dim_idx=0, type=FLOAT64)
  */
 class SparseArrayExample1 : public DimensionLabelFixture {
  public:

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -197,6 +197,7 @@ class SparseArrayExample1 : public DimensionLabelFixture {
 
     // Check results.
     for (uint64_t ii{0}; ii < 4; ++ii) {
+      INFO("Label data " + std::to_string(ii));
       CHECK(label_data[ii] == expected_label_data[ii]);
     }
   }
@@ -212,6 +213,7 @@ class SparseArrayExample1 : public DimensionLabelFixture {
 
     // Check results.
     for (uint64_t ii{0}; ii < 4; ++ii) {
+      INFO("Label data " + std::to_string(ii));
       CHECK(label_data[ii] == expected_label_data[ii]);
     }
   }
@@ -229,9 +231,11 @@ class SparseArrayExample1 : public DimensionLabelFixture {
 
     // Check the results.
     for (uint64_t ii{0}; ii < 4; ++ii) {
+      INFO("Index data " + std::to_string(ii));
       CHECK(index_data[ii] == expected_index_data[ii]);
     }
     for (uint64_t ii{0}; ii < 4; ++ii) {
+      INFO("Label data " + std::to_string(ii));
       CHECK(label_data[ii] == expected_label_data[ii]);
     }
   }
@@ -250,86 +254,24 @@ class SparseArrayExample1 : public DimensionLabelFixture {
 
 TEST_CASE_METHOD(
     SparseArrayExample1,
-    "Round trip dimension label and array data for sparse 1D array",
-    "[capi][query][DimensionLabel]") {
-  // Define the input data values.
-  std::vector<uint64_t> input_index_data{};
-  std::vector<double> input_label_data{};
-  std::vector<double> input_attr_data{};
-
-  // Define the expected output values for the labelled array.
-  std::vector<double> expected_label_data_sorted{};
-  std::vector<uint64_t> expected_index_data{};
-
-  SECTION("Write increasing labels", "[IncreasingLabels]") {
-    // Create array.
-    create_example(TILEDB_INCREASING_LABELS);
-
-    // Set input values.
-    input_index_data = {0, 1, 2, 3};
-    input_label_data = {-1.0, 0.0, 0.5, 1.0};
-    input_attr_data = {0.5, 1.0, 1.5, 2.0};
-
-    // Set expected output values.
-    expected_label_data_sorted = input_label_data;
-    expected_index_data = input_index_data;
-  }
-
-  SECTION("Write decreasing labels", "[DecreasingLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
-
-    // Set the data values.
-    input_index_data = {0, 1, 2, 3};
-    input_label_data = {1.0, 0.0, -0.5, -1.0};
-    input_attr_data = {0.5, 1.0, 1.5, 2.0};
-
-    // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {3, 2, 1, 0};
-  }
-
-  SECTION("Write unordered labels", "[UnorderedLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
-
-    // Set the data values.
-    input_index_data = {0, 3, 2, 1};
-    input_label_data = {1.0, 0.0, -0.5, -1.0};
-    input_attr_data = {0.5, 1.0, 1.5, 2.0};
-
-    // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {1, 2, 3, 0};
-  }
-
-  // Write the array and label.
-  write_array_with_label(input_index_data, input_attr_data, input_label_data);
-
-  // Check the dimension label arrays have the correct data.
-  check_indexed_array_data(input_label_data);
-  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
-
-  // Check data reader.
-  check_values_from_data_reader(input_label_data);
-}
-
-TEST_CASE_METHOD(
-    SparseArrayExample1,
     "Round trip dimension label data for sparse 1D array",
     "[capi][query][DimensionLabel]") {
-  // Define the input data values.
+  // Input vectors.
   std::vector<uint64_t> input_index_data{};
   std::vector<double> input_label_data{};
   std::vector<double> input_attr_data{};
 
-  // Define the expected output values for the labelled array.
-  std::vector<double> expected_label_data_sorted{};
-  std::vector<uint64_t> expected_index_data{};
+  // Expected output vectors.
+  std::vector<double> label_data_sorted_by_index{};
+  std::vector<double> label_data_sorted_by_label{};
+  std::vector<uint64_t> index_data_sorted_by_label{};
 
-  SECTION("Write increasing labels", "[IncreasingLabels]") {
-    // Create array.
-    create_example(TILEDB_INCREASING_LABELS);
+  // Dimension label parameters.
+  tiledb_label_order_t label_order;
+
+  SECTION("Write increasing labels and array", "[IncreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_INCREASING_LABELS;
 
     // Set input values.
     input_index_data = {0, 1, 2, 3};
@@ -337,43 +279,102 @@ TEST_CASE_METHOD(
     input_attr_data = {0.5, 1.0, 1.5, 2.0};
 
     // Set expected_output values.
-    expected_label_data_sorted = input_label_data;
-    expected_index_data = input_index_data;
+    label_data_sorted_by_index = input_label_data;
+    label_data_sorted_by_label = input_label_data;
+    index_data_sorted_by_label = input_index_data;
   }
 
-  SECTION("Write decreasing labels", "[DecreasingLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
+  SECTION("Write increasing labels only", "[IncreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_INCREASING_LABELS;
+
+    // Set input values.
+    input_index_data = {0, 1, 2, 3};
+    input_label_data = {-1.0, 0.0, 0.5, 1.0};
+    input_attr_data = {};
+
+    // Set expected_output values.
+    label_data_sorted_by_index = input_label_data;
+    label_data_sorted_by_label = input_label_data;
+    index_data_sorted_by_label = input_index_data;
+  }
+
+  SECTION("Write decreasing labels and array", "[DecreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_DECREASING_LABELS;
+
+    // Set the data values.
+    input_index_data = {0, 1, 2, 3};
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    label_data_sorted_by_index = input_label_data;
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {3, 2, 1, 0};
+  }
+
+  SECTION("Write decreasing labels only", "[DecreasingLabels]") {
+    // Set the label order.
+    label_order = TILEDB_DECREASING_LABELS;
 
     // Set the data values.
     input_index_data = {0, 1, 2, 3};
     input_label_data = {1.0, 0.0, -0.5, -1.0};
 
     // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {3, 2, 1, 0};
+    label_data_sorted_by_index = input_label_data;
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {3, 2, 1, 0};
   }
 
-  SECTION("Write unordered labels", "[UnorderedLabels]") {
-    // Create the array.
-    create_example(TILEDB_DECREASING_LABELS);
+  SECTION("Write unordered labels and array", "[UnorderedLabels]") {
+    // Set the label order.
+    label_order = TILEDB_UNORDERED_LABELS;
+
+    // Set the data values.
+    input_index_data = {0, 3, 2, 1};
+    input_label_data = {1.0, 0.0, -0.5, -1.0};
+    input_attr_data = {0.5, 1.0, 1.5, 2.0};
+
+    // Define expected output data.
+    label_data_sorted_by_index = {1.0, -1.0, -0.5, 0.0};
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {1, 2, 3, 0};
+  }
+
+  SECTION("Write unordered labels only", "[UnorderedLabels]") {
+    // Set the label order.
+    label_order = TILEDB_UNORDERED_LABELS;
 
     // Set the data values.
     input_index_data = {0, 3, 2, 1};
     input_label_data = {1.0, 0.0, -0.5, -1.0};
 
     // Define expected output data.
-    expected_label_data_sorted = {-1.0, -0.5, 0.0, 1.0};
-    expected_index_data = {1, 2, 3, 0};
+    label_data_sorted_by_index = {1.0, -1.0, -0.5, 0.0};
+    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+    index_data_sorted_by_label = {1, 2, 3, 0};
   }
 
-  // Write the array and label.
+  // Create and Write the array and label.
+  create_example(label_order);
   write_array_with_label(input_index_data, input_attr_data, input_label_data);
 
   // Check the dimension label arrays have the correct data.
-  check_indexed_array_data(input_label_data);
-  check_labelled_array_data(expected_index_data, expected_label_data_sorted);
+  {
+    INFO("Check indexed array data");
+    check_indexed_array_data(label_data_sorted_by_index);
+  }
+  {
+    INFO("Check labelled array data");
+    check_labelled_array_data(
+        index_data_sorted_by_label, label_data_sorted_by_label);
+  }
 
   // Check data reader.
-  check_values_from_data_reader(input_label_data);
+  {
+    INFO("Check data from data reader");
+    check_values_from_data_reader(label_data_sorted_by_index);
+  }
 }

--- a/test/src/test-dimension_labels-read-consistency.cc
+++ b/test/src/test-dimension_labels-read-consistency.cc
@@ -265,9 +265,10 @@ class ExampleFixedDimensionLabel : public TemporaryDirectoryFixture {
       const DimensionLabel& dimension_label,
       const tiledb::sm::QueryBuffer& label_data_buffer,
       const std::string& fragment_name) {
-    Query query{ctx->storage_manager(),
-                dimension_label.labelled_array(),
-                fragment_name};
+    Query query{
+        ctx->storage_manager(),
+        dimension_label.labelled_array(),
+        fragment_name};
 
     // Create index query buffer.
     std::vector<uint64_t> index_data(ncells_, 0);

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -230,6 +230,8 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/ast/query_ast.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/deletes_and_updates/deletes.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/deletes_and_updates/serialization.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/dimension_label/dimension_label_query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/hilbert_order.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/legacy/cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/legacy/reader.cc

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -232,6 +232,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/deletes_and_updates/serialization.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/dimension_label/dimension_label_query.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/dimension_label/dimension_label_query_create.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/hilbert_order.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/legacy/cell_slab_iter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/legacy/reader.cc

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -211,6 +211,11 @@ class DimensionLabelReference {
     return uri_;
   }
 
+  /** Returns ``true`` if the URI is relative to the array URI. */
+  inline bool uri_is_relative() const {
+    return relative_uri_;
+  }
+
  private:
   /** The index of the dimension the labels are attached to. */
   dimension_size_type dim_id_;

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/common.h"
 #include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/misc/constants.h"
 #include "tiledb/storage_format/serialization/serializers.h"
 #include "tiledb/type/range/range.h"
 
@@ -146,6 +147,13 @@ class DimensionLabelReference {
    */
   inline bool is_external() const {
     return is_external_;
+  }
+
+  /**
+   * Returns ``true`` is the label cells are variable length.
+   */
+  inline bool is_var() const {
+    return label_cell_val_num_ == constants::var_num;
   }
 
   /**

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -252,7 +252,12 @@ class DimensionLabelReference {
   /** The interval the labels are defined on. */
   Range label_domain_;
 
-  /** The dimension label schema */
+  /**
+   * The dimension label schema.
+   *
+   * The schema is used for creating the dimension label and is not included in
+   * the dimension label schema serialization and deserialization from disk.
+   */
   shared_ptr<const DimensionLabelSchema> schema_;
 
   /**

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -211,6 +211,20 @@ class DimensionLabelReference {
     return uri_;
   }
 
+  /**
+   * Returns a copy of the dimension label URI.
+   *
+   * If the dimension label is relative to the array URI, it will append the
+   * dimension label URI to the array URI.
+   *
+   * @param array_uri URI of the parent array for this dimension label
+   *     reference.
+   * @returns URI of the dimension label.
+   */
+  inline URI uri(const URI& array_uri) const {
+    return relative_uri_ ? array_uri.join_path(uri_) : uri_;
+  }
+
   /** Returns ``true`` if the URI is relative to the array URI. */
   inline bool uri_is_relative() const {
     return relative_uri_;

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -150,7 +150,7 @@ class DimensionLabelReference {
   }
 
   /**
-   * Returns ``true`` is the label cells are variable length.
+   * Returns ``true`` if the label cells are variable length.
    */
   inline bool is_var() const {
     return label_cell_val_num_ == constants::var_num;

--- a/tiledb/sm/array_schema/dimension_label_schema.cc
+++ b/tiledb/sm/array_schema/dimension_label_schema.cc
@@ -82,9 +82,9 @@ DimensionLabelSchema::DimensionLabelSchema(
   try {
     ensure_dimension_datatype_is_valid(label_type);
   } catch (...) {
-    throw std::invalid_argument(
+    std::throw_with_nested(std::invalid_argument(
         "Datatype Datatype::" + datatype_str(label_type) +
-        " is not a valid dimension datatype.");
+        " is not a valid dimension datatype."));
   }
   if (datatype_is_string(label_type) &&
       label_order != LabelOrder::UNORDERED_LABELS) {

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
@@ -286,7 +286,7 @@ int32_t tiledb_array_schema_add_dimension_label(
     const uint32_t dim_id,
     const char* name,
     tiledb_dimension_label_schema_t* dim_label_schema) noexcept {
-  return api_entry<detail::tiledb_array_schema_add_dimension_label>(
+  return api_entry_context<detail::tiledb_array_schema_add_dimension_label>(
       ctx, array_schema, dim_id, name, dim_label_schema);
 }
 
@@ -295,7 +295,7 @@ int32_t tiledb_array_schema_has_dimension_label(
     const tiledb_array_schema_t* array_schema,
     const char* name,
     int32_t* has_dim_label) noexcept {
-  return api_entry<detail::tiledb_array_schema_has_dimension_label>(
+  return api_entry_context<detail::tiledb_array_schema_has_dimension_label>(
       ctx, array_schema, name, has_dim_label);
 }
 
@@ -309,7 +309,7 @@ int32_t tiledb_dimension_label_schema_alloc(
     const void* label_domain,
     const void* label_tile_extent,
     tiledb_dimension_label_schema_t** dim_label_schema) noexcept {
-  return api_entry<detail::tiledb_dimension_label_schema_alloc>(
+  return api_entry_context<detail::tiledb_dimension_label_schema_alloc>(
       ctx,
       label_order,
       index_type,
@@ -333,7 +333,7 @@ int32_t tiledb_query_set_label_data_buffer(
     const char* name,
     void* buffer,
     uint64_t* buffer_size) noexcept {
-  return api_entry<detail::tiledb_query_set_label_data_buffer>(
+  return api_entry_context<detail::tiledb_query_set_label_data_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
@@ -343,7 +343,7 @@ int32_t tiledb_query_set_label_offsets_buffer(
     const char* name,
     uint64_t* buffer,
     uint64_t* buffer_size) noexcept {
-  return api_entry<detail::tiledb_query_set_label_offsets_buffer>(
+  return api_entry_context<detail::tiledb_query_set_label_offsets_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
@@ -353,7 +353,7 @@ int32_t tiledb_query_get_label_data_buffer(
     const char* name,
     void** buffer,
     uint64_t** buffer_size) noexcept {
-  return api_entry<detail::tiledb_query_get_label_data_buffer>(
+  return api_entry_context<detail::tiledb_query_get_label_data_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
@@ -363,7 +363,7 @@ int32_t tiledb_query_get_label_offsets_buffer(
     const char* name,
     uint64_t** buffer,
     uint64_t** buffer_size) noexcept {
-  return api_entry<detail::tiledb_query_get_label_offsets_buffer>(
+  return api_entry_context<detail::tiledb_query_get_label_offsets_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
@@ -44,7 +44,7 @@ namespace tiledb::common::detail {
 int32_t tiledb_array_schema_add_dimension_label(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    uint32_t dim_id,
+    const uint32_t dim_id,
     const char* name,
     tiledb_dimension_label_schema_t* dim_label_schema) {
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array_schema) ||
@@ -136,6 +136,54 @@ void tiledb_dimension_label_schema_free(
     delete *dim_label_schema;
     *dim_label_schema = nullptr;
   }
+}
+
+int32_t tiledb_query_set_label_data_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void* buffer,
+    uint64_t* buffer_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+  query->query_->set_label_data_buffer(name, buffer, buffer_size);
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_set_label_offsets_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t* buffer,
+    uint64_t* buffer_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+  query->query_->set_label_offsets_buffer(name, buffer, buffer_size);
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_label_data_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+  query->query_->get_label_data_buffer(name, buffer, buffer_size);
+  return TILEDB_OK;
+}
+
+int32_t tiledb_query_get_label_offsets_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t** buffer,
+    uint64_t** buffer_size) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
+    return TILEDB_ERR;
+  query->query_->get_label_offsets_buffer(name, buffer, buffer_size);
+  return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_add_label_range(
@@ -235,7 +283,7 @@ int32_t tiledb_subarray_get_label_range_var_size(
 int32_t tiledb_array_schema_add_dimension_label(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    uint32_t dim_id,
+    const uint32_t dim_id,
     const char* name,
     tiledb_dimension_label_schema_t* dim_label_schema) noexcept {
   return api_entry<detail::tiledb_array_schema_add_dimension_label>(
@@ -277,6 +325,46 @@ void tiledb_dimension_label_schema_free(
     tiledb_dimension_label_schema_t** dim_label_schema) noexcept {
   return api_entry_void<detail::tiledb_dimension_label_schema_free>(
       dim_label_schema);
+}
+
+int32_t tiledb_query_set_label_data_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void* buffer,
+    uint64_t* buffer_size) noexcept {
+  return api_entry<detail::tiledb_query_set_label_data_buffer>(
+      ctx, query, name, buffer, buffer_size);
+}
+
+int32_t tiledb_query_set_label_offsets_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t* buffer,
+    uint64_t* buffer_size) noexcept {
+  return api_entry<detail::tiledb_query_set_label_offsets_buffer>(
+      ctx, query, name, buffer, buffer_size);
+}
+
+int32_t tiledb_query_get_label_data_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size) noexcept {
+  return api_entry<detail::tiledb_query_get_label_data_buffer>(
+      ctx, query, name, buffer, buffer_size);
+}
+
+int32_t tiledb_query_get_label_offsets_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t** buffer,
+    uint64_t** buffer_size) noexcept {
+  return api_entry<detail::tiledb_query_get_label_offsets_buffer>(
+      ctx, query, name, buffer, buffer_size);
 }
 
 int32_t tiledb_subarray_add_label_range(

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.h
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.h
@@ -230,11 +230,10 @@ TILEDB_EXPORT int32_t tiledb_query_set_label_data_buffer(
  * @param name The name of the dimension label to set the buffer for.
  * @param buffer This buffer holds the starting offsets of each cell value in
  *     the buffer set by `tiledb_query_set_label_data_buffer`.
- * @param buffer_size In the case of writes, it is the size of `buffer_off`
- *     in bytes. In the case of reads, this initially contains the allocated
- *     size of `buffer_off`, but after the *end of the query*
- *     (`tiledb_query_submit`) it will contain the size of the useful (read)
- *     data in `buffer_off`.
+ * @param buffer_size In the case of writes, it is the size of `buffer` in
+ *     bytes. In the case of reads, this initially contains the allocated size
+ *     of `buffer`, but after the *end of the query* (`tiledb_query_submit`)
+ *     it will contain the size of the useful (read) data in `buffer`.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_query_set_label_offsets_buffer(

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.h
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.h
@@ -78,7 +78,7 @@ typedef struct tiledb_dimension_label_schema_t tiledb_dimension_label_schema_t;
 TILEDB_EXPORT int32_t tiledb_array_schema_add_dimension_label(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    uint32_t dim_id,
+    const uint32_t dim_id,
     const char* name,
     tiledb_dimension_label_schema_t* dim_label_schema) TILEDB_NOEXCEPT;
 
@@ -180,6 +180,126 @@ TILEDB_EXPORT int32_t tiledb_dimension_label_schema_alloc(
  */
 TILEDB_EXPORT void tiledb_dimension_label_schema_free(
     tiledb_dimension_label_schema_t** dim_label_schema) TILEDB_NOEXCEPT;
+
+/**
+ * Sets the buffer for an dimension label to a query, which will
+ * either hold the values to be written (if it is a write query), or will hold
+ * the results from a read query.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int32_t label1[100];
+ * uint64_t label1_size = sizeof(label1);
+ * tiledb_query_set_label_data_buffer(
+ *     ctx, query, "label1", label1, &label1_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The name of the dimension label to set the buffer for.
+ * @param buffer The buffer that either have the input data to be written,
+ *     or will hold the data to be read.
+ * @param buffer_size In the case of writes, this is the size of `buffer`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer`, but after the termination of the query
+ *     it will contain the size of the useful (read) data in `buffer`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_set_label_data_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void* buffer,
+    uint64_t* buffer_size) TILEDB_NOEXCEPT;
+
+/**
+ * Sets the starting offsets of each cell value in the data buffer.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint64_t label1[100];
+ * uint64_t label1_size = sizeof(label1);
+ * tiledb_query_set_label_offsets_buffer(
+ *     ctx, query, "label1", label1, &label1_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The name of the dimension label to set the buffer for.
+ * @param buffer This buffer holds the starting offsets of each cell value in
+ *     the buffer set by `tiledb_query_set_label_data_buffer`.
+ * @param buffer_size In the case of writes, it is the size of `buffer_off`
+ *     in bytes. In the case of reads, this initially contains the allocated
+ *     size of `buffer_off`, but after the *end of the query*
+ *     (`tiledb_query_submit`) it will contain the size of the useful (read)
+ *     data in `buffer_off`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_set_label_offsets_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t* buffer,
+    uint64_t* buffer_size) TILEDB_NOEXCEPT;
+
+/**
+ * Gets the buffer of a fixed-sized dimension label from a query. If the
+ * buffer has not been set, then `buffer` is set to `nullptr`.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int* label1;
+ * uint64_t* label1_size;
+ * tiledb_query_get_label_data_buffer(
+ *     ctx, query, "label1", &label1, &label1_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The name of the dimension label to get the buffer for.
+ * @param buffer The buffer to retrieve.
+ * @param buffer_size A pointer to the size of the buffer. Note that this is
+ *     a double pointer and returns the original variable address from
+ *     `tiledb_query_set_label_data_buffer`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_label_data_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    void** buffer,
+    uint64_t** buffer_size) TILEDB_NOEXCEPT;
+
+/**
+ * Gets the starting offsets of each cell value in the data buffer.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int* label1;
+ * uint64_t* label1_size;
+ * tiledb_query_get_label_offsets_buffer(
+ *     ctx, query, "label1", &label1, &label1_size);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param name The name of the dimension label to get the buffer for.
+ * @param buffer The buffer to retrieve.
+ * @param buffer_size A pointer to the size of the buffer. Note that this is
+ *     a double pointer and returns the original variable address from
+ *     `tiledb_query_set_label_offsets_buffer`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_get_label_offsets_buffer(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* name,
+    uint64_t** buffer,
+    uint64_t** buffer_size) TILEDB_NOEXCEPT;
 
 /**
  * Adds a 1D range along a subarray for a dimension label, which is in the form

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -237,6 +237,14 @@ QueryType DimensionLabel::query_type() const {
       "not been opened");
 }
 
+const DimensionLabelSchema& DimensionLabel::schema() const {
+  if (!schema_) {
+    throw std::logic_error(
+        "DimensionLabel schema does not exist. DimensionLabel must be opened.");
+  }
+  return *schema_;
+}
+
 void create_dimension_label(
     const URI& uri,
     StorageManager& storage_manager,

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/array/array_directory.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/array_schema/dimension_label_reference.h"
 #include "tiledb/sm/array_schema/dimension_label_schema.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/enums/label_order.h"
@@ -72,6 +73,52 @@ const Dimension* DimensionLabel::index_dimension() const {
     throw std::logic_error(
         "DimensionLabel schema does not exist. DimensionLabel must be opened.");
   return schema_->index_dimension();
+}
+
+void DimensionLabel::is_compatible(
+    const DimensionLabelReference& dim_label_ref, const Dimension* dim) const {
+  if (!schema_)
+    throw std::logic_error(
+        "DimensionLabel schema does not exist. DimensionLabel must be opened.");
+
+  // Check the dimension label schema matches the definition provided in
+  // the dimension label reference.
+  if (!schema_->is_compatible_label(dim)) {
+    throw StatusException(Status_DimensionLabelError(
+        "Error opening dimension label; Found dimension label does not match "
+        "array dimension."));
+  }
+  if (schema_->label_order() != dim_label_ref.label_order()) {
+    throw StatusException(Status_DimensionLabelError(
+        "Error opening dimension label; The label order of the loaded "
+        "dimension label is " +
+        label_order_str(schema_->label_order()) +
+        ", but the expected label order was " +
+        label_order_str(dim_label_ref.label_order()) + "."));
+  }
+  if (schema_->label_dimension()->type() != dim_label_ref.label_type()) {
+    throw StatusException(Status_DimensionLabelError(
+        "Error opening dimension label; The label datatype of the loaded "
+        "dimension label is " +
+        datatype_str(schema_->label_dimension()->type()) +
+        ", but the expected label datatype was " +
+        datatype_str(dim_label_ref.label_type()) + "."));
+  }
+  if (!(schema_->label_dimension()->domain() == dim_label_ref.label_domain())) {
+    throw StatusException(Status_DimensionLabelError(
+        "Error opening dimension label; The label domain of the loaded "
+        "dimension label does not match the expected domain."));
+  }
+  if (schema_->label_dimension()->cell_val_num() !=
+      dim_label_ref.label_cell_val_num()) {
+    throw StatusException(Status_DimensionLabelError(
+        "Error opening dimension label; The label cell value number of the "
+        "loaded "
+        "dimension label is " +
+        std::to_string(schema_->label_dimension()->cell_val_num()) +
+        ", but the expected label cell value number was " +
+        std::to_string(dim_label_ref.label_cell_val_num()) + "."));
+  }
 }
 
 const Attribute* DimensionLabel::label_attribute() const {

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -139,6 +139,9 @@ class DimensionLabel {
   /** Returns the query type the dimension label was opened with. */
   QueryType query_type() const;
 
+  /** Returns a reference to the dimension label schema. */
+  const DimensionLabelSchema& schema() const;
+
  private:
   /**********************/
   /* Private attributes */

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -79,6 +79,15 @@ class DimensionLabel {
   /** Returns the index dimension in the indexed array. */
   const Dimension* index_dimension() const;
 
+  /**
+   * Throws an exception if the dimension label is not compatible with an input
+   * dimension label reference.
+   *
+   * @param dim_label_ref Dimension label reference to check compatibility with.
+   */
+  void is_compatible(
+      const DimensionLabelReference& dim_label_ref, const Dimension* dim) const;
+
   /** Returns the array with indices stored on the dimension. */
   inline shared_ptr<Array> indexed_array() const {
     return indexed_array_;

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -257,6 +257,10 @@ URI URI::join_path(const std::string& path) const {
   }
 }
 
+URI URI::join_path(const URI& uri) const {
+  return join_path(uri.to_string());
+}
+
 std::string URI::last_path_part() const {
   return uri_.substr(uri_.find_last_of('/') + 1);
 }

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -242,6 +242,14 @@ class URI {
    */
   URI join_path(const std::string& path) const;
 
+  /**
+   * Joins the URI with the input URI.
+   *
+   * @param uri The URI to append.
+   * @return The resulting URI.
+   */
+  URI join_path(const URI& uri) const;
+
   /** Returns the last part of the URI (i.e., excluding the parent). */
   std::string last_path_part() const;
 

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -1,0 +1,365 @@
+/**
+ * @file dimension_label_queries.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "tiledb/sm/query/dimension_label/array_dimension_label_queries.h"
+#include "tiledb/common/common.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension_label_reference.h"
+#include "tiledb/sm/array_schema/dimension_label_schema.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/encryption_type.h"
+#include "tiledb/sm/enums/label_order.h"
+#include "tiledb/sm/enums/query_status.h"
+#include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/query/dimension_label/dimension_label_query.h"
+#include "tiledb/sm/query/query.h"
+#include "tiledb/storage_format/uri/generate_uri.h"
+
+#include <algorithm>
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
+    StorageManager* storage_manager,
+    Array* array,
+    const Subarray& subarray,
+    const std::unordered_map<std::string, QueryBuffer>& label_buffers,
+    const std::unordered_map<std::string, QueryBuffer>& array_buffers,
+    const optional<std::string>& fragment_name)
+    : range_queries_(subarray.dim_num(), nullptr)
+    , range_query_status_{QueryStatus::UNINITIALIZED} {
+  switch (array->get_query_type()) {
+    case (QueryType::READ):
+      add_range_queries(
+          storage_manager, array, subarray, label_buffers, array_buffers);
+      add_data_queries_for_read(
+          storage_manager, array, subarray, label_buffers);
+      break;
+
+    case (QueryType::WRITE):
+
+      add_range_queries(
+          storage_manager, array, subarray, label_buffers, array_buffers);
+      add_data_queries_for_write(
+          storage_manager,
+          array,
+          subarray,
+          label_buffers,
+          array_buffers,
+          fragment_name.has_value() ?
+              fragment_name.value() :
+              storage_format::generate_fragment_name(
+                  array->timestamp_end_opened_at(),
+                  array->array_schema_latest().write_version()));
+      break;
+
+    case (QueryType::DELETE):
+    case (QueryType::UPDATE):
+    case (QueryType::MODIFY_EXCLUSIVE):
+      if (!label_buffers.empty() || subarray.has_label_ranges()) {
+        throw StatusException(Status_DimensionLabelQueryError(
+            "Failed to add dimension label queries. Query type " +
+            query_type_str(array->get_query_type()) +
+            " is not supported for dimension labels."));
+      }
+      break;
+
+    default:
+      throw StatusException(Status_DimensionLabelQueryError(
+          "Failed to add dimension label queries. Unknown query type " +
+          query_type_str(array->get_query_type()) + "."));
+  }
+  range_query_status_ = range_queries_map_.empty() ? QueryStatus::COMPLETED :
+                                                     QueryStatus::INPROGRESS;
+}
+
+void ArrayDimensionLabelQueries::cancel() {
+  for (auto& [label_name, query] : range_queries_map_) {
+    query->cancel();
+  }
+  for (auto& [label_name, query] : data_queries_) {
+    query->cancel();
+  }
+}
+
+void ArrayDimensionLabelQueries::finalize() {
+  for (auto& [label_name, query] : range_queries_map_) {
+    query->finalize();
+  }
+  for (auto& [label_name, query] : data_queries_) {
+    query->finalize();
+  }
+}
+
+void ArrayDimensionLabelQueries::process_data_queries() {
+  // TODO: Parallel?
+  for (auto& [label_name, query] : data_queries_) {
+    query->process();
+  }
+}
+
+void ArrayDimensionLabelQueries::process_range_queries(Subarray& subarray) {
+  // TODO: Parallel?
+  for (auto& [label_name, query] : range_queries_map_) {
+    query->process();
+  }
+
+  // TODO: Do something smart for throwing errors and setting ranges.
+  // Update the subarray.
+  for (dimension_size_type dim_idx{0}; dim_idx < subarray.dim_num();
+       ++dim_idx) {
+    const auto& range_query = range_queries_[dim_idx];
+
+    // Continue to next dimension index if no range query.
+    if (!range_query) {
+      continue;
+    }
+
+    // Throw for now if this is reached. This function is still mainly a
+    // placeholder for the time being.
+    throw StatusException(Status_DimensionLabelQueryError(
+        "Support for querying arrays by label ranges is not yet implemented."));
+  }
+}
+
+void ArrayDimensionLabelQueries::add_data_queries_for_read(
+    StorageManager* storage_manager,
+    Array* array,
+    const Subarray& subarray,
+    const std::unordered_map<std::string, QueryBuffer>& label_buffers) {
+  for (const auto& [label_name, label_buffer] : label_buffers) {
+    // Skip adding a new query if this dimension label was already used to
+    // add a range query above.
+    if (range_queries_map_.find(label_name) != range_queries_map_.end()) {
+      continue;
+    }
+
+    // Get the dimension label reference from the array.
+    const auto& dim_label_ref =
+        array->array_schema_latest().dimension_label_reference(label_name);
+    // TODO: Ensure label order type is valid with
+    // ensure_label_order_is_valid.
+
+    // Open the indexed array.
+    auto* dim_label = open_dimension_label(
+        storage_manager, array, dim_label_ref, QueryType::READ, true, false);
+
+    // Create the data query.
+    data_queries_[label_name] = tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+        DimensionLabelReadDataQuery,
+        storage_manager,
+        dim_label,
+        subarray,
+        label_buffer,
+        dim_label_ref.dimension_id()));
+  }
+}
+
+void ArrayDimensionLabelQueries::add_data_queries_for_write(
+    StorageManager* storage_manager,
+    Array* array,
+    const Subarray& subarray,
+    const std::unordered_map<std::string, QueryBuffer>& label_buffers,
+    const std::unordered_map<std::string, QueryBuffer>& array_buffers,
+    const std::string& fragment_name) {
+  for (const auto& [label_name, label_buffer] : label_buffers) {
+    // Skip adding a new query if this dimension label was already used to
+    // add a range query above.
+    if (range_queries_map_.find(label_name) != range_queries_map_.end()) {
+      continue;
+    }
+
+    // Get the dimension label reference from the array.
+    const auto& dim_label_ref =
+        array->array_schema_latest().dimension_label_reference(label_name);
+
+    // Open both arrays in the dimension label.
+    auto* dim_label = open_dimension_label(
+        storage_manager, array, dim_label_ref, QueryType::WRITE, true, true);
+
+    // Get the index_buffer from the array buffers.
+    const auto& dim_name = array->array_schema_latest()
+                               .dimension_ptr(dim_label_ref.dimension_id())
+                               ->name();
+    const auto& index_buffer_pair = array_buffers.find(dim_name);
+
+    switch (dim_label_ref.label_order()) {
+      case (LabelOrder::INCREASING_LABELS):
+      case (LabelOrder::DECREASING_LABELS):
+        if (index_buffer_pair == array_buffers.end()) {
+          data_queries_[label_name] =
+              tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+                  OrderedWriteDataQuery,
+                  storage_manager,
+                  dim_label,
+                  subarray,
+                  label_buffer,
+                  dim_label_ref.dimension_id(),
+                  fragment_name));
+        } else {
+          data_queries_[label_name] =
+              tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+                  OrderedWriteDataQuery,
+                  storage_manager,
+                  dim_label,
+                  index_buffer_pair->second,
+                  label_buffer,
+                  fragment_name));
+        }
+        break;
+
+      case (LabelOrder::UNORDERED_LABELS):
+        if (index_buffer_pair == array_buffers.end()) {
+          throw StatusException(Status_DimensionLabelQueryError(
+              "Cannot read range data from unordered label '" + label_name +
+              "'; Missing a data buffer for dimension '" + dim_name + "'."));
+        }
+        data_queries_[label_name] = tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+            UnorderedWriteDataQuery,
+            storage_manager,
+            dim_label,
+            index_buffer_pair->second,
+            label_buffer,
+            fragment_name));
+        break;
+
+      default:
+        // Invalid label order type.
+        throw StatusException(Status_DimensionLabelQueryError(
+            "Cannot initialize dimension label '" + label_name +
+            "'; Dimension label order " +
+            label_order_str(dim_label_ref.label_order()) + " not supported."));
+    }
+  }
+}
+
+void ArrayDimensionLabelQueries::add_range_queries(
+    StorageManager*,
+    Array*,
+    const Subarray& subarray,
+    const std::unordered_map<std::string, QueryBuffer>&,
+    const std::unordered_map<std::string, QueryBuffer>&) {
+  // Add queries for dimension labels set on the subarray.
+  for (ArraySchema::dimension_size_type dim_idx{0};
+       dim_idx < subarray.dim_num();
+       ++dim_idx) {
+    // Continue to the next dimension if this dimension does not have any
+    // label ranges.
+    if (!subarray.has_label_ranges(dim_idx)) {
+      continue;
+    }
+
+    // This function and infrastructure around the range queries is currently
+    // a placeholder.
+    throw StatusException(Status_DimensionLabelQueryError(
+        "Querying arrays by dimension label ranges has not yet been "
+        "implemented."));
+  }
+}
+
+bool ArrayDimensionLabelQueries::completed() const {
+  return std::all_of(
+             range_queries_map_.cbegin(),
+             range_queries_map_.cend(),
+             [](const auto& query) { return query.second->completed(); }) &&
+         std::all_of(
+             data_queries_.cbegin(),
+             data_queries_.cend(),
+             [](const auto& query) { return query.second->completed(); });
+}
+
+DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
+    StorageManager* storage_manager,
+    Array* array,
+    const DimensionLabelReference& dim_label_ref,
+    const QueryType& query_type,
+    const bool open_indexed_array,
+    const bool open_labelled_array) {
+  const auto& uri = dim_label_ref.uri();
+  bool is_relative = true;  // TODO: Fix to move this to array
+  auto dim_label_uri =
+      is_relative ? array->array_uri().join_path(uri.to_string()) : uri;
+
+  // Create dimension label.
+  dimension_labels_[dim_label_ref.name()] = tdb_unique_ptr<DimensionLabel>(
+      tdb_new(DimensionLabel, dim_label_uri, storage_manager));
+  auto* dim_label = dimension_labels_[dim_label_ref.name()].get();
+
+  // Currently there is no way to open just one of these arrays. This is a
+  // placeholder for a single array open is implemented.
+  if (open_indexed_array || open_labelled_array) {
+    // Open the dimension label.
+    // TODO: Fix how the encryption is handled.
+    // TODO: Fix the timestamps for writes.
+    dim_label->open(
+        query_type,
+        array->timestamp_start(),
+        array->timestamp_end(),
+        EncryptionType::NO_ENCRYPTION,
+        nullptr,
+        0);
+
+    // Check the dimension label schema matches the definition provided in
+    // the dimension label reference.
+    // TODO: Move to array schema.
+    const auto& label_schema = dim_label->schema();
+    if (!label_schema.is_compatible_label(
+            array->array_schema_latest().dimension_ptr(
+                dim_label_ref.dimension_id()))) {
+      throw StatusException(
+          Status_DimensionLabelQueryError("TODO: Add error msg."));
+    }
+    if (label_schema.label_order() != dim_label_ref.label_order()) {
+      throw StatusException(
+          Status_DimensionLabelQueryError("TODO: Add error msg."));
+    }
+    if (label_schema.label_dimension()->type() != dim_label_ref.label_type()) {
+      throw StatusException(
+          Status_DimensionLabelQueryError("TODO: Add error msg."));
+    }
+    if (!(label_schema.label_dimension()->domain() ==
+          dim_label_ref.label_domain())) {
+      throw StatusException(
+          Status_DimensionLabelQueryError("TODO: Add error msg."));
+    }
+    if (label_schema.label_dimension()->cell_val_num() !=
+        dim_label_ref.label_cell_val_num()) {
+      throw StatusException(
+          Status_DimensionLabelQueryError("TODO: Add error msg."));
+    }
+  }
+
+  return dim_label;
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -222,13 +222,13 @@ void ArrayDimensionLabelQueries::add_data_queries_for_read(
         array, dim_label_ref, QueryType::READ, true, false);
 
     // Create the data query.
-    data_queries_.emplace_back(tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+    data_queries_.emplace_back(tdb_new(
         DimensionLabelReadDataQuery,
         storage_manager_,
         dim_label,
         subarray,
         label_buffer,
-        dim_label_ref.dimension_id())));
+        dim_label_ref.dimension_id()));
     data_queries_map_[label_name] = data_queries_.back().get();
   }
 }
@@ -263,7 +263,7 @@ void ArrayDimensionLabelQueries::add_data_queries_for_write(
       case (LabelOrder::INCREASING_LABELS):
       case (LabelOrder::DECREASING_LABELS):
         // Create order label writer.
-        data_queries_.emplace_back(tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+        data_queries_.emplace_back(tdb_new(
             OrderedWriteDataQuery,
             storage_manager_,
             dim_label,
@@ -273,13 +273,13 @@ void ArrayDimensionLabelQueries::add_data_queries_for_write(
                 QueryBuffer() :
                 index_buffer_pair->second,
             dim_label_ref.dimension_id(),
-            fragment_name_)));
+            fragment_name_));
         data_queries_map_[label_name] = data_queries_.back().get();
         break;
 
       case (LabelOrder::UNORDERED_LABELS):
         // Create unordered label writer.
-        data_queries_.emplace_back(tdb_unique_ptr<DimensionLabelQuery>(tdb_new(
+        data_queries_.emplace_back(tdb_new(
             UnorderedWriteDataQuery,
             storage_manager_,
             dim_label,
@@ -289,7 +289,7 @@ void ArrayDimensionLabelQueries::add_data_queries_for_write(
                 QueryBuffer() :
                 index_buffer_pair->second,
             dim_label_ref.dimension_id(),
-            fragment_name_)));
+            fragment_name_));
         data_queries_map_[label_name] = data_queries_.back().get();
         break;
 
@@ -334,9 +334,9 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
     const bool open_labelled_array) {
   // Get the URI fo the dimension label from the dimension label reference.
   const auto& uri = dim_label_ref.uri();
-  bool is_relative = true;
-  auto dim_label_uri =
-      is_relative ? array->array_uri().join_path(uri.to_string()) : uri;
+  auto dim_label_uri = dim_label_ref.uri_is_relative() ?
+                           array->array_uri().join_path(uri.to_string()) :
+                           uri;
 
   // Create the dimension label.
   dimension_labels_[dim_label_ref.name()] = tdb_unique_ptr<DimensionLabel>(
@@ -363,7 +363,7 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
             array->array_schema_latest().dimension_ptr(
                 dim_label_ref.dimension_id()))) {
       throw StatusException(Status_DimensionLabelQueryError(
-          "Error opening dimesnion label; Found dimension label does not match "
+          "Error opening dimension label; Found dimension label does not match "
           "array dimension."));
     }
     if (label_schema.label_order() != dim_label_ref.label_order()) {

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -78,7 +78,7 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
             array->array_schema_latest().write_version());
       }
 
-      // Add dimesnion label queries.
+      // Add dimension label queries.
       add_range_queries(array, subarray, label_buffers, array_buffers);
       add_data_queries_for_write(array, subarray, label_buffers, array_buffers);
       break;

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -54,12 +54,14 @@ namespace tiledb::sm {
 
 ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
     StorageManager* storage_manager,
+    stats::Stats* stats,
     Array* array,
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
     const std::unordered_map<std::string, QueryBuffer>& array_buffers,
     const optional<std::string>& fragment_name)
     : storage_manager_(storage_manager)
+    , stats_(stats)
     , range_queries_(subarray.dim_num(), nullptr)
     , range_query_status_{QueryStatus::UNINITIALIZED}
     , fragment_name_{fragment_name} {
@@ -225,6 +227,7 @@ void ArrayDimensionLabelQueries::add_data_queries_for_read(
     data_queries_.emplace_back(tdb_new(
         DimensionLabelReadDataQuery,
         storage_manager_,
+        stats_->create_child("DimensionLabelQuery"),
         dim_label,
         subarray,
         label_buffer,
@@ -266,6 +269,7 @@ void ArrayDimensionLabelQueries::add_data_queries_for_write(
         data_queries_.emplace_back(tdb_new(
             OrderedWriteDataQuery,
             storage_manager_,
+            stats_->create_child("DimensionLabelQuery"),
             dim_label,
             subarray,
             label_buffer,
@@ -282,6 +286,7 @@ void ArrayDimensionLabelQueries::add_data_queries_for_write(
         data_queries_.emplace_back(tdb_new(
             UnorderedWriteDataQuery,
             storage_manager_,
+            stats_->create_child("DimensionLabelQuery"),
             dim_label,
             subarray,
             label_buffer,

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -24,6 +24,10 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Class for managing all dimension label queries in an array query.
  */
 
 #include "tiledb/sm/query/dimension_label/array_dimension_label_queries.h"
@@ -197,10 +201,6 @@ void ArrayDimensionLabelQueries::process_range_queries(Subarray& subarray) {
 
   range_query_status_ = QueryStatus::COMPLETED;
 }
-
-/*******************/
-/* PRIVATE METHODS */
-/*******************/
 
 void ArrayDimensionLabelQueries::add_data_queries_for_read(
     Array* array,

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -137,30 +137,6 @@ bool ArrayDimensionLabelQueries::completed() const {
              [](const auto& query) { return query.second->completed(); });
 }
 
-void ArrayDimensionLabelQueries::finalize() {
-  // Finalize range queries.
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      range_queries_.size(),
-      [&](const size_t dim_idx) {
-        if (range_queries_[dim_idx]) {
-          range_queries_[dim_idx]->finalize();
-        }
-        return Status::Ok();
-      }));
-
-  // Finalize data queries.
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      data_queries_.size(),
-      [&](const size_t query_idx) {
-        data_queries_[query_idx]->finalize();
-        return Status::Ok();
-      }));
-}
-
 void ArrayDimensionLabelQueries::process_data_queries() {
   throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(),

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -284,12 +284,12 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
     const bool open_indexed_array,
     const bool open_labelled_array) {
   // Create the dimension label.
-  auto label_iter =
-      dimension_labels_.insert({dim_label_ref.name(),
-                                tdb_unique_ptr<DimensionLabel>(tdb_new(
-                                    DimensionLabel,
-                                    dim_label_ref.uri(array->array_uri()),
-                                    storage_manager_))});
+  auto label_iter = dimension_labels_.try_emplace(
+      dim_label_ref.name(),
+      tdb_new(
+          DimensionLabel,
+          dim_label_ref.uri(array->array_uri()),
+          storage_manager_));
   DimensionLabel* dim_label = (label_iter.first->second).get();
 
   // Currently there is no way to open just one of these arrays. This is a

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -209,12 +209,6 @@ void ArrayDimensionLabelQueries::add_data_queries_for_read(
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers) {
   for (const auto& [label_name, label_buffer] : label_buffers) {
-    // Skip adding a new query if this dimension label was already used to
-    // add a range query above.
-    if (range_queries_map_.find(label_name) != range_queries_map_.end()) {
-      continue;
-    }
-
     // Get the dimension label reference from the array.
     const auto& dim_label_ref =
         array->array_schema_latest().dimension_label_reference(label_name);
@@ -344,9 +338,11 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
                            uri;
 
   // Create the dimension label.
-  dimension_labels_[dim_label_ref.name()] = tdb_unique_ptr<DimensionLabel>(
-      tdb_new(DimensionLabel, dim_label_uri, storage_manager_));
-  auto* dim_label = dimension_labels_[dim_label_ref.name()].get();
+  auto label_iter = dimension_labels_.insert(
+      {dim_label_ref.name(),
+       tdb_unique_ptr<DimensionLabel>(
+           tdb_new(DimensionLabel, dim_label_uri, storage_manager_))});
+  DimensionLabel* dim_label = (label_iter.first->second).get();
 
   // Currently there is no way to open just one of these arrays. This is a
   // placeholder for a single array open is implemented.
@@ -361,48 +357,12 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
         nullptr,
         0);
 
-    // Check the dimension label schema matches the definition provided in
-    // the dimension label reference.
-    const auto& label_schema = dim_label->schema();
-    if (!label_schema.is_compatible_label(
-            array->array_schema_latest().dimension_ptr(
-                dim_label_ref.dimension_id()))) {
-      throw StatusException(Status_DimensionLabelQueryError(
-          "Error opening dimension label; Found dimension label does not match "
-          "array dimension."));
-    }
-    if (label_schema.label_order() != dim_label_ref.label_order()) {
-      throw StatusException(Status_DimensionLabelQueryError(
-          "Error opening dimension label; The label order of the loaded "
-          "dimension label is " +
-          label_order_str(label_schema.label_order()) +
-          ", but the expected label order was " +
-          label_order_str(dim_label_ref.label_order()) + "."));
-    }
-    if (label_schema.label_dimension()->type() != dim_label_ref.label_type()) {
-      throw StatusException(Status_DimensionLabelQueryError(
-          "Error opening dimension label; The label datatype of the loaded "
-          "dimension label is " +
-          datatype_str(label_schema.label_dimension()->type()) +
-          ", but the expected label datatype was " +
-          datatype_str(dim_label_ref.label_type()) + "."));
-    }
-    if (!(label_schema.label_dimension()->domain() ==
-          dim_label_ref.label_domain())) {
-      throw StatusException(Status_DimensionLabelQueryError(
-          "Error opening dimension label; The label domain of the loaded "
-          "dimension label does not match the expected domain."));
-    }
-    if (label_schema.label_dimension()->cell_val_num() !=
-        dim_label_ref.label_cell_val_num()) {
-      throw StatusException(Status_DimensionLabelQueryError(
-          "Error opening dimension label; The label cell value number of the "
-          "loaded "
-          "dimension label is " +
-          std::to_string(label_schema.label_dimension()->cell_val_num()) +
-          ", but the expected label cell value number was " +
-          std::to_string(dim_label_ref.label_cell_val_num()) + "."));
-    }
+    // Check the dimension label is compatible with the dim label reference and
+    // dimension from the parent array.
+    dim_label->is_compatible(
+        dim_label_ref,
+        array->array_schema_latest().dimension_ptr(
+            dim_label_ref.dimension_id()));
   }
 
   return dim_label;

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -283,17 +283,13 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
     const QueryType& query_type,
     const bool open_indexed_array,
     const bool open_labelled_array) {
-  // Get the URI fo the dimension label from the dimension label reference.
-  const auto& uri = dim_label_ref.uri();
-  auto dim_label_uri = dim_label_ref.uri_is_relative() ?
-                           array->array_uri().join_path(uri.to_string()) :
-                           uri;
-
   // Create the dimension label.
-  auto label_iter = dimension_labels_.insert(
-      {dim_label_ref.name(),
-       tdb_unique_ptr<DimensionLabel>(
-           tdb_new(DimensionLabel, dim_label_uri, storage_manager_))});
+  auto label_iter =
+      dimension_labels_.insert({dim_label_ref.name(),
+                                tdb_unique_ptr<DimensionLabel>(tdb_new(
+                                    DimensionLabel,
+                                    dim_label_ref.uri(array->array_uri()),
+                                    storage_manager_))});
   DimensionLabel* dim_label = (label_iter.first->second).get();
 
   // Currently there is no way to open just one of these arrays. This is a

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -105,30 +105,6 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
                                                      QueryStatus::INPROGRESS;
 }
 
-void ArrayDimensionLabelQueries::cancel() {
-  // Cancel range queries.
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      range_queries_.size(),
-      [&](const size_t dim_idx) {
-        if (range_queries_[dim_idx]) {
-          range_queries_[dim_idx]->cancel();
-        }
-        return Status::Ok();
-      }));
-
-  // Cancel data queries.
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      data_queries_.size(),
-      [&](const size_t query_idx) {
-        data_queries_[query_idx]->cancel();
-        return Status::Ok();
-      }));
-}
-
 bool ArrayDimensionLabelQueries::completed() const {
   return range_query_status_ == QueryStatus::COMPLETED &&
          std::all_of(

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/common.h"
 #include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/query/dimension_label/dimension_label_query.h"
 
 #include <unordered_map>
@@ -51,7 +52,6 @@ class StorageManager;
 class Subarray;
 
 enum class QueryType : uint8_t;
-enum class QueryStatus : uint8_t;
 
 /**
  * Return a Status_DimensionQueryError error class Status with a given
@@ -97,10 +97,25 @@ class ArrayDimensionLabelQueries {
   bool completed() const;
 
   /** TODO: docs */
+  inline bool completed_range_queries() const {
+    return range_query_status_ == QueryStatus::COMPLETED;
+  }
+
+  /** TODO: docs */
   void cancel();
 
   /** TODO: docs */
   void finalize();
+
+  /** TODO: docs */
+  inline bool has_data_query() const {
+    return !data_queries_.empty();
+  }
+
+  /** TODO: docs */
+  inline bool has_range_query() const {
+    return !range_queries_map_.empty();
+  }
 
   /** TODO: docs */
   inline bool has_range_query(dimension_size_type dim_idx) const {
@@ -115,11 +130,6 @@ class ArrayDimensionLabelQueries {
    * Updates subarray with data.
    **/
   void process_range_queries(Subarray& subarray);
-
-  /** TODO: docs */
-  inline QueryStatus range_query_status() const {
-    return range_query_status_;
-  }
 
  private:
   /** The storage manager. */

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -1,0 +1,179 @@
+/**
+ * @file array_dimension_label_queries.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Class for managing all dimension label queries in an array query.
+ */
+
+#ifndef TILEDB_ARRAY_DIMENSION_LABEL_QUERIES_H
+#define TILEDB_ARRAY_DIMENSION_LABEL_QUERIES_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/query/dimension_label/dimension_label_query.h"
+
+#include <unordered_map>
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+class Array;
+class DimensionLabelReference;
+class Query;
+class QueryBuffer;
+class StorageManager;
+class Subarray;
+
+enum class QueryType : uint8_t;
+enum class QueryStatus : uint8_t;
+
+/**
+ * Return a Status_DimensionQueryError error class Status with a given
+ * message.
+ *
+ * Note: Returns error as a QueryError.
+ ***/
+inline Status Status_DimensionLabelQueryError(const std::string& msg) {
+  return {"[TileDB::Query] Error", msg};
+}
+
+class ArrayDimensionLabelQueries {
+ public:
+  /**
+   * Size type for the number of dimensions of an array and for dimension
+   * indices.
+   *
+   * Note: This should be the same as `Domain::dimension_size_type`. We're
+   * not including `domain.h`, otherwise we'd use that definition here.
+   */
+  using dimension_size_type = unsigned int;
+
+  /** TODO */
+  using range_size_type = uint64_t;
+
+  /** Default constructor is not C.41 compliant. */
+  ArrayDimensionLabelQueries() = delete;
+
+  /** Constructor. */
+  ArrayDimensionLabelQueries(
+      StorageManager* storage_manager,
+      Array* array,
+      const Subarray& subarray,
+      const std::unordered_map<std::string, QueryBuffer>& label_buffers,
+      const std::unordered_map<std::string, QueryBuffer>& array_buffers,
+      const optional<std::string>& fragment_name);
+
+  /** Disable copy and move. */
+  DISABLE_COPY_AND_COPY_ASSIGN(ArrayDimensionLabelQueries);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(ArrayDimensionLabelQueries);
+
+  /** TODO: docs */
+  bool completed() const;
+
+  /** TODO: docs */
+  void cancel();
+
+  /** TODO: docs */
+  void finalize();
+
+  /** TODO: docs */
+  inline bool has_range_query(dimension_size_type dim_idx) const {
+    return range_queries_[dim_idx] != nullptr;
+  }
+
+  /** TODO: docs */
+  void process_data_queries();
+
+  /** TODO: docs
+   *
+   * Updates subarray with data.
+   **/
+  void process_range_queries(Subarray& subarray);
+
+  /** TODO: docs */
+  inline QueryStatus range_query_status() const {
+    return range_query_status_;
+  }
+
+ private:
+  /** TODO: docs */
+  std::unordered_map<std::string, tdb_unique_ptr<DimensionLabel>>
+      dimension_labels_;
+
+  /** TODO: docs */
+  std::unordered_map<std::string, tdb_unique_ptr<DimensionLabelQuery>>
+      range_queries_map_;
+
+  /** TODO: docs */
+  std::vector<DimensionLabelQuery*> range_queries_;
+
+  /** TODO: docs */
+  std::unordered_map<std::string, tdb_unique_ptr<DimensionLabelQuery>>
+      data_queries_;
+
+  /** TODO: docs */
+  QueryStatus range_query_status_;
+
+  /** TODO: docs */
+  void add_data_queries_for_read(
+      StorageManager* storage_manager,
+      Array* array,
+      const Subarray& subarray,
+      const std::unordered_map<std::string, QueryBuffer>& label_buffers);
+
+  /** TODO: docs */
+  void add_data_queries_for_write(
+      StorageManager* storage_manager,
+      Array* array,
+      const Subarray& subarray,
+      const std::unordered_map<std::string, QueryBuffer>& label_buffers,
+      const std::unordered_map<std::string, QueryBuffer>& array_buffers,
+      const std::string& fragment_name);
+
+  /** TODO: docs */
+  void add_range_queries(
+      StorageManager* storage_manager,
+      Array* array,
+      const Subarray& subarray,
+      const std::unordered_map<std::string, QueryBuffer>& label_buffers,
+      const std::unordered_map<std::string, QueryBuffer>& array_buffers);
+
+  /** TODO: docs */
+  DimensionLabel* open_dimension_label(
+      StorageManager* storage_manager,
+      Array* array,
+      const DimensionLabelReference& dim_label_ref,
+      const QueryType& query_type,
+      const bool open_indexed_array,
+      const bool open_labelled_array);
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -74,9 +74,6 @@ class ArrayDimensionLabelQueries {
    */
   using dimension_size_type = unsigned int;
 
-  /** TODO */
-  using range_size_type = uint64_t;
-
   /** Default constructor is not C.41 compliant. */
   ArrayDimensionLabelQueries() = delete;
 
@@ -93,42 +90,47 @@ class ArrayDimensionLabelQueries {
   DISABLE_COPY_AND_COPY_ASSIGN(ArrayDimensionLabelQueries);
   DISABLE_MOVE_AND_MOVE_ASSIGN(ArrayDimensionLabelQueries);
 
-  /** TODO: docs */
+  /** Returns ``true`` if all queries are completed. */
   bool completed() const;
 
-  /** TODO: docs */
+  /** Returns ``true`` if the range queries are completed. */
   inline bool completed_range_queries() const {
     return range_query_status_ == QueryStatus::COMPLETED;
   }
 
-  /** TODO: docs */
+  /** Cancels all dimension label queries. */
   void cancel();
 
-  /** TODO: docs */
+  /** Finalizes all dimension label queries. */
   void finalize();
 
-  /** TODO: docs */
+  /** Returns ``true`` if there are any data queries. */
   inline bool has_data_query() const {
     return !data_queries_.empty();
   }
 
-  /** TODO: docs */
+  /** Returns ``true`` if there are any range queries. */
   inline bool has_range_query() const {
     return !range_queries_map_.empty();
   }
 
-  /** TODO: docs */
+  /**
+   * Returns ``true`` if there is a range query on the requested dimension.
+   *
+   * @param dim_idx Index to check for a range query on.
+   */
   inline bool has_range_query(dimension_size_type dim_idx) const {
     return range_queries_[dim_idx] != nullptr;
   }
 
-  /** TODO: docs */
+  /** Process all data queries. */
   void process_data_queries();
 
-  /** TODO: docs
+  /**
+   * Process all data queries and updates the ranges on the parent subarray.
    *
-   * Updates subarray with data.
-   **/
+   * @param subarray The subarray to set the updated dimension ranges on.
+   */
   void process_range_queries(Subarray& subarray);
 
  private:
@@ -168,27 +170,55 @@ class ArrayDimensionLabelQueries {
 
   optional<std::string> fragment_name_;
 
-  /** TODO: docs */
+  /**
+   * Initializes all queries for reading label data.
+   *
+   * @param array The array for the parent query.
+   * @param subarray The subarray for the parent query.
+   * @param label_buffers A map of query buffers with label buffers.
+   */
   void add_data_queries_for_read(
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers);
 
-  /** TODO: docs */
+  /**
+   * Initializes all queries for writing label data.
+   *
+   * @param array The array for the parent query.
+   * @param subarray The subarray for the parent query.
+   * @param label_buffers A map of query buffers with label buffers.
+   * @param array_buffers Non-label buffers set on the parent query.
+   */
   void add_data_queries_for_write(
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
       const std::unordered_map<std::string, QueryBuffer>& array_buffers);
 
-  /** TODO: docs */
+  /**
+   * Initializes all queries for reading dimension ranges.
+   *
+   *
+   * @param array The array for the parent query.
+   * @param subarray The subarray for the parent query.
+   * @param label_buffers A map of query buffers with label buffers.
+   * @param array_buffers Non-label buffers set on the parent query.
+   */
   void add_range_queries(
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
       const std::unordered_map<std::string, QueryBuffer>& array_buffers);
 
-  /** TODO: docs */
+  /**
+   * Opens a dimension label.
+   *
+   * @param array The array the dimension label is defined on.
+   * @param query_type The query type to open the dimension label as.
+   * @param open_indexed_array If ``true``, open the indexed array.
+   * @param open_labelled_array If ``true``, open the labelled array.
+   */
   DimensionLabel* open_dimension_label(
       Array* array,
       const DimensionLabelReference& dim_label_ref,

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -122,43 +122,57 @@ class ArrayDimensionLabelQueries {
   }
 
  private:
-  /** TODO: docs */
+  /** The storage manager. */
+  StorageManager* storage_manager_;
+
+  /** Map from label name to dimension label opened by this query. */
   std::unordered_map<std::string, tdb_unique_ptr<DimensionLabel>>
       dimension_labels_;
 
-  /** TODO: docs */
+  /** Map from label name to dimension label range query. */
   std::unordered_map<std::string, tdb_unique_ptr<DimensionLabelQuery>>
       range_queries_map_;
 
-  /** TODO: docs */
+  /**
+   * Non-owning vector for accesing query by dimension index.
+   *
+   * Note: This vector is always sized to the number of dimensions in the array.
+   * There can be at most on query per dimension. If there is no query on the
+   * dimension, it contains a nullpointer.
+   */
   std::vector<DimensionLabelQuery*> range_queries_;
 
-  /** TODO: docs */
-  std::unordered_map<std::string, tdb_unique_ptr<DimensionLabelQuery>>
-      data_queries_;
+  /**
+   * Dimension label data queries.
+   *
+   * Note: For the data queries, the element order to the queries is
+   * unimportant and does not correspond to dimension index or any other value.
+   */
+  std::vector<tdb_unique_ptr<DimensionLabelQuery>> data_queries_;
 
-  /** TODO: docs */
+  /** Non-owning map from label name to dimension label data query. */
+  std::unordered_map<std::string, DimensionLabelQuery*> data_queries_map_;
+
+  /** The status of the range queries. */
   QueryStatus range_query_status_;
+
+  optional<std::string> fragment_name_;
 
   /** TODO: docs */
   void add_data_queries_for_read(
-      StorageManager* storage_manager,
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers);
 
   /** TODO: docs */
   void add_data_queries_for_write(
-      StorageManager* storage_manager,
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
-      const std::unordered_map<std::string, QueryBuffer>& array_buffers,
-      const std::string& fragment_name);
+      const std::unordered_map<std::string, QueryBuffer>& array_buffers);
 
   /** TODO: docs */
   void add_range_queries(
-      StorageManager* storage_manager,
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
@@ -166,7 +180,6 @@ class ArrayDimensionLabelQueries {
 
   /** TODO: docs */
   DimensionLabel* open_dimension_label(
-      StorageManager* storage_manager,
       Array* array,
       const DimensionLabelReference& dim_label_ref,
       const QueryType& query_type,

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -53,16 +53,6 @@ class Subarray;
 
 enum class QueryType : uint8_t;
 
-/**
- * Return a Status_DimensionQueryError error class Status with a given
- * message.
- *
- * Note: Returns error as a QueryError.
- ***/
-inline Status Status_DimensionLabelQueryError(const std::string& msg) {
-  return {"[TileDB::Query] Error", msg};
-}
-
 class ArrayDimensionLabelQueries {
  public:
   /**
@@ -77,7 +67,16 @@ class ArrayDimensionLabelQueries {
   /** Default constructor is not C.41 compliant. */
   ArrayDimensionLabelQueries() = delete;
 
-  /** Constructor. */
+  /** Constructor.
+   *
+   * @param storage_manager Storage manager object.
+   * @param array Parent array the dimension labels are defined on.
+   * @param subarray Subarray for the query on the parent array.
+   * @param label_buffers A map of query buffers containing label data.
+   * @param array_bufffers A map of query buffers containing dimension and
+   *     attribute data for the parent array.
+   * @param fragment_name Optional fragment name for writing fragments.
+   */
   ArrayDimensionLabelQueries(
       StorageManager* storage_manager,
       Array* array,
@@ -118,6 +117,8 @@ class ArrayDimensionLabelQueries {
    * Returns ``true`` if there is a range query on the requested dimension.
    *
    * @param dim_idx Index to check for a range query on.
+   * @returns ``true if there is a range query on the requested dimension and
+   *     ``false`` otherwise.
    */
   inline bool has_range_query(dimension_size_type dim_idx) const {
     return range_queries_[dim_idx] != nullptr;
@@ -168,13 +169,19 @@ class ArrayDimensionLabelQueries {
   /** The status of the range queries. */
   QueryStatus range_query_status_;
 
+  /**
+   * The name of the new fragment to be created for writes.
+   *
+   * If not set, the fragment will be created usint the latest array timestamp
+   * and a generated UUID.
+   */
   optional<std::string> fragment_name_;
 
   /**
    * Initializes all queries for reading label data.
    *
-   * @param array The array for the parent query.
-   * @param subarray The subarray for the parent query.
+   * @param array Array for the parent query.
+   * @param subarray Subarray for the parent query.
    * @param label_buffers A map of query buffers with label buffers.
    */
   void add_data_queries_for_read(
@@ -185,8 +192,8 @@ class ArrayDimensionLabelQueries {
   /**
    * Initializes all queries for writing label data.
    *
-   * @param array The array for the parent query.
-   * @param subarray The subarray for the parent query.
+   * @param array Array for the parent query.
+   * @param subarray Subarray for the parent query.
    * @param label_buffers A map of query buffers with label buffers.
    * @param array_buffers Non-label buffers set on the parent query.
    */
@@ -200,8 +207,8 @@ class ArrayDimensionLabelQueries {
    * Initializes all queries for reading dimension ranges.
    *
    *
-   * @param array The array for the parent query.
-   * @param subarray The subarray for the parent query.
+   * @param array Array for the parent query.
+   * @param subarray Subarray for the parent query.
    * @param label_buffers A map of query buffers with label buffers.
    * @param array_buffers Non-label buffers set on the parent query.
    */
@@ -214,8 +221,8 @@ class ArrayDimensionLabelQueries {
   /**
    * Opens a dimension label.
    *
-   * @param array The array the dimension label is defined on.
-   * @param query_type The query type to open the dimension label as.
+   * @param array Array the dimension label is defined on.
+   * @param query_type Query type to open the dimension label as.
    * @param open_indexed_array If ``true``, open the indexed array.
    * @param open_labelled_array If ``true``, open the labelled array.
    */

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -1,4 +1,4 @@
-/**
+/*
  * @file array_dimension_label_queries.h
  *
  * @section LICENSE
@@ -37,6 +37,7 @@
 #include "tiledb/sm/dimension_label/dimension_label.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/query/dimension_label/dimension_label_query.h"
+#include "tiledb/sm/stats/global_stats.h"
 
 #include <unordered_map>
 
@@ -79,6 +80,7 @@ class ArrayDimensionLabelQueries {
    */
   ArrayDimensionLabelQueries(
       StorageManager* storage_manager,
+      stats::Stats* stats,
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
@@ -137,6 +139,9 @@ class ArrayDimensionLabelQueries {
  private:
   /** The storage manager. */
   StorageManager* storage_manager_;
+
+  /** TODO: Docs */
+  stats::Stats* stats_;
 
   /** Map from label name to dimension label opened by this query. */
   std::unordered_map<std::string, tdb_unique_ptr<DimensionLabel>>

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -152,7 +152,7 @@ class ArrayDimensionLabelQueries {
       range_queries_map_;
 
   /**
-   * Non-owning vector for accesing query by dimension index.
+   * Non-owning vector for accessing query by dimension index.
    *
    * Note: This vector is always sized to the number of dimensions in the array.
    * There can be at most on query per dimension. If there is no query on the
@@ -177,7 +177,7 @@ class ArrayDimensionLabelQueries {
   /**
    * The name of the new fragment to be created for writes.
    *
-   * If not set, the fragment will be created usint the latest array timestamp
+   * If not set, the fragment will be created using the latest array timestamp
    * and a generated UUID.
    */
   optional<std::string> fragment_name_;

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -102,9 +102,6 @@ class ArrayDimensionLabelQueries {
   /** Cancels all dimension label queries. */
   void cancel();
 
-  /** Finalizes all dimension label queries. */
-  void finalize();
-
   /** Returns ``true`` if there are any data queries. */
   inline bool has_data_query() const {
     return !data_queries_.empty();

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -99,9 +99,6 @@ class ArrayDimensionLabelQueries {
     return range_query_status_ == QueryStatus::COMPLETED;
   }
 
-  /** Cancels all dimension label queries. */
-  void cancel();
-
   /** Returns ``true`` if there are any data queries. */
   inline bool has_data_query() const {
     return !data_queries_.empty();

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -1,5 +1,5 @@
 /**
- * @file dimension_label_data_query.cc
+ * @file dimension_label_query.cc
  *
  * @section LICENSE
  *

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -1,0 +1,289 @@
+/**
+ * @file dimension_label_data_query.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "tiledb/sm/query/dimension_label/dimension_label_query.h"
+#include "tiledb/common/common.h"
+#include "tiledb/sm/dimension_label/dimension_label.h"
+#include "tiledb/sm/enums/query_status.h"
+#include "tiledb/sm/query/query.h"
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/subarray/subarray.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+inline Status Status_DimensionLabelQueryError(const std::string& msg) {
+  return {"[TileDB::Query] Error", msg};
+}
+
+DimensionLabelQuery::DimensionLabelQuery(
+    StorageManager* storage_manager,
+    DimensionLabel* dimension_label,
+    bool add_indexed_query,
+    bool add_labelled_query,
+    optional<std::string> fragment_name)
+    : indexed_array_query{add_indexed_query ?
+                              tdb_unique_ptr<Query>(tdb_new(
+                                  Query,
+                                  storage_manager,
+                                  dimension_label->indexed_array(),
+                                  fragment_name)) :
+                              nullptr}
+    , labelled_array_query{add_labelled_query ?
+                               tdb_unique_ptr<Query>(tdb_new(
+                                   Query,
+                                   storage_manager,
+                                   dimension_label->labelled_array(),
+                                   fragment_name)) :
+                               nullptr} {
+}
+
+void DimensionLabelQuery::cancel() {
+  if (indexed_array_query) {
+    throw_if_not_ok(indexed_array_query->cancel());
+  }
+  if (labelled_array_query) {
+    throw_if_not_ok(labelled_array_query->cancel());
+  }
+}
+
+bool DimensionLabelQuery::completed() const {
+  return (!indexed_array_query ||
+          indexed_array_query->status() == QueryStatus::COMPLETED) &&
+         (!labelled_array_query ||
+          labelled_array_query->status() == QueryStatus::COMPLETED);
+}
+
+void DimensionLabelQuery::finalize() {
+  if (indexed_array_query) {
+    throw_if_not_ok(indexed_array_query->finalize());
+  }
+  if (labelled_array_query) {
+    throw_if_not_ok(labelled_array_query->finalize());
+  }
+}
+
+void DimensionLabelQuery::process() {
+  if (indexed_array_query) {
+    throw_if_not_ok(indexed_array_query->init());
+    throw_if_not_ok(indexed_array_query->process());
+  }
+  if (labelled_array_query) {
+    throw_if_not_ok(labelled_array_query->init());
+    throw_if_not_ok(labelled_array_query->process());
+  }
+}
+
+DimensionLabelReadDataQuery::DimensionLabelReadDataQuery(
+    StorageManager* storage_manager,
+    DimensionLabel* dimension_label,
+    const Subarray& parent_subarray,
+    const QueryBuffer& label_buffer,
+    const uint32_t dim_idx)
+    : DimensionLabelQuery{storage_manager, dimension_label, true, false} {
+  // Set the layout (ordered, 1D).
+  throw_if_not_ok(indexed_array_query->set_layout(Layout::ROW_MAJOR));
+
+  // Set the subarray.
+  Subarray subarray{*indexed_array_query->subarray()};
+  throw_if_not_ok(
+      subarray.set_ranges_for_dim(0, parent_subarray.ranges_for_dim(dim_idx)));
+  throw_if_not_ok(indexed_array_query->set_subarray(subarray));
+
+  // Set the label data buffer.
+  indexed_array_query->set_buffer(
+      dimension_label->label_attribute()->name(), label_buffer);
+}
+
+tdb_unique_ptr<IndexData> create_index_data(
+    const Datatype type, const Range& input_range) {
+  // Create index data if it is not provided.
+  // TODO: add if statement in here.
+  switch (type) {
+    case Datatype::INT8:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<int8_t>, input_range));
+    case Datatype::UINT8:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<uint8_t>, input_range));
+    case Datatype::INT16:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<int16_t>, input_range));
+    case Datatype::UINT16:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<uint16_t>, input_range));
+    case Datatype::INT32:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<int32_t>, input_range));
+    case Datatype::UINT32:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<uint32_t>, input_range));
+    case Datatype::INT64:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<int64_t>, input_range));
+    case Datatype::UINT64:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<uint64_t>, input_range));
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return tdb_unique_ptr<IndexData>(
+          tdb_new(TypedIndexData<uint8_t>, input_range));
+    default:
+      throw StatusException(Status_DimensionLabelQueryError(
+          "Unexpected dimension datatype " + datatype_str(type)));
+  }
+}
+
+OrderedWriteDataQuery::OrderedWriteDataQuery(
+    StorageManager* storage_manager,
+    DimensionLabel* dimension_label,
+    const QueryBuffer& index_buffer,
+    const QueryBuffer& label_buffer,
+    optional<std::string> fragment_name)
+    : DimensionLabelQuery{
+          storage_manager, dimension_label, true, true, fragment_name} {
+  // Verify only one dimension label is set.
+  if (!dimension_label->labelled_array()->is_empty() ||
+      !dimension_label->indexed_array()->is_empty()) {
+    throw StatusException(Status_DimensionLabelQueryError(
+        "Cannot write to dimension label. Currently ordered dimension "
+        "labels can only be written to once."));
+  }
+  // TODO: Check sort
+  // Set-up labelled array query (sparse array)
+  throw_if_not_ok(labelled_array_query->set_layout(Layout::UNORDERED));
+  labelled_array_query->set_buffer(
+      dimension_label->label_attribute()->name(), label_buffer);
+  labelled_array_query->set_buffer(
+      dimension_label->index_attribute()->name(), index_buffer);
+
+  // Set-up indexed array query (dense array)
+  throw_if_not_ok(indexed_array_query->set_layout(Layout::ROW_MAJOR));
+  indexed_array_query->set_buffer(
+      dimension_label->label_attribute()->name(), label_buffer);
+}
+
+OrderedWriteDataQuery::OrderedWriteDataQuery(
+    StorageManager* storage_manager,
+    DimensionLabel* dimension_label,
+    const Subarray& parent_subarray,
+    const QueryBuffer& label_buffer,
+    const uint32_t dim_idx,
+    optional<std::string> fragment_name)
+    : DimensionLabelQuery{
+          storage_manager, dimension_label, true, true, fragment_name} {
+  // Verify only one dimension label is set.
+  if (!dimension_label->labelled_array()->is_empty() ||
+      !dimension_label->indexed_array()->is_empty()) {
+    throw StatusException(Status_DimensionLabelQueryError(
+        "Cannot write to dimension label. Currently ordered dimension "
+        "labels can only be written to once."));
+  }
+  if (!parent_subarray.is_default(dim_idx)) {
+    const auto& ranges = parent_subarray.ranges_for_dim(dim_idx);
+    if (ranges.size() != 1) {
+      throw StatusException(Status_DimensionLabelQueryError(
+          "Failed to create dimension label query. Dimension label writes can "
+          "only be set for a single range ."));
+    }
+    const Range& input_range = ranges[0];
+    const Range& index_domain = dimension_label->index_dimension()->domain();
+    if (!(input_range == index_domain)) {
+      throw StatusException(Status_DimensionLabelQueryError(
+          "Failed to create dimension label query. Currently dimension "
+          "labels only support writing the full array."));
+    }
+  }
+  // TODO: Check sort
+
+  // Create index data for attribute on sparse labelled array
+  index_data_ = create_index_data(
+      dimension_label->index_dimension()->type(),
+      parent_subarray.ranges_for_dim(dim_idx)[0]);
+
+  // Set-up labelled array query (sparse array)
+  throw_if_not_ok(labelled_array_query->set_layout(Layout::UNORDERED));
+  labelled_array_query->set_buffer(
+      dimension_label->label_attribute()->name(), label_buffer);
+  labelled_array_query->set_data_buffer(
+      dimension_label->index_attribute()->name(),
+      index_data_->data(),
+      index_data_->data_size(),
+      true);
+
+  // Set-up indexed array query (dense array)
+  throw_if_not_ok(indexed_array_query->set_layout(Layout::ROW_MAJOR));
+  indexed_array_query->set_buffer(
+      dimension_label->label_attribute()->name(), label_buffer);
+}
+
+UnorderedWriteDataQuery::UnorderedWriteDataQuery(
+    StorageManager* storage_manager,
+    DimensionLabel* dimension_label,
+    const QueryBuffer& index_buffer,
+    const QueryBuffer& label_buffer,
+    optional<std::string> fragment_name)
+    : DimensionLabelQuery{
+          storage_manager, dimension_label, true, true, fragment_name} {
+  // Set-up labelled array (sparse array)
+  throw_if_not_ok(labelled_array_query->set_layout(Layout::UNORDERED));
+  labelled_array_query->set_buffer(
+      dimension_label->label_dimension()->name(), label_buffer);
+  labelled_array_query->set_buffer(
+      dimension_label->index_attribute()->name(), index_buffer);
+
+  // Set-up indexed array query (sparse array)
+  throw_if_not_ok(indexed_array_query->set_layout(Layout::UNORDERED));
+  indexed_array_query->set_buffer(
+      dimension_label->label_attribute()->name(), label_buffer);
+  indexed_array_query->set_buffer(
+      dimension_label->index_dimension()->name(), index_buffer);
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -27,7 +27,15 @@
  *
  * @section DESCRIPTION
  *
- * Classes for querying a dimension label.
+ * Classes for querying (reading/writing) a dimension label.
+ *
+ * Note: The current implementation uses a class that stores two `Query` objects
+ * and all operations check if each of the query is initialized or is `nullptr`.
+ * This is to support the temporary dual-array dimension label design. Once a
+ * reader for the ordered dimension label is implemented and the projections for
+ * the unordered dimension label are implemented, each `DimensionLabelQuery`
+ * will only contain a single `Query` object that must be constructed on
+ * initialization.
  */
 
 #include "tiledb/sm/query/dimension_label/dimension_label_query.h"
@@ -190,6 +198,10 @@ tdb_unique_ptr<IndexData> create_index_data(
 
 /**
  * Typed implementation to check if data is sorted.
+ *
+ * TODO: This is a quick-and-dirty implementation while we decide where sorting
+ * is handled for ordered dimension labels. If we keep this design, we should
+ * consider optimizing (parallelizing?) the loops in this check.
  *
  * @param buffer Buffer to check for sort.
  * @param buffer_size Total size of the buffer.

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -124,7 +124,6 @@ DimensionLabelReadDataQuery::DimensionLabelReadDataQuery(
 tdb_unique_ptr<IndexData> create_index_data(
     const Datatype type, const Range& input_range) {
   // Create index data if it is not provided.
-  // TODO: add if statement in here.
   switch (type) {
     case Datatype::INT8:
       return tdb_unique_ptr<IndexData>(

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -121,7 +121,7 @@ DimensionLabelReadDataQuery::DimensionLabelReadDataQuery(
   throw_if_not_ok(indexed_array_query->set_subarray(subarray));
 
   // Set the label data buffer.
-  indexed_array_query->set_buffer(
+  indexed_array_query->set_dimension_label_buffer(
       dimension_label->label_attribute()->name(), label_buffer);
 }
 
@@ -393,7 +393,7 @@ OrderedWriteDataQuery::OrderedWriteDataQuery(
 
   // Set-up labelled array query (sparse array)
   throw_if_not_ok(labelled_array_query->set_layout(Layout::UNORDERED));
-  labelled_array_query->set_buffer(
+  labelled_array_query->set_dimension_label_buffer(
       dimension_label->label_attribute()->name(), label_buffer);
   if (use_local_index) {
     throw_if_not_ok(labelled_array_query->set_data_buffer(
@@ -402,13 +402,13 @@ OrderedWriteDataQuery::OrderedWriteDataQuery(
         index_data_->data_size(),
         true));
   } else {
-    labelled_array_query->set_buffer(
+    labelled_array_query->set_dimension_label_buffer(
         dimension_label->index_attribute()->name(), index_buffer);
   }
 
   // Set-up indexed array query (dense array)
   throw_if_not_ok(indexed_array_query->set_layout(Layout::ROW_MAJOR));
-  indexed_array_query->set_buffer(
+  indexed_array_query->set_dimension_label_buffer(
       dimension_label->label_attribute()->name(), label_buffer);
 }
 
@@ -443,7 +443,7 @@ UnorderedWriteDataQuery::UnorderedWriteDataQuery(
 
   // Set-up labelled array (sparse array).
   throw_if_not_ok(labelled_array_query->set_layout(Layout::UNORDERED));
-  labelled_array_query->set_buffer(
+  labelled_array_query->set_dimension_label_buffer(
       dimension_label->label_dimension()->name(), label_buffer);
   if (use_local_index) {
     throw_if_not_ok(labelled_array_query->set_data_buffer(
@@ -452,13 +452,13 @@ UnorderedWriteDataQuery::UnorderedWriteDataQuery(
         index_data_->data_size(),
         true));
   } else {
-    labelled_array_query->set_buffer(
+    labelled_array_query->set_dimension_label_buffer(
         dimension_label->index_attribute()->name(), index_buffer);
   }
 
   // Set-up indexed array query (sparse array).
   throw_if_not_ok(indexed_array_query->set_layout(Layout::UNORDERED));
-  indexed_array_query->set_buffer(
+  indexed_array_query->set_dimension_label_buffer(
       dimension_label->label_attribute()->name(), label_buffer);
   if (use_local_index) {
     throw_if_not_ok(indexed_array_query->set_data_buffer(
@@ -467,7 +467,7 @@ UnorderedWriteDataQuery::UnorderedWriteDataQuery(
         index_data_->data_size(),
         true));
   } else {
-    indexed_array_query->set_buffer(
+    indexed_array_query->set_dimension_label_buffer(
         dimension_label->index_dimension()->name(), index_buffer);
   }
 }

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -94,15 +94,6 @@ bool DimensionLabelQuery::completed() const {
           labelled_array_query->status() == QueryStatus::COMPLETED);
 }
 
-void DimensionLabelQuery::finalize() {
-  if (indexed_array_query) {
-    throw_if_not_ok(indexed_array_query->finalize());
-  }
-  if (labelled_array_query) {
-    throw_if_not_ok(labelled_array_query->finalize());
-  }
-}
-
 void DimensionLabelQuery::process() {
   if (indexed_array_query) {
     throw_if_not_ok(indexed_array_query->init());

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -78,15 +78,6 @@ DimensionLabelQuery::DimensionLabelQuery(
                                nullptr} {
 }
 
-void DimensionLabelQuery::cancel() {
-  if (indexed_array_query) {
-    throw_if_not_ok(indexed_array_query->cancel());
-  }
-  if (labelled_array_query) {
-    throw_if_not_ok(labelled_array_query->cancel());
-  }
-}
-
 bool DimensionLabelQuery::completed() const {
   return (!indexed_array_query ||
           indexed_array_query->status() == QueryStatus::COMPLETED) &&

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -27,7 +27,15 @@
  *
  * @section DESCRIPTION
  *
- * Classes for querying a dimension label.
+ * Classes for querying (reading/writing) a dimension label.
+ *
+ * Note: The current implementation uses a class that stores two `Query` objects
+ * and all operations check if each of the query is initialized or is `nullptr`.
+ * This is to support the temporary dual-array dimension label design. Once a
+ * reader for the ordered dimension label is implemented and the projections for
+ * the unordered dimension label are implemented, each `DimensionLabelQuery`
+ * will only contain a single `Query` object that must be constructed on
+ * initialization.
  */
 
 #ifndef TILEDB_DIMENSION_LABEL_QUERY_H

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -1,0 +1,186 @@
+/**
+ * @file dimension_label_query.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Classes for query a dimension label.
+ */
+
+#ifndef TILEDB_DIMENSION_LABEL_QUERY_H
+#define TILEDB_DIMENSION_LABEL_QUERY_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/type/range/range.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+class DimensionLabel;
+class Query;
+class QueryBuffer;
+class StorageManager;
+class Subarray;
+
+class DimensionLabelQuery {
+ public:
+  /** Default constructor. */
+  DimensionLabelQuery() = default;
+
+  /**
+   * General constructor.
+   *
+   * TODO finish docs
+   */
+  DimensionLabelQuery(
+      StorageManager* storage_manager,
+      DimensionLabel* dimension_label,
+      bool add_indexed_query,
+      bool add_labelled_query,
+      optional<std::string> fragment_name = nullopt);
+
+  virtual ~DimensionLabelQuery() = default;
+
+  /** TODO: docs */
+  void cancel();
+
+  /** TODO: docs */
+  bool completed() const;
+
+  /** TODO: docs */
+  void finalize();
+
+  /** TODO: docs */
+  void process();
+
+  /** TODO: docs */
+  tdb_unique_ptr<Query> indexed_array_query{nullptr};
+
+  /** TODO: docs */
+  tdb_unique_ptr<Query> labelled_array_query{nullptr};
+};
+
+/** TODO: Docs */
+class DimensionLabelReadDataQuery : public DimensionLabelQuery {
+ public:
+  DimensionLabelReadDataQuery() = delete;
+
+  DimensionLabelReadDataQuery(
+      StorageManager* storage_manager,
+      DimensionLabel* dimension_label,
+      const Subarray& parent_subarray,
+      const QueryBuffer& label_buffer,
+      const uint32_t dim_idx);
+};
+
+/** TODO: Docs */
+class IndexData {
+ public:
+  virtual ~IndexData() = default;
+  virtual void* data() = 0;
+  virtual uint64_t* data_size() = 0;
+};
+
+/** TODO: Docs */
+template <
+    typename T,
+    typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+class TypedIndexData : public IndexData {
+ public:
+  TypedIndexData(const type::Range& range)
+      : data_{}
+      , data_size_{0} {
+    auto range_data = static_cast<const T*>(range.data());
+    T min_value = range_data[0];
+    T max_value = range_data[1];
+    if (max_value < min_value) {
+      throw std::invalid_argument(
+          "Invalid range - cannot have lower bound greater than the upper "
+          "bound.");
+    }
+    data_.reserve(max_value - min_value + 1);
+    for (T val = min_value; val <= max_value; ++val) {
+      data_.push_back(val);
+    }
+    data_size_ = sizeof(T) * data_.size();
+  }
+
+  void* data() override {
+    return data_.data();
+  }
+
+  uint64_t* data_size() override {
+    return &data_size_;
+  }
+
+ private:
+  std::vector<T> data_;
+  uint64_t data_size_;
+};
+
+/** TODO: Docs */
+class OrderedWriteDataQuery : public DimensionLabelQuery {
+ public:
+  /** Default constructor is not C.41 compliant. */
+  OrderedWriteDataQuery() = delete;
+
+  /** Constructor for when index buffer is set. */
+  OrderedWriteDataQuery(
+      StorageManager* storage_manager,
+      DimensionLabel* dimension_label,
+      const QueryBuffer& index_buffer,
+      const QueryBuffer& label_buffer,
+      optional<std::string> fragment_name);
+
+  /** Constructor for when index buffer is not set. */
+  OrderedWriteDataQuery(
+      StorageManager* storage_manager,
+      DimensionLabel* dimension_label,
+      const Subarray& parent_subarray,
+      const QueryBuffer& label_buffer,
+      const uint32_t dim_idx,
+      optional<std::string> fragment_name);
+
+ private:
+  tdb_unique_ptr<IndexData> index_data_;
+};
+
+/** TODO: Docs */
+class UnorderedWriteDataQuery : public DimensionLabelQuery {
+ public:
+  UnorderedWriteDataQuery() = delete;
+  UnorderedWriteDataQuery(
+      StorageManager* storage_manager,
+      DimensionLabel* dimension_label,
+      const QueryBuffer& index_buffer,
+      const QueryBuffer& label_buffer,
+      optional<std::string> fragment_name);
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -42,6 +42,7 @@
 #define TILEDB_DIMENSION_LABEL_QUERY_H
 
 #include "tiledb/common/common.h"
+#include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/type/range/range.h"
 
 using namespace tiledb::common;
@@ -64,8 +65,8 @@ inline Status Status_DimensionLabelQueryError(const std::string& msg) {
 
 class DimensionLabelQuery {
  public:
-  /** Default constructor. */
-  DimensionLabelQuery() = default;
+  /** Default constructor is not C.41 compliant. */
+  DimensionLabelQuery() = delete;
 
   /**
    * General constructor.
@@ -79,6 +80,7 @@ class DimensionLabelQuery {
    */
   DimensionLabelQuery(
       StorageManager* storage_manager,
+      stats::Stats* stats,
       DimensionLabel* dimension_label,
       bool add_indexed_query,
       bool add_labelled_query,
@@ -104,6 +106,9 @@ class DimensionLabelQuery {
   void process();
 
  protected:
+  /** TODO: Docs */
+  stats::Stats* stats_;
+
   /** Query on the dimension label indexed array. */
   tdb_unique_ptr<Query> indexed_array_query{nullptr};
 
@@ -128,6 +133,7 @@ class DimensionLabelReadDataQuery : public DimensionLabelQuery {
    */
   DimensionLabelReadDataQuery(
       StorageManager* storage_manager,
+      stats::Stats* stats,
       DimensionLabel* dimension_label,
       const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,
@@ -220,6 +226,7 @@ class OrderedWriteDataQuery : public DimensionLabelQuery {
    */
   OrderedWriteDataQuery(
       StorageManager* storage_manager,
+      stats::Stats* stats,
       DimensionLabel* dimension_label,
       const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,
@@ -256,6 +263,7 @@ class UnorderedWriteDataQuery : public DimensionLabelQuery {
    */
   UnorderedWriteDataQuery(
       StorageManager* storage_manager,
+      stats::Stats* stats,
       DimensionLabel* dimension_label,
       const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -173,28 +173,14 @@ class OrderedWriteDataQuery : public DimensionLabelQuery {
   OrderedWriteDataQuery() = delete;
 
   /**
-   * Constructor for when index buffer is set.
-   *
-   * @param storage_manager Storage manager object.
-   * @param dimension_label Opened dimension label for the query.
-   * @param index_buffer Query buffer for the index data.
-   * @param label_buffer Query buffer for the label data.
-   * @param fragment_name Name to use when writing the fragment.
-   */
-  OrderedWriteDataQuery(
-      StorageManager* storage_manager,
-      DimensionLabel* dimension_label,
-      const QueryBuffer& index_buffer,
-      const QueryBuffer& label_buffer,
-      optional<std::string> fragment_name);
-
-  /**
    * Constructor for when index buffer is not set.
    *
    * @param storage_manager Storage manager object.
    * @param dimension_label Opened dimension label for the query.
    * @param parent_subarrray Subarray of the parent array.
    * @param label_buffer Query buffer for the label data.
+   * @param label_buffer Query buffer for the index data. May be empty if no
+   *     index buffer is set.
    * @param dim_idx Index of the dimension on the parent array this dimension
    *     label is for.
    * @param fragment_name Name to use when writing the fragment.
@@ -204,6 +190,7 @@ class OrderedWriteDataQuery : public DimensionLabelQuery {
       DimensionLabel* dimension_label,
       const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,
+      const QueryBuffer& index_buffer,
       const uint32_t dim_idx,
       optional<std::string> fragment_name);
 
@@ -229,9 +216,14 @@ class UnorderedWriteDataQuery : public DimensionLabelQuery {
   UnorderedWriteDataQuery(
       StorageManager* storage_manager,
       DimensionLabel* dimension_label,
-      const QueryBuffer& index_buffer,
+      const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,
+      const QueryBuffer& index_buffer,
+      const uint32_t dim_idx,
       optional<std::string> fragment_name);
+
+ private:
+  tdb_unique_ptr<IndexData> index_data_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * Classes for query a dimension label.
+ * Classes for querying a dimension label.
  */
 
 #ifndef TILEDB_DIMENSION_LABEL_QUERY_H
@@ -45,6 +45,14 @@ class Query;
 class QueryBuffer;
 class StorageManager;
 class Subarray;
+
+/**
+ * Return a Status_DimensionQueryError error class Status with a given
+ * message.
+ **/
+inline Status Status_DimensionLabelQueryError(const std::string& msg) {
+  return {"[TileDB::DimensionLabelQuery] Error", msg};
+}
 
 class DimensionLabelQuery {
  public:
@@ -98,14 +106,28 @@ class DimensionLabelQuery {
 /** Dimension label query for reading label data. */
 class DimensionLabelReadDataQuery : public DimensionLabelQuery {
  public:
+  /** Default constructor is not C.41 compliant. */
   DimensionLabelReadDataQuery() = delete;
 
+  /**
+   * Constructor.
+   *
+   * @param storage_manager Storage manager object.
+   * @param dimension_label Opened dimension label for the query.
+   * @param parent_subarrray Subarray of the parent array.
+   * @param label_buffer Query buffer for the label data.
+   * @param dim_idx Index of the dimension on the parent array this dimension
+   */
   DimensionLabelReadDataQuery(
       StorageManager* storage_manager,
       DimensionLabel* dimension_label,
       const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,
       const uint32_t dim_idx);
+
+  /** Disable copy and move. */
+  DISABLE_COPY_AND_COPY_ASSIGN(DimensionLabelReadDataQuery);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(DimensionLabelReadDataQuery);
 };
 
 /** Base class for internally managed index data. */
@@ -122,6 +144,9 @@ template <
     typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
 class TypedIndexData : public IndexData {
  public:
+  /** Default constructor is not C.41 compliant. */
+  TypedIndexData() = delete;
+
   /**
    * Constructor.
    *
@@ -179,7 +204,7 @@ class OrderedWriteDataQuery : public DimensionLabelQuery {
    * @param dimension_label Opened dimension label for the query.
    * @param parent_subarrray Subarray of the parent array.
    * @param label_buffer Query buffer for the label data.
-   * @param label_buffer Query buffer for the index data. May be empty if no
+   * @param index_buffer Query buffer for the index data. May be empty if no
    *     index buffer is set.
    * @param dim_idx Index of the dimension on the parent array this dimension
    *     label is for.
@@ -194,6 +219,10 @@ class OrderedWriteDataQuery : public DimensionLabelQuery {
       const uint32_t dim_idx,
       optional<std::string> fragment_name);
 
+  /** Disable copy and move. */
+  DISABLE_COPY_AND_COPY_ASSIGN(OrderedWriteDataQuery);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(OrderedWriteDataQuery);
+
  private:
   tdb_unique_ptr<IndexData> index_data_;
 };
@@ -201,7 +230,7 @@ class OrderedWriteDataQuery : public DimensionLabelQuery {
 /** Writer for unordered dimension labels. */
 class UnorderedWriteDataQuery : public DimensionLabelQuery {
  public:
-  /** Default constructor is not C.41. */
+  /** Default constructor is not C.41 compliant. */
   UnorderedWriteDataQuery() = delete;
 
   /**
@@ -209,8 +238,12 @@ class UnorderedWriteDataQuery : public DimensionLabelQuery {
    *
    * @param storage_manager Storage manager object.
    * @param dimension_label Opened dimension label for the query.
-   * @param index_buffer Query buffer for the index data.
+   * @param parent_subarrray Subarray of the parent array.
    * @param label_buffer Query buffer for the label data.
+   * @param index_buffer Query buffer for the index data. May be empty if no
+   *     index buffer is set.
+   * @param dim_idx Index of the dimension on the parent array this dimension
+   *     label is for.
    * @param fragment_name Name to use when writing the fragment.
    */
   UnorderedWriteDataQuery(
@@ -221,6 +254,10 @@ class UnorderedWriteDataQuery : public DimensionLabelQuery {
       const QueryBuffer& index_buffer,
       const uint32_t dim_idx,
       optional<std::string> fragment_name);
+
+  /** Disable copy and move. */
+  DISABLE_COPY_AND_COPY_ASSIGN(UnorderedWriteDataQuery);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(UnorderedWriteDataQuery);
 
  private:
   tdb_unique_ptr<IndexData> index_data_;

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -99,9 +99,6 @@ class DimensionLabelQuery {
   /** Returns ``true`` if the query status for both queries is completed. */
   bool completed() const;
 
-  /** Finalizes both queries if they exist. */
-  void finalize();
-
   /** Processes both queries if they exist. */
   void process();
 

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -93,9 +93,6 @@ class DimensionLabelQuery {
   DISABLE_COPY_AND_COPY_ASSIGN(DimensionLabelQuery);
   DISABLE_MOVE_AND_MOVE_ASSIGN(DimensionLabelQuery);
 
-  /** Cancel both queries if they exist. */
-  void cancel();
-
   /** Returns ``true`` if the query status for both queries is completed. */
   bool completed() const;
 

--- a/tiledb/sm/query/dimension_label/dimension_label_query_create.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query_create.cc
@@ -1,0 +1,86 @@
+/**
+ * @file dimension_label_query_create.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Factory for creating dimension label query objects.
+ */
+
+#include "tiledb/sm/query/dimension_label/dimension_label_query_create.h"
+#include "tiledb/sm/enums/label_order.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+DimensionLabelQuery* DimensionLabelQueryCreate::make_write_query(
+    const std::string& label_name,
+    LabelOrder label_order,
+    StorageManager* storage_manager,
+    stats::Stats* stats,
+    DimensionLabel* dimension_label,
+    const Subarray& parent_subarray,
+    const QueryBuffer& label_buffer,
+    const QueryBuffer& index_buffer,
+    const uint32_t dim_idx,
+    optional<std::string> fragment_name) {
+  switch (label_order) {
+    case (LabelOrder::INCREASING_LABELS):
+    case (LabelOrder::DECREASING_LABELS):
+      // Create order label writer.
+      return tdb_new(
+          OrderedWriteDataQuery,
+          storage_manager,
+          stats,
+          dimension_label,
+          parent_subarray,
+          label_buffer,
+          index_buffer,
+          dim_idx,
+          fragment_name);
+
+    case (LabelOrder::UNORDERED_LABELS):
+      // Create unordered label writer.
+      return tdb_new(
+          UnorderedWriteDataQuery,
+          storage_manager,
+          stats,
+          dimension_label,
+          parent_subarray,
+          label_buffer,
+          index_buffer,
+          dim_idx,
+          fragment_name);
+
+    default:
+      // Invalid label order type.
+      throw StatusException(Status_DimensionLabelQueryError(
+          "Cannot initialize dimension label '" + label_name +
+          "'; Dimension label order " + label_order_str(label_order) +
+          " not supported."));
+  }
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/dimension_label/dimension_label_query_create.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query_create.cc
@@ -30,6 +30,7 @@
 
 #include "tiledb/sm/query/dimension_label/dimension_label_query_create.h"
 #include "tiledb/sm/enums/label_order.h"
+#include "tiledb/sm/query/query.h"
 
 using namespace tiledb::common;
 

--- a/tiledb/sm/query/dimension_label/dimension_label_query_create.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query_create.h
@@ -1,0 +1,64 @@
+/**
+ * @file dimension_label_query_create.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Factory for creating DimensionLabelQuery objects.
+ */
+
+#ifndef TILEDB_DIMENSION_LABEL_QUERY_CREATE_H
+#define TILEDB_DIMENSION_LABEL_QUERY_CREATE_H
+
+#include "tiledb/sm/query/dimension_label/dimension_label_query.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+enum class LabelOrder : uint8_t;
+
+class DimensionLabelQueryCreate {
+ public:
+  /**
+   * Factory method for read data query.
+   */
+  static DimensionLabelQuery* make_write_query(
+      const std::string& label_name,
+      LabelOrder label_order,
+      StorageManager* storage_manager,
+      stats::Stats* stats,
+      DimensionLabel* dimension_label,
+      const Subarray& parent_subarray,
+      const QueryBuffer& label_buffer,
+      const QueryBuffer& index_buffer,
+      const uint32_t dim_idx,
+      optional<std::string> fragment_name);
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1361,12 +1361,12 @@ Status Query::process() {
   // Check if the query is completed or not.
   if ((only_dim_label_query() || !strategy_->incomplete()) &&
       (!dim_label_queries_ || dim_label_queries_->completed())) {
-    // Main query and dimension label query are both completed. Set status to
-    // complete and handle the callback.
-    status_ = QueryStatus::COMPLETED;
+    // Main query and dimension label query are both completed. Handle the
+    // callback, then set status to complete.
     if (callback_ != nullptr) {
       callback_(callback_data_);
     }
+    status_ = QueryStatus::COMPLETED;
   } else {
     // Either the main query or the dimension lable query are incomplete.
     status_ = QueryStatus::INCOMPLETE;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1820,9 +1820,7 @@ void Query::set_buffer(const std::string& name, const QueryBuffer& buffer) {
     throw_if_not_ok(
         set_data_buffer(name, buffer.buffer_var_, buffer.buffer_var_size_));
     throw_if_not_ok(set_offsets_buffer(
-        name,
-        static_cast<uint64_t* const>(buffer.buffer_),
-        buffer.buffer_size_));
+        name, static_cast<uint64_t*>(buffer.buffer_), buffer.buffer_size_));
   } else {
     // Fixed-length buffer. Set data buffer only.
     throw_if_not_ok(set_data_buffer(name, buffer.buffer_, buffer.buffer_size_));

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -962,13 +962,12 @@ void Query::get_label_data_buffer(
   // Return the buffer
   auto it = label_buffers_.find(name);
   if (it != label_buffers_.end()) {
-    if (array_schema_->dimension_label_reference(name).label_cell_val_num() !=
-        constants::var_num) {
-      *buffer = it->second.buffer_;
-      *buffer_size = it->second.buffer_size_;
-    } else {
+    if (array_schema_->dimension_label_reference(name).is_var()) {
       *buffer = it->second.buffer_var_;
       *buffer_size = it->second.buffer_var_size_;
+    } else {
+      *buffer = it->second.buffer_;
+      *buffer_size = it->second.buffer_size_;
     }
     return;
   }
@@ -996,8 +995,7 @@ void Query::get_label_offsets_buffer(
   }
 
   // Error if it is fixed-sized
-  if (array_schema_->dimension_label_reference(name).label_cell_val_num() !=
-      constants::var_num) {
+  if (!array_schema_->dimension_label_reference(name).is_var()) {
     throw StatusException(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));
@@ -1961,8 +1959,7 @@ void Query::set_label_data_buffer(
 
   // Set dimension label buffer on the appropriate buffer depending if the label
   // is fixed or variable length.
-  (array_schema_->dimension_label_reference(name).label_cell_val_num() ==
-   constants::var_num) ?
+  array_schema_->dimension_label_reference(name).is_var() ?
       label_buffers_[name].set_data_var_buffer(buffer, buffer_size) :
       label_buffers_[name].set_data_buffer(buffer, buffer_size);
 }
@@ -1999,8 +1996,7 @@ void Query::set_label_offsets_buffer(
   }
 
   // Check the dimension labe is in fact variable length.
-  if (array_schema_->dimension_label_reference(name).label_cell_val_num() !=
-      constants::var_num) {
+  if (!array_schema_->dimension_label_reference(name).is_var()) {
     throw StatusException(Status_QueryError(
         std::string("Cannot set buffer; Input attribute/dimension '") + name +
         "' is fixed-sized"));

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1213,6 +1213,12 @@ Status Query::init() {
 
     // Create dimension label queries and remove labels from subarray.
     if (uses_dimension_labels()) {
+      if (type_ == QueryType::WRITE && layout_ == Layout::GLOBAL_ORDER) {
+        return logger_->status(
+            Status_QueryError("Cannot init query; Querying dimension labels is "
+                              "not supported on global order writes"));
+      }
+
       // Initialize the dimension label queries.
       dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
           ArrayDimensionLabelQueries,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1812,7 +1812,8 @@ Status Query::set_buffer(
   return Status::Ok();
 }
 
-void Query::set_buffer(const std::string& name, const QueryBuffer& buffer) {
+void Query::set_dimension_label_buffer(
+    const std::string& name, const QueryBuffer& buffer) {
   if (buffer.buffer_var_ || buffer.buffer_var_size_) {
     // Variable-length buffer. Set data buffer and offsets buffer.
     throw_if_not_ok(

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1221,6 +1221,7 @@ Status Query::init() {
       dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
           ArrayDimensionLabelQueries,
           storage_manager_,
+          stats_->create_child("ArrayDimensionLabelQueries"),
           array_,
           subarray_,
           label_buffers_,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1211,12 +1211,8 @@ Status Query::init() {
 
     RETURN_NOT_OK(check_buffer_names());
 
-    // Cache if dimension label queries are needed.
-    bool uses_labels = uses_dimension_labels();
-    bool only_labels = uses_labels && only_dim_label_query();
-
     // Create dimension label queries and remove labels from subarray.
-    if (uses_labels) {
+    if (uses_dimension_labels()) {
       // Initialize the dimension label queries.
       dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
           ArrayDimensionLabelQueries,
@@ -1236,8 +1232,8 @@ Status Query::init() {
       // data for the entire sparse array, the output for the dimension label
       // data needs to be re-arranged to match the coordinate form we use for
       // sparse reads. This has not yet been implemented.
-      if (!only_labels && type_ == QueryType::READ && !array_schema_->dense() &&
-          dim_label_queries_->has_data_query()) {
+      if (!only_dim_label_query() && type_ == QueryType::READ &&
+          !array_schema_->dense() && dim_label_queries_->has_data_query()) {
         return logger_->status(Status_QueryError(
             "Cannot initialize query; Reading dimension label data is not yet "
             "supported on sparse arrays."));
@@ -1245,7 +1241,7 @@ Status Query::init() {
     }
 
     // Create the query strategy if querying main array.
-    if (!only_labels) {
+    if (!only_dim_label_query()) {
       RETURN_NOT_OK(create_strategy());
     }
   }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1243,10 +1243,8 @@ Status Query::init() {
       }
     }
 
-    // Create the query strategy if possible. May need to wait for range queries
-    // to be completed and for the subarray to be updated.
-    if (!uses_labels ||
-        (!only_labels && dim_label_queries_->completed_range_queries())) {
+    // Create the query strategy if querying main array.
+    if (!only_labels) {
       RETURN_NOT_OK(create_strategy());
     }
   }
@@ -1327,12 +1325,6 @@ Status Query::process() {
             "Cannot process query; No range set on dimension " +
             std::to_string(dim_idx) + " after update dimension label ranges."));
       }
-    }
-
-    // Label queries are completed and the subarray is fully updated. We can
-    // create the query strategy now.
-    if (!only_dim_label_query()) {
-      RETURN_NOT_OK(create_strategy());
     }
   }
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1982,6 +1982,7 @@ void Query::set_label_offsets_buffer(
       throw StatusException(
           Status_QueryError("Cannot set buffer; " + name + " buffer is null"));
     }
+
     // Check buffer size
     if (buffer_offsets_size == nullptr) {
       throw StatusException(Status_QueryError(

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1220,20 +1220,14 @@ Status Query::init() {
     // Create dimension label queries and remove labels from subarray.
     if (uses_labels) {
       // Initialize the dimension label queries.
-      try {
-        dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
-            ArrayDimensionLabelQueries,
-            storage_manager_,
-            array_,
-            subarray_,
-            label_buffers_,
-            buffers_,
-            fragment_name_));
-      } catch (...) {
-        std::throw_with_nested(StatusException(
-            Status_QueryError("Cannot initialize query; Failed to initialize "
-                              "dimension label queries.")));
-      }
+      dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
+          ArrayDimensionLabelQueries,
+          storage_manager_,
+          array_,
+          subarray_,
+          label_buffers_,
+          buffers_,
+          fragment_name_));
 
       // Do not allow reading data from dimension labels for sparse arrays
       // unless we are only returning the dimension label data. Otherwise, the
@@ -1313,13 +1307,7 @@ Status Query::process() {
   // continuing to the main query.
   if (dim_label_queries_ && dim_label_queries_->completed_range_queries()) {
     // Process the dimension label queries.
-    try {
-      dim_label_queries_->process_range_queries(subarray_);
-    } catch (...) {
-      std::throw_with_nested(StatusException(
-          Status_QueryError("Cannot process query; Failed to read data from "
-                            "dimension label ranges.")));
-    }
+    dim_label_queries_->process_range_queries(subarray_);
 
     // The dimension label query did not complete. For now, we are failing on
     // this step. In the future, this may be updated to allow incomplete

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -440,11 +440,23 @@ class Query {
   Status get_data_buffer(
       const char* name, void** buffer, uint64_t** buffer_size) const;
 
-  /** TODO */
+  /**
+   * Retrieves the data buffer of a fixed or variable-sized dimension label.
+   *
+   * @param name The name of the the label.
+   * @param buffer The buffer to be retrieved.
+   * @param buffer_size The size of the buffer.
+   */
   void get_label_data_buffer(
       const std::string& name, void** buffer, uint64_t** buffer_size) const;
 
-  /** TODO */
+  /**
+   * Retrieves the offset buffer for a variable-sized dimension label.
+   *
+   * @param name The name of the label.
+   * @param buffer The buffer to be retrieved.
+   * @param buffer_size The size of the buffer.
+   */
   void get_label_offsets_buffer(
       const std::string& name, uint64_t** buffer, uint64_t** buffer_size) const;
 
@@ -672,14 +684,30 @@ class Query {
    **/
   void set_buffer(const std::string& name, const QueryBuffer& buffer);
 
-  /** TODO */
+  /**
+   * Sets the label data buffer for fixed or variable sized dimension labels.
+   *
+   * @param name The name of the dimension label to set the data buffer for.
+   * @param buffer The buffer for the data.
+   * @param buffer_size The size of the data.
+   * @param check_null_buffers If ``true`` verify buffer and buffersize are not
+   *     nullptrs.
+   */
   void set_label_data_buffer(
       const std::string& name,
       void* const buffer,
       uint64_t* const buffer_size,
       const bool check_null_buffers = true);
 
-  /** TODO */
+  /**
+   * Sets the label offsets buffer for variable sized dimension labels.
+   *
+   * @param name The name of the dimension label to set the offsets buffer for.
+   * @param buffer_offsets The buffer for offsets for the variable size data.
+   * @param buffer_offsets_size The size of the offsets buffer.
+   * @param check_null_buffers If ``true`` verify buffer and buffersize are not
+   *     nullptrs.
+   */
   void set_label_offsets_buffer(
       const std::string& name,
       uint64_t* const buffer_offsets,
@@ -1158,6 +1186,11 @@ class Query {
 
   /**
    * Returns true if only querying dimension labels.
+   *
+   * The query will only query dimension labels if all the following are true:
+   * 1. At most one dimension buffer is set.
+   * 2. No attribute buffers are set.
+   * 3. At least one label buffer is set.
    */
   bool only_dim_label_query() const;
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -682,7 +682,8 @@ class Query {
    * @param name Name of the dimension or attribute to set the buffer for.
    * @param buffer The query buffer to get the data from.
    **/
-  void set_buffer(const std::string& name, const QueryBuffer& buffer);
+  void set_dimension_label_buffer(
+      const std::string& name, const QueryBuffer& buffer);
 
   /**
    * Sets the label data buffer for fixed or variable sized dimension labels.

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -675,7 +675,7 @@ class Query {
    * QueryBuffer.
    *
    * This function is intended to be a convenience method for use setting
-   * buffers for dimesnion labels.
+   * buffers for dimension labels.
    *
    * @WARNING Does not check for or copy validity data.
    *

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -579,6 +579,11 @@ class Query {
    */
   const std::vector<UpdateValue>& update_values() const;
 
+  /**
+   * Returns true if this query requires the use of dimension labels.
+   */
+  bool uses_dimension_labels() const;
+
   /** Processes a query. */
   Status process();
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -59,6 +59,7 @@ namespace tiledb {
 namespace sm {
 
 class Array;
+class ArrayDimensionLabelQueries;
 class StorageManager;
 
 enum class QueryStatus : uint8_t;
@@ -439,6 +440,14 @@ class Query {
   Status get_data_buffer(
       const char* name, void** buffer, uint64_t** buffer_size) const;
 
+  /** TODO */
+  void get_label_data_buffer(
+      const std::string& name, void** buffer, uint64_t** buffer_size) const;
+
+  /** TODO */
+  void get_label_offsets_buffer(
+      const std::string& name, uint64_t** buffer, uint64_t** buffer_size) const;
+
   /**
    * Retrieves the offset buffer for a var-sized attribute/dimension.
    *
@@ -642,6 +651,34 @@ class Query {
       const std::string& name,
       void* const buffer,
       uint64_t* const buffer_size,
+      const bool check_null_buffers = true);
+
+  /**
+   * Wrapper to set the internal buffer for a dimension or attribute from a
+   * QueryBuffer.
+   *
+   * This function is intended to be a convenience method for use setting
+   * buffers for dimesnion labels.
+   *
+   * @WARNING Does not check for or copy validity data.
+   *
+   * @param name Name of the dimension or attribute to set the buffer for.
+   * @param buffer The query buffer to get the data from.
+   **/
+  void set_buffer(const std::string& name, const QueryBuffer& buffer);
+
+  /** TODO */
+  void set_label_data_buffer(
+      const std::string& name,
+      void* const buffer,
+      uint64_t* const buffer_size,
+      const bool check_null_buffers = true);
+
+  /** TODO */
+  void set_label_offsets_buffer(
+      const std::string& name,
+      uint64_t* const buffer_offsets,
+      uint64_t* const buffer_offsets_size,
       const bool check_null_buffers = true);
 
   /**
@@ -1006,6 +1043,12 @@ class Query {
    * */
   std::unordered_map<std::string, QueryBuffer> buffers_;
 
+  /** Maps label names to their buffers. */
+  std::unordered_map<std::string, QueryBuffer> label_buffers_;
+
+  /** Dimension label queries that are part of the main query. */
+  tdb_unique_ptr<ArrayDimensionLabelQueries> dim_label_queries_;
+
   /** Keeps track of the coords data. */
   CoordsInfo coords_info_;
 
@@ -1107,6 +1150,11 @@ class Query {
    * @return Status
    */
   Status check_buffers_correctness();
+
+  /**
+   * Returns true if only querying dimension labels.
+   */
+  bool only_dim_label_query() const;
 
   /**
    * This is a deprecated API.

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1239,6 +1239,12 @@ Status query_to_capnp(
   auto type = query.type();
   auto array = query.array();
 
+  if (query.uses_dimension_labels()) {
+    return LOG_STATUS(Status_SerializationError(
+        "Cannot serialize; serialization is not yet supported for queries "
+        "using dimension labels."));
+  }
+
   if (array == nullptr) {
     return LOG_STATUS(
         Status_SerializationError("Cannot serialize; array is null."));

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1867,7 +1867,7 @@ const std::vector<Range>& Subarray::ranges_for_label(
         "Cannot get label ranges; No ranges set on dimension label '" +
         label_name + "'"));
   }
-  return label_range_subset_[dim_idx].value().ranges.ranges();
+  return label_range_subset_[dim_idx]->get_ranges();
 }
 
 Status Subarray::set_ranges_for_dim(

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -609,6 +609,10 @@ const std::vector<Range>& Subarray::get_attribute_ranges(
   return ranges;
 }
 
+const std::string& Subarray::get_label_name(const uint32_t dim_index) const {
+  return label_range_subset_[dim_index]->name;
+}
+
 void Subarray::get_label_range(
     const std::string& label_name,
     uint64_t range_idx,
@@ -933,6 +937,10 @@ bool Subarray::empty() const {
   return range_num() == 0;
 }
 
+bool Subarray::empty(uint32_t dim_idx) const {
+  return range_subset_[dim_idx].is_empty();
+}
+
 QueryType Subarray::get_query_type() const {
   if (array_ == nullptr)
     throw StatusException(Status_SubarrayError(
@@ -1069,6 +1077,25 @@ Subarray Subarray::get_subarray(uint64_t start, uint64_t end) const {
   ret.compute_range_offsets();
 
   return ret;
+}
+
+void Subarray::remove_label_ranges() {
+  label_range_subset_.clear();
+  label_range_subset_.resize(array_->array_schema_latest().dim_num(), nullopt);
+}
+
+bool Subarray::has_label_ranges() const {
+  return std::any_of(
+      label_range_subset_.cbegin(),
+      label_range_subset_.cend(),
+      [](const auto& range_subset) {
+        return range_subset.has_value() && !range_subset->ranges.is_empty();
+      });
+}
+
+bool Subarray::has_label_ranges(const uint32_t dim_index) const {
+  return label_range_subset_[dim_index].has_value() &&
+         !label_range_subset_[dim_index]->ranges.is_empty();
 }
 
 bool Subarray::is_default(uint32_t dim_index) const {
@@ -1827,6 +1854,20 @@ void Subarray::set_attribute_ranges(
         attr_name + "'."));
   }
   attr_range_subset_[attr_name] = ranges;
+}
+
+const std::vector<Range>& Subarray::ranges_for_label(
+    const std::string& label_name) const {
+  auto dim_idx = array_->array_schema_latest()
+                     .dimension_label_reference(label_name)
+                     .dimension_id();
+  if (!label_range_subset_[dim_idx].has_value() ||
+      label_range_subset_[dim_idx].value().name != label_name) {
+    throw StatusException(Status_SubarrayError(
+        "Cannot get label ranges; No ranges set on dimension label '" +
+        label_name + "'"));
+  }
+  return label_range_subset_[dim_idx].value().ranges.ranges();
 }
 
 Status Subarray::set_ranges_for_dim(

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -964,7 +964,8 @@ class Subarray {
   /**
    * Returns the `Range` vector for the given dimension label.
    *
-   * @param label_name The name of the label to return ranges for.
+   * @param label_name Name of the label to return ranges for.
+   * @returns Vector of ranges on the requested dimension label.
    */
   const std::vector<Range>& ranges_for_label(
       const std::string& label_name) const;

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -1227,6 +1227,10 @@ class Subarray {
     LabelRangeSubset(
         const DimensionLabelReference& ref, bool coalesce_ranges = true);
 
+    inline const std::vector<Range>& get_ranges() const {
+      return ranges.ranges();
+    }
+
     /** Name of the dimension label. */
     std::string name;
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -382,6 +382,13 @@ class Subarray {
       const std::string& attr_name) const;
 
   /**
+   * Returns the name of the dimension label at the dimension index.
+   *
+   * @param dim_index Index of the dimension to return the label name for.
+   */
+  const std::string& get_label_name(const uint32_t dim_index) const;
+
+  /**
    * Retrieves a range from a dimension label name in the form (start, end,
    * stride).
    *
@@ -630,6 +637,9 @@ class Subarray {
   /** Returns the domain the subarray is constructed from. */
   NDRange domain() const;
 
+  /** ``True`` if the dimension of the subarray does not contain any ranges. */
+  bool empty(uint32_t dim_idx) const;
+
   /** ``True`` if the subarray does not contain any ranges. */
   bool empty() const;
 
@@ -863,6 +873,24 @@ class Subarray {
   Subarray get_subarray(uint64_t start, uint64_t end) const;
 
   /**
+   * Returns ``true`` if the any dimension in the subarray have label ranges
+   * set.
+   */
+  bool has_label_ranges() const;
+
+  /**
+   * Returns ``true`` if the dimension index has label ranges set.
+   *
+   * @param dim_idx The dimension index to check for ranges.
+   */
+  bool has_label_ranges(const uint32_t dim_index) const;
+
+  /**
+   * Removes all label ranges from the subarray.
+   */
+  void remove_label_ranges();
+
+  /**
    * Set default indicator for dimension subarray. Used by serialization only
    * @param dim_index
    * @param is_default
@@ -932,6 +960,14 @@ class Subarray {
    */
   void set_attribute_ranges(
       const std::string& attr_name, const std::vector<Range>& ranges);
+
+  /**
+   * Returns the `Range` vector for the given dimension label.
+   *
+   * @param label_name The name of the label to return ranges for.
+   */
+  const std::vector<Range>& ranges_for_label(
+      const std::string& label_name) const;
 
   /**
    * Directly sets the `Range` vector for the given dimension index, making


### PR DESCRIPTION
Adds experimental support for getting dimension label data back 

* C-API
   * Adds set/get methods for dimension label buffers.
   
* Dimension Label
  * Add checks for label type on construction.
  * Set unordered dimension labels to have duplicates enabled by default (no dups requires special writer.

* Subarray
  * Add the following new methods:
    * `get_label_name`: Get the name of the label w/ ranges by the dimension index.
    * `empty`: Check if just a single dimension is empty.
    * `has_label_ranges`: Adds 2 methods for checking if there are label
       ranges. One for the whole subarray and one for a specific dimension.
    * `remove_label_ranges`: Removes all label ranges from the subarray.

* Query
  * Adds support for setting/getting label buffers.
  * Adds support for processing sub-queries on dimension labels.

* New classes:
  * `ArrayDimensionLabelQueries`: Manages all dimension labels and dimension label 
     queries needed to complete a query on an array with dimension labels. Currently
     only support for returning label data from dimension labels has been implemented.
  * `DimensionLabelQuery`: Class for executing a single query on a dimension label.
---
TYPE:  FEATURE
DESC: Adds experimental dimension label query (data query only)
