### PR TITLE
Consolidation: add fragment max size.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -246,6 +246,8 @@ void check_save_to_file() {
      << "\n";
   ss << "sm.consolidation.amplification 1.0\n";
   ss << "sm.consolidation.buffer_size 50000000\n";
+  ss << "sm.consolidation.max_fragment_size " << std::to_string(UINT64_MAX)
+     << "\n";
   ss << "sm.consolidation.mode fragments\n";
   ss << "sm.consolidation.purge_deleted_cells false\n";
   ss << "sm.consolidation.step_max_frags 4294967295\n";
@@ -638,6 +640,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.consolidation.step_min_frags"] = "4294967295";
   all_param_values["sm.consolidation.step_max_frags"] = "4294967295";
   all_param_values["sm.consolidation.buffer_size"] = "50000000";
+  all_param_values["sm.consolidation.max_fragment_size"] =
+      std::to_string(UINT64_MAX);
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";
   all_param_values["sm.consolidation.mode"] = "fragments";
   all_param_values["sm.read_range_oob"] = "warn";

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -159,10 +159,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: 50,000,000
  * - `sm.consolidation.max_fragment_size` <br>
  *    **Experimental** <br>
- *    The size (in bytes) of the maximum fragment size that will be created
- *    by consolidation. When the fragment size is reached, consolidation will
- *    continue the operation in a new fragment. The result will be a multiple
- *    fragments, but with seperate MBRs. <br>
+ *    The size (in bytes) of the maximum on-disk fragment size that will be
+ *    created by consolidation. When it is reached, consolidation will continue
+ *    the operation in a new fragment. The result will be a multiple fragments,
+ *    but with seperate MBRs. <br>
  * - `sm.consolidation.steps` <br>
  *    The number of consolidation steps to be performed when executing
  *    the consolidation algorithm.<br>

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -157,6 +157,12 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    The size (in bytes) of the attribute buffers used during
  *    consolidation. <br>
  *    **Default**: 50,000,000
+ * - `sm.consolidation.max_fragment_size` <br>
+ *    **Experimental** <br>
+ *    The size (in bytes) of the maximum fragment size that will be created
+ *    by consolidation. When the fragment size is reached, consolidation will
+ *    continue the operation in a new fragment. The result will be a multiple
+ *    fragments, but with seperate MBRs. <br>
  * - `sm.consolidation.steps` <br>
  *    The number of consolidation steps to be performed when executing
  *    the consolidation algorithm.<br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -117,6 +117,8 @@ const std::string Config::SM_IO_CONCURRENCY_LEVEL =
 const std::string Config::SM_SKIP_CHECKSUM_VALIDATION = "false";
 const std::string Config::SM_CONSOLIDATION_AMPLIFICATION = "1.0";
 const std::string Config::SM_CONSOLIDATION_BUFFER_SIZE = "50000000";
+const std::string Config::SM_CONSOLIDATION_MAX_FRAGMENT_SIZE =
+    std::to_string(UINT64_MAX);
 const std::string Config::SM_CONSOLIDATION_PURGE_DELETED_CELLS = "false";
 const std::string Config::SM_CONSOLIDATION_STEPS = "4294967295";
 const std::string Config::SM_CONSOLIDATION_STEP_MIN_FRAGS = "4294967295";
@@ -296,6 +298,8 @@ Config::Config() {
   param_values_["sm.consolidation.amplification"] =
       SM_CONSOLIDATION_AMPLIFICATION;
   param_values_["sm.consolidation.buffer_size"] = SM_CONSOLIDATION_BUFFER_SIZE;
+  param_values_["sm.consolidation.max_fragment_size"] =
+      SM_CONSOLIDATION_MAX_FRAGMENT_SIZE;
   param_values_["sm.consolidation.purge_deleted_cells"] =
       SM_CONSOLIDATION_PURGE_DELETED_CELLS;
   param_values_["sm.consolidation.step_min_frags"] =
@@ -648,6 +652,9 @@ Status Config::unset(const std::string& param) {
   } else if (param == "sm.consolidation.buffer_size") {
     param_values_["sm.consolidation.buffer_size"] =
         SM_CONSOLIDATION_BUFFER_SIZE;
+  } else if (param == "sm.consolidation.max_fragment_size") {
+    param_values_["sm.consolidation.max_fragment_size"] =
+        SM_CONSOLIDATION_MAX_FRAGMENT_SIZE;
   } else if (param == "sm.consolidation.purge_deleted_cells") {
     param_values_["sm.consolidation.steps"] =
         SM_CONSOLIDATION_PURGE_DELETED_CELLS;
@@ -895,6 +902,8 @@ Status Config::sanity_check(
   } else if (param == "sm.consolidation.amplification") {
     RETURN_NOT_OK(utils::parse::convert(value, &vf));
   } else if (param == "sm.consolidation.buffer_size") {
+    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
+  } else if (param == "sm.consolidation.max_fragment_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.consolidation.purge_deleted_cells") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -260,6 +260,9 @@ class Config {
   /** The buffer size for each attribute used in consolidation. */
   static const std::string SM_CONSOLIDATION_BUFFER_SIZE;
 
+  /** The maximum fragment size used in consolidation. */
+  static const std::string SM_CONSOLIDATION_MAX_FRAGMENT_SIZE;
+
   /** Purge deleted cells or not. */
   static const std::string SM_CONSOLIDATION_PURGE_DELETED_CELLS;
 

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -614,6 +614,7 @@ Status FragmentConsolidator::create_queries(
   *query_w = tdb_new(Query, storage_manager_, array_for_writes, fragment_name);
   RETURN_NOT_OK((*query_w)->set_layout(Layout::GLOBAL_ORDER));
   RETURN_NOT_OK((*query_w)->disable_checks_consolidation());
+  (*query_w)->set_fragment_size(config_.max_fragment_size_);
   if (array_for_reads->array_schema_latest().dense()) {
     RETURN_NOT_OK((*query_w)->set_subarray_unsafe(subarray));
   }
@@ -861,6 +862,12 @@ Status FragmentConsolidator::set_config(const Config& config) {
   config_.buffer_size_ = 0;
   RETURN_NOT_OK(merged_config.get<uint64_t>(
       "sm.consolidation.buffer_size", &config_.buffer_size_, &found));
+  assert(found);
+  config_.max_fragment_size_ = 0;
+  RETURN_NOT_OK(merged_config.get<uint64_t>(
+      "sm.consolidation.max_fragment_size",
+      &config_.max_fragment_size_,
+      &found));
   assert(found);
   config_.size_ratio_ = 0.0f;
   RETURN_NOT_OK(merged_config.get<float>(

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -154,6 +154,8 @@ class FragmentConsolidator : public Consolidator {
     float amplification_;
     /** Attribute buffer size. */
     uint64_t buffer_size_;
+    /** Max fragment size. */
+    uint64_t max_fragment_size_;
     /**
      * Number of consolidation steps performed in a single
      * consolidation invocation.

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -342,8 +342,8 @@ class Config {
    *    **Default**: 50,000,000
    * - `sm.consolidation.max_fragment_size` <br>
    *    **Experimental** <br>
-   *    The size (in bytes) of the maximum fragment size that will be created
-   *    by consolidation. When the fragment size is reached, consolidation will
+   *    The size (in bytes) of the maximum on-disk fragment size that will be
+   *    created by consolidation. When it is reached, consolidation will
    *    continue the operation in a new fragment. The result will be a multiple
    *    fragments, but with seperate MBRs. <br>
    *    **Default**: UINT64_MAX

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -340,6 +340,13 @@ class Config {
    *    The size (in bytes) of the attribute buffers used during
    *    consolidation. <br>
    *    **Default**: 50,000,000
+   * - `sm.consolidation.max_fragment_size` <br>
+   *    **Experimental** <br>
+   *    The size (in bytes) of the maximum fragment size that will be created
+   *    by consolidation. When the fragment size is reached, consolidation will
+   *    continue the operation in a new fragment. The result will be a multiple
+   *    fragments, but with seperate MBRs. <br>
+   *    **Default**: UINT64_MAX
    * - `sm.consolidation.steps` <br>
    *    The number of consolidation steps to be performed when executing
    *    the consolidation algorithm.<br>


### PR DESCRIPTION
NOTE: this is a follow up to https://github.com/TileDB-Inc/TileDB/pull/3605 so it should only be reviewed once the other PR is merged.

This adds an experimental setting to consolidation so that the user can
specify a maximum fragment size. When consolidation reaches that size,
it will create continue the operation in a new fragment. The result will
be fragments that are fully disjoint in MBRs.

---
TYPE: IMPROVEMENT
DESC: Consolidation: add fragment max size.