### PR TITLE
CI fixes for release builds and cURL

### DIFF
--- a/.github/workflows/full-ci-dummy.yml
+++ b/.github/workflows/full-ci-dummy.yml
@@ -1,4 +1,4 @@
-name: "Build Docs"
+name: "CI Placeholder (docs only)"
 on:
   pull_request:
     branches:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -12,13 +12,6 @@ on:
     #                                                                            #
     ##############################################################################
 
-    paths-ignore:
-      - '.github/workflows/quarto-render.yml'
-      - '_quarto.yml'
-      - 'quarto-materials/*'
-      - '**/.md'
-      - 'doc/source/conf.py'
-      - 'tiledb/sm/c_api/tiledb_version.h'
   pull_request:
     branches:
       - '*'  # must quote since "*" is a YAML reserved character; we want a string

--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -77,7 +77,9 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_curl.tar.gz
-      URL "https://curl.se/download/curl-7.74.0.tar.gz"
+      URL
+        "https://github.com/TileDB-Inc/tiledb-deps-mirror/releases/download/2.11-deps/curl-7.74.0.tar.gz"
+        "https://curl.se/download/curl-7.74.0.tar.gz"
       URL_HASH SHA1=cd7239cf9223b39ade86a14eb37fe68f5656eae9
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}


### PR DESCRIPTION
- Remove path-based restriction for `dev`, `release-`, and `tag` branch targets to ensure that the workflow is executed unconditionally
- Add a cURL mirror on tiledb-deps-mirror to fix download issues due to CMake built-in downloader SSL failures (as far as I can tell)

---
TYPE: NO_HISTORY