### PR TITLE
Add `tiledb_status_code`

### DIFF
--- a/tiledb/api/c_api/api_external_common.h
+++ b/tiledb/api/c_api/api_external_common.h
@@ -118,9 +118,18 @@ typedef int32_t capi_status_t;
 inline capi_status_t tiledb_status(capi_return_t x) {
   return x;
 }
-#else
-capi_status_t tiledb_status(capi_return_t x);
 #endif
+
+/**
+ * Extract a status code from a return value.
+ *
+ * This function is as a pure "C" equivalent for `tiledb_status`, which is an
+ * inline C++ function, not visible in the "C" context.
+ *
+ * @param x A value returned from a CAPI call
+ * @return The status code within that value
+ */
+TILEDB_EXPORT capi_status_t tiledb_status_code(capi_return_t x);
 
 /**
  * @name Status codes

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -95,6 +95,14 @@ struct tiledb_subarray_transient_local_t : public tiledb_subarray_t {
   }
 };
 
+/*
+ * The Definition for a "C" function can't be in a header.
+ */
+capi_status_t tiledb_status_code(capi_return_t x) {
+  return tiledb_status(x);  // An inline C++ function
+}
+
+
 /* ****************************** */
 /*  IMPLEMENTATION FUNCTIONS      */
 /* ****************************** */


### PR DESCRIPTION
Add an `extern "C"` facade `tiledb_status_code`, for use in a pure "C" context where the C++ `tiledb_status` is not available.

---
TYPE: C_API
DESC: Add `tiledb_status_code`
