### PR TITLE
Global order writer: allow splitting fragments.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -217,6 +217,7 @@ if (TILEDB_CPP_API)
     src/unit-cppapi-fragment_info.cc
     src/unit-cppapi-group.cc
     src/unit-cppapi-hilbert.cc
+    src/unit-cppapi-max-fragment-size.cc
     src/unit-cppapi-metadata.cc
     src/unit-cppapi-nullable.cc
     src/unit-cppapi-query.cc

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -31,7 +31,7 @@
  */
 
 #include <test/support/tdb_catch.h>
-#include "helpers.h"
+#include "test/support/src/helpers.h"
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -1,0 +1,362 @@
+/**
+ * @file   unit-cppapi-max-fragment-size.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C++ API for maximum fragment size.
+ */
+
+#include <test/support/tdb_catch.h>
+#include "helpers.h"
+#include "tiledb/common/stdx_string.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/utils.h"
+
+#include <numeric>
+
+using namespace tiledb;
+
+struct CPPMaxFragmentSizeFx {
+  const int max_domain = 1000000;
+  const char* array_name = "cpp_max_fragment_size";
+
+  CPPMaxFragmentSizeFx()
+      : vfs_(ctx_) {
+    if (vfs_.is_dir(array_name)) {
+      vfs_.remove_dir(array_name);
+    }
+  }
+
+  void create_simple_sparse_array() {
+    // Create a simple schema with one int dimension and one int attribute.
+    Domain domain(ctx_);
+    auto d1 = Dimension::create<int>(ctx_, "d1", {{1, max_domain}}, 2);
+    domain.add_dimensions(d1);
+
+    auto a1 = Attribute::create<int>(ctx_, "a1");
+
+    ArraySchema schema(ctx_, TILEDB_SPARSE);
+    schema.set_domain(domain);
+    schema.add_attributes(a1);
+    schema.set_capacity(10);
+
+    Array::create(array_name, schema);
+  }
+
+  void write_simple_sparse_array(
+      uint64_t fragment_size,
+      uint64_t start_val,
+      std::vector<uint64_t> write_sizes) {
+    // Open array and create query.
+    Array array(ctx_, array_name, TILEDB_WRITE);
+    Query query(ctx_, array, TILEDB_WRITE);
+
+    // Set the maximum size for the fragments.
+    query.ptr().get()->query_->set_fragment_size(fragment_size);
+
+    // Perform writes of the requested sizes.
+    for (auto num_vals : write_sizes) {
+      // Fill in the dimension and attribute with increasing numbers.
+      std::vector<int> d1_buff(num_vals);
+      std::iota(d1_buff.begin(), d1_buff.end(), start_val + 1);
+
+      std::vector<int> a1_buff(num_vals);
+      std::iota(a1_buff.begin(), a1_buff.end(), start_val);
+
+      // Perform the write.
+      query.set_data_buffer("d1", d1_buff);
+      query.set_data_buffer("a1", a1_buff);
+      query.set_layout(TILEDB_GLOBAL_ORDER);
+      REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+      start_val += num_vals;
+    }
+
+    // Finalize the query.
+    query.finalize();
+  }
+
+  void read_simple_sparse_array(uint64_t num_vals) {
+    std::vector<int> d1_buff(num_vals);
+    std::vector<int> a1_buff(num_vals);
+
+    // Read the whole array.
+    Array array(ctx_, array_name, TILEDB_READ);
+    Query query(ctx_, array, TILEDB_READ);
+    query.set_data_buffer("d1", d1_buff);
+    query.set_data_buffer("a1", a1_buff);
+    query.set_layout(TILEDB_GLOBAL_ORDER);
+    REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+    // Validate each data points.
+    for (int i = 0; i < static_cast<int>(num_vals); i++) {
+      CHECK(d1_buff[i] == i + 1);
+      CHECK(a1_buff[i] == i);
+    }
+  }
+
+  void create_complex_sparse_array() {
+    // Create a schema with two dimensions, one int attribute and one string
+    // attribute. The second dimension will only have one possible value to
+    // keep the data order simple for validation.
+    Domain domain(ctx_);
+    auto d1 = Dimension::create<int>(ctx_, "d1", {{1, max_domain}}, 2);
+    auto d2 = Dimension::create<int>(ctx_, "d2", {{1, 1}}, 1);
+    domain.add_dimensions(d1, d2);
+
+    auto a1 = Attribute::create<int>(ctx_, "a1");
+
+    auto a2 = Attribute::create<std::string>(ctx_, "a2");
+    a2.set_nullable(true);
+
+    ArraySchema schema(ctx_, TILEDB_SPARSE);
+    schema.set_domain(domain);
+    schema.add_attributes(a1, a2);
+    schema.set_capacity(10);
+
+    Array::create(array_name, schema);
+  }
+
+  void write_complex_sparse_array(
+      uint64_t fragment_size,
+      uint64_t start_val,
+      std::vector<uint64_t> write_sizes) {
+    // Open array and create query.
+    Array array(ctx_, array_name, TILEDB_WRITE);
+    Query query(ctx_, array, TILEDB_WRITE);
+
+    // Set the maximum size for the fragments.
+    query.ptr().get()->query_->set_fragment_size(fragment_size);
+
+    // Perform writes of the requested sizes.
+    for (auto num_vals : write_sizes) {
+      // Fill one the dimension and attributes with increasing numbers. One
+      // dimension will have the same value across the board.
+      std::vector<int> d1_buff(num_vals);
+      std::iota(d1_buff.begin(), d1_buff.end(), start_val + 1);
+
+      std::vector<int> d2_buff(num_vals, 1);
+
+      std::vector<int> a1_buff(num_vals);
+      std::iota(a1_buff.begin(), a1_buff.end(), start_val);
+
+      // For the string attribute, convert the increasing value from int to
+      // string.
+      std::vector<uint64_t> a2_offsets;
+      std::vector<uint8_t> a2_val(num_vals, 1);
+      a2_offsets.reserve(num_vals);
+      std::string a2_var;
+      uint64_t offset = 0;
+      for (uint64_t i = start_val; i < start_val + num_vals; i++) {
+        auto val = std::to_string(i);
+        a2_offsets.emplace_back(offset);
+        offset += val.size();
+        a2_var += val;
+      }
+
+      // Perform the write.
+      query.set_data_buffer("d1", d1_buff);
+      query.set_data_buffer("d2", d2_buff);
+      query.set_data_buffer("a1", a1_buff);
+      query.set_offsets_buffer("a2", a2_offsets);
+      query.set_data_buffer("a2", a2_var);
+      query.set_validity_buffer("a2", a2_val);
+      query.set_layout(TILEDB_GLOBAL_ORDER);
+      REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+      start_val += num_vals;
+    }
+
+    // Finalize the query.
+    query.finalize();
+  }
+
+  void read_complex_sparse_array(uint64_t num_vals) {
+    std::vector<int> d1_buff(num_vals);
+    std::vector<int> d2_buff(num_vals);
+    std::vector<int> a1_buff(num_vals);
+    std::vector<uint64_t> a2_offsets(num_vals);
+    std::vector<uint8_t> a2_val(num_vals);
+    std::string a2_var;
+    a2_var.resize(num_vals * std::to_string(num_vals).size());
+
+    // Read the whole array.
+    Array array(ctx_, array_name, TILEDB_READ);
+    Query query(ctx_, array, TILEDB_READ);
+    query.set_data_buffer("d1", d1_buff);
+    query.set_data_buffer("d2", d2_buff);
+    query.set_data_buffer("a1", a1_buff);
+    query.set_data_buffer("a2", a2_var);
+    query.set_offsets_buffer("a2", a2_offsets);
+    query.set_validity_buffer("a2", a2_val);
+    query.set_layout(TILEDB_GLOBAL_ORDER);
+    REQUIRE(query.submit() == Query::Status::COMPLETE);
+
+    // Validate each data points.
+    uint64_t offset = 0;
+    for (int i = 0; i < static_cast<int>(num_vals); i++) {
+      CHECK(d1_buff[i] == i + 1);
+      CHECK(d2_buff[i] == 1);
+      CHECK(a1_buff[i] == i);
+
+      auto val = std::to_string(i);
+      CHECK(a2_offsets[i] == offset);
+      for (uint64_t c = 0; c < val.size(); c++) {
+        CHECK(a2_var[offset + c] == val[c]);
+      }
+      offset += val.size();
+      CHECK(a2_val[i] == 1);
+    }
+  }
+
+  void consolidate_fragments() {
+    auto config = ctx_.config();
+    Array::consolidate(ctx_, array_name, &config);
+  }
+
+  void vacuum_fragments() {
+    auto config = ctx_.config();
+    Array::vacuum(ctx_, array_name, &config);
+  }
+
+  void consolidate_commits() {
+    auto config = ctx_.config();
+    config["sm.consolidation.mode"] = "commits";
+    Array::consolidate(ctx_, array_name, &config);
+  }
+
+  void vacuum_commits() {
+    auto config = ctx_.config();
+    config["sm.vacuum.mode"] = "commits";
+    Array::vacuum(ctx_, array_name, &config);
+  }
+
+  void check_num_commits_files(
+      uint64_t exp_num_wrt,
+      uint64_t exp_num_con_commits,
+      uint64_t exp_num_ign,
+      uint64_t exp_num_vac) {
+    std::string commit_dir = tiledb::test::get_commit_dir(array_name);
+    std::vector<std::string> commits{vfs_.ls(commit_dir)};
+    uint64_t num_wrt = 0;
+    uint64_t num_con_commits = 0;
+    uint64_t num_ign = 0;
+    uint64_t num_vac = 0;
+    for (auto commit : commits) {
+      if (tiledb::sm::utils::parse::ends_with(
+              commit, tiledb::sm::constants::write_file_suffix)) {
+        num_wrt++;
+      } else if (tiledb::sm::utils::parse::ends_with(
+                     commit, tiledb::sm::constants::con_commits_file_suffix)) {
+        num_con_commits++;
+      } else if (tiledb::sm::utils::parse::ends_with(
+                     commit, tiledb::sm::constants::ignore_file_suffix)) {
+        num_ign++;
+      } else if (tiledb::sm::utils::parse::ends_with(
+                     commit, tiledb::sm::constants::vacuum_file_suffix)) {
+        num_vac++;
+      }
+    }
+
+    CHECK(num_wrt == exp_num_wrt);
+    CHECK(num_con_commits == exp_num_con_commits);
+    CHECK(num_ign == exp_num_ign);
+    CHECK(num_vac == exp_num_vac);
+  }
+
+  ~CPPMaxFragmentSizeFx() {
+    if (vfs_.is_dir(array_name)) {
+      vfs_.remove_dir(array_name);
+    }
+  }
+
+  Context ctx_;
+  VFS vfs_;
+};
+
+TEST_CASE_METHOD(
+    CPPMaxFragmentSizeFx,
+    "C++ API: Max fragment size, simple schema",
+    "[cppapi][max-frag-size][simple]") {
+  create_simple_sparse_array();
+
+  SECTION("no continuations") {
+    write_simple_sparse_array(10000, 0, {10000});
+  }
+
+  SECTION("with continuations") {
+    write_simple_sparse_array(10000, 0, {5000, 2495, 2505});
+  }
+  read_simple_sparse_array(10000);
+  CHECK(tiledb::test::num_fragments(array_name) == 15);
+}
+
+TEST_CASE_METHOD(
+    CPPMaxFragmentSizeFx,
+    "C++ API: Max fragment size, complex schema",
+    "[cppapi][max-frag-size][complex]") {
+  create_complex_sparse_array();
+
+  SECTION("no continuations") {
+    write_complex_sparse_array(10000, 0, {10000});
+  }
+
+  SECTION("with continuations") {
+    write_complex_sparse_array(10000, 0, {5000, 2495, 2505});
+  }
+
+  read_complex_sparse_array(10000);
+  CHECK(tiledb::test::num_fragments(array_name) == 39);
+}
+
+TEST_CASE_METHOD(
+    CPPMaxFragmentSizeFx,
+    "C++ API: Max fragment size, consolidate multiple fragments write",
+    "[cppapi][max-frag-size][consolidate]") {
+  create_simple_sparse_array();
+  write_simple_sparse_array(10000, 0, {5000, 2495, 2505});
+  CHECK(tiledb::test::num_fragments(array_name) == 15);
+  write_simple_sparse_array(std::numeric_limits<uint64_t>::max(), 10000, {100});
+  CHECK(tiledb::test::num_fragments(array_name) == 16);
+
+  // Run fragment consolidation and vacuum.
+  check_num_commits_files(1, 1, 0, 0);
+  consolidate_fragments();
+  check_num_commits_files(2, 1, 0, 1);
+  vacuum_fragments();
+  check_num_commits_files(1, 1, 1, 0);
+  read_simple_sparse_array(10100);
+
+  // Run commits consolidation, it should clean up the commits directory.
+  consolidate_commits();
+  check_num_commits_files(1, 2, 1, 0);
+  vacuum_commits();
+  check_num_commits_files(0, 1, 0, 0);
+  read_simple_sparse_array(10100);
+}

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -1054,17 +1054,17 @@ Status ArraySchema::set_tile_order(Layout tile_order) {
   return Status::Ok();
 }
 
