### PR TITLE
Remove stale declarations from query

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -68,6 +68,7 @@
 #include "tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h"
 #include "tiledb/sm/query/writers/writer_base.h"
 #include "tiledb/sm/serialization/config.h"
+#include "tiledb/sm/serialization/fragment_metadata.h"
 #include "tiledb/sm/serialization/query.h"
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -195,15 +195,6 @@ Status query_est_result_size_deserialize(
 
 #ifdef TILEDB_SERIALIZATION
 
-Status fragment_metadata_from_capnp(
-    const shared_ptr<const ArraySchema>& array_schema,
-    const capnp::FragmentMetadata::Reader& frag_meta_reader,
-    shared_ptr<FragmentMetadata> frag_meta);
-
-Status fragment_metadata_to_capnp(
-    const FragmentMetadata& frag_meta,
-    capnp::FragmentMetadata::Builder* frag_meta_builder);
-
 Status global_write_state_to_capnp(
     const Query& query,
     GlobalOrderWriter& globalwriter,


### PR DESCRIPTION
https://github.com/TileDB-Inc/TileDB/pull/3530 left some leftover declarations for fragment metadata in query.h, this PR is fixing this.

---
TYPE: IMPROVEMENT
DESC: Remove stale declarations from query
