### PR TITLE
Fix duplicate logger instantiations when using libtiledbsoma with tiledb-py

### DIFF
--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -281,9 +281,14 @@ std::string Logger::add_tag(const std::string& tag, uint64_t id) {
 /* ********************************* */
 
 Logger& global_logger(Logger::Format format) {
-  static std::string name = (format == Logger::Format::JSON) ?
-                                Logger::global_logger_json_name :
-                                Logger::global_logger_default_name;
+  static auto ts_micro =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+  static std::string name =
+      (format == Logger::Format::JSON) ?
+          "\"" + std::to_string(ts_micro) + "-Global\":\"1\"" :
+          std::to_string(ts_micro) + "-Global";
   static Logger l(name, format, true);
   return l;
 }

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -371,12 +371,6 @@ class Logger {
     JSON,
   };
 
-  /** The name of the global logger */
-  static inline constexpr char global_logger_default_name[] = "Global";
-
-  /** The name of the global logger in json format */
-  static inline constexpr char global_logger_json_name[] = "\"Global\":\"1\"";
-
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -49,7 +49,7 @@ namespace sm {
 Context::Context(const Config& config)
     : last_error_(nullopt)
     , logger_(make_shared<Logger>(
-          HERE(), "Context: " + std::to_string(++logger_id_)))
+          HERE(), logger_prefix_ + std::to_string(++logger_id_)))
     , compute_tp_(get_compute_thread_count(config))
     , io_tp_(get_io_thread_count(config))
     , stats_(make_shared<stats::Stats>(HERE(), "Context"))

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -118,6 +118,13 @@ class Context {
   /** The class logger. */
   shared_ptr<Logger> logger_;
 
+  /** The class unique logger prefix */
+  inline static std::string logger_prefix_ =
+      std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count()) +
+      "-Context: ";
+
   /**
    * Counter for generating unique identifiers for `Logger` objects.
    */


### PR DESCRIPTION
In Single cell project, `libtiledb` is loaded twice: once by `tiledbsoma` and once by `tiledb-py`. Those 2 instances of the same library cause `spdlog` to try to register twice `Loggers` with the same name (for the static `global_logger` and for `Context:` loggers). The reason seems to be that `spdlog` maintains a single global registry for those two instances. 

This PR is introducing a workaround for this issue by prefixing `global_logger` and `Context:` logger names with a unique id, that we chose to be the nanosecond of creation of the logger. We consider this number unique due to the fact that the two libraries can't be loaded simultaneously.

---
TYPE: BUG
DESC: Fix duplicate logger instantiations when using libtiledbsoma with tiledb-py
