### PR TITLE
Use `BCRYPT_USE_SYSTEM_PREFERRED_RNG` in `Win32CNG::get_random_bytes`.

### DIFF
--- a/tiledb/sm/crypto/crypto_win32.cc
+++ b/tiledb/sm/crypto/crypto_win32.cc
@@ -51,20 +51,11 @@ Status Win32CNG::get_random_bytes(unsigned num_bytes, Buffer* output) {
   if (output->free_space() < num_bytes)
     RETURN_NOT_OK(output->realloc(output->alloced_size() + num_bytes));
 
-  BCRYPT_ALG_HANDLE alg_handle;
-  if (!NT_SUCCESS(BCryptOpenAlgorithmProvider(
-          &alg_handle, BCRYPT_RNG_ALGORITHM, nullptr, 0)))
-    return Status_EncryptionError(
-        "Win32CNG error; generating random bytes: error opening algorithm.");
-
   if (!NT_SUCCESS(BCryptGenRandom(
-          alg_handle, (unsigned char*)output->cur_data(), num_bytes, 0))) {
-    BCryptCloseAlgorithmProvider(alg_handle, 0);
+          nullptr, (unsigned char*)output->cur_data(), num_bytes, BCRYPT_USE_SYSTEM_PREFERRED_RNG))) {
     return Status_EncryptionError(
         "Win32CNG error; generating random bytes: error generating bytes.");
   }
-
-  BCryptCloseAlgorithmProvider(alg_handle, 0);
 
   output->advance_size(num_bytes);
   output->advance_offset(num_bytes);


### PR DESCRIPTION
I found this while browsing TileDB's sources. The [`BCryptGenRandom`](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom) function has this flag which allows us to avoid allocating a provider object and just pass null to this parameter.

---
TYPE: IMPROVEMENT
DESC: Use `BCRYPT_USE_SYSTEM_PREFERRED_RNG` in `Win32CNG::get_random_bytes`, saving one CNG provider allocation.
