### PR TITLE
add c_api tiledb_group_get_is_relative_uri_by_name()

### DIFF
--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -538,16 +538,16 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
 
   rc =
-      tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, nullptr);
+      tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
   REQUIRE(rc == TILEDB_OK);
   rc =
-      tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, nullptr);
+      tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "two");
   REQUIRE(rc == TILEDB_OK);
   rc =
-      tiledb_group_add_member(ctx_, group2, array3_uri.c_str(), false, nullptr);
+      tiledb_group_add_member(ctx_, group2, array3_uri.c_str(), false, "three");
   REQUIRE(rc == TILEDB_OK);
   rc =
-      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, nullptr);
+      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, "four");
   REQUIRE(rc == TILEDB_OK);
 
   // Close group from write mode
@@ -562,6 +562,27 @@ TEST_CASE_METHOD(
 
   rc = tiledb_group_open(ctx_, group2, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
+
+  uint8_t is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group1, "one", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 0);
+  is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group1, "two", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 0);
+  is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group2, "three", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 0);
+  is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group1, "four", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 0);
 
   std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group1_received =
       read_group(group1);
@@ -795,16 +816,16 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
 
   rc = tiledb_group_add_member(
-      ctx_, group1, array1_relative_uri.c_str(), true, nullptr);
+      ctx_, group1, array1_relative_uri.c_str(), true, "five");
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_group_add_member(
-      ctx_, group1, array2_relative_uri.c_str(), true, nullptr);
+      ctx_, group1, array2_relative_uri.c_str(), true, "six");
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_group_add_member(
-      ctx_, group2, array3_relative_uri.c_str(), true, nullptr);
+      ctx_, group2, array3_relative_uri.c_str(), true, "seven");
   REQUIRE(rc == TILEDB_OK);
   rc =
-      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, nullptr);
+      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, "eight");
   REQUIRE(rc == TILEDB_OK);
 
   // Close group from write mode
@@ -819,6 +840,27 @@ TEST_CASE_METHOD(
 
   rc = tiledb_group_open(ctx_, group2, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
+
+  uint8_t is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group1, "five", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 1);
+  is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group1, "six", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 1);
+  is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group2, "seven", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 1);
+  is_relative = 255;
+  rc = tiledb_group_get_is_relative_uri_by_name(
+      ctx_, group1, "eight", &is_relative);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(is_relative == 0);
 
   std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group1_received =
       read_group(group1);

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -632,7 +632,9 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
-    GroupFx, "C API: Group, write/read with named members", "[capi][group][metadata][read]") {
+    GroupFx,
+    "C API: Group, write/read with named members",
+    "[capi][group][metadata][read]") {
   // Create and open group in write mode
   // TODO: refactor for each supported FS.
   std::string temp_dir = fs_vec_[0]->temp_dir();

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -538,16 +538,151 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
 
   rc =
-      tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
+      tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, nullptr);
   REQUIRE(rc == TILEDB_OK);
   rc =
