### PR TITLE
Bitsort filter: preallocate filtered buffer for dim tiles.

### DIFF
--- a/tiledb/sm/filter/bitsort_filter.cc
+++ b/tiledb/sm/filter/bitsort_filter.cc
@@ -194,7 +194,6 @@ void BitSortFilter::run_forward_dim_tile(
 
   // Obtain the pointer to the filtered data buffer.
   FilteredBuffer& filtered_buffer = dim_tile->filtered_buffer();
-  filtered_buffer.expand(cell_num * sizeof(DimType));
   DimType* filtered_buffer_data = filtered_buffer.data_as<DimType>();
 
   // Keep track of the data we should write to the tile.

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -800,12 +800,15 @@ Status WriterBase::filter_tiles_bitsort(
   args.reserve(tile_num);
   for (uint64_t i = 0; i < attr_tiles.size(); i++) {
     auto& tile = attr_tiles[i];
+    auto cell_num = tile.cell_num();
 
     // Collect the dim tiles argument.
     std::vector<Tile*> dim_tiles_temp;
     dim_tiles_temp.reserve(dim_tiles.size());
     for (const auto& elem : dim_tiles) {
-      dim_tiles_temp.emplace_back(&((*elem)[i].fixed_tile()));
+      Tile* dim_tile = &((*elem)[i].fixed_tile());
+      dim_tiles_temp.emplace_back(dim_tile);
+      dim_tile->filtered_buffer().expand(cell_num * dim_tile->cell_size());
     }
 
     args.emplace_back(&(tile.fixed_tile()), dim_tiles_temp, false, false);


### PR DESCRIPTION
Currently, the bitsort filter expands the filtered buffer for dimension tiles at the filter level. Unfortunately, when there are multiple chunks processed in parallel, this expansion is not safe and causes issues. The fix is to preallocate the dimension tiles before the filter processes the tiles.

---
TYPE: IMPROVEMENT
DESC: Bitsort filter: preallocate filtered buffer for dim tiles.
