### PR TITLE
Document dictionary encoding format

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -5,7 +5,11 @@ title: Format Specification
 **Notes:**
 
 * The current TileDB format version number is **16** (`uint32_t`).
-* All data written by TileDB and referenced in this document is **little-endian**.
+* Data written by TileDB and referenced in this document is **little-endian**
+  with the following exceptions:
+
+  - [Dictionary filter](filters/dictionary_encoding.md)
+  - RLE filter
 
 ## Table of Contents
 

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -32,6 +32,7 @@ The filter has internal format:
 
 TileDB supports the following filters:
 * [XOR Filter](./filters/xor.md)
+* [Dictionary Encoding Filter](./filters/dictionary_encoding.md)
 
 ## Filter Options
 
@@ -64,4 +65,4 @@ The filter options for `TILEDB_FILTER_POSITIVE_DELTA` has internal format:
 
 ### Other Filter Options
 
-The remaining filters \(`TILEDB_FILTER_{BITSHUFFLE,BYTESHUFFLE,CHECKSUM_MD5,CHECKSUM_256}` do not serialize any options.
+The remaining filters \(`TILEDB_FILTER_{BITSHUFFLE,BYTESHUFFLE,CHECKSUM_MD5,CHECKSUM_256,DICTIONARY}` do not serialize any options.

--- a/format_spec/filters/dictionary_encoding.md
+++ b/format_spec/filters/dictionary_encoding.md
@@ -1,0 +1,25 @@
+---
+title: Dictionary Encoding Filter
+---
+
+The Dictionary Encoding filter compresses losslessly string data by creating a set of unique strings (called the `dictionary`) from the input data and substituting the string data on disk with their position in the dictionary.
+As an example in pseudocode:
+
+  ```
+  input_data = "HG543232", "HG543232", "HG543232", "HG54", "HG54", "A", "HG543232", "HG54"]
+  # apply dictionary encoding ->
+  dictionary = ["HG543232", "HG54", "A"]
+  output_data = [0, 0, 0, 1, 1, 2, 0, 1]
+  ```
+
+# Filter Enum Value
+
+The filter enum value for the Dictionary Encoding filter is `14` (`TILEDB_FILTER_DICTIONARY` enum).
+
+# Input and Output Layout
+
+* Input is an array of strings `[str1|...|strN]`.
+* Output is an array of integers `[num1|...|numN]`, that are actually the indices in the dictionary of the strings that appeared in input, in the order that they appeared. The integer datasize depends on the input and is chosen between `uint8_t`, `uint16_t`, `uint32_t` or `uint64_t` as the minimum datasize that can hold the size of the dictionary, aka the number of unique strings in input and stored in output metadata.
+* Output metadata are in the form: `[output_datasize|dict_string_datasize|dictionary]` where `dictionary` is in the form: `[num_of_strings|size_str1|str1|...|size_strN|strN]`. `output_datasize` refers to the chosen datasize of the integers in output while `dict_string_datasize` refers to the minimum integer size that can hold the maximum length string in input and is also chosen between `uint8_t`, `uint16_t`, `uint32_t` or `uint64_t`.
+
+All the above integers are stored in big-endian format.


### PR DESCRIPTION
Describe and document the on-disk format of the dictionary filter in `TileDB/format_spec/filters/`.

---
TYPE: FORMAT
DESC: Document dictionary encoding format.