-      tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "two");
+      tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+  rc =
+      tiledb_group_add_member(ctx_, group2, array3_uri.c_str(), false, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+  rc =
+      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Close group from write mode
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Reopen in read mode
+  rc = tiledb_group_open(ctx_, group1, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_group_open(ctx_, group2, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group1_received =
+      read_group(group1);
+  REQUIRE_THAT(
+      group1_received, Catch::Matchers::UnorderedEquals(group1_expected));
+
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group2_received =
+      read_group(group2);
+  REQUIRE_THAT(
+      group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Remove assets from group
+  set_group_timestamp(group1, 2);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  set_group_timestamp(group2, 2);
+  rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_group_remove_member(ctx_, group1, group2_uri.c_str());
+  REQUIRE(rc == TILEDB_OK);
+  // Group is the latest element
+  group1_expected.resize(group1_expected.size() - 1);
+
+  rc = tiledb_group_remove_member(ctx_, group2, array3_uri.c_str());
+  REQUIRE(rc == TILEDB_OK);
+  // There should be nothing left in group2
+  group2_expected.clear();
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check read again
+  set_group_timestamp(group1, 2);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  set_group_timestamp(group2, 2);
+  rc = tiledb_group_open(ctx_, group2, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  group1_received = read_group(group1);
+  REQUIRE_THAT(
+      group1_received, Catch::Matchers::UnorderedEquals(group1_expected));
+
+  group2_received = read_group(group2);
+  REQUIRE_THAT(
+      group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_group_free(&group1);
+  tiledb_group_free(&group2);
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    GroupFx, "C API: Group, write/read with named members", "[capi][group][metadata][read]") {
+  // Create and open group in write mode
+  // TODO: refactor for each supported FS.
+  std::string temp_dir = fs_vec_[0]->temp_dir();
+  create_temp_dir(temp_dir);
+
+  const tiledb::sm::URI array1_uri(temp_dir + "array1");
+  const tiledb::sm::URI array2_uri(temp_dir + "array2");
+  const tiledb::sm::URI array3_uri(temp_dir + "array3");
+  create_array(array1_uri.to_string());
+  create_array(array2_uri.to_string());
+  create_array(array3_uri.to_string());
+
+  tiledb::sm::URI group1_uri(temp_dir + "group1");
+  REQUIRE(tiledb_group_create(ctx_, group1_uri.c_str()) == TILEDB_OK);
+
+  tiledb::sm::URI group2_uri(temp_dir + "group2");
+  REQUIRE(tiledb_group_create(ctx_, group2_uri.c_str()) == TILEDB_OK);
+
+  // Set expected
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group1_expected = {
+      {array1_uri, TILEDB_ARRAY},
+      {array2_uri, TILEDB_ARRAY},
+      {group2_uri, TILEDB_GROUP},
+  };
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group2_expected = {
+      {array3_uri, TILEDB_ARRAY},
+  };
+
+  tiledb_group_t* group1;
+  int rc = tiledb_group_alloc(ctx_, group1_uri.c_str(), &group1);
+  REQUIRE(rc == TILEDB_OK);
+  set_group_timestamp(group1, 1);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_group_t* group2;
+  rc = tiledb_group_alloc(ctx_, group2_uri.c_str(), &group2);
+  REQUIRE(rc == TILEDB_OK);
+  set_group_timestamp(group2, 1);
+  rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "two");
   REQUIRE(rc == TILEDB_OK);
   rc =
       tiledb_group_add_member(ctx_, group2, array3_uri.c_str(), false, "three");
   REQUIRE(rc == TILEDB_OK);
-  rc =
-      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, "four");
+  rc = tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, "four");
   REQUIRE(rc == TILEDB_OK);
 
   // Close group from write mode
@@ -762,6 +897,156 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     GroupFx,
     "C API: Group, write/read, relative",
+    "[capi][group][metadata][read]") {
+  // Create and open group in write mode
+  // TODO: refactor for each supported FS.
+  std::string temp_dir = fs_vec_[0]->temp_dir();
+  create_temp_dir(temp_dir);
+
+  tiledb::sm::URI group1_uri(temp_dir + "group1");
+  REQUIRE(tiledb_group_create(ctx_, group1_uri.c_str()) == TILEDB_OK);
+
+  tiledb::sm::URI group2_uri(temp_dir + "group2");
+  REQUIRE(tiledb_group_create(ctx_, group2_uri.c_str()) == TILEDB_OK);
+
+  REQUIRE(
+      tiledb_vfs_create_dir(ctx_, vfs_, (temp_dir + "group1/arrays").c_str()) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_vfs_create_dir(ctx_, vfs_, (temp_dir + "group2/arrays").c_str()) ==
+      TILEDB_OK);
+
+  const std::string array1_relative_uri("arrays/array1");
+  const tiledb::sm::URI array1_uri(temp_dir + "group1/arrays/array1");
+  const std::string array2_relative_uri("arrays/array2");
+  const tiledb::sm::URI array2_uri(temp_dir + "group1/arrays/array2");
+  const std::string array3_relative_uri("arrays/array3");
+  const tiledb::sm::URI array3_uri(temp_dir + "group2/arrays/array3");
+  create_array(array1_uri.to_string());
+  create_array(array2_uri.to_string());
+  create_array(array3_uri.to_string());
+
+  // Set expected
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group1_expected = {
+      {array1_uri, TILEDB_ARRAY},
+      {array2_uri, TILEDB_ARRAY},
+      {group2_uri, TILEDB_GROUP},
+  };
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group2_expected = {
+      {array3_uri, TILEDB_ARRAY},
+  };
+
+  tiledb_group_t* group1;
+  int rc = tiledb_group_alloc(ctx_, group1_uri.c_str(), &group1);
+  REQUIRE(rc == TILEDB_OK);
+  set_group_timestamp(group1, 1);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_group_t* group2;
+  rc = tiledb_group_alloc(ctx_, group2_uri.c_str(), &group2);
+  REQUIRE(rc == TILEDB_OK);
+  set_group_timestamp(group2, 1);
+  rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_group_add_member(
+      ctx_, group1, array1_relative_uri.c_str(), true, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_add_member(
+      ctx_, group1, array2_relative_uri.c_str(), true, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_add_member(
+      ctx_, group2, array3_relative_uri.c_str(), true, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+  rc =
+      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, nullptr);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Close group from write mode
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Reopen in read mode
+  rc = tiledb_group_open(ctx_, group1, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_group_open(ctx_, group2, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group1_received =
+      read_group(group1);
+  REQUIRE_THAT(
+      group1_received, Catch::Matchers::UnorderedEquals(group1_expected));
+
+  std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> group2_received =
+      read_group(group2);
+  REQUIRE_THAT(
+      group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Remove assets from group
+  set_group_timestamp(group1, 2);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  set_group_timestamp(group2, 2);
+  rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_group_remove_member(ctx_, group1, group2_uri.c_str());
+  REQUIRE(rc == TILEDB_OK);
+  // Group is the latest element
+  group1_expected.resize(group1_expected.size() - 1);
+
+  rc = tiledb_group_remove_member(ctx_, group2, array3_relative_uri.c_str());
+  REQUIRE(rc == TILEDB_OK);
+  // There should be nothing left in group2
+  group2_expected.clear();
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check read again
+  set_group_timestamp(group1, 2);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  set_group_timestamp(group2, 2);
+  rc = tiledb_group_open(ctx_, group2, TILEDB_READ);
+  REQUIRE(rc == TILEDB_OK);
+
+  group1_received = read_group(group1);
+  REQUIRE_THAT(
+      group1_received, Catch::Matchers::UnorderedEquals(group1_expected));
+
+  group2_received = read_group(group2);
+  REQUIRE_THAT(
+      group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_group_close(ctx_, group2);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_group_free(&group1);
+  tiledb_group_free(&group2);
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    GroupFx,
+    "C API: Group, write/read, relative with named members",
     "[capi][group][metadata][read]") {
   // Create and open group in write mode
   // TODO: refactor for each supported FS.

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -658,3 +658,137 @@ TEST_CASE_METHOD(
   group2.close();
   remove_temp_dir(temp_dir);
 }
+
+TEST_CASE_METHOD(
+    GroupCPPFx,
+    "C++ API: Group, write/read, relative named",
+    "[cppapi][group][read]") {
+  // Create and open group in write mode
+  // TODO: refactor for each supported FS.
+  std::string temp_dir = fs_vec_[0]->temp_dir();
+  create_temp_dir(temp_dir);
+
+  tiledb::sm::URI group1_uri(temp_dir + "group1");
+  tiledb::Group::create(ctx_, group1_uri.to_string());
+
+  tiledb::sm::URI group2_uri(temp_dir + "group2");
+  tiledb::Group::create(ctx_, group2_uri.to_string());
+
+  REQUIRE(
+      tiledb_vfs_create_dir(
+          ctx_.ptr().get(), vfs_, (temp_dir + "group1/arrays").c_str()) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_vfs_create_dir(
+          ctx_.ptr().get(), vfs_, (temp_dir + "group2/arrays").c_str()) ==
+      TILEDB_OK);
+
+  const std::string array1_relative_uri("arrays/array1");
+  const tiledb::sm::URI array1_uri(temp_dir + "group1/arrays/array1");
+  const std::string array2_relative_uri("arrays/array2");
+  const tiledb::sm::URI array2_uri(temp_dir + "group1/arrays/array2");
+  const std::string array3_relative_uri("arrays/array3");
+  const tiledb::sm::URI array3_uri(temp_dir + "group2/arrays/array3");
+  create_array(array1_uri.to_string());
+  create_array(array2_uri.to_string());
+  create_array(array3_uri.to_string());
+
+  // Set expected
+  std::vector<tiledb::Object> group1_expected = {
+      tiledb::Object(
+          tiledb::Object::Type::Array, array1_uri.to_string(), "one"),
+      tiledb::Object(
+          tiledb::Object::Type::Array, array2_uri.to_string(), "two"),
+      tiledb::Object(
+          tiledb::Object::Type::Group, group2_uri.to_string(), "three"),
+  };
+  std::vector<tiledb::Object> group2_expected = {
+      tiledb::Object(
+          tiledb::Object::Type::Array, array3_uri.to_string(), "four"),
+  };
+
+  tiledb::Group group1(ctx_, group1_uri.to_string(), TILEDB_WRITE);
+  group1.close();
+  set_group_timestamp(&group1, 1);
+  group1.open(TILEDB_WRITE);
+
+  tiledb::Group group2(ctx_, group2_uri.to_string(), TILEDB_WRITE);
+  group2.close();
+  set_group_timestamp(&group2, 1);
+  group2.open(TILEDB_WRITE);
+
+  group1.add_member(array1_relative_uri, true, "one");
+  group1.add_member(array2_relative_uri, true, "two");
+  group1.add_member(group2_uri.to_string(), false, "three");
+
+  group2.add_member(array3_relative_uri, true, "four");
+
+  // Close group from write mode
+  group1.close();
+  group2.close();
+
+  // Reopen in read mode
+  group1.open(TILEDB_READ);
+  group2.open(TILEDB_READ);
+
+  std::vector<tiledb::Object> group1_received = read_group(group1);
+  REQUIRE_THAT(
+      group1_received, Catch::Matchers::UnorderedEquals(group1_expected));
+
+  std::vector<tiledb::Object> group2_received = read_group(group2);
+  REQUIRE_THAT(
+      group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
+
+  bool is_relative;
+  is_relative = group1.is_relative("one");
+  REQUIRE(is_relative == true);
+  is_relative = group1.is_relative("two");
+  REQUIRE(is_relative == true);
+  is_relative = group1.is_relative("three");
+  REQUIRE(is_relative == false);
+  is_relative = group2.is_relative("four");
+  REQUIRE(is_relative == true);
+
+  REQUIRE_THROWS(group2.is_relative("nonexistent"));
+
+  // Close group
+  group1.close();
+  group2.close();
+
+  // Remove assets from group
+  set_group_timestamp(&group1, 2);
+  group1.open(TILEDB_WRITE);
+  set_group_timestamp(&group2, 2);
+  group2.open(TILEDB_WRITE);
+
+  group1.remove_member(group2_uri.to_string());
+  // Group is the latest element
+  group1_expected.resize(group1_expected.size() - 1);
+
+  group2.remove_member(array3_relative_uri);
+  // There should be nothing left in group2
+  group2_expected.clear();
+
+  // Close group
+  group1.close();
+  group2.close();
+
+  // Check read again
+  set_group_timestamp(&group1, 2);
+  group1.open(TILEDB_READ);
+  set_group_timestamp(&group2, 2);
+  group2.open(TILEDB_READ);
+
+  group1_received = read_group(group1);
+  REQUIRE_THAT(
+      group1_received, Catch::Matchers::UnorderedEquals(group1_expected));
+
+  group2_received = read_group(group2);
+  REQUIRE_THAT(
+      group2_received, Catch::Matchers::UnorderedEquals(group2_expected));
+
+  // Close group
+  group1.close();
+  group2.close();
+  remove_temp_dir(temp_dir);
+}

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -857,6 +857,38 @@ TILEDB_EXPORT int32_t tiledb_group_get_member_by_name(
     tiledb_object_t* type) TILEDB_NOEXCEPT;
 
 /**
+ * Get a member of a group by name and relative characteristic of that name
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_group_t* group;
+ * tiledb_group_alloc(ctx, "s3://tiledb_bucket/my_group", &group);
+ * tiledb_group_open(ctx, group, TILEDB_WRITE);
+ * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_array", true, "array1");
+ * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_group_2", false,
+ * "group2");
+ *
+ * tiledb_group_close(ctx, group);
+ * tiledb_group_open(ctx, group, TILEDB_READ);
+ * uint8_t is_relative;
+ * tiledb_group_get_is_relative_uri_by_name(ctx, group, "array1", &is_relative);
+ *
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param group An group opened in READ mode.
+ * @param name name of member to fetch
+ * @param is_relative to receive relative characteristic of named member
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_group_get_is_relative_uri_by_name(
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* name,
+    uint8_t* relative) TILEDB_NOEXCEPT;
+
+/**
  * Checks if the group is open.
  *
  * @param ctx The TileDB context.

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -856,6 +856,8 @@ TILEDB_EXPORT int32_t tiledb_group_get_member_by_name(
     char** uri,
     tiledb_object_t* type) TILEDB_NOEXCEPT;
 
+/* (clang format was butchering the tiledb_group_add_member() calls) */
+/* clang-format off */
 /**
  * Get a member of a group by name and relative characteristic of that name
  *
@@ -865,9 +867,10 @@ TILEDB_EXPORT int32_t tiledb_group_get_member_by_name(
  * tiledb_group_t* group;
  * tiledb_group_alloc(ctx, "s3://tiledb_bucket/my_group", &group);
  * tiledb_group_open(ctx, group, TILEDB_WRITE);
- * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_array", true, "array1");
- * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_group_2", false,
- * "group2");
+ * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_array", true,
+ *     "array1"); 
+ * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_group_2", 
+ *     false, "group2");
  *
  * tiledb_group_close(ctx, group);
  * tiledb_group_open(ctx, group, TILEDB_READ);
@@ -882,6 +885,7 @@ TILEDB_EXPORT int32_t tiledb_group_get_member_by_name(
  * @param is_relative to receive relative characteristic of named member
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
+/* clang-format on */
 TILEDB_EXPORT int32_t tiledb_group_get_is_relative_uri_by_name(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -836,7 +836,6 @@ TILEDB_EXPORT int32_t tiledb_group_get_is_relative_uri_by_name(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* name,
-    //char** uri,
     uint8_t *relative) TILEDB_NOEXCEPT {
   return api_entry<detail::tiledb_group_get_is_relative_uri_by_name>(
       ctx, group, name, relative);

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -513,29 +513,17 @@ int32_t tiledb_group_get_is_relative_uri_by_name(
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, group) == TILEDB_ERR)
     return TILEDB_ERR;
-  if (is_relative == nullptr)
-    return TILEDB_ERR;
-
-  try {
-    auto&& [st, uri_str, object_type, name_str, relative] =
-        group->group_->member_by_name(name);
-    if (!st.ok()) {
-      save_error(ctx, st);
-      return TILEDB_ERR;
-    }
-
-    *is_relative = *relative ? 1 : 0;
-
-    return TILEDB_OK;
-  } catch (const std::exception& e) {
-    auto st = Status_Error(
-        std::string("Internal TileDB uncaught exception; ") + e.what());
-    LOG_STATUS(st);
-    save_error(ctx, st);
+  if (is_relative == nullptr) {
     return TILEDB_ERR;
   }
 
-  return TILEDB_ERR;
+  auto&& [st, uri_str, object_type, name_str, relative] =
+      group->group_->member_by_name(name);
+  throw_if_not_ok(st);
+
+  *is_relative = *relative ? 1 : 0;
+
+  return TILEDB_OK;
 }
 
 int32_t tiledb_group_get_uri(
@@ -836,8 +824,8 @@ TILEDB_EXPORT int32_t tiledb_group_get_is_relative_uri_by_name(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* name,
-    uint8_t *relative) TILEDB_NOEXCEPT {
-  return api_entry<detail::tiledb_group_get_is_relative_uri_by_name>(
+    uint8_t* relative) TILEDB_NOEXCEPT {
+  return api_entry_context<detail::tiledb_group_get_is_relative_uri_by_name>(
       ctx, group, name, relative);
 }
 

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -397,6 +397,20 @@ class Group {
     return tiledb::Object(type, uri_str, name);
   }
 
+  /**
+   * retrieve the relative attribute for a named member
+   *
+   * @param name of member to retrieve associated relative indicator.
+   */
+  bool is_relative(std::string name) const {
+    auto& ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    uint8_t is_relative;
+    ctx.handle_error(tiledb_group_get_is_relative_uri_by_name(
+        c_ctx, group_.get(), name.c_str(), &is_relative));
+    return is_relative != 0;
+  }
+
   std::string dump(const bool recursive) const {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -776,13 +776,15 @@ tuple<
     Status,
     optional<std::string>,
     optional<ObjectType>,
-    optional<std::string>>
+    optional<std::string>,
+    optional<bool>>
 Group::member_by_name(const std::string& name) {
   std::lock_guard<std::mutex> lck(mtx_);
 
   // Check if group is open
   if (!is_open_) {
     return {Status_GroupError("Cannot get member by name; Group is not open"),
+            std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt};
@@ -794,12 +796,14 @@ Group::member_by_name(const std::string& name) {
                 "Cannot get member; Group was not opened in read mode"),
             std::nullopt,
             std::nullopt,
+            std::nullopt,
             std::nullopt};
   }
 
   auto it = members_by_name_.find(name);
   if (it == members_by_name_.end()) {
     return {Status_GroupError(name + " does not exist in group"),
+            std::nullopt,
             std::nullopt,
             std::nullopt,
             std::nullopt};
@@ -811,7 +815,8 @@ Group::member_by_name(const std::string& name) {
     uri = group_uri_.join_path(member->uri().to_string()).to_string();
   }
 
-  return {Status::Ok(), uri, member->type(), member->name()};
+  return {
+      Status::Ok(), uri, member->type(), member->name(), member->relative()};
 }
 
 std::string Group::dump(

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -658,7 +658,7 @@ Group::members() const {
   return members_;
 }
 
-void Group::serialize(Serializer &) {
+void Group::serialize(Serializer&) {
   throw StatusException(Status_GroupError("Invalid call to Group::serialize"));
 }
 
@@ -668,15 +668,17 @@ void Group::apply_and_serialize(Serializer& serializer) {
 }
 
 std::optional<tdb_shared_ptr<Group>> Group::deserialize(
-    Deserializer &deserializer, const URI& group_uri, StorageManager* storage_manager) {
+    Deserializer& deserializer,
+    const URI& group_uri,
+    StorageManager* storage_manager) {
   uint32_t version = 0;
   version = deserializer.read<uint32_t>();
   if (version == 1) {
     return GroupV1::deserialize(deserializer, group_uri, storage_manager);
   }
 
-  throw StatusException(
-      Status_GroupError("Unsupported group version " + std::to_string(version)));
+  throw StatusException(Status_GroupError(
+      "Unsupported group version " + std::to_string(version)));
 }
 
 const URI& Group::group_uri() const {

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -359,7 +359,8 @@ class Group {
       Status,
       optional<std::string>,
       optional<ObjectType>,
-      optional<std::string>>
+      optional<std::string>,
+      optional<bool>>
   member_by_name(const std::string& name);
 
   /** Returns `true` if the group is open. */


### PR DESCRIPTION
add c_api tiledb_group_get_is_relative_uri_by_name(), modifying existing code to include return of that characteristic, plus modifying tests to access this change (seems no tests were previously exercising functionality leading to ::member_by_name() either, now happens)

---
TYPE: FEATURE
DESC: add c_api tiledb_group_get_is_relative_uri_by_name()
