### PR TITLE
Fix find_heap_api_violations.py

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -157,7 +157,9 @@ def iter_file_violations(file_path: str) -> Iterable[Violation]:
 
 def iter_dir_violations(dir_path: str) -> Iterable[Violation]:
     for directory, subdirlist, file_names in os.walk(dir_path):
-        if os.path.basename(directory) not in ignored_dirs:
+        if os.path.basename(directory) in ignored_dirs:
+            subdirlist.clear()
+        else:
             for file_name in file_names:
                 if file_name not in ignored_files and file_name.endswith((".h", ".cc")):
                     yield from iter_file_violations(os.path.join(directory, file_name))


### PR DESCRIPTION
This prevents us from recursing through ignored directories now that the `c_api` directory has a subdirectory layout.

---
TYPE: BUG
DESC: Fix find_heap_api_violations.py
