### PR TITLE
Implement delete_group API

### DIFF
--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1982,12 +1982,14 @@ TEST_CASE_METHOD(
   // Try to delete group
   REQUIRE_THROWS_WITH(
       group.delete_group(GROUP_NAME),
-      Catch::Contains("Query type must be MODIFY_EXCLUSIVE"));
+      Catch::Matchers::ContainsSubstring(
+          "Query type must be MODIFY_EXCLUSIVE"));
   group.close();
 
   // Try to delete group after close
   REQUIRE_THROWS_WITH(
-      group.delete_group(GROUP_NAME), Catch::Contains("Group is not open"));
+      group.delete_group(GROUP_NAME),
+      Catch::Matchers::ContainsSubstring("Group is not open"));
 
   remove_dir(GROUP_NAME);
 }

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1608,12 +1608,11 @@ TEST_CASE_METHOD(
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 3);
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 5);
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 7);
-  std::string commit_dir = tiledb::test::get_commit_dir(SPARSE_ARRAY_NAME);
 
   if (consolidate) {
     consolidate_commits_sparse(vacuum);
     CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 4);
-    CommitsDirectory commits_dir(vfs_, commit_dir);
+    CommitsDirectory commits_dir(vfs_, SPARSE_ARRAY_NAME);
     if (vacuum) {
       CHECK(commits_dir.dir_size() == 1);
     } else {
@@ -1635,7 +1634,7 @@ TEST_CASE_METHOD(
   if (consolidate) {
     /* Note: An ignore file is written by delete_fragments if there are
      * consolidated commits to be ignored by the delete. */
-    CommitsDirectory commits_dir(vfs_, commit_dir);
+    CommitsDirectory commits_dir(vfs_, SPARSE_ARRAY_NAME);
     CHECK(
         commits_dir.file_count(
             tiledb::sm::constants::con_commits_file_suffix) == 1);
@@ -1686,8 +1685,7 @@ TEST_CASE_METHOD(
   num_commits++;
   num_fragments++;
   if (!vacuum) {
-    std::string commit_dir = tiledb::test::get_commit_dir(SPARSE_ARRAY_NAME);
-    CommitsDirectory commits_dir(vfs_, commit_dir);
+    CommitsDirectory commits_dir(vfs_, SPARSE_ARRAY_NAME);
     CHECK(
         commits_dir.file_count(tiledb::sm::constants::vacuum_file_suffix) == 1);
   } else {
@@ -1802,7 +1800,6 @@ TEST_CASE_METHOD(
   auto meta = vfs_.ls(
       array_name + "/" + tiledb::sm::constants::array_metadata_dir_name);
   CHECK(meta.size() == 1);
-  std::string commit_dir = tiledb::test::get_commit_dir(SPARSE_ARRAY_NAME);
 
   if (consolidate) {
     // Consolidate commits
@@ -1815,7 +1812,7 @@ TEST_CASE_METHOD(
     Array::consolidate(ctx_, SPARSE_ARRAY_NAME, &config);
 
     // Validate working directory
-    CommitsDirectory commits_dir(vfs_, commit_dir);
+    CommitsDirectory commits_dir(vfs_, SPARSE_ARRAY_NAME);
     CHECK(commits_dir.dir_size() == 5);
     CHECK(
         commits_dir.file_count(
@@ -1851,7 +1848,7 @@ TEST_CASE_METHOD(
   if (consolidate) {
     /* Note: An ignore file is written by delete_fragments if there are
      * consolidated commits to be ignored by the delete. */
-    CommitsDirectory commits_dir(vfs_, commit_dir);
+    CommitsDirectory commits_dir(vfs_, SPARSE_ARRAY_NAME);
     CHECK(
         commits_dir.file_count(
             tiledb::sm::constants::con_commits_file_suffix) == 1);
@@ -2009,6 +2006,7 @@ TEST_CASE_METHOD(
       vfs_.ls(GROUP_NAME + tiledb::sm::constants::group_metadata_dir_name);
   CHECK(group_meta_dir.size() == 3);
 
+  // Conditionally consolidate and vacuum group and validate data
   if (consolidate) {
     auto config = ctx_.config();
     config["sm.consolidation.mode"] = "group_meta";

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -2067,9 +2067,9 @@ TEST_CASE_METHOD(
   }
 
   // Delete group in modify exclusive mode
+  /* Note: delete_group will close the group, no need to do so here. */
   group.open(TILEDB_MODIFY_EXCLUSIVE);
   group.delete_group(GROUP_NAME.c_str());
-  group.close();
 
   // Validate group data
   REQUIRE(vfs_.is_file(extraneous_file_path));
@@ -2155,7 +2155,6 @@ TEST_CASE_METHOD(
   // Recursively delete group in modify exclusive mode
   group.open(TILEDB_MODIFY_EXCLUSIVE);
   group.delete_group(GROUP_NAME.c_str(), true);
-  group.close();
 
   // Validate group data
   REQUIRE(vfs_.is_file(extraneous_file_path));

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -267,8 +267,7 @@ struct CPPMaxFragmentSizeFx {
       uint64_t exp_num_con_commits,
       uint64_t exp_num_ign,
       uint64_t exp_num_vac) {
-    std::string commit_dir = tiledb::test::get_commit_dir(array_name);
-    tiledb::test::CommitsDirectory commits_dir(vfs_, commit_dir);
+    tiledb::test::CommitsDirectory commits_dir(vfs_, array_name);
     CHECK(
         commits_dir.file_count(tiledb::sm::constants::write_file_suffix) ==
         exp_num_wrt);

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -268,31 +268,20 @@ struct CPPMaxFragmentSizeFx {
       uint64_t exp_num_ign,
       uint64_t exp_num_vac) {
     std::string commit_dir = tiledb::test::get_commit_dir(array_name);
-    std::vector<std::string> commits{vfs_.ls(commit_dir)};
-    uint64_t num_wrt = 0;
-    uint64_t num_con_commits = 0;
-    uint64_t num_ign = 0;
-    uint64_t num_vac = 0;
-    for (auto commit : commits) {
-      if (tiledb::sm::utils::parse::ends_with(
-              commit, tiledb::sm::constants::write_file_suffix)) {
-        num_wrt++;
-      } else if (tiledb::sm::utils::parse::ends_with(
-                     commit, tiledb::sm::constants::con_commits_file_suffix)) {
-        num_con_commits++;
-      } else if (tiledb::sm::utils::parse::ends_with(
-                     commit, tiledb::sm::constants::ignore_file_suffix)) {
-        num_ign++;
-      } else if (tiledb::sm::utils::parse::ends_with(
-                     commit, tiledb::sm::constants::vacuum_file_suffix)) {
-        num_vac++;
-      }
-    }
-
-    CHECK(num_wrt == exp_num_wrt);
-    CHECK(num_con_commits == exp_num_con_commits);
-    CHECK(num_ign == exp_num_ign);
-    CHECK(num_vac == exp_num_vac);
+    tiledb::test::CommitsDirectory commits_dir(vfs_, commit_dir);
+    CHECK(
+        commits_dir.file_count(tiledb::sm::constants::write_file_suffix) ==
+        exp_num_wrt);
+    CHECK(
+        commits_dir.file_count(
+            tiledb::sm::constants::con_commits_file_suffix) ==
+        exp_num_con_commits);
+    CHECK(
+        commits_dir.file_count(tiledb::sm::constants::ignore_file_suffix) ==
+        exp_num_ign);
+    CHECK(
+        commits_dir.file_count(tiledb::sm::constants::vacuum_file_suffix) ==
+        exp_num_vac);
   }
 
   void validate_disjoint_domains() {

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -34,6 +34,7 @@
 #include <test/support/tdb_catch.h>
 #include "serialization_wrappers.h"
 #include "tiledb/common/logger.h"
+#include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -1260,7 +1261,15 @@ int32_t num_commits(const std::string& array_name) {
   // Get all URIs in the array directory
   auto uris =
       vfs.ls(array_name + "/" + tiledb::sm::constants::array_commits_dir_name);
-  return static_cast<uint32_t>(uris.size());
+  uint32_t num_commits = static_cast<uint32_t>(uris.size());
+
+  // Filter out non-wrt files
+  for (auto uri : uris) {
+    if (!sm::utils::parse::ends_with(uri, sm::constants::write_file_suffix))
+      num_commits--;
+  }
+
+  return num_commits;
 }
 
 int32_t num_fragments(const std::string& array_name) {

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1258,18 +1258,9 @@ int32_t num_commits(const std::string& array_name) {
   Context ctx;
   VFS vfs(ctx);
 
-  // Get all URIs in the array directory
-  auto uris =
-      vfs.ls(array_name + "/" + tiledb::sm::constants::array_commits_dir_name);
-  uint32_t num_commits = static_cast<uint32_t>(uris.size());
-
-  // Filter out non-wrt files
-  for (auto uri : uris) {
-    if (!sm::utils::parse::ends_with(uri, sm::constants::write_file_suffix))
-      num_commits--;
-  }
-
-  return num_commits;
+  // Get the number of write files in the commit directory
+  CommitsDirectory commits_dir(vfs, array_name);
+  return commits_dir.file_count(sm::constants::write_file_suffix);
 }
 
 int32_t num_fragments(const std::string& array_name) {
@@ -1327,8 +1318,8 @@ const std::map<std::string, uint64_t>& FileCount::file_count() const {
   return file_count_;
 }
 
-uint64_t FileCount::file_count(std::string name) {
-  return file_count_[name];
+uint64_t FileCount::file_count(std::string extension) {
+  return file_count_[extension];
 }
 
 uint64_t FileCount::dir_size() {

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1305,6 +1305,45 @@ std::string get_commit_dir(std::string array_dir) {
   return array_dir + "/" + tiledb::sm::constants::array_commits_dir_name;
 }
 
+CommitsDirectory::CommitsDirectory(VFS vfs, std::string path) {
+  auto commits = vfs.ls(path);
+  for (auto commit : commits) {
+    if (tiledb::sm::utils::parse::ends_with(
+            commit, tiledb::sm::constants::vacuum_file_suffix)) {
+      file_count_[tiledb::sm::constants::vacuum_file_suffix]++;
+    } else if (tiledb::sm::utils::parse::ends_with(
+                   commit, tiledb::sm::constants::write_file_suffix)) {
+      file_count_[tiledb::sm::constants::write_file_suffix]++;
+    } else if (tiledb::sm::utils::parse::ends_with(
+                   commit, tiledb::sm::constants::delete_file_suffix)) {
+      file_count_[tiledb::sm::constants::delete_file_suffix]++;
+    } else if (tiledb::sm::utils::parse::ends_with(
+                   commit, tiledb::sm::constants::update_file_suffix)) {
+      file_count_[tiledb::sm::constants::update_file_suffix]++;
+    } else if (tiledb::sm::utils::parse::ends_with(
+                   commit, tiledb::sm::constants::con_commits_file_suffix)) {
+      file_count_[tiledb::sm::constants::con_commits_file_suffix]++;
+    } else if (tiledb::sm::utils::parse::ends_with(
+                   commit, tiledb::sm::constants::ignore_file_suffix)) {
+      file_count_[tiledb::sm::constants::ignore_file_suffix]++;
+    }
+  }
+
+  dir_size_ = commits.size();
+}
+
+const std::map<std::string, uint64_t>& CommitsDirectory::file_count() const {
+  return file_count_;
+}
+
+uint64_t CommitsDirectory::file_count(std::string name) {
+  return file_count_[name];
+}
+
+uint64_t CommitsDirectory::dir_size() {
+  return dir_size_;
+}
+
 template <class T>
 void check_counts(span<T> vals, std::vector<uint64_t> expected) {
   auto expected_size = static_cast<T>(expected.size());

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -759,13 +759,17 @@ std::string get_fragment_dir(std::string array_dir);
  */
 std::string get_commit_dir(std::string array_dir);
 
-/* List the given path and store the counts of each file type. */
-class CommitsDirectory {
+/**
+ * Base class that lists the given path, ensures each directory has the
+ * expected file extensions, and stores the counts of each file type.
+ */
+class FileCount {
  public:
   // Constructors and destructors.
-  CommitsDirectory() = delete;
-  CommitsDirectory(VFS vfs, std::string path);
-  ~CommitsDirectory() = default;
+  FileCount() = delete;
+  FileCount(
+      VFS vfs, std::string path, std::vector<std::string> expected_extensions);
+  ~FileCount() = default;
 
   // Private member accessors.
   const std::map<std::string, uint64_t>& file_count() const;
@@ -776,6 +780,24 @@ class CommitsDirectory {
   // Store the number of each file type.
   std::map<std::string, uint64_t> file_count_;
   uint64_t dir_size_;
+};
+
+/* Inherit the FileCount base class for commits file extensions. */
+class CommitsDirectory : public FileCount {
+ public:
+  // Constructors and destructors.
+  CommitsDirectory() = delete;
+  CommitsDirectory(VFS vfs, std::string path)
+      : FileCount(
+            vfs,
+            path,
+            {tiledb::sm::constants::vacuum_file_suffix,
+             tiledb::sm::constants::write_file_suffix,
+             tiledb::sm::constants::delete_file_suffix,
+             tiledb::sm::constants::update_file_suffix,
+             tiledb::sm::constants::con_commits_file_suffix,
+             tiledb::sm::constants::ignore_file_suffix}){};
+  ~CommitsDirectory() = default;
 };
 
 /**

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -760,37 +760,61 @@ std::string get_fragment_dir(std::string array_dir);
 std::string get_commit_dir(std::string array_dir);
 
 /**
- * Base class that lists the given path, ensures each directory has the
- * expected file extensions, and stores the counts of each file type.
+ * This class checks for and maintains a count of
+ * each expected file extension on the given path.
  */
 class FileCount {
  public:
-  // Constructors and destructors.
-  FileCount() = delete;
   FileCount(
       VFS vfs, std::string path, std::vector<std::string> expected_extensions);
   ~FileCount() = default;
 
-  // Private member accessors.
+  /* ********************************* */
+  /*               API                 */
+  /* ********************************* */
+
+  /**
+   * Retrieve the file counts of all extensions.
+   *
+   * @return std::map<std::string, uint64_t> file counts of all extensions
+   */
   const std::map<std::string, uint64_t>& file_count() const;
-  uint64_t file_count(std::string name);
+
+  /**
+   * Retrieve the file count of the given file extension
+   *
+   * @param name
+   * @return uint64_t file count of the given extension
+   */
+  uint64_t file_count(std::string extension);
+
+  /**
+   * Retrieve the size of the path
+   *
+   * @return uint64_t path size
+   */
   uint64_t dir_size();
 
  private:
-  // Store the number of each file type.
+  /* ********************************* */
+  /*           ATTRIBUTES              */
+  /* ********************************* */
+
+  /** The file extension name and its count on the path. */
   std::map<std::string, uint64_t> file_count_;
+
+  /** The full size of the path. */
   uint64_t dir_size_;
 };
 
-/* Inherit the FileCount base class for commits file extensions. */
+/** This class checks for and maintains a count of the expected file extensions
+ * in the commits directory the given array path. */
 class CommitsDirectory : public FileCount {
  public:
-  // Constructors and destructors.
-  CommitsDirectory() = delete;
-  CommitsDirectory(VFS vfs, std::string path)
+  CommitsDirectory(VFS vfs, std::string array_name)
       : FileCount(
             vfs,
-            path,
+            array_name + "/" + tiledb::sm::constants::array_commits_dir_name,
             {tiledb::sm::constants::vacuum_file_suffix,
              tiledb::sm::constants::write_file_suffix,
              tiledb::sm::constants::delete_file_suffix,

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -759,6 +759,25 @@ std::string get_fragment_dir(std::string array_dir);
  */
 std::string get_commit_dir(std::string array_dir);
 
+/* List the given path and store the counts of each file type. */
+class CommitsDirectory {
+ public:
+  // Constructors and destructors.
+  CommitsDirectory() = delete;
+  CommitsDirectory(VFS vfs, std::string path);
+  ~CommitsDirectory() = default;
+
+  // Private member accessors.
+  const std::map<std::string, uint64_t>& file_count() const;
+  uint64_t file_count(std::string name);
+  uint64_t dir_size();
+
+ private:
+  // Store the number of each file type.
+  std::map<std::string, uint64_t> file_count_;
+  uint64_t dir_size_;
+};
+
 /**
  * Check count of values against a vector of expected counts for an array.
  */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3707,21 +3707,10 @@ int32_t tiledb_array_consolidate_fragments(
 
 int32_t tiledb_array_vacuum(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
-  // Sanity checks
-  if (sanity_check(ctx) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  try {
-    ctx->storage_manager()->array_vacuum(
-        array_uri,
-        (config == nullptr) ? ctx->storage_manager()->config() :
-                              config->config());
-  } catch (std::exception& e) {
-    auto st = Status_StorageManagerError(e.what());
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
-  }
+  ctx->storage_manager()->array_vacuum(
+      array_uri,
+      (config == nullptr) ? ctx->storage_manager()->config() :
+                            config->config());
 
   return TILEDB_OK;
 }
@@ -5687,8 +5676,7 @@ int32_t tiledb_fragment_info_set_config(
     return TILEDB_ERR;
   api::ensure_config_is_valid(config);
 
-  throw_if_not_ok(
-      fragment_info->fragment_info_->set_config(config->config()));
+  throw_if_not_ok(fragment_info->fragment_info_->set_config(config->config()));
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3711,10 +3711,17 @@ int32_t tiledb_array_vacuum(
   if (sanity_check(ctx) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  throw_if_not_ok(ctx->storage_manager()->array_vacuum(
-      array_uri,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
+  try {
+    ctx->storage_manager()->array_vacuum(
+        array_uri,
+        (config == nullptr) ? ctx->storage_manager()->config() :
+                              config->config());
+  } catch (std::exception& e) {
+    auto st = Status_StorageManagerError(e.what());
+    LOG_STATUS_NO_RETURN_VALUE(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -623,6 +623,24 @@ TILEDB_EXPORT int32_t tiledb_group_put_metadata(
     const void* value) TILEDB_NOEXCEPT;
 
 /**
+ * It deletes written data from an open group. The group must
+ * be opened in MODIFY_EXCLSUIVE mode, otherwise the function will error out.
+ *
+ * @param ctx The TileDB context.
+ * @param group An group opened in MODIFY_EXCLUSIVE mode.
+ * @param uri The address of the group item to be deleted.
+ * @param recursive True if all data inside the group is to be deleted.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note if recursive == false, data added to the group will be left as-is.
+ */
+TILEDB_EXPORT int32_t tiledb_group_delete_group(
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* uri,
+    const uint8_t recursive) TILEDB_NOEXCEPT;
+
+/**
  * It deletes a metadata key-value item from an open group. The group must
  * be opened in WRITE mode, otherwise the function will error out.
  *

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -623,7 +623,7 @@ TILEDB_EXPORT int32_t tiledb_group_put_metadata(
     const void* value) TILEDB_NOEXCEPT;
 
 /**
- * It deletes written data from an open group. The group must
+ * Deletes written data from an open group. The group must
  * be opened in MODIFY_EXCLSUIVE mode, otherwise the function will error out.
  *
  * @param ctx The TileDB context.
@@ -641,7 +641,7 @@ TILEDB_EXPORT int32_t tiledb_group_delete_group(
     const uint8_t recursive) TILEDB_NOEXCEPT;
 
 /**
- * It deletes a metadata key-value item from an open group. The group must
+ * Deletes a metadata key-value item from an open group. The group must
  * be opened in WRITE mode, otherwise the function will error out.
  *
  * @param ctx The TileDB context.

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -190,15 +190,7 @@ int32_t tiledb_group_delete_group(
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, group) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  // Delete group
-  try {
-    group->group_->delete_group(tiledb::sm::URI(uri), recursive);
-  } catch (std::exception& e) {
-    auto st = sm::Status_GroupError(e.what());
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
-  }
+  group->group_->delete_group(tiledb::sm::URI(uri), recursive);
   return TILEDB_OK;
 }
 
@@ -628,17 +620,10 @@ int32_t tiledb_group_vacuum_metadata(
   if (sanity_check(ctx) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  try {
-    ctx->storage_manager()->group_metadata_vacuum(
-        group_uri,
-        (config == nullptr) ? ctx->storage_manager()->config() :
-                              config->config());
-  } catch (std::exception& e) {
-    auto st = Status_StorageManagerError(e.what());
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
-  }
+  ctx->storage_manager()->group_metadata_vacuum(
+      group_uri,
+      (config == nullptr) ? ctx->storage_manager()->config() :
+                            config->config());
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -182,12 +182,32 @@ int32_t tiledb_group_put_metadata(
   return TILEDB_OK;
 }
 
+int32_t tiledb_group_delete_group(
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* uri,
+    const uint8_t recursive) {
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, group) == TILEDB_ERR)
+    return TILEDB_ERR;
+
+  // Delete group
+  try {
+    group->group_->delete_group(tiledb::sm::URI(uri), recursive);
+  } catch (std::exception& e) {
+    auto st = sm::Status_GroupError(e.what());
+    LOG_STATUS(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+  return TILEDB_OK;
+}
+
 int32_t tiledb_group_delete_metadata(
     tiledb_ctx_t* ctx, tiledb_group_t* group, const char* key) {
   if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, group) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  // Put metadata
+  // Delete metadata
   throw_if_not_ok(group->group_->delete_metadata(key));
 
   return TILEDB_OK;
@@ -685,6 +705,15 @@ TILEDB_EXPORT int32_t tiledb_group_put_metadata(
     const void* value) TILEDB_NOEXCEPT {
   return api_entry<detail::tiledb_group_put_metadata>(
       ctx, group, key, value_type, value_num, value);
+}
+
+TILEDB_EXPORT int32_t tiledb_group_delete_group(
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* uri,
+    const uint8_t recursive) TILEDB_NOEXCEPT {
+  return api_entry<detail::tiledb_group_delete_group>(
+      ctx, group, uri, recursive);
 }
 
 TILEDB_EXPORT int32_t tiledb_group_delete_metadata(

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -195,7 +195,7 @@ int32_t tiledb_group_delete_group(
     group->group_->delete_group(tiledb::sm::URI(uri), recursive);
   } catch (std::exception& e) {
     auto st = sm::Status_GroupError(e.what());
-    LOG_STATUS(st);
+    LOG_STATUS_NO_RETURN_VALUE(st);
     save_error(ctx, st);
     return TILEDB_ERR;
   }

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -404,13 +404,13 @@ int32_t tiledb_group_get_member_by_index(
     auto&& [uri_str, object_type, name_str] =
         group->group_->member_by_index(index);
 
-    *type = static_cast<tiledb_object_t>(object_type.value());
-    *uri = static_cast<char*>(std::malloc(uri_str.value().size() + 1));
+    *type = static_cast<tiledb_object_t>(object_type);
+    *uri = static_cast<char*>(std::malloc(uri_str.size() + 1));
     if (*uri == nullptr)
       return TILEDB_ERR;
 
-    std::memcpy(*uri, uri_str.value().data(), uri_str.value().size());
-    (*uri)[uri_str.value().size()] = '\0';
+    std::memcpy(*uri, uri_str.data(), uri_str.size());
+    (*uri)[uri_str.size()] = '\0';
 
     *name = nullptr;
     if (name_str.has_value()) {
@@ -446,13 +446,13 @@ int32_t tiledb_group_get_member_by_name(
     auto&& [uri_str, object_type, name_str, ignored_relative] =
         group->group_->member_by_name(name);
 
-    *type = static_cast<tiledb_object_t>(object_type.value());
-    *uri = static_cast<char*>(std::malloc(uri_str.value().size() + 1));
+    *type = static_cast<tiledb_object_t>(object_type);
+    *uri = static_cast<char*>(std::malloc(uri_str.size() + 1));
     if (*uri == nullptr)
       return TILEDB_ERR;
 
-    std::memcpy(*uri, uri_str.value().data(), uri_str.value().size());
-    (*uri)[uri_str.value().size()] = '\0';
+    std::memcpy(*uri, uri_str.data(), uri_str.size());
+    (*uri)[uri_str.size()] = '\0';
 
   } catch (const std::exception& e) {
     auto st = Status_Error(
@@ -480,7 +480,7 @@ int32_t tiledb_group_get_is_relative_uri_by_name(
   try {
     auto&& [uri_str, object_type, name_str, relative] =
         group->group_->member_by_name(name);
-    *is_relative = *relative ? 1 : 0;
+    *is_relative = relative ? 1 : 0;
   } catch (const std::exception& e) {
     auto st = Status_Error(
         std::string("Internal TileDB uncaught exception; ") + e.what());

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -377,15 +377,7 @@ int32_t tiledb_group_get_member_count(
     return TILEDB_ERR;
 
   try {
-    auto&& [st, member_count] = group->group_->member_count();
-    if (!st.ok()) {
-      save_error(ctx, st);
-      return TILEDB_ERR;
-    }
-
-    *count = member_count.value();
-
-    return TILEDB_OK;
+    *count = group->group_->member_count();
   } catch (const std::exception& e) {
     auto st = Status_Error(
         std::string("Internal TileDB uncaught exception; ") + e.what());
@@ -394,7 +386,7 @@ int32_t tiledb_group_get_member_count(
     return TILEDB_ERR;
   }
 
-  return TILEDB_ERR;
+  return TILEDB_OK;
 }
 
 int32_t tiledb_group_get_member_by_index(
@@ -409,12 +401,8 @@ int32_t tiledb_group_get_member_by_index(
     return TILEDB_ERR;
 
   try {
-    auto&& [st, uri_str, object_type, name_str] =
+    auto&& [uri_str, object_type, name_str] =
         group->group_->member_by_index(index);
-    if (!st.ok()) {
-      save_error(ctx, st);
-      return TILEDB_ERR;
-    }
 
     *type = static_cast<tiledb_object_t>(object_type.value());
     *uri = static_cast<char*>(std::malloc(uri_str.value().size() + 1));
@@ -433,8 +421,6 @@ int32_t tiledb_group_get_member_by_index(
       std::memcpy(*name, name_str.value().data(), name_str.value().size());
       (*name)[name_str.value().size()] = '\0';
     }
-
-    return TILEDB_OK;
   } catch (const std::exception& e) {
     auto st = Status_Error(
         std::string("Internal TileDB uncaught exception; ") + e.what());
@@ -443,7 +429,7 @@ int32_t tiledb_group_get_member_by_index(
     return TILEDB_ERR;
   }
 
-  return TILEDB_ERR;
+  return TILEDB_OK;
 }
 
 int32_t tiledb_group_get_member_by_name(
@@ -457,12 +443,8 @@ int32_t tiledb_group_get_member_by_name(
     return TILEDB_ERR;
 
   try {
-    auto&& [st, uri_str, object_type, name_str, ignored_relative] =
+    auto&& [uri_str, object_type, name_str, ignored_relative] =
         group->group_->member_by_name(name);
-    if (!st.ok()) {
-      save_error(ctx, st);
-      return TILEDB_ERR;
-    }
 
     *type = static_cast<tiledb_object_t>(object_type.value());
     *uri = static_cast<char*>(std::malloc(uri_str.value().size() + 1));
@@ -472,7 +454,6 @@ int32_t tiledb_group_get_member_by_name(
     std::memcpy(*uri, uri_str.value().data(), uri_str.value().size());
     (*uri)[uri_str.value().size()] = '\0';
 
-    return TILEDB_OK;
   } catch (const std::exception& e) {
     auto st = Status_Error(
         std::string("Internal TileDB uncaught exception; ") + e.what());
@@ -481,7 +462,7 @@ int32_t tiledb_group_get_member_by_name(
     return TILEDB_ERR;
   }
 
-  return TILEDB_ERR;
+  return TILEDB_OK;
 }
 
 int32_t tiledb_group_get_is_relative_uri_by_name(
@@ -496,11 +477,17 @@ int32_t tiledb_group_get_is_relative_uri_by_name(
     return TILEDB_ERR;
   }
 
-  auto&& [st, uri_str, object_type, name_str, relative] =
-      group->group_->member_by_name(name);
-  throw_if_not_ok(st);
-
-  *is_relative = *relative ? 1 : 0;
+  try {
+    auto&& [uri_str, object_type, name_str, relative] =
+        group->group_->member_by_name(name);
+    *is_relative = *relative ? 1 : 0;
+  } catch (const std::exception& e) {
+    auto st = Status_Error(
+        std::string("Internal TileDB uncaught exception; ") + e.what());
+    LOG_STATUS_NO_RETURN_VALUE(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb_group.cc
+++ b/tiledb/sm/c_api/tiledb_group.cc
@@ -628,10 +628,17 @@ int32_t tiledb_group_vacuum_metadata(
   if (sanity_check(ctx) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  throw_if_not_ok(ctx->storage_manager()->group_metadata_vacuum(
-      group_uri,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
+  try {
+    ctx->storage_manager()->group_metadata_vacuum(
+        group_uri,
+        (config == nullptr) ? ctx->storage_manager()->config() :
+                              config->config());
+  } catch (std::exception& e) {
+    auto st = Status_StorageManagerError(e.what());
+    LOG_STATUS_NO_RETURN_VALUE(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -40,8 +40,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*          CONSTRUCTOR           */
@@ -146,10 +145,11 @@ Status ArrayMetaConsolidator::consolidate(
   return Status::Ok();
 }
 
-Status ArrayMetaConsolidator::vacuum(const char* array_name) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum array metadata; Array name cannot be null"));
+void ArrayMetaConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr) {
+    throw Status_StorageManagerError(
+        "Cannot vacuum array metadata; Array name cannot be null");
+  }
 
   // Get the array metadata URIs and vacuum file URIs to be vacuum
   auto vfs = storage_manager_->vfs();
@@ -166,14 +166,8 @@ Status ArrayMetaConsolidator::vacuum(const char* array_name) {
   auto vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
 
   // Delete the array metadata and vacuum files
-  try {
-    vfs->remove_files(compute_tp, array_meta_uris_to_vacuum);
-    vfs->remove_files(compute_tp, vac_uris_to_vacuum);
-  } catch (std::exception& e) {
-    RETURN_NOT_OK(Status_Error(e.what()));
-  }
-
-  return Status::Ok();
+  vfs->remove_files(compute_tp, array_meta_uris_to_vacuum);
+  vfs->remove_files(compute_tp, vac_uris_to_vacuum);
 }
 
 /* ****************************** */
@@ -195,5 +189,4 @@ Status ArrayMetaConsolidator::set_config(const Config& config) {
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -162,25 +162,16 @@ Status ArrayMetaConsolidator::vacuum(const char* array_name) {
       0,
       std::numeric_limits<uint64_t>::max());
 
-  const auto& array_meta_uris_to_vacuum = array_dir.array_meta_uris_to_vacuum();
-  const auto& vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
+  auto array_meta_uris_to_vacuum = array_dir.array_meta_uris_to_vacuum();
+  auto vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
 
-  // Delete the array metadata files
-  auto status = parallel_for(
-      compute_tp, 0, array_meta_uris_to_vacuum.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs->remove_file(array_meta_uris_to_vacuum[i]));
-
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  // Delete vacuum files
-  status =
-      parallel_for(compute_tp, 0, vac_uris_to_vacuum.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs->remove_file(vac_uris_to_vacuum[i]));
-        return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
+  // Delete the array metadata and vacuum files
+  try {
+    vfs->remove_files(compute_tp, array_meta_uris_to_vacuum);
+    vfs->remove_files(compute_tp, vac_uris_to_vacuum);
+  } catch (std::exception& e) {
+    RETURN_NOT_OK(Status_Error(e.what()));
+  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -162,12 +162,9 @@ void ArrayMetaConsolidator::vacuum(const char* array_name) {
       0,
       std::numeric_limits<uint64_t>::max());
 
-  auto array_meta_uris_to_vacuum = array_dir.array_meta_uris_to_vacuum();
-  auto vac_uris_to_vacuum = array_dir.array_meta_vac_uris_to_vacuum();
-
   // Delete the array metadata and vacuum files
-  vfs->remove_files(compute_tp, array_meta_uris_to_vacuum);
-  vfs->remove_files(compute_tp, vac_uris_to_vacuum);
+  vfs->remove_files(compute_tp, array_dir.array_meta_uris_to_vacuum());
+  vfs->remove_files(compute_tp, array_dir.array_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/array_meta_consolidator.h
+++ b/tiledb/sm/consolidator/array_meta_consolidator.h
@@ -43,8 +43,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Handles array metadata consolidation. */
 class ArrayMetaConsolidator : public Consolidator {
@@ -92,9 +91,8 @@ class ArrayMetaConsolidator : public Consolidator {
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to consolidate.
-   * @return Status
    */
-  Status vacuum(const char* array_name);
+  void vacuum(const char* array_name);
 
  private:
   /* ********************************* */
@@ -112,7 +110,6 @@ class ArrayMetaConsolidator : public Consolidator {
   Consolidator::ConsolidationConfigBase config_;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_ARRAY_META_CONSOLIDATOR_H

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -43,8 +43,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*          CONSTRUCTOR           */
@@ -103,10 +102,11 @@ Status CommitsConsolidator::consolidate(
   return Status::Ok();
 }
 
-Status CommitsConsolidator::vacuum(const char* array_name) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum array metadata; Array name cannot be null"));
+void CommitsConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr) {
+    throw Status_StorageManagerError(
+        "Cannot vacuum array metadata; Array name cannot be null");
+  }
 
   // Get the array metadata URIs and vacuum file URIs to be vacuum
   auto vfs = storage_manager_->vfs();
@@ -125,15 +125,8 @@ Status CommitsConsolidator::vacuum(const char* array_name) {
       array_dir.consolidated_commits_uris_to_vacuum();
 
   // Delete the commits and vacuum files
-  try {
-    vfs->remove_files(compute_tp, commits_uris_to_vacuum);
-    vfs->remove_files(compute_tp, consolidated_commits_uris_to_vacuum);
-  } catch (std::exception& e) {
-    RETURN_NOT_OK(Status_Error(e.what()));
-  }
-
-  return Status::Ok();
+  vfs->remove_files(compute_tp, commits_uris_to_vacuum);
+  vfs->remove_files(compute_tp, consolidated_commits_uris_to_vacuum);
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -120,13 +120,10 @@ void CommitsConsolidator::vacuum(const char* array_name) {
       utils::time::timestamp_now_ms(),
       ArrayDirectoryMode::COMMITS);
 
-  auto commits_uris_to_vacuum = array_dir.commit_uris_to_vacuum();
-  auto consolidated_commits_uris_to_vacuum =
-      array_dir.consolidated_commits_uris_to_vacuum();
-
   // Delete the commits and vacuum files
-  vfs->remove_files(compute_tp, commits_uris_to_vacuum);
-  vfs->remove_files(compute_tp, consolidated_commits_uris_to_vacuum);
+  vfs->remove_files(compute_tp, array_dir.commit_uris_to_vacuum());
+  vfs->remove_files(
+      compute_tp, array_dir.consolidated_commits_uris_to_vacuum());
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/commits_consolidator.h
+++ b/tiledb/sm/consolidator/commits_consolidator.h
@@ -43,8 +43,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Handles commits consolidation. */
 class CommitsConsolidator : public Consolidator {
@@ -90,12 +89,10 @@ class CommitsConsolidator : public Consolidator {
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to consolidate.
-   * @return Status
    */
-  Status vacuum(const char* array_name);
+  void vacuum(const char* array_name);
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_COMMITS_CONSOLIDATOR_H

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -41,8 +41,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ********************************* */
 /*          FACTORY METHODS          */
@@ -121,9 +120,8 @@ Status Consolidator::consolidate(
       Status_ConsolidatorError("Cannot consolidate; Invalid object"));
 }
 
-Status Consolidator::vacuum([[maybe_unused]] const char* array_name) {
-  return logger_->status(
-      Status_ConsolidatorError("Cannot vacuum; Invalid object"));
+void Consolidator::vacuum([[maybe_unused]] const char* array_name) {
+  throw Status_ConsolidatorError("Cannot vacuum; Invalid object");
 }
 
 void Consolidator::check_array_uri(const char* array_name) {
@@ -132,5 +130,4 @@ void Consolidator::check_array_uri(const char* array_name) {
   }
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -44,8 +44,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class ArraySchema;
 class Config;
@@ -123,9 +122,8 @@ class Consolidator {
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to vacuum.
-   * @return Status
    */
-  virtual Status vacuum(const char* array_name);
+  virtual void vacuum(const char* array_name);
 
  protected:
   /* ********************************* */
@@ -175,7 +173,6 @@ class Consolidator {
   inline static std::atomic<uint64_t> logger_id_ = 0;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_FRAGMENT_H

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -302,11 +302,8 @@ void FragmentConsolidator::vacuum(const char* array_name) {
   auto filtered_fragment_uris = array_dir.filtered_fragment_uris(true);
   const auto& fragment_uris_to_vacuum =
       filtered_fragment_uris.fragment_uris_to_vacuum();
-  auto commit_uris_to_vacuum = filtered_fragment_uris.commit_uris_to_vacuum();
   const auto& commit_uris_to_ignore =
       filtered_fragment_uris.commit_uris_to_ignore();
-  auto vac_uris_to_vacuum =
-      filtered_fragment_uris.fragment_vac_uris_to_vacuum();
 
   if (commit_uris_to_ignore.size() > 0) {
     throw_if_not_ok(storage_manager_->write_commit_ignore_file(
@@ -314,8 +311,9 @@ void FragmentConsolidator::vacuum(const char* array_name) {
   }
 
   // Delete the commit and vacuum files
-  vfs->remove_files(compute_tp, commit_uris_to_vacuum);
-  vfs->remove_files(compute_tp, vac_uris_to_vacuum);
+  vfs->remove_files(compute_tp, filtered_fragment_uris.commit_uris_to_vacuum());
+  vfs->remove_files(
+      compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
 
   // Delete fragment directories
   auto status = parallel_for(

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -316,13 +316,12 @@ void FragmentConsolidator::vacuum(const char* array_name) {
       compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
 
   // Delete fragment directories
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
         RETURN_NOT_OK(vfs->remove_dir(fragment_uris_to_vacuum[i]));
 
         return Status::Ok();
-      });
-  throw_if_not_ok(status);
+      }));
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -46,8 +46,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class ArraySchema;
 class Config;
@@ -123,9 +122,8 @@ class FragmentConsolidator : public Consolidator {
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to vacuum.
-   * @return Status
    */
-  Status vacuum(const char* array_name);
+  void vacuum(const char* array_name);
 
  private:
   /* ********************************* */
@@ -333,7 +331,6 @@ class FragmentConsolidator : public Consolidator {
   ConsolidationConfig config_;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_FRAGMENT_CONSOLIDATOR_H

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -210,7 +210,7 @@ void FragmentMetaConsolidator::vacuum(const char* array_name) {
   }
 
   // Vacuum
-  auto status =
+  throw_if_not_ok(
       parallel_for(compute_tp, 0, fragment_meta_uris.size(), [&](size_t i) {
         auto& uri = fragment_meta_uris[i];
         std::pair<uint64_t, uint64_t> timestamp_range;
@@ -218,8 +218,7 @@ void FragmentMetaConsolidator::vacuum(const char* array_name) {
         if (timestamp_range.second != t_latest)
           RETURN_NOT_OK(vfs->remove_file(uri));
         return Status::Ok();
-      });
-  throw_if_not_ok(status);
+      }));
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -44,8 +44,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*          CONSTRUCTOR           */
@@ -184,10 +183,11 @@ Status FragmentMetaConsolidator::consolidate(
   return Status::Ok();
 }
 
-Status FragmentMetaConsolidator::vacuum(const char* array_name) {
-  if (array_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum fragment metadata; Array name cannot be null"));
+void FragmentMetaConsolidator::vacuum(const char* array_name) {
+  if (array_name == nullptr) {
+    throw Status_StorageManagerError(
+        "Cannot vacuum fragment metadata; Array name cannot be null");
+  }
 
   // Get the consolidated fragment metadata URIs to be deleted
   // (all except the last one)
@@ -203,7 +203,7 @@ Status FragmentMetaConsolidator::vacuum(const char* array_name) {
   uint64_t t_latest = 0;
   for (const auto& uri : fragment_meta_uris) {
     std::pair<uint64_t, uint64_t> timestamp_range;
-    RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
+    throw_if_not_ok(utils::parse::get_timestamp_range(uri, &timestamp_range));
     if (timestamp_range.second > t_latest) {
       t_latest = timestamp_range.second;
     }
@@ -219,10 +219,7 @@ Status FragmentMetaConsolidator::vacuum(const char* array_name) {
           RETURN_NOT_OK(vfs->remove_file(uri));
         return Status::Ok();
       });
-  RETURN_NOT_OK(status);
-
-  return Status::Ok();
+  throw_if_not_ok(status);
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.h
@@ -43,8 +43,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Handles fragment metadata consolidation. */
 class FragmentMetaConsolidator : public Consolidator {
@@ -90,12 +89,10 @@ class FragmentMetaConsolidator : public Consolidator {
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to consolidate.
-   * @return Status
    */
-  Status vacuum(const char* array_name);
+  void vacuum(const char* array_name);
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_FRAGMENT_META_CONSOLIDATOR_H

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -42,8 +42,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*          CONSTRUCTOR           */
@@ -145,10 +144,11 @@ Status GroupMetaConsolidator::consolidate(
   return Status::Ok();
 }
 
-Status GroupMetaConsolidator::vacuum(const char* group_name) {
-  if (group_name == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum group metadata; Group name cannot be null"));
+void GroupMetaConsolidator::vacuum(const char* group_name) {
+  if (group_name == nullptr) {
+    throw Status_StorageManagerError(
+        "Cannot vacuum group metadata; Group name cannot be null");
+  }
 
   // Get the group metadata URIs and vacuum file URIs to be vacuumed
   auto vfs = storage_manager_->vfs();
@@ -162,21 +162,15 @@ Status GroupMetaConsolidator::vacuum(const char* group_name) {
         0,
         std::numeric_limits<uint64_t>::max());
   } catch (const std::logic_error& le) {
-    return LOG_STATUS(Status_GroupDirectoryError(le.what()));
+    throw Status_GroupDirectoryError(le.what());
   }
 
   auto group_meta_uris_to_vacuum = group_dir.group_meta_uris_to_vacuum();
   auto vac_uris_to_vacuum = group_dir.group_meta_vac_uris_to_vacuum();
 
   // Delete the group metadata and vacuum files
-  try {
-    vfs->remove_files(compute_tp, group_meta_uris_to_vacuum);
-    vfs->remove_files(compute_tp, vac_uris_to_vacuum);
-  } catch (std::exception& e) {
-    RETURN_NOT_OK(Status_Error(e.what()));
-  }
-
-  return Status::Ok();
+  vfs->remove_files(compute_tp, group_meta_uris_to_vacuum);
+  vfs->remove_files(compute_tp, vac_uris_to_vacuum);
 }
 
 /* ****************************** */
@@ -198,5 +192,4 @@ Status GroupMetaConsolidator::set_config(const Config& config) {
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -165,12 +165,9 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
     throw Status_GroupDirectoryError(le.what());
   }
 
-  auto group_meta_uris_to_vacuum = group_dir.group_meta_uris_to_vacuum();
-  auto vac_uris_to_vacuum = group_dir.group_meta_vac_uris_to_vacuum();
-
   // Delete the group metadata and vacuum files
-  vfs->remove_files(compute_tp, group_meta_uris_to_vacuum);
-  vfs->remove_files(compute_tp, vac_uris_to_vacuum);
+  vfs->remove_files(compute_tp, group_dir.group_meta_uris_to_vacuum());
+  vfs->remove_files(compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/group_meta_consolidator.h
+++ b/tiledb/sm/consolidator/group_meta_consolidator.h
@@ -41,8 +41,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Handles group metadata consolidation. */
 class GroupMetaConsolidator : public Consolidator {
@@ -90,9 +89,8 @@ class GroupMetaConsolidator : public Consolidator {
    * Performs the vacuuming operation.
    *
    * @param group_name URI of group to consolidate.
-   * @return Status
    */
-  Status vacuum(const char* group_name);
+  void vacuum(const char* group_name);
 
  private:
   /* ********************************* */
@@ -110,7 +108,6 @@ class GroupMetaConsolidator : public Consolidator {
   Consolidator::ConsolidationConfigBase config_;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_GROUP_META_CONSOLIDATOR

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -42,7 +42,7 @@ namespace tiledb {
 class Group {
  public:
   /**
-   * @brief Constructor. This opens the group for the given query type. The
+   * @brief Constructor. Opens the group for the given query type. The
    * destructor calls the `close()` method.
    *
    * **Example:**
@@ -82,7 +82,7 @@ class Group {
   }
 
   /**
-   * @brief Opens the group. The group is opened using a query type as input.
+   * @brief Opens the group using a query type as input.
    *
    * This is to indicate that queries created for this `Group`
    * object will inherit the query type. In other words, `Group`
@@ -187,7 +187,7 @@ class Group {
   }
 
   /**
-   * It puts a metadata key-value item to an open group. The group must
+   * Puts a metadata key-value item to an open group. The group must
    * be opened in WRITE mode, otherwise the function will error out.
    *
    * @param key The key of the metadata item to be added. UTF-8 encodings
@@ -212,7 +212,7 @@ class Group {
   }
 
   /**
-   * It deletes written data from an open group. The group must
+   * Deletes written data from an open group. The group must
    * be opened in MODIFY_EXCLSUIVE mode, otherwise the function will error out.
    *
    * @param uri The address of the group item to be deleted.
@@ -228,7 +228,7 @@ class Group {
   }
 
   /**
-   * It deletes a metadata key-value item from an open group. The group must
+   * Deletes a metadata key-value item from an open group. The group must
    * be opened in WRITE mode, otherwise the function will error out.
    *
    * @param key The key of the metadata item to be deleted.
@@ -246,7 +246,7 @@ class Group {
   }
 
   /**
-   * It gets a metadata key-value item from an open group. The group must
+   * Gets a metadata key-value item from an open group. The group must
    * be opened in READ mode, otherwise the function will error out.
    *
    * @param key The key of the metadata item to be retrieved. UTF-8 encodings
@@ -304,7 +304,7 @@ class Group {
   }
 
   /**
-   * It gets a metadata item from an open group using an index.
+   * Gets a metadata item from an open group using an index.
    * The group must be opened in READ mode, otherwise the function will
    * error out.
    *

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -213,7 +213,7 @@ class Group {
 
   /**
    * Deletes written data from an open group. The group must
-   * be opened in MODIFY_EXCLSUIVE mode, otherwise the function will error out.
+   * be opened in MODIFY_EXCLUSIVE mode, otherwise the function will error out.
    *
    * @param uri The address of the group item to be deleted.
    * @param recursive True if all data inside the group is to be deleted.

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -1,5 +1,5 @@
 /**
- * @file   group.h
+ * @file   group_experimental.h
  *
  * @author Ravi Gaddipati
  *
@@ -7,7 +7,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -209,6 +209,22 @@ class Group {
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(tiledb_group_put_metadata(
         c_ctx, group_.get(), key.c_str(), value_type, value_num, value));
+  }
+
+  /**
+   * It deletes written data from an open group. The group must
+   * be opened in MODIFY_EXCLSUIVE mode, otherwise the function will error out.
+   *
+   * @param uri The address of the group item to be deleted.
+   * @param recursive True if all data inside the group is to be deleted.
+   *
+   * @note if recursive == false, data added to the group will be left as-is.
+   */
+  void delete_group(const std::string& uri, bool recursive = false) {
+    auto& ctx = ctx_.get();
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(
+        tiledb_group_delete_group(c_ctx, group_.get(), uri.c_str(), recursive));
   }
 
   /**
@@ -421,6 +437,46 @@ class Group {
     std::string ret(str);
     free(str);
     return ret;
+  }
+
+  /**
+   * Consolidates the group metadata into a single group metadata file.
+   *
+   * **Example:**
+   * @code{.cpp}
+   * tiledb::Group::consolidate_metadata(ctx, "s3://bucket-name/group-name");
+   * @endcode
+   *
+   * @param ctx TileDB context
+   * @param uri The URI of the TileDB group to be consolidated.
+   * @param config Configuration parameters for the consolidation.
+   */
+  static void consolidate_metadata(
+      const Context& ctx,
+      const std::string& uri,
+      Config* const config = nullptr) {
+    ctx.handle_error(tiledb_group_consolidate_metadata(
+        ctx.ptr().get(), uri.c_str(), config ? config->ptr().get() : nullptr));
+  }
+
+  /**
+   * Cleans up the group metadata.
+   *
+   * **Example:**
+   * @code{.cpp}
+   * tiledb::Group::vacuum_metadata(ctx, "s3://bucket-name/group-name");
+   * @endcode
+   *
+   * @param ctx TileDB context
+   * @param uri The URI of the TileDB group to vacuum.
+   * @param config Configuration parameters for the vacuuming.
+   */
+  static void vacuum_metadata(
+      const Context& ctx,
+      const std::string& uri,
+      Config* const config = nullptr) {
+    ctx.handle_error(tiledb_group_vacuum_metadata(
+        ctx.ptr().get(), uri.c_str(), config ? config->ptr().get() : nullptr));
   }
 
  private:

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -502,6 +502,21 @@ Status VFS::remove_file(const URI& uri) const {
       Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
+void VFS::remove_files(ThreadPool* compute_tp, std::vector<URI>& uris) const {
+  throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
+    RETURN_NOT_OK(remove_file(uris[i]));
+    return Status::Ok();
+  }));
+}
+
+void VFS::remove_files(
+    ThreadPool* compute_tp, std::vector<TimestampedURI>& uris) const {
+  throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
+    RETURN_NOT_OK(remove_file(uris[i].uri_));
+    return Status::Ok();
+  }));
+}
+
 Status VFS::max_parallel_ops(const URI& uri, uint64_t* ops) const {
   bool found;
   *ops = 0;
@@ -1687,13 +1702,14 @@ VFS::multipart_upload_state(const URI& uri) {
     }
     return {Status::Ok(), state};
 #else
-    return {LOG_STATUS(Status_VFSError("TileDB was built without S3 support")),
-            nullopt};
+    return {
+        LOG_STATUS(Status_VFSError("TileDB was built without S3 support")),
+        nullopt};
 #endif
   } else if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return {LOG_STATUS(Status_VFSError("Not yet supported for Azure")),
-            nullopt};
+    return {
+        LOG_STATUS(Status_VFSError("Not yet supported for Azure")), nullopt};
 #else
     return {
         LOG_STATUS(Status_VFSError("TileDB was built without Azure support")),
@@ -1703,14 +1719,16 @@ VFS::multipart_upload_state(const URI& uri) {
 #ifdef HAVE_GCS
     return {LOG_STATUS(Status_VFSError("Not yet supported for GCS")), nullopt};
 #else
-    return {LOG_STATUS(Status_VFSError("TileDB was built without GCS support")),
-            nullopt};
+    return {
+        LOG_STATUS(Status_VFSError("TileDB was built without GCS support")),
+        nullopt};
 #endif
   }
 
-  return {LOG_STATUS(
-              Status_VFSError("Unsupported URI schemes: " + uri.to_string())),
-          nullopt};
+  return {
+      LOG_STATUS(
+          Status_VFSError("Unsupported URI schemes: " + uri.to_string())),
+      nullopt};
 }
 
 Status VFS::set_multipart_upload_state(

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -502,7 +502,8 @@ Status VFS::remove_file(const URI& uri) const {
       Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
 }
 
-void VFS::remove_files(ThreadPool* compute_tp, std::vector<URI>& uris) const {
+void VFS::remove_files(
+    ThreadPool* compute_tp, const std::vector<URI>& uris) const {
   throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
     RETURN_NOT_OK(remove_file(uris[i]));
     return Status::Ok();
@@ -510,7 +511,7 @@ void VFS::remove_files(ThreadPool* compute_tp, std::vector<URI>& uris) const {
 }
 
 void VFS::remove_files(
-    ThreadPool* compute_tp, std::vector<TimestampedURI>& uris) const {
+    ThreadPool* compute_tp, const std::vector<TimestampedURI>& uris) const {
   throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
     RETURN_NOT_OK(remove_file(uris[i].uri_));
     return Status::Ok();

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -263,6 +263,23 @@ class VFS {
   Status remove_file(const URI& uri) const;
 
   /**
+   * Deletes files in parallel from the given vector of files.
+   *
+   * @param compute_tp The compute-bound ThreadPool.
+   * @param uris The URIs of the files.
+   */
+  void remove_files(ThreadPool* compute_tp, std::vector<URI>& uris) const;
+
+  /**
+   * Deletes files in parallel from the given vector of timestamped files.
+   *
+   * @param compute_tp The compute-bound ThreadPool.
+   * @param uris The TimestampedURIs of the files.
+   */
+  void remove_files(
+      ThreadPool* compute_tp, std::vector<TimestampedURI>& uris) const;
+
+  /**
    * Retrieves the size of a file.
    *
    * @param uri The URI of the file.

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -268,7 +268,7 @@ class VFS {
    * @param compute_tp The compute-bound ThreadPool.
    * @param uris The URIs of the files.
    */
-  void remove_files(ThreadPool* compute_tp, std::vector<URI>& uris) const;
+  void remove_files(ThreadPool* compute_tp, const std::vector<URI>& uris) const;
 
   /**
    * Deletes files in parallel from the given vector of timestamped files.
@@ -277,7 +277,7 @@ class VFS {
    * @param uris The TimestampedURIs of the files.
    */
   void remove_files(
-      ThreadPool* compute_tp, std::vector<TimestampedURI>& uris) const;
+      ThreadPool* compute_tp, const std::vector<TimestampedURI>& uris) const;
 
   /**
    * Retrieves the size of a file.

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -774,8 +774,8 @@ uint64_t Group::member_count() const {
   return members_.size();
 }
 
-tuple<optional<std::string>, optional<ObjectType>, optional<std::string>>
-Group::member_by_index(uint64_t index) {
+tuple<std::string, ObjectType, optional<std::string>> Group::member_by_index(
+    uint64_t index) {
   std::lock_guard<std::mutex> lck(mtx_);
 
   // Check if group is open
@@ -805,11 +805,7 @@ Group::member_by_index(uint64_t index) {
   return {uri, member->type(), member->name()};
 }
 
-tuple<
-    optional<std::string>,
-    optional<ObjectType>,
-    optional<std::string>,
-    optional<bool>>
+tuple<std::string, ObjectType, optional<std::string>, bool>
 Group::member_by_name(const std::string& name) {
   std::lock_guard<std::mutex> lck(mtx_);
 

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -319,6 +319,7 @@ void Group::delete_group(const URI& uri, bool recursive) {
     throw DeleteGroupStatusException("Query type must be MODIFY_EXCLUSIVE");
   }
 
+  // Delete group members within the group when deleting recursively
   if (recursive) {
     for (auto member : members_vec_) {
       URI uri = member->uri();
@@ -336,6 +337,7 @@ void Group::delete_group(const URI& uri, bool recursive) {
     }
   }
 
+  // Delete group data
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -321,11 +321,10 @@ void Group::delete_group(const URI& uri, bool recursive) {
       }
 
       if (member->type() == ObjectType::ARRAY) {
-        throw_if_not_ok(
-            storage_manager_->delete_array(uri.to_string().c_str()));
+        storage_manager_->delete_array(uri.to_string().c_str());
       } else if (member->type() == ObjectType::GROUP) {
         GroupV1 group_rec(uri, storage_manager_);
-        group_rec.open(QueryType::MODIFY_EXCLUSIVE);
+        throw_if_not_ok(group_rec.open(QueryType::MODIFY_EXCLUSIVE));
         group_rec.delete_group(uri, true);
       }
     }
@@ -758,15 +757,17 @@ tuple<Status, optional<uint64_t>> Group::member_count() const {
   std::lock_guard<std::mutex> lck(mtx_);
   // Check if group is open
   if (!is_open_) {
-    return {Status_GroupError("Cannot get member count; Group is not open"),
-            std::nullopt};
+    return {
+        Status_GroupError("Cannot get member count; Group is not open"),
+        std::nullopt};
   }
 
   // Check mode
   if (query_type_ != QueryType::READ) {
-    return {Status_GroupError(
-                "Cannot get member; Group was not opened in read mode"),
-            std::nullopt};
+    return {
+        Status_GroupError(
+            "Cannot get member; Group was not opened in read mode"),
+        std::nullopt};
   }
 
   return {Status::Ok(), members_.size()};
@@ -782,19 +783,21 @@ Group::member_by_index(uint64_t index) {
 
   // Check if group is open
   if (!is_open_) {
-    return {Status_GroupError("Cannot get member by index; Group is not open"),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt};
+    return {
+        Status_GroupError("Cannot get member by index; Group is not open"),
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
   }
 
   // Check mode
   if (query_type_ != QueryType::READ) {
-    return {Status_GroupError(
-                "Cannot get member; Group was not opened in read mode"),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt};
+    return {
+        Status_GroupError(
+            "Cannot get member; Group was not opened in read mode"),
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
   }
 
   if (index >= members_vec_.size()) {
@@ -828,30 +831,33 @@ Group::member_by_name(const std::string& name) {
 
   // Check if group is open
   if (!is_open_) {
-    return {Status_GroupError("Cannot get member by name; Group is not open"),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt};
+    return {
+        Status_GroupError("Cannot get member by name; Group is not open"),
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
   }
 
   // Check mode
   if (query_type_ != QueryType::READ) {
-    return {Status_GroupError(
-                "Cannot get member; Group was not opened in read mode"),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt};
+    return {
+        Status_GroupError(
+            "Cannot get member; Group was not opened in read mode"),
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
   }
 
   auto it = members_by_name_.find(name);
   if (it == members_by_name_.end()) {
-    return {Status_GroupError(name + " does not exist in group"),
-            std::nullopt,
-            std::nullopt,
-            std::nullopt,
-            std::nullopt};
+    return {
+        Status_GroupError(name + " does not exist in group"),
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt};
   }
 
   auto member = it->second;

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -340,6 +340,9 @@ void Group::delete_group(const URI& uri, bool recursive) {
   } else {
     storage_manager_->delete_group(uri.c_str());
   }
+
+  // Close the deleted group
+  throw_if_not_ok(this->close());
 }
 
 Status Group::delete_metadata(const char* key) {

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -341,31 +341,26 @@ class Group {
   /**
    * Get count of members
    *
-   * @return tuple of Status and optional member count
+   * @return member count
    */
-  tuple<Status, optional<uint64_t>> member_count() const;
+  uint64_t member_count() const;
 
   /**
    * Get a member by index
    *
    * @param index of member
-   * @return Tuple of Status, URI string, ObjectType, optional name
+   * @return Tuple of URI string, ObjectType, name
    */
-  tuple<
-      Status,
-      optional<std::string>,
-      optional<ObjectType>,
-      optional<std::string>>
+  tuple<optional<std::string>, optional<ObjectType>, optional<std::string>>
   member_by_index(uint64_t index);
 
   /**
    * Get a member by name
    *
    * @param name of member
-   * @return Tuple of Status, URI string, ObjectType, optional name
+   * @return Tuple of URI string, ObjectType, name, bool
    */
   tuple<
-      Status,
       optional<std::string>,
       optional<ObjectType>,
       optional<std::string>,

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -349,7 +349,7 @@ class Group {
    * Get a member by index
    *
    * @param index of member
-   * @return Tuple of URI string, ObjectType, optional name
+   * @return Tuple of URI string, ObjectType, optional GroupMember name
    */
   tuple<std::string, ObjectType, optional<std::string>> member_by_index(
       uint64_t index);
@@ -358,7 +358,8 @@ class Group {
    * Get a member by name
    *
    * @param name of member
-   * @return Tuple of URI string, ObjectType, optional name, bool
+   * @return Tuple of URI string, ObjectType, optional GroupMember name,
+   * bool which is true if the URI is relative to the group.
    */
   tuple<std::string, ObjectType, optional<std::string>, bool> member_by_name(
       const std::string& name);

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -95,6 +95,16 @@ class Group {
   Status clear();
 
   /**
+   * Deletes data from an group opened in MODIFY_EXCLUSIVE mode.
+   *
+   * Note: if recursive == false, data added to the group will be left as-is.
+   *
+   * @param uri The address of the group to be deleted.
+   * @param recursive True if all data inside the group is to be deleted.
+   */
+  void delete_group(const URI& uri, bool recursive = false);
+
+  /**
    * Deletes metadata from an group opened in WRITE mode.
    *
    * @param key The key of the metadata item to be deleted.

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -95,7 +95,7 @@ class Group {
   Status clear();
 
   /**
-   * Deletes data from an group opened in MODIFY_EXCLUSIVE mode.
+   * Deletes data from and closes a group opened in MODIFY_EXCLUSIVE mode.
    *
    * Note: if recursive == false, data added to the group will be left as-is.
    *

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -349,23 +349,19 @@ class Group {
    * Get a member by index
    *
    * @param index of member
-   * @return Tuple of URI string, ObjectType, name
+   * @return Tuple of URI string, ObjectType, optional name
    */
-  tuple<optional<std::string>, optional<ObjectType>, optional<std::string>>
-  member_by_index(uint64_t index);
+  tuple<std::string, ObjectType, optional<std::string>> member_by_index(
+      uint64_t index);
 
   /**
    * Get a member by name
    *
    * @param name of member
-   * @return Tuple of URI string, ObjectType, name, bool
+   * @return Tuple of URI string, ObjectType, optional name, bool
    */
-  tuple<
-      optional<std::string>,
-      optional<ObjectType>,
-      optional<std::string>,
-      optional<bool>>
-  member_by_name(const std::string& name);
+  tuple<std::string, ObjectType, optional<std::string>, bool> member_by_name(
+      const std::string& name);
 
   /** Returns `true` if the group is open. */
   bool is_open() const;

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -152,6 +152,7 @@ Status GroupDirectory::load() {
       is_group = true;
       group_file_uris_.insert(group_file_uris_.begin(), uri);
     }
+
     if (uri.last_path_part() == constants::group_detail_dir_name) {
       is_group = true;
     }

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -77,6 +77,10 @@ const URI& GroupDirectory::uri() const {
   return uri_;
 }
 
+const std::vector<URI>& GroupDirectory::group_file_uris() const {
+  return group_file_uris_;
+}
+
 /** Returns the latest array schema URI. */
 const URI& GroupDirectory::latest_group_details_uri() const {
   return latest_group_details_uri_;
@@ -144,8 +148,11 @@ Status GroupDirectory::load() {
   // Error check
   bool is_group = false;
   for (const auto& uri : root_dir_uris) {
-    if (uri.last_path_part() == constants::group_filename ||
-        uri.last_path_part() == constants::group_detail_dir_name) {
+    if (uri.last_path_part() == constants::group_filename) {
+      is_group = true;
+      group_file_uris_.insert(group_file_uris_.begin(), uri);
+    }
+    if (uri.last_path_part() == constants::group_detail_dir_name) {
       is_group = true;
     }
   }

--- a/tiledb/sm/group/group_directory.h
+++ b/tiledb/sm/group/group_directory.h
@@ -99,6 +99,9 @@ class GroupDirectory {
   /** Returns the group URI. */
   const URI& uri() const;
 
+  /** Returns the URIs of all group files. */
+  const std::vector<URI>& group_file_uris() const;
+
   /** Returns the URIs of the group metadata files to vacuum. */
   const std::vector<URI>& group_meta_uris_to_vacuum() const;
 
@@ -143,6 +146,9 @@ class GroupDirectory {
 
   /** A thread pool used for parallelism. */
   ThreadPool* tp_;
+
+  /** The URIs of all group files. */
+  std::vector<URI> group_file_uris_;
 
   /** Latest group details URI. */
   URI latest_group_details_uri_;

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1270,6 +1270,23 @@ Status RestClient::patch_group_to_rest(const URI& uri, Group* group) {
       stats_, url, serialization_type_, &serialized, &returned_data, cache_key);
 }
 
+void RestClient::delete_group_from_rest(const URI& uri) {
+  /* #TODO Implement API endpoint on TileDBCloud. */
+  // Init curl and form the URL
+  Curl curlc(logger_);
+  std::string group_ns, group_uri;
+  throw_if_not_ok(uri.get_rest_components(&group_ns, &group_uri));
+  const std::string cache_key = group_ns + ":" + group_uri;
+  throw_if_not_ok(
+      curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
+                          "/" + curlc.url_escape(group_uri);
+
+  Buffer returned_data;
+  throw_if_not_ok(curlc.delete_data(
+      stats_, url, serialization_type_, &returned_data, cache_key));
+}
+
 Status RestClient::ensure_json_null_delimited_string(Buffer* buffer) {
   if (serialization_type_ == SerializationType::JSON &&
       buffer->value<char>(buffer->size() - 1) != '\0') {
@@ -1417,6 +1434,11 @@ Status RestClient::post_group_from_rest(const URI&, Group*) {
 
 Status RestClient::patch_group_to_rest(const URI&, Group*) {
   return LOG_STATUS(
+      Status_RestError("Cannot use rest client; serialization not enabled."));
+}
+
+void RestClient::delete_group_from_rest(const URI&) {
+  throw StatusException(
       Status_RestError("Cannot use rest client; serialization not enabled."));
 }
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -225,11 +225,12 @@ RestClient::get_array_schema_from_rest(const URI& uri) {
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK_TUPLE(
       ensure_json_null_delimited_string(&returned_data), nullopt);
-  return {Status::Ok(),
-          make_shared<ArraySchema>(
-              HERE(),
-              serialization::array_schema_deserialize(
-                  serialization_type_, returned_data))};
+  return {
+      Status::Ok(),
+      make_shared<ArraySchema>(
+          HERE(),
+          serialization::array_schema_deserialize(
+              serialization_type_, returned_data))};
 }
 
 Status RestClient::post_array_schema_to_rest(
@@ -316,7 +317,7 @@ Status RestClient::post_array_from_rest(const URI& uri, Array* array) {
 }
 
 void RestClient::delete_array_from_rest(const URI& uri) {
-  /* #TODO Implement API endpoint on TileDBCloud. */
+  // #TODO Implement API endpoint on TileDBCloud.
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
@@ -1271,7 +1272,7 @@ Status RestClient::patch_group_to_rest(const URI& uri, Group* group) {
 }
 
 void RestClient::delete_group_from_rest(const URI& uri) {
-  /* #TODO Implement API endpoint on TileDBCloud. */
+  // #TODO Implement API endpoint on TileDBCloud.
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
@@ -1316,9 +1317,10 @@ Status RestClient::set_header(const std::string&, const std::string&) {
 
 tuple<Status, optional<shared_ptr<ArraySchema>>>
 RestClient::get_array_schema_from_rest(const URI&) {
-  return {LOG_STATUS(Status_RestError(
-              "Cannot use rest client; serialization not enabled.")),
-          nullopt};
+  return {
+      LOG_STATUS(Status_RestError(
+          "Cannot use rest client; serialization not enabled.")),
+      nullopt};
 }
 
 Status RestClient::post_array_schema_to_rest(const URI&, const ArraySchema&) {
@@ -1395,16 +1397,18 @@ Status RestClient::post_array_schema_evolution_to_rest(
 
 tuple<Status, std::optional<bool>> RestClient::check_array_exists_from_rest(
     const URI&) {
-  return {LOG_STATUS(Status_RestError(
-              "Cannot use rest client; serialization not enabled.")),
-          std::nullopt};
+  return {
+      LOG_STATUS(Status_RestError(
+          "Cannot use rest client; serialization not enabled.")),
+      std::nullopt};
 }
 
 tuple<Status, std::optional<bool>> RestClient::check_group_exists_from_rest(
     const URI&) {
-  return {LOG_STATUS(Status_RestError(
-              "Cannot use rest client; serialization not enabled.")),
-          std::nullopt};
+  return {
+      LOG_STATUS(Status_RestError(
+          "Cannot use rest client; serialization not enabled.")),
+      std::nullopt};
 }
 
 Status RestClient::post_group_metadata_from_rest(const URI&, Group*) {

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -284,6 +284,14 @@ class RestClient {
   Status patch_group_to_rest(const URI& uri, Group* group);
 
   /**
+   * Deletes all written data from group at the given URI from the REST server.
+   *
+   * #TODO Implement API endpoint on TileDBCloud.
+   * @param uri Group URI to delete
+   */
+  void delete_group_from_rest(const URI& uri);
+
+  /**
    * Post group create to the REST server.
    *
    * @param uri Group UI

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -627,31 +627,15 @@ void StorageManagerCanonical::delete_array(const char* array_name) {
       std::numeric_limits<uint64_t>::max());
 
   // Get the metadata and schema uris to be deleted
-  /* Note: metadata files may not be present, try to delete anyway */
-  const auto& array_meta_uris = array_dir.array_meta_uris();
-  const auto& fragment_meta_uris = array_dir.fragment_meta_uris();
-  const auto& array_schema_uris = array_dir.array_schema_uris();
+  // Note: metadata files may not be present, try to delete anyway
+  auto array_meta_uris = array_dir.array_meta_uris();
+  auto fragment_meta_uris = array_dir.fragment_meta_uris();
+  auto array_schema_uris = array_dir.array_schema_uris();
 
-  // Delete array metadata files
-  throw_if_not_ok(
-      parallel_for(compute_tp_, 0, array_meta_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(array_meta_uris[i].uri_));
-        return Status::Ok();
-      }));
-
-  // Delete fragment metadata files
-  throw_if_not_ok(
-      parallel_for(compute_tp_, 0, fragment_meta_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(fragment_meta_uris[i]));
-        return Status::Ok();
-      }));
-
-  // Delete array schema files
-  throw_if_not_ok(
-      parallel_for(compute_tp_, 0, array_schema_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(array_schema_uris[i]));
-        return Status::Ok();
-      }));
+  // Delete array metadata, fragment metadata and array schema files
+  vfs_->remove_files(compute_tp_, array_meta_uris);
+  vfs_->remove_files(compute_tp_, fragment_meta_uris);
+  vfs_->remove_files(compute_tp_, array_schema_uris);
 }
 
 Status StorageManagerCanonical::delete_fragments(
@@ -722,38 +706,12 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
       group_dir.group_meta_vac_uris_to_vacuum();
   auto group_file_uris = group_dir.group_file_uris();
 
-  // Delete the group detail files
-  throw_if_not_ok(
-      parallel_for(compute_tp_, 0, group_detail_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(group_detail_uris[i].uri_));
-        return Status::Ok();
-      }));
-
-  // Delete the group metadata files
-  throw_if_not_ok(
-      parallel_for(compute_tp_, 0, group_meta_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(group_meta_uris[i].uri_));
-        return Status::Ok();
-      }));
-
-  throw_if_not_ok(parallel_for(
-      compute_tp_, 0, group_meta_uris_to_vacuum.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(group_meta_uris_to_vacuum[i]));
-        return Status::Ok();
-      }));
-
-  throw_if_not_ok(parallel_for(
-      compute_tp_, 0, group_meta_vac_uris_to_vacuum.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(group_meta_vac_uris_to_vacuum[i]));
-        return Status::Ok();
-      }));
-
-  // Delete the group files
-  throw_if_not_ok(
-      parallel_for(compute_tp_, 0, group_file_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs_->remove_file(group_file_uris[i]));
-        return Status::Ok();
-      }));
+  // Delete the group detail, group metadata and group files
+  vfs_->remove_files(compute_tp_, group_detail_uris);
+  vfs_->remove_files(compute_tp_, group_meta_uris);
+  vfs_->remove_files(compute_tp_, group_meta_uris_to_vacuum);
+  vfs_->remove_files(compute_tp_, group_meta_vac_uris_to_vacuum);
+  vfs_->remove_files(compute_tp_, group_file_uris);
 }
 
 Status StorageManagerCanonical::array_vacuum(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -714,13 +714,11 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
   vfs_->remove_files(compute_tp_, group_file_uris);
 }
 
-Status StorageManagerCanonical::array_vacuum(
+void StorageManagerCanonical::array_vacuum(
     const char* array_name, const Config& config) {
   auto mode = Consolidator::mode_from_config(config, true);
   auto consolidator = Consolidator::create(mode, config, this);
-  return consolidator->vacuum(array_name);
-
-  return Status::Ok();
+  consolidator->vacuum(array_name);
 }
 
 Status StorageManagerCanonical::array_metadata_consolidate(
@@ -2538,27 +2536,27 @@ Status StorageManagerCanonical::group_metadata_consolidate(
       group_name, EncryptionType::NO_ENCRYPTION, nullptr, 0);
 }
 
-Status StorageManagerCanonical::group_metadata_vacuum(
+void StorageManagerCanonical::group_metadata_vacuum(
     const char* group_name, const Config& config) {
   // Check group URI
   URI group_uri(group_name);
   if (group_uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum group metadata; Invalid URI"));
+    throw Status_StorageManagerError(
+        "Cannot vacuum group metadata; Invalid URI");
   }
 
   // Check if group exists
   ObjectType obj_type;
-  RETURN_NOT_OK(object_type(group_uri, &obj_type));
+  throw_if_not_ok(object_type(group_uri, &obj_type));
 
   if (obj_type != ObjectType::GROUP) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot vacuum group metadata; Group does not exist"));
+    throw Status_StorageManagerError(
+        "Cannot vacuum group metadata; Group does not exist");
   }
 
   auto consolidator =
       Consolidator::create(ConsolidationMode::GROUP_META, config, this);
-  return consolidator->vacuum(group_name);
+  consolidator->vacuum(group_name);
 }
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -626,16 +626,11 @@ void StorageManagerCanonical::delete_array(const char* array_name) {
       0,
       std::numeric_limits<uint64_t>::max());
 
-  // Get the metadata and schema uris to be deleted
-  // Note: metadata files may not be present, try to delete anyway
-  auto array_meta_uris = array_dir.array_meta_uris();
-  auto fragment_meta_uris = array_dir.fragment_meta_uris();
-  auto array_schema_uris = array_dir.array_schema_uris();
-
   // Delete array metadata, fragment metadata and array schema files
-  vfs_->remove_files(compute_tp_, array_meta_uris);
-  vfs_->remove_files(compute_tp_, fragment_meta_uris);
-  vfs_->remove_files(compute_tp_, array_schema_uris);
+  // Note: metadata files may not be present, try to delete anyway
+  vfs_->remove_files(compute_tp_, array_dir.array_meta_uris());
+  vfs_->remove_files(compute_tp_, array_dir.fragment_meta_uris());
+  vfs_->remove_files(compute_tp_, array_dir.array_schema_uris());
 }
 
 Status StorageManagerCanonical::delete_fragments(
@@ -699,19 +694,12 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
       0,
       std::numeric_limits<uint64_t>::max());
 
-  auto group_detail_uris = group_dir.group_detail_uris();
-  auto group_meta_uris = group_dir.group_meta_uris();
-  auto group_meta_uris_to_vacuum = group_dir.group_meta_uris_to_vacuum();
-  auto group_meta_vac_uris_to_vacuum =
-      group_dir.group_meta_vac_uris_to_vacuum();
-  auto group_file_uris = group_dir.group_file_uris();
-
   // Delete the group detail, group metadata and group files
-  vfs_->remove_files(compute_tp_, group_detail_uris);
-  vfs_->remove_files(compute_tp_, group_meta_uris);
-  vfs_->remove_files(compute_tp_, group_meta_uris_to_vacuum);
-  vfs_->remove_files(compute_tp_, group_meta_vac_uris_to_vacuum);
-  vfs_->remove_files(compute_tp_, group_file_uris);
+  vfs_->remove_files(compute_tp_, group_dir.group_detail_uris());
+  vfs_->remove_files(compute_tp_, group_dir.group_meta_uris());
+  vfs_->remove_files(compute_tp_, group_dir.group_meta_uris_to_vacuum());
+  vfs_->remove_files(compute_tp_, group_dir.group_meta_vac_uris_to_vacuum());
+  vfs_->remove_files(compute_tp_, group_dir.group_file_uris());
 }
 
 void StorageManagerCanonical::array_vacuum(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -327,10 +327,11 @@ tuple<
 StorageManagerCanonical::array_open_for_writes(Array* array) {
   // Checks
   if (!vfs_->supports_uri_scheme(array->array_uri()))
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot open array; URI scheme unsupported.")),
-            nullopt,
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot open array; URI scheme unsupported.")),
+        nullopt,
+        nullopt};
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
@@ -349,9 +350,10 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
       err << version;
       err << ") is not the library format version (";
       err << constants::format_version << ")";
-      return {logger_->status(Status_StorageManagerError(err.str())),
-              nullopt,
-              nullopt};
+      return {
+          logger_->status(Status_StorageManagerError(err.str())),
+          nullopt,
+          nullopt};
     }
   } else {
     if (version > constants::format_version) {
@@ -360,9 +362,10 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
       err << version;
       err << ") is newer than library format version (";
       err << constants::format_version << ")";
-      return {logger_->status(Status_StorageManagerError(err.str())),
-              nullopt,
-              nullopt};
+      return {
+          logger_->status(Status_StorageManagerError(err.str())),
+          nullopt,
+          nullopt};
     }
   }
 
@@ -681,7 +684,6 @@ Status StorageManagerCanonical::delete_fragments(
 }
 
 void StorageManagerCanonical::delete_group(const char* group_name) {
-  Status st;
   if (group_name == nullptr) {
     throw Status_StorageManagerError(
         "[delete_group] Group name cannot be null");
@@ -1566,9 +1568,10 @@ StorageManagerCanonical::load_array_schema_from_uri(
   Deserializer deserializer(tile.data(), tile.size());
 
   try {
-    return {Status::Ok(),
-            make_shared<ArraySchema>(
-                HERE(), ArraySchema::deserialize(deserializer, schema_uri))};
+    return {
+        Status::Ok(),
+        make_shared<ArraySchema>(
+            HERE(), ArraySchema::deserialize(deserializer, schema_uri))};
   } catch (const StatusException& e) {
     return {Status_StorageManagerError(e.what()), nullopt};
   }
@@ -1581,9 +1584,10 @@ StorageManagerCanonical::load_array_schema_latest(
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot load array schema; Invalid array URI")),
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot load array schema; Invalid array URI")),
+        nullopt};
 
   // Load schema from URI
   const URI& schema_uri = array_dir.latest_array_schema_uri();
@@ -1625,15 +1629,17 @@ StorageManagerCanonical::load_all_array_schemas(
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot load all array schemas; Invalid array URI")),
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot load all array schemas; Invalid array URI")),
+        nullopt};
 
   const std::vector<URI>& schema_uris = array_dir.array_schema_uris();
   if (schema_uris.empty()) {
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot get the array schema vector; No array schemas found.")),
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot get the array schema vector; No array schemas found.")),
+        nullopt};
   }
 
   std::vector<shared_ptr<ArraySchema>> schema_vector;

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -474,6 +474,13 @@ class StorageManagerCanonical {
       const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
 
   /**
+   * Cleans up the group data.
+   *
+   * @param group_name The name of the group whose data is to be deleted.
+   */
+  void delete_group(const char* group_name);
+
+  /**
    * Cleans up the array, such as its consolidated fragments and array
    * metadata. Note that this will coarsen the granularity of time traveling
    * (see docs for more information).

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -487,9 +487,8 @@ class StorageManagerCanonical {
    *
    * @param array_name The name of the array to be vacuumed.
    * @param config Configuration parameters for vacuuming.
-   * @return Status
    */
-  Status array_vacuum(const char* array_name, const Config& config);
+  void array_vacuum(const char* array_name, const Config& config);
 
   /**
    * Consolidates the metadata of an array into a single file.
@@ -1119,9 +1118,8 @@ class StorageManagerCanonical {
    * @param config Configuration parameters for vacuuming
    *     (`nullptr` means default, which will use the config associated with
    *      this instance).
-   * @return Status
    */
-  Status group_metadata_vacuum(const char* group_name, const Config& config);
+  void group_metadata_vacuum(const char* group_name, const Config& config);
 
  private:
   /* ********************************* */


### PR DESCRIPTION
Implement `delete_group` API. As in the `delete_[array, fragments]` APIs, the StorageManager is used to delete _only_ the items created by TileDB. Anything extraneous added by users will be ignored. 

Additionally, this API has support for recursive deletes. If a `Group` has members of `ObjectType::Array` and/or `ObjectType::Group`, those members will be removed along with the top-level group. 

A REST path has been added; note the TileDBCloud endpoint is to be implemented. 

---
TYPE: FEATURE
DESC: Implement delete_group API
