### PR TITLE
Sparse global order reader: fixing incomplete reason for rest queries.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -117,6 +117,10 @@ bool SparseGlobalOrderReader<BitmapType>::incomplete() const {
 template <class BitmapType>
 QueryStatusDetailsReason
 SparseGlobalOrderReader<BitmapType>::status_incomplete_reason() const {
+  if (array_->is_remote()) {
+    return QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
+  }
+
   return incomplete() ? QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE :
                         QueryStatusDetailsReason::REASON_NONE;
 }

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -108,11 +108,13 @@ bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
 template <class BitmapType>
 QueryStatusDetailsReason
 SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
-  if (array_->is_remote())
+  if (array_->is_remote()) {
     return QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
+  }
 
-  if (!incomplete())
+  if (!incomplete()) {
     return QueryStatusDetailsReason::REASON_NONE;
+  }
 
   return result_tiles_.empty() ?
              QueryStatusDetailsReason::REASON_MEMORY_BUDGET :


### PR DESCRIPTION
For rest queries, the sparse global order reader should always return QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE in status_incomplete_reason().

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: fixing incomplete reason for rest queries.
