### PR TITLE
Array Metadata related refactoring, use Serializer/Deserializer instead of Buffer

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1190,8 +1190,8 @@ Status Array::load_metadata() {
         array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
   } else {
     assert(array_dir_.loaded());
-    RETURN_NOT_OK(storage_manager_->load_array_metadata(
-        array_dir_, *encryption_key_, &metadata_));
+    storage_manager_->load_array_metadata(
+        array_dir_, *encryption_key_, &metadata_);
   }
   metadata_loaded_ = true;
   return Status::Ok();

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -872,8 +872,8 @@ Status Group::load_metadata() {
     RETURN_NOT_OK(rest_client->post_group_metadata_from_rest(group_uri_, this));
   } else {
     assert(group_dir_->loaded());
-    RETURN_NOT_OK(storage_manager_->load_group_metadata(
-        group_dir_, *encryption_key_, &metadata_));
+    storage_manager_->load_group_metadata(
+        group_dir_, *encryption_key_, &metadata_);
   }
   metadata_loaded_ = true;
   return Status::Ok();

--- a/tiledb/sm/metadata/CMakeLists.txt
+++ b/tiledb/sm/metadata/CMakeLists.txt
@@ -50,6 +50,8 @@ if (TILEDB_TESTS)
     find_package(Catch_EP REQUIRED)
     target_link_libraries(unit_metadata PUBLIC Catch2::Catch2)
 
+    target_link_libraries(unit_metadata PRIVATE tile)
+
     # Sources for tests
     target_sources(unit_metadata PUBLIC test/main.cc test/unit_metadata.cc)
 

--- a/tiledb/sm/metadata/CMakeLists.txt
+++ b/tiledb/sm/metadata/CMakeLists.txt
@@ -49,7 +49,6 @@ if (TILEDB_TESTS)
     target_link_libraries(unit_metadata PRIVATE metadata)
     find_package(Catch_EP REQUIRED)
     target_link_libraries(unit_metadata PUBLIC Catch2::Catch2)
-
     target_link_libraries(unit_metadata PRIVATE tile)
 
     # Sources for tests

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -126,7 +126,6 @@ class Metadata {
       const std::vector<shared_ptr<Tile>>& metadata_tiles);
 
   /** Serializes all key-value metadata items into the input buffer. */
-  // Status serialize(Buffer* buff) const;
   void serialize(Serializer& serializer) const;
 
   /** Returns the timestamp range. */
