### PR TITLE
Fixes decreasing dim label reader range order

### DIFF
--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -509,7 +509,6 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   IndexType search_for_range_fixed(
       uint64_t r,
       uint8_t range_index,
-      uint8_t bound_index,
       const IndexType& domain_low,
       const IndexType& tile_extent);
 

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -509,6 +509,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   IndexType search_for_range_fixed(
       uint64_t r,
       uint8_t range_index,
+      uint8_t bound_index,
       const IndexType& domain_low,
       const IndexType& tile_extent);
 


### PR DESCRIPTION
Input ranges for decreasing dimension labels should still have the smaller value first.

---
TYPE: BUG
DESC: Fixes dim label reader range order to always take valid ranges
