### PR TITLE
Document that the callback of `tiledb_query_submit_async` is executed in an internal thread pool thread.

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -4354,7 +4354,7 @@ tiledb_query_submit(tiledb_ctx_t* ctx, tiledb_query_t* query) TILEDB_NOEXCEPT;
  * @param ctx The TileDB context.
  * @param query The query to be submitted.
  * @param callback The function to be called when the query completes.
- * @param callback_data The data to be passed to the callback function.
+ * @param callback_data The data to be passed to the \p callback function.
  * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
  *
  * @note `tiledb_query_finalize` must be invoked after finish writing in
@@ -4371,6 +4371,11 @@ tiledb_query_submit(tiledb_ctx_t* ctx, tiledb_query_t* query) TILEDB_NOEXCEPT;
  *    buffers are needed for the query to proceed. In this case, the users
  *    must reallocate their buffers (increasing their size), reset the buffers
  *    with `tiledb_query_set_buffer`, and resubmit the query.
+ *
+ * @note \p callback will be executed in a thread managed by TileDB's internal
+ *    thread pool. To allow TileDB to reuse the thread and avoid starving the
+ *    thread pool, long-running callbacks should be dispatched to another
+ *    thread.
  */
 TILEDB_EXPORT int32_t tiledb_query_submit_async(
     tiledb_ctx_t* ctx,


### PR DESCRIPTION
After a question of mine, it was determined that the callback of `tiledb_query_submit_async` is executed in an internal thread of TileDB's thread pool. I found it useful to document it.

---
TYPE: C_API
DESC: Document that the callback of `tiledb_query_submit_async` is executed in an internal thread pool thread.