### PR TITLE
Dimension labels: Adding ordered dimension label reader.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-gs.cc
   src/unit-hdfs-filesystem.cc
   src/unit-lru_cache.cc
+  src/unit-ordered-dim-label-reader.cc
   src/unit-tile-metadata.cc
   src/unit-tile-metadata-generator.cc
   src/unit-bytevecvalue.cc

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -1,0 +1,799 @@
+/**
+ * @file   unit-ordered-dim-label-reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the ordered dimension label reader.
+ */
+
+#include <test/support/tdb_catch.h>
+#include "helpers.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/query/readers/ordered_dim_label_reader.h"
+
+#include <numeric>
+
+using namespace tiledb;
+
+template <typename T>
+struct CPPOrderedDimLabelReaderFixedFx {
+  const char* array_name = "cpp_ordered_dim_label_reader";
+
+  CPPOrderedDimLabelReaderFixedFx()
+      : vfs_(ctx_)
+      , labels_(100, std::numeric_limits<T>::lowest())
+      , min_index_(std::numeric_limits<int>::max())
+      , max_index_(std::numeric_limits<int>::min()) {
+    Config config;
+    config["sm.query.dense.qc_coords_mode"] = "true";
+    ctx_ = Context(config);
+    vfs_ = VFS(ctx_);
+    increasing_labels_ = true;
+
+    using namespace tiledb;
+
+    if (vfs_.is_dir(array_name)) {
+      vfs_.remove_dir(array_name);
+    }
+
+    Domain domain(ctx_);
+    auto d = Dimension::create<int>(ctx_, "index", {{1, 100}}, 10);
+    domain.add_dimensions(d);
+
+    auto a = Attribute::create<T>(ctx_, "labels");
+
+    ArraySchema schema(ctx_, TILEDB_DENSE);
+    schema.set_domain(domain);
+    schema.add_attributes(a);
+
+    Array::create(array_name, schema);
+  }
+
+  ~CPPOrderedDimLabelReaderFixedFx() {
+    if (vfs_.is_dir(array_name)) {
+      vfs_.remove_dir(array_name);
+    }
+  }
+
+  void write_labels(int min_index, int max_index, std::vector<T> labels) {
+    Array array(ctx_, array_name, TILEDB_WRITE);
+    Query query(ctx_, array, TILEDB_WRITE);
+    Subarray subarray(ctx_, array);
+    subarray.add_range(0, min_index, max_index);
+
+    query.set_subarray(subarray)
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_data_buffer("labels", labels);
+    query.submit();
+    array.close();
+
+    // Update the labels_ vector. It will contain the full dataset.
+    int i = min_index;
+    for (auto& label : labels) {
+      labels_[i++] = label;
+    }
+
+    min_index_ = std::min(min_index_, min_index);
+    max_index_ = std::max(max_index_, max_index);
+  }
+
+  std::vector<int> read_labels(std::vector<T> ranges) {
+    std::vector<int> index(ranges.size());
+    Array array(ctx_, array_name, TILEDB_READ);
+    Query query(ctx_, array, TILEDB_READ);
+
+    // Set attribute ranges.
+    std::vector<Range> input_ranges;
+    for (uint64_t r = 0; r < ranges.size() / 2; r++) {
+      input_ranges.emplace_back(&ranges[r * 2], &ranges[r * 2 + 1], sizeof(T));
+    }
+
+    Subarray subarray(ctx_, array);
+    subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+    query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+    query.set_data_buffer("index", index);
+    query.set_subarray(subarray);
+    query.submit();
+    array.close();
+
+    return index;
+  }
+
+  void read_all_possible_labels() {
+    for (int first = min_index_; first <= max_index_; first++) {
+      for (int second = first; second <= max_index_; second++) {
+        std::vector<int> index(2);
+        Array array(ctx_, array_name, TILEDB_READ);
+        Query query(ctx_, array, TILEDB_READ);
+
+        // Set attribute ranges.
+        std::vector<Range> input_ranges;
+        T boundary_modifier = increasing_labels_ ? 1 : -1;
+
+        // Get the value in between the labels we are testing for or a label
+        // before the first one.
+        T range_start = first == min_index_ ?
+                            labels_[first] - boundary_modifier :
+                            (labels_[first] + labels_[first - 1]) / 2;
+
+        // Get the value in between the labels we are testing for or a label
+        // after the last one.
+        T range_end = second == max_index_ ?
+                          labels_[second] + boundary_modifier :
+                          (labels_[second] + labels_[second + 1]) / 2;
+
+        input_ranges.emplace_back(&range_start, &range_end, sizeof(T));
+
+        Subarray subarray(ctx_, array);
+        subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+        query.ptr()->query_->set_dimension_label_ordered_read(
+            increasing_labels_);
+        query.set_data_buffer("index", index);
+        query.set_subarray(subarray);
+        query.submit();
+        array.close();
+
+        CHECK(index[0] == first);
+        CHECK(index[1] == second);
+      }
+    }
+  }
+
+  Context ctx_;
+  VFS vfs_;
+  std::vector<T> labels_;
+  int min_index_;
+  int max_index_;
+  bool increasing_labels_;
+};
+
+struct CPPOrderedDimLabelReaderFixedDoubleFx
+    : public CPPOrderedDimLabelReaderFixedFx<double> {};
+
+struct CPPOrderedDimLabelReaderFixedIntFx
+    : public CPPOrderedDimLabelReaderFixedFx<int> {};
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: Invalid no ranges",
+    "[ordered-dim-label-reader][invalid][no-ranges]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+
+  std::vector<int> index(2);
+
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+  Subarray subarray(ctx_, array);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  query.set_subarray(subarray);
+  query.set_data_buffer("index", index);
+
+  REQUIRE_THROWS_AS(query.submit(), tiledb::TileDBError);
+
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: Invalid no buffers",
+    "[ordered-dim-label-reader][invalid][no-buffers]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+
+  // Set attribute ranges.
+  double val = 0;
+  std::vector<Range> input_ranges;
+  input_ranges.emplace_back(&val, &val, sizeof(double));
+
+  Subarray subarray(ctx_, array);
+  subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  query.set_subarray(subarray);
+
+  REQUIRE_THROWS_WITH(
+      query.submit(),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: "
+      "Cannot initialize ordered dim label reader; Buffers not set");
+
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: Invalid wrong buffer name",
+    "[ordered-dim-label-reader][invalid][wrong-buffer-name]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+
+  std::vector<double> labels(2);
+
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+
+  // Set attribute ranges.
+  double val = 0;
+  std::vector<Range> input_ranges;
+  input_ranges.emplace_back(&val, &val, sizeof(double));
+
+  Subarray subarray(ctx_, array);
+  subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  query.set_subarray(subarray);
+  query.set_data_buffer("labels", labels);
+
+  REQUIRE_THROWS_WITH(
+      query.submit(),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: "
+      "Cannot initialize ordered dim label reader; Wrong buffer set");
+
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: Invalid wrong buffer size",
+    "[ordered-dim-label-reader][invalid][wrong-buffer-size]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+
+  std::vector<int> index(3);
+
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+
+  // Set attribute ranges.
+  double val = 0;
+  std::vector<Range> input_ranges;
+  input_ranges.emplace_back(&val, &val, sizeof(double));
+
+  Subarray subarray(ctx_, array);
+  subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  query.set_subarray(subarray);
+  query.set_data_buffer("index", index);
+
+  REQUIRE_THROWS_WITH(
+      query.submit(),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: "
+      "Cannot initialize ordered dim label reader; Wrong buffer size");
+
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: Invalid ranges set",
+    "[ordered-dim-label-reader][invalid][ranges-set]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+
+  std::vector<int> index(2);
+
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+
+  // Set attribute ranges.
+  double val = 0;
+  std::vector<Range> input_ranges;
+  input_ranges.emplace_back(&val, &val, sizeof(double));
+
+  Subarray subarray(ctx_, array);
+  subarray.add_range(0, 1, 1);
+  subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  query.set_subarray(subarray);
+  query.set_data_buffer("index", index);
+
+  REQUIRE_THROWS_WITH(
+      query.submit(),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: "
+      "Cannot initialize ordered dim label reader; Subarray is set");
+
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed double labels, single fragment, "
+    "increasing",
+    "[ordered-dim-label-reader][fixed][double][single-fragment][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed double labels, single fragment, "
+    "decreasing",
+    "[ordered-dim-label-reader][fixed][double][single-fragment][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed double labels, multiple fragments, "
+    "increasing",
+    "[ordered-dim-label-reader][fixed][double][multiple-fragments]["
+    "increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  write_labels(19, 22, {0.45, 0.55, 0.65, 0.75});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed double labels, multiple fragments, "
+    "decreasing",
+    "[ordered-dim-label-reader][fixed][double][multiple-fragments]["
+    "decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  write_labels(19, 22, {0.75, 0.65, 0.55, 0.45});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed double labels, lots of fragment, "
+    "increasing",
+    "[ordered-dim-label-reader][fixed][double][lots-of-fragment][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  write_labels(26, 35, {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0});
+  write_labels(36, 45, {2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0});
+  write_labels(46, 55, {3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0});
+  write_labels(56, 65, {4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0});
+  write_labels(66, 75, {5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed double labels, lots of fragment, "
+    "decreasing",
+    "[ordered-dim-label-reader][fixed][double][lots-of-fragment][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {6.0, 5.9, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1});
+  write_labels(26, 35, {5.0, 4.9, 4.8, 4.7, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1});
+  write_labels(36, 45, {4.0, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1});
+  write_labels(46, 55, {3.0, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1});
+  write_labels(56, 65, {2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1});
+  write_labels(66, 75, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, single fragment, "
+    "increasing",
+    "[ordered-dim-label-reader][fixed][int][single-fragment][increasing]") {
+  write_labels(16, 25, {1, 3, 5, 7, 9, 11, 13, 15, 17, 19});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, single fragment, "
+    "decreasing",
+    "[ordered-dim-label-reader][fixed][int][single-fragment][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {19, 17, 15, 13, 11, 9, 7, 5, 3, 1});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, multiple fragments, "
+    "increasing",
+    "[ordered-dim-label-reader][fixed][int][multiple-fragments]["
+    "increasing]") {
+  write_labels(16, 25, {10, 20, 30, 40, 50, 60, 70, 80, 90, 100});
+  write_labels(19, 22, {45, 55, 65, 75});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, multiple fragments, "
+    "decreasing",
+    "[ordered-dim-label-reader][fixed][int][multiple-fragments]["
+    "decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {100, 90, 80, 70, 60, 50, 40, 30, 20, 10});
+  write_labels(19, 22, {75, 65, 55, 45});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, boundary conditions in "
+    "binary search, increasing",
+    "[ordered-dim-label-reader][fixed][int][boundary][binary-search]["
+    "increasing]") {
+  write_labels(16, 25, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  CHECK(read_labels({2, 3}) == std::vector({17, 18}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, boundary conditions in "
+    "binary search, decreasing",
+    "[ordered-dim-label-reader][fixed][int][boundary][binary-search]["
+    "decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {10, 9, 8, 7, 6, 5, 4, 3, 2, 1});
+  CHECK(read_labels({9, 8}) == std::vector({17, 18}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, boundary conditions in "
+    "tile search, increasing",
+    "[ordered-dim-label-reader][fixed][int][boundary][tile-search]["
+    "increasing]") {
+  write_labels(16, 25, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+  CHECK(read_labels({5, 6}) == std::vector({20, 21}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedIntFx,
+    "Ordered dimension label reader: fixed int labels, boundary conditions in "
+    "tile search, decreasing",
+    "[ordered-dim-label-reader][fixed][int][boundary][tile-search]["
+    "decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {10, 9, 8, 7, 6, 5, 4, 3, 2, 1});
+  CHECK(read_labels({6, 5}) == std::vector({20, 21}));
+}
+
+struct CPPOrderedDimLabelReaderVarFx {
+  const char* array_name = "cpp_ordered_dim_label_reader";
+
+  CPPOrderedDimLabelReaderVarFx()
+      : vfs_(ctx_)
+      , labels_(100, std::numeric_limits<double>::lowest())
+      , min_index_(std::numeric_limits<int>::max())
+      , max_index_(std::numeric_limits<int>::min()) {
+    Config config;
+    config["sm.query.dense.qc_coords_mode"] = "true";
+    ctx_ = Context(config);
+    vfs_ = VFS(ctx_);
+    increasing_labels_ = true;
+
+    using namespace tiledb;
+
+    if (vfs_.is_dir(array_name)) {
+      vfs_.remove_dir(array_name);
+    }
+
+    Domain domain(ctx_);
+    auto d = Dimension::create<int>(ctx_, "index", {{1, 100}}, 10);
+    domain.add_dimensions(d);
+
+    auto a = Attribute::create<std::string>(ctx_, "labels");
+
+    ArraySchema schema(ctx_, TILEDB_DENSE);
+    schema.set_domain(domain);
+    schema.add_attributes(a);
+
+    Array::create(array_name, schema);
+  }
+
+  ~CPPOrderedDimLabelReaderVarFx() {
+    if (vfs_.is_dir(array_name)) {
+      vfs_.remove_dir(array_name);
+    }
+  }
+
+  void write_labels(int min_index, int max_index, std::vector<double> labels) {
+    // Generate string labels from doubles.
+    std::vector<uint64_t> offsets;
+    std::stringstream stream;
+    uint64_t offset = 0;
+    for (auto& label : labels) {
+      stream << std::fixed << std::setprecision(2) << label;
+      offsets.emplace_back(offset);
+      offset += 4;
+    }
+    auto labels_data = stream.str();
+
+    Array array(ctx_, array_name, TILEDB_WRITE);
+    Query query(ctx_, array, TILEDB_WRITE);
+    Subarray subarray(ctx_, array);
+    subarray.add_range(0, min_index, max_index);
+
+    query.set_subarray(subarray)
+        .set_layout(TILEDB_ROW_MAJOR)
+        .set_data_buffer("labels", labels_data)
+        .set_offsets_buffer("labels", offsets);
+    query.submit();
+    array.close();
+
+    // Update the labels_ vector. It will contain the full dataset.
+    int i = min_index;
+    for (auto& label : labels) {
+      labels_[i++] = label;
+    }
+
+    min_index_ = std::min(min_index_, min_index);
+    max_index_ = std::max(max_index_, max_index);
+  }
+
+  std::vector<int> read_labels(std::vector<double> ranges) {
+    std::vector<int> index(ranges.size());
+    Array array(ctx_, array_name, TILEDB_READ);
+    Query query(ctx_, array, TILEDB_READ);
+
+    // Set attribute ranges.
+    std::vector<Range> input_ranges;
+    for (uint64_t r = 0; r < ranges.size() / 2; r++) {
+      // Set attribute ranges.
+      std::stringstream stream;
+      stream << std::fixed << std::setprecision(2) << ranges[r * 2]
+             << ranges[r * 2 + 1];
+      auto labels_data = stream.str();
+
+      input_ranges.emplace_back(
+          labels_data.data(), 4, labels_data.data() + 4, 4);
+    }
+
+    Subarray subarray(ctx_, array);
+    subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+    query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+    query.set_data_buffer("index", index);
+    query.set_subarray(subarray);
+    query.submit();
+    array.close();
+
+    return index;
+  }
+
+  void read_all_possible_labels() {
+    for (int first = min_index_; first <= max_index_; first++) {
+      for (int second = first; second <= max_index_; second++) {
+        std::vector<int> index(2);
+        Array array(ctx_, array_name, TILEDB_READ);
+        Query query(ctx_, array, TILEDB_READ);
+        double boundary_modifier = increasing_labels_ ? 0.01 : -0.01;
+
+        // Set attribute ranges.
+        std::vector<Range> input_ranges;
+
+        // Get the value in between the labels we are testing for or a label
+        // before the first one.
+        double range_start = first == min_index_ ?
+                                 labels_[first] - boundary_modifier :
+                                 (labels_[first] + labels_[first - 1]) / 2;
+
+        // Get the value in between the labels we are testing for or a label
+        // after the last one.
+        double range_end = second == max_index_ ?
+                               labels_[second] + boundary_modifier :
+                               (labels_[second] + labels_[second + 1]) / 2;
+
+        // Set attribute ranges.
+        std::stringstream stream;
+        stream << std::fixed << std::setprecision(2) << range_start
+               << range_end;
+        auto labels_data = stream.str();
+
+        input_ranges.emplace_back(
+            labels_data.data(), 4, labels_data.data() + 4, 4);
+
+        Subarray subarray(ctx_, array);
+        subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+        query.ptr()->query_->set_dimension_label_ordered_read(
+            increasing_labels_);
+        query.set_data_buffer("index", index);
+        query.set_subarray(subarray);
+        query.submit();
+        array.close();
+
+        CHECK(index[0] == first);
+        CHECK(index[1] == second);
+      }
+    }
+  }
+
+  Context ctx_;
+  VFS vfs_;
+  std::vector<double> labels_;
+  int min_index_;
+  int max_index_;
+  bool increasing_labels_;
+};
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, single fragment, increasing",
+    "[ordered-dim-label-reader][var][single-fragment][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, single fragment, decreasing",
+    "[ordered-dim-label-reader][var][single-fragment][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, multiple fragments, "
+    "increasing",
+    "[ordered-dim-label-reader][var][multiple-fragments][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  write_labels(19, 22, {0.45, 0.55, 0.65, 0.75});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, multiple fragments, "
+    "decreasing",
+    "[ordered-dim-label-reader][var][multiple-fragments][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  write_labels(19, 22, {0.75, 0.65, 0.55, 0.45});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, lots of fragment, increasing",
+    "[ordered-dim-label-reader][var][lots-of-fragment][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  write_labels(26, 35, {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0});
+  write_labels(36, 45, {2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0});
+  write_labels(46, 55, {3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0});
+  write_labels(56, 65, {4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0});
+  write_labels(66, 75, {5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, lots of fragment, decreasing",
+    "[ordered-dim-label-reader][var][lots-of-fragment][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {6.0, 5.9, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1});
+  write_labels(26, 35, {5.0, 4.9, 4.8, 4.7, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1});
+  write_labels(36, 45, {4.0, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1});
+  write_labels(46, 55, {3.0, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1});
+  write_labels(56, 65, {2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1});
+  write_labels(66, 75, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  read_all_possible_labels();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, boundary conditions in binary "
+    "search, increasing",
+    "[ordered-dim-label-reader][var][boundary][binary-search][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  CHECK(read_labels({0.2, 0.3}) == std::vector({17, 18}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, boundary conditions in binary "
+    "search, decreasing",
+    "[ordered-dim-label-reader][var][boundary][binary-search][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  CHECK(read_labels({0.9, 0.8}) == std::vector({17, 18}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, boundary conditions in tile "
+    "search, increasing",
+    "[ordered-dim-label-reader][var][boundary][tile-search][increasing]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  CHECK(read_labels({0.5, 0.6}) == std::vector({20, 21}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, boundary conditions in tile "
+    "search, decreasing",
+    "[ordered-dim-label-reader][var][boundary][tile-search][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
+  CHECK(read_labels({0.6, 0.5}) == std::vector({20, 21}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: memory budget forcing internal loops",
+    "[ordered-dim-label-reader][memory-budget]") {
+  // Budget should only allow to load one tile in memory.
+  Config cfg;
+  cfg.set("sm.mem.total_budget", "100");
+  ctx_ = Context(cfg);
+
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+
+  // First range is in the first tile, second range in the second one.
+  std::vector<double> ranges{0.15, 0.35, 0.75, 0.85};
+  std::vector<int> index(ranges.size());
+
+  // Set attribute ranges.
+  std::vector<Range> input_ranges;
+  for (uint64_t r = 0; r < ranges.size() / 2; r++) {
+    input_ranges.emplace_back(
+        &ranges[r * 2], &ranges[r * 2 + 1], sizeof(double));
+  }
+
+  Subarray subarray(ctx_, array);
+  subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  query.set_data_buffer("index", index);
+  query.set_subarray(subarray);
+  query.submit();
+  array.close();
+
+  CHECK(index == std::vector({17, 18, 23, 23}));
+
+  // Check the internal loop count against expected value.
+  auto stats =
+      ((sm::OrderedDimLabelReader*)query.ptr()->query_->strategy())->stats();
+  REQUIRE(stats != nullptr);
+  auto counters = stats->counters();
+  REQUIRE(counters != nullptr);
+  auto loop_num =
+      counters->find("Context.StorageManager.Query.Reader.loop_num");
+  CHECK(2 == loop_num->second);
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed labels, multiple ranges",
+    "[ordered-dim-label-reader][fixed][double][multi-range]") {
+  write_labels(16, 25, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+  write_labels(26, 35, {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0});
+  auto index = read_labels({0.85, 1.25, 0.15, 0.75, 1.75, 2.05});
+  CHECK(index == std::vector({24, 27, 17, 22, 33, 35}));
+}

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -397,6 +397,46 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed labels, empty range, increasing",
+    "[ordered-dim-label-reader][fixed][double][empty-range][increasing]") {
+  write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
+  REQUIRE_THROWS_WITH(
+      read_labels({2.1, 2.8}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({-2.0, 0.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({5.0, 6.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: fixed labels, empty range, decreasing",
+    "[ordered-dim-label-reader][fixed][double][empty-range][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(1, 4, {4.0, 3.0, 2.0, 1.0});
+  std::vector<double> ranges{2.1, 2.8};
+  REQUIRE_THROWS_WITH(
+      read_labels({2.8, 2.1}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({0.0, -2.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({6.0, 5.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+}
+
+TEST_CASE_METHOD(
     CPPOrderedDimLabelReaderFixedIntFx,
     "Ordered dimension label reader: fixed int labels, single fragment, "
     "increasing",
@@ -740,6 +780,46 @@ TEST_CASE_METHOD(
   increasing_labels_ = false;
   write_labels(16, 25, {1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1});
   CHECK(read_labels({0.6, 0.5}) == std::vector({20, 21}));
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, empty range, increasing",
+    "[ordered-dim-label-reader][var][empty-range][increasing]") {
+  write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
+  REQUIRE_THROWS_WITH(
+      read_labels({2.1, 2.8}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({-2.0, 0.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({5.0, 6.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderVarFx,
+    "Ordered dimension label reader: var labels, empty range, decreasing",
+    "[ordered-dim-label-reader][var][empty-range][decreasing]") {
+  increasing_labels_ = false;
+  write_labels(1, 4, {4.0, 3.0, 2.0, 1.0});
+  std::vector<double> ranges{2.1, 2.8};
+  REQUIRE_THROWS_WITH(
+      read_labels({2.8, 2.1}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({0.0, -2.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
+  REQUIRE_THROWS_WITH(
+      read_labels({6.0, 5.0}),
+      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
+      "contained no values");
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -376,8 +376,6 @@ TEST_CASE_METHOD(
   write_labels(26, 35, {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0});
   write_labels(36, 45, {2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0});
   write_labels(46, 55, {3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0});
-  write_labels(56, 65, {4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0});
-  write_labels(66, 75, {5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0});
   read_all_possible_labels();
 }
 
@@ -387,8 +385,6 @@ TEST_CASE_METHOD(
     "decreasing",
     "[ordered-dim-label-reader][fixed][double][lots-of-fragment][decreasing]") {
   increasing_labels_ = false;
-  write_labels(16, 25, {6.0, 5.9, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1});
-  write_labels(26, 35, {5.0, 4.9, 4.8, 4.7, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1});
   write_labels(36, 45, {4.0, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1});
   write_labels(46, 55, {3.0, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1});
   write_labels(56, 65, {2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1});
@@ -725,8 +721,6 @@ TEST_CASE_METHOD(
   write_labels(26, 35, {1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0});
   write_labels(36, 45, {2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0});
   write_labels(46, 55, {3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0});
-  write_labels(56, 65, {4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0});
-  write_labels(66, 75, {5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0});
   read_all_possible_labels();
 }
 
@@ -735,8 +729,6 @@ TEST_CASE_METHOD(
     "Ordered dimension label reader: var labels, lots of fragment, decreasing",
     "[ordered-dim-label-reader][var][lots-of-fragment][decreasing]") {
   increasing_labels_ = false;
-  write_labels(16, 25, {6.0, 5.9, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1});
-  write_labels(26, 35, {5.0, 4.9, 4.8, 4.7, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1});
   write_labels(36, 45, {4.0, 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1});
   write_labels(46, 55, {3.0, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1});
   write_labels(56, 65, {2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1});

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -491,34 +491,30 @@ struct CPPFixedTileMetadataFx {
         if constexpr (std::is_same<TestType, char>::value) {
           for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
             // Validate min.
-            auto&& [min, min_size] =
-                frag_meta[f]->get_tile_min_as<TestType>("a", tile_idx);
-            CHECK(min_size == cell_val_num);
+            const auto min =
+                frag_meta[f]->get_tile_min_as<std::string_view>("a", tile_idx);
+            CHECK(min.size() == cell_val_num);
 
             // For strings, the index is stored in a signed value, switch to
             // the index to unsigned.
             int64_t idx = (int64_t)correct_tile_mins_[f][tile_idx] -
                           (int64_t)std::numeric_limits<char>::min();
             CHECK(
-                0 == strncmp(
-                         (const char*)min,
-                         string_ascii_[idx].c_str(),
-                         cell_val_num));
+                0 ==
+                strncmp(min.data(), string_ascii_[idx].c_str(), cell_val_num));
 
             // Validate max.
-            auto&& [max, max_size] =
-                frag_meta[f]->get_tile_max_as<TestType>("a", tile_idx);
-            CHECK(max_size == cell_val_num);
+            const auto max =
+                frag_meta[f]->get_tile_max_as<std::string_view>("a", tile_idx);
+            CHECK(max.size() == cell_val_num);
 
             // For strings, the index is stored in a signed value, switch to
             // the index to unsigned.
             idx = (int64_t)correct_tile_maxs_[f][tile_idx] -
                   (int64_t)std::numeric_limits<char>::min();
             CHECK(
-                0 == strncmp(
-                         (const char*)max,
-                         string_ascii_[idx].c_str(),
-                         cell_val_num));
+                0 ==
+                strncmp(max.data(), string_ascii_[idx].c_str(), cell_val_num));
 
             // Validate no sum.
             CHECK_THROWS_WITH(
@@ -530,16 +526,20 @@ struct CPPFixedTileMetadataFx {
           (void)cell_val_num;
           for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
             // Validate min.
-            auto&& [min, min_size] =
+            const auto min =
                 frag_meta[f]->get_tile_min_as<TestType>("a", tile_idx);
-            CHECK(min_size == sizeof(TestType));
-            CHECK(0 == memcmp(min, &correct_tile_mins_[f][tile_idx], min_size));
+            CHECK(
+                0 ==
+                memcmp(
+                    &min, &correct_tile_mins_[f][tile_idx], sizeof(TestType)));
 
             // Validate max.
-            auto&& [max, max_size] =
+            const auto max =
                 frag_meta[f]->get_tile_max_as<TestType>("a", tile_idx);
-            CHECK(max_size == sizeof(TestType));
-            CHECK(0 == memcmp(max, &correct_tile_maxs_[f][tile_idx], max_size));
+            CHECK(
+                0 ==
+                memcmp(
+                    &max, &correct_tile_maxs_[f][tile_idx], sizeof(TestType)));
 
             if constexpr (!std::is_same<TestType, unsigned char>::value) {
               // Validate sum.
@@ -862,12 +862,12 @@ struct CPPVarTileMetadataFx {
 
           // Validate no min.
           CHECK_THROWS_WITH(
-              frag_meta[f]->get_tile_min_as<char>("d", tile_idx),
+              frag_meta[f]->get_tile_min_as<uint32_t>("d", tile_idx),
               "FragmentMetadata: Trying to access metadata that's not present");
 
           // Validate no max.
           CHECK_THROWS_WITH(
-              frag_meta[f]->get_tile_max_as<char>("d", tile_idx),
+              frag_meta[f]->get_tile_max_as<uint32_t>("d", tile_idx),
               "FragmentMetadata: Trying to access metadata that's not present");
 
           // Validate sum.
@@ -940,18 +940,22 @@ struct CPPVarTileMetadataFx {
     if (!all_null) {
       for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
         // Validate min.
-        auto&& [min, min_size] =
-            frag_meta[f]->get_tile_min_as<char>("a", tile_idx);
+        const auto min =
+            frag_meta[f]->get_tile_min_as<std::string_view>("a", tile_idx);
         int idx = correct_tile_mins_[f][tile_idx];
-        CHECK(min_size == strings_[idx].size());
-        CHECK(0 == strncmp(min, strings_[idx].c_str(), strings_[idx].size()));
+        CHECK(min.size() == strings_[idx].size());
+        CHECK(
+            0 ==
+            strncmp(min.data(), strings_[idx].c_str(), strings_[idx].size()));
 
         // Validate max.
-        auto&& [max, max_size] =
-            frag_meta[f]->get_tile_max_as<char>("a", tile_idx);
+        const auto max =
+            frag_meta[f]->get_tile_max_as<std::string_view>("a", tile_idx);
         idx = correct_tile_maxs_[f][tile_idx];
-        CHECK(max_size == strings_[idx].size());
-        CHECK(0 == strncmp(max, strings_[idx].c_str(), strings_[idx].size()));
+        CHECK(max.size() == strings_[idx].size());
+        CHECK(
+            0 ==
+            strncmp(max.data(), strings_[idx].c_str(), strings_[idx].size()));
 
         // Validate no sum.
         CHECK_THROWS_WITH(
@@ -1182,16 +1186,12 @@ struct CPPFixedTileMetadataPartialFx {
     // Validate attribute metadta.
     for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
       // Validate min.
-      auto&& [min, min_size] =
-          frag_meta[0]->get_tile_min_as<char>("a", tile_idx);
-      CHECK(min_size == sizeof(double));
-      CHECK(0 == memcmp(min, &correct_tile_mins[tile_idx], min_size));
+      const auto min = frag_meta[0]->get_tile_min_as<double>("a", tile_idx);
+      CHECK(0 == memcmp(&min, &correct_tile_mins[tile_idx], sizeof(double)));
 
       // Validate max.
-      auto&& [max, max_size] =
-          frag_meta[0]->get_tile_max_as<char>("a", tile_idx);
-      CHECK(max_size == sizeof(double));
-      CHECK(0 == memcmp(max, &correct_tile_maxs[tile_idx], max_size));
+      const auto max = frag_meta[0]->get_tile_max_as<double>("a", tile_idx);
+      CHECK(0 == memcmp(&max, &correct_tile_maxs[tile_idx], sizeof(double)));
 
       // Validate sum.
       auto sum = frag_meta[0]->get_tile_sum("a", tile_idx);
@@ -1359,16 +1359,20 @@ struct CPPVarTileMetadataPartialFx {
     // Validate attribute metadta.
     for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
       // Validate min.
-      auto&& [min, min_size] =
-          frag_meta[0]->get_tile_min_as<char>("a", tile_idx);
-      CHECK(min_size == correct_tile_mins[tile_idx].size());
-      CHECK(0 == memcmp(min, correct_tile_mins[tile_idx].data(), min_size));
+      const auto min =
+          frag_meta[0]->get_tile_min_as<std::string_view>("a", tile_idx);
+      CHECK(min.size() == correct_tile_mins[tile_idx].size());
+      CHECK(
+          0 ==
+          memcmp(min.data(), correct_tile_mins[tile_idx].data(), min.size()));
 
       // Validate max.
-      auto&& [max, max_size] =
-          frag_meta[0]->get_tile_max_as<char>("a", tile_idx);
-      CHECK(max_size == correct_tile_maxs[tile_idx].size());
-      CHECK(0 == memcmp(max, correct_tile_maxs[tile_idx].data(), max_size));
+      const auto max =
+          frag_meta[0]->get_tile_max_as<std::string_view>("a", tile_idx);
+      CHECK(max.size() == correct_tile_maxs[tile_idx].size());
+      CHECK(
+          0 ==
+          memcmp(max.data(), correct_tile_maxs[tile_idx].data(), max.size()));
     }
 
     // Close array.

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -237,6 +237,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_condition.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/dense_reader.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/ordered_dim_label_reader.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/reader_base.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/result_tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/sparse_global_order_reader.cc

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -648,20 +648,23 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @return Status, value, size.
+   * @return Value, size.
    */
-  tuple<Status, optional<void*>, optional<uint64_t>> get_tile_min(
+  template <typename T>
+  tuple<T*, uint64_t> get_tile_min_as(
       const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the tile max value for a given attribute or dimension and tile
    * index.
    *
+   * @tparam Type to return the data as.
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @return Status, value, size.
+   * @return Value, size.
    */
-  tuple<Status, optional<void*>, optional<uint64_t>> get_tile_max(
+  template <typename T>
+  tuple<T*, uint64_t> get_tile_max_as(
       const std::string& name, uint64_t tile_idx);
 
   /**
@@ -670,10 +673,9 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @return Status, sum.
+   * @return Sum.
    */
-  tuple<Status, optional<void*>> get_tile_sum(
-      const std::string& name, uint64_t tile_idx);
+  void* get_tile_sum(const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the tile null count value for a given attribute or dimension
@@ -681,44 +683,41 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @return Status, count.
+   * @return Count.
    */
-  tuple<Status, optional<uint64_t>> get_tile_null_count(
-      const std::string& name, uint64_t tile_idx);
+  uint64_t get_tile_null_count(const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the min value for a given attribute or dimension.
    *
    * @param name The input attribute/dimension.
-   * @return Status, value.
+   * @return Value.
    */
-  tuple<Status, optional<std::vector<uint8_t>>> get_min(
-      const std::string& name);
+  std::vector<uint8_t>& get_min(const std::string& name);
 
   /**
    * Retrieves the max value for a given attribute or dimension.
    *
    * @param name The input attribute/dimension.
-   * @return Status, value.
+   * @return Value.
    */
-  tuple<Status, optional<std::vector<uint8_t>>> get_max(
-      const std::string& name);
+  std::vector<uint8_t>& get_max(const std::string& name);
 
   /**
    * Retrieves the sum value for a given attribute or dimension.
    *
    * @param name The input attribute/dimension.
-   * @return Status, sum.
+   * @return Sum.
    */
-  tuple<Status, optional<void*>> get_sum(const std::string& name);
+  void* get_sum(const std::string& name);
 
   /**
    * Retrieves the null count value for a given attribute or dimension.
    *
    * @param name The input attribute/dimension.
-   * @return Status, count.
+   * @return Count.
    */
-  tuple<Status, optional<uint64_t>> get_null_count(const std::string& name);
+  uint64_t get_null_count(const std::string& name);
 
   /**
    * Set the processed conditions. The processed conditions is the list

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -648,11 +648,10 @@ class FragmentMetadata {
    *
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @return Value, size.
+   * @return Value.
    */
   template <typename T>
-  tuple<T*, uint64_t> get_tile_min_as(
-      const std::string& name, uint64_t tile_idx);
+  T get_tile_min_as(const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the tile max value for a given attribute or dimension and tile
@@ -661,11 +660,10 @@ class FragmentMetadata {
    * @tparam Type to return the data as.
    * @param name The input attribute/dimension.
    * @param tile_idx The index of the tile in the metadata.
-   * @return Value, size.
+   * @return Value.
    */
   template <typename T>
-  tuple<T*, uint64_t> get_tile_max_as(
-      const std::string& name, uint64_t tile_idx);
+  T get_tile_max_as(const std::string& name, uint64_t tile_idx);
 
   /**
    * Retrieves the tile sum value for a given attribute or dimension and tile

--- a/tiledb/sm/misc/types.cc
+++ b/tiledb/sm/misc/types.cc
@@ -41,5 +41,22 @@ std::string ByteVecValue::rvalue_as<std::string>() const {
       reinterpret_cast<const std::string::value_type*>(x_.data()), x_.size());
 }
 
+// Explicit template instantiations
+template <class T>
+T ByteVecValue::rvalue_as() const {
+  return *static_cast<const T*>(static_cast<const void*>(x_.data()));
+}
+
+// Explicit template instantiations
+template char ByteVecValue::rvalue_as<char>() const;
+template int8_t ByteVecValue::rvalue_as<int8_t>() const;
+template uint8_t ByteVecValue::rvalue_as<uint8_t>() const;
+template int16_t ByteVecValue::rvalue_as<int16_t>() const;
+template uint16_t ByteVecValue::rvalue_as<uint16_t>() const;
+template int ByteVecValue::rvalue_as<int>() const;
+template uint32_t ByteVecValue::rvalue_as<uint32_t>() const;
+template int64_t ByteVecValue::rvalue_as<int64_t>() const;
+template uint64_t ByteVecValue::rvalue_as<uint64_t>() const;
+
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -947,6 +947,13 @@ class Query {
   /** Called from serialization to mark the query as remote */
   void set_remote_query();
 
+  /**
+   * Set a flag to specify we are doing an ordered dimension label read.
+   *
+   * @param increaging_order Is the query on an array with increasing order?
+   */
+  void set_dimension_label_ordered_read(bool increaging_order);
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -1083,6 +1090,12 @@ class Query {
 
   /** It tracks if this is a remote query */
   bool remote_query_;
+
+  /** Flag to specify we are doing a dimension label ordered read. */
+  bool is_dimension_label_ordered_read_;
+
+  /** Is the dimension label ordered read on an array with increasing order? */
+  bool dimension_label_increasing_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -950,9 +950,10 @@ class Query {
   /**
    * Set a flag to specify we are doing an ordered dimension label read.
    *
-   * @param increaging_order Is the query on an array with increasing order?
+   * @param increasing_order Is the query on an array with increasing order? If
+   * not assume decreasing order.
    */
-  void set_dimension_label_ordered_read(bool increaging_order);
+  void set_dimension_label_ordered_read(bool increasing_order);
 
  private:
   /* ********************************* */
@@ -1094,7 +1095,12 @@ class Query {
   /** Flag to specify we are doing a dimension label ordered read. */
   bool is_dimension_label_ordered_read_;
 
-  /** Is the dimension label ordered read on an array with increasing order? */
+  /**
+   * Is the dimension label ordered read on an array with increasing order? If
+   * not assume decreasing order.
+   *
+   * NOTE: Only used when is_dimension_label_order_read_ == true.
+   */
   bool dimension_label_increasing_;
 
   /* ********************************* */

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -1,0 +1,1083 @@
+/**
+ * @file   ordered_dim_label_reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class OrderedDimLabelReader.
+ */
+
+#include "tiledb/common/logger.h"
+
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/fragment/fragment_metadata.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/query/legacy/cell_slab_iter.h"
+#include "tiledb/sm/query/query_macros.h"
+#include "tiledb/sm/query/readers/ordered_dim_label_reader.h"
+#include "tiledb/sm/query/readers/result_tile.h"
+#include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
+#include "tiledb/sm/subarray/subarray.h"
+
+#include <numeric>
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm::stats;
+
+namespace tiledb {
+namespace sm {
+
+class OrderedDimLabelReaderStatusException : public StatusException {
+ public:
+  explicit OrderedDimLabelReaderStatusException(const std::string& message)
+      : StatusException("OrderedDimLabelReader", message) {
+  }
+};
+
+/* ****************************** */
+/*          CONSTRUCTORS          */
+/* ****************************** */
+
+OrderedDimLabelReader::OrderedDimLabelReader(
+    stats::Stats* stats,
+    shared_ptr<Logger> logger,
+    StorageManager* storage_manager,
+    Array* array,
+    Config& config,
+    std::unordered_map<std::string, QueryBuffer>& buffers,
+    Subarray& subarray,
+    Layout layout,
+    QueryCondition& condition,
+    bool increasing_labels,
+    bool skip_checks_serialization)
+    : ReaderBase(
+          stats,
+          logger->clone("OrderedDimLabelReader", ++logger_id_),
+          storage_manager,
+          array,
+          config,
+          buffers,
+          subarray,
+          layout,
+          condition)
+    , ranges_(
+          subarray.get_attribute_ranges(array_schema_.attributes()[0]->name()))
+    , label_name_(array_schema_.attributes()[0]->name())
+    , label_type_(array_schema_.attributes()[0]->type())
+    , label_var_size_(array_schema_.attributes()[0]->var_size())
+    , increasing_labels_(increasing_labels)
+    , index_dim_(array_schema_.domain().dimension_ptr(0))
+    , non_empty_domains_(fragment_metadata_.size())
+    , tile_idx_min_(std::numeric_limits<uint64_t>::max())
+    , tile_idx_max_(std::numeric_limits<uint64_t>::min())
+    , result_tiles_(fragment_metadata_.size())
+    , domain_tile_idx_(fragment_metadata_.size()) {
+  // Sanity checks.
+  if (storage_manager_ == nullptr) {
+    throw OrderedDimLabelReaderStatusException(
+        "Cannot initialize ordered dim label reader; Storage manager not set");
+  }
+
+  if (!skip_checks_serialization && buffers_.empty()) {
+    throw OrderedDimLabelReaderStatusException(
+        "Cannot initialize ordered dim label reader; Buffers not set");
+  }
+
+  if (buffers_.size() != 1) {
+    throw OrderedDimLabelReaderStatusException(
+        "Cannot initialize ordered dim label reader; Only one buffer allowed");
+  }
+
+  for (const auto& b : buffers_) {
+    if (b.first != index_dim_->name()) {
+      throw OrderedDimLabelReaderStatusException(
+          "Cannot initialize ordered dim label reader; Wrong buffer set");
+    }
+
+    if (*b.second.buffer_size_ !=
+        ranges_.size() * 2 * datatype_size(index_dim_->type())) {
+      throw OrderedDimLabelReaderStatusException(
+          "Cannot initialize ordered dim label reader; Wrong buffer size");
+    }
+
+    if (b.second.buffer_var_size_ != 0) {
+      throw OrderedDimLabelReaderStatusException(
+          "Cannot initialize ordered dim label reader; Wrong buffer var size");
+    }
+  }
+
+  if (!skip_checks_serialization && subarray_.is_set()) {
+    throw OrderedDimLabelReaderStatusException(
+        "Cannot initialize ordered dim label reader; Subarray is set");
+  }
+
+  bool found = false;
+  if (!config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found)
+           .ok()) {
+    throw OrderedDimLabelReaderStatusException("Cannot get setting");
+  }
+  assert(found);
+
+  uint64_t tile_cache_size = 0;
+  if (!config_.get<uint64_t>("sm.tile_cache_size", &tile_cache_size, &found)
+           .ok()) {
+    throw OrderedDimLabelReaderStatusException("Cannot get setting");
+  }
+  assert(found);
+  disable_cache_ = tile_cache_size == 0;
+}
+
+/* ****************************** */
+/*               API              */
+/* ****************************** */
+
+bool OrderedDimLabelReader::incomplete() const {
+  return false;
+}
+
+QueryStatusDetailsReason OrderedDimLabelReader::status_incomplete_reason()
+    const {
+  return QueryStatusDetailsReason::REASON_NONE;
+}
+
+Status OrderedDimLabelReader::initialize_memory_budget() {
+  return Status::Ok();
+}
+
+Status OrderedDimLabelReader::dowork() {
+  auto timer_se = stats_->start_timer("dowork");
+  assert(condition_.empty());
+
+  get_dim_attr_stats();
+  reset_buffer_sizes();
+
+  // Load tile offsets and tile var sizes.
+  std::vector<std::string> names = {label_name_};
+  RETURN_NOT_OK(load_tile_offsets(subarray_, names));
+  RETURN_NOT_OK(load_tile_var_sizes(subarray_, names));
+
+  // Load the dimension labels min/max values.
+  load_label_min_max_values();
+
+  // Do the read.
+  label_read();
+
+  return Status::Ok();
+}
+
+void OrderedDimLabelReader::reset() {
+}
+
+/* ********************************* */
+/*           PRIVATE METHODS         */
+/* ********************************* */
+
+void OrderedDimLabelReader::label_read() {
+  // Do the label read depending on the index type.
+  auto type{index_dim_->type()};
+  switch (type) {
+    case Datatype::INT8:
+      return label_read<int8_t>();
+    case Datatype::UINT8:
+      return label_read<uint8_t>();
+    case Datatype::INT16:
+      return label_read<int16_t>();
+    case Datatype::UINT16:
+      return label_read<uint16_t>();
+    case Datatype::INT32:
+      return label_read<int>();
+    case Datatype::UINT32:
+      return label_read<unsigned>();
+    case Datatype::INT64:
+      return label_read<int64_t>();
+    case Datatype::UINT64:
+      return label_read<uint64_t>();
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return label_read<int64_t>();
+    default:
+      throw OrderedDimLabelReaderStatusException(
+          "Cannot read ordered label array; Unsupported domain type");
+  }
+}
+
+template <typename IndexType>
+void OrderedDimLabelReader::label_read() {
+  // Sanity checks.
+  assert(std::is_integral<IndexType>::value);
+
+  // Precompute data.
+  compute_domain_tile_indexes<IndexType>();
+  compute_non_empty_domain<IndexType>();
+  compute_range_tile_indexes<IndexType>();
+
+  // Save the offsets into the user buffer if we make more than one iteration
+  // because of memory budgetting.
+  uint64_t buffer_offset = 0;
+  do {
+    stats_->add_counter("loop_num", 1);
+
+    // Create result tiles.
+    uint64_t max_range = create_result_tiles<IndexType>();
+    std::vector<ResultTile*> result_tiles;
+    for (auto& result_tile_map : result_tiles_) {
+      for (auto& result_tile : result_tile_map) {
+        if (!result_tile.second.covered()) {
+          result_tiles.push_back(&result_tile.second);
+        }
+      }
+    }
+
+    // Read/unfilter tiles.
+    throw_if_not_ok(read_attribute_tiles({label_name_}, result_tiles));
+    throw_if_not_ok(unfilter_tiles(label_name_, result_tiles));
+
+    // Compute/copy results.
+    throw_if_not_ok(parallel_for(
+        storage_manager_->compute_tp(), 0, max_range, [&](uint64_t r) {
+          if (!label_var_size_) {
+            if (increasing_labels_) {
+              copy_range_indexes_fixed<IndexType>(buffer_offset, r);
+            } else {
+              copy_range_indexes_fixed<IndexType>(buffer_offset, r);
+            }
+          } else {
+            if (increasing_labels_) {
+              copy_range_indexes_var<IndexType>(buffer_offset, r);
+            } else {
+              copy_range_indexes_var<IndexType>(buffer_offset, r);
+            }
+          }
+          return Status::Ok();
+        }));
+
+    // Truncate ranges_ for the next iteration.
+    for (auto& rt_map : result_tiles_) {
+      rt_map.clear();
+    }
+    ranges_.erase(ranges_.begin(), ranges_.begin() + max_range);
+    range_tile_indexes_.erase(
+        range_tile_indexes_.begin(), range_tile_indexes_.begin() + max_range);
+
+    // Move the offset into the user buffer for the next iteration.
+    buffer_offset += max_range;
+  } while (ranges_.size() > 0);
+}
+
+template <typename IndexType>
+void OrderedDimLabelReader::compute_domain_tile_indexes() {
+  auto timer_se = stats_->start_timer("compute_domain_tile_indexes");
+
+  // Compute the tile index (inside of the full domain) of the first tile for
+  // each fragments.
+  auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
+  const IndexType* dim_dom =
+      static_cast<const IndexType*>(index_dim_->domain().data());
+  throw_if_not_ok(parallel_for(
+      storage_manager_->compute_tp(),
+      0,
+      fragment_metadata_.size(),
+      [&](uint64_t f) {
+        non_empty_domains_[f] =
+            fragment_metadata_[f]->non_empty_domain()[0].data();
+        const IndexType* non_empty_domain =
+            static_cast<const IndexType*>(non_empty_domains_[f]);
+        domain_tile_idx_[f] = index_dim_->tile_idx<IndexType>(
+            non_empty_domain[0], dim_dom[0], tile_extent);
+        return Status::Ok();
+      }));
+}
+
+template <typename IndexType>
+void OrderedDimLabelReader::compute_range_tile_indexes() {
+  auto timer_se = stats_->start_timer("compute_range_tile_indexes");
+
+  // Compute the tile (by index) where the label values include each range
+  // start and end. This is stored in the following value, by fragment/range.
+  std::vector<std::vector<FragmentRangeTileIndexes>>
+      per_fragment_range_tile_indexes(ranges_.size());
+  for (uint64_t r = 0; r < ranges_.size(); r++) {
+    per_fragment_range_tile_indexes[r].resize(fragment_metadata_.size());
+  }
+  throw_if_not_ok(parallel_for_2d(
+      storage_manager_->compute_tp(),
+      0,
+      fragment_metadata_.size(),
+      0,
+      ranges_.size(),
+      [&](uint64_t f, uint64_t r) {
+        per_fragment_range_tile_indexes[r][f] =
+            get_tile_indexes_for_range(f, r);
+        return Status::Ok();
+      }));
+
+  // Compute the tile indexes (min/max) that can potentially contain the label
+  // value for each range start/end.
+  range_tile_indexes_.resize(ranges_.size());
+  throw_if_not_ok(parallel_for(
+      storage_manager_->compute_tp(), 0, ranges_.size(), [&](uint64_t r) {
+        range_tile_indexes_[r] = RangeTileIndexes(
+            tile_idx_min_, tile_idx_max_, per_fragment_range_tile_indexes[r]);
+        return Status::Ok();
+      }));
+}
+
+template <typename IndexType>
+void OrderedDimLabelReader::compute_non_empty_domain() {
+  auto timer_se = stats_->start_timer("compute_non_empty_domain");
+
+  IndexType min = std::numeric_limits<IndexType>::max();
+  IndexType max = std::numeric_limits<IndexType>::min();
+
+  for (unsigned f = 0; f < fragment_metadata_.size(); f++) {
+    auto frag_non_empty_domain =
+        static_cast<const IndexType*>(non_empty_domains_[f]);
+    min = std::min(min, frag_non_empty_domain[0]);
+    max = std::max(max, frag_non_empty_domain[1]);
+  }
+
+  non_empty_domain_ = Range(&min, &max, sizeof(IndexType));
+
+  // Save the minimum/maximum tile indexes (in the full domain) to be used
+  // later.
+  auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
+  const IndexType* dim_dom =
+      static_cast<const IndexType*>(index_dim_->domain().data());
+  tile_idx_min_ = index_dim_->tile_idx(min, dim_dom[0], tile_extent);
+  tile_idx_max_ = index_dim_->tile_idx(max, dim_dom[0], tile_extent);
+}
+
+void OrderedDimLabelReader::load_label_min_max_values() {
+  auto timer_se = stats_->start_timer("load_label_min_max_values");
+  const auto encryption_key = array_->encryption_key();
+
+  // Load min/max data for all fragments.
+  throw_if_not_ok(parallel_for(
+      storage_manager_->compute_tp(),
+      0,
+      fragment_metadata_.size(),
+      [&](const uint64_t i) {
+        auto& fragment = fragment_metadata_[i];
+        std::vector<std::string> names_min = {label_name_};
+        RETURN_NOT_OK(fragment->load_tile_min_values(
+            *encryption_key, std::move(names_min)));
+        std::vector<std::string> names_max = {label_name_};
+        RETURN_NOT_OK(fragment->load_tile_max_values(
+            *encryption_key, std::move(names_max)));
+        return Status::Ok();
+      }));
+}
+
+template <typename LabelType>
+OrderedDimLabelReader::FragmentRangeTileIndexes
+OrderedDimLabelReader::get_tile_indexes_for_range(unsigned f, uint64_t r) {
+  const auto tile_num = fragment_metadata_[f]->tile_num();
+  uint64_t start_index = 0, end_index = tile_num - 1;
+
+  const LabelType* start_val =
+      static_cast<const LabelType*>(ranges_[r].start_fixed());
+  const LabelType* end_val =
+      static_cast<const LabelType*>(ranges_[r].end_fixed());
+
+  // Check if either the start or end range is fully excluded from the fragment.
+  IndexValueType start_val_type = IndexValueType::EQUAL,
+                 end_val_type = IndexValueType::EQUAL;
+
+  if (increasing_labels_) {
+    // Start with the minimum of the first tile.
+    auto&& [min, min_size] =
+        fragment_metadata_[f]->get_tile_min_as<LabelType>(label_name_, 0);
+    if (*start_val < *min) {
+      start_val_type = IndexValueType::LT;
+    }
+    if (*end_val < *min) {
+      end_val_type = IndexValueType::LT;
+    }
+
+    // Now with the maximum of the last tile.
+    auto&& [max, max_size] = fragment_metadata_[f]->get_tile_max_as<LabelType>(
+        label_name_, tile_num - 1);
+    if (*start_val > *max) {
+      start_val_type = IndexValueType::GT;
+    }
+    if (*end_val > *max) {
+      end_val_type = IndexValueType::GT;
+    }
+  } else {
+    // Start with the minimum of the first tile.
+    auto&& [max, max_size] =
+        fragment_metadata_[f]->get_tile_max_as<LabelType>(label_name_, 0);
+    if (*start_val > *max) {
+      start_val_type = IndexValueType::LT;
+    }
+    if (*end_val > *max) {
+      end_val_type = IndexValueType::LT;
+    }
+
+    // Now with the maximum of the last tile.
+    auto&& [min, min_size] = fragment_metadata_[f]->get_tile_min_as<LabelType>(
+        label_name_, tile_num - 1);
+    if (*start_val < *min) {
+      start_val_type = IndexValueType::GT;
+    }
+    if (*end_val < *min) {
+      end_val_type = IndexValueType::GT;
+    }
+  }
+
+  // If the start range is included, find in which tile.
+  if (start_val_type == IndexValueType::EQUAL) {
+    for (; start_index < tile_num; start_index++) {
+      if (increasing_labels_) {
+        auto&& [max, size] = fragment_metadata_[f]->get_tile_max_as<LabelType>(
+            label_name_, start_index);
+        if (*max >= *start_val) {
+          break;
+        }
+      } else {
+        auto&& [min, size] = fragment_metadata_[f]->get_tile_min_as<LabelType>(
+            label_name_, start_index);
+        if (*min <= *start_val) {
+          break;
+        }
+      }
+    }
+  }
+
+  // If the end range is included, find in which tile.
+  if (end_val_type == IndexValueType::EQUAL) {
+    for (;; end_index--) {
+      if (increasing_labels_) {
+        auto&& [min, size] = fragment_metadata_[f]->get_tile_min_as<LabelType>(
+            label_name_, end_index);
+        if (end_index == 0 || *min <= *end_val) {
+          break;
+        }
+      } else {
+        auto&& [max, size] = fragment_metadata_[f]->get_tile_max_as<LabelType>(
+            label_name_, end_index);
+        if (end_index == 0 || *max >= *end_val) {
+          break;
+        }
+      }
+    }
+  }
+
+  return FragmentRangeTileIndexes(
+      start_index + domain_tile_idx_[f],
+      start_val_type,
+      end_index + domain_tile_idx_[f],
+      end_val_type);
+}
+
+template <>
+OrderedDimLabelReader::FragmentRangeTileIndexes
+OrderedDimLabelReader::get_tile_indexes_for_range<char>(
+    unsigned f, uint64_t r) {
+  const auto tile_num = fragment_metadata_[f]->tile_num();
+  uint64_t start_index = 0, end_index = tile_num - 1;
+
+  const auto start_val = ranges_[r].start_str();
+  const auto end_val = ranges_[r].end_str();
+
+  // Check if either the start or range is fully excluded from the fragment.
+  IndexValueType start_val_type = IndexValueType::EQUAL,
+                 end_val_type = IndexValueType::EQUAL;
+
+  if (increasing_labels_) {
+    // Start with the minimum of the first tile.
+    auto&& [min, min_size] =
+        fragment_metadata_[f]->get_tile_min_as<char>(label_name_, 0);
+    auto tile_min = std::string_view(min, min_size);
+    if (start_val < tile_min) {
+      start_val_type = IndexValueType::LT;
+    }
+    if (end_val < tile_min) {
+      end_val_type = IndexValueType::LT;
+    }
+
+    // Now with the maximum of the last tile.
+    auto&& [max, max_size] =
+        fragment_metadata_[f]->get_tile_max_as<char>(label_name_, tile_num - 1);
+    auto tile_max = std::string_view(max, max_size);
+    if (start_val > tile_max) {
+      start_val_type = IndexValueType::GT;
+    }
+    if (end_val > tile_max) {
+      end_val_type = IndexValueType::GT;
+    }
+  } else {
+    // Start with the minimum of the first tile.
+    auto&& [max, max_size] =
+        fragment_metadata_[f]->get_tile_max_as<char>(label_name_, 0);
+    auto tile_max = std::string_view(max, max_size);
+    if (start_val > tile_max) {
+      start_val_type = IndexValueType::LT;
+    }
+    if (end_val > tile_max) {
+      end_val_type = IndexValueType::LT;
+    }
+
+    // Now with the maximum of the last tile.
+    auto&& [min, min_size] =
+        fragment_metadata_[f]->get_tile_min_as<char>(label_name_, tile_num - 1);
+    auto tile_min = std::string_view(min, min_size);
+    if (start_val < tile_min) {
+      start_val_type = IndexValueType::GT;
+    }
+    if (end_val < tile_min) {
+      end_val_type = IndexValueType::GT;
+    }
+  }
+
+  if (start_val_type == IndexValueType::EQUAL) {
+    for (; start_index < tile_num; start_index++) {
+      if (increasing_labels_) {
+        auto&& [max, size] = fragment_metadata_[f]->get_tile_max_as<char>(
+            label_name_, start_index);
+        auto tile_max = std::string_view(max, size);
+        if (tile_max >= ranges_[r].start_str()) {
+          break;
+        }
+      } else {
+        auto&& [min, size] = fragment_metadata_[f]->get_tile_min_as<char>(
+            label_name_, start_index);
+        auto tile_min = std::string_view(min, size);
+        if (tile_min <= ranges_[r].start_str()) {
+          break;
+        }
+      }
+    }
+  }
+
+  if (end_val_type == IndexValueType::EQUAL) {
+    for (;; end_index--) {
+      if (increasing_labels_) {
+        auto&& [min, size] = fragment_metadata_[f]->get_tile_min_as<char>(
+            label_name_, end_index);
+        auto tile_min = std::string_view(min, size);
+        if (end_index == 0 || tile_min <= ranges_[r].end_str()) {
+          break;
+        }
+      } else {
+        auto&& [max, size] = fragment_metadata_[f]->get_tile_max_as<char>(
+            label_name_, end_index);
+        auto tile_max = std::string_view(max, size);
+        if (end_index == 0 || tile_max >= ranges_[r].end_str()) {
+          break;
+        }
+      }
+    }
+  }
+
+  return FragmentRangeTileIndexes(
+      start_index + domain_tile_idx_[f],
+      start_val_type,
+      end_index + domain_tile_idx_[f],
+      end_val_type);
+}
+
+OrderedDimLabelReader::FragmentRangeTileIndexes
+OrderedDimLabelReader::get_tile_indexes_for_range(unsigned f, uint64_t r) {
+  switch (label_type_) {
+    case Datatype::INT8:
+      return get_tile_indexes_for_range<int8_t>(f, r);
+    case Datatype::UINT8:
+      return get_tile_indexes_for_range<uint8_t>(f, r);
+    case Datatype::INT16:
+      return get_tile_indexes_for_range<int16_t>(f, r);
+    case Datatype::UINT16:
+      return get_tile_indexes_for_range<uint16_t>(f, r);
+    case Datatype::INT32:
+      return get_tile_indexes_for_range<int32_t>(f, r);
+    case Datatype::UINT32:
+      return get_tile_indexes_for_range<uint32_t>(f, r);
+    case Datatype::INT64:
+      return get_tile_indexes_for_range<int64_t>(f, r);
+    case Datatype::UINT64:
+      return get_tile_indexes_for_range<uint64_t>(f, r);
+    case Datatype::FLOAT32:
+      return get_tile_indexes_for_range<float>(f, r);
+    case Datatype::FLOAT64:
+      return get_tile_indexes_for_range<double>(f, r);
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return get_tile_indexes_for_range<int64_t>(f, r);
+    case Datatype::STRING_ASCII:
+      return get_tile_indexes_for_range<char>(f, r);
+    default:
+      throw OrderedDimLabelReaderStatusException("Invalid dimension type");
+  }
+}
+
+uint64_t OrderedDimLabelReader::label_tile_size(unsigned f, uint64_t t) const {
+  uint64_t tile_size = fragment_metadata_[f]->tile_size(label_name_, t);
+  if (label_var_size_) {
+    auto&& [st, size] = fragment_metadata_[f]->tile_var_size(label_name_, t);
+    throw_if_not_ok(st);
+    tile_size += *size;
+  }
+
+  return tile_size;
+}
+
+template <typename IndexType>
+bool OrderedDimLabelReader::tile_overwritten(
+    unsigned frag_idx,
+    uint64_t tile_idx,
+    const IndexType& domain_low,
+    const IndexType& tile_extent) const {
+  // Compute the first and last index for this tile.
+  IndexType tile_range[2]{
+      index_dim_->tile_coord_low(tile_idx, domain_low, tile_extent),
+      index_dim_->tile_coord_high(tile_idx, domain_low, tile_extent)};
+  Range r(tile_range, 2 * sizeof(IndexType));
+
+  // Use the non empty domains for all fragments to see if the tile is covered.
+  auto fragment_num = (unsigned)fragment_metadata_.size();
+  for (unsigned f = frag_idx + 1; f < fragment_num; ++f) {
+    if (index_dim_->covered(r, fragment_metadata_[f]->non_empty_domain()[0])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+template <typename IndexType>
+uint64_t OrderedDimLabelReader::create_result_tiles() {
+  auto timer_se = stats_->start_timer("create_result_tiles");
+
+  uint64_t max_range = 0;
+  uint64_t total_mem_used = 0;
+  const IndexType* dim_dom =
+      static_cast<const IndexType*>(index_dim_->domain().data());
+  auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
+
+  // Process ranges one by one.
+  for (uint64_t r = 0; r < ranges_.size(); r++) {
+    // Add tiles for each fragments.
+    for (unsigned f = 0; f < fragment_metadata_.size(); f++) {
+      // Add the tiles for the start/end range.
+      for (auto range_index : {RangeIndex::START, RangeIndex::END}) {
+        for (uint64_t i = range_tile_indexes_[r].min(range_index);
+             i <= range_tile_indexes_[r].max(range_index);
+             i++) {
+          if ((i >= domain_tile_idx_[f]) &&
+              (i < domain_tile_idx_[f] + fragment_metadata_[f]->tile_num()) &&
+              (result_tiles_[f].count(i) == 0)) {
+            // Make sure the tile can fit in the budget.
+            uint64_t frag_tile_idx = i - domain_tile_idx_[f];
+            uint64_t tile_size = label_tile_size(f, frag_tile_idx);
+            bool covered =
+                tile_overwritten<IndexType>(f, i, dim_dom[0], tile_extent);
+            if (covered || total_mem_used + tile_size < memory_budget_) {
+              total_mem_used += tile_size;
+              result_tiles_[f].emplace(
+                  std::piecewise_construct,
+                  std::forward_as_tuple(i),
+                  std::forward_as_tuple(
+                      f, frag_tile_idx, array_schema_, covered));
+            } else {
+              if (r == 0) {
+                throw OrderedDimLabelReaderStatusException(
+                    "Can't process a single range, increase memory budget");
+              }
+              return r;
+            }
+          }
+        }
+      }
+    }
+    max_range = r;
+  }
+
+  return max_range + 1;
+}
+
+template <typename IndexType, typename LabelType>
+LabelType OrderedDimLabelReader::get_value_at_fixed(
+    const IndexType& index,
+    const IndexType& domain_low,
+    const IndexType& tile_extent) {
+  // Start with the most recent fragment.
+  unsigned f = static_cast<unsigned>(fragment_metadata_.size() - 1);
+  while (true) {
+    const IndexType* non_empty_domain =
+        static_cast<const IndexType*>(non_empty_domains_[f]);
+    // If the value is in the non empty domain for the fragment, get it.
+    if (index >= non_empty_domain[0] && index <= non_empty_domain[1]) {
+      // Get the tile index in the current fragment.
+      auto tile_idx = index_dim_->tile_idx(index, domain_low, tile_extent);
+
+      // Get the cell index in the current tile.
+      auto index_in_tile =
+          index - index_dim_->tile_coord_low(tile_idx, domain_low, tile_extent);
+
+      // Finally get the data.
+      auto& rt = result_tiles_[f].at(tile_idx);
+      const auto label_data = rt.tile_tuple(label_name_)
+                                  ->fixed_tile()
+                                  .template data_as<LabelType>();
+      return label_data[index_in_tile];
+    }
+
+    // We should always find the value before the last fragment.
+    if (f == 0) {
+      throw OrderedDimLabelReaderStatusException("Couldn't find value");
+    }
+
+    // Try the next fragment.
+    f--;
+  }
+}
+
+template <typename IndexType, typename LabelType, typename Op>
+IndexType OrderedDimLabelReader::search_for_range_fixed(
+    uint64_t r,
+    RangeIndex range_index,
+    const IndexType& domain_low,
+    const IndexType& tile_extent) {
+  // Get the value we are looking for.
+  LabelType value;
+  if (range_index == RangeIndex::START) {
+    value = *static_cast<const LabelType*>(ranges_[r].start_fixed());
+  } else {
+    value = *static_cast<const LabelType*>(ranges_[r].end_fixed());
+  }
+
+  // Minimum index to look into.
+  auto non_empty_domain =
+      static_cast<const IndexType*>(non_empty_domain_.data());
+  auto t_min = range_tile_indexes_[r].min(range_index);
+  auto left = std::max(
+      index_dim_->tile_coord_low(t_min, domain_low, tile_extent),
+      non_empty_domain[0]);
+
+  // Maximum index to look into.
+  auto t_max = range_tile_indexes_[r].max(range_index);
+  auto right = std::min(
+      index_dim_->tile_coord_high(t_max, domain_low, tile_extent),
+      non_empty_domain[1]);
+
+  // Run a binary search.
+  Op cmp;
+  while (left != right - 1) {
+    // Check against mid.
+    IndexType mid = left + (right - left) / 2;
+    if (cmp(get_value_at_fixed<IndexType, LabelType>(
+                mid, domain_low, tile_extent),
+            value)) {
+      right = mid;
+    } else {
+      left = mid;
+    }
+  }
+
+  // Do one last comparison to decide to return left or right.
+  if (range_index == RangeIndex::START) {
+    return (
+               cmp(get_value_at_fixed<IndexType, LabelType>(
+                       left, domain_low, tile_extent),
+                   value)) ?
+               left :
+               right;
+  } else {
+    return (
+               cmp(get_value_at_fixed<IndexType, LabelType>(
+                       right, domain_low, tile_extent),
+                   value)) ?
+               left :
+               right;
+  }
+}
+
+template <typename IndexType, typename LabelType>
+void OrderedDimLabelReader::compute_range_indexes_fixed(
+    IndexType* dest, uint64_t r) {
+  // For easy reference.
+  auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
+  const IndexType* dim_dom =
+      static_cast<const IndexType*>(index_dim_->domain().data());
+
+  // Set the results.
+  if (increasing_labels_) {
+    dest[0] = search_for_range_fixed<
+        IndexType,
+        LabelType,
+        std::greater_equal<LabelType>>(
+        r, RangeIndex::START, dim_dom[0], tile_extent);
+    dest[1] =
+        search_for_range_fixed<IndexType, LabelType, std::greater<LabelType>>(
+            r, RangeIndex::END, dim_dom[0], tile_extent);
+  } else {
+    dest[0] = search_for_range_fixed<
+        IndexType,
+        LabelType,
+        std::less_equal<LabelType>>(
+        r, RangeIndex::START, dim_dom[0], tile_extent);
+    dest[1] =
+        search_for_range_fixed<IndexType, LabelType, std::less<LabelType>>(
+            r, RangeIndex::END, dim_dom[0], tile_extent);
+  }
+}
+
+template <typename IndexType>
+void OrderedDimLabelReader::copy_range_indexes_fixed(
+    uint64_t buffer_offset, uint64_t r) {
+  auto timer_se = stats_->start_timer("copy_range_indexes_fixed");
+
+  auto dest = static_cast<IndexType*>(buffers_[index_dim_->name()].buffer_) +
+              (buffer_offset + r) * 2;
+  switch (label_type_) {
+    case Datatype::INT8:
+      compute_range_indexes_fixed<IndexType, int8_t>(dest, r);
+      break;
+    case Datatype::UINT8:
+      compute_range_indexes_fixed<IndexType, uint8_t>(dest, r);
+      break;
+    case Datatype::INT16:
+      compute_range_indexes_fixed<IndexType, int16_t>(dest, r);
+      break;
+    case Datatype::UINT16:
+      compute_range_indexes_fixed<IndexType, uint16_t>(dest, r);
+      break;
+    case Datatype::INT32:
+      compute_range_indexes_fixed<IndexType, int32_t>(dest, r);
+      break;
+    case Datatype::UINT32:
+      compute_range_indexes_fixed<IndexType, uint32_t>(dest, r);
+      break;
+    case Datatype::INT64:
+      compute_range_indexes_fixed<IndexType, int64_t>(dest, r);
+      break;
+    case Datatype::UINT64:
+      compute_range_indexes_fixed<IndexType, uint64_t>(dest, r);
+      break;
+    case Datatype::FLOAT32:
+      compute_range_indexes_fixed<IndexType, float>(dest, r);
+      break;
+    case Datatype::FLOAT64:
+      compute_range_indexes_fixed<IndexType, double>(dest, r);
+      break;
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      compute_range_indexes_fixed<IndexType, int64_t>(dest, r);
+      break;
+    default:
+      throw OrderedDimLabelReaderStatusException("Invalid dimension type");
+  }
+}
+
+template <typename IndexType>
+std::string_view OrderedDimLabelReader::get_value_at_var(
+    const IndexType& index,
+    const IndexType& domain_low,
+    const IndexType& tile_extent) {
+  // Start with the most recent fragment.
+  unsigned f = static_cast<unsigned>(fragment_metadata_.size() - 1);
+  while (true) {
+    const IndexType* non_empty_domain =
+        static_cast<const IndexType*>(non_empty_domains_[f]);
+    // If the value is in the non empty domain for the fragment, get it.
+    if (index >= non_empty_domain[0] && index <= non_empty_domain[1]) {
+      // Get the tile index in the current fragment.
+      auto tile_idx = index_dim_->tile_idx(index, domain_low, tile_extent);
+
+      // Get the cell index in the current tile.
+      auto index_in_tile =
+          index - index_dim_->tile_coord_low(tile_idx, domain_low, tile_extent);
+
+      // Finally get the data.
+      auto& rt = result_tiles_[f][tile_idx];
+      auto tile_tuple = rt.tile_tuple(label_name_);
+      auto offsets_data = tile_tuple->fixed_tile().template data_as<uint64_t>();
+      auto& var_tile = tile_tuple->var_tile();
+      auto offset = offsets_data[index_in_tile];
+
+      auto size = static_cast<size_t>(index_in_tile) == rt.cell_num() - 1 ?
+                      var_tile.size() - offset :
+                      offsets_data[index_in_tile + 1] - offset;
+      return std::string_view(&var_tile.template data_as<char>()[offset], size);
+    }
+
+    // We should always find the value before the last fragment.
+    if (f == 0) {
+      throw OrderedDimLabelReaderStatusException("Couldn't find value");
+    }
+
+    // Try the next fragment.
+    f--;
+  }
+}
+
+template <typename IndexType, typename Op>
+IndexType OrderedDimLabelReader::search_for_range_var(
+    uint64_t r,
+    RangeIndex range_index,
+    const IndexType& domain_low,
+    const IndexType& tile_extent) {
+  // Get the value we are looking for.
+  std::string_view value;
+  if (range_index == RangeIndex::START) {
+    value = ranges_[r].start_str();
+  } else {
+    value = ranges_[r].end_str();
+  }
+
+  // Minimum index to look into.
+  auto non_empty_domain =
+      static_cast<const IndexType*>(non_empty_domain_.data());
+  auto t_min = range_tile_indexes_[r].min(range_index);
+  auto left = std::max(
+      index_dim_->tile_coord_low(t_min, domain_low, tile_extent),
+      non_empty_domain[0]);
+
+  // Maximum index to look into.
+  auto t_max = range_tile_indexes_[r].max(range_index);
+  auto right = std::min(
+      index_dim_->tile_coord_high(t_max, domain_low, tile_extent),
+      non_empty_domain[1]);
+
+  // Run a binary search.
+  Op cmp;
+  while (left != right - 1) {
+    // Check against mid.
+    IndexType mid = left + (right - left) / 2;
+    if (cmp(get_value_at_var(mid, domain_low, tile_extent), value)) {
+      right = mid;
+    } else {
+      left = mid;
+    }
+  }
+
+  // Do one last comparison to decide to return left or right.
+  if (range_index == RangeIndex::START) {
+    return (cmp(get_value_at_var(left, domain_low, tile_extent), value)) ?
+               left :
+               right;
+  } else {
+    return (cmp(get_value_at_var(right, domain_low, tile_extent), value)) ?
+               left :
+               right;
+  }
+}
+
+template <typename IndexType>
+void OrderedDimLabelReader::copy_range_indexes_var(
+    uint64_t buffer_offset, uint64_t r) {
+  auto timer_se = stats_->start_timer("copy_range_indexes_var");
+
+  // For easy reference.
+  auto dest = static_cast<IndexType*>(buffers_[index_dim_->name()].buffer_) +
+              (buffer_offset + r) * 2;
+  auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
+  const IndexType* dim_dom =
+      static_cast<const IndexType*>(index_dim_->domain().data());
+
+  // Set the results.
+  if (increasing_labels_) {
+    dest[0] =
+        search_for_range_var<IndexType, std::greater_equal<std::string_view>>(
+            r, RangeIndex::START, dim_dom[0], tile_extent);
+    dest[1] = search_for_range_var<IndexType, std::greater<std::string_view>>(
+        r, RangeIndex::END, dim_dom[0], tile_extent);
+  } else {
+    dest[0] =
+        search_for_range_var<IndexType, std::less_equal<std::string_view>>(
+            r, RangeIndex::START, dim_dom[0], tile_extent);
+    dest[1] = search_for_range_var<IndexType, std::less<std::string_view>>(
+        r, RangeIndex::END, dim_dom[0], tile_extent);
+  }
+}
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -1,0 +1,533 @@
+/**
+ * @file   ordered_dim_label_reader.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class OrderedDimLabelReader.
+ */
+
+#ifndef TILEDB_ORDERED_DIM_LABEL_READER
+#define TILEDB_ORDERED_DIM_LABEL_READER
+
+#include <atomic>
+
+#include "tiledb/common/common.h"
+#include "tiledb/common/logger_public.h"
+#include "tiledb/common/status.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/query/iquery_strategy.h"
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/readers/reader_base.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class Array;
+class StorageManager;
+
+/** Processes dense read queries. */
+class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
+ public:
+  /** Enum to refer to start/end range by index. */
+  enum class RangeIndex : uint8_t {
+    START,
+    END,
+  };
+
+  /**
+   * Enum used to qualify the tile index found for a range. Tne index could be
+   * equal, meaning that the searched value was contained in the found tile
+   * index, greater than, meaning that the searched value should be found after
+   * the tile, or less than meaning the value should be found before the tile.
+   */
+  enum class IndexValueType : uint8_t {
+    EQUAL,
+    GT,
+    LT,
+  };
+
+  /**
+   * Class to store range data for a range inside of a particular fragment.
+   * This will store the index of the start value, with the index value type
+   * qualifier and the same for the end value.
+   */
+  class FragmentRangeTileIndexes {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+    FragmentRangeTileIndexes() = default;
+
+    FragmentRangeTileIndexes(
+        uint64_t start_idx,
+        IndexValueType start_value_type,
+        uint64_t end_idx,
+        IndexValueType end_value_type)
+        : indexes_({start_idx, end_idx})
+        , value_types_({start_value_type, end_value_type}) {
+    }
+
+    /* ********************************* */
+    /*                 API               */
+    /* ********************************* */
+
+    /** Returns the start tile index. */
+    inline uint64_t idx(RangeIndex range_index) {
+      return indexes_[static_cast<uint8_t>(range_index)];
+    }
+
+    /** Index value type for the start index. */
+    inline IndexValueType val_type(RangeIndex range_index) {
+      return value_types_[static_cast<uint8_t>(range_index)];
+    }
+
+   private:
+    /* ********************************* */
+    /*         PRIVATE ATTRIBUTES        */
+    /* ********************************* */
+
+    /** Stores the tile indexes. */
+    std::vector<uint64_t> indexes_;
+
+    /**
+     * Stores if the indexes values are an equal, greater than or less than
+     * values.
+     */
+    std::vector<IndexValueType> value_types_;
+  };
+
+  /**
+   * Class storing the min/max tile indexes required to find a specific values
+   * of a range. This contains the min/max for the start and end value of the
+   * range.
+   */
+  class RangeTileIndexes {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+    RangeTileIndexes() = default;
+
+    RangeTileIndexes(
+        uint64_t tile_idx_min,
+        uint64_t tile_idx_max,
+        std::vector<FragmentRangeTileIndexes>& fragment_range_tile_indexes) {
+      // Uses the values computed per fragments to compute the min/max.
+      std::vector<uint64_t> min = {std::numeric_limits<uint64_t>::max(),
+                                   std::numeric_limits<uint64_t>::max()};
+      std::vector<uint64_t> max = {std::numeric_limits<uint64_t>::min(),
+                                   std::numeric_limits<uint64_t>::min()};
+
+      // While processing the tiles that we know to possibly contain the
+      // searched values (IndexValueType::EQUAL), also compute the minimum
+      // and maximum values that we see that hint where we can find the values
+      // (IndexValueType::GT or IndexValueType::LT). When a searched value is
+      // contained between two tiles, that is all we will have to find the
+      // values.
+      std::vector<uint64_t> lt = {tile_idx_max, tile_idx_max};
+      std::vector<uint64_t> gt = {tile_idx_min, tile_idx_min};
+
+      // Go through all fragments.
+      for (unsigned f = 0; f < fragment_range_tile_indexes.size(); f++) {
+        for (auto range_index : {RangeIndex::START, RangeIndex::END}) {
+          auto ri = static_cast<uint8_t>(range_index);
+          auto idx = fragment_range_tile_indexes[f].idx(range_index);
+          auto val_type = fragment_range_tile_indexes[f].val_type(range_index);
+
+          // Expand the range of min/max when we see a tile that we know
+          // contains the value.
+          if (val_type == IndexValueType::EQUAL) {
+            min[ri] = std::min(idx, min[ri]);
+            max[ri] = std::max(idx, max[ri]);
+          } else if (val_type == IndexValueType::GT) {
+            // Save the last tile that we know to be greater then the start.
+            gt[ri] = std::max(idx, gt[ri]);
+          } else {
+            // Save the first tile that we know to be less than the start.
+            lt[ri] = std::min(idx, lt[ri]);
+          }
+
+          // No tiles had an equal value type, use the hints to set a min/max.
+          if (min[ri] == std::numeric_limits<uint64_t>::max()) {
+            min[ri] = gt[ri];
+            max[ri] = lt[ri];
+          }
+        }
+      }
+
+      range_tile_indexes_ = {{min[0], max[0]}, {min[1], max[1]}};
+    }
+
+    /* ********************************* */
+    /*                 API               */
+    /* ********************************* */
+
+    /** Returns the minimum tile index. */
+    inline uint64_t min(RangeIndex range_index) {
+      return range_tile_indexes_[static_cast<uint8_t>(range_index)].first;
+    }
+
+    /** Returns the maximum tile index. */
+    inline uint64_t max(RangeIndex range_index) {
+      return range_tile_indexes_[static_cast<uint8_t>(range_index)].second;
+    }
+
+   private:
+    /* ********************************* */
+    /*         PRIVATE ATTRIBUTES        */
+    /* ********************************* */
+
+    /**
+     * Tile indexes vector. Stores the start/end ranges as a pair of min/max.
+     */
+    std::vector<std::pair<uint64_t, uint64_t>> range_tile_indexes_;
+  };
+
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  OrderedDimLabelReader(
+      stats::Stats* stats,
+      shared_ptr<Logger> logger,
+      StorageManager* storage_manager,
+      Array* array,
+      Config& config,
+      std::unordered_map<std::string, QueryBuffer>& buffers,
+      Subarray& subarray,
+      Layout layout,
+      QueryCondition& condition,
+      bool increasing_order,
+      bool skip_checks_serialization);
+
+  /** Destructor. */
+  ~OrderedDimLabelReader() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(OrderedDimLabelReader);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(OrderedDimLabelReader);
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /** Finalizes the reader. */
+  Status finalize() {
+    return Status::Ok();
+  }
+
+  /**
+   * Returns `true` if the query was incomplete, i.e., if all subarray
+   * partitions in the read state have not been processed or there
+   * was some buffer overflow.
+   */
+  bool incomplete() const;
+
+  /** Returns the status details reason. */
+  QueryStatusDetailsReason status_incomplete_reason() const;
+
+  /** Initialize the memory budget variables. */
+  Status initialize_memory_budget();
+
+  /** Performs a read query using its set members. */
+  Status dowork();
+
+  /** Resets the reader object. */
+  void reset();
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** UID of the logger instance */
+  inline static std::atomic<uint64_t> logger_id_ = 0;
+
+  /** Ranges to be retreived for the attribute. */
+  std::vector<Range> ranges_;
+
+  /** Stores the label attribute name. */
+  std::string label_name_;
+
+  /** Stores the dimension label type. */
+  Datatype label_type_;
+
+  /** Stores if the dimension label is var sized. */
+  bool label_var_size_;
+
+  /** Are the labels increasing? */
+  bool increasing_labels_;
+
+  /** Stores a pointer to the index dimension. */
+  const Dimension* index_dim_;
+
+  /** Save pointers to the non empty domain for each fragments. */
+  std::vector<const void*> non_empty_domains_;
+
+  /** Non empty domain for the array. */
+  Range non_empty_domain_;
+
+  /** Minimum tile index in the full domain. */
+  uint64_t tile_idx_min_;
+
+  /** Maximum tile index in the full domain. */
+  uint64_t tile_idx_max_;
+
+  /**
+   * Per fragment map to hold the result tiles. The key for the maps is the
+   * tile index.
+   */
+  std::vector<std::unordered_map<uint64_t, OrderedDimLabelResultTile>>
+      result_tiles_;
+
+  /** Tile index (inside of the domain) of the first tile of each fragments.
+   */
+  std::vector<uint64_t> domain_tile_idx_;
+
+  /**
+   * Stores the tile indexes (min/max) that can potentially contain the label
+   * value for each range start/end.
+   */
+  std::vector<RangeTileIndexes> range_tile_indexes_;
+
+  /** Total memory budget. */
+  uint64_t memory_budget_;
+
+  /* ********************************* */
+  /*           PRIVATE METHODS         */
+  /* ********************************* */
+
+  /** Performs a read on an ordered label array. */
+  void label_read();
+
+  /**
+   * Performs a read on an ordered label array.
+   *
+   * @tparam The index type.
+   */
+  template <typename IndexType>
+  void label_read();
+
+  /**
+   * Compute the tile index (inside of the full domain) of the first tile of
+   * each fragments.
+   *
+   * @tparam The index type.
+   */
+  template <typename IndexType>
+  void compute_domain_tile_indexes();
+
+  /**
+   * Compute the tile indexes (min/max) that can potentially contain the label
+   * value for each range start/end.
+   *
+   * @tparam The index type.
+   */
+  template <typename IndexType>
+  void compute_range_tile_indexes();
+
+  /**
+   * Compute the non empty domain for the index dimension.
+   *
+   * @tparam The index type.
+   */
+  template <typename IndexType>
+  void compute_non_empty_domain();
+
+  /** Load the tile min max values for the index attribute. */
+  void load_label_min_max_values();
+
+  /**
+   * Template specialization of the 'get_tile_indexes_for_range' function.
+   *
+   * @tparam The label type.
+   * @param f Fragment to get the tile indexes for.
+   * @param r Range to get the tile indexes for.
+   *
+   * @return Pair of the min/max index ranges.
+   */
+  template <typename LabelType>
+  FragmentRangeTileIndexes get_tile_indexes_for_range(unsigned f, uint64_t r);
+
+  /**
+   * Get tile indexes (which tile should contain the desired range) for a
+   * specific range/fragment.
+   *
+   * @param f Fragment to get the tile indexes for.
+   * @param r Range to get the tile indexes for.
+   *
+   * @return FragmentRangeTileIndexes.
+   */
+  FragmentRangeTileIndexes get_tile_indexes_for_range(unsigned f, uint64_t r);
+
+  /**
+   * Returns the tile size of a particular label tile.
+   *
+   * @param f Fragment index.
+   * @param t Tile index.
+   * @return Tile size.
+   */
+  uint64_t label_tile_size(unsigned f, uint64_t t) const;
+
+  /**
+   * Returns if a particular tile is covered by a later fragment.
+   *
+   * @tparam Index type.
+   * @param frag_idx Fragment index.
+   * @param tile_idx Tile index.
+   * @param domain_low Lowest possible value for the index domain.
+   * @param tile_extent Tile extent.
+   * @return 'true' if the tile is covered by a later fragment.
+   */
+  template <typename IndexType>
+  bool tile_overwritten(
+      unsigned frag_idx,
+      uint64_t tile_idx,
+      const IndexType& domain_low,
+      const IndexType& tile_extent) const;
+
+  /**
+   * Creates the result tiles required to do the range to index search.
+   *
+   * @tparam Index type.
+   * @return Max range to process.
+   */
+  template <typename IndexType>
+  uint64_t create_result_tiles();
+
+  /**
+   * Get the fixed label value at a specific index.
+   *
+   * @tparam Index type.
+   * @tparam Label type.
+   * @param index Index value.
+   * @param domain_low Lowest possible value for the index domain.
+   * @param tile_extent Tile extent.
+   * @return Label value.
+   */
+  template <typename IndexType, typename LabelType>
+  LabelType get_value_at_fixed(
+      const IndexType& index,
+      const IndexType& domain_low,
+      const IndexType& tile_extent);
+
+  /**
+   * Search for a label defined in the specified range for fixed size labels.
+   *
+   * @tparam Index type.
+   * @tparam Label type.
+   * @tparam Op type (std::greater for increasing and std::less for
+   * decreasing).
+   * @param r Range to process.
+   * @param range_index Range index (start or end).
+   * @param domain_low Lowest possible value for the index domain.
+   * @param tile_extent Tile extent.
+   * @return Index for the searched label.
+   */
+  template <typename IndexType, typename LabelType, typename Op>
+  IndexType search_for_range_fixed(
+      uint64_t r,
+      RangeIndex range_index,
+      const IndexType& domain_low,
+      const IndexType& tile_extent);
+
+  /**
+   * Compute the indexes value for a fixed label range.
+   *
+   * @tparam Index type.
+   * @tparam Label type.
+   * @param dest Destination inside of the user buffers.
+   * @param r Range to compute indexes for.
+   */
+  template <typename IndexType, typename LabelType>
+  void compute_range_indexes_fixed(IndexType* dest, uint64_t r);
+
+  /**
+   * Compute and copy the range indexes for a specific range, for fixed size
+   * labels.
+   *
+   * @tparam Index type.
+   * @param buffer_offset Current offset into the user buffer.
+   * @param r Range index to compute/copy.
+   */
+  template <typename IndexType>
+  void copy_range_indexes_fixed(uint64_t buffer_offset, uint64_t r);
+
+  /**
+   * Get the var label value at a specific index.
+   *
+   * @tparam Index type.
+   * @tparam Label type.
+   * @param index Index value.
+   * @param domain_low Lowest possible value for the index domain.
+   * @param tile_extent Tile extent.
+   * @return Label value.
+   */
+  template <typename IndexType>
+  std::string_view get_value_at_var(
+      const IndexType& index,
+      const IndexType& domain_low,
+      const IndexType& tile_extent);
+
+  /**
+   * Search for a label defined in the specified range for var size labels.
+   *
+   * @tparam Index type.
+   * @tparam Op type (std::greater for increasing and std::less for
+   * decreasing).
+   * @param r Range to process.
+   * @param range_index Range index (start or end).
+   * @param domain_low Lowest possible value for the index domain.
+   * @param tile_extent Tile extent.
+   * @return Index for the searched label.
+   */
+  template <typename IndexType, typename Op>
+  IndexType search_for_range_var(
+      uint64_t r,
+      RangeIndex range_index,
+      const IndexType& domain_low,
+      const IndexType& tile_extent);
+
+  /**
+   * Compute and copy the range indexes for a specific range, for var size
+   * labels.
+   *
+   * @tparam Index type.
+   * @param buffer_offset Current offset into the user buffer.
+   * @param r Range index to compute/copy.
+   */
+  template <typename IndexType>
+  void copy_range_indexes_var(uint64_t buffer_offset, uint64_t r);
+};  // namespace sm
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_ORDERED_DIM_LABEL_READER

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -307,7 +307,8 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   std::vector<std::unordered_map<uint64_t, OrderedDimLabelResultTile>>
       result_tiles_;
 
-  /** Tile index (inside of the domain) of the first tile of each fragments.
+  /**
+   * Tile index (inside of the domain) of the first tile of each fragments.
    */
   std::vector<uint64_t> domain_tile_idx_;
 
@@ -336,30 +337,26 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   void label_read();
 
   /**
-   * Compute the tile index (inside of the full domain) of the first tile of
-   * each fragments.
-   *
-   * @tparam The index type.
-   */
-  template <typename IndexType>
-  void compute_domain_tile_indexes();
-
-  /**
-   * Compute the tile indexes (min/max) that can potentially contain the label
-   * value for each range start/end.
-   *
-   * @tparam The index type.
-   */
-  template <typename IndexType>
-  void compute_range_tile_indexes();
-
-  /**
-   * Compute the non empty domain for the index dimension.
+   * Compute the non empty domain for the index dimension. Also caches the non
+   * empty domain of each fragments for future use and saves the non empty
+   * domain in tile indexes in `tile_idx_min_` and `tile_idx_max_`.
    *
    * @tparam The index type.
    */
   template <typename IndexType>
   void compute_non_empty_domain();
+
+  /**
+   * Compute the tile index (inside of the full dimension domain) of the first
+   * tile of each fragments.
+   *
+   * Also compute the tile indexes (min/max) that can potentially contain the
+   * label value for each range start/end.
+   *
+   * @tparam The index type.
+   */
+  template <typename IndexType>
+  void compute_tile_indexes();
 
   /** Load the tile min max values for the index attribute. */
   void load_label_min_max_values();
@@ -467,7 +464,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    * @param r Range to compute indexes for.
    */
   template <typename IndexType, typename LabelType>
-  void compute_range_indexes_fixed(IndexType* dest, uint64_t r);
+  void compute_and_copy_range_indexes_fixed(IndexType* dest, uint64_t r);
 
   /**
    * Compute and copy the range indexes for a specific range, for fixed size
@@ -478,7 +475,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    * @param r Range index to compute/copy.
    */
   template <typename IndexType>
-  void copy_range_indexes_fixed(uint64_t buffer_offset, uint64_t r);
+  void compute_and_copy_range_indexes_fixed(uint64_t buffer_offset, uint64_t r);
 
   /**
    * Get the var label value at a specific index.
@@ -524,8 +521,8 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    * @param r Range index to compute/copy.
    */
   template <typename IndexType>
-  void copy_range_indexes_var(uint64_t buffer_offset, uint64_t r);
-};  // namespace sm
+  void compute_and_copy_range_indexes_var(uint64_t buffer_offset, uint64_t r);
+};
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -108,13 +108,13 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
     /* ********************************* */
 
     /** Stores the tile indexes. */
-    std::vector<uint64_t> indexes_;
+    std::array<uint64_t, 2> indexes_;
 
     /**
      * Stores if the indexes values are an equal, greater than or less than
      * values.
      */
-    std::vector<IndexValueType> value_types_;
+    std::array<IndexValueType, 2> value_types_;
   };
 
   /**
@@ -305,7 +305,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   /**
    * Tile index (inside of the domain) of the first tile of each fragments.
    */
-  std::vector<uint64_t> domain_tile_idx_;
+  std::vector<uint64_t> array_tile_idx_per_frag_;
 
   /**
    * Stores the tile indexes (min/max) that can potentially contain the label

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -299,8 +299,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    * Per fragment map to hold the result tiles. The key for the maps is the
    * tile index.
    */
-  std::vector<std::unordered_map<uint64_t, OrderedDimLabelResultTile>>
-      result_tiles_;
+  std::vector<std::unordered_map<uint64_t, ResultTile>> result_tiles_;
 
   /**
    * Tile index (inside of the domain) of the first tile of each fragments.
@@ -411,7 +410,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    * Creates the result tiles required to do the range to index search.
    *
    * @tparam Index type.
-   * @return Max range to process.
+   * @return Max range result tiles were processed for.
    */
   template <typename IndexType>
   uint64_t create_result_tiles();

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -1045,6 +1045,62 @@ class UnorderedWithDupsResultTile : public ResultTileWithBitmap<BitmapType> {
   }
 };
 
+/** Result tile used for ordered dimension labels. */
+class OrderedDimLabelResultTile : public ResultTile {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  OrderedDimLabelResultTile() = default;
+
+  OrderedDimLabelResultTile(
+      unsigned frag_idx,
+      uint64_t tile_idx,
+      const ArraySchema& array_schema,
+      const bool covered)
+      : ResultTile(frag_idx, tile_idx, array_schema)
+      , covered_(covered) {
+  }
+
+  /** Move constructor. */
+  OrderedDimLabelResultTile(OrderedDimLabelResultTile&& other) noexcept {
+    // Swap with the argument
+    swap(other);
+  }
+
+  /** Move-assign operator. */
+  OrderedDimLabelResultTile& operator=(OrderedDimLabelResultTile&& other) {
+    // Swap with the argument
+    swap(other);
+
+    return *this;
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(OrderedDimLabelResultTile);
+
+  /* ********************************* */
+  /*          PUBLIC METHODS           */
+  /* ********************************* */
+
+  /** Returns true if the tile is covered by another in a later fragment. */
+  inline bool covered() {
+    return covered_;
+  }
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(OrderedDimLabelResultTile& tile) {
+    ResultTile::swap(tile);
+    std::swap(covered_, tile.covered_);
+  }
+
+ private:
+  /* ********************************* */
+  /*        PRIVATE ATTRIBUTES         */
+  /* ********************************* */
+  /** Is the tile is covered by another in a later fragment? */
+  bool covered_;
+};
+
 }  // namespace sm
 }  // namespace tiledb
 

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -1045,62 +1045,6 @@ class UnorderedWithDupsResultTile : public ResultTileWithBitmap<BitmapType> {
   }
 };
 
-/** Result tile used for ordered dimension labels. */
-class OrderedDimLabelResultTile : public ResultTile {
- public:
-  /* ********************************* */
-  /*     CONSTRUCTORS & DESTRUCTORS    */
-  /* ********************************* */
-  OrderedDimLabelResultTile() = default;
-
-  OrderedDimLabelResultTile(
-      unsigned frag_idx,
-      uint64_t tile_idx,
-      const ArraySchema& array_schema,
-      const bool covered)
-      : ResultTile(frag_idx, tile_idx, array_schema)
-      , covered_(covered) {
-  }
-
-  /** Move constructor. */
-  OrderedDimLabelResultTile(OrderedDimLabelResultTile&& other) noexcept {
-    // Swap with the argument
-    swap(other);
-  }
-
-  /** Move-assign operator. */
-  OrderedDimLabelResultTile& operator=(OrderedDimLabelResultTile&& other) {
-    // Swap with the argument
-    swap(other);
-
-    return *this;
-  }
-
-  DISABLE_COPY_AND_COPY_ASSIGN(OrderedDimLabelResultTile);
-
-  /* ********************************* */
-  /*          PUBLIC METHODS           */
-  /* ********************************* */
-
-  /** Returns true if the tile is covered by another in a later fragment. */
-  inline bool covered() {
-    return covered_;
-  }
-
-  /** Swaps the contents (all field values) of this tile with the given tile. */
-  void swap(OrderedDimLabelResultTile& tile) {
-    ResultTile::swap(tile);
-    std::swap(covered_, tile.covered_);
-  }
-
- private:
-  /* ********************************* */
-  /*        PRIVATE ATTRIBUTES         */
-  /* ********************************* */
-  /** Is the tile is covered by another in a later fragment? */
-  bool covered_;
-};
-
 }  // namespace sm
 }  // namespace tiledb
 


### PR DESCRIPTION
This adds the reader for converting dimension label ranges to indexes for ordered dimension labels. The ranges are set on the attribute using the internal `set_attribute_ranges` API. The reader uses the fact that the labels are ordered to select the tiles to read using the min/max values for the label attribute. It can then determine which tile ranges (in the index domain) to load. Once the tiles are loaded in memory, it runs a binary search for the index that is contained by the specified ranges.

---
TYPE: IMPROVEMENT
DESC: Dimension labels: Adding ordered dimension label reader.
