### PR TITLE
Replaces domain_str with range_str

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -79,8 +79,8 @@ struct ArraySchemaFx {
   const tiledb_datatype_t DIM_TYPE = TILEDB_INT64;
   const char* DIM_TYPE_STR = "INT64";
   const int64_t DIM_DOMAIN[4] = {0, 99, 20, 60};
-  const char* DIM1_DOMAIN_STR = "[0,99]";
-  const char* DIM2_DOMAIN_STR = "[20,60]";
+  const char* DIM1_DOMAIN_STR = "[0, 99]";
+  const char* DIM2_DOMAIN_STR = "[20, 60]";
   const uint64_t DIM_DOMAIN_SIZE = sizeof(DIM_DOMAIN) / DIM_NUM;
   const uint32_t FILL_VALUE = 10;
   const char* FILL_VALUE_STR = "10";

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -246,7 +246,7 @@ void Dimension::dump(FILE* out) const {
   if (out == nullptr)
     out = stdout;
   // Retrieve domain and tile extent strings
-  std::string domain_s = domain_str();
+  std::string domain_s = type::range_str(domain_, type_);
   std::string tile_extent_s = tile_extent_str();
 
   // Dump
@@ -1712,109 +1712,6 @@ Status Dimension::check_tile_extent_upper_floor_internal(
   }
 
   return Status::Ok();
-}
-
-std::string Dimension::domain_str() const {
-  std::stringstream ss;
-
-  if (domain_.empty())
-    return constants::null_str;
-
-  const int* domain_int32;
-  const int64_t* domain_int64;
-  const float* domain_float32;
-  const double* domain_float64;
-  const int8_t* domain_int8;
-  const uint8_t* domain_uint8;
-  const int16_t* domain_int16;
-  const uint16_t* domain_uint16;
-  const uint32_t* domain_uint32;
-  const uint64_t* domain_uint64;
-
-  switch (type_) {
-    case Datatype::INT32:
-      domain_int32 = (const int32_t*)domain_.data();
-      ss << "[" << domain_int32[0] << "," << domain_int32[1] << "]";
-      return ss.str();
-    case Datatype::INT64:
-      domain_int64 = (const int64_t*)domain_.data();
-      ss << "[" << domain_int64[0] << "," << domain_int64[1] << "]";
-      return ss.str();
-    case Datatype::FLOAT32:
-      domain_float32 = (const float*)domain_.data();
-      ss << "[" << domain_float32[0] << "," << domain_float32[1] << "]";
-      return ss.str();
-    case Datatype::FLOAT64:
-      domain_float64 = (const double*)domain_.data();
-      ss << "[" << domain_float64[0] << "," << domain_float64[1] << "]";
-      return ss.str();
-    case Datatype::INT8:
-      domain_int8 = (const int8_t*)domain_.data();
-      ss << "[" << int(domain_int8[0]) << "," << int(domain_int8[1]) << "]";
-      return ss.str();
-    case Datatype::UINT8:
-      domain_uint8 = (const uint8_t*)domain_.data();
-      ss << "[" << int(domain_uint8[0]) << "," << int(domain_uint8[1]) << "]";
-      return ss.str();
-    case Datatype::INT16:
-      domain_int16 = (const int16_t*)domain_.data();
-      ss << "[" << domain_int16[0] << "," << domain_int16[1] << "]";
-      return ss.str();
-    case Datatype::UINT16:
-      domain_uint16 = (const uint16_t*)domain_.data();
-      ss << "[" << domain_uint16[0] << "," << domain_uint16[1] << "]";
-      return ss.str();
-    case Datatype::UINT32:
-      domain_uint32 = (const uint32_t*)domain_.data();
-      ss << "[" << domain_uint32[0] << "," << domain_uint32[1] << "]";
-      return ss.str();
-    case Datatype::UINT64:
-      domain_uint64 = (const uint64_t*)domain_.data();
-      ss << "[" << domain_uint64[0] << "," << domain_uint64[1] << "]";
-      return ss.str();
-    case Datatype::DATETIME_YEAR:
-    case Datatype::DATETIME_MONTH:
-    case Datatype::DATETIME_WEEK:
-    case Datatype::DATETIME_DAY:
-    case Datatype::DATETIME_HR:
-    case Datatype::DATETIME_MIN:
-    case Datatype::DATETIME_SEC:
-    case Datatype::DATETIME_MS:
-    case Datatype::DATETIME_US:
-    case Datatype::DATETIME_NS:
-    case Datatype::DATETIME_PS:
-    case Datatype::DATETIME_FS:
-    case Datatype::DATETIME_AS:
-    case Datatype::TIME_HR:
-    case Datatype::TIME_MIN:
-    case Datatype::TIME_SEC:
-    case Datatype::TIME_MS:
-    case Datatype::TIME_US:
-    case Datatype::TIME_NS:
-    case Datatype::TIME_PS:
-    case Datatype::TIME_FS:
-    case Datatype::TIME_AS:
-      domain_int64 = (const int64_t*)domain_.data();
-      ss << "[" << domain_int64[0] << "," << domain_int64[1] << "]";
-      return ss.str();
-
-    case Datatype::BLOB:
-    case Datatype::CHAR:
-    case Datatype::BOOL:
-    case Datatype::STRING_ASCII:
-    case Datatype::STRING_UTF8:
-    case Datatype::STRING_UTF16:
-    case Datatype::STRING_UTF32:
-    case Datatype::STRING_UCS2:
-    case Datatype::STRING_UCS4:
-    case Datatype::ANY:
-      // Not supported domain type
-      assert(false);
-      return "";
-  }
-
-  assert(false);
-  return "";
 }
 
 void Dimension::ensure_datatype_is_supported(Datatype type) const {

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -1002,9 +1002,6 @@ class Dimension {
   Status check_tile_extent_upper_floor_internal(
       const T_EXTENT* domain, T_EXTENT tile_extent) const;
 
-  /** Returns the domain in string format. */
-  std::string domain_str() const;
-
   /** Throws error if the input type is not a supported Dimension Datatype. */
   void ensure_datatype_is_supported(Datatype type) const;
 

--- a/tiledb/sm/fragment/single_fragment_info.h
+++ b/tiledb/sm/fragment/single_fragment_info.h
@@ -191,82 +191,10 @@ class SingleFragmentInfo {
       const std::vector<Datatype>& dim_types) const {
     std::stringstream ss;
     for (uint32_t d = 0; d < (uint32_t)dim_types.size(); ++d) {
-      switch (dim_types[d]) {
-        case Datatype::INT8:
-          ss << "[" << ((int8_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((int8_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::UINT8:
-          ss << "[" << ((uint8_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((uint8_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::INT16:
-          ss << "[" << ((int16_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((int16_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::UINT16:
-          ss << "[" << ((uint16_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((uint16_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::INT32:
-          ss << "[" << ((int32_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((int32_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::UINT32:
-          ss << "[" << ((uint32_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((uint32_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::INT64:
-          ss << "[" << ((int64_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((int64_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::UINT64:
-          ss << "[" << ((uint64_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((uint64_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::FLOAT32:
-          ss << "[" << ((float*)non_empty_domain_[d].data())[0] << ", "
-             << ((float*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::FLOAT64:
-          ss << "[" << ((double*)non_empty_domain_[d].data())[0] << ", "
-             << ((double*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::DATETIME_YEAR:
-        case Datatype::DATETIME_MONTH:
-        case Datatype::DATETIME_WEEK:
-        case Datatype::DATETIME_DAY:
-        case Datatype::DATETIME_HR:
-        case Datatype::DATETIME_MIN:
-        case Datatype::DATETIME_SEC:
-        case Datatype::DATETIME_MS:
-        case Datatype::DATETIME_US:
-        case Datatype::DATETIME_NS:
-        case Datatype::DATETIME_PS:
-        case Datatype::DATETIME_FS:
-        case Datatype::DATETIME_AS:
-        case Datatype::TIME_HR:
-        case Datatype::TIME_MIN:
-        case Datatype::TIME_SEC:
-        case Datatype::TIME_MS:
-        case Datatype::TIME_US:
-        case Datatype::TIME_NS:
-        case Datatype::TIME_PS:
-        case Datatype::TIME_FS:
-        case Datatype::TIME_AS:
-          ss << "[" << ((int64_t*)non_empty_domain_[d].data())[0] << ", "
-             << ((int64_t*)non_empty_domain_[d].data())[1] << "]";
-          break;
-        case Datatype::STRING_ASCII:
-          ss << "[" << std::string(non_empty_domain_[d].start_str()) << ", "
-             << std::string(non_empty_domain_[d].end_str()) << "]";
-          break;
-        default:
-          assert(false);
-          break;
-      }
-      if (d != (uint32_t)dim_types.size() - 1)
+      ss << type::range_str(non_empty_domain_[d], dim_types[d]);
+      if (d != (uint32_t)dim_types.size() - 1) {
         ss << " x ";
+      }
     }
 
     return ss.str();


### PR DESCRIPTION
Re-use range_str method instead of creating duplicate switch structures. Adds a space into the domain string for dimensions.

---
TYPE: IMPROVEMENT
DESC: Replaces domain_str with range_str