### PR TITLE
remove EXCLUDE_FROM_ALL added for unknown reason in Catch2 ver3 upgrade

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -264,14 +264,14 @@ jobs:
           Write-Host "cmds: '$cmds'"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
-             Write-Host "Tests failed. CMake exit status: " $LastExitCocde
+             Write-Host "Tests failed. tiledb_unit exit status: " $LastExitCocde
              $host.SetShouldExit($LastExitCode)
           }
 
           $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\test\ci\test_assert.exe -d=yes"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
-             Write-Host "Tests failed. CMake exit status: " $LastExitCocde
+             Write-Host "Tests failed. test_assert exit status: " $LastExitCocde
              $host.SetShouldExit($LastExitCode)
           }
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -259,18 +259,22 @@ jobs:
           }
 
           # Actually run tests
-          #~ $cmds = "cmake --build $env:BUILD_BUILDDIRECTORY\tiledb --target check --config $CMakeBuildType -- /verbosity:minimal"
-          #~ Write-Host "cmds: '$cmds'"
-          #~ Invoke-Expression $cmds
-          #$cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\tiledb_unit.exe -d=yes | c:\msys64\usr\bin\awk '/1: ::set-output/{sub(/.*1: /, `"`"); print; next} 1'"
+
           $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\tiledb_unit.exe -d=yes"
           Write-Host "cmds: '$cmds'"
           Invoke-Expression $cmds
-
           if ($LastExitCode -ne 0) {
              Write-Host "Tests failed. CMake exit status: " $LastExitCocde
              $host.SetShouldExit($LastExitCode)
           }
+
+          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\test\ci\test_assert.exe -d=yes"
+          Invoke-Expression $cmds
+          if ($LastExitCode -ne 0) {
+             Write-Host "Tests failed. CMake exit status: " $LastExitCocde
+             $host.SetShouldExit($LastExitCode)
+          }
+
 
           if ($env:TILEDB_WEBP -eq "ON") {
             $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\tiledb\sm\compressors\$CMakeBuildType\unit_link_webp.exe"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -268,7 +268,7 @@ jobs:
              $host.SetShouldExit($LastExitCode)
           }
 
-          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$CMakeBuildType\test\ci\test_assert.exe -d=yes"
+          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\ci\$CMakeBuildType\test_assert.exe -d=yes"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
              Write-Host "Tests failed. test_assert exit status: " $LastExitCocde

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -90,6 +90,7 @@ jobs:
           # Bypass Catch2 Framework stdout interception with awk on test output
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
+          ./tiledb/test/ci/test_assert -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
           ###################################################
           # Stop helper processes, if applicable

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -88,9 +88,9 @@ jobs:
           # Run tests
 
           # Bypass Catch2 Framework stdout interception with awk on test output
+          ./tiledb/test/regression/tiledb_regression -d yes
+          ./tiledb/test/ci/test_assert -d yes
           ./tiledb/test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
-          ./tiledb/test/regression/tiledb_regression -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
-          ./tiledb/test/ci/test_assert -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 
           ###################################################
           # Stop helper processes, if applicable

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -52,7 +52,8 @@ jobs:
           # Build all unit tests
           make -C tiledb tests -j4
           # Run all unit tests
-          make -C tiledb test ARGS="-R '^unit_'"
+          make -C tiledb test ARGS="-R '^unit_'" -R "test_assert"
+          make -C tiledb test ARGS="-R 'test_ci_asserts'"
 
           popd
       - name: "Print log files (failed build only)"

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -46,8 +46,8 @@ jobs:
             -DTILEDB_GCS=${TILEDB_GCS} \
             -DTILEDB_S3=${TILEDB_S3} \
             -DTILEDB_SERIALIZATION=${TILEDB_SERIALIZATION} \
-            -DTILEDB_WEBP=${TILEDB_WEBP}
-            -DTILEDB_WEBP=${TILEDB_ASSERTIONS}
+            -DTILEDB_WEBP=${TILEDB_WEBP} \
+            -DTILEDB_ASSERTIONS=${TILEDB_ASSERTIONS}
           make -j4
           # Build all unit tests
           make -C tiledb tests -j4

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -4,6 +4,7 @@ on:
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
+  TILEDB_ASSERTIONS: ON
   TILEDB_S3: OFF
   TILEDB_AZURE: OFF
   TILEDB_GCS: OFF
