### PR TITLE
Misc CI fixes

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -20,8 +20,9 @@ on:
         default: ''
         required: true
         type: string
-      timeout: 90
-        descript: 'Job timeout (minutes)'
+      timeout:
+        default: 90
+        description: 'Job timeout (minutes)'
         required: false
         type: number
 

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.timeout || 90 }}
     name: ${{matrix.os}} - ${{ inputs.ci_backend }}${{ inputs.ci_option }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -20,6 +20,10 @@ on:
         default: ''
         required: true
         type: string
+      timeout: 90
+        descript: 'Job timeout (minutes)'
+        required: false
+        type: number
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF

--- a/.github/workflows/full-ci-dummy.yml
+++ b/.github/workflows/full-ci-dummy.yml
@@ -1,4 +1,4 @@
-name: "Full CI"
+name: "Build Docs"
 on:
   pull_request:
     branches:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -66,12 +66,14 @@ jobs:
     with:
       ci_backend: S3
       matrix_image: macos-11
+      timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
   ci6:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: GCS
       matrix_image: macos-11
+      timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
   ci7:
     uses: ./.github/workflows/ci-linux_mac.yml

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -1,4 +1,4 @@
-name: "Full CI (actual)"
+name: "Full CI"
 on:
   push:
     branches:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -1,4 +1,4 @@
-name: "Full CI"
+name: "Full CI (actual)"
 on:
   push:
     branches:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -31,7 +31,7 @@ on:
       - 'tiledb/sm/c_api/tiledb_version.h'
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 ## NOTE: the job names below must be unique!


### PR DESCRIPTION
- Make doc and CI job names unique for display purposes. Both workflows still use `full_ci_passed` as the final step name for branch protection.
- Fix running of full_ci jobs on non-PR commits -- `head_ref` is not available, so use fallback to run number
- Provide option to override per-job timeout, and set timeout for macOS jobs to 120m

---
TYPE: NO_HISTORY
