### PR TITLE
Fix unit-cppapi-update-queries test failure when throwing UpdateValue exception

### DIFF
--- a/test/src/unit-capi-update-queries.cc
+++ b/test/src/unit-capi-update-queries.cc
@@ -218,9 +218,8 @@ TEST_CASE_METHOD(
   }
 
   // Check the update value.
-  auto st = query->query_->update_values()[0].check(
-      array->array_->array_schema_latest());
-  CHECK(!st.ok());
+  CHECK_THROWS(query->query_->update_values()[0].check(
+      array->array_->array_schema_latest()));
 
   // Clean up.
   tiledb_query_free(&query);

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -295,8 +295,6 @@ TEST_CASE_METHOD(
   std::vector<sm::UpdateValue> uvs2;
   val = 2;
   uvs2.emplace_back("a1", &val, sizeof(int32_t));
-  val = 1;
-  uvs2.emplace_back("d1", &val, sizeof(int32_t));
 
   write_update_condition(qc, uvs, 1, encrypt);
   check_update_conditions({qc}, {uvs}, 2, encrypt);

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -102,12 +102,14 @@ void UpdatesFx::create_sparse_array(bool allows_dups, bool encrypt) {
 
   // Create attributes.
   auto a1 = Attribute::create<int32_t>(ctx_, "a1");
+  auto a2 = Attribute::create<int32_t>(ctx_, "a2");
 
   // Create array schmea.
   ArraySchema schema(ctx_, TILEDB_SPARSE);
   schema.set_domain(domain);
   schema.set_capacity(20);
   schema.add_attributes(a1);
+  schema.add_attributes(a2);
 
   if (allows_dups) {
     schema.set_allows_dups(true);
@@ -256,10 +258,8 @@ TEST_CASE("C++ API: Test setting an update value", "[cppapi][updates]") {
   QueryExperimental::add_update_value_to_query(
       ctx, query, "a", &val, sizeof(val));
 
-  CHECK(query.ptr()
-            ->query_->update_values()[0]
-            .check(array.ptr()->array_->array_schema_latest())
-            .ok());
+  query.ptr()->query_->update_values()[0]
+            .check(array.ptr()->array_->array_schema_latest());
 
   array.close();
 
@@ -295,6 +295,8 @@ TEST_CASE_METHOD(
   std::vector<sm::UpdateValue> uvs2;
   val = 2;
   uvs2.emplace_back("a1", &val, sizeof(int32_t));
+  val = 1;
+  uvs2.emplace_back("a2", &val, sizeof(int32_t));
 
   write_update_condition(qc, uvs, 1, encrypt);
   check_update_conditions({qc}, {uvs}, 2, encrypt);

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -128,7 +128,7 @@ Status DeletesAndUpdates::dowork() {
 
   // Check that the update values are valid.
   for (auto& update_value : update_values_) {
-    std::ignore = update_value.check(array_schema_);
+    throw_if_not_ok(update_value.check(array_schema_));
   }
 
   // Get a new fragment name for the delete.

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -128,7 +128,7 @@ Status DeletesAndUpdates::dowork() {
 
   // Check that the update values are valid.
   for (auto& update_value : update_values_) {
-    throw_if_not_ok(update_value.check(array_schema_));
+    update_value.check(array_schema_);
   }
 
   // Get a new fragment name for the delete.

--- a/tiledb/sm/query/update_value.cc
+++ b/tiledb/sm/query/update_value.cc
@@ -79,17 +79,17 @@ UpdateValue::UpdateValue(UpdateValue&& rhs)
 UpdateValue::~UpdateValue() {
 }
 
-Status UpdateValue::check(const ArraySchema& array_schema) const {
+void UpdateValue::check(const ArraySchema& array_schema) const {
   const uint64_t update_value_size = update_value_data_.size();
 
   // Ensure field name exists.
   if (!array_schema.is_field(field_name_)) {
-    return Status_UpdateValueError("Field name doesn't exist");
+    throw Status_UpdateValueError("Field name doesn't exist");
   }
 
   // Ensure field is an attribute.
   if (!array_schema.is_attr(field_name_)) {
-    return Status_UpdateValueError("Can only update attributes");
+    throw Status_UpdateValueError("Can only update attributes");
   }
 
   const auto nullable = array_schema.is_nullable(field_name_);
@@ -102,7 +102,7 @@ Status UpdateValue::check(const ArraySchema& array_schema) const {
   if (update_value_view_.content() == nullptr) {
     if ((!nullable) &&
         (type != Datatype::STRING_ASCII && type != Datatype::CHAR)) {
-      return Status_UpdateValueError(
+      throw Status_UpdateValueError(
           "Null value can only be used with nullable attributes");
     }
   }
@@ -110,7 +110,7 @@ Status UpdateValue::check(const ArraySchema& array_schema) const {
   // Ensure that non string fixed size attributes store only one value per cell.
   if (cell_val_num != 1 && type != Datatype::STRING_ASCII &&
       type != Datatype::CHAR && (!var_size)) {
-    return Status_UpdateValueError(
+    throw Status_UpdateValueError(
         "Value node attribute must have one value per cell for non-string "
         "fixed size attributes: " +
         field_name_);
@@ -121,12 +121,12 @@ Status UpdateValue::check(const ArraySchema& array_schema) const {
   if (cell_size != constants::var_size && cell_size != update_value_size &&
       !(nullable && update_value_view_.content() == nullptr) &&
       type != Datatype::STRING_ASCII && type != Datatype::CHAR && (!var_size)) {
-    return Status_UpdateValueError(
+    throw Status_UpdateValueError(
         "Value node condition value size mismatch: " +
         std::to_string(cell_size) + " != " + std::to_string(update_value_size));
   }
 
-  return Status::Ok();
+  return;
 }
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/update_value.cc
+++ b/tiledb/sm/query/update_value.cc
@@ -84,12 +84,12 @@ void UpdateValue::check(const ArraySchema& array_schema) const {
 
   // Ensure field name exists.
   if (!array_schema.is_field(field_name_)) {
-    throw Status_UpdateValueError("Field name doesn't exist");
+    throw StatusException(Status_UpdateValueError("Field name doesn't exist"));
   }
 
   // Ensure field is an attribute.
   if (!array_schema.is_attr(field_name_)) {
-    throw Status_UpdateValueError("Can only update attributes");
+    throw StatusException(Status_UpdateValueError("Can only update attributes"));
   }
 
   const auto nullable = array_schema.is_nullable(field_name_);
@@ -102,18 +102,18 @@ void UpdateValue::check(const ArraySchema& array_schema) const {
   if (update_value_view_.content() == nullptr) {
     if ((!nullable) &&
         (type != Datatype::STRING_ASCII && type != Datatype::CHAR)) {
-      throw Status_UpdateValueError(
-          "Null value can only be used with nullable attributes");
+      throw StatusException(Status_UpdateValueError(
+          "Null value can only be used with nullable attributes"));
     }
   }
 
   // Ensure that non string fixed size attributes store only one value per cell.
   if (cell_val_num != 1 && type != Datatype::STRING_ASCII &&
       type != Datatype::CHAR && (!var_size)) {
-    throw Status_UpdateValueError(
+    throw StatusException(Status_UpdateValueError(
         "Value node attribute must have one value per cell for non-string "
         "fixed size attributes: " +
-        field_name_);
+        field_name_));
   }
 
   // Ensure that the condition value size matches the attribute's
@@ -121,9 +121,9 @@ void UpdateValue::check(const ArraySchema& array_schema) const {
   if (cell_size != constants::var_size && cell_size != update_value_size &&
       !(nullable && update_value_view_.content() == nullptr) &&
       type != Datatype::STRING_ASCII && type != Datatype::CHAR && (!var_size)) {
-    throw Status_UpdateValueError(
+    throw StatusException(Status_UpdateValueError(
         "Value node condition value size mismatch: " +
-        std::to_string(cell_size) + " != " + std::to_string(update_value_size));
+        std::to_string(cell_size) + " != " + std::to_string(update_value_size)));
   }
 
   return;

--- a/tiledb/sm/query/update_value.h
+++ b/tiledb/sm/query/update_value.h
@@ -88,9 +88,8 @@ class UpdateValue {
    * Verifies that the object respects the array schema.
    *
    * @param array_schema The current array schema.
-   * @return Status
    */
-  Status check(const ArraySchema& array_schema) const;
+  void check(const ArraySchema& array_schema) const;
 
  private:
   /* ********************************* */


### PR DESCRIPTION
The unit-cppapi-update-queries test was adding an UpdateValue for a dimension rather than an attribute. The test started failing with https://github.com/TileDB-Inc/TileDB/blob/77d84f4f8171b944181d990af94bb7c078bf7188/tiledb/sm/query/update_value.cc#L92 when we started throwing the ignored exception.

---
TYPE: BUG
DESC: Fix unit-cppapi-update-queries test failure when throwing UpdateValue exception.
