### PR TITLE
Do not allow creation of sparse array with zero capacity.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ doc/source/_sidebar.rst.inc
 doc/source/gensidebar.pyc
 examples/cmake_project/build
 CMakeUserPresets.json
+.vs/
 
 # Quarto dev-cache
 /.quarto/

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1070,6 +1070,23 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     ArraySchemaFx,
+    "C API: Test sparse array schema with invalid capacity",
+    "[capi][array-schema]") {
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  int rc = tiledb_array_schema_alloc(ctx_, TILEDB_SPARSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check that zero capacity fails
+  rc = tiledb_array_schema_set_capacity(ctx_, array_schema, 0);
+  REQUIRE(rc == TILEDB_ERR);
+
+  // Clean up
+  tiledb_array_schema_free(&array_schema);
+}
+
+TEST_CASE_METHOD(
+    ArraySchemaFx,
     "C API: Test array schema with invalid dimension domain and tile extent",
     "[capi][array-schema]") {
   // Domain range exceeds type range - error

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -946,8 +946,13 @@ void ArraySchema::set_name(const std::string& name) {
   name_ = name;
 }
 
-void ArraySchema::set_capacity(uint64_t capacity) {
+Status ArraySchema::set_capacity(uint64_t capacity) {
+  if (array_type_ == ArrayType::SPARSE && capacity == 0)
+    return LOG_STATUS(Status_ArraySchemaError(
+        "Sparse arrays cannot have their capacity equal to zero."));
+
   capacity_ = capacity;
+  return Status::Ok();
 }
 
 Status ArraySchema::set_coords_filter_pipeline(const FilterPipeline* pipeline) {

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -138,6 +138,11 @@ ArraySchema::ArraySchema(
     dim_map_[dim->name()] = dim;
   }
 
+  if (array_type_ == ArrayType::SPARSE && capacity_ == 0)
+    throw StatusException(
+        Status_ArraySchemaError("Array schema check failed; Sparse arrays "
+                                "cannot have their capacity equal to zero."));
+
   // Create attribute map
   if (!attributes_.empty()) {
     for (auto attr_iter : attributes_) {

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -396,7 +396,7 @@ class ArraySchema {
   Status set_coords_filter_pipeline(const FilterPipeline* pipeline);
 
   /** Sets the tile capacity. */
-  void set_capacity(uint64_t capacity);
+  Status set_capacity(uint64_t capacity);
 
   /** Sets the cell order. */
   Status set_cell_order(Layout cell_order);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1728,7 +1728,10 @@ int32_t tiledb_array_schema_set_capacity(
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, array_schema) == TILEDB_ERR)
     return TILEDB_ERR;
-  array_schema->array_schema_->set_capacity(capacity);
+  if (SAVE_ERROR_CATCH(
+          ctx,
+          array_schema->array_schema_->set_capacity(capacity)))
+    return TILEDB_ERR;
   return TILEDB_OK;
 }
 


### PR DESCRIPTION
This PR adds validation in the `ArraySchema` class, ensuring that if it describes a sparse array the capacity cannot be zero.

[SC-22089](https://app.shortcut.com/tiledb-inc/story/22089/do-not-allow-creation-of-sparse-array-with-zero-capacity)

---
TYPE: BUG
DESC: Do not allow creation of sparse array with zero capacity.