### PR TITLE
Add QueryType to Consistency multimap

### DIFF
--- a/tiledb/sm/array/consistency.cc
+++ b/tiledb/sm/array/consistency.cc
@@ -86,8 +86,7 @@ ConsistencyController::entry_type ConsistencyController::register_array(
     }
   }
 
-  return array_registry_.insert(
-      {uri, std::tuple<Array&, const QueryType>(array, query_type)});
+  return array_registry_.insert({uri, array_entry(array, query_type)});
 }
 
 void ConsistencyController::deregister_array(

--- a/tiledb/sm/array/consistency.cc
+++ b/tiledb/sm/array/consistency.cc
@@ -58,26 +58,26 @@ ConsistencySentry::~ConsistencySentry() {
 }
 
 ConsistencySentry ConsistencyController::make_sentry(
-    const URI uri, Array& array, const QueryType& query_type) {
+    const URI uri, Array& array, const QueryType query_type) {
   return ConsistencySentry{*this, register_array(uri, array, query_type)};
 }
 
 ConsistencyController::entry_type ConsistencyController::register_array(
-    const URI uri, Array& array, const QueryType& query_type) {
+    const URI uri, Array& array, const QueryType query_type) {
   if (uri.empty()) {
     throw std::runtime_error(
         "[ConsistencyController::register_array] URI cannot be empty.");
   }
 
   std::lock_guard<std::mutex> lock(mtx_);
-  if (this->is_open(uri)) {
+  auto iter = array_registry_.find(uri);
+  if (iter != array_registry_.end()) {
     if (query_type == QueryType::MODIFY_EXCLUSIVE) {
       throw std::runtime_error(
           "[ConsistencyController::register_array] Array already open; must "
           "close array before opening for exclusive modification.");
     } else {
-      auto iter = array_registry_.find(uri);
-      if (iter->second.get_query_type() == QueryType::MODIFY_EXCLUSIVE) {
+      if (std::get<1>(iter->second) == QueryType::MODIFY_EXCLUSIVE) {
         throw std::runtime_error(
             "[ConsistencyController::register_array] Must close array opened "
             "for exclusive modification before opening an array at the same "
@@ -86,7 +86,8 @@ ConsistencyController::entry_type ConsistencyController::register_array(
     }
   }
 
-  return array_registry_.insert({uri, array});
+  return array_registry_.insert(
+      {uri, std::tuple<Array&, const QueryType>(array, query_type)});
 }
 
 void ConsistencyController::deregister_array(
@@ -96,9 +97,8 @@ void ConsistencyController::deregister_array(
 }
 
 bool ConsistencyController::is_open(const URI uri) {
-  for (auto iter : array_registry_) {
-    if (iter.first == uri)
-      return true;
+  if (array_registry_.find(uri) != array_registry_.end()) {
+    return true;
   }
   return false;
 }

--- a/tiledb/sm/array/test/unit_consistency.h
+++ b/tiledb/sm/array/test/unit_consistency.h
@@ -57,8 +57,8 @@ class ConsistencySentry;
 
 namespace tiledb::sm {
 
-using entry_type = std::
-    multimap<const URI, std::tuple<Array&, const QueryType>>::const_iterator;
+using array_entry = std::tuple<Array&, const QueryType>;
+using entry_type = std::multimap<const URI, array_entry>::const_iterator;
 
 class WhiteboxConsistencyController : public ConsistencyController {
  public:

--- a/tiledb/sm/array/test/unit_consistency.h
+++ b/tiledb/sm/array/test/unit_consistency.h
@@ -57,7 +57,8 @@ class ConsistencySentry;
 
 namespace tiledb::sm {
 
-using entry_type = std::multimap<const URI, Array&>::const_iterator;
+using entry_type = std::
+    multimap<const URI, std::tuple<Array&, const QueryType>>::const_iterator;
 
 class WhiteboxConsistencyController : public ConsistencyController {
  public:
@@ -65,7 +66,7 @@ class WhiteboxConsistencyController : public ConsistencyController {
   ~WhiteboxConsistencyController() = default;
 
   entry_type register_array(
-      const URI uri, Array& array, const QueryType& query_type) {
+      const URI uri, Array& array, const QueryType query_type) {
     return ConsistencyController::register_array(uri, array, query_type);
   }
 
@@ -74,7 +75,7 @@ class WhiteboxConsistencyController : public ConsistencyController {
   }
 
   ConsistencySentry make_sentry(
-      const URI uri, Array& array, const QueryType& query_type) {
+      const URI uri, Array& array, const QueryType query_type) {
     return ConsistencyController::make_sentry(uri, array, query_type);
   }
 


### PR DESCRIPTION
At present, **Array openness != registration**. Until these two operations are fully atomic, we may not fetch any data from an Array that may not be fully opened. As such, the Array's QueryType has been added into the Consistency multimap. Access to the query type is needed in array registration to ensure exclusivity when opening/registering with type `MODIFY_EXCLUSIVE`. 

---
TYPE: BUG
DESC: Don't fetch Array data in Controller until the Array is fully open
