### PR TITLE
Removes non-C.41 range setting (part 1)

### DIFF
--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -2283,9 +2283,7 @@ TEST_CASE_METHOD(
   // Check unsplittable
   tiledb::sm::Subarray subarray(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  Range r;
-  r.set_str_range("bb", "bb");
-  CHECK(subarray.add_range(0, std::move(r), true).ok());
+  CHECK(subarray.add_range(0, Range("bb", "bb"), true).ok());
   ThreadPool tp(4);
   Config config;
   SubarrayPartitioner partitioner(
@@ -2321,8 +2319,7 @@ TEST_CASE_METHOD(
   // Check full
   tiledb::sm::Subarray subarray_full(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  r.set_str_range("a", "bb");
-  CHECK(subarray_full.add_range(0, std::move(r), true).ok());
+  CHECK(subarray_full.add_range(0, Range("a", "bb"), true).ok());
   SubarrayPartitioner partitioner_full(
       &config,
       subarray_full,
@@ -2349,8 +2346,7 @@ TEST_CASE_METHOD(
   // Check split
   tiledb::sm::Subarray subarray_split(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  r.set_str_range("a", "bb");
-  CHECK(subarray_split.add_range(0, std::move(r), true).ok());
+  CHECK(subarray_split.add_range(0, Range("a", "bb"), true).ok());
   SubarrayPartitioner partitioner_split(
       &config,
       subarray_split,
@@ -2387,8 +2383,7 @@ TEST_CASE_METHOD(
   // Check no split 2 MBRs
   tiledb::sm::Subarray subarray_no_split(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  r.set_str_range("bb", "cc");
-  CHECK(subarray_no_split.add_range(0, std::move(r), true).ok());
+  CHECK(subarray_no_split.add_range(0, Range("bb", "cc"), true).ok());
   SubarrayPartitioner partitioner_no_split(
       &config,
       subarray_no_split,
@@ -2417,8 +2412,7 @@ TEST_CASE_METHOD(
   // Check split 2 MBRs
   tiledb::sm::Subarray subarray_split_2(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  r.set_str_range("bb", "cc");
-  CHECK(subarray_split_2.add_range(0, std::move(r), true).ok());
+  CHECK(subarray_split_2.add_range(0, Range("bb", "cc"), true).ok());
   SubarrayPartitioner partitioner_split_2(
       &config,
       subarray_split_2,
@@ -2556,9 +2550,7 @@ TEST_CASE_METHOD(
 
   tiledb::sm::Subarray subarray(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  Range r;
-  r.set_str_range("cc", "ccd");
-  CHECK(subarray.add_range(0, std::move(r), true).ok());
+  CHECK(subarray.add_range(0, Range("cc", "ccd"), true).ok());
   ThreadPool tp(4);
   Config config;
   SubarrayPartitioner partitioner(

--- a/test/src/unit-rtree.cc
+++ b/test/src/unit-rtree.cc
@@ -53,7 +53,7 @@ std::vector<NDRange> create_mbrs(const std::vector<T>& mbrs) {
   for (uint64_t m = 0; m < mbr_num; ++m) {
     ret[m].resize(D);
     for (unsigned d = 0; d < D; ++d) {
-      ret[m][d].set_range(&mbrs[2 * D * m + 2 * d], r_size);
+      ret[m][d] = Range(&mbrs[2 * D * m + 2 * d], r_size);
     }
   }
 
@@ -71,8 +71,8 @@ std::vector<NDRange> create_mbrs(
   uint64_t r2_size = 2 * sizeof(T2);
   for (uint64_t m = 0; m < mbr_num; ++m) {
     ret[m].resize(2);
-    ret[m][0].set_range(&r1[2 * m], r1_size);
-    ret[m][1].set_range(&r2[2 * m], r2_size);
+    ret[m][0] = Range(&r1[2 * m], r1_size);
+    ret[m][1] = Range(&r2[2 * m], r2_size);
   }
 
   return ret;
@@ -153,7 +153,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   NDRange range1(1);
   NDRange mbr1(1);
   int32_t mbr1_r[] = {5, 10};
-  mbr1[0].set_range(mbr1_r, 2 * sizeof(int32_t));
+  mbr1[0] = Range(mbr1_r, 2 * sizeof(int32_t));
   int32_t r1_no_left[] = {0, 1};
   int32_t r1_left[] = {4, 7};
   int32_t r1_exact[] = {5, 10};
@@ -161,25 +161,25 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   int32_t r1_contained[] = {6, 7};
   int32_t r1_right[] = {7, 11};
   int32_t r1_no_right[] = {11, 15};
-  range1[0].set_range(r1_no_left, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_no_left, 2 * sizeof(int32_t));
   double ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 0.0);
-  range1[0].set_range(r1_left, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_left, 2 * sizeof(int32_t));
   ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 3.0 / 6);
-  range1[0].set_range(r1_exact, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_exact, 2 * sizeof(int32_t));
   ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 1.0);
-  range1[0].set_range(r1_full, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_full, 2 * sizeof(int32_t));
   ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 1.0);
-  range1[0].set_range(r1_contained, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_contained, 2 * sizeof(int32_t));
   ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 2.0 / 6);
-  range1[0].set_range(r1_right, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_right, 2 * sizeof(int32_t));
   ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 4.0 / 6);
-  range1[0].set_range(r1_no_right, 2 * sizeof(int32_t));
+  range1[0] = Range(r1_no_right, 2 * sizeof(int32_t));
   ratio1 = dom1.overlap_ratio(range1, is_default, mbr1);
   CHECK(ratio1 == 0.0);
 
@@ -207,21 +207,21 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   NDRange range2(2);
   int64_t mbr2_r[] = {5, 10, 2, 9};
   NDRange mbr2(2);
-  mbr2[0].set_range(&mbr2_r[0], 2 * sizeof(int64_t));
-  mbr2[1].set_range(&mbr2_r[2], 2 * sizeof(int64_t));
+  mbr2[0] = Range(&mbr2_r[0], 2 * sizeof(int64_t));
+  mbr2[1] = Range(&mbr2_r[2], 2 * sizeof(int64_t));
   int64_t r2_no[] = {6, 7, 10, 12};
   int64_t r2_full[] = {4, 11, 2, 9};
   int64_t r2_partial[] = {7, 11, 4, 5};
-  range2[0].set_range(&r2_no[0], 2 * sizeof(int64_t));
-  range2[1].set_range(&r2_no[2], 2 * sizeof(int64_t));
+  range2[0] = Range(&r2_no[0], 2 * sizeof(int64_t));
+  range2[1] = Range(&r2_no[2], 2 * sizeof(int64_t));
   double ratio2 = dom2.overlap_ratio(range2, is_default, mbr2);
   CHECK(ratio2 == 0.0);
-  range2[0].set_range(&r2_full[0], 2 * sizeof(int64_t));
-  range2[1].set_range(&r2_full[2], 2 * sizeof(int64_t));
+  range2[0] = Range(&r2_full[0], 2 * sizeof(int64_t));
+  range2[1] = Range(&r2_full[2], 2 * sizeof(int64_t));
   ratio2 = dom2.overlap_ratio(range2, is_default, mbr2);
   CHECK(ratio2 == 1.0);
-  range2[0].set_range(&r2_partial[0], 2 * sizeof(int64_t));
-  range2[1].set_range(&r2_partial[2], 2 * sizeof(int64_t));
+  range2[0] = Range(&r2_partial[0], 2 * sizeof(int64_t));
+  range2[1] = Range(&r2_partial[2], 2 * sizeof(int64_t));
   ratio2 = dom2.overlap_ratio(range2, is_default, mbr2);
   CHECK(ratio2 == (4.0 / 6) * (2.0 / 8));
 
@@ -240,29 +240,29 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   NDRange rangef(1);
   float mbrf_r[] = {5.0f, 10.0f};
   NDRange mbrf(1);
-  mbrf[0].set_range(mbrf_r, 2 * sizeof(float));
+  mbrf[0] = Range(mbrf_r, 2 * sizeof(float));
   float rf_no_left[] = {0.0, 1.0};
   float rf_left[] = {4.0, 7.0};
   float rf_exact[] = {5.0, 10.0};
   float rf_full[] = {4.0, 11.0};
   float rf_right[] = {7.0, 11.0};
   float rf_no_right[] = {11.0, 15.0};
-  rangef[0].set_range(rf_no_left, 2 * sizeof(float));
+  rangef[0] = Range(rf_no_left, 2 * sizeof(float));
   double ratiof = dom2f.overlap_ratio(rangef, is_default, mbrf);
   CHECK(ratiof == 0.0);
-  rangef[0].set_range(rf_left, 2 * sizeof(float));
+  rangef[0] = Range(rf_left, 2 * sizeof(float));
   ratiof = dom2f.overlap_ratio(rangef, is_default, mbrf);
   CHECK(ratiof == 2.0 / 5);
-  rangef[0].set_range(rf_exact, 2 * sizeof(float));
+  rangef[0] = Range(rf_exact, 2 * sizeof(float));
   ratiof = dom2f.overlap_ratio(rangef, is_default, mbrf);
   CHECK(ratiof == 1.0);
-  rangef[0].set_range(rf_full, 2 * sizeof(float));
+  rangef[0] = Range(rf_full, 2 * sizeof(float));
   ratiof = dom2f.overlap_ratio(rangef, is_default, mbrf);
   CHECK(ratiof == 1.0);
-  rangef[0].set_range(rf_right, 2 * sizeof(float));
+  rangef[0] = Range(rf_right, 2 * sizeof(float));
   ratiof = dom2f.overlap_ratio(rangef, is_default, mbrf);
   CHECK(ratiof == 3.0 / 5);
-  rangef[0].set_range(rf_no_right, 2 * sizeof(float));
+  rangef[0] = Range(rf_no_right, 2 * sizeof(float));
   ratiof = dom2f.overlap_ratio(rangef, is_default, mbrf);
   CHECK(ratiof == 0.0);
 }
@@ -293,17 +293,17 @@ TEST_CASE("RTree: Test 1D R-tree, height 2", "[rtree][1d][2h]") {
   int32_t r_no[] = {25, 30};
   int32_t r_full[] = {0, 22};
   int32_t r_partial[] = {6, 21};
-  range[0].set_range(r_no, 2 * sizeof(int32_t));
+  range[0] = Range(r_no, 2 * sizeof(int32_t));
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
-  range[0].set_range(r_full, 2 * sizeof(int32_t));
+  range[0] = Range(r_full, 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
   CHECK(overlap.tile_ranges_[0].first == 0);
   CHECK(overlap.tile_ranges_[0].second == 2);
-  range[0].set_range(r_partial, 2 * sizeof(int32_t));
+  range[0] = Range(r_partial, 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 2);
@@ -343,17 +343,17 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
   int32_t r_only_tiles[] = {10, 20};
   int32_t r_only_ranges[] = {30, 69};
   int32_t r_tiles_and_ranges[] = {1, 32};
-  range[0].set_range(r_no, 2 * sizeof(int32_t));
+  range[0] = Range(r_no, 2 * sizeof(int32_t));
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
-  range[0].set_range(r_full, 2 * sizeof(int32_t));
+  range[0] = Range(r_full, 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
   CHECK(overlap.tile_ranges_[0].first == 0);
   CHECK(overlap.tile_ranges_[0].second == 7);
-  range[0].set_range(r_only_tiles, 2 * sizeof(int32_t));
+  range[0] = Range(r_only_tiles, 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 2);
@@ -361,7 +361,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
   CHECK(overlap.tiles_[0].second == 1.0 / 6);
   CHECK(overlap.tiles_[1].first == 2);
   CHECK(overlap.tiles_[1].second == 1.0 / 3);
-  range[0].set_range(r_only_ranges, 2 * sizeof(int32_t));
+  range[0] = Range(r_only_ranges, 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 2);
@@ -369,7 +369,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
   CHECK(overlap.tile_ranges_[0].second == 5);
   CHECK(overlap.tile_ranges_[1].first == 6);
   CHECK(overlap.tile_ranges_[1].second == 7);
-  range[0].set_range(r_tiles_and_ranges, 2 * sizeof(int32_t));
+  range[0] = Range(r_tiles_and_ranges, 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.size() == 1);
   CHECK(overlap.tile_ranges_[0].first == 0);
@@ -409,20 +409,20 @@ TEST_CASE("RTree: Test 2D R-tree, height 2", "[rtree][2d][2h]") {
   int32_t r_no[] = {25, 30, 1, 10};
   int32_t r_full[] = {1, 20, 1, 20};
   int32_t r_partial[] = {5, 12, 8, 12};
-  range[0].set_range(&r_no[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_no[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_no[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_no[2], 2 * sizeof(int32_t));
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
-  range[0].set_range(&r_full[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_full[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_full[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_full[2], 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
   CHECK(overlap.tile_ranges_[0].first == 0);
   CHECK(overlap.tile_ranges_[0].second == 2);
-  range[0].set_range(&r_partial[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_partial[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_partial[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_partial[2], 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 2);
@@ -466,20 +466,20 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
   int32_t r_only_tiles[] = {10, 14, 12, 21};
   int32_t r_only_ranges[] = {11, 42, 20, 42};
   int32_t r_tiles_and_ranges[] = {19, 50, 25, 50};
-  range[0].set_range(&r_no[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_no[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_no[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_no[2], 2 * sizeof(int32_t));
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
-  range[0].set_range(&r_full[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_full[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_full[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_full[2], 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
   CHECK(overlap.tile_ranges_[0].first == 0);
   CHECK(overlap.tile_ranges_[0].second == 8);
-  range[0].set_range(&r_only_tiles[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_only_tiles[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_only_tiles[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_only_tiles[2], 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 2);
@@ -487,8 +487,8 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
   CHECK(overlap.tiles_[0].second == 4.0 / 6);
   CHECK(overlap.tiles_[1].first == 3);
   CHECK(overlap.tiles_[1].second == (4.0 / 5) * (2.0 / 3));
-  range[0].set_range(&r_only_ranges[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_only_ranges[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_only_ranges[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_only_ranges[2], 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 2);
@@ -496,8 +496,8 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
   CHECK(overlap.tile_ranges_[0].second == 5);
   CHECK(overlap.tile_ranges_[1].first == 6);
   CHECK(overlap.tile_ranges_[1].second == 8);
-  range[0].set_range(&r_tiles_and_ranges[0], 2 * sizeof(int32_t));
-  range[1].set_range(&r_tiles_and_ranges[2], 2 * sizeof(int32_t));
+  range[0] = Range(&r_tiles_and_ranges[0], 2 * sizeof(int32_t));
+  range[1] = Range(&r_tiles_and_ranges[2], 2 * sizeof(int32_t));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.size() == 1);
   CHECK(overlap.tile_ranges_[0].first == 6);
@@ -537,8 +537,8 @@ TEST_CASE(
   NDRange range_no(2);
   uint8_t uint8_r_no[] = {6, 7};
   int32_t int32_r_no[] = {1, 10};
-  range_no[0].set_range(uint8_r_no, sizeof(uint8_r_no));
-  range_no[1].set_range(int32_r_no, sizeof(int32_r_no));
+  range_no[0] = Range(uint8_r_no, sizeof(uint8_r_no));
+  range_no[1] = Range(int32_r_no, sizeof(int32_r_no));
   double ratio = dom.overlap_ratio(range_no, is_default, mbrs[0]);
   CHECK(ratio == 0.0);
 
@@ -546,8 +546,8 @@ TEST_CASE(
   NDRange range_full(2);
   uint8_t uint8_r_full[] = {0, 10};
   int32_t int32_r_full[] = {1, 10};
-  range_full[0].set_range(uint8_r_full, sizeof(uint8_r_full));
-  range_full[1].set_range(int32_r_full, sizeof(int32_r_full));
+  range_full[0] = Range(uint8_r_full, sizeof(uint8_r_full));
+  range_full[1] = Range(int32_r_full, sizeof(int32_r_full));
   ratio = dom.overlap_ratio(range_full, is_default, mbrs[0]);
   CHECK(ratio == 1.0);
   ratio = dom.overlap_ratio(range_full, is_default, mbrs[1]);
@@ -557,8 +557,8 @@ TEST_CASE(
   NDRange range_part(2);
   uint8_t uint8_r_part[] = {1, 1};
   int32_t int32_r_part[] = {5, 5};
-  range_part[0].set_range(uint8_r_part, sizeof(uint8_r_part));
-  range_part[1].set_range(int32_r_part, sizeof(int32_r_part));
+  range_part[0] = Range(uint8_r_part, sizeof(uint8_r_part));
+  range_part[1] = Range(int32_r_part, sizeof(int32_r_part));
   ratio = dom.overlap_ratio(range_part, is_default, mbrs[0]);
   CHECK(ratio == 0.25);
 }
@@ -593,8 +593,8 @@ TEST_CASE(
   NDRange range_no(2);
   uint64_t uint64_r_no[] = {6, 7};
   float float_r_no[] = {.1f, .9f};
-  range_no[0].set_range(uint64_r_no, sizeof(uint64_r_no));
-  range_no[1].set_range(float_r_no, sizeof(float_r_no));
+  range_no[0] = Range(uint64_r_no, sizeof(uint64_r_no));
+  range_no[1] = Range(float_r_no, sizeof(float_r_no));
   double ratio = dom.overlap_ratio(range_no, is_default, mbrs[0]);
   CHECK(ratio == 0.0);
 
@@ -602,8 +602,8 @@ TEST_CASE(
   NDRange range_full(2);
   uint64_t uint64_r_full[] = {0, 10};
   float float_r_full[] = {.1f, 1.0f};
-  range_full[0].set_range(uint64_r_full, sizeof(uint64_r_full));
-  range_full[1].set_range(float_r_full, sizeof(float_r_full));
+  range_full[0] = Range(uint64_r_full, sizeof(uint64_r_full));
+  range_full[1] = Range(float_r_full, sizeof(float_r_full));
   ratio = dom.overlap_ratio(range_full, is_default, mbrs[0]);
   CHECK(ratio == 1.0);
   ratio = dom.overlap_ratio(range_full, is_default, mbrs[1]);
@@ -613,8 +613,8 @@ TEST_CASE(
   NDRange range_part(2);
   uint64_t uint64_r_part[] = {1, 1};
   float float_r_part[] = {.5f, .55f};
-  range_part[0].set_range(uint64_r_part, sizeof(uint64_r_part));
-  range_part[1].set_range(float_r_part, sizeof(float_r_part));
+  range_part[0] = Range(uint64_r_part, sizeof(uint64_r_part));
+  range_part[1] = Range(float_r_part, sizeof(float_r_part));
   ratio = dom.overlap_ratio(range_part, is_default, mbrs[0]);
   CHECK(ratio == 0.25);
 }
@@ -655,8 +655,8 @@ TEST_CASE(
   NDRange range_no(2);
   uint8_t uint8_r_no[] = {6, 7};
   int32_t int32_r_no[] = {1, 10};
-  range_no[0].set_range(uint8_r_no, sizeof(uint8_r_no));
-  range_no[1].set_range(int32_r_no, sizeof(int32_r_no));
+  range_no[0] = Range(uint8_r_no, sizeof(uint8_r_no));
+  range_no[1] = Range(int32_r_no, sizeof(int32_r_no));
   auto overlap = rtree.get_tile_overlap(range_no, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
@@ -665,8 +665,8 @@ TEST_CASE(
   NDRange range_full(2);
   uint8_t uint8_r_full[] = {0, 100};
   int32_t int32_r_full[] = {1, 100};
-  range_full[0].set_range(uint8_r_full, sizeof(uint8_r_full));
-  range_full[1].set_range(int32_r_full, sizeof(int32_r_full));
+  range_full[0] = Range(uint8_r_full, sizeof(uint8_r_full));
+  range_full[1] = Range(int32_r_full, sizeof(int32_r_full));
   overlap = rtree.get_tile_overlap(range_full, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
@@ -677,8 +677,8 @@ TEST_CASE(
   NDRange range_part(2);
   uint8_t uint8_r_part[] = {4, 15};
   int32_t int32_r_part[] = {7, 20};
-  range_part[0].set_range(uint8_r_part, sizeof(uint8_r_part));
-  range_part[1].set_range(int32_r_part, sizeof(int32_r_part));
+  range_part[0] = Range(uint8_r_part, sizeof(uint8_r_part));
+  range_part[1] = Range(int32_r_part, sizeof(int32_r_part));
   overlap = rtree.get_tile_overlap(range_part, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 2);
@@ -726,8 +726,8 @@ TEST_CASE(
   NDRange range_no(2);
   uint8_t uint8_r_no[] = {6, 7};
   int32_t int32_r_no[] = {1, 10};
-  range_no[0].set_range(uint8_r_no, sizeof(uint8_r_no));
-  range_no[1].set_range(int32_r_no, sizeof(int32_r_no));
+  range_no[0] = Range(uint8_r_no, sizeof(uint8_r_no));
+  range_no[1] = Range(int32_r_no, sizeof(int32_r_no));
   auto overlap = rtree.get_tile_overlap(range_no, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
@@ -736,8 +736,8 @@ TEST_CASE(
   NDRange range_full(2);
   uint8_t uint8_r_full[] = {0, 100};
   int32_t int32_r_full[] = {1, 100};
-  range_full[0].set_range(uint8_r_full, sizeof(uint8_r_full));
-  range_full[1].set_range(int32_r_full, sizeof(int32_r_full));
+  range_full[0] = Range(uint8_r_full, sizeof(uint8_r_full));
+  range_full[1] = Range(int32_r_full, sizeof(int32_r_full));
   overlap = rtree.get_tile_overlap(range_full, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
@@ -748,8 +748,8 @@ TEST_CASE(
   NDRange range_part(2);
   uint8_t uint8_r_part[] = {4, 15};
   int32_t int32_r_part[] = {7, 20};
-  range_part[0].set_range(uint8_r_part, sizeof(uint8_r_part));
-  range_part[1].set_range(int32_r_part, sizeof(int32_r_part));
+  range_part[0] = Range(uint8_r_part, sizeof(uint8_r_part));
+  range_part[1] = Range(int32_r_part, sizeof(int32_r_part));
   overlap = rtree.get_tile_overlap(range_part, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 2);
@@ -762,8 +762,8 @@ TEST_CASE(
   NDRange range_ranges(2);
   uint8_t uint8_r_ranges[] = {11, 26};
   int32_t int32_r_ranges[] = {11, 40};
-  range_ranges[0].set_range(uint8_r_ranges, sizeof(uint8_r_ranges));
-  range_ranges[1].set_range(int32_r_ranges, sizeof(int32_r_ranges));
+  range_ranges[0] = Range(uint8_r_ranges, sizeof(uint8_r_ranges));
+  range_ranges[1] = Range(int32_r_ranges, sizeof(int32_r_ranges));
   overlap = rtree.get_tile_overlap(range_ranges, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
@@ -774,8 +774,8 @@ TEST_CASE(
   NDRange range_mixed(2);
   uint8_t uint8_r_mixed[] = {4, 26};
   int32_t int32_r_mixed[] = {8, 40};
-  range_mixed[0].set_range(uint8_r_mixed, sizeof(uint8_r_mixed));
-  range_mixed[1].set_range(int32_r_mixed, sizeof(int32_r_mixed));
+  range_mixed[0] = Range(uint8_r_mixed, sizeof(uint8_r_mixed));
+  range_mixed[1] = Range(int32_r_mixed, sizeof(int32_r_mixed));
   overlap = rtree.get_tile_overlap(range_mixed, is_default);
   CHECK(overlap.tiles_.size() == 1);
   CHECK(overlap.tiles_[0].first == 1);
@@ -798,8 +798,7 @@ std::vector<NDRange> create_str_mbrs(const std::vector<std::string>& mbrs) {
     for (unsigned d = 0; d < D; ++d) {
       const auto& start = mbrs[2 * D * m + 2 * d];
       const auto& end = mbrs[2 * D * m + 2 * d + 1];
-      ret[m][d].set_range_var(
-          start.data(), start.size(), end.data(), end.size());
+      ret[m][d] = Range(start.data(), start.size(), end.data(), end.size());
     }
   }
 
@@ -820,9 +819,9 @@ std::vector<NDRange> create_str_int32_mbrs(
     ret[m].resize(2);
     const auto& start = mbrs_str[2 * m];
     const auto& end = mbrs_str[2 * m + 1];
-    ret[m][0].set_range_var(start.data(), start.size(), end.data(), end.size());
+    ret[m][0] = Range(start.data(), start.size(), end.data(), end.size());
     int32_t range[] = {mbrs_int[2 * m], mbrs_int[2 * m + 1]};
-    ret[m][1].set_range(range, sizeof(range));
+    ret[m][1] = Range(range, sizeof(range));
   }
 
   return ret;
@@ -859,7 +858,7 @@ TEST_CASE(
   NDRange range(1);
   std::string r_no_start = "c";
   std::string r_no_end = "dd";
-  range[0].set_range_var(
+  range[0] = Range(
       r_no_start.data(), r_no_start.size(), r_no_end.data(), r_no_end.size());
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
@@ -868,7 +867,7 @@ TEST_CASE(
   // Full overlap
   std::string r_full_start = "a";
   std::string r_full_end = "iii";
-  range[0].set_range_var(
+  range[0] = Range(
       r_full_start.data(),
       r_full_start.size(),
       r_full_end.data(),
@@ -882,7 +881,7 @@ TEST_CASE(
   // Partial overlap
   std::string r_partial_start = "b";
   std::string r_partial_end = "f";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start.data(),
       r_partial_start.size(),
       r_partial_end.data(),
@@ -898,7 +897,7 @@ TEST_CASE(
   // Partial overlap
   r_partial_start = "eek";
   r_partial_end = "fff";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start.data(),
       r_partial_start.size(),
       r_partial_end.data(),
@@ -948,7 +947,7 @@ TEST_CASE(
   NDRange range(1);
   std::string r_no_start = "c";
   std::string r_no_end = "dd";
-  range[0].set_range_var(
+  range[0] = Range(
       r_no_start.data(), r_no_start.size(), r_no_end.data(), r_no_end.size());
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
@@ -957,7 +956,7 @@ TEST_CASE(
   // Full overlap
   std::string r_full_start = "a";
   std::string r_full_end = "oopp";
-  range[0].set_range_var(
+  range[0] = Range(
       r_full_start.data(),
       r_full_start.size(),
       r_full_end.data(),
@@ -971,7 +970,7 @@ TEST_CASE(
   // Partial overlap
   std::string r_partial_start = "b";
   std::string r_partial_end = "f";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start.data(),
       r_partial_start.size(),
       r_partial_end.data(),
@@ -987,7 +986,7 @@ TEST_CASE(
   // Partial overlap mixed
   r_partial_start = "h";
   r_partial_end = "p";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start.data(),
       r_partial_start.size(),
       r_partial_end.data(),
@@ -1041,9 +1040,9 @@ TEST_CASE(
   NDRange range(2);
   std::string r_no_start = "c";
   std::string r_no_end = "dd";
-  range[0].set_range_var(
+  range[0] = Range(
       r_no_start.data(), r_no_start.size(), r_no_end.data(), r_no_end.size());
-  range[1].set_range_var(
+  range[1] = Range(
       r_no_start.data(), r_no_start.size(), r_no_end.data(), r_no_end.size());
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
@@ -1052,14 +1051,14 @@ TEST_CASE(
   // Full overlap
   std::string r_full_start_1 = "a";
   std::string r_full_end_1 = "nn";
-  range[0].set_range_var(
+  range[0] = Range(
       r_full_start_1.data(),
       r_full_start_1.size(),
       r_full_end_1.data(),
       r_full_end_1.size());
   std::string r_full_start_2 = "e";
   std::string r_full_end_2 = "r";
-  range[1].set_range_var(
+  range[1] = Range(
       r_full_start_2.data(),
       r_full_start_2.size(),
       r_full_end_2.data(),
@@ -1073,14 +1072,14 @@ TEST_CASE(
   // Partial overlap
   std::string r_partial_start_1 = "h";
   std::string r_partial_end_1 = "i";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start_1.data(),
       r_partial_start_1.size(),
       r_partial_end_1.data(),
       r_partial_end_1.size());
   std::string r_partial_start_2 = "j";
   std::string r_partial_end_2 = "k";
-  range[1].set_range_var(
+  range[1] = Range(
       r_partial_start_2.data(),
       r_partial_start_2.size(),
       r_partial_end_2.data(),
@@ -1094,14 +1093,14 @@ TEST_CASE(
   // Partial overlap
   r_partial_start_1 = "b";
   r_partial_end_1 = "gggg";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start_1.data(),
       r_partial_start_1.size(),
       r_partial_end_1.data(),
       r_partial_end_1.size());
   r_partial_start_2 = "eee";
   r_partial_end_2 = "lll";
-  range[1].set_range_var(
+  range[1] = Range(
       r_partial_start_2.data(),
       r_partial_start_2.size(),
       r_partial_end_2.data(),
@@ -1147,10 +1146,10 @@ TEST_CASE(
   NDRange range(2);
   std::string r_no_start = "c";
   std::string r_no_end = "dd";
-  range[0].set_range_var(
+  range[0] = Range(
       r_no_start.data(), r_no_start.size(), r_no_end.data(), r_no_end.size());
   int32_t r_no[] = {1, 20};
-  range[1].set_range(r_no, sizeof(r_no));
+  range[1] = Range(r_no, sizeof(r_no));
   auto overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.empty());
@@ -1158,13 +1157,13 @@ TEST_CASE(
   // Full overlap
   std::string r_full_start_1 = "a";
   std::string r_full_end_1 = "nn";
-  range[0].set_range_var(
+  range[0] = Range(
       r_full_start_1.data(),
       r_full_start_1.size(),
       r_full_end_1.data(),
       r_full_end_1.size());
   int32_t r_full[] = {1, 20};
-  range[1].set_range(r_full, sizeof(r_full));
+  range[1] = Range(r_full, sizeof(r_full));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tiles_.empty());
   CHECK(overlap.tile_ranges_.size() == 1);
@@ -1174,13 +1173,13 @@ TEST_CASE(
   // Partial overlap
   std::string r_partial_start_1 = "h";
   std::string r_partial_end_1 = "i";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start_1.data(),
       r_partial_start_1.size(),
       r_partial_end_1.data(),
       r_partial_end_1.size());
   int32_t r_partial[] = {11, 12};
-  range[1].set_range(r_partial, sizeof(r_partial));
+  range[1] = Range(r_partial, sizeof(r_partial));
   overlap = rtree.get_tile_overlap(range, is_default);
   CHECK(overlap.tile_ranges_.empty());
   CHECK(overlap.tiles_.size() == 1);
@@ -1192,14 +1191,14 @@ TEST_CASE(
   // Partial overlap
   r_partial_start_1 = "b";
   r_partial_end_1 = "gggg";
-  range[0].set_range_var(
+  range[0] = Range(
       r_partial_start_1.data(),
       r_partial_start_1.size(),
       r_partial_end_1.data(),
       r_partial_end_1.size());
   r_partial_start_2 = "eee";
   r_partial_end_2 = "lll";
-  range[1].set_range_var(
+  range[1] = Range(
       r_partial_start_2.data(),
       r_partial_start_2.size(),
       r_partial_end_2.data(),

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -454,29 +454,27 @@ class Dimension {
    * Computes the minimum bounding range of the values stored in
    * `tile`. Applicable only to fixed-size dimensions.
    */
-  Status compute_mbr(const Tile& tile, Range* mbr) const;
+  Range compute_mbr(const Tile& tile) const;
 
   /**
    * Computed the minimum bounding range of the values stored in
    * `tile`.
    */
   template <class T>
-  static Status compute_mbr(const Tile& tile, Range* mbr);
+  static Range compute_mbr(const Tile& tile);
 
   /**
    * Computes the minimum bounding range of the values stored in
    * `tile_val`. Applicable only to var-sized dimensions.
    */
-  Status compute_mbr_var(
-      const Tile& tile_off, const Tile& tile_val, Range* mbr) const;
+  Range compute_mbr_var(const Tile& tile_off, const Tile& tile_val) const;
 
   /**
    * Computes the minimum bounding range of the values stored in
    * `tile_val`. Applicable only to var-sized dimensions.
    */
   template <class T>
-  static Status compute_mbr_var(
-      const Tile& tile_off, const Tile& tile_val, Range* mbr);
+  static Range compute_mbr_var(const Tile& tile_off, const Tile& tile_val);
 
   /**
    * Crops the input 1D range such that it does not exceed the
@@ -799,13 +797,13 @@ class Dimension {
    * Stores the appropriate templated compute_mbr() function based on the
    * dimension datatype.
    */
-  std::function<Status(const Tile&, Range*)> compute_mbr_func_;
+  std::function<Range(const Tile&)> compute_mbr_func_;
 
   /**
    * Stores the appropriate templated compute_mbr_var() function based on the
    * dimension datatype.
    */
-  std::function<Status(const Tile&, const Tile&, Range*)> compute_mbr_var_func_;
+  std::function<Range(const Tile&, const Tile&)> compute_mbr_var_func_;
 
   /**
    * Stores the appropriate templated crop_range() function based on the

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -521,7 +521,7 @@ Status FragmentMetadata::add_max_buffer_sizes(
   uint64_t offset = 0;
   for (unsigned d = 0; d < dim_num; ++d) {
     auto r_size{2 * array_schema_->dimension_ptr(d)->coord_size()};
-    sub_nd[d].set_range(&sub_ptr[offset], r_size);
+    sub_nd[d] = Range(&sub_ptr[offset], r_size);
     offset += r_size;
   }
 
@@ -2774,7 +2774,7 @@ Status FragmentMetadata::load_mbrs(ConstBuffer* buff) {
     NDRange mbr(dim_num);
     for (unsigned d = 0; d < dim_num; ++d) {
       auto r_size{2 * domain.dimension_ptr(d)->coord_size()};
-      mbr[d].set_range(buff->cur_data(), r_size);
+      mbr[d] = Range(buff->cur_data(), r_size);
       buff->advance_offset(r_size);
     }
     throw_if_not_ok(rtree_.set_leaf(m, mbr));
@@ -2882,13 +2882,13 @@ Status FragmentMetadata::load_non_empty_domain_v5_or_higher(ConstBuffer* buff) {
       auto dim{domain.dimension_ptr(d)};
       if (!dim->var_size()) {  // Fixed-sized
         auto r_size = 2 * dim->coord_size();
-        non_empty_domain_[d].set_range(buff->cur_data(), r_size);
+        non_empty_domain_[d] = Range(buff->cur_data(), r_size);
         buff->advance_offset(r_size);
       } else {  // Var-sized
         uint64_t r_size, start_size;
         RETURN_NOT_OK(buff->read(&r_size, sizeof(uint64_t)));
         RETURN_NOT_OK(buff->read(&start_size, sizeof(uint64_t)));
-        non_empty_domain_[d].set_range(buff->cur_data(), r_size, start_size);
+        non_empty_domain_[d] = Range(buff->cur_data(), r_size, start_size);
         buff->advance_offset(r_size);
       }
     }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -244,8 +244,7 @@ Status Query::add_range_var(
         " for sm.read_range_obb. Acceptable values are 'error' or 'warn'."));
 
   // Add range
-  Range r;
-  r.set_range_var(start, start_size, end, end_size);
+  Range r{start, start_size, end, end_size};
   return subarray_.add_range(dim_idx, std::move(r), read_range_oob == "error");
 }
 

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -544,14 +544,11 @@ Status WriterBase::compute_coords_metadata(
           const auto& dim_name = dim->name();
           auto tiles_it = tiles.find(dim_name);
           assert(tiles_it != tiles.end());
-          if (!dim->var_size())
-            RETURN_NOT_OK(
-                dim->compute_mbr(tiles_it->second[i].fixed_tile(), &mbr[d]));
-          else
-            throw_if_not_ok(dim->compute_mbr_var(
-                tiles_it->second[i].offset_tile(),
-                tiles_it->second[i].var_tile(),
-                &mbr[d]));
+          mbr[d] = dim->var_size() ?
+                       dim->compute_mbr_var(
+                           tiles_it->second[i].offset_tile(),
+                           tiles_it->second[i].var_tile()) :
+                       dim->compute_mbr(tiles_it->second[i].fixed_tile());
         }
 
         throw_if_not_ok(meta->set_mbr(i, mbr));

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -382,7 +382,7 @@ void RTree::deserialize_v1_v4(
       for (unsigned d = 0; d < dim_num; ++d) {
         auto r_size{2 * domain->dimension_ptr(d)->coord_size()};
         auto data = deserializer.get_ptr<void>(r_size);
-        levels_[l][m][d].set_range(data, r_size);
+        levels_[l][m][d] = Range(data, r_size);
       }
     }
   }
@@ -411,13 +411,13 @@ void RTree::deserialize_v5(Deserializer& deserializer, const Domain* domain) {
         if (!dim->var_size()) {  // Fixed-sized
           auto r_size = 2 * dim->coord_size();
           auto data = deserializer.get_ptr<void>(r_size);
-          levels_[l][m][d].set_range(data, r_size);
+          levels_[l][m][d] = Range(data, r_size);
         } else {  // Var-sized
           // range_size | start_size | range
           auto r_size = deserializer.read<uint64_t>();
           auto start_size = deserializer.read<uint64_t>();
           auto data = deserializer.get_ptr<void>(r_size);
-          levels_[l][m][d].set_range(data, r_size, start_size);
+          levels_[l][m][d] = Range(data, r_size, start_size);
         }
       }
     }

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -452,7 +452,6 @@ std::pair<Status, std::optional<NDRange>> deserialize_non_empty_domain_rv(
     auto nonEmptyDomains = r.getNonEmptyDomains();
 
     for (uint32_t i = 0; i < nonEmptyDomains.size(); i++) {
-      Range range;
       auto nonEmptyDomainObj = nonEmptyDomains[i];
       // We always store nonEmptyDomain as uint8 lists for the heterogeneous/var
       // length version
@@ -464,12 +463,10 @@ std::pair<Status, std::optional<NDRange>> deserialize_non_empty_domain_rv(
 
       if (nonEmptyDomainObj.hasSizes()) {
         auto sizes = nonEmptyDomainObj.getSizes();
-        range.set_range(vec.data(), vec.size(), sizes[0]);
+        ndRange.emplace_back(vec.data(), vec.size(), sizes[0]);
       } else {
-        range.set_range(vec.data(), vec.size());
+        ndRange.emplace_back(vec.data(), vec.size());
       }
-
-      ndRange.emplace_back(range);
     }
   }
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -614,9 +614,8 @@ Status Subarray::add_range_var(
   }
 
   // Add range
-  Range r;
-  r.set_range_var(start, start_size, end, end_size);
-  return this->add_range(dim_idx, std::move(r), err_on_range_oob_);
+  return this->add_range(
+      dim_idx, Range(start, start_size, end, end_size), err_on_range_oob_);
 }
 
 Status Subarray::add_range_var_by_name(

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -677,7 +677,7 @@ class Subarray {
    * Retrieves a range of a given dimension at a given range index.
    *
    * @note Note that the retrieved range may be invalid if
-   *     Subarray::set_range() is called after this function. In that case,
+   *     Subarray::add_range() is called after this function. In that case,
    *     make sure to make a copy in the caller function.
    */
   Status get_range(
@@ -688,7 +688,7 @@ class Subarray {
    * The range is in the form (start, end).
    *
    * @note Note that the retrieved range may be invalid if
-   *     Subarray::set_range() is called after this function. In that case,
+   *     Subarray::add_range() is called after this function. In that case,
    *     make sure to make a copy in the caller function.
    */
   Status get_range(

--- a/tiledb/sm/subarray/test/unit_range_subset.cc
+++ b/tiledb/sm/subarray/test/unit_range_subset.cc
@@ -363,11 +363,9 @@ TEST_CASE("RangeSetAndSuperset::sort - STRING_ASCII") {
     const std::string d2{"dog"};
     const std::string d3{"ax"};
     const std::string d4{"bird"};
-    Range r1{};
-    r1.set_str_range(d1, d2);
+    Range r1{d1, d2};
     range_subset.add_range(r1);
-    Range r2{};
-    r2.set_str_range(d3, d4);
+    Range r2{d3, d4};
     range_subset.add_range(r2);
     CHECK(range_subset.num_ranges() == 2);
     // Create ThreadPool.

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -63,13 +63,13 @@ class Range {
       , partition_depth_(0) {
   }
 
-  /** Constructor setting a range. */
+  /** Constructs a range and sets fixed data. */
   Range(const void* range, uint64_t range_size)
       : Range() {
     set_range(range, range_size);
   }
 
-  /** Constructor setting a range. */
+  /** Constructs a range and sets variable data. */
   Range(const void* range, uint64_t range_size, uint64_t range_start_size)
       : Range() {
     set_range(range, range_size, range_start_size);
@@ -90,6 +90,13 @@ class Range {
       : Range() {
     set_range_var(start, start_size, end, end_size);
   }
+
+  /** Constructs a range and sets variable data. */
+  Range(const std::string& s1, const std::string& s2)
+      : Range() {
+    set_str_range(s1, s2);
+  }
+
   /** Copy constructor. */
   Range(const Range&) = default;
 

--- a/tiledb/type/range/test/unit_range_str.cc
+++ b/tiledb/type/range/test/unit_range_str.cc
@@ -86,10 +86,9 @@ TEST_CASE("Test range_str for empty range", "[range][!mayfail]") {
 }
 
 TEST_CASE("Test range_str for string range", "[range][!mayfail]") {
-  Range range{};
   std::string start{"start"};
   std::string end{"end"};
-  range.set_str_range(start, end);
+  Range range{start, end};
   std::string expected_output{"[start, end]"};
   REQUIRE(range_str(range, Datatype::STRING_ASCII) == expected_output);
 }


### PR DESCRIPTION
Removes uses of `set_range`, `set_range_var`, and `set_str_range` that can be easily replaced with construction.

---
TYPE:  IMPROVEMENT 
DESC: Removes non-C.41 range setting (part 1)