@@ -46,6 +47,7 @@ jobs:
             -DTILEDB_S3=${TILEDB_S3} \
             -DTILEDB_SERIALIZATION=${TILEDB_SERIALIZATION} \
             -DTILEDB_WEBP=${TILEDB_WEBP}
+            -DTILEDB_WEBP=${TILEDB_ASSERTIONS}
           make -j4
           # Build all unit tests
           make -C tiledb tests -j4

--- a/test/ci/CMakeLists.txt
+++ b/test/ci/CMakeLists.txt
@@ -4,7 +4,6 @@ find_package(Catch_EP REQUIRED)
 
 add_executable(
   test_assert
-  EXCLUDE_FROM_ALL
   test_assert.cc
 )
 

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -51,7 +51,8 @@ TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
   int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
   
   // in case value is one not currently accepted, report what was returned.
-  std::cout << "retval is " << retval << " from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert" << std::endl;
+  std::cout << "retval is " << retval << " (0x" << std::hex << retval 
+            << ") from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert" << std::endl;
 
 #ifdef TILEDB_ASSERTIONS
   REQUIRE(

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -50,6 +50,7 @@ std::vector<int> assert_exit_codes{
 TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
   int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
   
+  // in case value is one not currently accepted, report what was returned.
   std::cout << "retval is " << retval << " from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert" << std::endl;
 
 #ifdef TILEDB_ASSERTIONS

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -49,6 +49,8 @@ std::vector<int> assert_exit_codes{
 
 TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
   int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
+  
+  std::cout << "retval is " << retval << " from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert" << std::endl;
 
 #ifdef TILEDB_ASSERTIONS
   REQUIRE(

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -55,7 +55,7 @@ TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
       std::find(assert_exit_codes.begin(), assert_exit_codes.end(), retval) !=
       assert_exit_codes.end());
 #else
-  (void)assert_exit_code;
+  (void)assert_exit_codes;
   REQUIRE(retval == 0);
 #endif
 }

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -43,16 +43,18 @@
 std::vector<int> assert_exit_codes{3};
 #else
 std::vector<int> assert_exit_codes{
-    0x8600 /* core dump */
+    0x6,   /* SIGABRT */
+    0x8600 /* core dump, which may be caused by SIGABRT */
 };
 #endif
 
 TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
   int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
-  
+
   // in case value is one not currently accepted, report what was returned.
-  std::cout << "retval is " << retval << " (0x" << std::hex << retval 
-            << ") from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert" << std::endl;
+  std::cout << "retval is " << retval << " (0x" << std::hex << retval
+            << ") from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert"
+            << std::endl;
 
 #ifdef TILEDB_ASSERTIONS
   REQUIRE(

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -34,20 +34,26 @@
 #define CATCH_CONFIG_MAIN
 #include <test/support/tdb_catch.h>
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
+#include <list>
 
 #ifdef _WIN32
-constexpr int assert_exit_code = 3;
+std::vector<int> assert_exit_codes{3};
 #else
-constexpr int assert_exit_code = 6;
+std::vector<int> assert_exit_codes{
+    0x8600 /* core dump */
+};
 #endif
 
 TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
   int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
 
 #ifdef TILEDB_ASSERTIONS
-  REQUIRE(retval == assert_exit_code);
+  REQUIRE(
+      std::find(assert_exit_codes.begin(), assert_exit_codes.end(), retval) !=
+      assert_exit_codes.end());
 #else
   (void)assert_exit_code;
   REQUIRE(retval == 0);


### PR DESCRIPTION
remove EXCLUDE_FROM_ALL added for unknown reason in Catch2 ver3 upgrade which caused test_assert[.exe] to not be built and subsequent build failure.

---
TYPE: BUG
DESC: remove EXCLUDE_FROM_ALL added for unknown reason in Catch2 ver3 upgrade
