### PR TITLE
Remove labelled array from dimension label

### DIFF
--- a/test/src/experimental_helpers.cc
+++ b/test/src/experimental_helpers.cc
@@ -40,8 +40,6 @@ void add_dimension_label(
     const uint32_t dim_idx,
     tiledb_label_order_t label_order,
     tiledb_datatype_t label_datatype,
-    const void* label_domain,
-    const void* label_tile_extent,
     const void* index_tile_extent) {
   // Get the dimension type and domain from the array schema.
   const auto* dim = array_schema->array_schema_->dimension_ptr(dim_idx);
@@ -50,20 +48,38 @@ void add_dimension_label(
 
   // Create the dimension label.
   tiledb_dimension_label_schema_t* dim_label_schema;
-  REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
+  auto rc = tiledb_dimension_label_schema_alloc(
       ctx,
       label_order,
       static_cast<tiledb_datatype_t>(dim_type),
       dim_domain.data(),
       index_tile_extent,
       label_datatype,
-      label_domain,
-      label_tile_extent,
-      &dim_label_schema));
+      nullptr,
+      nullptr,
+      &dim_label_schema);
+  if (rc != TILEDB_OK) {
+    tiledb_error_t* err = NULL;
+    tiledb_ctx_get_last_error(ctx, &err);
+    const char* msg;
+    tiledb_error_message(err, &msg);
+    UNSCOPED_INFO(msg);
+  }
+  REQUIRE(rc == TILEDB_OK);
 
   // Add the dimension label to the array schema.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
-      ctx, array_schema, dim_idx, label_name.c_str(), dim_label_schema));
+  rc = tiledb_array_schema_add_dimension_label(
+      ctx, array_schema, dim_idx, label_name.c_str(), dim_label_schema);
+  if (rc != TILEDB_OK) {
+    tiledb_error_t* err = NULL;
+    tiledb_ctx_get_last_error(ctx, &err);
+    const char* msg;
+    tiledb_error_message(err, &msg);
+    UNSCOPED_INFO(msg);
+  }
+  REQUIRE(rc == TILEDB_OK);
+
+  // Free the dimension label schema.
   tiledb_dimension_label_schema_free(&dim_label_schema);
 }
 

