### PR TITLE
Throw exceptions from parallel_for and fix filter_pipeline bug of not…

### DIFF
--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -3319,8 +3319,10 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
-    CHECK_THROWS(
-        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp));
+    CHECK_THROWS_WITH(
+        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp),
+        "[TileDB::Filter] Error: Positive delta filter error: delta is not "
+        "positive.");
   }
 }
 
@@ -3505,8 +3507,10 @@ TEST_CASE(
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
-    CHECK_THROWS(
-        pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp));
+    CHECK_THROWS_WITH(
+        pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp),
+        "[TileDB::Filter] Error: Positive delta filter error: delta is not "
+        "positive.");
   }
 
   Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
@@ -3973,8 +3977,9 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     pipeline.add_filter(EncryptionAES256GCMFilter());
 
     // No key set
-    CHECK_THROWS(
-        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp));
+    CHECK_THROWS_WITH(
+        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp),
+        "[TileDB::Filter] Error: Encryption error; bad key.");
 
     // Create and set a key
     char key[32];
@@ -4005,8 +4010,11 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     key[0]++;
     filter->set_key(key);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK_THROWS(pipeline.run_reverse(
-        &test::g_helper_stats, &tile, nullptr, &tp, config));
+    CHECK_THROWS_WITH(
+        pipeline.run_reverse(
+            &test::g_helper_stats, &tile, nullptr, &tp, config),
+        "[TileDB::Encryption] Error: OpenSSL error; error finalizing "
+        "decryption.");
 
     // Fix key and check success. Note: this test depends on the implementation
     // leaving the tile data unmodified when the decryption fails, which is not

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -3319,8 +3319,8 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
-    CHECK(
-        !pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
+    CHECK_THROWS(
+        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp));
   }
 }
 
@@ -3505,9 +3505,8 @@ TEST_CASE(
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
-    CHECK(
-        !pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
-             .ok());
+    CHECK_THROWS(
+        pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp));
   }
 
   Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
@@ -3974,8 +3973,8 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     pipeline.add_filter(EncryptionAES256GCMFilter());
 
     // No key set
-    CHECK(
-        !pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
+    CHECK_THROWS(
+        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp));
 
     // Create and set a key
     char key[32];
@@ -4006,9 +4005,8 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     key[0]++;
     filter->set_key(key);
     CHECK(tile.alloc_data(nelts * sizeof(uint64_t)).ok());
-    CHECK(!pipeline
-               .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-               .ok());
+    CHECK_THROWS(pipeline.run_reverse(
+        &test::g_helper_stats, &tile, nullptr, &tp, config));
 
     // Fix key and check success. Note: this test depends on the implementation
     // leaving the tile data unmodified when the decryption fails, which is not

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -4013,8 +4013,7 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     CHECK_THROWS_WITH(
         pipeline.run_reverse(
             &test::g_helper_stats, &tile, nullptr, &tp, config),
-        "[TileDB::Encryption] Error: OpenSSL error; error finalizing "
-        "decryption.");
+        Catch::Matchers::StartsWith("[TileDB::Encryption] Error:"));
 
     // Fix key and check success. Note: this test depends on the implementation
     // leaving the tile data unmodified when the decryption fails, which is not

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -403,16 +403,16 @@ TEST_CASE_METHOD(
   write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -424,16 +424,16 @@ TEST_CASE_METHOD(
   std::vector<double> ranges{2.1, 2.8};
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -790,16 +790,16 @@ TEST_CASE_METHOD(
   write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -811,16 +811,16 @@ TEST_CASE_METHOD(
   std::vector<double> ranges{2.1, 2.8};
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 5.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -339,10 +339,8 @@ void FilterPipeline::filter_chunks_reverse(
   }
 
   if (total_size != tile.size()) {
-    auto e = FilterPipelineStatusException(
+    throw FilterPipelineStatusException(
         "Error incorrect unfiltered tile size allocated.");
-    LOG_STATUS(e);
-    throw e;
   }
 
   // Run each chunk through the entire pipeline.

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -388,9 +388,8 @@ class FilterPipeline {
    *    will be written.
    * @param compute_tp The thread pool for compute-bound tasks.
    * @param config The global config.
-   * @return Status
    */
-  Status filter_chunks_reverse(
+  void filter_chunks_reverse(
       Tile& tile,
       Tile* const offsets_tile,
       const std::vector<tuple<void*, uint32_t, uint32_t, uint32_t>>& input,

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -270,9 +270,7 @@ Status parallel_for(
   }
 
   // Wait for all instances of `execute_subrange` to complete.
-  // This is ignoring the wait status as we use failed_exception for propagating
-  // the tasks exceptions.
-  std::ignore = tp->wait_all(tasks);
+  throw_if_not_ok(tp->wait_all(tasks));
 
   if (failed_exception.has_value()) {
     std::rethrow_exception(failed_exception.value());


### PR DESCRIPTION
Throw exceptions from `parallel_for` and fix `filter_pipeline` bug of not clearing tile data when exceptions happen.

Not catching exceptions in `filter_pipeline` `run_reverse_internal` function was leading to data buffers not being cleared and causing assertion failures for the subsequent test cases.

---
TYPE: BUG
DESC: Throw exceptions from `parallel_for` and fix `filter_pipeline` bug of not clearing tile data when exceptions happen.

