### PR TITLE
Dense consolidation: set correct non-empty domain.

### DIFF
--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -1883,7 +1883,7 @@ TEST_CASE(
       "- To vacuum URIs:\n" + "  > " + written_frag_uri_1 + "\n  > " +
       written_frag_uri_2 + "\n  > " + written_frag_uri_3 + "\n" +
       "- Fragment #1:\n" + "  > URI: " + uri + "\n" + "  > Type: dense\n" +
-      "  > Non-empty domain: [1, 10]\n" + "  > Size: 3208\n" +
+      "  > Non-empty domain: [1, 6]\n" + "  > Size: 3208\n" +
       "  > Cell num: 10\n" + "  > Timestamp range: [1, 3]\n" +
       "  > Format version: " + ver + "\n" +
       "  > Has consolidated metadata: no\n";

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -243,7 +243,6 @@ Status FragmentConsolidator::consolidate_fragments(
       count++;
       domain.expand_ndrange(
           frag_info.non_empty_domain(), &union_non_empty_domains);
-      domain.expand_to_tiles(&union_non_empty_domains);
       to_consolidate.emplace_back(frag_info.uri(), frag_info.timestamp_range());
     }
   }
@@ -590,9 +589,12 @@ Status FragmentConsolidator::create_queries(
   *query_r = tdb_new(Query, storage_manager_, array_for_reads);
   RETURN_NOT_OK((*query_r)->set_layout(Layout::GLOBAL_ORDER));
 
-  // Refactored reader optimizes for no subarray.
-  if (!config_.use_refactored_reader_ || dense) {
-    RETURN_NOT_OK((*query_r)->set_subarray_unsafe(subarray));
+  // Dense consolidation will do a tile aligned read.
+  if (dense) {
+    NDRange read_subarray = subarray;
+    auto& domain{array_for_reads->array_schema_latest().domain()};
+    domain.expand_to_tiles(&read_subarray);
+    RETURN_NOT_OK((*query_r)->set_subarray_unsafe(read_subarray));
   }
 
   // Enable consolidation with timestamps on the reader, if applicable.
@@ -701,7 +703,6 @@ Status FragmentConsolidator::compute_next_to_consolidate(
           m_union[i][j] = m_union[i - 1][j];
           domain.expand_ndrange(
               fragments[i + j].non_empty_domain(), &m_union[i][j]);
-          domain.expand_to_tiles(&m_union[i][j]);
           if (!sparse && !are_consolidatable(
                              domain, fragment_info, j, j + i, m_union[i][j])) {
             // Mark this entry as invalid

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -195,7 +195,10 @@ WriterBase::WriterBase(
   }
 
   if (!skip_checks_serialization) {
-    check_subarray();
+    // Consolidation might set a subarray that is not tile aligned.
+    if (!disable_checks_consolidation) {
+      check_subarray();
+    }
     check_buffer_sizes();
   }
 


### PR DESCRIPTION
When performing dense consolidation, we expanded the non empty domain of the read/write operations to full tiles so that the global order writer can write full tiles. This writer has not been built with the same computations that allow to write partial tiles like the ordered writer. This change still uses the tile aligned reads so that the dense reader provide full tiles, with fill values to the global order writer but it enables the consolidator to set a non tile aligned subarray on the writer, which is only used to set the non empty domain. That way, if users write fragments that are not tile aligned and consolidate, they will not get more data after consolidation with fill values.

---
TYPE: IMPROVEMENT
DESC: Dense consolidation: set correct non-empty domain.