-void ArraySchema::set_version(uint32_t version) {
+void ArraySchema::set_version(format_version_t version) {
   version_ = version;
 }
 
-uint32_t ArraySchema::write_version() const {
+format_version_t ArraySchema::write_version() const {
   return version_ < constants::back_compat_writes_min_format_version ?
              constants::format_version :
              version_;
 }
 
-uint32_t ArraySchema::version() const {
+format_version_t ArraySchema::version() const {
   return version_;
 }
 

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -411,13 +411,13 @@ class ArraySchema {
   Status set_tile_order(Layout tile_order);
 
   /** Set version of schema, only used for serialization */
-  void set_version(uint32_t version);
+  void set_version(format_version_t version);
 
   /** Returns the version to write in. */
-  uint32_t write_version() const;
+  format_version_t write_version() const;
 
   /** Returns the array schema version. */
-  uint32_t version() const;
+  format_version_t version() const;
 
   /** Set a timestamp range for the array schema */
   Status set_timestamp_range(
@@ -456,7 +456,7 @@ class ArraySchema {
   URI array_uri_;
 
   /** The format version of this array schema. */
-  uint32_t version_;
+  format_version_t version_;
 
   /**
    * The timestamp the array schema was written.

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -97,8 +97,10 @@ Status CommitsConsolidator::consolidate(
 
   // Get the file name.
   auto& to_consolidate = array_dir.commit_uris_to_consolidate();
-  return storage_manager_->write_consolidated_commits_file(
+  storage_manager_->write_consolidated_commits_file(
       write_version, array_dir, to_consolidate);
+
+  return Status::Ok();
 }
 
 Status CommitsConsolidator::vacuum(const char* array_name) {

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -97,59 +97,8 @@ Status CommitsConsolidator::consolidate(
 
   // Get the file name.
   auto& to_consolidate = array_dir.commit_uris_to_consolidate();
-  auto&& [st1, name] = array_dir.compute_new_fragment_name(
-      to_consolidate.front(), to_consolidate.back(), write_version);
-  RETURN_NOT_OK(st1);
-
-  // Compute size of consolidated file. Save the sizes of the files to re-use
-  // below.
-  storage_size_t total_size = 0;
-  const auto base_uri_size = array_dir.uri().to_string().size();
-  std::vector<storage_size_t> file_sizes(to_consolidate.size());
-  for (uint64_t i = 0; i < to_consolidate.size(); i++) {
-    const auto& uri = to_consolidate[i];
-    total_size += uri.to_string().size() - base_uri_size + 1;
-
-    // If the file is a delete, add the file size to the count and the size of
-    // the size variable.
-    if (stdx::string::ends_with(
-            uri.to_string(), constants::delete_file_suffix)) {
-      RETURN_NOT_OK(storage_manager_->vfs()->file_size(uri, &file_sizes[i]));
-      total_size += file_sizes[i];
-      total_size += sizeof(storage_size_t);
-    }
-  }
-
-  // Write consolidated file, URIs are relative to the array URI.
-  std::vector<uint8_t> data(total_size);
-  storage_size_t file_index = 0;
-  for (uint64_t i = 0; i < to_consolidate.size(); i++) {
-    // Add the uri.
-    const auto& uri = to_consolidate[i];
-    std::string relative_uri = uri.to_string().substr(base_uri_size) + "\n";
-    memcpy(&data[file_index], relative_uri.data(), relative_uri.size());
-    file_index += relative_uri.size();
-
-    // For deletes, read the delete condition to the output file.
-    if (stdx::string::ends_with(
-            uri.to_string(), constants::delete_file_suffix)) {
-      memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
-      file_index += sizeof(storage_size_t);
-      RETURN_NOT_OK(storage_manager_->vfs()->read(
-          uri, 0, &data[file_index], file_sizes[i]));
-      file_index += file_sizes[i];
-    }
-  }
-
-  // Write the file to storage.
-  URI consolidated_commits_uri =
-      array_dir.get_commits_dir(write_version)
-          .join_path(name.value() + constants::con_commits_file_suffix);
-  RETURN_NOT_OK(storage_manager_->vfs()->write(
-      consolidated_commits_uri, data.data(), data.size()));
-  RETURN_NOT_OK(storage_manager_->vfs()->close_file(consolidated_commits_uri));
-
-  return Status::Ok();
+  return storage_manager_->write_consolidated_commits_file(
+      write_version, array_dir, to_consolidate);
 }
 
 Status CommitsConsolidator::vacuum(const char* array_name) {

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -368,7 +368,7 @@ template <>
 void FragmentMetadata::compute_fragment_min_max_sum<char>(
     const std::string& name);
 
-Status FragmentMetadata::compute_fragment_min_max_sum_null_count() {
+void FragmentMetadata::compute_fragment_min_max_sum_null_count() {
   std::vector<std::string> names;
   names.reserve(idx_map_.size());
   for (auto& it : idx_map_) {
@@ -376,7 +376,7 @@ Status FragmentMetadata::compute_fragment_min_max_sum_null_count() {
   }
 
   // Process all attributes in parallel.
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, idx_map_.size(), [&](uint64_t n) {
         // For easy reference.
         const auto& name = names[n];
@@ -461,10 +461,7 @@ Status FragmentMetadata::compute_fragment_min_max_sum_null_count() {
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK(status);
-
-  return Status::Ok();
+      }));
 }
 
 void FragmentMetadata::set_array_schema(

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -619,10 +619,8 @@ class FragmentMetadata {
 
   /**
    * Compute fragment min, max, sum, null count for all dimensions/attributes.
-   *
-   * @return Status.
    */
-  Status compute_fragment_min_max_sum_null_count();
+  void compute_fragment_min_max_sum_null_count();
 
   /**
    * Sets array schema pointer.

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -1041,6 +1041,15 @@ class Query {
    */
   void set_dimension_label_ordered_read(bool increasing_order);
 
+  /**
+   * Set the fragment size.
+   *
+   * @param fragment_size Fragment size.
+   */
+  void set_fragment_size(uint64_t fragment_size) {
+    fragment_size_ = fragment_size;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -1194,6 +1203,14 @@ class Query {
    * NOTE: Only used when is_dimension_label_order_read_ == true.
    */
   bool dimension_label_increasing_;
+
+  /**
+   * The desired fragment size. The writer will create a new fragment once
+   * this size has been reached.
+   *
+   * Note: This is only used for global order writes.
+   */
+  uint64_t fragment_size_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -772,8 +772,11 @@ Status GlobalOrderWriter::global_write() {
   // Filter all tiles
   RETURN_CANCEL_OR_ERROR(filter_tiles(&tiles));
 
-  for (uint64_t idx = 0; idx < tile_num;) {
+  uint64_t idx = 0;
+  while (idx < tile_num) {
     auto frag_meta = global_write_state_->frag_meta_;
+
+    // Compute the number of tiles that will fit in this fragment.
     auto num = num_tiles_to_write(idx, tile_num, tiles);
 
     // Set new number of tiles in the fragment metadata
@@ -1376,7 +1379,6 @@ uint64_t GlobalOrderWriter::num_tiles_to_write(
     }
 
     if (current_fragment_size_ + tile_size > fragment_size_) {
-      current_fragment_size_ = 0;
       return t - start;
     }
 
@@ -1415,6 +1417,7 @@ Status GlobalOrderWriter::start_new_fragment() {
   fragment_uri_ = frag_dir_uri.join_path(new_fragment_str);
 
   // Create a new fragment.
+  current_fragment_size_ = 0;
   RETURN_NOT_OK(create_fragment(
       !coords_info_.has_coords_, global_write_state_->frag_meta_));
 

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -52,6 +52,7 @@
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
 #include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/storage_format/uri/generate_uri.h"
 
 using namespace tiledb;
 using namespace tiledb::common;
@@ -59,6 +60,13 @@ using namespace tiledb::sm::stats;
 
 namespace tiledb {
 namespace sm {
+
+class GlobalOrderWriterStatusException : public StatusException {
+ public:
+  explicit GlobalOrderWriterStatusException(const std::string& message)
+      : StatusException("GlobalOrderWriter", message) {
+  }
+};
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -73,6 +81,7 @@ GlobalOrderWriter::GlobalOrderWriter(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
+    uint64_t fragment_size,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     bool disable_checks_consolidation,
     std::vector<std::string>& processed_conditions,
@@ -95,11 +104,13 @@ GlobalOrderWriter::GlobalOrderWriter(
           remote_query,
           fragment_name,
           skip_checks_serialization)
-    , processed_conditions_(processed_conditions) {
+    , processed_conditions_(processed_conditions)
+    , fragment_size_(fragment_size)
+    , current_fragment_size_(0) {
   if (layout != Layout::GLOBAL_ORDER) {
-    throw StatusException(Status_WriterError(
+    throw GlobalOrderWriterStatusException(
         "Failed to initialize global order writer. Layout " +
-        layout_str(layout) + " is not global order."));
+        layout_str(layout) + " is not global order.");
   }
 }
 
@@ -118,10 +129,20 @@ Status GlobalOrderWriter::dowork() {
   // In case the user has provided a coordinates buffer
   RETURN_NOT_OK(split_coords_buffer());
 
-  if (check_coord_oob_)
+  if (check_coord_oob_) {
     RETURN_NOT_OK(check_coord_oob());
+  }
 
-  RETURN_NOT_OK(global_write());
+  try {
+    auto status = global_write();
+    if (!status.ok()) {
+      clean_up();
+      return status;
+    }
+  } catch (...) {
+    clean_up();
+    std::throw_with_nested(std::runtime_error("[GlobalOrderWriter::dowork] "));
+  }
 
   return Status::Ok();
 }
@@ -130,7 +151,13 @@ Status GlobalOrderWriter::finalize() {
   auto timer_se = stats_->start_timer("finalize");
 
   if (global_write_state_ != nullptr) {
-    return finalize_global_write_state();
+    try {
+      throw_if_not_ok(finalize_global_write_state());
+    } catch (...) {
+      clean_up();
+      std::throw_with_nested(
+          std::runtime_error("[GlobalOrderWriter::dowork] "));
+    }
   }
 
   return Status::Ok();
@@ -140,6 +167,132 @@ void GlobalOrderWriter::reset() {
   if (global_write_state_ != nullptr) {
     nuke_global_write_state();
   }
+}
+
+Status GlobalOrderWriter::alloc_global_write_state() {
+  // Create global array state object
+  if (global_write_state_ != nullptr)
+    return logger_->status(
+        Status_WriterError("Cannot initialize global write state; State not "
+                           "properly finalized"));
+  global_write_state_.reset(new GlobalWriteState);
+
+  // Alloc FragmentMetadata object
+  global_write_state_->frag_meta_ = make_shared<FragmentMetadata>(HERE());
+  // Used in serialization when FragmentMetadata is built from ground up
+  global_write_state_->frag_meta_->set_storage_manager(storage_manager_);
+
+  return Status::Ok();
+}
+
+Status GlobalOrderWriter::init_global_write_state() {
+  auto uri = global_write_state_->frag_meta_->fragment_uri();
+
+  // Initialize global write state for attribute and coordinates
+  for (const auto& it : buffers_) {
+    // Initialize last tiles
+    const auto& name = it.first;
+    const auto var_size = array_schema_.var_size(name);
+    const auto nullable = array_schema_.is_nullable(name);
+    const auto cell_size = array_schema_.cell_size(name);
+    const auto type = array_schema_.type(name);
+    const auto& domain{array_schema_.domain()};
+    const auto capacity = array_schema_.capacity();
+    const auto cell_num_per_tile =
+        coords_info_.has_coords_ ? capacity : domain.cell_num_per_tile();
+    auto last_tile_vector =
+        std::pair<std::string, WriterTileVector>(name, WriterTileVector());
+    try {
+      last_tile_vector.second.emplace_back(WriterTile(
+          array_schema_,
+          cell_num_per_tile,
+          var_size,
+          nullable,
+          cell_size,
+          type));
+    } catch (const std::logic_error& le) {
+      return Status_WriterError(le.what());
+    }
+    global_write_state_->last_tiles_.emplace(std::move(last_tile_vector));
+
+    // Initialize cells written
+    global_write_state_->cells_written_[name] = 0;
+
+    // Initialize last var offsets
+    global_write_state_->last_var_offsets_[name] = 0;
+  }
+
+  return Status::Ok();
+}
+
+GlobalOrderWriter::GlobalWriteState* GlobalOrderWriter::get_global_state() {
+  return global_write_state_.get();
+}
+
+std::pair<Status, std::unordered_map<std::string, VFS::MultiPartUploadState>>
+GlobalOrderWriter::multipart_upload_state(bool client) {
+  if (client) {
+    return {Status::Ok(), global_write_state_->multipart_upload_state_};
+  }
+
+  auto meta = global_write_state_->frag_meta_;
+  std::unordered_map<std::string, VFS::MultiPartUploadState> result;
+
+  // TODO: to be refactored, there are multiple places in writers where
+  // we iterate over the internal fragment files manually
+  const auto buf_names = buffer_names();
+  for (const auto& name : buf_names) {
+    auto&& [st1, uri] = meta->uri(name);
+    RETURN_NOT_OK_TUPLE(st1, {});
+
+    auto&& [st2, state] = storage_manager_->vfs()->multipart_upload_state(*uri);
+    RETURN_NOT_OK_TUPLE(st2, {});
+    // If there is no entry for this uri, probably multipart upload is disabled
+    // or no write was issued so far
+    if (!state.has_value()) {
+      return {Status::Ok(), {}};
+    }
+    result[uri->remove_trailing_slash().last_path_part()] = std::move(*state);
+
+    if (array_schema_.var_size(name)) {
+      auto&& [status, var_uri] = meta->var_uri(name);
+      RETURN_NOT_OK_TUPLE(status, {});
+
+      auto&& [st, var_state] =
+          storage_manager_->vfs()->multipart_upload_state(*var_uri);
+      RETURN_NOT_OK_TUPLE(st, {});
+      result[var_uri->remove_trailing_slash().last_path_part()] =
+          std::move(*var_state);
+    }
+    if (array_schema_.is_nullable(name)) {
+      auto&& [status, validity_uri] = meta->validity_uri(name);
+      RETURN_NOT_OK_TUPLE(status, {});
+
+      auto&& [st, val_state] =
+          storage_manager_->vfs()->multipart_upload_state(*validity_uri);
+      RETURN_NOT_OK_TUPLE(st, {});
+      result[validity_uri->remove_trailing_slash().last_path_part()] =
+          std::move(*val_state);
+    }
+  }
+
+  return {Status::Ok(), result};
+}
+
+Status GlobalOrderWriter::set_multipart_upload_state(
+    const std::string& uri,
+    const VFS::MultiPartUploadState& state,
+    bool client) {
+  if (client) {
+    global_write_state_->multipart_upload_state_[uri] = state;
+    return Status::Ok();
+  }
+
+  // uri in this case holds only the buffer name
+  auto absolute_uri =
+      global_write_state_->frag_meta_->fragment_uri().join_path(uri);
+  return storage_manager_->vfs()->set_multipart_upload_state(
+      absolute_uri, state);
 }
 
 /* ****************************** */
@@ -239,16 +392,19 @@ Status GlobalOrderWriter::check_global_order() const {
   auto timer_se = stats_->start_timer("check_global_order");
 
   // Check if applicable
-  if (!check_global_order_)
+  if (!check_global_order_) {
     return Status::Ok();
+  }
 
   // Applicable only to sparse writes - exit if coordinates do not exist
-  if (!coords_info_.has_coords_ || coords_info_.coords_num_ == 0)
+  if (!coords_info_.has_coords_ || coords_info_.coords_num_ == 0) {
     return Status::Ok();
+  }
 
   // Special case for Hilbert
-  if (array_schema_.cell_order() == Layout::HILBERT)
+  if (array_schema_.cell_order() == Layout::HILBERT) {
     return check_global_order_hilbert();
+  }
 
   // Make sure the last cell written by a previous write comes before the
   // first cell of this write in the global order
@@ -349,9 +505,19 @@ Status GlobalOrderWriter::check_global_order_hilbert() const {
   return Status::Ok();
 }
 
-void GlobalOrderWriter::clean_up(const URI& uri) {
-  throw_if_not_ok(storage_manager_->vfs()->remove_dir(uri));
-  global_write_state_.reset(nullptr);
+void GlobalOrderWriter::clean_up() {
+  if (global_write_state_ != nullptr) {
+    auto meta = global_write_state_->frag_meta_;
+    const auto& uri = meta->fragment_uri();
+    throw_if_not_ok(storage_manager_->vfs()->remove_dir(uri));
+    global_write_state_.reset(nullptr);
+
+    // Cleanup all fragments pending commit.
+    for (auto& uri : frag_uris_to_commit_) {
+      throw_if_not_ok(storage_manager_->vfs()->remove_dir(uri));
+    }
+    frag_uris_to_commit_.clear();
+  }
 }
 
 Status GlobalOrderWriter::filter_last_tiles(uint64_t cell_num) {
@@ -362,8 +528,8 @@ Status GlobalOrderWriter::filter_last_tiles(uint64_t cell_num) {
 
   // Compute coordinates metadata
   auto meta = global_write_state_->frag_meta_;
-  RETURN_NOT_OK(
-      compute_coords_metadata(global_write_state_->last_tiles_, meta));
+  auto mbrs = compute_mbrs(global_write_state_->last_tiles_);
+  set_coords_metadata(0, 1, global_write_state_->last_tiles_, mbrs, meta);
 
   // Compute tile metadata.
   RETURN_NOT_OK(compute_tiles_metadata(1, global_write_state_->last_tiles_));
@@ -474,12 +640,11 @@ Status GlobalOrderWriter::finalize_global_write_state() {
   Status st = global_write_handle_last_tile();
   if (!st.ok()) {
     throw_if_not_ok(close_files(meta));
-    clean_up(uri);
     return st;
   }
 
   // Close all files
-  RETURN_NOT_OK_ELSE(close_files(meta), clean_up(uri));
+  RETURN_NOT_OK(close_files(meta));
 
   // Check that the same number of cells was written across attributes
   // and dimensions
@@ -487,7 +652,6 @@ Status GlobalOrderWriter::finalize_global_write_state() {
   for (const auto& it : buffers_) {
     const auto& name = it.first;
     if (global_write_state_->cells_written_[name] != cell_num) {
-      clean_up(uri);
       return logger_->status(Status_WriterError(
           "Failed to finalize global write state; Different "
           "number of cells written across attributes and coordinates"));
@@ -496,7 +660,6 @@ Status GlobalOrderWriter::finalize_global_write_state() {
 
   // No cells written, clean up empty fragment.
   if (cell_num == 0) {
-    clean_up(uri);
     return Status::Ok();
   }
 
@@ -505,7 +668,6 @@ Status GlobalOrderWriter::finalize_global_write_state() {
     auto expected_cell_num =
         array_schema_.domain().cell_num(subarray_.ndrange(0));
     if (cell_num != expected_cell_num) {
-      clean_up(uri);
       std::stringstream ss;
       ss << "Failed to finalize global write state; Number "
          << "of cells written (" << cell_num
@@ -518,31 +680,36 @@ Status GlobalOrderWriter::finalize_global_write_state() {
   // Set the processed conditions
   meta->set_processed_conditions(processed_conditions_);
 
-  // Compute fragment min/max/sum/null count
-  RETURN_NOT_OK_ELSE(
-      meta->compute_fragment_min_max_sum_null_count(), clean_up(uri));
+  // Compute fragment min/max/sum/null count and flush fragment metadata to
+  // storage
+  meta->compute_fragment_min_max_sum_null_count();
+  meta->store(array_->get_encryption_key());
 
-  // Flush fragment metadata to storage
-  try {
-    meta->store(array_->get_encryption_key());
-  } catch (...) {
-    clean_up(uri);
-    throw;
+  // Add written fragment infos
+  for (auto& frag_uri : frag_uris_to_commit_) {
+    RETURN_NOT_OK(add_written_fragment_info(frag_uri));
   }
-
-  // Add written fragment info
-  RETURN_NOT_OK_ELSE(add_written_fragment_info(uri), clean_up(uri));
+  RETURN_NOT_OK(add_written_fragment_info(uri));
 
   // The following will make the fragment visible
-  URI commit_uri;
-  try {
-    commit_uri = array_->array_directory().get_commit_uri(uri);
-  } catch (std::exception& e) {
-    RETURN_NOT_OK(storage_manager_->vfs()->remove_dir(uri));
-    std::throw_with_nested(
-        std::logic_error("[GlobalOrderWriter::finalize_global_write_state] "));
+  URI commit_uri = array_->array_directory().get_commit_uri(uri);
+
+  // Write either one commit file or a consolidated commit file if multiple
+  // fragments were written.
+  if (frag_uris_to_commit_.size() == 0) {
+    RETURN_NOT_OK(storage_manager_->vfs()->touch(commit_uri));
+  } else {
+    std::vector<URI> commit_uris;
+    commit_uris.reserve(frag_uris_to_commit_.size() + 1);
+    for (auto& uri : frag_uris_to_commit_) {
+      commit_uris.emplace_back(array_->array_directory().get_commit_uri(uri));
+    }
+    commit_uris.emplace_back(commit_uri);
+
+    auto write_version = array_->array_schema_latest().write_version();
+    RETURN_NOT_OK(storage_manager_->write_consolidated_commits_file(
+        write_version, array_->array_directory(), commit_uris));
   }
-  RETURN_NOT_OK_ELSE(storage_manager_->vfs()->touch(commit_uri), clean_up(uri));
 
   // Delete global write state
   global_write_state_.reset(nullptr);
@@ -561,8 +728,6 @@ Status GlobalOrderWriter::global_write() {
         !coords_info_.has_coords_, global_write_state_->frag_meta_));
     RETURN_CANCEL_OR_ERROR(init_global_write_state());
   }
-  auto frag_meta = global_write_state_->frag_meta_;
-  auto uri = frag_meta->fragment_uri();
 
   // Check for coordinate duplicates
   if (coords_info_.has_coords_) {
@@ -572,12 +737,12 @@ Status GlobalOrderWriter::global_write() {
 
   // Retrieve coordinate duplicates
   std::set<uint64_t> coord_dups;
-  if (dedup_coords_)
+  if (dedup_coords_) {
     RETURN_CANCEL_OR_ERROR(compute_coord_dups(&coord_dups));
+  }
 
   std::unordered_map<std::string, WriterTileVector> tiles;
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      prepare_full_tiles(coord_dups, &tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(prepare_full_tiles(coord_dups, &tiles));
 
   // Find number of tiles and gather stats
   uint64_t tile_num = 0;
@@ -598,27 +763,42 @@ Status GlobalOrderWriter::global_write() {
     return Status::Ok();
   }
 
-  // Set new number of tiles in the fragment metadata
-  auto new_num_tiles = frag_meta->tile_index_base() + tile_num;
-  throw_if_not_ok(frag_meta->set_num_tiles(new_num_tiles));
-
   // Compute coordinate metadata (if coordinates are present)
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      compute_coords_metadata(tiles, frag_meta), clean_up(uri));
+  auto mbrs = compute_mbrs(tiles);
 
   // Compute tile metadata.
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      compute_tiles_metadata(tile_num, tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(compute_tiles_metadata(tile_num, tiles));
 
   // Filter all tiles
-  RETURN_CANCEL_OR_ERROR_ELSE(filter_tiles(&tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(filter_tiles(&tiles));
 
-  // Write tiles for all attributes
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      write_all_tiles(frag_meta, &tiles), clean_up(uri));
+  for (uint64_t idx = 0; idx < tile_num;) {
+    auto frag_meta = global_write_state_->frag_meta_;
+    auto num = num_tiles_to_write(idx, tile_num, tiles);
 
-  // Increment the tile index base for the next global order write.
-  frag_meta->set_tile_index_base(new_num_tiles);
+    // Set new number of tiles in the fragment metadata
+    auto new_num_tiles = frag_meta->tile_index_base() + num;
+    throw_if_not_ok(frag_meta->set_num_tiles(new_num_tiles));
+
+    if (new_num_tiles == 0) {
+      throw GlobalOrderWriterStatusException(
+          "Fragment size doesn't allow to write a single tile");
+    }
+
+    set_coords_metadata(idx, idx + num, tiles, mbrs, frag_meta);
+
+    // Write tiles for all attributes
+    RETURN_CANCEL_OR_ERROR(write_all_tiles(idx, idx + num, frag_meta, &tiles));
+    idx += num;
+
+    // If we didn't write all tiles, close this fragment and start another.
+    if (idx != tile_num) {
+      RETURN_CANCEL_OR_ERROR(start_new_fragment());
+    }
+
+    // Increment the tile index base for the next global order write.
+    frag_meta->set_tile_index_base(new_num_tiles);
+  }
 
   return Status::Ok();
 }
@@ -637,75 +817,16 @@ Status GlobalOrderWriter::global_write_handle_last_tile() {
   // Reserve space for the last tile in the fragment metadata
   auto meta = global_write_state_->frag_meta_;
   throw_if_not_ok(meta->set_num_tiles(meta->tile_index_base() + 1));
-  const auto& uri = global_write_state_->frag_meta_->fragment_uri();
 
   // Filter last tiles
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      filter_last_tiles(cell_num_last_tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(filter_last_tiles(cell_num_last_tiles));
 
   // Write the last tiles
   RETURN_CANCEL_OR_ERROR(
-      write_all_tiles(meta, &global_write_state_->last_tiles_));
+      write_all_tiles(0, 1, meta, &global_write_state_->last_tiles_));
 
   // Increment the tile index base.
   meta->set_tile_index_base(meta->tile_index_base() + 1);
-
-  return Status::Ok();
-}
-
-Status GlobalOrderWriter::alloc_global_write_state() {
-  // Create global array state object
-  if (global_write_state_ != nullptr)
-    return logger_->status(
-        Status_WriterError("Cannot initialize global write state; State not "
-                           "properly finalized"));
-  global_write_state_.reset(new GlobalWriteState);
-
-  // Alloc FragmentMetadata object
-  global_write_state_->frag_meta_ = make_shared<FragmentMetadata>(HERE());
-  // Used in serialization when FragmentMetadata is built from ground up
-  global_write_state_->frag_meta_->set_storage_manager(storage_manager_);
-
-  return Status::Ok();
-}
-
-Status GlobalOrderWriter::init_global_write_state() {
-  auto uri = global_write_state_->frag_meta_->fragment_uri();
-
-  // Initialize global write state for attribute and coordinates
-  for (const auto& it : buffers_) {
-    // Initialize last tiles
-    const auto& name = it.first;
-    const auto var_size = array_schema_.var_size(name);
-    const auto nullable = array_schema_.is_nullable(name);
-    const auto cell_size = array_schema_.cell_size(name);
-    const auto type = array_schema_.type(name);
-    const auto& domain{array_schema_.domain()};
-    const auto capacity = array_schema_.capacity();
-    const auto cell_num_per_tile =
-        coords_info_.has_coords_ ? capacity : domain.cell_num_per_tile();
-    auto last_tile_vector =
-        std::pair<std::string, WriterTileVector>(name, WriterTileVector());
-    try {
-      last_tile_vector.second.emplace_back(WriterTile(
-          array_schema_,
-          cell_num_per_tile,
-          var_size,
-          nullable,
-          cell_size,
-          type));
-    } catch (const std::logic_error& le) {
-      clean_up(uri);
-      return Status_WriterError(le.what());
-    }
-    global_write_state_->last_tiles_.emplace(std::move(last_tile_vector));
-
-    // Initialize cells written
-    global_write_state_->cells_written_[name] = 0;
-
-    // Initialize last var offsets
-    global_write_state_->last_var_offsets_[name] = 0;
-  }
 
   return Status::Ok();
 }
@@ -1210,74 +1331,110 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
   return Status::Ok();
 }
 
-GlobalOrderWriter::GlobalWriteState* GlobalOrderWriter::get_global_state() {
-  return global_write_state_.get();
-}
-
-std::pair<Status, std::unordered_map<std::string, VFS::MultiPartUploadState>>
-GlobalOrderWriter::multipart_upload_state(bool client) {
-  if (client) {
-    return {Status::Ok(), global_write_state_->multipart_upload_state_};
-  }
-
-  auto meta = global_write_state_->frag_meta_;
-  std::unordered_map<std::string, VFS::MultiPartUploadState> result;
-
-  // TODO: to be refactored, there are multiple places in writers where
-  // we iterate over the internal fragment files manually
+uint64_t GlobalOrderWriter::num_tiles_to_write(
+    uint64_t start,
+    uint64_t tile_num,
+    std::unordered_map<std::string, WriterTileVector>& tiles) {
+  // Cache variables to prevent map lookups.
   const auto buf_names = buffer_names();
-  for (const auto& name : buf_names) {
-    auto&& [st1, uri] = meta->uri(name);
-    RETURN_NOT_OK_TUPLE(st1, {});
-
-    auto&& [st2, state] = storage_manager_->vfs()->multipart_upload_state(*uri);
-    RETURN_NOT_OK_TUPLE(st2, {});
-    // If there is no entry for this uri, probably multipart upload is disabled
-    // or no write was issued so far
-    if (!state.has_value()) {
-      return {Status::Ok(), {}};
-    }
-    result[uri->remove_trailing_slash().last_path_part()] = std::move(*state);
-
-    if (array_schema_.var_size(name)) {
-      auto&& [status, var_uri] = meta->var_uri(name);
-      RETURN_NOT_OK_TUPLE(status, {});
-
-      auto&& [st, var_state] =
-          storage_manager_->vfs()->multipart_upload_state(*var_uri);
-      RETURN_NOT_OK_TUPLE(st, {});
-      result[var_uri->remove_trailing_slash().last_path_part()] =
-          std::move(*var_state);
-    }
-    if (array_schema_.is_nullable(name)) {
-      auto&& [status, validity_uri] = meta->validity_uri(name);
-      RETURN_NOT_OK_TUPLE(status, {});
-
-      auto&& [st, val_state] =
-          storage_manager_->vfs()->multipart_upload_state(*validity_uri);
-      RETURN_NOT_OK_TUPLE(st, {});
-      result[validity_uri->remove_trailing_slash().last_path_part()] =
-          std::move(*val_state);
-    }
+  std::vector<bool> var_size;
+  std::vector<bool> nullable;
+  std::vector<WriterTileVector*> writer_tile_vectors;
+  var_size.reserve(buf_names.size());
+  nullable.reserve(buf_names.size());
+  writer_tile_vectors.reserve(buf_names.size());
+  for (auto& name : buf_names) {
+    var_size.emplace_back(array_schema_.var_size(name));
+    nullable.emplace_back(array_schema_.is_nullable(name));
+    writer_tile_vectors.emplace_back(&tiles[name]);
   }
 
-  return {Status::Ok(), result};
+  // Make sure we don't write more than the desired fragment size.
+  uint64_t size = current_fragment_size_;
+  for (uint64_t t = start; t < tile_num; t++) {
+    uint64_t tile_size = 0;
+    for (uint64_t a = 0; a < buf_names.size(); a++) {
+      if (var_size[a]) {
+        tile_size += writer_tile_vectors[a]
+                         ->at(t)
+                         .offset_tile()
+                         .filtered_buffer()
+                         .size();
+        tile_size +=
+            writer_tile_vectors[a]->at(t).var_tile().filtered_buffer().size();
+      } else {
+        tile_size +=
+            writer_tile_vectors[a]->at(t).fixed_tile().filtered_buffer().size();
+      }
+
+      if (nullable[a]) {
+        tile_size += writer_tile_vectors[a]
+                         ->at(t)
+                         .validity_tile()
+                         .filtered_buffer()
+                         .size();
+      }
+    }
+
+    if (size + tile_size > fragment_size_) {
+      current_fragment_size_ = 0;
+      return t - start;
+    }
+
+    size += tile_size;
+  }
+
+  current_fragment_size_ = size;
+  return tile_num - start;
 }
 
-Status GlobalOrderWriter::set_multipart_upload_state(
-    const std::string& uri,
-    const VFS::MultiPartUploadState& state,
-    bool client) {
-  if (client) {
-    global_write_state_->multipart_upload_state_[uri] = state;
-    return Status::Ok();
+Status GlobalOrderWriter::start_new_fragment() {
+  auto frag_meta = global_write_state_->frag_meta_;
+  auto& uri = frag_meta->fragment_uri();
+
+  // Close all files
+  RETURN_NOT_OK(close_files(frag_meta));
+
+  // Set the processed conditions
+  frag_meta->set_processed_conditions(processed_conditions_);
+
+  // Compute fragment min/max/sum/null count
+  frag_meta->compute_fragment_min_max_sum_null_count();
+
+  // Flush fragment metadata to storage
+  frag_meta->store(array_->get_encryption_key());
+
+  // Check that the same number of cells was written across attributes
+  // and dimensions
+  auto cells_written =
+      global_write_state_->cells_written_[buffers_.begin()->first];
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+    if (global_write_state_->cells_written_[name] != cells_written) {
+      return logger_->status(Status_WriterError(
+          "Failed to finalize global write state; Different "
+          "number of cells written across attributes and coordinates"));
+    }
   }
 
-  // uri in this case holds only the buffer name
-  auto absolute_uri =
-      global_write_state_->frag_meta_->fragment_uri().join_path(uri);
-  return storage_manager_->vfs()->set_multipart_upload_state(
-      absolute_uri, state);
+  frag_uris_to_commit_.emplace_back(uri);
+
+  // Make a new fragment URI.
+  const auto write_version = array_->array_schema_latest().write_version();
+  std::pair<uint64_t, uint64_t> timestamp_range;
+  RETURN_NOT_OK(
+      utils::parse::get_timestamp_range(fragment_uri_, &timestamp_range));
+  auto frag_dir_uri =
+      array_->array_directory().get_fragments_dir(write_version);
+  auto new_fragment_str = storage_format::generate_uri(
+      timestamp_range.first, timestamp_range.second, write_version);
+  fragment_uri_ = frag_dir_uri.join_path(new_fragment_str);
+
+  // Create a new fragment.
+  RETURN_NOT_OK(create_fragment(
+      !coords_info_.has_coords_, global_write_state_->frag_meta_));
+
+  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -378,6 +378,11 @@ class GlobalOrderWriter : public WriterBase {
       uint64_t tile_num,
       std::unordered_map<std::string, WriterTileVector>& tiles);
 
+  /**
+   * Close the current fragment and start a new one. The closed fragment will
+   * be added to `frag_uris_to_commit_` so that all fragments in progress can
+   * be written at once.
+   */
   Status start_new_fragment();
 };
 

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -92,8 +92,10 @@ class GlobalOrderWriter : public WriterBase {
     /** The last hilbert value written. */
     uint64_t last_hilbert_value_;
 
-    /** A mapping of buffer names to multipart upload state used by clients
-     * to track the write state in remote global order writes */
+    /**
+     * A mapping of buffer names to multipart upload state used by clients
+     * to track the write state in remote global order writes
+     */
     std::unordered_map<std::string, VFS::MultiPartUploadState>
         multipart_upload_state_;
   };
@@ -112,6 +114,7 @@ class GlobalOrderWriter : public WriterBase {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
+      uint64_t fragment_size,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       bool disable_checks_consolidation,
       std::vector<std::string>& processed_conditions,
@@ -187,6 +190,24 @@ class GlobalOrderWriter : public WriterBase {
   /** The processed conditions. */
   std::vector<std::string>& processed_conditions_;
 
+  /**
+   * List of fragment URIs to commit. This is the list of fragments that were
+   * written to disk but pending to be commited upon the success of the full
+   * write operation.
+   */
+  std::vector<URI> frag_uris_to_commit_;
+
+  /**
+   * The desired fragment size, in bytes. The writer will create a new fragment
+   * once this size has been reached.
+   */
+  uint64_t fragment_size_;
+
+  /**
+   * Size currently written to the fragment.
+   */
+  uint64_t current_fragment_size_;
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
@@ -220,7 +241,7 @@ class GlobalOrderWriter : public WriterBase {
    * Invoked on error. It removes the directory of the input URI and
    * resets the global write state.
    */
-  void clean_up(const URI& uri);
+  void clean_up();
 
   /**
    * Computes the positions of the coordinate duplicates (if any). Note
@@ -341,6 +362,23 @@ class GlobalOrderWriter : public WriterBase {
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
       WriterTileVector* tiles) const;
+
+  /**
+   * Return the number of tiles to write depending on the desired fragment
+   * size. The tiles passed in as an argument should have already been
+   * filtered.
+   *
+   * @param start Current tile index.
+   * @param tile_num Number of tiles in the tiles vectors.
+   * @param tiles Map of vector of tiles, per attributes.
+   * @return Number of tiles to write.
+   */
+  uint64_t num_tiles_to_write(
+      uint64_t start,
+      uint64_t tile_num,
+      std::unordered_map<std::string, WriterTileVector>& tiles);
+
+  Status start_new_fragment();
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/writers/ordered_writer.h
+++ b/tiledb/sm/query/writers/ordered_writer.h
@@ -91,9 +91,15 @@ class OrderedWriter : public WriterBase {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
+  /** Fragment URI. */
+  std::optional<URI> frag_uri_;
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /** Invoked on error. It removes the directory of the input URI. */
+  void clean_up();
 
   /**
    * Writes in an ordered layout (col- or row-major order). Applicable only

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -463,7 +463,7 @@ Status UnorderedWriter::prepare_tiles_fixed(
 
   uint64_t last_tile_cell_num = (cell_num - dups_num) % capacity;
   if (last_tile_cell_num != 0) {
-    tile_it->final_size(last_tile_cell_num);
+    tile_it->set_final_size(last_tile_cell_num);
   }
 
   return Status::Ok();
@@ -582,7 +582,7 @@ Status UnorderedWriter::prepare_tiles_var(
 
   uint64_t last_tile_cell_num = (cell_num - dups_num) % capacity;
   if (last_tile_cell_num != 0) {
-    tile_it->final_size(last_tile_cell_num);
+    tile_it->set_final_size(last_tile_cell_num);
   }
 
   return Status::Ok();
@@ -673,7 +673,7 @@ Status UnorderedWriter::unordered_write() {
   RETURN_CANCEL_OR_ERROR(filter_tiles(&tiles));
 
   // Write tiles for all attributes and coordinates
-  RETURN_CANCEL_OR_ERROR(write_all_tiles(0, tile_num, frag_meta, &tiles));
+  RETURN_CANCEL_OR_ERROR(write_tiles(0, tile_num, frag_meta, &tiles));
 
   // Compute fragment min/max/sum/null count and write the fragment metadata
   frag_meta->compute_fragment_min_max_sum_null_count();

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -93,7 +93,8 @@ UnorderedWriter::UnorderedWriter(
           coords_info,
           remote_query,
           fragment_name,
-          skip_checks_serialization) {
+          skip_checks_serialization)
+    , frag_uri_(std::nullopt) {
   if (layout != Layout::UNORDERED) {
     throw StatusException(Status_WriterError(
         "Failed to initialize UnorderedWriter; The unordered writer does not "
@@ -123,10 +124,20 @@ Status UnorderedWriter::dowork() {
   // In case the user has provided a coordinates buffer
   RETURN_NOT_OK(split_coords_buffer());
 
-  if (check_coord_oob_)
+  if (check_coord_oob_) {
     RETURN_NOT_OK(check_coord_oob());
+  }
 
-  RETURN_NOT_OK(unordered_write());
+  try {
+    auto status = unordered_write();
+    if (!status.ok()) {
+      clean_up();
+      return status;
+    }
+  } catch (...) {
+    clean_up();
+    std::throw_with_nested(std::runtime_error("['UnorderedWriter::dowork] "));
+  }
 
   return Status::Ok();
 }
@@ -143,6 +154,12 @@ void UnorderedWriter::reset() {
 /* ****************************** */
 /*        PRIVATE METHODS         */
 /* ****************************** */
+
+void UnorderedWriter::clean_up() {
+  if (frag_uri_.has_value()) {
+    throw_if_not_ok(storage_manager_->vfs()->remove_dir(frag_uri_.value()));
+  }
+}
 
 Status UnorderedWriter::check_coord_dups(
     const std::vector<uint64_t>& cell_pos) const {
@@ -239,10 +256,6 @@ Status UnorderedWriter::check_coord_dups(
   RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
 
   return Status::Ok();
-}
-
-void UnorderedWriter::clean_up(const URI& uri) {
-  throw_if_not_ok(storage_manager_->vfs()->remove_dir(uri));
 }
 
 Status UnorderedWriter::compute_coord_dups(
@@ -620,25 +633,24 @@ Status UnorderedWriter::unordered_write() {
 
   // Retrieve coordinate duplicates
   std::set<uint64_t> coord_dups;
-  if (dedup_coords_)
+  if (dedup_coords_) {
     RETURN_CANCEL_OR_ERROR(compute_coord_dups(cell_pos, &coord_dups));
+  }
 
   // Create new fragment
   auto frag_meta = make_shared<FragmentMetadata>(HERE());
   RETURN_CANCEL_OR_ERROR(create_fragment(false, frag_meta));
-  const auto& uri = frag_meta->fragment_uri();
+  frag_uri_ = frag_meta->fragment_uri();
 
   // Prepare tiles
   std::unordered_map<std::string, WriterTileVector> tiles;
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      prepare_tiles(cell_pos, coord_dups, &tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(prepare_tiles(cell_pos, coord_dups, &tiles));
 
   // Clear the boolean vector for coordinate duplicates
   coord_dups.clear();
 
   // No tiles
   if (tiles.empty() || tiles.begin()->second.empty()) {
-    clean_up(uri);
     return Status::Ok();
   }
 
@@ -651,45 +663,29 @@ Status UnorderedWriter::unordered_write() {
   stats_->add_counter("cell_num", cell_pos.size());
 
   // Compute coordinates metadata
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      compute_coords_metadata(tiles, frag_meta), clean_up(uri));
+  auto mbrs = compute_mbrs(tiles);
+  set_coords_metadata(0, tile_num, tiles, mbrs, frag_meta);
 
   // Compute tile metadata.
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      compute_tiles_metadata(tile_num, tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(compute_tiles_metadata(tile_num, tiles));
 
   // Filter all tiles
-  RETURN_CANCEL_OR_ERROR_ELSE(filter_tiles(&tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(filter_tiles(&tiles));
 
   // Write tiles for all attributes and coordinates
-  RETURN_CANCEL_OR_ERROR_ELSE(
-      write_all_tiles(frag_meta, &tiles), clean_up(uri));
+  RETURN_CANCEL_OR_ERROR(write_all_tiles(0, tile_num, frag_meta, &tiles));
 
-  // Compute fragment min/max/sum/null count
-  RETURN_NOT_OK_ELSE(
-      frag_meta->compute_fragment_min_max_sum_null_count(), clean_up(uri));
-
-  // Write the fragment metadata
-  try {
-    frag_meta->store(array_->get_encryption_key());
-  } catch (...) {
-    clean_up(uri);
-    throw;
-  }
+  // Compute fragment min/max/sum/null count and write the fragment metadata
+  frag_meta->compute_fragment_min_max_sum_null_count();
+  frag_meta->store(array_->get_encryption_key());
 
   // Add written fragment info
-  RETURN_NOT_OK_ELSE(add_written_fragment_info(uri), clean_up(uri));
+  RETURN_NOT_OK(add_written_fragment_info(frag_uri_.value()));
 
   // The following will make the fragment visible
-  URI commit_uri;
-  try {
-    commit_uri = array_->array_directory().get_commit_uri(uri);
-  } catch (std::exception& e) {
-    RETURN_NOT_OK(storage_manager_->vfs()->remove_dir(uri));
-    std::throw_with_nested(
-        std::logic_error("[UnorderedWriter::unordered_write] "));
-  }
-  RETURN_NOT_OK_ELSE(storage_manager_->vfs()->touch(commit_uri), clean_up(uri));
+  URI commit_uri = array_->array_directory().get_commit_uri(frag_uri_.value());
+
+  RETURN_NOT_OK(storage_manager_->vfs()->touch(commit_uri));
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/writers/unordered_writer.h
+++ b/tiledb/sm/query/writers/unordered_writer.h
@@ -91,9 +91,15 @@ class UnorderedWriter : public WriterBase {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
+  /** Fragment URI. */
+  std::optional<URI> frag_uri_;
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /** Invoked on error. It removes the directory of the input URI. */
+  void clean_up();
 
   /**
    * Throws an error if there are coordinate duplicates.
@@ -103,12 +109,6 @@ class UnorderedWriter : public WriterBase {
    * @return Status
    */
   Status check_coord_dups(const std::vector<uint64_t>& cell_pos) const;
-
-  /**
-   * Invoked on error. It removes the directory of the input URI and
-   * resets the global write state.
-   */
-  void clean_up(const URI& uri);
 
   /**
    * Computes the positions of the coordinate duplicates (if any). Note

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -213,6 +213,8 @@ WriterBase::WriterBase(
   auto frag_dir_uri =
       array_->array_directory().get_fragments_dir(write_version);
   fragment_uri_ = frag_dir_uri.join_path(new_fragment_str);
+  throw_if_not_ok(utils::parse::get_timestamp_range(
+      fragment_uri_, &fragment_timestamp_range_));
 }
 
 WriterBase::~WriterBase() {
@@ -308,9 +310,7 @@ Status WriterBase::initialize_memory_budget() {
 /* ****************************** */
 
 Status WriterBase::add_written_fragment_info(const URI& uri) {
-  std::pair<uint64_t, uint64_t> timestamp_range;
-  RETURN_NOT_OK(utils::parse::get_timestamp_range(uri, &timestamp_range));
-  written_fragment_info_.emplace_back(uri, timestamp_range);
+  written_fragment_info_.emplace_back(uri, fragment_timestamp_range_);
   return Status::Ok();
 }
 
@@ -935,7 +935,7 @@ Status WriterBase::split_coords_buffer() {
   return Status::Ok();
 }
 
-Status WriterBase::write_all_tiles(
+Status WriterBase::write_tiles(
     const uint64_t start_tile_idx,
     const uint64_t end_tile_idx,
     shared_ptr<FragmentMetadata> frag_meta,

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -516,18 +516,19 @@ Status WriterBase::close_files(shared_ptr<FragmentMetadata> meta) const {
   return Status::Ok();
 }
 
-Status WriterBase::compute_coords_metadata(
-    const std::unordered_map<std::string, WriterTileVector>& tiles,
-    shared_ptr<FragmentMetadata> meta) const {
+std::vector<NDRange> WriterBase::compute_mbrs(
+    const std::unordered_map<std::string, WriterTileVector>& tiles) const {
   auto timer_se = stats_->start_timer("compute_coord_meta");
 
   // Applicable only if there are coordinates
-  if (!coords_info_.has_coords_)
-    return Status::Ok();
+  if (!coords_info_.has_coords_) {
+    return std::vector<NDRange>();
+  }
 
   // Check if tiles are empty
-  if (tiles.empty() || tiles.begin()->second.empty())
-    return Status::Ok();
+  if (tiles.empty() || tiles.begin()->second.empty()) {
+    return std::vector<NDRange>();
+  }
 
   // Compute number of tiles. Assumes all attributes and
   // and dimensions have the same number of tiles
@@ -535,36 +536,61 @@ Status WriterBase::compute_coords_metadata(
   auto dim_num = array_schema_.dim_num();
 
   // Compute MBRs
+  std::vector<NDRange> mbrs(tile_num);
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, tile_num, [&](uint64_t i) {
-        NDRange mbr(dim_num);
+        mbrs[i].resize(dim_num);
         std::vector<const void*> data(dim_num);
         for (unsigned d = 0; d < dim_num; ++d) {
           auto dim{array_schema_.dimension_ptr(d)};
           const auto& dim_name = dim->name();
           auto tiles_it = tiles.find(dim_name);
           assert(tiles_it != tiles.end());
-          mbr[d] = dim->var_size() ?
-                       dim->compute_mbr_var(
-                           tiles_it->second[i].offset_tile(),
-                           tiles_it->second[i].var_tile()) :
-                       dim->compute_mbr(tiles_it->second[i].fixed_tile());
+          mbrs[i][d] = dim->var_size() ?
+                           dim->compute_mbr_var(
+                               tiles_it->second[i].offset_tile(),
+                               tiles_it->second[i].var_tile()) :
+                           dim->compute_mbr(tiles_it->second[i].fixed_tile());
         }
 
-        throw_if_not_ok(meta->set_mbr(i, mbr));
         return Status::Ok();
       });
+  throw_if_not_ok(status);
 
-  RETURN_NOT_OK(status);
+  return mbrs;
+}
+
+void WriterBase::set_coords_metadata(
+    const uint64_t start_tile_idx,
+    const uint64_t end_tile_idx,
+    const std::unordered_map<std::string, WriterTileVector>& tiles,
+    const std::vector<NDRange>& mbrs,
+    shared_ptr<FragmentMetadata> meta) const {
+  // Applicable only if there are coordinates
+  if (!coords_info_.has_coords_) {
+    return;
+  }
+
+  // Check if tiles are empty
+  if (tiles.empty() || tiles.begin()->second.empty()) {
+    return;
+  }
+
+  auto status = parallel_for(
+      storage_manager_->compute_tp(),
+      start_tile_idx,
+      end_tile_idx,
+      [&](uint64_t i) {
+        throw_if_not_ok(meta->set_mbr(i - start_tile_idx, mbrs[i]));
+        return Status::Ok();
+      });
+  throw_if_not_ok(status);
 
   // Set last tile cell number
   auto dim_0{array_schema_.dimension_ptr(0)};
   const auto& dim_tiles = tiles.find(dim_0->name())->second;
-  const auto& last_tile_pos = dim_tiles.size() - 1;
-  auto cell_num = dim_tiles[last_tile_pos].cell_num();
+  auto cell_num = dim_tiles[end_tile_idx - 1].cell_num();
   meta->set_last_tile_cell_num(cell_num);
-
-  return Status::Ok();
 }
 
 Status WriterBase::compute_tiles_metadata(
@@ -910,9 +936,11 @@ Status WriterBase::split_coords_buffer() {
 }
 
 Status WriterBase::write_all_tiles(
+    const uint64_t start_tile_idx,
+    const uint64_t end_tile_idx,
     shared_ptr<FragmentMetadata> frag_meta,
     std::unordered_map<std::string, WriterTileVector>* const tiles) {
-  auto timer_se = stats_->start_timer("tiles");
+  auto timer_se = stats_->start_timer("write_num_tiles");
 
   assert(!tiles->empty());
 
@@ -921,7 +949,8 @@ Status WriterBase::write_all_tiles(
     tasks.push_back(storage_manager_->io_tp()->execute([&, this]() {
       auto& attr = it.first;
       auto& tiles = it.second;
-      RETURN_CANCEL_OR_ERROR(write_tiles(attr, frag_meta, 0, &tiles));
+      RETURN_CANCEL_OR_ERROR(write_tiles(
+          start_tile_idx, end_tile_idx, attr, frag_meta, 0, &tiles));
 
       // Fix var size attributes metadata.
       const auto var_size = array_schema_.var_size(attr);
@@ -929,11 +958,11 @@ Status WriterBase::write_all_tiles(
           array_schema_.var_size(attr)) {
         frag_meta->convert_tile_min_max_var_sizes_to_offsets(attr);
 
-        uint64_t idx = 0;
-        for (auto& tile : tiles) {
-          frag_meta->set_tile_min_var(attr, idx, tile.min());
-          frag_meta->set_tile_max_var(attr, idx, tile.max());
-          idx++;
+        for (uint64_t idx = start_tile_idx; idx < end_tile_idx; idx++) {
+          frag_meta->set_tile_min_var(
+              attr, idx - start_tile_idx, tiles[idx].min());
+          frag_meta->set_tile_max_var(
+              attr, idx - start_tile_idx, tiles[idx].max());
         }
       }
       return Status::Ok();
@@ -949,6 +978,8 @@ Status WriterBase::write_all_tiles(
 }
 
 Status WriterBase::write_tiles(
+    const uint64_t start_tile_idx,
+    const uint64_t end_tile_idx,
     const std::string& name,
     shared_ptr<FragmentMetadata> frag_meta,
     uint64_t start_tile_id,
@@ -957,8 +988,9 @@ Status WriterBase::write_tiles(
   auto timer_se = stats_->start_timer("tiles");
 
   // Handle zero tiles
-  if (tiles->empty())
+  if (tiles->empty()) {
     return Status::Ok();
+  }
 
   // For easy reference
   const bool var_size = array_schema_.var_size(name);
@@ -986,10 +1018,10 @@ Status WriterBase::write_tiles(
   // Compute and set var buffer sizes for the min/max metadata
   const auto has_min_max_md = has_min_max_metadata(name, var_size);
   const auto has_sum_md = has_sum_metadata(name, var_size);
-  auto tile_num = tiles->size();
 
   // Write tiles
-  for (size_t i = 0, tile_id = start_tile_id; i < tile_num; ++i, ++tile_id) {
+  for (size_t i = start_tile_idx, tile_id = start_tile_id; i < end_tile_idx;
+       ++i, ++tile_id) {
     auto& tile = (*tiles)[i];
     auto& t = var_size ? tile.offset_tile() : tile.fixed_tile();
     RETURN_NOT_OK(storage_manager_->write(

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -180,6 +180,9 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   /** The name of the new fragment to be created. */
   URI fragment_uri_;
 
+  /** Timestamps for the new fragment to be created. */
+  std::pair<uint64_t, uint64_t> fragment_timestamp_range_;
+
   /** Stores information about the written fragments. */
   std::vector<WrittenFragmentInfo>& written_fragment_info_;
 
@@ -423,7 +426,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    *     attribute or dimension.
    * @return Status
    */
-  Status write_all_tiles(
+  Status write_tiles(
       const uint64_t start_tile_idx,
       const uint64_t end_tile_idx,
       shared_ptr<FragmentMetadata> frag_meta,

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2418,9 +2418,9 @@ Status global_write_state_to_capnp(
 
   auto& cells_written = write_state.cells_written_;
   if (!cells_written.empty()) {
-    auto cells_writen_builder = state_builder->initCellsWritten();
+    auto cells_written_builder = state_builder->initCellsWritten();
     auto entries_builder =
-        cells_writen_builder.initEntries(cells_written.size());
+        cells_written_builder.initEntries(cells_written.size());
     uint64_t index = 0;
     for (auto& entry : cells_written) {
       entries_builder[index].setKey(entry.first);

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -607,6 +607,66 @@ Status StorageManager::write_commit_ignore_file(
   return Status::Ok();
 }
 
+Status StorageManager::write_consolidated_commits_file(
+    format_version_t write_version,
+    ArrayDirectory array_dir,
+    const std::vector<URI>& commit_uris) {
+  // Compute the file name.
+  auto&& [st1, name] = array_dir.compute_new_fragment_name(
+      commit_uris.front(), commit_uris.back(), write_version);
+  RETURN_NOT_OK(st1);
+
+  // Compute size of consolidated file. Save the sizes of the files to re-use
+  // below.
+  storage_size_t total_size = 0;
+  const auto base_uri_size = array_dir.uri().to_string().size();
+  std::vector<storage_size_t> file_sizes(commit_uris.size());
+  for (uint64_t i = 0; i < commit_uris.size(); i++) {
+    const auto& uri = commit_uris[i];
+    total_size += uri.to_string().size() - base_uri_size + 1;
+
+    // If the file is a delete, add the file size to the count and the size of
+    // the size variable.
+    if (stdx::string::ends_with(
+            uri.to_string(), constants::delete_file_suffix)) {
+      RETURN_NOT_OK(this->vfs()->file_size(uri, &file_sizes[i]));
+      total_size += file_sizes[i];
+      total_size += sizeof(storage_size_t);
+    }
+  }
+
+  // Write consolidated file, URIs are relative to the array URI.
+  std::vector<uint8_t> data(total_size);
+  storage_size_t file_index = 0;
+  for (uint64_t i = 0; i < commit_uris.size(); i++) {
+    // Add the uri.
+    const auto& uri = commit_uris[i];
+    std::string relative_uri = uri.to_string().substr(base_uri_size) + "\n";
+    memcpy(&data[file_index], relative_uri.data(), relative_uri.size());
+    file_index += relative_uri.size();
+
+    // For deletes, read the delete condition to the output file.
+    if (stdx::string::ends_with(
+            uri.to_string(), constants::delete_file_suffix)) {
+      memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
+      file_index += sizeof(storage_size_t);
+      RETURN_NOT_OK(
+          this->vfs()->read(uri, 0, &data[file_index], file_sizes[i]));
+      file_index += file_sizes[i];
+    }
+  }
+
+  // Write the file to storage.
+  URI consolidated_commits_uri =
+      array_dir.get_commits_dir(write_version)
+          .join_path(name.value() + constants::con_commits_file_suffix);
+  RETURN_NOT_OK(
+      this->vfs()->write(consolidated_commits_uri, data.data(), data.size()));
+  RETURN_NOT_OK(this->vfs()->close_file(consolidated_commits_uri));
+
+  return Status::Ok();
+}
+
 Status StorageManager::delete_fragments(
     const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end) {
   Status st;

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -450,7 +450,7 @@ class StorageManagerCanonical {
    * @param array_dir ArrayDirectory where the data is stored.
    * @param commit_uris Commit files to include.
    */
-  Status write_consolidated_commits_file(
+  void write_consolidated_commits_file(
       format_version_t write_version,
       ArrayDirectory array_dir,
       const std::vector<URI>& commit_uris);

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -444,6 +444,18 @@ class StorageManagerCanonical {
       ArrayDirectory array_dir, const std::vector<URI>& commit_uris_to_ignore);
 
   /**
+   * Writes a consolidated commits file.
+   *
+   * @param write_version Write version.
+   * @param array_dir ArrayDirectory where the data is stored.
+   * @param commit_uris Commit files to include.
+   */
+  Status write_consolidated_commits_file(
+      format_version_t write_version,
+      ArrayDirectory array_dir,
+      const std::vector<URI>& commit_uris);
+
+  /**
    * Cleans up the array fragments.
    *
    * @param array_name The name of the array to be vacuumed.

--- a/tiledb/sm/tile/writer_tile.cc
+++ b/tiledb/sm/tile/writer_tile.cc
@@ -86,7 +86,8 @@ WriterTile::WriterTile(
     , var_pre_filtered_size_(0)
     , min_size_(0)
     , max_size_(0)
-    , null_count_(0) {
+    , null_count_(0)
+    , cell_num_(cell_num_per_tile) {
 }
 
 WriterTile::WriterTile(WriterTile&& tile)
@@ -100,7 +101,8 @@ WriterTile::WriterTile(WriterTile&& tile)
     , max_(std::move(tile.max_))
     , max_size_(std::move(tile.max_size_))
     , sum_(std::move(tile.sum_))
-    , null_count_(std::move(tile.null_count_)) {
+    , null_count_(std::move(tile.null_count_))
+    , cell_num_(std::move(tile.cell_num_)) {
 }
 
 WriterTile& WriterTile::operator=(WriterTile&& tile) {
@@ -153,6 +155,7 @@ void WriterTile::swap(WriterTile& tile) {
   std::swap(max_size_, tile.max_size_);
   std::swap(sum_, tile.sum_);
   std::swap(null_count_, tile.null_count_);
+  std::swap(cell_num_, tile.cell_num_);
 }
 
 }  // namespace sm

--- a/tiledb/sm/tile/writer_tile.h
+++ b/tiledb/sm/tile/writer_tile.h
@@ -193,6 +193,8 @@ class WriterTile {
    * @param size Final size.
    */
   inline void final_size(uint64_t size) {
+    cell_num_ = size;
+
     if (var_tile_.has_value()) {
       fixed_tile_.set_size(size * constants::cell_var_offset_size);
     } else {
@@ -210,7 +212,7 @@ class WriterTile {
    * @return Cell number.
    */
   inline uint64_t cell_num() const {
-    return fixed_tile_.cell_num();
+    return cell_num_;
   }
 
   /** Swaps the contents (all field values) of this tile with the given tile. */
@@ -256,6 +258,9 @@ class WriterTile {
 
   /** Count of null values. */
   uint64_t null_count_;
+
+  /** Cell num. */
+  uint64_t cell_num_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/tile/writer_tile.h
+++ b/tiledb/sm/tile/writer_tile.h
@@ -192,7 +192,7 @@ class WriterTile {
    *
    * @param size Final size.
    */
-  inline void final_size(uint64_t size) {
+  inline void set_final_size(uint64_t size) {
     cell_num_ = size;
 
     if (var_tile_.has_value()) {


### PR DESCRIPTION
This enables to set a value for the global order writer for the desired fragment size. The writer will then, when it reaches that limit, finish writing the current fragment and create a new fragment to continue the operation. At the end of the write, if there is more than one fragment in progress, a consolidated commit file will be written so that an atomic file system operation is done to commit the fragments to the array.

This change also cleans up the clean up code in the writers when the operation fails and we need to remove a partially written fragment.

---
TYPE: IMPROVEMENT
DESC: Global order writer: allow splitting fragments.
