### PR TITLE
 [Backport release-2.11] Add missing query_type in array_open capnp (#3616)

### DIFF
--- a/.github/workflows/build-macOS11-GCS.yml
+++ b/.github/workflows/build-macOS11-GCS.yml
@@ -39,7 +39,7 @@ jobs:
         os:
           -  macos-11
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     name: Build - ${{matrix.os}} - GCS
     steps:
       - name: 'prep macos for core dumps'

--- a/.github/workflows/build-macOS11-S3.yml
+++ b/.github/workflows/build-macOS11-S3.yml
@@ -40,7 +40,7 @@ jobs:
         os:
           -  macos-11
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     name: Build - ${{ matrix.os }} - S3
     steps:
       - name: 'prep macos for core dumps'

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -423,12 +423,6 @@ tuple<Status, optional<shared_ptr<ArraySchema>>> Array::get_array_schema()
 }
 
 Status Array::get_query_type(QueryType* query_type) const {
-  // Error if the array is not open
-  if (!is_open_) {
-    return LOG_STATUS(
-        Status_ArrayError("Cannot get query_type; Array is not open"));
-  }
-
   *query_type = query_type_;
 
   return Status::Ok();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -409,6 +409,11 @@ class Array {
   /** Checks the config to see if refactored array open should be used. */
   bool use_refactored_array_open() const;
 
+  /** Set the query type to open the array for. */
+  inline void set_query_type(QueryType query_type) {
+    query_type_ = query_type;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -451,8 +456,8 @@ class Array {
   /** `True` if the array has been opened. */
   std::atomic<bool> is_open_;
 
-  /** The query type the array was opened for. */
-  QueryType query_type_;
+  /** The query type the array was opened for. Default: READ */
+  QueryType query_type_ = QueryType::READ;
 
   /**
    * The starting timestamp between to open `open_array_` at.

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -245,6 +245,10 @@ Status array_open_to_capnp(
   auto config = array.config();
   RETURN_NOT_OK(config_to_capnp(&config, &config_builder));
 
+  QueryType query_type = QueryType::READ;
+  RETURN_NOT_OK(array.get_query_type(&query_type));
+  array_open_builder->setQueryType(query_type_str(query_type));
+
   return Status::Ok();
 }
 
@@ -260,6 +264,13 @@ Status array_open_from_capnp(
     RETURN_NOT_OK(
         config_from_capnp(array_open_reader.getConfig(), &decoded_config));
     RETURN_NOT_OK(array->set_config(*decoded_config));
+  }
+
+  if (array_open_reader.hasQueryType()) {
+    auto query_type_str = array_open_reader.getQueryType();
+    QueryType query_type = QueryType::READ;
+    RETURN_NOT_OK(query_type_enum(query_type_str, &query_type));
+    array->set_query_type(query_type);
   }
 
   return Status::Ok();

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
@@ -516,17 +516,17 @@ const ::capnp::_::RawSchema s_a45730f57e0460b4 = {
   4, 8, i_a45730f57e0460b4, nullptr, nullptr, { &s_a45730f57e0460b4, nullptr, bd_a45730f57e0460b4, 0, sizeof(bd_a45730f57e0460b4) / sizeof(bd_a45730f57e0460b4[0]), nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<33> b_facceeafd4472c68 = {
+static const ::capnp::_::AlignedData<49> b_facceeafd4472c68 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     104,  44,  71, 212, 175, 238, 204, 250,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      1,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 226,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     29,   0,   0,   0,  63,   0,   0,   0,
+     29,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
@@ -534,20 +534,36 @@ static const ::capnp::_::AlignedData<33> b_facceeafd4472c68 = {
     112,  58,  65, 114, 114,  97, 121,  79,
     112, 101, 110,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   1,   0,   1,   0,
-      4,   0,   0,   0,   3,   0,   4,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     13,   0,   0,   0,  58,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-      8,   0,   0,   0,   3,   0,   1,   0,
-     20,   0,   0,   0,   2,   0,   1,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  82,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     56,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    113, 117, 101, 114, 121,  84, 121, 112,
+    101,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
@@ -556,11 +572,11 @@ static const ::capnp::_::AlignedData<33> b_facceeafd4472c68 = {
 static const ::capnp::_::RawSchema* const d_facceeafd4472c68[] = {
   &s_b6c95b4b8111ad36,
 };
-static const uint16_t m_facceeafd4472c68[] = {0};
-static const uint16_t i_facceeafd4472c68[] = {0};
+static const uint16_t m_facceeafd4472c68[] = {0, 1};
+static const uint16_t i_facceeafd4472c68[] = {0, 1};
 const ::capnp::_::RawSchema s_facceeafd4472c68 = {
-  0xfacceeafd4472c68, b_facceeafd4472c68.words, 33, d_facceeafd4472c68, m_facceeafd4472c68,
-  1, 1, i_facceeafd4472c68, nullptr, nullptr, { &s_facceeafd4472c68, nullptr, nullptr, 0, 0, nullptr }
+  0xfacceeafd4472c68, b_facceeafd4472c68.words, 49, d_facceeafd4472c68, m_facceeafd4472c68,
+  1, 2, i_facceeafd4472c68, nullptr, nullptr, { &s_facceeafd4472c68, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<254> b_d71de32f98e296fe = {

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
@@ -160,7 +160,7 @@ struct ArrayOpen {
   class Pipeline;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(facceeafd4472c68, 0, 1)
+    CAPNP_DECLARE_STRUCT_HEADER(facceeafd4472c68, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -1881,6 +1881,9 @@ class ArrayOpen::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
+  inline bool hasQueryType() const;
+  inline ::capnp::Text::Reader getQueryType() const;
+
  private:
   ::capnp::_::StructReader _reader;
   template <typename, ::capnp::Kind>
@@ -1929,6 +1932,13 @@ class ArrayOpen::Builder {
       ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
+
+  inline bool hasQueryType();
+  inline ::capnp::Text::Builder getQueryType();
+  inline void setQueryType(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initQueryType(unsigned int size);
+  inline void adoptQueryType(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownQueryType();
 
  private:
   ::capnp::_::StructBuilder _builder;
@@ -10580,6 +10590,44 @@ ArrayOpen::Builder::disownConfig() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool ArrayOpen::Reader::hasQueryType() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool ArrayOpen::Builder::hasQueryType() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader ArrayOpen::Reader::getQueryType() const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder ArrayOpen::Builder::getQueryType() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void ArrayOpen::Builder::setQueryType(::capnp::Text::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::set(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      value);
+}
+inline ::capnp::Text::Builder ArrayOpen::Builder::initQueryType(
+    unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::init(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      size);
+}
+inline void ArrayOpen::Builder::adoptQueryType(
+    ::capnp::Orphan<::capnp::Text>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::Text> ArrayOpen::Builder::disownQueryType() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool ArraySchema::Reader::hasArrayType() const {

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -62,6 +62,8 @@ struct Array {
 struct ArrayOpen {
   config @0 :Config;
   # Config
+  queryType @1 :Text;
+  # Query type to open the array for
 }
 
 

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
@@ -516,17 +516,17 @@ const ::capnp::_::RawSchema s_a45730f57e0460b4 = {
   4, 8, i_a45730f57e0460b4, nullptr, nullptr, { &s_a45730f57e0460b4, nullptr, bd_a45730f57e0460b4, 0, sizeof(bd_a45730f57e0460b4) / sizeof(bd_a45730f57e0460b4[0]), nullptr }
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<33> b_facceeafd4472c68 = {
+static const ::capnp::_::AlignedData<49> b_facceeafd4472c68 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
     104,  44,  71, 212, 175, 238, 204, 250,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      1,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0, 226,   0,   0,   0,
      33,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     29,   0,   0,   0,  63,   0,   0,   0,
+     29,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
@@ -534,20 +534,36 @@ static const ::capnp::_::AlignedData<33> b_facceeafd4472c68 = {
     112,  58,  65, 114, 114,  97, 121,  79,
     112, 101, 110,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   1,   0,   1,   0,
-      4,   0,   0,   0,   3,   0,   4,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     13,   0,   0,   0,  58,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-      8,   0,   0,   0,   3,   0,   1,   0,
-     20,   0,   0,   0,   2,   0,   1,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  82,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     56,   0,   0,   0,   2,   0,   1,   0,
      99, 111, 110, 102, 105, 103,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
      54, 173,  17, 129,  75,  91, 201, 182,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    113, 117, 101, 114, 121,  84, 121, 112,
+    101,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
@@ -556,11 +572,11 @@ static const ::capnp::_::AlignedData<33> b_facceeafd4472c68 = {
 static const ::capnp::_::RawSchema* const d_facceeafd4472c68[] = {
   &s_b6c95b4b8111ad36,
 };
-static const uint16_t m_facceeafd4472c68[] = {0};
-static const uint16_t i_facceeafd4472c68[] = {0};
+static const uint16_t m_facceeafd4472c68[] = {0, 1};
+static const uint16_t i_facceeafd4472c68[] = {0, 1};
 const ::capnp::_::RawSchema s_facceeafd4472c68 = {
-  0xfacceeafd4472c68, b_facceeafd4472c68.words, 33, d_facceeafd4472c68, m_facceeafd4472c68,
-  1, 1, i_facceeafd4472c68, nullptr, nullptr, { &s_facceeafd4472c68, nullptr, nullptr, 0, 0, nullptr }
+  0xfacceeafd4472c68, b_facceeafd4472c68.words, 49, d_facceeafd4472c68, m_facceeafd4472c68,
+  1, 2, i_facceeafd4472c68, nullptr, nullptr, { &s_facceeafd4472c68, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<254> b_d71de32f98e296fe = {

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
@@ -160,7 +160,7 @@ struct ArrayOpen {
   class Pipeline;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(facceeafd4472c68, 0, 1)
+    CAPNP_DECLARE_STRUCT_HEADER(facceeafd4472c68, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -1881,6 +1881,9 @@ class ArrayOpen::Reader {
   inline bool hasConfig() const;
   inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
 
+  inline bool hasQueryType() const;
+  inline ::capnp::Text::Reader getQueryType() const;
+
  private:
   ::capnp::_::StructReader _reader;
   template <typename, ::capnp::Kind>
@@ -1929,6 +1932,13 @@ class ArrayOpen::Builder {
       ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
   inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
   disownConfig();
+
+  inline bool hasQueryType();
+  inline ::capnp::Text::Builder getQueryType();
+  inline void setQueryType(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initQueryType(unsigned int size);
+  inline void adoptQueryType(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownQueryType();
 
  private:
   ::capnp::_::StructBuilder _builder;
@@ -10580,6 +10590,44 @@ ArrayOpen::Builder::disownConfig() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool ArrayOpen::Reader::hasQueryType() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool ArrayOpen::Builder::hasQueryType() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader ArrayOpen::Reader::getQueryType() const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder ArrayOpen::Builder::getQueryType() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void ArrayOpen::Builder::setQueryType(::capnp::Text::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::set(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      value);
+}
+inline ::capnp::Text::Builder ArrayOpen::Builder::initQueryType(
+    unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::init(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      size);
+}
+inline void ArrayOpen::Builder::adoptQueryType(
+    ::capnp::Orphan<::capnp::Text>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::Text> ArrayOpen::Builder::disownQueryType() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
+      _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool ArraySchema::Reader::hasArrayType() const {


### PR DESCRIPTION
Currently in Array open v2 we are not specifying in what "mode" we are requesting to open the array. Thus the Cloud side unconditionally opens the array in READ mode (https://github.com/TileDB-Inc/TileDB-Cloud-REST/blob/master/internal/arrays/v2/array.go#L252).

This PR fixes this issue by adding a `query_type` CAPNP field to be used by Cloud to open the array.

---
TYPE: BUG
DESC: Add missing query_type in array_open capnp
