### PR TITLE
Updates Array and Group to use optional for timestamp end

### DIFF
--- a/test/src/helpers.cc
+++ b/test/src/helpers.cc
@@ -1504,7 +1504,8 @@ void submit_and_finalize_serialized_query(
   tiledb_query_type_t type;
   tiledb_query_get_type(ctx, query, &type);
   auto uri = query->query_->array()->array_uri().to_string();
-  uint64_t timestamp = query->query_->array()->timestamp_end_opened_at();
+  uint64_t timestamp =
+      query->query_->array()->opened_timestamp_end_or_sentinel();
   Array copy_array(context, uri, type, timestamp);
   Query copy_query(context, copy_array);
   std::vector<uint8_t> serialized;

--- a/test/src/test-dimension_labels-read-consistency.cc
+++ b/test/src/test-dimension_labels-read-consistency.cc
@@ -188,9 +188,10 @@ class ExampleFixedDimensionLabel : public TemporaryDirectoryFixture {
         QueryType::WRITE, EncryptionType::NO_ENCRYPTION, nullptr, 0);
 
     // Generate single fragment name for queries.
-    auto timestamp = dimension_label.indexed_array()->timestamp_end_opened_at();
+    auto timestamp =
+        dimension_label.indexed_array()->opened_timestamp_end_or_sentinel();
     auto timestamp2 =
-        dimension_label.labelled_array()->timestamp_end_opened_at();
+        dimension_label.labelled_array()->opened_timestamp_end_or_sentinel();
     REQUIRE(timestamp == timestamp2);
     auto fragment_name = tiledb::storage_format::generate_fragment_name(
         timestamp, constants::format_version);

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -82,7 +82,7 @@ Array::Array(
     , is_opening_or_closing_(false)
     , timestamp_start_(0)
     , timestamp_end_(UINT64_MAX)
-    , timestamp_end_opened_at_(UINT64_MAX)
+    , opened_timestamp_end_(UINT64_MAX)
     , storage_manager_(storage_manager)
     , config_(storage_manager_->config())
     , remote_(array_uri.is_tiledb())
@@ -257,7 +257,7 @@ Status Array::open(
   metadata_loaded_ = false;
   non_empty_domain_computed_ = false;
   timestamp_start_ = timestamp_start;
-  timestamp_end_opened_at_ = timestamp_end;
+  opened_timestamp_end_ = timestamp_end;
   query_type_ = query_type;
 
   /* Note: the open status MUST be exception safe. If anything interrupts the
@@ -311,14 +311,14 @@ Status Array::open(
       throw StatusException(st);
     }
 
-    if (timestamp_end_opened_at_ == UINT64_MAX) {
+    if (opened_timestamp_end_ == UINT64_MAX) {
       if (query_type == QueryType::READ) {
-        timestamp_end_opened_at_ = utils::time::timestamp_now_ms();
+        opened_timestamp_end_ = utils::time::timestamp_now_ms();
       } else if (
           query_type == QueryType::WRITE ||
           query_type == QueryType::MODIFY_EXCLUSIVE ||
           query_type == QueryType::DELETE) {
-        timestamp_end_opened_at_ = 0;
+        opened_timestamp_end_ = 0;
       } else if (query_type == QueryType::UPDATE) {
         bool found = false;
         bool allow_updates = false;
@@ -365,7 +365,7 @@ Status Array::open(
           storage_manager_->compute_tp(),
           array_uri_,
           timestamp_start_,
-          timestamp_end_opened_at_);
+          opened_timestamp_end_);
 
       auto&& [st, array_schema_latest, array_schemas, fragment_metadata] =
           storage_manager_->array_open_for_reads(this);
@@ -384,7 +384,7 @@ Status Array::open(
           storage_manager_->compute_tp(),
           array_uri_,
           timestamp_start_,
-          timestamp_end_opened_at_,
+          opened_timestamp_end_,
           ArrayDirectoryMode::SCHEMA_ONLY);
 
       auto&& [st, array_schema_latest, array_schemas] =
@@ -395,7 +395,7 @@ Status Array::open(
       array_schema_latest_ = array_schema_latest.value();
       array_schemas_all_ = array_schemas.value();
 
-      metadata_.reset(timestamp_end_opened_at_);
+      metadata_.reset(opened_timestamp_end_);
     } else if (
         query_type == QueryType::DELETE || query_type == QueryType::UPDATE) {
       array_dir_ = ArrayDirectory(
@@ -403,7 +403,7 @@ Status Array::open(
           storage_manager_->compute_tp(),
           array_uri_,
           timestamp_start_,
-          timestamp_end_opened_at_,
+          opened_timestamp_end_,
           ArrayDirectoryMode::READ);
 
       auto&& [st, array_schema_latest, array_schemas] =
@@ -434,7 +434,7 @@ Status Array::open(
         return LOG_STATUS(Status_ArrayError(err.str()));
       }
 
-      metadata_.reset(timestamp_end_opened_at_);
+      metadata_.reset(opened_timestamp_end_);
     } else {
       throw Status_ArrayError("Cannot open array; Unsupported query type.");
     }
@@ -478,7 +478,7 @@ Status Array::close() {
           throw Status_ArrayError(
               "Error closing array; remote array with no REST client.");
         st = rest_client->post_array_metadata_to_rest(
-            array_uri_, timestamp_start_, timestamp_end_opened_at_, this);
+            array_uri_, timestamp_start_, opened_timestamp_end_, this);
         if (!st.ok())
           throw StatusException(st);
       }
@@ -719,7 +719,8 @@ const EncryptionKey& Array::get_encryption_key() const {
 }
 
 Status Array::reopen() {
-  if (timestamp_end_ == timestamp_end_opened_at_) {
+  // Note: This is only for arrays opened in READ mode.
+  if (timestamp_end_ == opened_timestamp_end_) {
     // The user has not set `timestamp_end_` since it was last opened.
     // In this scenario, re-open at the current timestamp.
     return reopen(timestamp_start_, utils::time::timestamp_now_ms());
@@ -744,15 +745,15 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   clear_last_max_buffer_sizes();
 
   timestamp_start_ = timestamp_start;
-  timestamp_end_opened_at_ = timestamp_end;
+  opened_timestamp_end_ = timestamp_end;
   fragment_metadata_.clear();
   metadata_.clear();
   metadata_loaded_ = false;
   non_empty_domain_.clear();
   non_empty_domain_computed_ = false;
 
-  if (timestamp_end_opened_at_ == UINT64_MAX) {
-    timestamp_end_opened_at_ = utils::time::timestamp_now_ms();
+  if (opened_timestamp_end_ == UINT64_MAX) {
+    opened_timestamp_end_ = utils::time::timestamp_now_ms();
   }
 
   if (remote_) {
@@ -769,7 +770,7 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
         storage_manager_->compute_tp(),
         array_uri_,
         timestamp_start_,
-        timestamp_end_opened_at_,
+        opened_timestamp_end_,
         query_type_ == QueryType::READ ? ArrayDirectoryMode::READ :
                                          ArrayDirectoryMode::SCHEMA_ONLY);
   } catch (const std::logic_error& le) {
@@ -805,8 +806,13 @@ uint64_t Array::timestamp_end() const {
   return timestamp_end_;
 }
 
-uint64_t Array::timestamp_end_opened_at() const {
-  return timestamp_end_opened_at_;
+uint64_t Array::opened_timestamp_end_or_sentinel() const {
+  return opened_timestamp_end_;
+}
+
+uint64_t Array::opened_timestamp_end_or_current() const {
+  return opened_timestamp_end_ == 0 ? utils::time::timestamp_now_ms() :
+                                      opened_timestamp_end_;
 }
 
 Status Array::set_config(Config config) {
@@ -1187,7 +1193,7 @@ Status Array::load_metadata() {
           "Cannot load metadata; remote array with no REST client."));
     }
     RETURN_NOT_OK(rest_client->get_array_metadata_from_rest(
-        array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
+        array_uri_, timestamp_start_, opened_timestamp_end_, this));
   } else {
     assert(array_dir_.loaded());
     RETURN_NOT_OK(storage_manager_->load_array_metadata(
@@ -1205,7 +1211,7 @@ Status Array::load_remote_non_empty_domain() {
           "Cannot load metadata; remote array with no REST client."));
     }
     RETURN_NOT_OK(rest_client->get_array_non_empty_domain(
-        this, timestamp_start_, timestamp_end_opened_at_));
+        this, timestamp_start_, opened_timestamp_end_));
     non_empty_domain_computed_ = true;
   }
   return Status::Ok();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -291,17 +291,17 @@ class Array {
   uint64_t timestamp_end() const;
 
   /**
-   * Returns the timestamp at which the array was opened.
-   *
-   * * If the array was not yet opened, this will return ``UINT64_MAX``.
-   * * If the array was opened in a mode other than READ and it is set to
-   *   use the current time, it will return return ``0``.
+   * Returns the timestamp at which the array was opened or ``UINT64_MAX`` if
+   * the array is not yet opened or set to use the current time.
    */
   uint64_t opened_timestamp_end_or_sentinel() const;
 
   /**
    * Returns the timestamp at which the array was opened or the current
    * time if the array opened timestamp was not set.
+   *
+   * Note: This function is intended to be used after the array is opened. If
+   * called before the array is opened, it will return ``UINT64_MAX``.
    */
   uint64_t opened_timestamp_end_or_current() const;
 
@@ -516,8 +516,8 @@ class Array {
    * The ending timestamp between to open `open_array_` at.
    *
    * In TileDB, timestamps are in ms elapsed since
-   * 1970-01-01 00:00:00 +0000 (UTC). A value of UINT64_T will be interpretted
-   * as the current timestamp. This value is only used for setting
+   * 1970-01-01 00:00:00 +0000 (UTC). A value of ``UINT64_MAX`` will be
+   * interpretted as the current timestamp. This value is only used for setting
    * ``opened_timestamp_end_``.
    */
   uint64_t timestamp_end_;
@@ -526,10 +526,11 @@ class Array {
    * The ending timestamp that the array was last opened at.
    *
    * In TileDB, timestamps are in ms elapsed since
-   * 1970-01-01 00:00:00 +0000 (UTC). If the array is set to use the current
-   * time and it was not opened in READ mode, then this will be set to 0.
+   * 1970-01-01 00:00:00 +0000 (UTC). If the array is set to uee the current
+   * time and it was not opened in READ mode, then this will be set to nullop.
+   * Before the array is opened this will be ``UINT64_MAX``.
    */
-  uint64_t opened_timestamp_end_;
+  optional<uint64_t> opened_timestamp_end_;
 
   /** TileDB storage manager. */
   StorageManager* storage_manager_;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -290,8 +290,20 @@ class Array {
   /** Returns the end timestamp. */
   uint64_t timestamp_end() const;
 
-  /** Returns the timestamp at which the array was opened. */
-  uint64_t timestamp_end_opened_at() const;
+  /**
+   * Returns the timestamp at which the array was opened.
+   *
+   * * If the array was not yet opened, this will return ``UINT64_MAX``.
+   * * If the array was opened in a mode other than READ and it is set to
+   *   use the current time, it will return return ``0``.
+   */
+  uint64_t opened_timestamp_end_or_sentinel() const;
+
+  /**
+   * Returns the timestamp at which the array was opened or the current
+   * time if the array opened timestamp was not set.
+   */
+  uint64_t opened_timestamp_end_or_current() const;
 
   /** Directly set the timestamp start value. */
   Status set_timestamp_start(uint64_t timestamp_start);
@@ -502,20 +514,22 @@ class Array {
 
   /**
    * The ending timestamp between to open `open_array_` at.
+   *
    * In TileDB, timestamps are in ms elapsed since
-   * 1970-01-01 00:00:00 +0000 (UTC). A value of UINT64_T
-   * will be interpretted as the current timestamp.
+   * 1970-01-01 00:00:00 +0000 (UTC). A value of UINT64_T will be interpretted
+   * as the current timestamp. This value is only used for setting
+   * ``opened_timestamp_end_``.
    */
   uint64_t timestamp_end_;
 
   /**
-   * The ending timestamp that the array was last opened
-   * at. This is useful when `timestamp_end_` has been
-   * set to UINT64_T. In this scenario, this variable will
-   * store the timestamp for the time that the array was
-   * opened.
+   * The ending timestamp that the array was last opened at.
+   *
+   * In TileDB, timestamps are in ms elapsed since
+   * 1970-01-01 00:00:00 +0000 (UTC). If the array is set to use the current
+   * time and it was not opened in READ mode, then this will be set to 0.
    */
-  uint64_t timestamp_end_opened_at_;
+  uint64_t opened_timestamp_end_;
 
   /** TileDB storage manager. */
   StorageManager* storage_manager_;

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -385,18 +385,23 @@ class ArrayDirectory {
   std::vector<DeleteTileLocation> delete_tiles_location_;
 
   /**
-   * Only array fragments, metadata, etc. that
-   * were created within timestamp range
-   *    [`timestamp_start`, `timestamp_end`] will be considered when
-   *     fetching URIs.
+   * The start of the timestamp range to consider.
+   *
+   * Only array fragments, metadata, etc. that were created within timestamp
+   * range [`timestamp_start`, `timestamp_end`] will be considered when fetching
+   * URIs.
    */
   uint64_t timestamp_start_;
 
   /**
-   * Only array fragments, metadata, etc. that
-   * were created within timestamp range
-   *    [`timestamp_start`, `timestamp_end`] will be considered when
-   *     fetching URIs.
+   * The end of the timestamp range to consider.
+   *
+   * Only array fragments, metadata, etc. that were created within timestamp
+   * range [`timestamp_start`, `timestamp_end`] will be considered when fetching
+   * URIs.
+   *
+   * Note: For arrays opened in modes other than ``READ`` using the current
+   * timestamp, this will be set to ``UINT64_MAX``.
    */
   uint64_t timestamp_end_;
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4012,7 +4012,7 @@ int32_t tiledb_array_get_open_timestamp_end(
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  *timestamp_end = array->array_->timestamp_end_opened_at();
+  *timestamp_end = array->array_->opened_timestamp_end_or_sentinel();
 
   return TILEDB_OK;
 }
@@ -4163,7 +4163,7 @@ int32_t tiledb_array_get_timestamp(
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  *timestamp = array->array_->timestamp_end_opened_at();
+  *timestamp = array->array_->opened_timestamp_end_or_sentinel();
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5748,9 +5748,9 @@ TILEDB_EXPORT int32_t tiledb_array_get_open_timestamp_start(
 
 /**
  * Gets the ending timestamp used when opening (and reopening) the array.
- * This is an inclusive bound. If UINT64_MAX was set, this will return
- * the timestamp at the time the array was opened. If the array has not
- * yet been opened, it will return UINT64_MAX.`
+ * This is an inclusive bound. If UINT64_MAX was set and opened in READ mode,
+ * this will return the timestamp at the time the array was opened. If the array
+ * has not yet been opened, it will return UINT64_MAX.`
  *
  * **Example:**
  *

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -417,6 +417,7 @@ class Group {
 
   /**
    * The starting timestamp between to open at.
+   *
    * In TileDB, timestamps are in ms elapsed since
    * 1970-01-01 00:00:00 +0000 (UTC).
    */
@@ -424,11 +425,14 @@ class Group {
 
   /**
    * The ending timestamp between to open at.
+   *
    * In TileDB, timestamps are in ms elapsed since
-   * 1970-01-01 00:00:00 +0000 (UTC). A value of UINT64_T
-   * will be interpreted as the current timestamp.
+   * 1970-01-01 00:00:00 +0000 (UTC).
+   *
+   * If timestamp is not set or it set to UINT64_MAX, the end timestamp will be
+   * interpreted as the current timestamp.
    */
-  uint64_t timestamp_end_;
+  optional<uint64_t> timestamp_end_;
 
   /**
    * The private encryption key used to encrypt the group.

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -347,7 +347,6 @@ void Metadata::swap(Metadata* metadata) {
 
 void Metadata::reset(uint64_t timestamp) {
   clear();
-  timestamp = (timestamp != 0) ? timestamp : utils::time::timestamp_now_ms();
   timestamp_range_ = std::make_pair(timestamp, timestamp);
 }
 

--- a/tiledb/sm/query/deletes_and_updates/deletes.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes.cc
@@ -124,7 +124,7 @@ Status Deletes::dowork() {
   RETURN_NOT_OK(condition_.check(array_schema_));
 
   // Get a new fragment name for the delete.
-  uint64_t timestamp = array_->timestamp_end_opened_at();
+  uint64_t timestamp = array_->opened_timestamp_end_or_current();
   auto write_version = array_->array_schema_latest().write_version();
   auto new_fragment_str =
       storage_format::generate_fragment_name(timestamp, write_version) +

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1832,7 +1832,7 @@ Status Reader::get_all_result_coords(
   // Apply partial overlap condition, if required.
   const auto frag_meta = fragment_metadata_[tile->frag_idx()];
   const bool partial_overlap = frag_meta->partial_time_overlap(
-      array_->timestamp_start(), array_->timestamp_end_opened_at());
+      array_->timestamp_start(), array_->opened_timestamp_end_or_current());
   if (fragment_metadata_[tile->frag_idx()]->has_timestamps() &&
       partial_overlap) {
     std::vector<uint8_t> result_bitmap(coords_num, 1);

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -201,7 +201,7 @@ WriterBase::WriterBase(
   check_var_attr_offsets();
 
   // Get the timestamp the array was opened and the array write version.
-  uint64_t timestamp = array_->timestamp_end_opened_at();
+  uint64_t timestamp = array_->opened_timestamp_end_or_current();
   auto write_version = array_->array_schema_latest().write_version();
 
   // Set the fragment URI using either the provided fragment name or a generated
@@ -643,7 +643,7 @@ Status WriterBase::create_fragment(
   // Get write version, timestamp array was opened,  and a reference to the
   // array directory.
   auto write_version = array_->array_schema_latest().write_version();
-  uint64_t timestamp = array_->timestamp_end_opened_at();
+  uint64_t timestamp = array_->opened_timestamp_end_or_current();
   auto& array_dir = array_->array_directory();
 
   // Create the directories.

--- a/tiledb/storage_format/uri/generate_uri.cc
+++ b/tiledb/storage_format/uri/generate_uri.cc
@@ -27,7 +27,6 @@
  */
 
 #include "tiledb/storage_format/uri/generate_uri.h"
-#include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/misc/uuid.h"
 
 #include <sstream>
@@ -49,8 +48,6 @@ std::string generate_uri(
 
 std::string generate_fragment_name(
     uint64_t timestamp, uint32_t format_version) {
-  timestamp =
-      (timestamp != 0) ? timestamp : sm::utils::time::timestamp_now_ms();
   return generate_uri(timestamp, timestamp, format_version);
 }
 


### PR DESCRIPTION
This PR updates both `Array` and `Group` to use an optional integer for the timestamp end instead of a straight integer. The purpose of this change is to prevent bugs that occur when not taking into account the possibility of a sentinel value of 0 when using the timestamp.

This change has a few effects:
* Fixes checking timestamp overlap for query type `DELETE` in the `ArrayDirectory` and `Deletes` query strategy.
* Changes `tiledb_array_get_open_timestamp_end` to return `UINT64_MAX` instead of `0` when the array was set to use the current time for a query type other than `READ`.
* Changes fragment names to use `0` and not the current timestamp when opening the array with `timestamp_end=0`.

---
TYPE: IMPROVEMENT
DESC: Replaces sentinel value of 0 with nullopt for ending timestamp in arrays and groups
