### PR TITLE
Add .gitattributes classification for capnp-generated files

### DIFF
--- a/tiledb/sm/serialization/.gitattributes
+++ b/tiledb/sm/serialization/.gitattributes
@@ -1,0 +1,3 @@
+# Exclude the capnp generated files to reduce reported size of diffs on GitHub
+posix/*   linguist-generated=true
+win32/*   linguist-generated=true


### PR DESCRIPTION
Make REST PRs less scary by reducing reported size of diff.

---
TYPE: NO_HISTORY
