### PR TITLE
Global order writes serialization: no tests when serialization disabled.

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -1222,6 +1222,16 @@ TEST_CASE(
     "Backwards compatibility: Upgrades an array of older version and "
     "write/read it",
     "[backwards-compat][upgrade-version][write-read-new-version]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   std::string array_name(arrays_dir + "/non_split_coords_v1_4_0");
   Context ctx;
   std::string schema_folder;
@@ -1268,15 +1278,6 @@ TEST_CASE(
   query_write.set_data_buffer("d1", d1_write);
   query_write.set_data_buffer("d2", d2_write);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     query_write.submit();
     query_write.finalize();

--- a/test/src/unit-capi-any.cc
+++ b/test/src/unit-capi-any.cc
@@ -47,7 +47,7 @@ struct AnyFx {
   void create_array(const std::string& array_name);
   void delete_array(const std::string& array_name);
   void read_array(const std::string& array_name);
-  void write_array(const std::string& array_name);
+  void write_array(const std::string& array_name, const bool serialized_writes);
 };
 
 // Create a simple dense 1D array
@@ -110,7 +110,8 @@ void AnyFx::create_array(const std::string& array_name) {
   tiledb_ctx_free(&ctx);
 }
 
-void AnyFx::write_array(const std::string& array_name) {
+void AnyFx::write_array(
+    const std::string& array_name, const bool serialized_writes) {
   // Create TileDB context
   tiledb_ctx_t* ctx;
   int rc = tiledb_ctx_alloc(NULL, &ctx);
@@ -164,15 +165,6 @@ void AnyFx::write_array(const std::string& array_name) {
       ctx, query, attributes[0], (uint64_t*)buffers[0], &buffer_sizes[0]);
   REQUIRE(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx, query);
     CHECK(rc == TILEDB_OK);
@@ -288,10 +280,20 @@ void AnyFx::delete_array(const std::string& array_name) {
 }
 
 TEST_CASE_METHOD(AnyFx, "C API: Test `ANY` datatype", "[capi][any]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   std::string array_name = "foo";
   delete_array(array_name);
   create_array(array_name);
-  write_array(array_name);
+  write_array(array_name, serialized_writes);
   read_array(array_name);
   delete_array(array_name);
 }

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -877,11 +877,11 @@ TEST_CASE_METHOD(
     SECTION("no serialization") {
       serialized_writes = false;
     }
-    SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
+    SECTION("serialization enabled global order write") {
       serialized_writes = true;
-#endif
     }
+#endif
   }
 
   SECTION("- with encryption") {
@@ -1459,11 +1459,11 @@ TEST_CASE_METHOD(
     SECTION("no serialization") {
       serialized_writes = false;
     }
-    SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
+    SECTION("serialization enabled global order write") {
       serialized_writes = true;
-#endif
     }
+#endif
   }
 
   SECTION("- with encryption") {

--- a/test/src/unit-capi-attributes.cc
+++ b/test/src/unit-capi-attributes.cc
@@ -169,11 +169,11 @@ TEST_CASE_METHOD(
   SECTION("no serialization") {
     serialized_writes = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
     serialized_writes = true;
-#endif
   }
+#endif
 
   for (const auto& attr_name : attr_names) {
     for (const auto& fs : fs_vec_) {
@@ -283,11 +283,11 @@ TEST_CASE_METHOD(
   SECTION("no serialization") {
     serialized_writes = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
     serialized_writes = true;
-#endif
   }
+#endif
   for (const auto& fs : fs_vec_) {
     std::string temp_dir = fs->temp_dir();
     std::string array_name = temp_dir;
@@ -399,11 +399,11 @@ TEST_CASE_METHOD(
   SECTION("no serialization") {
     serialized_writes = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
     serialized_writes = true;
-#endif
   }
+#endif
   for (const auto& fs : fs_vec_) {
     std::string temp_dir = fs->temp_dir();
     std::string array_name = temp_dir;

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -96,18 +96,19 @@ struct ConsolidationFx {
   void write_dense_vector_del_2();
   void write_dense_vector_del_3();
   void write_dense_array_metadata();
-  void write_dense_full();
+  void write_dense_full(const bool serialized_writes);
   void write_dense_subarray(
+      const bool serialized_writes,
       uint64_t min1 = 3,
       uint64_t max1 = 4,
       uint64_t min2 = 3,
       uint64_t max2 = 4);
-  void write_sparse_full();
+  void write_sparse_full(const bool serialized_writes);
   void write_sparse_unordered();
   void write_sparse_row(uint64_t row_idx);
-  void write_sparse_heterogeneous_full();
+  void write_sparse_heterogeneous_full(const bool serialized_writes);
   void write_sparse_heterogeneous_unordered();
-  void write_sparse_string_full();
+  void write_sparse_string_full(const bool serialized_writes);
   void write_sparse_string_unordered();
   void read_dense_array_metadata();
   void read_dense_vector(uint64_t timestamp = UINT64_MAX);
@@ -1583,7 +1584,7 @@ void ConsolidationFx::write_dense_array_metadata() {
   tiledb_array_free(&array);
 }
 
-void ConsolidationFx::write_dense_full() {
+void ConsolidationFx::write_dense_full(const bool serialized_writes) {
   // Set attributes
   const char* attributes[] = {"a1", "a2", "a3"};
 
@@ -1663,15 +1664,6 @@ void ConsolidationFx::write_dense_full() {
       ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -1691,7 +1683,11 @@ void ConsolidationFx::write_dense_full() {
 }
 
 void ConsolidationFx::write_dense_subarray(
-    uint64_t min1, uint64_t max1, uint64_t min2, uint64_t max2) {
+    const bool serialized_writes,
+    uint64_t min1,
+    uint64_t max1,
+    uint64_t min2,
+    uint64_t max2) {
   // Prepare cell buffers
   int buffer_a1[] = {112, 113, 114, 115};
   uint64_t buffer_a2[] = {0, 1, 3, 6};
@@ -1754,15 +1750,6 @@ void ConsolidationFx::write_dense_subarray(
       ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -1781,7 +1768,7 @@ void ConsolidationFx::write_dense_subarray(
   tiledb_query_free(&query);
 }
 
-void ConsolidationFx::write_sparse_full() {
+void ConsolidationFx::write_sparse_full(const bool serialized_writes) {
   // Prepare cell buffers
   int buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7};
   uint64_t buffer_a2[] = {0, 1, 3, 6, 10, 11, 13, 16};
@@ -1870,15 +1857,6 @@ void ConsolidationFx::write_sparse_full() {
       ctx_, query, attributes[4], buffers[5], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -2084,7 +2062,8 @@ void ConsolidationFx::write_sparse_row(uint64_t row_idx) {
   tiledb_query_free(&query);
 }
 
-void ConsolidationFx::write_sparse_heterogeneous_full() {
+void ConsolidationFx::write_sparse_heterogeneous_full(
+    const bool serialized_writes) {
   // Prepare cell buffers
   int buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7};
   uint64_t buffer_a2[] = {0, 1, 3, 6, 10, 11, 13, 16};
@@ -2174,15 +2153,6 @@ void ConsolidationFx::write_sparse_heterogeneous_full() {
       ctx_, query, attributes[4], buffers[5], &buffer_sizes[5]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -2294,7 +2264,7 @@ void ConsolidationFx::write_sparse_heterogeneous_unordered() {
   tiledb_query_free(&query);
 }
 
-void ConsolidationFx::write_sparse_string_full() {
+void ConsolidationFx::write_sparse_string_full(const bool serialized_writes) {
   // Prepare cell buffers
   int buffer_a1[] = {0, 1, 2, 3, 4, 6, 7, 5};
   uint64_t buffer_a2[] = {0, 1, 3, 6, 10, 11, 14, 18};
@@ -2392,15 +2362,6 @@ void ConsolidationFx::write_sparse_string_full() {
       ctx_, query, attributes[4], (uint64_t*)buffers[5], &buffer_sizes[5]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -4538,19 +4499,25 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, dense",
     "[capi][consolidation][dense]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_dense_array();
   create_dense_array();
 
   SECTION("- write full, subarray") {
-    write_dense_full();
-    write_dense_subarray();
+    write_dense_full(serialized_writes);
+    write_dense_subarray(serialized_writes);
     consolidate_dense();
     read_dense_full_subarray();
   }
 
   SECTION("- write subarray, full") {
-    write_dense_subarray();
-    write_dense_full();
+    write_dense_subarray(serialized_writes);
+    write_dense_full(serialized_writes);
     consolidate_dense();
     read_dense_subarray_full();
   }
@@ -4560,8 +4527,8 @@ TEST_CASE_METHOD(
     encryption_type_ = TILEDB_AES_256_GCM;
     encryption_key_ = "0123456789abcdeF0123456789abcdeF";
     create_dense_array();
-    write_dense_subarray();
-    write_dense_full();
+    write_dense_subarray(serialized_writes);
+    write_dense_full(serialized_writes);
     consolidate_dense();
     read_dense_subarray_full();
   }
@@ -4573,11 +4540,17 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, sparse",
     "[capi][consolidation][sparse]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_array();
   create_sparse_array();
 
   SECTION("- write full, unordered") {
-    write_sparse_full();
+    write_sparse_full(serialized_writes);
     write_sparse_unordered();
     consolidate_sparse();
     read_sparse_full_unordered();
@@ -4585,7 +4558,7 @@ TEST_CASE_METHOD(
 
   SECTION("- write unordered, full") {
     write_sparse_unordered();
-    write_sparse_full();
+    write_sparse_full(serialized_writes);
     consolidate_sparse();
     read_sparse_unordered_full();
   }
@@ -4596,7 +4569,7 @@ TEST_CASE_METHOD(
     encryption_key_ = "0123456789abcdeF0123456789abcdeF";
     create_sparse_array();
     write_sparse_unordered();
-    write_sparse_full();
+    write_sparse_full(serialized_writes);
     consolidate_sparse();
     read_sparse_unordered_full();
   }
@@ -6185,11 +6158,17 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, sparse heterogeneous",
     "[capi][consolidation][sparse][heter]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_heterogeneous_array();
   create_sparse_heterogeneous_array();
 
   SECTION("- write full, unordered") {
-    write_sparse_heterogeneous_full();
+    write_sparse_heterogeneous_full(serialized_writes);
     write_sparse_heterogeneous_unordered();
     consolidate_sparse_heterogeneous();
     read_sparse_heterogeneous_full_unordered();
@@ -6197,7 +6176,7 @@ TEST_CASE_METHOD(
 
   SECTION("- write unordered, full") {
     write_sparse_heterogeneous_unordered();
-    write_sparse_heterogeneous_full();
+    write_sparse_heterogeneous_full(serialized_writes);
     consolidate_sparse_heterogeneous();
     read_sparse_heterogeneous_unordered_full();
   }
@@ -6208,7 +6187,7 @@ TEST_CASE_METHOD(
     encryption_key_ = "0123456789abcdeF0123456789abcdeF";
     create_sparse_heterogeneous_array();
     write_sparse_heterogeneous_unordered();
-    write_sparse_heterogeneous_full();
+    write_sparse_heterogeneous_full(serialized_writes);
     consolidate_sparse_heterogeneous();
     read_sparse_heterogeneous_unordered_full();
   }
@@ -6220,11 +6199,17 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, sparse string",
     "[capi][consolidation][sparse][string]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_string_array();
   create_sparse_string_array();
 
   SECTION("- write full, unordered") {
-    write_sparse_string_full();
+    write_sparse_string_full(serialized_writes);
     write_sparse_string_unordered();
     consolidate_sparse_string();
     read_sparse_string_full_unordered();
@@ -6232,7 +6217,7 @@ TEST_CASE_METHOD(
 
   SECTION("- write unordered, full") {
     write_sparse_string_unordered();
-    write_sparse_string_full();
+    write_sparse_string_full(serialized_writes);
     consolidate_sparse_string();
     read_sparse_string_unordered_full();
   }
@@ -6243,7 +6228,7 @@ TEST_CASE_METHOD(
     encryption_key_ = "0123456789abcdeF0123456789abcdeF";
     create_sparse_string_array();
     write_sparse_string_unordered();
-    write_sparse_string_full();
+    write_sparse_string_full(serialized_writes);
     consolidate_sparse_string();
     read_sparse_string_unordered_full();
   }
@@ -6255,9 +6240,15 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidating fragment metadata, sparse string",
     "[capi][consolidation][fragment-meta][sparse][string]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_string_array();
   create_sparse_string_array();
-  write_sparse_string_full();
+  write_sparse_string_full(serialized_writes);
   write_sparse_string_unordered();
 
   // Validate read
@@ -6320,9 +6311,15 @@ TEST_CASE_METHOD(
     "C API: Test consolidating fragment metadata, sparse string, pass only "
     "context",
     "[capi][consolidation][fragment-meta][sparse][string]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_string_array();
   create_sparse_string_array();
-  write_sparse_string_full();
+  write_sparse_string_full(serialized_writes);
   write_sparse_string_unordered();
 
   // Validate read
@@ -6393,14 +6390,20 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation and timestamps",
     "[capi][consolidation][timestamps]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_dense_array();
   create_dense_array();
 
   SECTION("- consolidate fragments with timestamps") {
-    write_dense_subarray();
+    write_dense_subarray(serialized_writes);
     auto start = tiledb::sm::utils::time::timestamp_now_ms();
-    write_dense_subarray(1, 2, 1, 2);
-    write_dense_subarray(1, 2, 1, 2);
+    write_dense_subarray(serialized_writes, 1, 2, 1, 2);
+    write_dense_subarray(serialized_writes, 1, 2, 1, 2);
     auto end = tiledb::sm::utils::time::timestamp_now_ms();
     consolidate_dense("fragments", start, end);
 
@@ -6408,10 +6411,10 @@ TEST_CASE_METHOD(
   }
 
   SECTION("- consolidate fragments with timestamps, overlapping start") {
-    write_dense_subarray();
+    write_dense_subarray(serialized_writes);
     auto start = tiledb::sm::utils::time::timestamp_now_ms();
-    write_dense_subarray();
-    write_dense_subarray();
+    write_dense_subarray(serialized_writes);
+    write_dense_subarray(serialized_writes);
     auto end = tiledb::sm::utils::time::timestamp_now_ms();
     consolidate_dense("fragments", start, end);
 
@@ -6465,21 +6468,27 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test vacuuming and timestamps",
     "[capi][vacuuming][timestamps]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_dense_array();
   create_dense_array();
 
   SECTION("- vacuum fragments with timestamps") {
-    write_dense_subarray();
+    write_dense_subarray(serialized_writes);
 
     auto start1 = tiledb::sm::utils::time::timestamp_now_ms();
-    write_dense_subarray(1, 2, 3, 4);
-    write_dense_subarray(1, 2, 3, 4);
+    write_dense_subarray(serialized_writes, 1, 2, 3, 4);
+    write_dense_subarray(serialized_writes, 1, 2, 3, 4);
     auto end1 = tiledb::sm::utils::time::timestamp_now_ms();
     consolidate_dense("fragments", start1, end1);
 
     auto start2 = tiledb::sm::utils::time::timestamp_now_ms();
-    write_dense_subarray(1, 2, 1, 2);
-    write_dense_subarray(1, 2, 1, 2);
+    write_dense_subarray(serialized_writes, 1, 2, 1, 2);
+    write_dense_subarray(serialized_writes, 1, 2, 1, 2);
     auto end2 = tiledb::sm::utils::time::timestamp_now_ms();
 
     consolidate_dense("fragments", start2, end2);
@@ -6529,13 +6538,19 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, dense, commits",
     "[capi][consolidation][dense][commits]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_dense_array();
   create_dense_array();
 
   SECTION("- write full, subarray") {
     // Consolidation works.
-    write_dense_full();
-    write_dense_subarray();
+    write_dense_full(serialized_writes);
+    write_dense_subarray(serialized_writes);
     consolidate_dense("commits");
     read_dense_full_subarray();
     check_commits_dir_dense(1, 2, 0);
@@ -6574,8 +6589,8 @@ TEST_CASE_METHOD(
 
   SECTION("- write subarray, full") {
     // Consolidation works.
-    write_dense_subarray();
-    write_dense_full();
+    write_dense_subarray(serialized_writes);
+    write_dense_full(serialized_writes);
     consolidate_dense("commits");
     read_dense_subarray_full();
 
@@ -6618,8 +6633,8 @@ TEST_CASE_METHOD(
     create_dense_array();
 
     // Consolidation works.
-    write_dense_subarray();
-    write_dense_full();
+    write_dense_subarray(serialized_writes);
+    write_dense_full(serialized_writes);
     consolidate_dense("commits");
     read_dense_subarray_full();
 
@@ -6662,12 +6677,18 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, sparse, commits",
     "[capi][consolidation][sparse][commits]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_array();
   create_sparse_array();
 
   SECTION("- write full, unordered") {
     // Consolidation works.
-    write_sparse_full();
+    write_sparse_full(serialized_writes);
     write_sparse_unordered();
     consolidate_sparse("commits");
     read_sparse_full_unordered();
@@ -6708,7 +6729,7 @@ TEST_CASE_METHOD(
   SECTION("- write unordered, full") {
     // Consolidation works.
     write_sparse_unordered();
-    write_sparse_full();
+    write_sparse_full(serialized_writes);
     consolidate_sparse("commits");
     read_sparse_unordered_full();
     check_commits_dir_sparse(1, 2, 0);
@@ -6753,7 +6774,7 @@ TEST_CASE_METHOD(
 
     // Consolidation works.
     write_sparse_unordered();
-    write_sparse_full();
+    write_sparse_full(serialized_writes);
     consolidate_sparse("commits");
     read_sparse_unordered_full();
     check_commits_dir_sparse(1, 2, 0);
@@ -6803,6 +6824,12 @@ TEST_CASE_METHOD(
     return;
   }
 
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_sparse_array();
 
   // Get the v11 sparse array.
@@ -6813,7 +6840,7 @@ TEST_CASE_METHOD(
           ctx_, vfs_, v11_arrays_dir.c_str(), SPARSE_ARRAY_NAME) == TILEDB_OK);
 
   // Write v11 fragment.
-  write_sparse_full();
+  write_sparse_full(serialized_writes);
 
   // Upgrade to latest version.
   REQUIRE(
@@ -6867,12 +6894,18 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation, dense split fragments",
     "[capi][consolidation][dense][split-fragments]") {
+#ifdef TILEDB_SERIALIZATION
+  bool serialized_writes = GENERATE(true, false);
+#else
+  bool serialized_writes = false;
+#endif
+
   remove_dense_array();
   create_dense_array();
-  write_dense_subarray(1, 2, 1, 2);
-  write_dense_subarray(1, 2, 3, 4);
-  write_dense_subarray(3, 4, 1, 2);
-  write_dense_subarray(3, 4, 3, 4);
+  write_dense_subarray(serialized_writes, 1, 2, 1, 2);
+  write_dense_subarray(serialized_writes, 1, 2, 3, 4);
+  write_dense_subarray(serialized_writes, 3, 4, 1, 2);
+  write_dense_subarray(serialized_writes, 3, 4, 3, 4);
 
   // Create fragment info object
   tiledb_fragment_info_t* fragment_info = nullptr;

--- a/test/src/unit-capi-incomplete-2.cc
+++ b/test/src/unit-capi-incomplete-2.cc
@@ -59,8 +59,8 @@ struct IncompleteFx2 {
   // Functions
   void create_dense_array();
   void create_sparse_array();
-  void write_dense_full();
-  void write_sparse_full();
+  void write_dense_full(const bool serialized_writes);
+  void write_sparse_full(const bool serialized_writes);
   void check_dense_incomplete();
   void check_dense_until_complete();
   void check_dense_shrink_buffer_size();
@@ -250,7 +250,7 @@ void IncompleteFx2::create_sparse_array() {
   tiledb_array_schema_free(&array_schema);
 }
 
-void IncompleteFx2::write_dense_full() {
+void IncompleteFx2::write_dense_full(const bool serialized_writes) {
   // Set attributes
   const char* attributes[] = {"a1", "a2", "a3"};
 
@@ -311,15 +311,6 @@ void IncompleteFx2::write_dense_full() {
       ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -338,7 +329,7 @@ void IncompleteFx2::write_dense_full() {
   tiledb_query_free(&query);
 }
 
-void IncompleteFx2::write_sparse_full() {
+void IncompleteFx2::write_sparse_full(const bool serialized_writes) {
   // Prepare cell buffers
   int buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7};
   uint64_t buffer_a2[] = {0, 1, 3, 6, 10, 11, 13, 16};
@@ -408,15 +399,6 @@ void IncompleteFx2::write_sparse_full() {
       ctx_, query, attributes[4], buffers[5], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -1121,9 +1103,19 @@ TEST_CASE_METHOD(
     IncompleteFx2,
     "C API: Test incomplete read queries 2, dense",
     "[capi][incomplete-2][dense-incomplete-2]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   remove_dense_array();
   create_dense_array();
-  write_dense_full();
+  write_dense_full(serialized_writes);
   check_dense_incomplete();
   check_dense_until_complete();
   check_dense_shrink_buffer_size();
@@ -1137,9 +1129,19 @@ TEST_CASE_METHOD(
     IncompleteFx2,
     "C API: Test incomplete read queries 2, sparse",
     "[capi][incomplete-2][sparse-incomplete-2]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   remove_sparse_array();
   create_sparse_array();
-  write_sparse_full();
+  write_sparse_full(serialized_writes);
   check_sparse_incomplete();
   check_sparse_until_complete();
   check_sparse_unsplittable_overflow();

--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -61,8 +61,8 @@ struct IncompleteFx {
   // Functions
   void create_dense_array();
   void create_sparse_array();
-  void write_dense_full();
-  void write_sparse_full();
+  void write_dense_full(const bool serialized_writes);
+  void write_sparse_full(const bool serialized_writes);
   void check_dense_incomplete();
   void check_dense_incomplete_serialized();
   void check_dense_until_complete();
@@ -253,7 +253,7 @@ void IncompleteFx::create_sparse_array() {
   tiledb_array_schema_free(&array_schema);
 }
 
-void IncompleteFx::write_dense_full() {
+void IncompleteFx::write_dense_full(const bool serialized_writes) {
   // Set attributes
   const char* attributes[] = {"a1", "a2", "a3"};
 
@@ -314,15 +314,6 @@ void IncompleteFx::write_dense_full() {
       ctx_, query, attributes[2], buffers[3], &buffer_sizes[3]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -341,7 +332,7 @@ void IncompleteFx::write_dense_full() {
   tiledb_query_free(&query);
 }
 
-void IncompleteFx::write_sparse_full() {
+void IncompleteFx::write_sparse_full(const bool serialized_writes) {
   // Prepare cell buffers
   int buffer_a1[] = {0, 1, 2, 3, 4, 5, 6, 7};
   uint64_t buffer_a2[] = {0, 1, 3, 6, 10, 11, 13, 16};
@@ -411,15 +402,6 @@ void IncompleteFx::write_sparse_full() {
       ctx_, query, attributes[4], buffers[5], &buffer_sizes[4]);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -1229,9 +1211,19 @@ TEST_CASE_METHOD(
     IncompleteFx,
     "C API: Test incomplete read queries, dense",
     "[capi][incomplete][dense-incomplete]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   remove_dense_array();
   create_dense_array();
-  write_dense_full();
+  write_dense_full(serialized_writes);
   check_dense_incomplete();
   check_dense_until_complete();
   check_dense_shrink_buffer_size();
@@ -1245,9 +1237,19 @@ TEST_CASE_METHOD(
     IncompleteFx,
     "C API: Test incomplete read queries, sparse",
     "[capi][incomplete][sparse]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   remove_sparse_array();
   create_sparse_array();
-  write_sparse_full();
+  write_sparse_full(serialized_writes);
   check_sparse_incomplete();
   check_sparse_until_complete();
   check_sparse_unsplittable_overflow();
@@ -1261,9 +1263,17 @@ TEST_CASE_METHOD(
     IncompleteFx,
     "C API: Test incomplete read queries, dense, serialized",
     "[capi][incomplete][dense][serialization]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+
   remove_dense_array();
   create_dense_array();
-  write_dense_full();
+  write_dense_full(serialized_writes);
   check_dense_incomplete_serialized();
   remove_dense_array();
 }

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -1178,6 +1178,16 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Global order writes serialization",
     "[global-order-write][serialization][dense]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   uint64_t tile_extent = 2;
   ArraySchema schema(ctx, TILEDB_DENSE);
   Domain domain(ctx);
@@ -1225,15 +1235,6 @@ TEST_CASE_METHOD(
 
   uint64_t begin = 0;
   uint64_t end = chunk_size - 1;
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   while (begin < end) {
     query.set_data_buffer("a1", a1.data() + begin, end - begin + 1);
     query.set_data_buffer("a2", a2.data() + begin * 2, (end - begin + 1) * 2);

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -656,29 +656,16 @@ void SmokeTestFx::write(
     }
   }
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
-    rc = tiledb_query_submit(ctx_, query);
-    REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
 
-    tiledb_query_status_t status;
-    rc = tiledb_query_get_status(ctx_, query, &status);
-    CHECK(rc == TILEDB_OK);
-    CHECK(status == TILEDB_COMPLETED);
+  tiledb_query_status_t status;
+  rc = tiledb_query_get_status(ctx_, query, &status);
+  CHECK(rc == TILEDB_OK);
+  CHECK(status == TILEDB_COMPLETED);
 
-    rc = tiledb_query_finalize(ctx_, query);
-    REQUIRE(rc == TILEDB_OK);
-  } else {
-    submit_and_finalize_serialized_query(ctx_, query);
-  }
+  rc = tiledb_query_finalize(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
 
   // Clean up
   rc = tiledb_array_close(ctx_, array);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -5835,6 +5835,16 @@ TEST_CASE_METHOD(
     SparseArrayFx,
     "C API: Test sparse array, global order with 0-sized buffers",
     "[capi][sparse][global-check][zero-buffers]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   SupportedFsLocal local_fs;
   std::string array_name = local_fs.file_prefix() + local_fs.temp_dir() +
                            "sparse_write_global_check";
@@ -5881,15 +5891,6 @@ TEST_CASE_METHOD(
   rc = tiledb_query_set_data_buffer(ctx, query, "d2", coords_dim2, &zero_size);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx, query);
     CHECK(rc == TILEDB_OK);
@@ -6105,6 +6106,16 @@ TEST_CASE_METHOD(
     SparseArrayFx,
     "C API: Test sparse array, split coordinate buffers, global write",
     "[capi][sparse][split-coords][global]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   SupportedFsLocal local_fs;
   std::string array_name = local_fs.file_prefix() + local_fs.temp_dir() +
                            "sparse_split_coords_global";
@@ -6174,15 +6185,6 @@ TEST_CASE_METHOD(
       ctx_, query, "d2", buffer_d2, &buffer_d2_size);
   CHECK(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -6878,6 +6880,16 @@ TEST_CASE_METHOD(
     SparseArrayFx,
     "Sparse array: 2D, multi write global order",
     "[capi][sparse][2D][multi-write]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   // Create and write array
   SupportedFsLocal local_fs;
   std::string array_name = local_fs.file_prefix() + local_fs.temp_dir() +
@@ -6948,15 +6960,6 @@ TEST_CASE_METHOD(
     }
   }
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);

--- a/test/src/unit-capi-sparse_neg.cc
+++ b/test/src/unit-capi-sparse_neg.cc
@@ -62,7 +62,8 @@ struct SparseNegFx {
   void remove_temp_dir(const std::string& path);
   void create_sparse_vector(const std::string& path);
   void create_sparse_array(const std::string& path);
-  void write_sparse_vector(const std::string& path);
+  void write_sparse_vector(
+      const std::string& path, const bool serialized_writes);
   void write_sparse_array(const std::string& path);
   void read_sparse_vector(const std::string& path);
   void read_sparse_array_global(const std::string& path);
@@ -217,7 +218,8 @@ void SparseNegFx::create_sparse_array(const std::string& path) {
   tiledb_array_schema_free(&array_schema);
 }
 
-void SparseNegFx::write_sparse_vector(const std::string& path) {
+void SparseNegFx::write_sparse_vector(
+    const std::string& path, const bool serialized_writes) {
   // Open array
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, path.c_str(), &array);
@@ -238,15 +240,7 @@ void SparseNegFx::write_sparse_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
+
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -502,13 +496,23 @@ TEST_CASE_METHOD(
     SparseNegFx,
     "C API: Test 1d sparse vector with negative domain",
     "[capi][sparse-neg][sparse-neg-vector]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   SupportedFsLocal local_fs;
   std::string vector_name =
       local_fs.file_prefix() + local_fs.temp_dir() + "sparse_neg_vector";
   create_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
 
   create_sparse_vector(vector_name);
-  write_sparse_vector(vector_name);
+  write_sparse_vector(vector_name, serialized_writes);
   read_sparse_vector(vector_name);
 
   remove_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());

--- a/test/src/unit-capi-sparse_neg_2.cc
+++ b/test/src/unit-capi-sparse_neg_2.cc
@@ -62,7 +62,8 @@ struct SparseNegFx2 {
   void remove_temp_dir(const std::string& path);
   void create_sparse_vector(const std::string& path);
   void create_sparse_array(const std::string& path);
-  void write_sparse_vector(const std::string& path);
+  void write_sparse_vector(
+      const std::string& path, const bool serialized_writes);
   void write_sparse_array(const std::string& path);
   void read_sparse_vector(const std::string& path);
   void read_sparse_array_row(const std::string& path);
@@ -216,7 +217,8 @@ void SparseNegFx2::create_sparse_array(const std::string& path) {
   tiledb_array_schema_free(&array_schema);
 }
 
-void SparseNegFx2::write_sparse_vector(const std::string& path) {
+void SparseNegFx2::write_sparse_vector(
+    const std::string& path, const bool serialized_writes) {
   // Open array
   tiledb_array_t* array;
   int rc = tiledb_array_alloc(ctx_, path.c_str(), &array);
@@ -237,15 +239,7 @@ void SparseNegFx2::write_sparse_vector(const std::string& path) {
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);
   REQUIRE(rc == TILEDB_OK);
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
+
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx_, query);
     CHECK(rc == TILEDB_OK);
@@ -472,13 +466,23 @@ TEST_CASE_METHOD(
     SparseNegFx2,
     "C API: Test 1d sparse vector with negative domain 2",
     "[capi][sparse-neg-2][sparse-neg-vector-2]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   SupportedFsLocal local_fs;
   std::string vector_name =
       local_fs.file_prefix() + local_fs.temp_dir() + "sparse_neg_vector";
   create_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());
 
   create_sparse_vector(vector_name);
-  write_sparse_vector(vector_name);
+  write_sparse_vector(vector_name, serialized_writes);
   read_sparse_vector(vector_name);
 
   remove_temp_dir(local_fs.file_prefix() + local_fs.temp_dir());

--- a/test/src/unit-capi-string.cc
+++ b/test/src/unit-capi-string.cc
@@ -58,7 +58,7 @@ struct StringFx {
   void create_array(const std::string& array_name);
   void delete_array(const std::string& array_name);
   void read_array(const std::string& array_name);
-  void write_array(const std::string& array_name);
+  void write_array(const std::string& array_name, const bool serialized_writes);
 };
 
 // Create a simple dense 1D array with three string attributes
@@ -143,7 +143,8 @@ void StringFx::create_array(const std::string& array_name) {
   tiledb_ctx_free(&ctx);
 }
 
-void StringFx::write_array(const std::string& array_name) {
+void StringFx::write_array(
+    const std::string& array_name, const bool serialized_writes) {
   // Create TileDB context
   tiledb_ctx_t* ctx;
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
@@ -202,15 +203,6 @@ void StringFx::write_array(const std::string& array_name) {
       ctx, query, attributes[2], (uint64_t*)buffers[3], &buffer_sizes[3]);
   REQUIRE(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx, query);
     CHECK(rc == TILEDB_OK);
@@ -344,10 +336,20 @@ void StringFx::delete_array(const std::string& array_name) {
 }
 
 TEST_CASE_METHOD(StringFx, "C API: Test string support", "[capi][string]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   std::string array_name = "foo";
   delete_array(array_name);
   create_array(array_name);
-  write_array(array_name);
+  write_array(array_name, serialized_writes);
   read_array(array_name);
   delete_array(array_name);
 }

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -52,6 +52,7 @@ struct ConsolidationWithTimestampsFx {
   Context ctx_;
   VFS vfs_;
   sm::StorageManager* sm_;
+  bool serialized_writes_ = false;
 
   // Constructors/destructors.
   ConsolidationWithTimestampsFx();
@@ -92,7 +93,6 @@ struct ConsolidationWithTimestampsFx {
   void remove_sparse_array();
   void remove_array(const std::string& array_name);
   bool is_array(const std::string& array_name);
-  bool serialized_writes = false;
 };
 
 ConsolidationWithTimestampsFx::ConsolidationWithTimestampsFx()
@@ -177,7 +177,7 @@ void ConsolidationWithTimestampsFx::write_sparse(
   query.set_data_buffer("d1", dim1);
   query.set_data_buffer("d2", dim2);
 
-  if (!serialized_writes) {
+  if (!serialized_writes_) {
     query.submit();
     query.finalize();
   } else {
@@ -210,7 +210,7 @@ void ConsolidationWithTimestampsFx::write_sparse_v11(uint64_t timestamp) {
   query.set_data_buffer("a3", buffer_a3);
   query.set_data_buffer("d1", buffer_coords_dim1);
   query.set_data_buffer("d2", buffer_coords_dim2);
-  if (!serialized_writes) {
+  if (!serialized_writes_) {
     query.submit();
     query.finalize();
   } else {
@@ -381,13 +381,13 @@ TEST_CASE_METHOD(
   create_sparse_array();
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse(
       {0, 1, 2, 3, 4, 5, 6, 7},
@@ -416,13 +416,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
 
@@ -499,13 +499,13 @@ TEST_CASE_METHOD(
   create_sparse_array();
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse(
       {0, 1, 2, 3, 4, 5, 6, 7},
@@ -555,13 +555,13 @@ TEST_CASE_METHOD(
   }
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
 
   remove_sparse_array();
   create_sparse_array_v11();
@@ -644,13 +644,13 @@ TEST_CASE_METHOD(
   create_sparse_array();
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
 
   // Write fragments.
   for (uint64_t i = 0; i < 50; i++) {
@@ -693,13 +693,13 @@ TEST_CASE_METHOD(
   create_sparse_array(allow_dups);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
 
   // Write fragments.
   // We write 8 cells per fragments for 6 fragments. Then it gets consolidated
@@ -757,13 +757,13 @@ TEST_CASE_METHOD(
   create_sparse_array();
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write fragments.
   for (uint64_t i = 0; i < 50; i++) {
     std::vector<int> a(1);
@@ -808,13 +808,13 @@ TEST_CASE_METHOD(
   create_sparse_array();
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write fragments.
   // We write 8 cells per fragment for 6 fragments. Then it gets consolidated
   // into one. So we'll get in order 6xcell1, 6xcell2... total 48 cells. Tile
@@ -867,13 +867,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
 
@@ -962,13 +962,13 @@ TEST_CASE_METHOD(
   create_sparse_array();
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
 
@@ -1040,13 +1040,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1194,13 +1194,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1310,13 +1310,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1411,13 +1411,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1520,13 +1520,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1631,13 +1631,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1720,13 +1720,13 @@ TEST_CASE_METHOD(
     create_sparse_array(false);
 
     SECTION("no serialization") {
-      serialized_writes = false;
+      serialized_writes_ = false;
     }
-    SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-      serialized_writes = true;
-#endif
+    SECTION("serialization enabled global order write") {
+      serialized_writes_ = true;
     }
+#endif
     // Write first fragment.
     write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
     // Write second fragment.
@@ -1747,13 +1747,13 @@ TEST_CASE_METHOD(
     create_sparse_array(false);
 
     SECTION("no serialization") {
-      serialized_writes = false;
+      serialized_writes_ = false;
     }
-    SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-      serialized_writes = true;
-#endif
+    SECTION("serialization enabled global order write") {
+      serialized_writes_ = true;
     }
+#endif
     // Write first fragment.
     write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
     // Write second fragment.
@@ -1793,13 +1793,13 @@ TEST_CASE_METHOD(
   create_sparse_array(dups);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.
@@ -1877,13 +1877,13 @@ TEST_CASE_METHOD(
   create_sparse_array(true);
 
   SECTION("no serialization") {
-    serialized_writes = false;
+    serialized_writes_ = false;
   }
-  SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
+  SECTION("serialization enabled global order write") {
+    serialized_writes_ = true;
   }
+#endif
   // Write first fragment.
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
   // Write second fragment.

--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -232,6 +232,7 @@ TEST_CASE("C++ API: Filter lists on array", "[cppapi][filter]") {
 }
 
 void write_sparse_array_string_attr(
+    const bool serialized_writes,
     tiledb::Context ctx,
     const std::string& array_name,
     std::string& data,
@@ -249,16 +250,7 @@ void write_sparse_array_string_attr(
   query.set_data_buffer("d2", d2);
   query.set_data_buffer("a1", data).set_offsets_buffer("a1", data_offsets);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
+  if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();
   } else {
@@ -341,7 +333,7 @@ TEST_CASE(
 
   SECTION("Unordered write") {
     write_sparse_array_string_attr(
-        ctx, array_name, a1_data, a1_offsets, TILEDB_UNORDERED);
+        false, ctx, array_name, a1_data, a1_offsets, TILEDB_UNORDERED);
     SECTION("Row major read") {
       read_and_check_sparse_array_string_attr(
           ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
@@ -356,8 +348,18 @@ TEST_CASE(
     }
   }
   SECTION("Global order write") {
+#ifdef TILEDB_SERIALIZATION
+    bool serialized_writes = GENERATE(true, false);
+#else
+    bool serialized_writes = false;
+#endif
     write_sparse_array_string_attr(
-        ctx, array_name, a1_data, a1_offsets, TILEDB_GLOBAL_ORDER);
+        serialized_writes,
+        ctx,
+        array_name,
+        a1_data,
+        a1_offsets,
+        TILEDB_GLOBAL_ORDER);
     SECTION("Row major read") {
       read_and_check_sparse_array_string_attr(
           ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
@@ -378,6 +380,7 @@ TEST_CASE(
 }
 
 void write_dense_array_string_attr(
+    const bool serialized_writes,
     tiledb::Context ctx,
     const std::string& array_name,
     std::string& data,
@@ -392,16 +395,7 @@ void write_dense_array_string_attr(
   query.set_layout(layout);
   query.set_subarray<int64_t>({0, 1, 0, 2});
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
+  if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();
   } else {
@@ -485,13 +479,23 @@ TEST_CASE(
 
   SECTION("Ordered write") {
     write_dense_array_string_attr(
-        ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
+        false, ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
     read_and_check_dense_array_string_attr(
         ctx, array_name, a1_data, a1_offsets);
   }
   SECTION("Global order write") {
+#ifdef TILEDB_SERIALIZATION
+    bool serialized_writes = GENERATE(true, false);
+#else
+    bool serialized_writes = false;
+#endif
     write_dense_array_string_attr(
-        ctx, array_name, a1_data, a1_offsets, TILEDB_GLOBAL_ORDER);
+        serialized_writes,
+        ctx,
+        array_name,
+        a1_data,
+        a1_offsets,
+        TILEDB_GLOBAL_ORDER);
     read_and_check_dense_array_string_attr(
         ctx, array_name, a1_data, a1_offsets);
   }

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -515,6 +515,16 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test Hilbert, test writing in global order",
     "[cppapi][hilbert][write][global-order]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   Context ctx;
   VFS vfs(ctx);
   std::string array_name = "hilbert_array";
@@ -542,15 +552,7 @@ TEST_CASE(
   buff_a = {2, 3, 4, 1};
   buff_d1 = {1, 1, 5, 4};
   buff_d2 = {3, 1, 4, 2};
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
+
   if (!serialized_writes) {
     CHECK_NOTHROW(query_w.submit());
     query_w.finalize();

--- a/test/src/unit-cppapi-updates.cc
+++ b/test/src/unit-cppapi-updates.cc
@@ -120,6 +120,16 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API updates: empty second write", "[updates][updates-empty-write]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   const std::string array_name = "updates_empty_write";
   Context ctx;
   VFS vfs(ctx);
@@ -145,15 +155,6 @@ TEST_CASE(
   query_w1.set_layout(layout).set_data_buffer("d", data).set_offsets_buffer(
       "d", offsets);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     query_w1.submit();
     query_w1.finalize();

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -37,8 +37,6 @@
 
 using namespace tiledb;
 
-static bool serialized_writes = false;
-
 void create_sparse_array(const std::string& array_name) {
   Context ctx;
   VFS vfs(ctx);
@@ -66,6 +64,7 @@ void create_sparse_array(const std::string& array_name) {
 void write_sparse_array(
     Context ctx,
     const std::string& array_name,
+    const bool serialized_writes,
     std::vector<int32_t>& data,
     std::vector<uint64_t>& data_offsets,
     tiledb_layout_t layout) {
@@ -80,7 +79,7 @@ void write_sparse_array(
   query.set_data_buffer("attr", data);
   query.set_offsets_buffer("attr", data_offsets);
 
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
+  if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();
   } else {
@@ -93,6 +92,7 @@ void write_sparse_array(
 void write_sparse_array(
     Context ctx,
     const std::string& array_name,
+    const bool,  // serialized_writes,
     std::vector<int32_t>& data,
     std::vector<uint32_t>& data_offsets,
     tiledb_layout_t layout) {
@@ -110,7 +110,7 @@ void write_sparse_array(
       reinterpret_cast<uint64_t*>(data_offsets.data()),
       data_offsets.size());
   /* TODO: enable this when sc21681 is fixed
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
+  if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();
   } else {
@@ -273,6 +273,7 @@ void create_dense_array(const std::string& array_name) {
 void write_dense_array(
     Context ctx,
     const std::string& array_name,
+    const bool serialized_writes,
     std::vector<int32_t>& data,
     std::vector<uint64_t>& data_offsets,
     tiledb_layout_t layout,
@@ -303,15 +304,7 @@ void write_dense_array(
     query.set_subarray<int64_t>({1, 2, 1, 2});
   }
 
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
+  if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();
   } else {
@@ -324,6 +317,7 @@ void write_dense_array(
 void write_dense_array(
     Context ctx,
     const std::string& array_name,
+    bool serialized_writes,
     std::vector<int32_t>& data,
     std::vector<uint32_t>& data_offsets,
     tiledb_layout_t layout,
@@ -359,17 +353,9 @@ void write_dense_array(
     query.set_subarray<int64_t>({1, 2, 1, 2});
   }
 
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  /* TODO: enable this when sc21681 is fixed
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
-  */
-  if (!serialized_writes || layout != TILEDB_GLOBAL_ORDER) {
+  // TODO: remove this when sc21681 is fixed
+  serialized_writes = false;
+  if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();
   } else {
@@ -493,7 +479,8 @@ TEST_CASE(
     std::vector<uint64_t> byte_offsets = {0, 4, 12, 20};
 
     SECTION("Unordered write") {
-      write_sparse_array(ctx, array_name, data, byte_offsets, TILEDB_UNORDERED);
+      write_sparse_array(
+          ctx, array_name, false, data, byte_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, byte_offsets, TILEDB_ROW_MAJOR);
@@ -508,16 +495,18 @@ TEST_CASE(
       }
     }
     SECTION("Global order write") {
-      SECTION("no serialization") {
-        serialized_writes = false;
-      }
-      SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-        serialized_writes = true;
+      bool serialized_writes = GENERATE(true, false);
+#else
+      bool serialized_writes = false;
 #endif
-      }
       write_sparse_array(
-          ctx, array_name, data, byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx,
+          array_name,
+          serialized_writes,
+          data,
+          byte_offsets,
+          TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, byte_offsets, TILEDB_ROW_MAJOR);
@@ -543,7 +532,7 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
+          ctx, array_name, false, data, element_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
@@ -558,16 +547,18 @@ TEST_CASE(
       }
     }
     SECTION("Global order write") {
-      SECTION("no serialization") {
-        serialized_writes = false;
-      }
-      SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-        serialized_writes = true;
+      bool serialized_writes = GENERATE(true, false);
+#else
+      bool serialized_writes = false;
 #endif
-      }
       write_sparse_array(
-          ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+          ctx,
+          array_name,
+          serialized_writes,
+          data,
+          element_offsets,
+          TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
@@ -605,12 +596,13 @@ TEST_CASE(
     std::vector<uint64_t> byte_offsets = {0, 4, 12, 20};
 
     SECTION("Ordered write") {
-      write_dense_array(ctx, array_name, data, byte_offsets, TILEDB_ROW_MAJOR);
+      write_dense_array(
+          ctx, array_name, false, data, byte_offsets, TILEDB_ROW_MAJOR);
       read_and_check_dense_array(ctx, array_name, data, byte_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx, array_name, data, byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx, array_name, false, data, byte_offsets, TILEDB_GLOBAL_ORDER);
       read_and_check_dense_array(ctx, array_name, data, byte_offsets);
     }
   }
@@ -625,12 +617,12 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
+          ctx, array_name, false, data, element_offsets, TILEDB_ROW_MAJOR);
       read_and_check_dense_array(ctx, array_name, data, element_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+          ctx, array_name, false, data, element_offsets, TILEDB_GLOBAL_ORDER);
       read_and_check_dense_array(ctx, array_name, data, element_offsets);
     }
   }
@@ -659,7 +651,8 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_sparse_array(ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+      write_sparse_array(
+          ctx, array_name, false, data, data_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
@@ -686,7 +679,7 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+              ctx, array_name, false, data, data_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             read_and_check_sparse_array(
                 ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
@@ -701,16 +694,18 @@ TEST_CASE(
           }
         }
         SECTION("Global order write") {
-          SECTION("no serialization") {
-            serialized_writes = false;
-          }
-          SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-            serialized_writes = true;
+          bool serialized_writes = GENERATE(true, false);
+#else
+          bool serialized_writes = false;
 #endif
-          }
           write_sparse_array(
-              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              serialized_writes,
+              data,
+              data_offsets,
+              TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             read_and_check_sparse_array(
                 ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
@@ -735,7 +730,7 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
+              ctx, array_name, false, data, element_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             read_and_check_sparse_array(
                 ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
@@ -750,16 +745,18 @@ TEST_CASE(
           }
         }
         SECTION("Global order write") {
-          SECTION("no serialization") {
-            serialized_writes = false;
-          }
-          SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-            serialized_writes = true;
+          bool serialized_writes = GENERATE(true, false);
+#else
+          bool serialized_writes = false;
 #endif
-          }
           write_sparse_array(
-              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              serialized_writes,
+              data,
+              element_offsets,
+              TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             read_and_check_sparse_array(
                 ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
@@ -784,7 +781,7 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+              ctx, array_name, false, data, data_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             read_and_check_empty_coords_array(
                 ctx, array_name, TILEDB_ROW_MAJOR);
@@ -799,16 +796,18 @@ TEST_CASE(
           }
         }
         SECTION("Global order write") {
-          SECTION("no serialization") {
-            serialized_writes = false;
-          }
-          SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-            serialized_writes = true;
+          bool serialized_writes = GENERATE(true, false);
+#else
+          bool serialized_writes = false;
 #endif
-          }
           write_sparse_array(
-              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              serialized_writes,
+              data,
+              data_offsets,
+              TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             read_and_check_empty_coords_array(
                 ctx, array_name, TILEDB_ROW_MAJOR);
@@ -913,7 +912,8 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_sparse_array(ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+      write_sparse_array(
+          ctx, array_name, false, data, data_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         partial_read_and_check_sparse_array(
             ctx,
@@ -962,7 +962,7 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+              ctx, array_name, false, data, data_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
@@ -995,16 +995,18 @@ TEST_CASE(
           }
         }
         SECTION("Global order write") {
-          SECTION("no serialization") {
-            serialized_writes = false;
-          }
-          SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-            serialized_writes = true;
+          bool serialized_writes = GENERATE(true, false);
+#else
+          bool serialized_writes = false;
 #endif
-          }
           write_sparse_array(
-              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              serialized_writes,
+              data,
+              data_offsets,
+              TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
@@ -1051,7 +1053,7 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
+              ctx, array_name, false, data, element_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
@@ -1084,16 +1086,18 @@ TEST_CASE(
           }
         }
         SECTION("Global order write") {
-          SECTION("no serialization") {
-            serialized_writes = false;
-          }
-          SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-            serialized_writes = true;
+          bool serialized_writes = GENERATE(true, false);
+#else
+          bool serialized_writes = false;
 #endif
-          }
           write_sparse_array(
-              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              serialized_writes,
+              data,
+              element_offsets,
+              TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
@@ -1131,7 +1135,7 @@ TEST_CASE(
         // Write data with extra element
         data_offsets.push_back(sizeof(data[0]) * data.size());
         write_sparse_array(
-            ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
+            ctx, array_name, false, data, data_offsets, TILEDB_UNORDERED);
 
         // Submit read query
         Context ctx(config);
@@ -1232,7 +1236,8 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_dense_array(ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+      write_dense_array(
+          ctx, array_name, false, data, data_offsets, TILEDB_ROW_MAJOR);
       read_and_check_dense_array(ctx, array_name, data, data_offsets);
     }
 
@@ -1248,12 +1253,12 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+              ctx, array_name, false, data, data_offsets, TILEDB_ROW_MAJOR);
           read_and_check_dense_array(ctx, array_name, data, data_offsets);
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+              ctx, array_name, false, data, data_offsets, TILEDB_GLOBAL_ORDER);
           read_and_check_dense_array(ctx, array_name, data, data_offsets);
         }
       }
@@ -1268,12 +1273,17 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
+              ctx, array_name, false, data, element_offsets, TILEDB_ROW_MAJOR);
           read_and_check_dense_array(ctx, array_name, data, element_offsets);
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              false,
+              data,
+              element_offsets,
+              TILEDB_GLOBAL_ORDER);
           read_and_check_dense_array(ctx, array_name, data, element_offsets);
         }
       }
@@ -1361,7 +1371,8 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_dense_array(ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+      write_dense_array(
+          ctx, array_name, false, data, data_offsets, TILEDB_ROW_MAJOR);
       partial_read_and_check_dense_array(
           ctx,
           array_name,
@@ -1387,7 +1398,7 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+              ctx, array_name, false, data, data_offsets, TILEDB_ROW_MAJOR);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
@@ -1398,7 +1409,7 @@ TEST_CASE(
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+              ctx, array_name, false, data, data_offsets, TILEDB_GLOBAL_ORDER);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
@@ -1422,7 +1433,7 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
+              ctx, array_name, false, data, element_offsets, TILEDB_ROW_MAJOR);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
@@ -1433,7 +1444,12 @@ TEST_CASE(
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+              ctx,
+              array_name,
+              false,
+              data,
+              element_offsets,
+              TILEDB_GLOBAL_ORDER);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
@@ -1449,7 +1465,7 @@ TEST_CASE(
         // Write data with extra element
         data_offsets.push_back(sizeof(data[0]) * data.size());
         write_dense_array(
-            ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+            ctx, array_name, false, data, data_offsets, TILEDB_ROW_MAJOR);
 
         // Submit read query
         Array array(ctx, array_name, TILEDB_READ);
@@ -1552,7 +1568,7 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
+          ctx, array_name, false, data, data_byte_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
@@ -1567,16 +1583,18 @@ TEST_CASE(
       }
     }
     SECTION("Global order write") {
-      SECTION("no serialization") {
-        serialized_writes = false;
-      }
-      SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-        serialized_writes = true;
+      bool serialized_writes = GENERATE(true, false);
+#else
+      bool serialized_writes = false;
 #endif
-      }
       write_sparse_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx,
+          array_name,
+          serialized_writes,
+          data,
+          data_byte_offsets,
+          TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
@@ -1602,7 +1620,7 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx, array_name, data, data_element_offsets, TILEDB_UNORDERED);
+          ctx, array_name, false, data, data_element_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
@@ -1617,16 +1635,18 @@ TEST_CASE(
       }
     }
     SECTION("Global order write") {
-      SECTION("no serialization") {
-        serialized_writes = false;
-      }
-      SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-        serialized_writes = true;
+      bool serialized_writes = GENERATE(true, false);
+#else
+      bool serialized_writes = false;
 #endif
-      }
       write_sparse_array(
-          ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
+          ctx,
+          array_name,
+          serialized_writes,
+          data,
+          data_element_offsets,
+          TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
@@ -1652,7 +1672,7 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
+          ctx, array_name, false, data, data_byte_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
@@ -1667,16 +1687,18 @@ TEST_CASE(
       }
     }
     SECTION("Global order write") {
-      SECTION("no serialization") {
-        serialized_writes = false;
-      }
-      SECTION("serialization enabled global order write") {
 #ifdef TILEDB_SERIALIZATION
-        serialized_writes = true;
+      bool serialized_writes = GENERATE(true, false);
+#else
+      bool serialized_writes = false;
 #endif
-      }
       write_sparse_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx,
+          array_name,
+          serialized_writes,
+          data,
+          data_byte_offsets,
+          TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
             ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
@@ -1722,12 +1744,12 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
+          ctx, array_name, false, data, data_byte_offsets, TILEDB_ROW_MAJOR);
       read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx, array_name, false, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
   }
@@ -1742,12 +1764,17 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
+          ctx, array_name, false, data, data_element_offsets, TILEDB_ROW_MAJOR);
       read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
+          ctx,
+          array_name,
+          false,
+          data,
+          data_element_offsets,
+          TILEDB_GLOBAL_ORDER);
       read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
     }
   }
@@ -1762,12 +1789,12 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
+          ctx, array_name, false, data, data_byte_offsets, TILEDB_ROW_MAJOR);
       read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx, array_name, false, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
   }

--- a/test/src/unit-empty-var-length.cc
+++ b/test/src/unit-empty-var-length.cc
@@ -56,7 +56,7 @@ struct StringEmptyFx {
   void create_array(const std::string& array_name);
   void delete_array(const std::string& array_name);
   void read_array(const std::string& array_name);
-  void write_array(const std::string& array_name);
+  void write_array(const std::string& array_name, const bool serialized_writes);
 };
 
 // Create a simple dense 1D array with three string attributes
@@ -153,7 +153,8 @@ void StringEmptyFx::create_array(const std::string& array_name) {
   tiledb_ctx_free(&ctx);
 }
 
-void StringEmptyFx::write_array(const std::string& array_name) {
+void StringEmptyFx::write_array(
+    const std::string& array_name, const bool serialized_writes) {
   // Create TileDB context
   tiledb_ctx_t* ctx;
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
@@ -250,15 +251,6 @@ void StringEmptyFx::write_array(const std::string& array_name) {
       ctx, query, "a4", buffer_a4_offsets, &buffer_a4_offsets_size);
   REQUIRE(rc == TILEDB_OK);
 
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
   if (!serialized_writes) {
     rc = tiledb_query_submit(ctx, query);
     CHECK(rc == TILEDB_OK);
@@ -468,9 +460,20 @@ void StringEmptyFx::delete_array(const std::string& array_name) {
 TEST_CASE_METHOD(
     StringEmptyFx, "C API: Test empty support", "[capi][empty-var-length]") {
   std::string array_name = "empty_string";
+
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   delete_array(array_name);
   create_array(array_name);
-  write_array(array_name);
+  write_array(array_name, serialized_writes);
   read_array(array_name);
   delete_array(array_name);
 }

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -910,6 +910,16 @@ TEST_CASE_METHOD(
 TEST_CASE(
     "Sparse global order reader: user buffer cannot fit single cell",
     "[sparse-global-order][user-buffer][too-small]") {
+  bool serialized_writes = false;
+  SECTION("no serialization") {
+    serialized_writes = false;
+  }
+#ifdef TILEDB_SERIALIZATION
+  SECTION("serialization enabled global order write") {
+    serialized_writes = true;
+  }
+#endif
+
   std::string array_name = "test_sparse_global_order";
   Context ctx;
   VFS vfs(ctx);
@@ -948,15 +958,7 @@ TEST_CASE(
   query.set_data_buffer("d1", d1);
   query.set_data_buffer("a", a1_data);
   query.set_offsets_buffer("a", a1_offsets);
-  bool serialized_writes = false;
-  SECTION("no serialization") {
-    serialized_writes = false;
-  }
-  SECTION("serialization enabled global order write") {
-#ifdef TILEDB_SERIALIZATION
-    serialized_writes = true;
-#endif
-  }
+
   if (!serialized_writes) {
     CHECK_NOTHROW(query.submit());
     query.finalize();


### PR DESCRIPTION
This disables the global order writes serialization tests when serialization is disabled. It also moves the sections for the serialization flag to the root level instead of having it hidden inside of a function.

---
TYPE: IMPROVEMENT
DESC: Global order writes serialization: no tests when serialization disabled.
