### PR TITLE
Stop ignoring parallel_for task wait_all return status

### DIFF
--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -3294,8 +3294,10 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
-    CHECK(
-        !pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
+    CHECK_THROWS_WITH(
+        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp),
+        "[TileDB::Filter] Error: Positive delta filter error: delta is not "
+        "positive.");
   }
 }
 
@@ -3478,9 +3480,10 @@ TEST_CASE(
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
-    CHECK(
-        !pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
-             .ok());
+    CHECK_THROWS_WITH(
+        pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp),
+        "[TileDB::Filter] Error: Positive delta filter error: delta is not "
+        "positive.");
   }
 
   Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
@@ -3938,8 +3941,9 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     pipeline.add_filter(EncryptionAES256GCMFilter());
 
     // No key set
-    CHECK(
-        !pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
+    CHECK_THROWS_WITH(
+        pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp),
+        "[TileDB::Filter] Error: Encryption error; bad key.");
 
     // Create and set a key
     char key[32];
@@ -3972,9 +3976,10 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     filter->set_key(key);
 
     WhiteboxTile::reallocate_unfiltered_buffer(tile, tile_size);
-    CHECK(!pipeline
-               .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-               .ok());
+    CHECK_THROWS_WITH(
+        pipeline.run_reverse(
+            &test::g_helper_stats, &tile, nullptr, &tp, config),
+        Catch::Matchers::StartsWith("[TileDB::Encryption] Error:"));
 
     // Fix key and check success. Note: this test depends on the implementation
     // leaving the tile data unmodified when the decryption fails, which is not

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -403,16 +403,16 @@ TEST_CASE_METHOD(
   write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -424,16 +424,16 @@ TEST_CASE_METHOD(
   std::vector<double> ranges{2.1, 2.8};
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -790,16 +790,16 @@ TEST_CASE_METHOD(
   write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -811,16 +811,16 @@ TEST_CASE_METHOD(
   std::vector<double> ranges{2.1, 2.8};
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 5.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -270,9 +270,7 @@ Status parallel_for(
   }
 
   // Wait for all instances of `execute_subrange` to complete.
-  // This is ignoring the wait status as we use failed_exception for propagating
-  // the tasks exceptions.
-  std::ignore = tp->wait_all(tasks);
+  throw_if_not_ok(tp->wait_all(tasks));
 
   if (failed_exception.has_value()) {
     std::rethrow_exception(failed_exception.value());


### PR DESCRIPTION
Stop ignoring `parallel_for` task `wait_all` return status. 

This was causing test errors in filter_pipeline which were fixed after https://github.com/TileDB-Inc/TileDB/pull/3492

---
TYPE: BUG
DESC: Stop ignoring `parallel_for` task `wait_all` return status