@@ -212,7 +211,7 @@ class Metadata {
    * Sets the URIs of the metadata files that have been loaded
    * to this object.
    */
-  Status set_loaded_metadata_uris(
+  void set_loaded_metadata_uris(
       const std::vector<TimestampedURI>& loaded_metadata_uris);
 
   /**

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -42,6 +42,8 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/tile/tile.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 using namespace tiledb::common;
 
@@ -121,10 +123,11 @@ class Metadata {
    * deleted or overwritten metadata items considering the order.
    */
   static Metadata deserialize(
-      const std::vector<shared_ptr<Buffer>>& metadata_buffs);
+      const std::vector<shared_ptr<Tile>>& metadata_tiles);
 
   /** Serializes all key-value metadata items into the input buffer. */
-  Status serialize(Buffer* buff) const;
+  // Status serialize(Buffer* buff) const;
+  void serialize(Serializer& serializer) const;
 
   /** Returns the timestamp range. */
   const std::pair<uint64_t, uint64_t>& timestamp_range() const;

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -51,63 +51,60 @@ inline T& buffer_metadata(void* p) {
 
 TEST_CASE(
     "Metadata: Test metadata deserialization", "[metadata][deserialization]") {
-  std::vector<shared_ptr<Buffer>> metadata_buffs;
+  std::vector<shared_ptr<Tile>> metadata_tiles;
+
+  Metadata metadata_to_serialize1, metadata_to_serialize2,
+      metadata_to_serialize3;
 
   // key_1:a, value_1:100,200
   std::string key_1 = "key1";
-  auto key_1_size = static_cast<uint32_t>(key_1.size());
   std::vector<int> value_1_vector{100, 200};
 
   // key_2:key_2, value_2:1.1(double)
   std::string key_2 = "key2";
-  uint32_t key_2_size = static_cast<uint32_t>(key_2.size());
   uint32_t value_2_size = 1;
   double value_2 = 1.0;
 
   // key_3:key_3, value_3:strmetadata
   std::string key_3 = "key3";
-  uint32_t key_3_size = static_cast<uint32_t>(key_2.size());
   std::string value_3 = "strmetadata";
   uint32_t value_3_size = static_cast<uint32_t>(value_3.size());
 
-  char serialized_buffer_1[22];
-  char* p_1 = &serialized_buffer_1[0];
-  // set key_1:value_1 integer metadata
-  buffer_metadata<uint32_t, 0>(p_1) = static_cast<uint32_t>(key_1.size());
-  std::memcpy(&buffer_metadata<char, 4>(p_1), key_1.c_str(), key_1_size);
-  buffer_metadata<char, 8>(p_1) = 0;
-  buffer_metadata<char, 9>(p_1) = static_cast<char>(Datatype::INT32);
-  buffer_metadata<uint32_t, 10>(p_1) = (uint32_t)value_1_vector.size();
-  buffer_metadata<int32_t, 14>(p_1) = value_1_vector[0];
-  buffer_metadata<int32_t, 18>(p_1) = value_1_vector[1];
-  metadata_buffs.push_back(make_shared<Buffer>(
-      HERE(), &serialized_buffer_1, sizeof(serialized_buffer_1)));
+  metadata_to_serialize1.put(
+      key_1.c_str(), Datatype::INT32, 2, value_1_vector.data());
 
-  char serialized_buffer_2[22];
-  char* p_2 = &serialized_buffer_2[0];
-  // set key_2:value_2 double metadata
-  buffer_metadata<uint32_t, 0>(p_2) = static_cast<uint32_t>(key_2.size());
-  std::memcpy(&buffer_metadata<char, 4>(p_2), key_2.c_str(), key_2_size);
-  buffer_metadata<char, 8>(p_2) = 0;
-  buffer_metadata<char, 9>(p_2) = (char)Datatype::FLOAT64;
-  buffer_metadata<uint32_t, 10>(p_2) = value_2_size;
-  buffer_metadata<double, 14>(p_2) = value_2;
-  metadata_buffs.push_back(make_shared<Buffer>(
-      HERE(), &serialized_buffer_2, sizeof(serialized_buffer_2)));
+  SizeComputationSerializer size_computation_serializer1;
+  metadata_to_serialize1.serialize(size_computation_serializer1);
+  Tile tile1{Tile::from_generic(size_computation_serializer1.size())};
 
-  char serialized_buffer_3[25];
-  char* p_3 = &serialized_buffer_3[0];
-  // set key_3:value_3 string metadata
-  buffer_metadata<uint32_t, 0>(p_3) = static_cast<uint32_t>(key_3.size());
-  std::memcpy(&buffer_metadata<char, 4>(p_3), key_3.c_str(), key_3_size);
-  buffer_metadata<char, 8>(p_3) = 0;
-  buffer_metadata<char, 9>(p_3) = (char)Datatype::STRING_ASCII;
-  buffer_metadata<uint32_t, 10>(p_3) = value_3_size;
-  std::memcpy(&buffer_metadata<char, 14>(p_3), value_3.c_str(), value_3_size);
-  metadata_buffs.push_back(make_shared<Buffer>(
-      HERE(), &serialized_buffer_3, sizeof(serialized_buffer_3)));
+  Serializer serializer1(tile1.data(), tile1.size());
+  metadata_to_serialize1.serialize(serializer1);
 
-  auto meta{Metadata::deserialize(metadata_buffs)};
+  metadata_to_serialize2.put(key_2.c_str(), Datatype::FLOAT64, 1, &value_2);
+
+  SizeComputationSerializer size_computation_serializer2;
+  metadata_to_serialize2.serialize(size_computation_serializer2);
+  Tile tile2{Tile::from_generic(size_computation_serializer2.size())};
+
+  Serializer serializer2(tile2.data(), tile2.size());
+  metadata_to_serialize2.serialize(serializer2);
+
+  metadata_to_serialize3.put(
+      key_3.c_str(), Datatype::STRING_ASCII, value_3_size, value_3.data());
+
+  SizeComputationSerializer size_computation_serializer3;
+  metadata_to_serialize3.serialize(size_computation_serializer3);
+  Tile tile3{Tile::from_generic(size_computation_serializer3.size())};
+
+  Serializer serializer3(tile3.data(), tile3.size());
+  metadata_to_serialize3.serialize(serializer3);
+
+  metadata_tiles.resize(3);
+  metadata_tiles[0] = tdb::make_shared<Tile>(HERE(), std::move(tile1));
+  metadata_tiles[1] = tdb::make_shared<Tile>(HERE(), std::move(tile2));
+  metadata_tiles[2] = tdb::make_shared<Tile>(HERE(), std::move(tile3));
+
+  auto meta{Metadata::deserialize(metadata_tiles)};
 
   Datatype type;
   uint32_t v_num;

--- a/tiledb/sm/storage_manager/storage_manager.h
+++ b/tiledb/sm/storage_manager/storage_manager.h
@@ -186,7 +186,7 @@ class StorageManager {
    * Loads the group metadata from persistent storage based on
    * the input URI manager.
    */
-  Status load_group_metadata(
+  void load_group_metadata(
       const tdb_shared_ptr<GroupDirectory>& group_dir,
       const EncryptionKey& encryption_key,
       Metadata* metadata);
@@ -799,7 +799,7 @@ class StorageManager {
    * Loads the array metadata from persistent storage based on
    * the input URI manager.
    */
-  Status load_array_metadata(
+  void load_array_metadata(
       const ArrayDirectory& array_dir,
       const EncryptionKey& encryption_key,
       Metadata* metadata);

--- a/tiledb/storage_format/serialization/serializers.h
+++ b/tiledb/storage_format/serialization/serializers.h
@@ -189,7 +189,7 @@ class Deserializer {
    *
    * @return remaining unread bytes in deserializer.
    */
-  storage_size_t remaining_bytes() {
+  storage_size_t remaining_bytes() const {
     return size_;
   }
 

--- a/tiledb/storage_format/serialization/serializers.h
+++ b/tiledb/storage_format/serialization/serializers.h
@@ -185,6 +185,15 @@ class Deserializer {
   }
 
   /**
+   * Return remaining number of bytes to deserialize.
+   *
+   * @return remaining unread bytes in deserializer.
+   */
+  storage_size_t remaining_bytes() {
+    return size_;
+  }
+
+  /**
    * Return a pointer to serialized data.
    *
    * @tparam T Type of the data.


### PR DESCRIPTION
replace Buffer usage with Serializer/Deserializer in items StorageManager::store_metadata, StorageManager::load_array_metadata and related

---
TYPE: IMPROVEMENT
DESC: Array Metadata related refactoring, use Serializer/Deserializer instead of Buffer
