### PR TITLE
Use recursive pattern on .gitattribute for serialization generated su…

### DIFF
--- a/tiledb/sm/serialization/.gitattributes
+++ b/tiledb/sm/serialization/.gitattributes
@@ -1,3 +1,3 @@
 # Exclude the capnp generated files to reduce reported size of diffs on GitHub
-posix/*   linguist-generated=true
-win32/*   linguist-generated=true
+posix/**   linguist-generated=true
+win32/**   linguist-generated=true


### PR DESCRIPTION
The generated capnp files were still not excluded in https://github.com/TileDB-Inc/TileDB/pull/3530/files; this should fix it.


TYPE: NO_HISTORY