### PR TITLE
S3 macOS CI fixes

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -71,8 +71,8 @@ jobs:
 
   ci7:
     uses: ./.github/workflows/ci-linux_mac.yml
-    ci_option: Experimental
     with:
+      ci_option: Experimental
       matrix_image: ubuntu-22.04
       bootstrap_args: '--enable=experimental-features,serialization --enable-release-symbols'
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -68,10 +68,11 @@ jobs:
       matrix_image: macos-11
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
+
   ci7:
     uses: ./.github/workflows/ci-linux_mac.yml
+    ci_option: Experimental
     with:
-      ci_backend: GCS
       matrix_image: ubuntu-22.04
       bootstrap_args: '--enable=experimental-features,serialization --enable-release-symbols'
 

--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -102,7 +102,7 @@ if (NOT AWSSDK_FOUND)
       set(CONDITIONAL_PATCH patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch &&
                             patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch)
     endif()
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR NOT WIN32)
       set(CONDITIONAL_CXX_FLAGS "-DCMAKE_CXX_FLAGS=-Wno-nonnull -Wno-error=deprecated-declarations")
     endif()
 

--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -39,7 +39,7 @@ popd
 # Build and test libtiledb
 
 # Set up arguments for bootstrap.sh
-bootstrap_args="${bootstrap_args} --enable=verbose";
+bootstrap_args="${bootstrap_args} --enable-verbose";
 
 mkdir -p $GITHUB_WORKSPACE/build
 cd $GITHUB_WORKSPACE/build

--- a/scripts/run-minio.sh
+++ b/scripts/run-minio.sh
@@ -29,13 +29,13 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+if [[ "$BASH_SOURCE" = $0 ]]; then
+  # exit when *not* sourced (https://superuser.com/a/1288646)
+  echo "run-minio.sh was not sourced. Please set keys manually before running tests."
+fi
+
 die() {
   echo "$@" 1>&2 ; popd 2>/dev/null;
-
-  if [[ "$BASH_SOURCE" = $0 ]]; then
-    # exit when *not* sourced (https://superuser.com/a/1288646)
-    exit 1;
-  fi
 }
 
 run_cask_minio() {
@@ -57,8 +57,8 @@ run_docker_minio() {
 export_aws_keys() {
   export AWS_ACCESS_KEY_ID=minio
   export AWS_SECRET_ACCESS_KEY=miniosecretkey
-  export MINIO_ACCESS_KEY=minio
-  export MINIO_SECRET_KEY=miniosecretkey
+  export MINIO_ROOT_USER=minio
+  export MINIO_ROOT_PASSWORD=miniosecretkey
 }
 
 run() {

--- a/scripts/run-minio.sh
+++ b/scripts/run-minio.sh
@@ -40,7 +40,7 @@ die() {
 
 run_cask_minio() {
   # note: minio data directories *must* follow parameter arguments
-  minio server --certs-dir=/tmp/minio-data/test_certs --address localhost:9999 /tmp/minio-data &
+  minio server --certs-dir=/tmp/minio-data/test_certs --address 127.0.0.1:9999 /tmp/minio-data &
   export MINIO_PID=$!
   [[ "$?" -eq "0" ]] || die "could not run minio server"
 }


### PR DESCRIPTION
This PR re-enables S3 CI, which was not running due to duplicate bootstrap arguments.

Other minor improvements:
- Correct id for experimental CI target
- Update from deprecated minio environment variable names
- Fix AWS SDK build on new macOS w/ deprecated-declaration failures
- Add warning message when run-minio.sh not sourced

---
TYPE: NO_HISTORY
