### PR TITLE
Restructure parallel_for error handling.

### DIFF
--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -403,16 +403,16 @@ TEST_CASE_METHOD(
   write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -424,16 +424,16 @@ TEST_CASE_METHOD(
   std::vector<double> ranges{2.1, 2.8};
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -790,16 +790,16 @@ TEST_CASE_METHOD(
   write_labels(1, 4, {1.0, 2.0, 3.0, 4.0});
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 6.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(
@@ -811,16 +811,16 @@ TEST_CASE_METHOD(
   std::vector<double> ranges{2.1, 2.8};
   REQUIRE_THROWS_WITH(
       read_labels({2.1, 2.8}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({-2.0, 0.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
   REQUIRE_THROWS_WITH(
       read_labels({5.0, 5.0}),
-      "Error: Internal TileDB uncaught exception; OrderedDimLabelReader: Range "
-      "contained no values");
+      "Error: Internal TileDB uncaught exception; [TileDB::Task] Error: Caught "
+      "std::exception: OrderedDimLabelReader: Range contained no values");
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -180,66 +180,17 @@ Status parallel_for(
   assert(tp);
 
   /*
-   * Mutex protects atomicity of `failed*` local variables together. The first
-   * subrange to fail determines the return or exception value.
-   */
-  std::mutex failed_mutex;
-  /*
-   * If we were checking this variable inside either the main loop or the one in
-   * `execute_subrange`, then it would be better to use `atomic_bool` to lessen
-   * the lock overhead on the mutex. As it is, we do not prematurely stop any
-   * loop that is not the first to fail.
-   */
-  bool failed = false;
-  optional<std::exception_ptr> failed_exception{nullopt};
-  optional<Status> failed_status{nullopt};
-
-  /*
    * Executes subrange [subrange_start, subrange_end) that exists within the
    * range [begin, end).
-   *
-   * If all the functions `F` return OK, then so does this function. If a
-   * function fails but is not the first do so in this `parallel_for`
-   * invocation, then this function returns OK. If a first function to fail
-   * returns not OK, then this function returns that value. If a first function
-   * to fail throws, then this function throws that value.
    */
   std::function<Status(uint64_t, uint64_t)> execute_subrange =
-      [&failed, &failed_exception, &failed_status, &failed_mutex, &F](
+      [&F](
           const uint64_t subrange_start,
           const uint64_t subrange_end) -> Status {
     for (uint64_t i = subrange_start; i < subrange_end; ++i) {
-      Status st;
-      try {
-        st = F(i);
-        if (st.ok()) {
-          continue;
-        }
-        std::lock_guard<std::mutex> lock(failed_mutex);
-        if (!failed) {
-          failed_status = st;
-          failed = true;
-          return st;
-        }
-      } catch (...) {
-        std::lock_guard<std::mutex> lock(failed_mutex);
-        if (!failed) {
-          auto ce{std::current_exception()};
-          failed_exception = ce;
-          failed = true;
-          std::rethrow_exception(ce);
-        }
-      }
-      /*
-       * If we reach this line, then either the status was not OK or `F` threw.
-       * Now you'd think that we'd do something other than continue the loop in
-       * this case, like `break` and end the function. Nope. That's not the
-       * legacy behavior of this function. Nor is checking failure status in the
-       * loop that kicks off this function. Regardless, we are leaving the
-       * behavior exactly the same for now.
-       */
+      RETURN_NOT_OK(F(i));
     }
-    return Status{};
+    return Status::Ok();
   };
 
   // Calculate the length of the subrange that each thread will
@@ -270,17 +221,7 @@ Status parallel_for(
   }
 
   // Wait for all instances of `execute_subrange` to complete.
-  // This is ignoring the wait status as we use failed_exception for propagating
-  // the tasks exceptions.
-  std::ignore = tp->wait_all(tasks);
-
-  if (failed_exception.has_value()) {
-    std::rethrow_exception(failed_exception.value());
-  }
-  if (failed_status.has_value()) {
-    return failed_status.value();
-  }
-  return Status{};  // otherwise return OK
+  return tp->wait_all(tasks);
 }
 
 /**


### PR DESCRIPTION
Restructure `parallel_for` error handling. 

The logic of maintaining the first error while executing `parallel_for` subranges is redundant as it also happens inside the thread pool `wait_all_status` method.

---
TYPE: FEATURE
DESC: Restructure parallel_for error handling.