--- a/test/src/experimental_helpers.cc
+++ b/test/src/experimental_helpers.cc
@@ -51,12 +51,10 @@ void add_dimension_label(
   auto rc = tiledb_dimension_label_schema_alloc(
       ctx,
       label_order,
+      label_datatype,
       static_cast<tiledb_datatype_t>(dim_type),
       dim_domain.data(),
       index_tile_extent,
-      label_datatype,
-      nullptr,
-      nullptr,
       &dim_label_schema);
   if (rc != TILEDB_OK) {
     tiledb_error_t* err = NULL;

--- a/test/src/experimental_helpers.h
+++ b/test/src/experimental_helpers.h
@@ -52,8 +52,6 @@ namespace tiledb::test {
  * @param array_schema The array schema to add the dimension label to.
  * @param label_name The name of the dimension label.
  * @param dim_idx The dimension index to add the label on.
- * @param label_order The label order for the dimension label.
- * @param label_domain The dimension label domain.
  * @param label_tile_extent The dimension tile extent for the label.
  * @param index_tile_extent The dimension label tile extent for the index.
  */
@@ -64,8 +62,6 @@ void add_dimension_label(
     const uint32_t dim_idx,
     tiledb_label_order_t label_order,
     tiledb_datatype_t label_datatype,
-    const void* label_domain,
-    const void* label_tile_extent,
     const void* index_tile_extent);
 
 }  // namespace tiledb::test

--- a/test/src/experimental_helpers.h
+++ b/test/src/experimental_helpers.h
@@ -34,7 +34,6 @@
 #ifndef TILEDB_TEST_EXPERIMENTAL_HELPERS_H
 #define TILEDB_TEST_EXPERIMENTAL_HELPERS_H
 
-#include "catch.hpp"
 #include "helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/c_api/experimental/tiledb_dimension_label.h"

--- a/test/src/test-capi-array-many-dimension-labels.cc
+++ b/test/src/test-capi-array-many-dimension-labels.cc
@@ -488,7 +488,7 @@ TEST_CASE_METHOD(
 
   // Check the data when querying by dimension.
   {
-    INFO("Reading values from index ranges.")
+    INFO("Reading values from index ranges.");
     check_values(
         {{0, {1, 4}}, {1, {1, 4}}, {2, {1, 4}}, {3, {1, 8}}},
         {},

--- a/test/src/test-capi-array-many-dimension-labels.cc
+++ b/test/src/test-capi-array-many-dimension-labels.cc
@@ -76,10 +76,7 @@ class ExampleArray : public TemporaryDirectoryFixture {
  public:
   ExampleArray()
       : domain_{1, 4}
-      , t_domain_{1, 8}
-      , temporal_label_domain_{0, 100}
-      , spatial_label1_domain_{-10.0, 10.0}
-      , spatial_label2_domain_{0.0, 100.0} {
+      , t_domain_{1, 8} {
     // Create an array schema
     uint64_t tile_extent{4};
     auto array_schema = create_array_schema(
@@ -99,10 +96,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         false);
 
     // Add dimension labels.
-    double spatial_label1_tile = 20.0;
-    double spatial_label2_tile = 100.0;
-    int64_t temporal_tile = 101;
-
     add_dimension_label(
         ctx,
         array_schema,
@@ -110,8 +103,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         3,
         TILEDB_INCREASING_LABELS,
         TILEDB_DATETIME_SEC,
-        &temporal_label_domain_[0],
-        &temporal_tile,
         &tile_extent);
 
     add_dimension_label(
@@ -121,8 +112,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         0,
         TILEDB_INCREASING_LABELS,
         TILEDB_FLOAT64,
-        &spatial_label1_domain_[0],
-        &spatial_label1_tile,
         &tile_extent);
 
     add_dimension_label(
@@ -132,8 +121,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         1,
         TILEDB_INCREASING_LABELS,
         TILEDB_FLOAT64,
-        &spatial_label1_domain_[0],
-        &spatial_label1_tile,
         &tile_extent);
 
     add_dimension_label(
@@ -143,8 +130,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         2,
         TILEDB_INCREASING_LABELS,
         TILEDB_FLOAT64,
-        &spatial_label1_domain_[0],
-        &spatial_label1_tile,
         &tile_extent);
 
     add_dimension_label(
@@ -154,8 +139,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         0,
         TILEDB_DECREASING_LABELS,
         TILEDB_FLOAT64,
-        &spatial_label2_domain_[0],
-        &spatial_label2_tile,
         &tile_extent);
 
     add_dimension_label(
@@ -165,8 +148,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         1,
         TILEDB_DECREASING_LABELS,
         TILEDB_FLOAT64,
-        &spatial_label2_domain_[0],
-        &spatial_label2_tile,
         &tile_extent);
 
     add_dimension_label(
@@ -176,8 +157,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
         2,
         TILEDB_DECREASING_LABELS,
         TILEDB_FLOAT64,
-        &spatial_label2_domain_[0],
-        &spatial_label2_tile,
         &tile_extent);
 
     // Create array
@@ -439,15 +418,6 @@ class ExampleArray : public TemporaryDirectoryFixture {
 
   /** Domain for dimension t. */
   uint64_t t_domain_[2];
-
-  /** Domain for the dimension label on dimension t. */
-  int64_t temporal_label_domain_[2];
-
-  /** Domain for the dimension labels x, y, and z. */
-  double spatial_label1_domain_[2];
-
-  /** Domain for the dimension labels alpha, beta, and gamma. */
-  double spatial_label2_domain_[2];
 };
 
 TEST_CASE_METHOD(

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -92,8 +92,6 @@ class ArrayExample : public TemporaryDirectoryFixture {
         0,
         TILEDB_UNORDERED_LABELS,
         TILEDB_STRING_ASCII,
-        nullptr,
-        nullptr,
         &x_tile_extent);
     // Create array
     array_name = create_temporary_array("array_with_label_1", array_schema);

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -95,17 +95,8 @@ class DenseArrayExample1 : public TemporaryDirectoryFixture {
         false);
 
     // Add dimension label.
-    double label_tile_extent = 2.0;
     add_dimension_label(
-        ctx,
-        array_schema,
-        "x",
-        0,
-        label_order,
-        TILEDB_FLOAT64,
-        &label_domain_[0],
-        &label_tile_extent,
-        &x_tile_extent);
+        ctx, array_schema, "x", 0, label_order, TILEDB_FLOAT64, &x_tile_extent);
 
     // Create array
     array_name = create_temporary_array("array_with_label_1", array_schema);

--- a/test/src/test-capi-dimension_labels.cc
+++ b/test/src/test-capi-dimension_labels.cc
@@ -287,22 +287,14 @@ TEST_CASE_METHOD(
   URI label_uri{array_name + "/" + x_label_uri};
   DimensionLabel dim_label(label_uri, ctx->storage_manager());
   dim_label.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0);
-  CHECK(dim_label.index_dimension()->type() == Datatype::UINT64);
-  CHECK(dim_label.index_attribute()->type() == Datatype::UINT64);
-  CHECK(dim_label.label_attribute()->type() == label_datatype);
-  CHECK(dim_label.label_attribute()->type() == label_datatype);
+  CHECK(dim_label.schema().index_type() == Datatype::UINT64);
+  CHECK(dim_label.schema().label_type() == label_datatype);
   const auto& indexed_array_schema =
       dim_label.indexed_array()->array_schema_latest();
   CHECK(indexed_array_schema.domain().dim_num() == 1);
   CHECK(indexed_array_schema.attribute_num() == 1);
   CHECK(indexed_array_schema.dimension_ptr(0)->type() == Datatype::UINT64);
   CHECK(indexed_array_schema.attribute(0)->type() == label_datatype);
-  const auto& labelled_array_schema =
-      dim_label.labelled_array()->array_schema_latest();
-  CHECK(labelled_array_schema.domain().dim_num() == 1);
-  CHECK(labelled_array_schema.attribute_num() == 1);
-  CHECK(labelled_array_schema.dimension_ptr(0)->type() == label_datatype);
-  CHECK(labelled_array_schema.attribute(0)->type() == Datatype::UINT64);
   dim_label.close();
 
   // Free remaining resources

--- a/test/src/test-capi-dimension_labels.cc
+++ b/test/src/test-capi-dimension_labels.cc
@@ -78,19 +78,14 @@ class DimensionLabelTestFixture : public TemporaryDirectoryFixture {
    *  * Attributes:
    *    - a: (type=FLOAT64)
    *  * Dimesnion labels:
-   *    - x: (dim_idx=0, type=label_type, domain=label_domain, tile=tile_extent)
+   *    - x: (dim_idx=0, type=label_type)
    *
    * @param array_name Array name relative to the fixture temporary directory.
    * @param label_type The data type of the dimension label.
-   * @param label_domain The domain of the dimension label.
-   * @param tile_extent The tile extent of the dimension label.
    * @returns Full URI to the generated array.
    */
   std::string create_single_label_array(
-      std::string&& array_name,
-      tiledb_datatype_t label_type,
-      void* label_domain,
-      void* tile_extents);
+      std::string&& array_name, tiledb_datatype_t label_type);
 
   /**
    * Creates a sample test array with multiple dimension labels.
@@ -112,10 +107,7 @@ class DimensionLabelTestFixture : public TemporaryDirectoryFixture {
 };
 
 std::string DimensionLabelTestFixture::create_single_label_array(
-    std::string&& array_name,
-    tiledb_datatype_t label_type,
-    void* label_domain,
-    void* label_tile_extent) {
+    std::string&& array_name, tiledb_datatype_t label_type) {
   // Create an array schema
   uint64_t x_domain[2]{0, 63};
   uint64_t x_tile_extent{64};
@@ -141,12 +133,10 @@ std::string DimensionLabelTestFixture::create_single_label_array(
   REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
       ctx,
       TILEDB_UNORDERED_LABELS,
+      label_type,
       TILEDB_UINT64,
       x_domain,
       &x_tile_extent,
-      label_type,
-      label_domain,
-      label_tile_extent,
       &dim_label_schema));
 
   REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
@@ -188,17 +178,13 @@ std::string DimensionLabelTestFixture::create_multi_label_array(
   // Create and add dimension labels to schema.
   tiledb_dimension_label_schema_t* dim_label_schema;
   // l0
-  double l0_domain[] = {-10.0, 10.0};
-  double l0_tile_extent = 4.0;
   REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
       ctx,
       TILEDB_INCREASING_LABELS,
+      TILEDB_FLOAT64,
       TILEDB_UINT64,
       x_domain,
       &x_tile_extent,
-      TILEDB_FLOAT64,
-      l0_domain,
-      &l0_tile_extent,
       &dim_label_schema));
   REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "x", dim_label_schema));
@@ -207,12 +193,10 @@ std::string DimensionLabelTestFixture::create_multi_label_array(
   REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
       ctx,
       TILEDB_UNORDERED_LABELS,
+      TILEDB_STRING_ASCII,
       TILEDB_UINT64,
       x_domain,
       &x_tile_extent,
-      TILEDB_STRING_ASCII,
-      nullptr,
-      nullptr,
       &dim_label_schema));
   REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "id", dim_label_schema));
@@ -236,18 +220,14 @@ TEST_CASE(
   tiledb_ctx_alloc(NULL, &ctx);
   int64_t dim_domain[] = {1, 10};
   int64_t tile_extent = 5;
-  double label_domain[] = {-10.0, 10.0};
-  double label_tile_extent = 4.0;
   tiledb_dimension_label_schema_t* dim_label;
   REQUIRE_TILEDB_OK(tiledb_dimension_label_schema_alloc(
       ctx,
       TILEDB_INCREASING_LABELS,
+      TILEDB_FLOAT64,
       TILEDB_INT64,
       dim_domain,
       &tile_extent,
-      TILEDB_FLOAT64,
-      label_domain,
-      &label_tile_extent,
       &dim_label));
   tiledb_dimension_label_schema_free(&dim_label);
 }
@@ -259,13 +239,7 @@ TEST_CASE_METHOD(
   // Create and add dimension label schema (both fixed and variable length
   // examples).
   auto label_type = GENERATE(TILEDB_FLOAT64, TILEDB_STRING_ASCII);
-  double label_domain[] = {-10.0, 10.0};
-  double label_tile_extent = 4.0;
-  auto array_name = create_single_label_array(
-      "array0",
-      label_type,
-      (label_type == TILEDB_STRING_ASCII) ? nullptr : label_domain,
-      (label_type == TILEDB_STRING_ASCII) ? nullptr : &label_tile_extent);
+  auto array_name = create_single_label_array("array0", label_type);
 
   // Load array schema and check number of labels.
   tiledb_array_schema_t* loaded_array_schema{nullptr};

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -95,17 +95,8 @@ class SparseArrayExample1 : public TemporaryDirectoryFixture {
         false);
 
     // Add dimension label.
-    double label_tile_extent = 2.0;
     add_dimension_label(
-        ctx,
-        array_schema,
-        "x",
-        0,
-        label_order,
-        TILEDB_FLOAT64,
-        &label_domain_[0],
-        &label_tile_extent,
-        &x_tile_extent);
+        ctx, array_schema, "x", 0, label_order, TILEDB_FLOAT64, &x_tile_extent);
     // Create array
     array_name = create_temporary_array("array_with_label_1", array_schema);
     tiledb_array_schema_free(&array_schema);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -751,18 +751,24 @@ Status ArraySchema::add_dimension_label(
               std::to_string(nlabel_internal_),
           false};
   // Add dimension label
-  auto dim_label = make_shared<DimensionLabelReference>(
-      HERE(),
-      dim_id,
-      name,
-      uri,
-      dimension_label_schema->label_order(),
-      dimension_label_schema->label_dimension()->type(),
-      dimension_label_schema->label_dimension()->cell_val_num(),
-      dimension_label_schema->label_dimension()->domain(),
-      dimension_label_schema);
-  dimension_labels_.emplace_back(dim_label);
-  dimension_label_map_[name] = dim_label.get();
+  try {
+    auto dim_label = make_shared<DimensionLabelReference>(
+        HERE(),
+        dim_id,
+        name,
+        uri,
+        dimension_label_schema->label_order(),
+        dimension_label_schema->label_type(),
+        dimension_label_schema->label_cell_val_num(),
+        dimension_label_schema->label_domain(),
+        dimension_label_schema);
+    dimension_labels_.emplace_back(dim_label);
+    dimension_label_map_[name] = dim_label.get();
+  } catch (...) {
+    // TODO Add ArraySchemaStatusExcpetion.
+    std::throw_with_nested(StatusException(Status_ArraySchemaError(
+        "Failed to add dimension label '" + name + "'.")));
+  }
   ++nlabel_internal_;  // WARNING: not atomic
   return Status::Ok();
 }

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -63,14 +63,6 @@ enum class Datatype : uint8_t;
 enum class LabelOrder : uint8_t;
 enum class Layout : uint8_t;
 
-/** Class for locally generated status exceptions. */
-class ArraySchemaStatusException : public StatusException {
- public:
-  explicit ArraySchemaStatusException(const std::string& msg)
-      : StatusException("ArraySchema", msg) {
-  }
-};
-
 /** Specifies the array schema. */
 class ArraySchema {
  public:
@@ -554,7 +546,7 @@ class ArraySchema {
    * Returns false if the union of attribute and dimension names contain
    * duplicates.
    */
-  Status check_attribute_dimension_label_names() const;
+  void check_attribute_dimension_label_names() const;
 
   /**
    * Returns error if double delta compression is used in the zipped

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -63,6 +63,14 @@ enum class Datatype : uint8_t;
 enum class LabelOrder : uint8_t;
 enum class Layout : uint8_t;
 
+/** Class for locally generated status exceptions. */
+class ArraySchemaStatusException : public StatusException {
+ public:
+  explicit ArraySchemaStatusException(const std::string& msg)
+      : StatusException("ArraySchema", msg) {
+  }
+};
+
 /** Specifies the array schema. */
 class ArraySchema {
  public:

--- a/tiledb/sm/array_schema/dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/dimension_label_reference.cc
@@ -60,41 +60,59 @@ DimensionLabelReference::DimensionLabelReference(
     , schema_(schema)
     , is_external_(is_external)
     , relative_uri_(relative_uri) {
-  if (name.size() == 0)
+  if (name.size() == 0) {
     throw std::invalid_argument(
-        "Invalid dimension label name; Cannot set name to an empty string.");
-  if (uri.to_string().size() == 0)
+        "Cannot create dimension label reference; Cannot set name to an empty "
+        "string.");
+  }
+  if (uri.to_string().size() == 0) {
     throw std::invalid_argument(
-        "Invalid dimension label uri; Cannot set the URI to an emptry string.");
+        "Cannot create dimension label reference; Cannot set the URI to an "
+        "emptry string.");
+  }
+
+  // Check label type.
   ensure_dimension_datatype_is_valid(label_type);
   if (label_type == Datatype::STRING_ASCII) {
-    if (label_cell_val_num != constants::var_num)
+    if (label_cell_val_num != constants::var_num) {
       throw std::invalid_argument(
-          "Invalid number of values per coordinate for the string dimension "
+          "Cannot create dimension label reference; Invalid number of values "
+          "per coordinate for the string dimension "
           "label.");
-    if (!label_domain.empty())
+    }
+    if (!label_domain.empty() && label_domain.var_size()) {
       throw std::invalid_argument(
-          "Invalid domain; Setting the domain with type '" +
-          datatype_str(label_type) + "' is not allowed.");
+          "Cannot create dimension label reference; The label domain for a "
+          "dimension label with label type '" +
+          datatype_str(label_type) + "must be variable.");
+    }
   } else {
-    if (label_cell_val_num != 1)
+    if (label_cell_val_num != 1) {
       throw std::invalid_argument(
-          "Invalid number of values per coordiante; Currently only one value "
-          "per coordinate is supported for non-string dimension labels.");
-    if (label_domain.var_size())
+          "Cannot create dimension label reference; Invalid number of values "
+          "per coordiante; Currently only one value per coordinate is "
+          "supported for non-string dimension labels.");
+    }
+    if (!label_domain.empty()) {
+      if (label_domain.var_size()) {
+        throw std::invalid_argument(
+            "Cannot create dimension label reference; The label domain for a "
+            "dimension label with label type '" +
+            datatype_str(label_type) + "cannot be variable.");
+      }
+      if (!label_domain.empty() &&
+          label_domain.size() != 2 * datatype_size(label_type)) {
+        throw std::invalid_argument(
+            "Cannot create dimension label reference; The size of the label "
+            "domain does not match the size of the datatype.");
+      }
+    }
+    if (!is_external_ && !relative_uri_) {
       throw std::invalid_argument(
-          "Invalid domain; The label domain for a dimension label with label "
-          "type '" +
-          datatype_str(label_type) + "cannot be variable.");
-    if (label_domain.size() != 2 * datatype_size(label_type))
-      throw std::invalid_argument(
-          "Invalid domain; The size of the label domain does not match the "
-          "size of the datatype.");
+          "Cannot create dimension label reference; Dimension labels stored by "
+          "the array must have a relative URI.");
+    }
   }
-  if (!is_external_ && !relative_uri_)
-    throw std::invalid_argument(
-        "Cannot create dimension label reference; Dimension labels stored by "
-        "the array must have a relative URI.");
 }
 
 DimensionLabelReference::DimensionLabelReference(
@@ -123,60 +141,68 @@ DimensionLabelReference::DimensionLabelReference(
 //| Field                     | Type       |
 //| ------------------------- | ---------- |
 //| Dimension ID              | `uint32_t` |
-//| Label order               | `uint8_t` |
+//| Label order               | `uint8_t`  |
+//| Name length               | `uint64_t` |
+//| Name                      | `char []`  |
+//| Relative URI              | `bool`     |
+//| URI length                | `uint64_t` |
+//| URI                       | `char []`  |
 //| Label datatype            | `uint8_t`  |
 //| Label cell_val_num        | `uint32_t` |
-//| Is external               | `uint8_t`  |
-//| Relative URI              | `uint8_t`  |
 //| Label domain size         | `uint64_t` |
-//| Name length               | `uint64_t` |
-//| URI length                | `uint64_t` |
+//| Label domain start size   | `uint64_t` |
 //| Label domain data         | `uint8_t[]`|
-//| Name                      | `char []`  |
-//| URI                       | `char []`  |
+//| Is external               | `bool`     |
 shared_ptr<DimensionLabelReference> DimensionLabelReference::deserialize(
     Deserializer& deserializer, uint32_t) {
   try {
-    // Read imension ID
+    // Read dimension ID
     dimension_size_type dim_id = deserializer.read<uint32_t>();
-    // Read label order
-    uint8_t label_order_int = deserializer.read<uint8_t>();
-    auto label_order = label_order_from_int(label_order_int);
-    // Read label datatype
-    uint8_t label_type_int = deserializer.read<uint8_t>();
-    auto label_type = static_cast<Datatype>(label_type_int);
-    // Read label cell value number
-    uint32_t label_cell_val_num = deserializer.read<uint32_t>();
-    // Read if the label is external
-    uint8_t is_external_int = deserializer.read<uint8_t>();
-    auto is_external = static_cast<bool>(is_external_int);
-    // Read if the label URI is relative
-    uint8_t relative_uri_int = deserializer.read<uint8_t>();
-    auto relative_uri = static_cast<bool>(relative_uri_int);
-    // Read the length of the domain
-    uint64_t label_domain_size = deserializer.read<uint64_t>();
-    // Read the length of the name string
+
+    // Read dimension label name
     uint64_t name_size = deserializer.read<uint64_t>();
-    // Read the length of the name string
-    uint64_t uri_size = deserializer.read<uint64_t>();
-    // Read label name
+    std::string name(deserializer.get_ptr<char>(name_size), name_size);
+
+    // Read dimension label URI
+    auto relative_uri = deserializer.read<bool>();
+    auto uri_size = deserializer.read<uint64_t>();
+    std::string uri(deserializer.get_ptr<char>(uri_size), uri_size);
+
+    // Read label order
+    auto label_order = label_order_from_int(deserializer.read<uint8_t>());
+
+    // Read label datatype
+    auto label_type = static_cast<Datatype>(deserializer.read<uint8_t>());
+
+    // Read label cell value number
+    auto label_cell_val_num = deserializer.read<uint32_t>();
+
+    // Read label domain
     Range label_domain;
+    auto label_domain_size = deserializer.read<uint64_t>();
+    auto label_domain_start_size = deserializer.read<uint64_t>();
     if (label_domain_size != 0) {
-      std::vector<uint8_t> tmp(label_domain_size);
-      memcpy(
-          tmp.data(),
-          deserializer.get_ptr<uint8_t>(label_domain_size),
-          label_domain_size);
-      label_domain = Range(&tmp[0], label_domain_size);
+      if (label_domain_start_size == 0) {
+        label_domain = Range(
+            deserializer.get_ptr<uint8_t>(label_domain_size),
+            label_domain_size);
+      } else {
+        auto label_domain_end_size =
+            label_domain_size - label_domain_start_size;
+        auto range_start =
+            deserializer.get_ptr<uint8_t>(label_domain_start_size);
+        auto range_end = deserializer.get_ptr<uint8_t>(label_domain_end_size);
+        label_domain = Range(
+            range_start,
+            label_domain_start_size,
+            range_end,
+            label_domain_end_size);
+      }
     }
-    // Read label name
-    std::string name;
-    name.resize(name_size);
-    memcpy(name.data(), deserializer.get_ptr<uint8_t>(name_size), name_size);
-    // Read label URI
-    std::string uri;
-    uri.resize(uri_size);
-    memcpy(uri.data(), deserializer.get_ptr<uint8_t>(uri_size), uri_size);
+
+    // Read if dimension label is external
+    auto is_external = deserializer.read<bool>();
+
     // Construct and return a shared pointer to a DimensionLabelReference
     return make_shared<DimensionLabelReference>(
         HERE(),
@@ -218,39 +244,52 @@ void DimensionLabelReference::dump(FILE* out) const {
 //| Field                     | Type       |
 //| ------------------------- | ---------- |
 //| Dimension ID              | `uint32_t` |
-//| Label order               | `uint8_t` |
+//| Label order               | `uint8_t`  |
+//| Name length               | `uint64_t` |
+//| Name                      | `char []`  |
+//| Relative URI              | `bool`     |
+//| URI length                | `uint64_t` |
+//| URI                       | `char []`  |
 //| Label datatype            | `uint8_t`  |
 //| Label cell_val_num        | `uint32_t` |
-//| Is external               | `uint8_t`  |
-//| Relative URI              | `uint8_t`  |
 //| Label domain size         | `uint64_t` |
-//| Name length               | `uint64_t` |
-//| URI length                | `uint64_t` |
+//| Label domain start size   | `uint64_t` |
 //| Label domain data         | `uint8_t[]`|
-//| Name                      | `char []`  |
-//| URI                       | `char []`  |
+//| Is external               | `bool`     |
 void DimensionLabelReference::serialize(
     Serializer& serializer, uint32_t) const {
+  // Read dimension ID
   serializer.write<uint32_t>(dim_id_);
-  auto label_order_int = static_cast<uint8_t>(label_order_);
-  serializer.write<uint8_t>(label_order_int);
-  auto label_type_int = static_cast<uint8_t>(label_type_);
-  serializer.write<uint8_t>(label_type_int);
-  serializer.write<uint32_t>(label_cell_val_num_);
-  auto is_external_int = static_cast<uint8_t>(is_external_);
-  serializer.write<uint8_t>(is_external_int);
-  auto relative_uri_int = static_cast<uint8_t>(relative_uri_);
-  serializer.write<uint8_t>(relative_uri_int);
-  uint64_t label_domain_size =
-      datatype_is_string(label_type_) ? 0 : 2 * datatype_size(label_type_);
-  serializer.write<uint64_t>(label_domain_size);
+
+  // Read dimension label namea
   uint64_t name_size{name_.size()};
   serializer.write<uint64_t>(name_size);
-  uint64_t uri_size{uri_.to_string().size()};
-  serializer.write<uint64_t>(uri_size);
-  serializer.write(label_domain_.data(), label_domain_size);
   serializer.write(name_.c_str(), name_size);
+
+  // Read dimension label URI
+  serializer.write<bool>(relative_uri_);
+  uint64_t uri_size = (uri_.to_string().size());
+  serializer.write<uint64_t>(uri_size);
   serializer.write(uri_.c_str(), uri_size);
+
+  // Read label order
+  serializer.write<uint8_t>(static_cast<uint8_t>(label_order_));
+
+  // Read label datatype
+  auto label_type_int = static_cast<uint8_t>(label_type_);
+  serializer.write<uint8_t>(label_type_int);
+
+  // Read label cell value number
+  serializer.write<uint32_t>(label_cell_val_num_);
+
+  // Read label domain
+  // Note: start_size is 0 for non-variable length ranges.
+  serializer.write<uint64_t>(label_domain_.size());
+  serializer.write<uint64_t>(label_domain_.start_size());
+  serializer.write(label_domain_.data(), label_domain_.size());
+
+  // Write if the dimension label is external
+  serializer.write<uint8_t>(static_cast<uint8_t>(is_external_));
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/array_schema/dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/dimension_label_reference.cc
@@ -39,6 +39,14 @@ using namespace tiledb::type;
 
 namespace tiledb::sm {
 
+/** Class for locally generated status exceptions. */
+class DimensionLabelReferenceStatusException : public StatusException {
+ public:
+  explicit DimensionLabelReferenceStatusException(const std::string& msg)
+      : StatusException("DimensionLabelReference", msg) {
+  }
+};
+
 DimensionLabelReference::DimensionLabelReference(
     dimension_size_type dim_id,
     const std::string& name,

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -50,14 +50,6 @@ class DimensionLabelSchema;
 enum class Datatype : uint8_t;
 enum class LabelOrder : uint8_t;
 
-/** Class for locally generated status exceptions. */
-class DimensionLabelReferenceStatusException : public StatusException {
- public:
-  explicit DimensionLabelReferenceStatusException(const std::string& msg)
-      : StatusException("DimensionLabelReference", msg) {
-  }
-};
-
 /**
  * Class containing dimension label information required for usage
  * in a TileDB array schema.

--- a/tiledb/sm/array_schema/dimension_label_reference.h
+++ b/tiledb/sm/array_schema/dimension_label_reference.h
@@ -50,6 +50,14 @@ class DimensionLabelSchema;
 enum class Datatype : uint8_t;
 enum class LabelOrder : uint8_t;
 
+/** Class for locally generated status exceptions. */
+class DimensionLabelReferenceStatusException : public StatusException {
+ public:
+  explicit DimensionLabelReferenceStatusException(const std::string& msg)
+      : StatusException("DimensionLabelReference", msg) {
+  }
+};
+
 /**
  * Class containing dimension label information required for usage
  * in a TileDB array schema.

--- a/tiledb/sm/array_schema/dimension_label_schema.cc
+++ b/tiledb/sm/array_schema/dimension_label_schema.cc
@@ -33,42 +33,25 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
 #include "tiledb/sm/enums/array_type.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/types.h"
-#include "tiledb/type/range/range.h"
 
 using namespace tiledb::common;
 using namespace tiledb::type;
 
 namespace tiledb::sm {
 
-tuple<bool, optional<std::string>> have_compatible_types(
-    const Dimension* dim, const Attribute* attr) {
-  if (attr->nullable())
-    return {false, "Attribute cannot be nullable."};
-  if (dim->type() != attr->type())
-    return {false, "Attribute and dimension datatype do not match."};
-  if (dim->cell_val_num() != attr->cell_val_num())
-    return {false,
-            "Attribute and dimension number of values per cell do not match"};
-  return {true, nullopt};
-}
-
 DimensionLabelSchema::DimensionLabelSchema(
     LabelOrder label_order,
+    Datatype label_type,
     Datatype index_type,
     const void* index_domain,
-    const void* index_tile_extent,
-    Datatype label_type,
-    const void* label_domain,
-    const void* label_tile_extent)
+    const void* index_tile_extent)
     : label_order_(label_order)
     , indexed_array_schema_(make_shared<ArraySchema>(
           HERE(),
           label_order == LabelOrder::UNORDERED_LABELS ? ArrayType::SPARSE :
                                                         ArrayType::DENSE))
-    , labelled_array_schema_(
-          make_shared<ArraySchema>(HERE(), ArrayType::SPARSE)) {
+    , label_domain_{} {
   // Check the index data type is valid.
   if (!(datatype_is_integer(index_type) || datatype_is_datetime(index_type) ||
         datatype_is_time(index_type))) {
@@ -110,29 +93,13 @@ DimensionLabelSchema::DimensionLabelSchema(
     throw_if_not_ok(label_attr->set_cell_val_num(constants::var_num));
   throw_if_not_ok(indexed_array_schema_->add_attribute(label_attr));
   throw_if_not_ok(indexed_array_schema_->check());
-
-  // Set-up labelled array
-  if (label_order == LabelOrder::UNORDERED_LABELS) {
-    throw_if_not_ok(labelled_array_schema_->set_allows_dups(true));
-  }
-  std::vector<shared_ptr<Dimension>> label_dims{
-      make_shared<Dimension>(HERE(), "label", label_type)};
-  throw_if_not_ok(label_dims.back()->set_domain(label_domain));
-  throw_if_not_ok(label_dims.back()->set_tile_extent(label_tile_extent));
-  throw_if_not_ok(labelled_array_schema_->set_domain(make_shared<Domain>(
-      HERE(), Layout::ROW_MAJOR, label_dims, Layout::ROW_MAJOR)));
-  throw_if_not_ok(labelled_array_schema_->add_attribute(
-      make_shared<Attribute>(HERE(), "index", index_type)));
-  throw_if_not_ok(labelled_array_schema_->check());
 }
 
 DimensionLabelSchema::DimensionLabelSchema(
-    LabelOrder label_order,
-    shared_ptr<ArraySchema> indexed_array_schema,
-    shared_ptr<ArraySchema> labelled_array_schema)
+    LabelOrder label_order, shared_ptr<ArraySchema> indexed_array_schema)
     : label_order_(label_order)
     , indexed_array_schema_(indexed_array_schema)
-    , labelled_array_schema_(labelled_array_schema) {
+    , label_domain_{} {
   // Check arrays have one dimension and one attribute
   if (indexed_array_schema->dim_num() != 1)
     throw std::invalid_argument(
@@ -142,14 +109,6 @@ DimensionLabelSchema::DimensionLabelSchema(
     throw std::invalid_argument(
         "Invalid dimension label schema; Indexed array must have exactly one "
         "attribute.");
-  if (labelled_array_schema->dim_num() != 1)
-    throw std::invalid_argument(
-        "Invalid dimension label schema; Labelled array must be one "
-        "dimensional.");
-  if (labelled_array_schema->attribute_num() != 1)
-    throw std::invalid_argument(
-        "Invalid dimension label schema; Labelled array must have exactly one "
-        "attribute.");
   // Check the data type of the index
   auto index_type = indexed_array_schema_->dimension_ptr(0)->type();
   if (!(datatype_is_integer(index_type) || datatype_is_datetime(index_type) ||
@@ -158,25 +117,6 @@ DimensionLabelSchema::DimensionLabelSchema(
         "Failed to create dimension label schema; Currently labels are not "
         "support on dimensions with datatype Datatype::" +
         datatype_str(index_type));
-  // Check the types are consistent between the two arrays
-  auto [is_ok, msg] = have_compatible_types(
-      labelled_array_schema_->dimension_ptr(0),
-      indexed_array_schema_->attribute(0));
-  if (!is_ok)
-    throw std::invalid_argument(
-        "Invalid dimension label schema; Incompatible definitions of the "
-        "label "
-        "dimension and label attribute. " +
-        msg.value());
-  std::tie(is_ok, msg) = have_compatible_types(
-      indexed_array_schema_->dimension_ptr(0),
-      labelled_array_schema_->attribute(0));
-  if (!is_ok)
-    throw std::invalid_argument(
-        "Invalid dimension label schema; Incompatible definitions of the "
-        "index "
-        "dimension and index attribute. " +
-        msg.value());
 }
 
 DimensionLabelSchema::DimensionLabelSchema(
@@ -184,16 +124,26 @@ DimensionLabelSchema::DimensionLabelSchema(
   label_order_ = dim_label->label_order_;
   indexed_array_schema_ =
       make_shared<ArraySchema>(HERE(), *dim_label->indexed_array_schema_);
-  labelled_array_schema_ =
-      make_shared<ArraySchema>(HERE(), *dim_label->labelled_array_schema_);
-}
-
-const Attribute* DimensionLabelSchema::index_attribute() const {
-  return labelled_array_schema_->attribute(0);
+  label_domain_ = dim_label->label_domain_;
 }
 
 const Dimension* DimensionLabelSchema::index_dimension() const {
   return indexed_array_schema_->dimension_ptr(0);
+}
+
+/** Returns the number of values per cell for the index. */
+uint32_t DimensionLabelSchema::index_cell_val_num() const {
+  return index_dimension()->cell_val_num();
+}
+
+/** Returns a reference to the index domain. */
+const Range& DimensionLabelSchema::index_domain() const {
+  return index_dimension()->domain();
+}
+
+/** Returns the index datatype. */
+Datatype DimensionLabelSchema::index_type() const {
+  return index_dimension()->type();
 }
 
 bool DimensionLabelSchema::is_compatible_label(const Dimension* dim) const {
@@ -207,8 +157,19 @@ const Attribute* DimensionLabelSchema::label_attribute() const {
   return indexed_array_schema_->attribute(0);
 }
 
-const Dimension* DimensionLabelSchema::label_dimension() const {
-  return labelled_array_schema_->dimension_ptr(0);
+/** Returns the number of values per cell for the index. */
+uint32_t DimensionLabelSchema::label_cell_val_num() const {
+  return label_attribute()->cell_val_num();
+}
+
+/** Returns a reference to the index domain. */
+const Range& DimensionLabelSchema::label_domain() const {
+  return label_domain_;
+}
+
+/** Returns the index datatype. */
+Datatype DimensionLabelSchema::label_type() const {
+  return label_attribute()->type();
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/array_schema/test/unit_array_schema.cc
+++ b/tiledb/sm/array_schema/test/unit_array_schema.cc
@@ -67,9 +67,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     std::vector<shared_ptr<Attribute>> attrs{
         test::make_attribute<float>("x", Datatype::UINT64, false, 1, 0)};
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
-    auto status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch repeating dimension name") {
@@ -79,9 +77,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     std::vector<shared_ptr<Attribute>> attrs{
         test::make_attribute<float>("a", Datatype::UINT64, false, 1, 0)};
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
-    auto status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch repeating attribute name") {
@@ -91,9 +87,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
         test::make_attribute<float>("a", Datatype::UINT64, false, 1, 0),
         test::make_attribute<float>("a", Datatype::UINT64, false, 1, 0)};
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
-    auto status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch repeating label name shared with dim when adding label") {
@@ -139,9 +133,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     REQUIRE(status.ok());
     status = schema->add_dimension_label(0, "x", dim_label_schema, false, true);
     REQUIRE(status.ok());
-    status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch repeating label name not shared with dim when adding label") {
@@ -187,9 +179,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     REQUIRE(status.ok());
     status = schema->add_dimension_label(0, "y", dim_label_schema, false, true);
     REQUIRE(status.ok());
-    status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch shared label/attribute name when adding label") {
@@ -231,9 +221,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
         &index_tile_extent);
     status = schema->add_dimension_label(0, "a", dim_label_schema, false, true);
     REQUIRE(status.ok());
-    status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch shared label/dimension name when adding label") {
@@ -277,9 +265,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
         &index_tile_extent);
     status = schema->add_dimension_label(0, "y", dim_label_schema, false, true);
     REQUIRE(status.ok());
-    status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 
   SECTION("Catch shared label/dimension name when adding label") {
@@ -324,9 +310,7 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     status =
         schema->add_dimension_label(0, "y", dim_label_schema, false, false);
     REQUIRE(status.ok());
-    status = schema->check();
-    INFO(status.to_string());
-    REQUIRE(!status.ok());
+    REQUIRE_THROWS(schema->check());
   }
 }
 

--- a/tiledb/sm/array_schema/test/unit_array_schema.cc
+++ b/tiledb/sm/array_schema/test/unit_array_schema.cc
@@ -46,17 +46,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
         test::make_attribute<float>("a", Datatype::UINT64, false, 1, 0)};
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    double label_domain[2]{-1.0, 1.0};
-    double label_tile_extent{1};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
+        Datatype::FLOAT64,
         Datatype::UINT64,
         index_domain,
-        &index_tile_extent,
-        Datatype::FLOAT64,
-        label_domain,
-        &label_tile_extent);
+        &index_tile_extent);
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
     auto status =
         schema->add_dimension_label(0, "x", dim_label_schema, false, true);
@@ -108,17 +104,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     auto status =
         schema->add_dimension_label(0, "x", dim_label_schema, true, true);
     REQUIRE(status.ok());
@@ -135,17 +127,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     auto status =
         schema->add_dimension_label(0, "x", dim_label_schema, false, true);
     REQUIRE(status.ok());
@@ -164,17 +152,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     auto status =
         schema->add_dimension_label(0, "y", dim_label_schema, true, true);
     REQUIRE(status.ok());
@@ -191,17 +175,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     auto status =
         schema->add_dimension_label(0, "y", dim_label_schema, true, true);
     REQUIRE(status.ok());
@@ -221,17 +201,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto status = schema->check();
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     status = schema->add_dimension_label(0, "a", dim_label_schema, true, false);
     INFO(status.to_string());
     REQUIRE(!status.ok());
@@ -246,17 +222,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto status = schema->check();
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     status = schema->add_dimension_label(0, "a", dim_label_schema, false, true);
     REQUIRE(status.ok());
     status = schema->check();
@@ -274,17 +246,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto status = schema->check();
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     status = schema->add_dimension_label(0, "y", dim_label_schema, true, false);
     INFO(status.to_string());
     REQUIRE(!status.ok());
@@ -300,17 +268,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto status = schema->check();
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     status = schema->add_dimension_label(0, "y", dim_label_schema, false, true);
     REQUIRE(status.ok());
     status = schema->check();
@@ -328,17 +292,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto status = schema->check();
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     status = schema->add_dimension_label(0, "y", dim_label_schema, true, false);
     INFO(status.to_string());
     REQUIRE(!status.ok());
@@ -354,17 +314,13 @@ TEST_CASE("Test repeating names", "[array_schema]") {
     auto status = schema->check();
     uint64_t index_domain[2]{0, 15};
     uint64_t index_tile_extent{16};
-    uint64_t label_domain[2]{16, 31};
-    uint64_t label_tile_extent{16};
     auto dim_label_schema = make_shared<DimensionLabelSchema>(
         HERE(),
         LabelOrder::INCREASING_LABELS,
         Datatype::UINT64,
-        index_domain,
-        &index_tile_extent,
         Datatype::UINT64,
-        label_domain,
-        &label_tile_extent);
+        index_domain,
+        &index_tile_extent);
     status =
         schema->add_dimension_label(0, "y", dim_label_schema, false, false);
     REQUIRE(status.ok());
@@ -385,17 +341,13 @@ TEST_CASE(
   auto status = schema->check();
   uint64_t index_domain[2]{0, 15};
   uint64_t index_tile_extent{16};
-  uint64_t label_domain[2]{16, 31};
-  uint64_t label_tile_extent{16};
   auto dim_label_schema = make_shared<DimensionLabelSchema>(
       HERE(),
       LabelOrder::INCREASING_LABELS,
+      Datatype::UINT64,
       Datatype::INT64,
       index_domain,
-      &index_tile_extent,
-      Datatype::UINT64,
-      label_domain,
-      &label_tile_extent);
+      &index_tile_extent);
   status = schema->add_dimension_label(0, "x", dim_label_schema, true, false);
   REQUIRE(status.ok());
   status = schema->check();
@@ -415,17 +367,13 @@ TEST_CASE(
   auto status = schema->check();
   uint64_t index_domain[2]{0, 15};
   uint64_t index_tile_extent{16};
-  uint64_t label_domain[2]{16, 31};
-  uint64_t label_tile_extent{16};
   auto dim_label_schema = make_shared<DimensionLabelSchema>(
       HERE(),
       LabelOrder::INCREASING_LABELS,
       Datatype::UINT64,
-      index_domain,
-      &index_tile_extent,
       Datatype::UINT64,
-      label_domain,
-      &label_tile_extent);
+      index_domain,
+      &index_tile_extent);
   status = schema->add_dimension_label(0, "x", dim_label_schema, true, true);
   REQUIRE(status.ok());
   status = schema->add_dimension_label(0, "y", dim_label_schema, true, true);

--- a/tiledb/sm/array_schema/test/unit_dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension_label_reference.cc
@@ -77,6 +77,7 @@ TEST_CASE(
   CHECK(name == label2->name());
   CHECK(label2->label_type() == Datatype::FLOAT64);
   CHECK(label2->label_cell_val_num() == 1);
+  REQUIRE(!label2->label_domain().empty());
   auto domain2 = static_cast<const double*>(label2->label_domain().data());
   CHECK(domain2[0] == domain[0]);
   CHECK(domain2[1] == domain[1]);

--- a/tiledb/sm/array_schema/test/unit_dimension_label_schema.cc
+++ b/tiledb/sm/array_schema/test/unit_dimension_label_schema.cc
@@ -47,77 +47,14 @@ TEST_CASE(
   auto indexed_array_schema = test::make_array_schema(
       ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
   REQUIRE(indexed_array_schema->check().ok());
-  // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-  std::vector<shared_ptr<Dimension>> labelled_array_dims{
-      test::make_dimension<uint64_t>(
-          "label0", Datatype::UINT64, 1, 10, 20, 11)};
-  std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-      test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 1, 0)};
-  auto labelled_array_schema = test::make_array_schema(
-      ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-  REQUIRE(labelled_array_schema->check().ok());
   // Create dimension label schema
   REQUIRE_NOTHROW(DimensionLabelSchema(
-      LabelOrder::INCREASING_LABELS,
-      indexed_array_schema,
-      labelled_array_schema));
+      LabelOrder::INCREASING_LABELS, indexed_array_schema));
 }
 
 TEST_CASE(
     "Test invalid dimension label schema construction",
     "[dimension_label_schema]") {
-  SECTION("Mismatched index definition") {
-    // Create indexed array schema
-    std::vector<shared_ptr<Dimension>> indexed_array_dims{
-        test::make_dimension<uint64_t>("dim0", Datatype::UINT64, 1, 0, 10, 11)};
-    std::vector<shared_ptr<Attribute>> indexed_array_attrs{
-        test::make_attribute<uint64_t>(
-            "label0", Datatype::UINT64, false, 1, 0)};
-    auto indexed_array_schema = test::make_array_schema(
-        ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
-    REQUIRE(indexed_array_schema->check().ok());
-    // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-    std::vector<shared_ptr<Dimension>> labelled_array_dims{
-        test::make_dimension<uint64_t>(
-            "label0", Datatype::UINT64, 1, 10, 20, 11)};
-    std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-        test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 2, 0)};
-    auto labelled_array_schema = test::make_array_schema(
-        ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-    REQUIRE(labelled_array_schema->check().ok());
-    // Create dimension label schema
-    REQUIRE_THROWS(DimensionLabelSchema(
-        LabelOrder::INCREASING_LABELS,
-        indexed_array_schema,
-        labelled_array_schema));
-  }
-
-  SECTION("Mismatched label definition") {
-    // Create indexed array schema
-    std::vector<shared_ptr<Dimension>> indexed_array_dims{
-        test::make_dimension<uint64_t>("dim0", Datatype::UINT64, 1, 0, 10, 11)};
-    std::vector<shared_ptr<Attribute>> indexed_array_attrs{
-        test::make_attribute<uint64_t>(
-            "label0", Datatype::UINT64, false, 1, 0)};
-    auto indexed_array_schema = test::make_array_schema(
-        ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
-    REQUIRE(indexed_array_schema->check().ok());
-    // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-    std::vector<shared_ptr<Dimension>> labelled_array_dims{
-        test::make_dimension<uint32_t>(
-            "label0", Datatype::UINT32, 1, 10, 20, 11)};
-    std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-        test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 1, 0)};
-    auto labelled_array_schema = test::make_array_schema(
-        ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-    REQUIRE(labelled_array_schema->check().ok());
-    // Create dimension label schema
-    REQUIRE_THROWS(DimensionLabelSchema(
-        LabelOrder::INCREASING_LABELS,
-        indexed_array_schema,
-        labelled_array_schema));
-  }
-
   SECTION("Too many dimensions on index array") {
     // Create indexed array schema
     std::vector<shared_ptr<Dimension>> indexed_array_dims{
@@ -129,48 +66,9 @@ TEST_CASE(
     auto indexed_array_schema = test::make_array_schema(
         ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
     REQUIRE(indexed_array_schema->check().ok());
-    // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-    std::vector<shared_ptr<Dimension>> labelled_array_dims{
-        test::make_dimension<uint64_t>(
-            "label0", Datatype::UINT64, 1, 10, 20, 11)};
-    std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-        test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 1, 0)};
-    auto labelled_array_schema = test::make_array_schema(
-        ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-    REQUIRE(labelled_array_schema->check().ok());
     // Create dimension label schema
     REQUIRE_THROWS(DimensionLabelSchema(
-        LabelOrder::INCREASING_LABELS,
-        indexed_array_schema,
-        labelled_array_schema));
-  }
-
-  SECTION("Too many dimensions on label array") {
-    // Create indexed array schema
-    std::vector<shared_ptr<Dimension>> indexed_array_dims{
-        test::make_dimension<uint64_t>("dim0", Datatype::UINT64, 1, 0, 10, 11)};
-    std::vector<shared_ptr<Attribute>> indexed_array_attrs{
-        test::make_attribute<uint64_t>(
-            "label0", Datatype::UINT64, false, 1, 0)};
-    auto indexed_array_schema = test::make_array_schema(
-        ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
-    REQUIRE(indexed_array_schema->check().ok());
-    // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-    std::vector<shared_ptr<Dimension>> labelled_array_dims{
-        test::make_dimension<uint64_t>(
-            "label0", Datatype::UINT64, 1, 10, 20, 11),
-        test::make_dimension<uint64_t>(
-            "label1", Datatype::UINT64, 1, 10, 20, 11)};
-    std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-        test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 1, 0)};
-    auto labelled_array_schema = test::make_array_schema(
-        ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-    REQUIRE(labelled_array_schema->check().ok());
-    // Create dimension label schema
-    REQUIRE_THROWS(DimensionLabelSchema(
-        LabelOrder::INCREASING_LABELS,
-        indexed_array_schema,
-        labelled_array_schema));
+        LabelOrder::INCREASING_LABELS, indexed_array_schema));
   }
 
   SECTION("Too many label attributes") {
@@ -184,48 +82,9 @@ TEST_CASE(
     auto indexed_array_schema = test::make_array_schema(
         ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
     REQUIRE(indexed_array_schema->check().ok());
-    // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-    std::vector<shared_ptr<Dimension>> labelled_array_dims{
-        test::make_dimension<uint64_t>(
-            "label0", Datatype::UINT64, 1, 10, 20, 11)};
-    std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-        test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 1, 0)};
-    auto labelled_array_schema = test::make_array_schema(
-        ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-    REQUIRE(labelled_array_schema->check().ok());
     // Create dimension label schema
     REQUIRE_THROWS(DimensionLabelSchema(
-        LabelOrder::INCREASING_LABELS,
-        indexed_array_schema,
-        labelled_array_schema));
-  }
-
-  SECTION("Too many index attributes") {
-    // Create indexed array schema
-    std::vector<shared_ptr<Dimension>> indexed_array_dims{
-        test::make_dimension<uint64_t>("dim0", Datatype::UINT64, 1, 0, 10, 11)};
-    std::vector<shared_ptr<Attribute>> indexed_array_attrs{
-        test::make_attribute<uint64_t>(
-            "label0", Datatype::UINT64, false, 1, 0)};
-    auto indexed_array_schema = test::make_array_schema(
-        ArrayType::DENSE, indexed_array_dims, indexed_array_attrs);
-    REQUIRE(indexed_array_schema->check().ok());
-    // Create labelled array schema uint64_t label_domain[2] = {20, 30};
-    std::vector<shared_ptr<Dimension>> labelled_array_dims{
-        test::make_dimension<uint64_t>(
-            "label0", Datatype::UINT64, 1, 10, 20, 11),
-        test::make_dimension<uint64_t>(
-            "label1", Datatype::UINT64, 1, 10, 20, 11)};
-    std::vector<shared_ptr<Attribute>> labelled_array_attrs{
-        test::make_attribute<uint64_t>("dim0", Datatype::UINT64, false, 1, 0)};
-    auto labelled_array_schema = test::make_array_schema(
-        ArrayType::DENSE, labelled_array_dims, labelled_array_attrs);
-    REQUIRE(labelled_array_schema->check().ok());
-    // Create dimension label schema
-    REQUIRE_THROWS(DimensionLabelSchema(
-        LabelOrder::INCREASING_LABELS,
-        indexed_array_schema,
-        labelled_array_schema));
+        LabelOrder::INCREASING_LABELS, indexed_array_schema));
   }
 }
 
@@ -235,17 +94,13 @@ TEST_CASE(
   // Create dimension label schema
   uint64_t index_domain[2] = {0, 15};
   uint64_t index_tile_extent = 8;
-  double label_domain[2]{-1.0, 1.0};
-  double label_tile_extent{2.0};
   auto dimension_label_schema = make_shared<DimensionLabelSchema>(
       HERE(),
       LabelOrder::INCREASING_LABELS,
+      Datatype::FLOAT64,
       Datatype::UINT64,
       index_domain,
-      &index_tile_extent,
-      Datatype::FLOAT64,
-      label_domain,
-      &label_tile_extent);
+      &index_tile_extent);
   SECTION("Is valid") {
     auto dim =
         test::make_dimension<uint64_t>("dim", Datatype::UINT64, 1, 0, 15, 16);

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
@@ -83,8 +83,8 @@ int32_t tiledb_dimension_label_schema_alloc(
     const void* index_domain,
     const void* index_tile_extent,
     tiledb_datatype_t label_type,
-    const void* label_domain,
-    const void* label_tile_extent,
+    const void*,
+    const void*,
     tiledb_dimension_label_schema_t** dim_label_schema) {
   if (sanity_check(ctx) == TILEDB_ERR) {
     return TILEDB_ERR;
@@ -105,12 +105,10 @@ int32_t tiledb_dimension_label_schema_alloc(
       make_shared<tiledb::sm::DimensionLabelSchema>(
           HERE(),
           static_cast<tiledb::sm::LabelOrder>(label_order),
+          static_cast<tiledb::sm::Datatype>(label_type),
           static_cast<tiledb::sm::Datatype>(index_type),
           index_domain,
-          index_tile_extent,
-          static_cast<tiledb::sm::Datatype>(label_type),
-          label_domain,
-          label_tile_extent);
+          index_tile_extent);
   if ((*dim_label_schema)->dim_label_schema_ == nullptr) {
     delete *dim_label_schema;
     *dim_label_schema = nullptr;

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.cc
@@ -79,12 +79,10 @@ int32_t tiledb_array_schema_has_dimension_label(
 int32_t tiledb_dimension_label_schema_alloc(
     tiledb_ctx_t* ctx,
     tiledb_label_order_t label_order,
+    tiledb_datatype_t label_type,
     tiledb_datatype_t index_type,
     const void* index_domain,
     const void* index_tile_extent,
-    tiledb_datatype_t label_type,
-    const void*,
-    const void*,
     tiledb_dimension_label_schema_t** dim_label_schema) {
   if (sanity_check(ctx) == TILEDB_ERR) {
     return TILEDB_ERR;
@@ -260,22 +258,18 @@ int32_t tiledb_array_schema_has_dimension_label(
 int32_t tiledb_dimension_label_schema_alloc(
     tiledb_ctx_t* ctx,
     tiledb_label_order_t label_order,
+    tiledb_datatype_t label_type,
     tiledb_datatype_t index_type,
     const void* index_domain,
     const void* index_tile_extent,
-    tiledb_datatype_t label_type,
-    const void* label_domain,
-    const void* label_tile_extent,
     tiledb_dimension_label_schema_t** dim_label_schema) noexcept {
   return api_entry_with_context<detail::tiledb_dimension_label_schema_alloc>(
       ctx,
       label_order,
+      label_type,
       index_type,
       index_domain,
       index_tile_extent,
-      label_type,
-      label_domain,
-      label_tile_extent,
       dim_label_schema);
 }
 

--- a/tiledb/sm/c_api/experimental/tiledb_dimension_label.h
+++ b/tiledb/sm/c_api/experimental/tiledb_dimension_label.h
@@ -53,19 +53,14 @@ typedef struct tiledb_dimension_label_schema_t tiledb_dimension_label_schema_t;
  * @code{.c}
  * int64_t dim_domain[] = {1, 10};
  * int64_t tile_extent = 5;
- * double label_domain [] = {-10.0, 10.0};
- * double label_tile_extent = 4.0;
  * tiledb_dimension_label_schema_t* dim_label;
  * tiledb_dimension_label_schema_alloc(
  *     ctx,
  *     TILEDB_INCREASING_LABELS,
+ *     TILEDB_FLOAT64,
  *     TILEDB_INT64,
  *     dim_domain,
- *     &tile_extent,
- *     TILEDB_FLOAT64,
- *     label_domain,
- *     &label_tile_extent,
- *     &dim_label);
+ *     &tile_extent);
  * tiledb_array_schema_t* label_array_schema;
  * tiledb_array_schema_add_dimension_label(
  *     ctx,
@@ -114,43 +109,34 @@ TILEDB_EXPORT int32_t tiledb_array_schema_has_dimension_label(
  * @code{.c}
  * int64_t dim_domain[] = {1, 10};
  * int64_t tile_extent = 5;
- * double label_domain [] = {-10.0, 10.0};
- * double label_tile_extent = 4.0;
  * tiledb_dimension_label_schema_t* dim_label;
  * tiledb_dimension_label_schema_alloc(
  *     ctx,
  *     TILEDB_INCREASING_LABELS,
+ *     TILEDB_FLOAT64,
  *     TILEDB_INT64,
  *     dim_domain,
- *     &tile_extent,
- *     TILEDB_FLOAT64,
- *     label_domain,
- *     &label_tile_extent,
- *     &dim_label);
+ *     &tile_extent);
  * @endcode
  *
  * @param ctx The TileDB context.
  * @param label_type The label type.
+ * @param label_type The datatype for the new label dimension data.
  * @param index_type The datatype for the original dimension data. Must be the
  *     same as the dimension the dimension label is applied to.
  * @param index_domain The range the original dimension is defined on. Must be
  *     the same as the dimension the dimension label is applied to.
  * @param index_tile_extent The tile extent for the original dimension data on
  *     the dimension label.
- * @param label_type The datatype for the new label dimension data.
- * @param label_dim_domain The range the label data is defined on domain.
- * @param label_tile_extent The tile extent for the label data.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT int32_t tiledb_dimension_label_schema_alloc(
     tiledb_ctx_t* ctx,
     tiledb_label_order_t label_order,
+    tiledb_datatype_t label_type,
     tiledb_datatype_t index_type,
     const void* index_domain,
     const void* index_tile_extent,
-    tiledb_datatype_t label_type,
-    const void* label_domain,
-    const void* label_tile_extent,
     tiledb_dimension_label_schema_t** dim_label_schema) TILEDB_NOEXCEPT;
 
 /**

--- a/tiledb/sm/dimension_label/dimension_label.cc
+++ b/tiledb/sm/dimension_label/dimension_label.cc
@@ -51,21 +51,11 @@ DimensionLabel::DimensionLabel(const URI& uri, StorageManager* storage_manager)
     , storage_manager_(storage_manager)
     , indexed_array_(make_shared<Array>(
           HERE(), uri.join_path(indexed_array_name), storage_manager))
-    , labelled_array_(make_shared<Array>(
-          HERE(), uri.join_path(labelled_array_name), storage_manager))
     , schema_{nullptr} {
 }
 
 void DimensionLabel::close() {
   throw_if_not_ok(indexed_array_->close());
-  throw_if_not_ok(labelled_array_->close());
-}
-
-const Attribute* DimensionLabel::index_attribute() const {
-  if (!schema_)
-    throw std::logic_error(
-        "DimensionLabel schema does not exist. DimensionLabel must be opened.");
-  return schema_->index_attribute();
 }
 
 const Dimension* DimensionLabel::index_dimension() const {
@@ -96,25 +86,24 @@ void DimensionLabel::is_compatible(
         ", but the expected label order was " +
         label_order_str(dim_label_ref.label_order()) + ".");
   }
-  if (schema_->label_dimension()->type() != dim_label_ref.label_type()) {
+  if (schema_->label_type() != dim_label_ref.label_type()) {
     throw DimensionLabelStatusException(
         "Error opening dimension label; The label datatype of the loaded "
         "dimension label is " +
-        datatype_str(schema_->label_dimension()->type()) +
+        datatype_str(schema_->label_type()) +
         ", but the expected label datatype was " +
         datatype_str(dim_label_ref.label_type()) + ".");
   }
-  if (!(schema_->label_dimension()->domain() == dim_label_ref.label_domain())) {
+  if (!(schema_->label_domain() == dim_label_ref.label_domain())) {
     throw DimensionLabelStatusException(
         "Error opening dimension label; The label domain of the loaded "
         "dimension label does not match the expected domain.");
   }
-  if (schema_->label_dimension()->cell_val_num() !=
-      dim_label_ref.label_cell_val_num()) {
+  if (schema_->label_cell_val_num() != dim_label_ref.label_cell_val_num()) {
     throw DimensionLabelStatusException(
         "Error opening dimension label; The label cell value number of the "
         "loaded dimension label is " +
-        std::to_string(schema_->label_dimension()->cell_val_num()) +
+        std::to_string(schema_->label_cell_val_num()) +
         ", but the expected label cell value number was " +
         std::to_string(dim_label_ref.label_cell_val_num()) + ".");
   }
@@ -125,13 +114,6 @@ const Attribute* DimensionLabel::label_attribute() const {
     throw std::logic_error(
         "DimensionLabel schema does not exist. DimensionLabel must be opened.");
   return schema_->label_attribute();
-}
-
-const Dimension* DimensionLabel::label_dimension() const {
-  if (!schema_)
-    throw std::logic_error(
-        "DimensionLabel schema does not exist. DimensionLabel must be opened.");
-  return schema_->label_dimension();
 }
 
 LabelOrder DimensionLabel::label_order() const {
@@ -165,7 +147,7 @@ void DimensionLabel::open(
     EncryptionType encryption_type,
     const void* encryption_key,
     uint32_t key_length) {
-  // Open indexed array and get schema
+  // Open indexed array and get schema.
   throw_if_not_ok(indexed_array_->open(
       query_type,
       timestamp_start,
@@ -177,41 +159,14 @@ void DimensionLabel::open(
       indexed_array_->get_array_schema();
   throw_if_not_ok(index_status);
 
-  // Open labelled array and get schema
-  throw_if_not_ok(labelled_array_->open(
-      query_type,
-      timestamp_start,
-      timestamp_end,
-      encryption_type,
-      encryption_key,
-      key_length));
-  auto&& [label_status, labelled_array_schema] =
-      labelled_array_->get_array_schema();
-  throw_if_not_ok(label_status);
-  load_schema(indexed_array_schema.value(), labelled_array_schema.value());
+  // Open the dimension label schema.
+  load_schema(indexed_array_schema.value());
+
+  // Set the query type.
   query_type_ = query_type;
-
-  // Restrict reading to only shared fragments.
-  if (query_type_ == QueryType::READ) {
-    // Get label names
-    std::vector<TimestampedURI> indexed_frag_uris{
-        indexed_array_->array_directory()
-            .filtered_fragment_uris(false)
-            .fragment_uris()};
-    std::vector<TimestampedURI> labelled_frag_uris{
-        labelled_array_->array_directory()
-            .filtered_fragment_uris(false)
-            .fragment_uris()};
-
-    // Reload with only shared fragments.
-    throw_if_not_ok(indexed_array_->load_fragments(indexed_frag_uris));
-    throw_if_not_ok(labelled_array_->load_fragments(labelled_frag_uris));
-  }
 }
 
-void DimensionLabel::load_schema(
-    shared_ptr<ArraySchema> indexed_array_schema,
-    shared_ptr<ArraySchema> labelled_array_schema) {
+void DimensionLabel::load_schema(shared_ptr<ArraySchema> indexed_array_schema) {
   // Get dimension label schema metadata
   GroupV1 label_group{uri_, storage_manager_};
   throw_if_not_ok(label_group.open(QueryType::READ));
@@ -268,7 +223,7 @@ void DimensionLabel::load_schema(
 
   // Get array schemas
   schema_ = make_shared<DimensionLabelSchema>(
-      HERE(), label_order, indexed_array_schema, labelled_array_schema);
+      HERE(), label_order, indexed_array_schema);
 }
 
 QueryType DimensionLabel::query_type() const {
@@ -303,12 +258,6 @@ void create_dimension_label(
       uri.join_path(indexed_array_name.value()),
       schema.indexed_array_schema(),
       key));
-  std::optional<std::string> labelled_array_name{
-      DimensionLabel::labelled_array_name};
-  throw_if_not_ok(storage_manager.array_create(
-      uri.join_path(labelled_array_name.value()),
-      schema.labelled_array_schema(),
-      key));
 
   // Open dimension label group.
   GroupV1 label_group{uri, &storage_manager};
@@ -328,8 +277,6 @@ void create_dimension_label(
   // Add arrays to group.
   throw_if_not_ok(label_group.mark_member_for_addition(
       URI(indexed_array_name.value(), false), true, indexed_array_name));
-  throw_if_not_ok(label_group.mark_member_for_addition(
-      URI(labelled_array_name.value(), false), true, labelled_array_name));
 
   // Close group.
   throw_if_not_ok(label_group.close());

--- a/tiledb/sm/dimension_label/dimension_label.h
+++ b/tiledb/sm/dimension_label/dimension_label.h
@@ -62,7 +62,6 @@ class DimensionLabelStatusException : public StatusException {
 class DimensionLabel {
  public:
   inline const static std::string indexed_array_name{"indexed"};
-  inline const static std::string labelled_array_name{"labelled"};
   /**
    * Constructor.
    *
@@ -74,9 +73,6 @@ class DimensionLabel {
 
   /** Closes the arrays and frees all memory. */
   void close();
-
-  /** Returns the index attribute in the labelled array. */
-  const Attribute* index_attribute() const;
 
   /** Returns the index dimension in the indexed array. */
   const Dimension* index_dimension() const;
@@ -97,14 +93,6 @@ class DimensionLabel {
 
   /** Returns the label attribute in the indexed array. */
   const Attribute* label_attribute() const;
-
-  /** Returns the label dimension in the labelled array. */
-  const Dimension* label_dimension() const;
-
-  /** Returns the array with labels stored on the dimension. */
-  inline shared_ptr<Array> labelled_array() const {
-    return labelled_array_;
-  }
 
   /** Returns the order of the dimension label. */
   LabelOrder label_order() const;
@@ -167,9 +155,6 @@ class DimensionLabel {
   /** Array with index dimension */
   shared_ptr<Array> indexed_array_;
 
-  /** Array with label dimension */
-  shared_ptr<Array> labelled_array_;
-
   /** Latest dimension label schema  */
   shared_ptr<DimensionLabelSchema> schema_;
 
@@ -184,11 +169,8 @@ class DimensionLabel {
    * Loads and checks the dimension label schema.
    *
    * @param indexed_array_schema Array schema for the indexed array
-   * @param labelled_array_schema Array schema for the labelled array
    **/
-  void load_schema(
-      shared_ptr<ArraySchema> indexed_array_schema,
-      shared_ptr<ArraySchema> labelled_array_schema);
+  void load_schema(shared_ptr<ArraySchema> indexed_array_schema);
 };
 
 /**

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -201,8 +201,8 @@ void ArrayDimensionLabelQueries::add_read_queries(
     }
 
     // Open the indexed array.
-    auto* dim_label = open_dimension_label(
-        array, dim_label_ref, QueryType::READ, true, false);
+    auto* dim_label =
+        open_dimension_label(array, dim_label_ref, QueryType::READ);
 
     // Get subarray ranges.
     auto& label_ranges = subarray.ranges_for_label(label_name);
@@ -224,8 +224,7 @@ void ArrayDimensionLabelQueries::add_read_queries(
     auto dim_label_iter = dimension_labels_.find(label_name);
     auto* dim_label =
         dim_label_iter == dimension_labels_.end() ?
-            open_dimension_label(
-                array, dim_label_ref, QueryType::READ, true, false) :
+            open_dimension_label(array, dim_label_ref, QueryType::READ) :
             dim_label_iter->second.get();
 
     // Create the data query.
@@ -262,8 +261,8 @@ void ArrayDimensionLabelQueries::add_write_queries(
     }
 
     // Open both arrays in the dimension label.
-    auto* dim_label = open_dimension_label(
-        array, dim_label_ref, QueryType::WRITE, true, true);
+    auto* dim_label =
+        open_dimension_label(array, dim_label_ref, QueryType::WRITE);
 
     // Get the index_buffer from the array buffers.
     const auto& dim_name = array->array_schema_latest()
@@ -291,9 +290,7 @@ void ArrayDimensionLabelQueries::add_write_queries(
 DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
     Array* array,
     const DimensionLabelReference& dim_label_ref,
-    const QueryType& query_type,
-    const bool open_indexed_array,
-    const bool open_labelled_array) {
+    const QueryType& query_type) {
   // Create the dimension label.
   auto label_iter = dimension_labels_.try_emplace(
       dim_label_ref.name(),
@@ -303,26 +300,21 @@ DimensionLabel* ArrayDimensionLabelQueries::open_dimension_label(
           storage_manager_));
   DimensionLabel* dim_label = (label_iter.first->second).get();
 
-  // Currently there is no way to open just one of these arrays. This is a
-  // placeholder for a single array open is implemented.
-  if (open_indexed_array || open_labelled_array) {
-    // Open the dimension label. Handling encrypted dimension labels is not yet
-    // implemented.
-    dim_label->open(
-        query_type,
-        array->timestamp_start(),
-        array->timestamp_end(),
-        EncryptionType::NO_ENCRYPTION,
-        nullptr,
-        0);
+  // Open the dimension label. Handling encrypted dimension labels is not yet
+  // implemented.
+  dim_label->open(
+      query_type,
+      array->timestamp_start(),
+      array->timestamp_end(),
+      EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0);
 
-    // Check the dimension label is compatible with the dim label reference and
-    // dimension from the parent array.
-    dim_label->is_compatible(
-        dim_label_ref,
-        array->array_schema_latest().dimension_ptr(
-            dim_label_ref.dimension_id()));
-  }
+  // Check the dimension label is compatible with the dim label reference and
+  // dimension from the parent array.
+  dim_label->is_compatible(
+      dim_label_ref,
+      array->array_schema_latest().dimension_ptr(dim_label_ref.dimension_id()));
 
   return dim_label;
 }

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -224,15 +224,11 @@ class ArrayDimensionLabelQueries {
    *
    * @param array Array the dimension label is defined on.
    * @param query_type Query type to open the dimension label as.
-   * @param open_indexed_array If ``true``, open the indexed array.
-   * @param open_labelled_array If ``true``, open the labelled array.
    */
   DimensionLabel* open_dimension_label(
       Array* array,
       const DimensionLabelReference& dim_label_ref,
-      const QueryType& query_type,
-      const bool open_indexed_array,
-      const bool open_labelled_array);
+      const QueryType& query_type);
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/dimension_label/dimension_label_data_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_data_query.cc
@@ -311,11 +311,6 @@ UnorderedWriteDataQuery::UnorderedWriteDataQuery(
           Query,
           storage_manager,
           dimension_label->indexed_array(),
-          fragment_name))}
-    , labelled_array_query_{tdb_unique_ptr<Query>(tdb_new(
-          Query,
-          storage_manager,
-          dimension_label->labelled_array(),
           fragment_name))} {
   // Create locally stored index data if the index buffer is empty.
   bool use_local_index = index_buffer.buffer_ == nullptr;
@@ -334,21 +329,6 @@ UnorderedWriteDataQuery::UnorderedWriteDataQuery(
     index_data_ = tdb_unique_ptr<IndexData>(IndexDataCreate::make_index_data(
         dimension_label->index_dimension()->type(),
         parent_subarray.ranges_for_dim(dim_idx)[0]));
-  }
-
-  // Set-up labelled array (sparse array).
-  throw_if_not_ok(labelled_array_query_->set_layout(Layout::UNORDERED));
-  labelled_array_query_->set_dimension_label_buffer(
-      dimension_label->label_dimension()->name(), label_buffer);
-  if (use_local_index) {
-    throw_if_not_ok(labelled_array_query_->set_data_buffer(
-        dimension_label->index_attribute()->name(),
-        index_data_->data(),
-        index_data_->data_size(),
-        true));
-  } else {
-    labelled_array_query_->set_dimension_label_buffer(
-        dimension_label->index_attribute()->name(), index_buffer);
   }
 
   // Set-up indexed array query (sparse array).
@@ -374,18 +354,13 @@ void UnorderedWriteDataQuery::add_index_ranges_from_label(
 }
 
 bool UnorderedWriteDataQuery::completed() const {
-  return indexed_array_query_->status() == QueryStatus::COMPLETED &&
-         labelled_array_query_->status() == QueryStatus::COMPLETED;
+  return indexed_array_query_->status() == QueryStatus::COMPLETED;
 }
 
 void UnorderedWriteDataQuery::process() {
   // Write to main dimension label array.
   throw_if_not_ok(indexed_array_query_->init());
   throw_if_not_ok(indexed_array_query_->process());
-
-  // Write to projection array.
-  throw_if_not_ok(labelled_array_query_->init());
-  throw_if_not_ok(labelled_array_query_->process());
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/dimension_label/dimension_label_data_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_data_query.cc
@@ -254,7 +254,7 @@ OrderedWriteDataQuery::OrderedWriteDataQuery(
   if (!is_sorted_buffer(
           stats_,
           label_buffer,
-          dimension_label->label_dimension()->type(),
+          dimension_label->label_attribute()->type(),
           dimension_label->label_order() == LabelOrder::INCREASING_LABELS)) {
     throw DimensionLabelDataQueryStatusException(
         "Failed to create dimension label query. The label data is not in the "

--- a/tiledb/sm/query/dimension_label/dimension_label_data_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_data_query.h
@@ -251,9 +251,6 @@ class UnorderedWriteDataQuery : public DimensionLabelDataQuery {
   /** Query on the dimension label indexed array. */
   tdb_unique_ptr<Query> indexed_array_query_{nullptr};
 
-  /** Query on the dimension label labelled array. */
-  tdb_unique_ptr<Query> labelled_array_query_{nullptr};
-
   /** Internally managed index data for sparse write to labelled array. */
   tdb_unique_ptr<IndexData> index_data_;
 };

--- a/tiledb/sm/query/dimension_label/dimension_label_range_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_range_query.cc
@@ -58,7 +58,7 @@ OrderedRangeQuery::OrderedRangeQuery(
   // Set the subarray.
   Subarray subarray{*query_->subarray()};
   subarray.set_attribute_ranges(
-      dimension_label->label_dimension()->name(), label_ranges);
+      dimension_label->label_attribute()->name(), label_ranges);
   throw_if_not_ok(query_->set_subarray(subarray));
 
   // Set index data buffer that will store the computed ranges.


### PR DESCRIPTION
The dimension label design was revised to use a single array. This removes the extra unnecessary array and performs associated clean-up

---
TYPE: IMPROVEMENT
DESC: Removes unnecessary labelled array from dimension label
