### PR TITLE
Document `tiledb_mime_type_t`.

### DIFF
--- a/doc/source/c-api.rst
+++ b/doc/source/c-api.rst
@@ -98,6 +98,8 @@ Enumerations
     :project: TileDB-C
 .. doxygenenum:: tiledb_vfs_mode_t
     :project: TileDB-C
+.. doxygenenum:: tiledb_mime_type_t
+    :project: TileDB-C
 .. doxygenenum:: tiledb_encryption_type_t
     :project: TileDB-C
 


### PR DESCRIPTION
I noticed that `tiledb_mime_type_t` is not included in the C API documentation. This PR fixes that.

---
TYPE: C_API
DESC: Document `tiledb_mime_type_t`.