### PR TITLE
Adding rtree object library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -443,6 +443,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_add_ranges_list)
   add_dependencies(tests unit_consistency)
   add_dependencies(tests unit_range)
+  add_dependencies(tests unit_rtree)
 
   # C API support
   add_dependencies(tests unit_capi_handle unit_capi_exception_wrapper)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,7 +179,6 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-resource-pool.cc
   src/unit-result-coords.cc
   src/unit-result-tile.cc
-  src/unit-rtree.cc
   src/unit-s3-no-multipart.cc
   src/unit-s3.cc
   src/unit-sparse-global-order-reader.cc

--- a/tiledb/sm/filter/CMakeLists.txt
+++ b/tiledb/sm/filter/CMakeLists.txt
@@ -210,8 +210,6 @@ add_executable(compile_filter_pipeline EXCLUDE_FROM_ALL)
 add_dependencies(all_link_complete compile_filter_pipeline)
 target_link_libraries(compile_filter_pipeline PRIVATE filter_pipeline)
 target_sources(compile_filter_pipeline PRIVATE test/compile_filter_pipeline_main.cc)
-add_dependencies(all_link_complete compile_filter_pipeline)
-
 
 if (TILEDB_TESTS)
     add_executable(unit_filter_create EXCLUDE_FROM_ALL)

--- a/tiledb/sm/misc/test/compile_math_main.cc
+++ b/tiledb/sm/misc/test/compile_math_main.cc
@@ -30,6 +30,5 @@
 
 int main() {
   (void)tiledb::sm::utils::math::ceil(1, 1);
-  (void)tiledb::sm::utils::math::log(1, 1);
   return 0;
 }

--- a/tiledb/sm/rtree/CMakeLists.txt
+++ b/tiledb/sm/rtree/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/sm/CMakeLists.txt
+# tiledb/sm/rtree/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,21 +24,27 @@
 # THE SOFTWARE.
 #
 
-include(common-root)
+include(common NO_POLICY_SCOPE)
 
-add_subdirectory(array)
-add_subdirectory(array_schema)
-add_subdirectory(buffer)
-add_subdirectory(compressors)
-add_subdirectory(config)
-add_subdirectory(crypto)
-add_subdirectory(filesystem)
-add_subdirectory(filter)
-add_subdirectory(group)
-add_subdirectory(metadata)
-add_subdirectory(misc)
-add_subdirectory(query)
-add_subdirectory(rtree)
-add_subdirectory(stats)
-add_subdirectory(subarray)
-add_subdirectory(tile)
+#
+# Object library for other units to depend upon
+#
+add_library(rtree OBJECT rtree.cc)
+target_link_libraries(rtree PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+target_link_libraries(rtree PUBLIC dimension $<TARGET_OBJECTS:dimension>)
+target_link_libraries(rtree PUBLIC domain $<TARGET_OBJECTS:domain>)
+target_link_libraries(rtree PUBLIC math $<TARGET_OBJECTS:math>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_rtree EXCLUDE_FROM_ALL)
+add_dependencies(all_link_complete compile_rtree)
+target_link_libraries(compile_rtree PRIVATE rtree)
+target_sources(compile_rtree PRIVATE
+    test/compile_rtree_main.cc $<TARGET_OBJECTS:rtree>
+)
+
+if (TILEDB_TESTS)
+  add_subdirectory(test)
+endif()

--- a/tiledb/sm/rtree/test/CMakeLists.txt
+++ b/tiledb/sm/rtree/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/sm/CMakeLists.txt
+# tiledb/sm/rtree/test/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2021 TileDB, Inc.
+# Copyright (c) 2022 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,21 +24,18 @@
 # THE SOFTWARE.
 #
 
-include(common-root)
+find_package(Catch_EP REQUIRED)
 
-add_subdirectory(array)
-add_subdirectory(array_schema)
-add_subdirectory(buffer)
-add_subdirectory(compressors)
-add_subdirectory(config)
-add_subdirectory(crypto)
-add_subdirectory(filesystem)
-add_subdirectory(filter)
-add_subdirectory(group)
-add_subdirectory(metadata)
-add_subdirectory(misc)
-add_subdirectory(query)
-add_subdirectory(rtree)
-add_subdirectory(stats)
-add_subdirectory(subarray)
-add_subdirectory(tile)
+add_executable(unit_rtree EXCLUDE_FROM_ALL)
+target_link_libraries(unit_rtree
+    PRIVATE rtree
+    PUBLIC Catch2::Catch2WithMain
+)
+target_link_libraries(unit_rtree)
+target_sources(unit_rtree PUBLIC main.cc unit_rtree.cc)
+
+add_test(
+    NAME "unit_rtree"
+    COMMAND $<TARGET_FILE:unit_rtree>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tiledb/sm/rtree/test/compile_rtree_main.cc
+++ b/tiledb/sm/rtree/test/compile_rtree_main.cc
@@ -1,11 +1,11 @@
 /**
- * @file compile_math_main.cc
+ * @file compile_rtree_main.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,10 +26,9 @@
  * THE SOFTWARE.
  */
 
-#include "../tdb_math.h"
+#include "../rtree.h"
 
 int main() {
-  (void)tiledb::sm::utils::math::ceil(1, 1);
-  (void)tiledb::sm::utils::math::log(1, 1);
+  (void)sizeof(tiledb::sm::RTree);
   return 0;
 }

--- a/tiledb/sm/rtree/test/main.cc
+++ b/tiledb/sm/rtree/test/main.cc
@@ -1,11 +1,11 @@
 /**
- * @file compile_math_main.cc
+ * @file tiledb/sm/rtree/test/main.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,12 +24,11 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
  */
 
-#include "../tdb_math.h"
-
-int main() {
-  (void)tiledb::sm::utils::math::ceil(1, 1);
-  (void)tiledb::sm::utils::math::log(1, 1);
-  return 0;
-}
+#define CATCH_CONFIG_MAIN
+#include <test/support/tdb_catch.h>

--- a/tiledb/sm/rtree/test/unit_rtree.cc
+++ b/tiledb/sm/rtree/test/unit_rtree.cc
@@ -1,11 +1,11 @@
 /**
- * @file unit-RTree.cc
+ * @file unit_rtree.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This adds the rtree object library and moves the rtree unit tests from the integration test to a real unit test.

---
TYPE: IMPROVEMENT
DESC: Adding rtree object library.
