### PR TITLE
Adding attribute ordering checks to ordered dimension label reader.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ pr:
 
 variables:
   - name: MANYLINUX_IMAGE
-    value: quay.io/pypa/manylinux2010_x86_64:2022-04-24-d28e73e
+    value: quay.io/pypa/manylinux2014_x86_64:2022-11-06-7be974c
 
 stages:
   - stage: CI

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -233,8 +233,9 @@ TEST_CASE_METHOD(
 
   REQUIRE_THROWS_WITH(
       query.submit(),
-      ContainsSubstring("OrderedDimLabelReader: "
-      "Cannot initialize ordered dim label reader; Buffers not set"));
+      ContainsSubstring(
+          "OrderedDimLabelReader: "
+          "Cannot initialize ordered dim label reader; Buffers not set"));
 
   array.close();
 }
@@ -264,8 +265,9 @@ TEST_CASE_METHOD(
 
   REQUIRE_THROWS_WITH(
       query.submit(),
-      ContainsSubstring("OrderedDimLabelReader: "
-      "Cannot initialize ordered dim label reader; Wrong buffer set"));
+      ContainsSubstring(
+          "OrderedDimLabelReader: "
+          "Cannot initialize ordered dim label reader; Wrong buffer set"));
 
   array.close();
 }
@@ -295,8 +297,9 @@ TEST_CASE_METHOD(
 
   REQUIRE_THROWS_WITH(
       query.submit(),
-      ContainsSubstring("OrderedDimLabelReader: "
-      "Cannot initialize ordered dim label reader; Wrong buffer size"));
+      ContainsSubstring(
+          "OrderedDimLabelReader: "
+          "Cannot initialize ordered dim label reader; Wrong buffer size"));
 
   array.close();
 }
@@ -327,8 +330,9 @@ TEST_CASE_METHOD(
 
   REQUIRE_THROWS_WITH(
       query.submit(),
-      ContainsSubstring("OrderedDimLabelReader: "
-      "Cannot initialize ordered dim label reader; Subarray is set"));
+      ContainsSubstring(
+          "OrderedDimLabelReader: "
+          "Cannot initialize ordered dim label reader; Subarray is set"));
 
   array.close();
 }
@@ -887,9 +891,7 @@ TEST_CASE_METHOD(
   }
 
   REQUIRE_THROWS_WITH(
-      read_labels({8, 9}),
-      "Error: Internal TileDB uncaught exception; ReaderBase: Discontiuity "
-      "found in array domain");
+      read_labels({8, 9}), "ReaderBase: Discontiuity found in array domain");
 }
 
 TEST_CASE_METHOD(
@@ -949,9 +951,7 @@ TEST_CASE_METHOD(
   }
 
   REQUIRE_THROWS_WITH(
-      read_labels({8, 9}),
-      "Error: Internal TileDB uncaught exception; ReaderBase: Attribute out of "
-      "order");
+      read_labels({8, 9}), "ReaderBase: Attribute out of order");
 }
 
 TEST_CASE_METHOD(
@@ -1013,9 +1013,7 @@ TEST_CASE_METHOD(
   }
 
   REQUIRE_THROWS_WITH(
-      read_labels({0.8, 0.9}),
-      "Error: Internal TileDB uncaught exception; ReaderBase: Attribute out of "
-      "order");
+      read_labels({0.8, 0.9}), "ReaderBase: Attribute out of order");
 }
 
 TEST_CASE_METHOD(
@@ -1082,7 +1080,5 @@ TEST_CASE_METHOD(
   }
 
   REQUIRE_THROWS_WITH(
-      read_labels({0.8, 0.9}),
-      "Error: Internal TileDB uncaught exception; ReaderBase: Attribute out of "
-      "order");
+      read_labels({0.8, 0.9}), "ReaderBase: Attribute out of order");
 }

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -1051,6 +1051,11 @@ TEST_CASE_METHOD(
     write_labels(21, 25, {0.4, 0.7, 0.8, 0.9, 1.0});
   }
 
+  SECTION("Tile aligned validate min, equality") {
+    write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
+    write_labels(21, 25, {0.5, 0.7, 0.8, 0.9, 1.0});
+  }
+
   SECTION("Non tile aligned, contiguous, validate min") {
     write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6});
     write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -920,14 +920,34 @@ TEST_CASE_METHOD(
     write_labels(15, 26, {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18});
   }
 
+  SECTION("Non tile aligned, overlapped, equality 1") {
+    write_labels(11, 20, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+    write_labels(15, 16, {4, 6});
+  }
+
+  SECTION("Non tile aligned, overlapped, equality 2") {
+    write_labels(11, 20, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+    write_labels(15, 16, {5, 7});
+  }
+
   SECTION("Tile aligned validate min") {
     write_labels(16, 20, {1, 2, 3, 4, 5});
     write_labels(21, 25, {4, 7, 8, 9, 10});
   }
 
+  SECTION("Tile aligned validate min, equality") {
+    write_labels(16, 20, {1, 2, 3, 4, 5});
+    write_labels(21, 25, {5, 7, 8, 9, 10});
+  }
+
   SECTION("Non tile aligned, contiguous, validate min") {
     write_labels(16, 21, {1, 2, 3, 4, 5, 6});
     write_labels(22, 25, {5, 8, 9, 10});
+  }
+
+  SECTION("Non tile aligned, contiguous, validate min, equality") {
+    write_labels(16, 21, {1, 2, 3, 4, 5, 6});
+    write_labels(22, 25, {6, 8, 9, 10});
   }
 
   SECTION("Tile aligned, overlapped, validate min") {
@@ -940,8 +960,18 @@ TEST_CASE_METHOD(
     write_labels(16, 20, {1, 2, 3, 4, 5});
   }
 
+  SECTION("Tile aligned validate max, equality") {
+    write_labels(21, 25, {5, 7, 8, 9, 10});
+    write_labels(16, 20, {1, 2, 3, 4, 5});
+  }
+
   SECTION("Non tile aligned, contiguous, validate max") {
     write_labels(22, 25, {5, 8, 9, 10});
+    write_labels(16, 21, {1, 2, 3, 4, 5, 6});
+  }
+
+  SECTION("Non tile aligned, contiguous, validate max, equality") {
+    write_labels(22, 25, {6, 8, 9, 10});
     write_labels(16, 21, {1, 2, 3, 4, 5, 6});
   }
 
@@ -982,13 +1012,33 @@ TEST_CASE_METHOD(
         15, 26, {0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.8});
   }
 
+  SECTION("Non tile aligned, overlapped, equality 1") {
+    write_labels(11, 20, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+    write_labels(15, 16, {0.4, 0.6});
+  }
+
+  SECTION("Non tile aligned, overlapped, equality 2") {
+    write_labels(11, 20, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+    write_labels(15, 16, {0.5, 0.7});
+  }
+
   SECTION("Tile aligned validate min") {
     write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
     write_labels(21, 25, {0.4, 0.7, 0.8, 0.9, 1.0});
   }
 
+  SECTION("Tile aligned validate min, equality") {
+    write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
+    write_labels(21, 25, {0.5, 0.7, 0.8, 0.9, 1.0});
+  }
+
   SECTION("Non tile aligned, contiguous, validate min") {
     write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6});
+    write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
+  }
+
+  SECTION("Non tile aligned, contiguous, validate min, equality") {
+    write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.45, 0.5});
     write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
   }
 
@@ -1002,9 +1052,19 @@ TEST_CASE_METHOD(
     write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
   }
 
+  SECTION("Tile aligned validate max, equality") {
+    write_labels(21, 25, {0.5, 0.7, 0.8, 0.9, 1.0});
+    write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
+  }
+
   SECTION("Non tile aligned, contiguous, validate max") {
     write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
     write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6});
+  }
+
+  SECTION("Non tile aligned, contiguous, validate max, equality") {
+    write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
+    write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.45, 0.5});
   }
 
   SECTION("Tile aligned, overlapped, validate max") {
@@ -1044,6 +1104,16 @@ TEST_CASE_METHOD(
         15, 26, {0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.8});
   }
 
+  SECTION("Non tile aligned, overlapped, equality 1") {
+    write_labels(11, 20, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+    write_labels(15, 16, {0.4, 0.6});
+  }
+
+  SECTION("Non tile aligned, overlapped, equality 2") {
+    write_labels(11, 20, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+    write_labels(15, 16, {0.5, 0.7});
+  }
+
   SECTION("Tile aligned validate min") {
     write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
     write_labels(21, 25, {0.4, 0.7, 0.8, 0.9, 1.0});
@@ -1059,6 +1129,11 @@ TEST_CASE_METHOD(
     write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
   }
 
+  SECTION("Non tile aligned, contiguous, validate min, equality") {
+    write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.45, 0.5});
+    write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
+  }
+
   SECTION("Tile aligned, overlapped, validate min") {
     write_labels(6, 15, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
     write_labels(11, 20, {0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3});
@@ -1069,9 +1144,19 @@ TEST_CASE_METHOD(
     write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
   }
 
+  SECTION("Tile aligned validate max, equality") {
+    write_labels(21, 25, {0.5, 0.7, 0.8, 0.9, 1.0});
+    write_labels(16, 20, {0.1, 0.2, 0.3, 0.4, 0.5});
+  }
+
   SECTION("Non tile aligned, contiguous, validate max") {
     write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
     write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.5, 0.6});
+  }
+
+  SECTION("Non tile aligned, contiguous, validate max, equality") {
+    write_labels(22, 25, {0.5, 0.8, 0.9, 1.0});
+    write_labels(16, 21, {0.1, 0.2, 0.3, 0.4, 0.45, 0.5});
   }
 
   SECTION("Tile aligned, overlapped, validate max") {

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -413,8 +413,7 @@ struct CPPFixedTileMetadataFx {
             CHECK_THROWS_WITH(
                 frag_meta[f]->get_sum("a"),
                 "FragmentMetadata: Trying to access fragment sum metadata "
-                "that's not "
-                "present");
+                "that's not present");
           } else {
             // Validate min.
             auto& min = frag_meta[f]->get_min("a");
@@ -447,8 +446,7 @@ struct CPPFixedTileMetadataFx {
         CHECK_THROWS_WITH(
             frag_meta[f]->get_null_count("a"),
             "FragmentMetadata: Trying to access fragment null count metadata "
-            "that's not "
-            "present");
+            "that's not present");
       }
     }
 
@@ -569,8 +567,7 @@ struct CPPFixedTileMetadataFx {
         CHECK_THROWS_WITH(
             frag_meta[f]->get_tile_null_count("a", tile_idx),
             "FragmentMetadata: Trying to access tile null count metadata "
-            "that's not "
-            "present");
+            "that's not present");
       }
     }
 
@@ -929,8 +926,7 @@ struct CPPVarTileMetadataFx {
         CHECK_THROWS_WITH(
             frag_meta[f]->get_null_count("a"),
             "FragmentMetadata: Trying to access fragment null count metadata "
-            "that's not "
-            "present");
+            "that's not present");
       }
     }
 
@@ -991,8 +987,7 @@ struct CPPVarTileMetadataFx {
         CHECK_THROWS_WITH(
             frag_meta[f]->get_tile_null_count("a", tile_idx),
             "FragmentMetadata: Trying to access tile null count metadata "
-            "that's not "
-            "present");
+            "that's not present");
       }
     }
 

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -1,0 +1,597 @@
+/**
+ * @file attribute_order_validator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Class for validating fragment order for ordered attributes.
+ */
+
+#ifndef TILEDB_ATTRIBUTE_ORDER_VALIDATOR_H
+#define TILEDB_ATTRIBUTE_ORDER_VALIDATOR_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/fragment/fragment_metadata.h"
+#include "tiledb/sm/query/readers/result_tile.h"
+
+#include <vector>
+
+using namespace tiledb::common;
+
+class ArraySchema;
+
+namespace tiledb::sm {
+
+class AttributeOrderValidatorStatusException : public StatusException {
+ public:
+  explicit AttributeOrderValidatorStatusException(const std::string& message)
+      : StatusException("ReaderBase", message) {
+  }
+};
+
+/**
+ * Utilitary function that returns if a value is contained in a non empty
+ * domain.
+ *
+ * @tparam Index type
+ * @param v Value to check.
+ * @param domain Pointer to the domain values.
+ * @return Is the value in the given domain or not.
+ */
+template <typename IndexType>
+bool in_domain(IndexType v, const IndexType* domain) {
+  return v >= domain[0] && v <= domain[1];
+};
+
+class AttributeOrderValidator {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  AttributeOrderValidator() = delete;
+
+  /**
+   * Construct a new Order Validation Data object.
+   *
+   * @param attribute_name Name of the attribute to validate.
+   * @param num_frags Number of fragments.
+   */
+  AttributeOrderValidator(const std::string& attribute_name, uint64_t num_frags)
+      : attribute_name_(attribute_name)
+      , result_tiles_to_load_(num_frags)
+      , value_validated_(num_frags, {false, false})
+      , fragment_to_compare_against_(num_frags, {nullopt, nullopt})
+      , tile_to_compare_against_(num_frags) {
+  }
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /** Returns 'true' if tiles need to be loaded. */
+  inline bool need_to_load_tiles() {
+    for (auto& rt_map : result_tiles_to_load_) {
+      if (!rt_map.empty()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Returns a vector of pointers to tiles to load. */
+  std::vector<ResultTile*> tiles_to_load() {
+    std::vector<ResultTile*> ret;
+    uint64_t size = 0;
+    for (auto& rt_map : result_tiles_to_load_) {
+      size += rt_map.size();
+    }
+
+    ret.reserve(size);
+    for (auto& rt_map : result_tiles_to_load_) {
+      for (auto& rt : rt_map) {
+        ret.emplace_back(&rt.second);
+      }
+    }
+
+    return ret;
+  }
+
+  /**
+   * Removes duplicate checks for attribute ordering.
+   *
+   * For fragments with adjacent non-empty domains, we only need to check the
+   * interface once. This method marks all fragment bounds as validated except
+   * the bound on the most recent fragment.
+   *
+   * This also marks as validate fragment bounds that are covered or a min/max
+   * for the entire array's non-empty domain, as no check is needed in these
+   * cases.
+   *
+   * @tparam Index type.
+   * @param array_min_idx Minimum index value for the array.
+   * @param array_max_idx Maximum index value for the array.
+   * @param f Fragment index.
+   * @param non_empty_domains Vector of pointers to the non-empty domains for
+   *     each fragments.
+   */
+  template <typename IndexType>
+  void find_fragments_to_check(
+      IndexType array_min_idx,
+      IndexType array_max_idx,
+      uint64_t f,
+      const std::vector<const void*>& non_empty_domains) {
+    // Set useful variables for this fragment.
+    auto& validated = value_validated_[f];
+    auto& frag_to_compare = fragment_to_compare_against_[f];
+    const IndexType* non_empty_domain =
+        static_cast<const IndexType*>(non_empty_domains[f]);
+    auto min = non_empty_domain[0];
+    auto max = non_empty_domain[1];
+
+    // If the fragment minimum is also the array minimum, then it necessarily
+    // satisfies the required ordering.
+    validated.first = (min == array_min_idx);
+
+    // If the fragment maximum is also the array maximum, then it necessarily
+    // satisfies the required ordering.
+    validated.second = (max == array_max_idx);
+
+    // If both bounds are validated, then no fragments need to be checked and we
+    // can return.
+    if (validated.first && validated.second) {
+      return;
+    }
+
+    // Check if fragment is covered or already being checked.
+    for (uint64_t f2 = non_empty_domains.size() - 1; f2 > f; --f2) {
+      // Get the non-empty domain for this fragment.
+      const IndexType* non_empty_domain2 =
+          static_cast<const IndexType*>(non_empty_domains[f2]);
+
+      // Check if the lower bound can be validated.
+      if (!validated.first) {
+        // See if the min is covered by this fragment.
+        validated.first |= in_domain(min, non_empty_domain2);
+
+        // If the min is next to the max of a more recent fragment, it will
+        // be validated when processing that fragment.
+        validated.first |= min - 1 == non_empty_domain2[1];
+      }
+
+      // Check if the upper bound can be validated.
+      if (!validated.second) {
+        // See if the max is covered.
+        validated.second |= in_domain(max, non_empty_domain2);
+
+        // If the max is next to the min of a more recent fragment, it will
+        // be validated when processing that fragment.
+        validated.second |= max + 1 == non_empty_domain2[0];
+      }
+
+      // If both bounds are validated, then no fragments need to be checked and
+      // we can return.
+      if (validated.first && validated.second) {
+        return;
+      }
+    }
+
+    // Get fragment to check against for both the lower and upper boundaries
+    // of this fragment.
+    bool finished_lower_search = validated.first;
+    bool finished_upper_search = validated.second;
+    for (int64_t f2 = f - 1; f2 >= 0; --f2) {
+      // Get the non-empty domain for this fragment.
+      const IndexType* non_empty_domain2 =
+          static_cast<const IndexType*>(non_empty_domains[f2]);
+
+      // If not validated and fragment to check is not yet found, check if
+      // this fragment is over-lapping or directly proceeding the min.
+      if (!finished_lower_search && (in_domain(min, non_empty_domain2) ||
+                                     min - 1 == non_empty_domain2[1])) {
+        frag_to_compare.first = f2;
+        finished_lower_search = true;
+      }
+
+      // If not validated and fragment to check is not yet found, check if
+      // this fragment is over-lapping or directly following the max.
+      if (!finished_upper_search && (in_domain(max, non_empty_domain2) ||
+                                     max + 1 == non_empty_domain2[0])) {
+        frag_to_compare.second = f2;
+        finished_upper_search = true;
+      }
+
+      // If both fragments are either validated or the matching fragment was
+      // found, then we are done searching.
+      if (finished_lower_search && finished_upper_search) {
+        return;
+      }
+    }
+
+    // If the search/validation failed, then there is  a discontinuity in this
+    // array.
+    throw AttributeOrderValidatorStatusException(
+        "Discontiuity found in array domain");
+  }
+
+  /**
+   * Performs validation that can be done without loading tile.
+   *
+   * If a validation check fails, this will throw an error.
+   *
+   * @tparam Index type.
+   * @tparam Attribute type.
+   * @param index_dim The index dimension.
+   * @param f Fragment index.
+   * @param non_empty_domains Vector of pointers to the non-empty domain for
+   *     each fragment.
+   *
+   */
+  template <typename IndexType, typename AttributeType>
+  void validate_without_loading_tiles(
+      const ArraySchema& schema,
+      const Dimension* index_dim,
+      bool increasing_data,
+      uint64_t f,
+      const std::vector<const void*>& non_empty_domains,
+      const std::vector<shared_ptr<FragmentMetadata>> fragment_metadata,
+      const std::vector<uint64_t>& frag_first_array_tile_idx) {
+    // For easy reference.
+    const IndexType* non_empty_domain =
+        static_cast<const IndexType*>(non_empty_domains[f]);
+    const IndexType* dim_dom = index_dim->domain().typed_data<IndexType>();
+    auto tile_extent{index_dim->tile_extent().rvalue_as<IndexType>()};
+
+    if (!min_validated(f)) {
+      // Get the fragment number to compare against.
+      if (!fragment_to_compare_against_[f].first.has_value()) {
+        throw std::logic_error(
+            "Should know fragment value to compare for non-validated bound.");
+      }
+      auto f2 = fragment_to_compare_against_[f].first.value();
+
+      // Get the min index. See if the min is tile aligned.
+      auto min = non_empty_domain[0];
+      bool min_tile_aligned = min == index_dim->round_to_tile<IndexType>(
+                                         min, dim_dom[0], tile_extent);
+
+      // Get the tile index of the tile in f2 immediately proceeding f (with
+      // respect to tile index in f2). If f is tile aligned we need to subtract
+      // an additional value.
+      uint64_t f2_tile_idx = frag_first_array_tile_idx[f] -
+                             frag_first_array_tile_idx[f2] - min_tile_aligned;
+
+      // If we are tile aligned or the min is right next to the other
+      // fragment's max, we can validate. Otherwise we'll need to load
+      // the tile.
+      const IndexType* non_empty_domain2 =
+          static_cast<const IndexType*>(non_empty_domains[f2]);
+      if (min_tile_aligned || min - 1 == non_empty_domain2[1]) {
+        min_validated(f) = true;
+
+        // Check the order.
+        if (increasing_data) {
+          // Increasing data: The first value on f is the minimum on f. Check
+          // that it is greater than the last (maximum) value in the proceeding
+          // tile on f2.
+          auto value = fragment_metadata[f]->get_tile_min_as<AttributeType>(
+              attribute_name_, 0);
+
+          auto value_previous =
+              fragment_metadata[f2]->get_tile_max_as<AttributeType>(
+                  attribute_name_, f2_tile_idx);
+
+          if (value_previous >= value) {
+            throw AttributeOrderValidatorStatusException(
+                "Attribute out of order");
+          }
+        } else {
+          // Decreasing data: The first value on f is the maximum of f. Check
+          // that is is less than the last (minimum) value in the proceeding
+          // tile on f2.
+          auto value = fragment_metadata[f]->get_tile_max_as<AttributeType>(
+              attribute_name_, 0);
+
+          auto value_previous =
+              fragment_metadata[f2]->get_tile_min_as<AttributeType>(
+                  attribute_name_, f2_tile_idx);
+
+          if (value_previous <= value) {
+            throw AttributeOrderValidatorStatusException(
+                "Attribute out of order");
+          }
+        }
+      } else {
+        // Add the tile to the list of tiles to load.
+        add_tile_to_load(f, true, f2, f2_tile_idx, schema);
+      }
+    }
+
+    if (!max_validated(f)) {
+      // Get the fragment number to compare against.
+      if (!fragment_to_compare_against_[f].second.has_value()) {
+        throw std::logic_error(
+            "Should know fragment value to compare for non-validated bound.");
+      }
+      auto f2 = fragment_to_compare_against_[f].second.value();
+
+      // Get the max index and max tile index. See if the max is tile aligned.
+      auto max = non_empty_domain[1];
+      auto max_tile_idx = fragment_metadata[f]->tile_num() - 1;
+      bool max_tile_aligned = max + 1 == index_dim->round_to_tile<IndexType>(
+                                             max + 1, dim_dom[0], tile_extent);
+
+      // Get the tile index of the tile in f2 immediately following f (with
+      // respect to tile index in f2). If f is tile aligned we need to add an
+      // additional value.
+      uint64_t f2_tile_idx = max_tile_idx + frag_first_array_tile_idx[f] -
+                             frag_first_array_tile_idx[f2] + max_tile_aligned;
+
+      // If we are tile aligned or the max is right next to the other fragment's
+      // min, we can validate. Otherwise we'll need to load the tile.
+      const IndexType* non_empty_domain2 =
+          static_cast<const IndexType*>(non_empty_domains[f2]);
+      if (max_tile_aligned || max + 1 == non_empty_domain2[0]) {
+        max_validated(f) = true;
+
+        // Check the order.
+        if (increasing_data) {
+          // Increasing data: The last value on f is the maximum on f. Check
+          // that is less than the first (minimum) value on the following
+          // tile in f2.
+          auto value = fragment_metadata[f]->get_tile_max_as<AttributeType>(
+              attribute_name_, max_tile_idx);
+          auto value_next =
+              fragment_metadata[f2]->get_tile_min_as<AttributeType>(
+                  attribute_name_, f2_tile_idx);
+          if (value_next <= value) {
+            throw AttributeOrderValidatorStatusException(
+                "Attribute out of order");
+          }
+
+        } else {
+          // Decreasinging data: The last value on f is the minimum on f. Check
+          // that is greater than the first (maximum) value on the following
+          // tile in f2.
+          auto value = fragment_metadata[f]->get_tile_min_as<AttributeType>(
+              attribute_name_, max_tile_idx);
+          auto value_next =
+              fragment_metadata[f2]->get_tile_max_as<AttributeType>(
+                  attribute_name_, f2_tile_idx);
+          if (value_next >= value) {
+            throw AttributeOrderValidatorStatusException(
+                "Attribute out of order");
+          }
+        }
+
+      } else {
+        // Add the tile to the list of tiles to load.
+        add_tile_to_load(f, false, f2, f2_tile_idx, schema);
+      }
+    }
+  }
+
+  /**
+   * Performs validation that requires tile data.
+   *
+   * For best performance, only execute this method after first validating
+   * without loading tiles. If a validation check fails, this will throw an
+   * error.
+   *
+   * @tparam Index type.
+   * @tparam Attribute type.
+   * @param index_dim The index dimension.
+   * @param f Fragment index.
+   * @param non_empty_domains Vector of pointers to the non-empty domain for
+   *     each fragment.
+   *
+   */
+  template <typename IndexType, typename AttributeType>
+  void validate_with_loaded_tiles(
+      const Dimension* index_dim,
+      bool increasing_data,
+      uint64_t f,
+      const std::vector<const void*>& non_empty_domains,
+      const std::vector<shared_ptr<FragmentMetadata>> fragment_metadata,
+      const std::vector<uint64_t>& frag_first_array_tile_idx) {
+    const IndexType* non_empty_domain =
+        static_cast<const IndexType*>(non_empty_domains[f]);
+    const IndexType* dim_dom = index_dim->domain().typed_data<IndexType>();
+    auto tile_extent = index_dim->tile_extent().rvalue_as<IndexType>();
+
+    if (!min_validated(f)) {
+      // Get the min of the current fragment.
+      auto value = fragment_metadata[f]->get_tile_min_as<AttributeType>(
+          attribute_name_, 0);
+
+      // Get the previous value from the loaded tile.
+      auto rt = min_tile_to_compare_against(f);
+      const auto cell_idx =
+          non_empty_domain[0] -
+          index_dim->tile_coord_low(
+              rt->tile_idx() + frag_first_array_tile_idx[rt->frag_idx()],
+              dim_dom[0],
+              tile_extent) -
+          1;
+      AttributeType value_previous =
+          rt->attribute_value<AttributeType>(attribute_name_, cell_idx);
+
+      // Validate the order.
+      if (increasing_data) {
+        if (value_previous >= value) {
+          throw AttributeOrderValidatorStatusException(
+              "Attribute out of order");
+        }
+      } else {
+        if (value_previous <= value) {
+          throw AttributeOrderValidatorStatusException(
+              "Attribute out of order");
+        }
+      }
+    }
+
+    if (!max_validated(f)) {
+      // Get the min of the current fragment.
+      auto max_tile_idx = fragment_metadata[f]->tile_num() - 1;
+      auto value = fragment_metadata[f]->get_tile_max_as<AttributeType>(
+          attribute_name_, max_tile_idx);
+
+      // Get the previous value from the loaded tile.
+      auto rt = max_tile_to_compare_against(f);
+      const auto cell_idx =
+          non_empty_domain[1] -
+          index_dim->tile_coord_low(
+              rt->tile_idx() + frag_first_array_tile_idx[rt->frag_idx()],
+              dim_dom[0],
+              tile_extent) +
+          1;
+      AttributeType value_next =
+          rt->attribute_value<AttributeType>(attribute_name_, cell_idx);
+
+      // Validate the order.
+      if (increasing_data) {
+        if (value >= value_next) {
+          throw AttributeOrderValidatorStatusException(
+              "Attribute out of order");
+        }
+      } else {
+        if (value <= value_next) {
+          throw AttributeOrderValidatorStatusException(
+              "Attribute out of order");
+        }
+      }
+    }
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  std::string attribute_name_;
+
+  /** Map of result tiles to load, per fragments. */
+  std::vector<std::unordered_map<uint64_t, ResultTile>> result_tiles_to_load_;
+
+  /**
+   * Vector of pairs to store, per fragment, which min/max has been validated
+   * already.
+   */
+  std::vector<std::pair<bool, bool>> value_validated_;
+
+  /**
+   * Fragment to compare.
+   */
+  std::vector<std::pair<optional<uint64_t>, optional<uint64_t>>>
+      fragment_to_compare_against_;
+
+  /**
+   * Vector of pairs to store, per fragment, which tile we should compate data
+   * against for the min/max. The value is an index into
+   * `result_tiles_to_load_`.
+   */
+  std::vector<std::pair<uint64_t, uint64_t>> tile_to_compare_against_;
+
+  /* ********************************* */
+  /*         PRIVATE METHODS           */
+  /* ********************************* */
+
+  /**
+   * Add a tile to compare against when running the order validation against
+   * tile data.
+   *
+   * @param f Current fragment index.
+   * @param is_lower_bound Is this for the lower bound or upper bound.
+   * @param f_to_compare Fragment index of the tile to compare against.
+   * @param t_to_compare Tile index of the tile to compare against.
+   * @param schema Array schema.
+   */
+  inline void add_tile_to_load(
+      unsigned f,
+      bool is_lower_bound,
+      uint64_t f_to_compare,
+      uint64_t t_to_compare,
+      const ArraySchema& schema) {
+    auto it = result_tiles_to_load_[f].find(t_to_compare);
+    if (it == result_tiles_to_load_[f].end()) {
+      result_tiles_to_load_[f].emplace(
+          std::piecewise_construct,
+          std::forward_as_tuple(t_to_compare),
+          std::forward_as_tuple(f_to_compare, t_to_compare, schema));
+    }
+
+    if (is_lower_bound) {
+      tile_to_compare_against_[f].first = t_to_compare;
+    } else {
+      tile_to_compare_against_[f].second = t_to_compare;
+    }
+  }
+
+  /**
+   * Return the min validated value for a fragment.
+   *
+   * @param f Fragment index.
+   * @return reference to the min validated value.
+   */
+  inline bool& min_validated(unsigned f) {
+    return value_validated_[f].first;
+  }
+
+  /**
+   * Return the max validated value for a fragment.
+   *
+   * @param f Fragment index.
+   * @return reference to the max validated value.
+   */
+  inline bool& max_validated(unsigned f) {
+    return value_validated_[f].second;
+  }
+
+  /**
+   * Return the tile, for the fragment min, to compare against.
+   *
+   * @param f Fragment index.
+   * @return Tile to compare against.
+   */
+  inline ResultTile* min_tile_to_compare_against(unsigned f) {
+    return &result_tiles_to_load_[f][tile_to_compare_against_[f].first];
+  }
+
+  /**
+   * Return the tile, for the fragment max, to compare against.
+   *
+   * @param f Fragment index.
+   * @return Tile to compare against.
+   */
+  inline ResultTile* max_tile_to_compare_against(unsigned f) {
+    return &result_tiles_to_load_[f][tile_to_compare_against_[f].second];
+  }
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -510,7 +510,7 @@ class AttributeOrderValidator {
       fragment_to_compare_against_;
 
   /**
-   * Vector of pairs to store, per fragment, which tile we should compate data
+   * Vector of pairs to store, per fragment, which tile we should compare data
    * against for the min/max. The value is an index into
    * `result_tiles_to_load_`.
    */

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -64,7 +64,7 @@ class AttributeOrderValidatorStatusException : public StatusException {
  * @return Is the value in the given domain or not.
  */
 template <typename IndexType>
-bool in_domain(IndexType v, const IndexType* domain) {
+uint8_t in_domain(IndexType v, const IndexType* domain) {
   return v >= domain[0] && v <= domain[1];
 };
 

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -487,20 +487,11 @@ class AttributeOrderValidator {
 
   class AttributeOrderValidationData {
    public:
-    AttributeOrderValidationData()
-        : min_validated_(false)
-        , max_validated_(false)
-        , min_frag_to_compare_to_(nullopt)
-        , max_frag_to_compare_to_(nullopt)
-        , min_tile_to_compare_to_(nullopt)
-        , max_tile_to_compare_to_(nullopt) {
-    }
-
     /** Has the min has been validated already. */
-    bool min_validated_;
+    bool min_validated_{false};
 
     /** Has the max has been validated already. */
-    bool max_validated_;
+    bool max_validated_{false};
 
     /*
      * Which fragment index to validate the min bound against.
@@ -508,7 +499,7 @@ class AttributeOrderValidator {
      * If it was possible to validate the value without looking at another
      * fragment, this will be nullopt.
      */
-    optional<uint64_t> min_frag_to_compare_to_;
+    optional<uint64_t> min_frag_to_compare_to_{nullopt};
 
     /*
      * Which fragment index to validate the max bound against.
@@ -516,19 +507,19 @@ class AttributeOrderValidator {
      * If it was possible to validate the value without looking at another
      * fragment, this will be nullopt.
      */
-    optional<uint64_t> max_frag_to_compare_to_;
+    optional<uint64_t> max_frag_to_compare_to_{nullopt};
 
     /**
      * Which tile we should compare data against for the min. The value is an
      * index into `result_tiles_to_load_`.
      */
-    optional<uint64_t> min_tile_to_compare_to_;
+    optional<uint64_t> min_tile_to_compare_to_{nullopt};
 
     /**
      * Which tile we should compare data against for the max. The value is an
      * index into `result_tiles_to_load_`.
      */
-    optional<uint64_t> max_tile_to_compare_to_;
+    optional<uint64_t> max_tile_to_compare_to_ {nullopt};
   };
 
   /* ********************************* */

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -519,7 +519,7 @@ class AttributeOrderValidator {
      * Which tile we should compare data against for the max. The value is an
      * index into `result_tiles_to_load_`.
      */
-    optional<uint64_t> max_tile_to_compare_to_ {nullopt};
+    optional<uint64_t> max_tile_to_compare_to_{nullopt};
   };
 
   /* ********************************* */

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -95,11 +95,7 @@ OrderedDimLabelReader::OrderedDimLabelReader(
     , label_var_size_(array_schema_.attributes()[0]->var_size())
     , increasing_labels_(increasing_labels)
     , index_dim_(array_schema_.domain().dimension_ptr(0))
-    , non_empty_domains_(fragment_metadata_.size())
-    , tile_idx_min_(std::numeric_limits<uint64_t>::max())
-    , tile_idx_max_(std::numeric_limits<uint64_t>::min())
-    , result_tiles_(fragment_metadata_.size())
-    , frag_first_array_tile_idx_(fragment_metadata_.size()) {
+    , result_tiles_(fragment_metadata_.size()) {
   // Sanity checks.
   if (storage_manager_ == nullptr) {
     throw OrderedDimLabelReaderStatusException(
@@ -261,8 +257,24 @@ void OrderedDimLabelReader::label_read() {
   assert(std::is_integral<IndexType>::value);
 
   // Precompute data.
-  compute_non_empty_domain<IndexType>();
+  auto&& [non_empty_domain, non_empty_domains, frag_first_array_tile_idx] =
+      cache_dimension_label_data<IndexType>();
+  non_empty_domain_ = std::move(non_empty_domain);
+  non_empty_domains_ = std::move(non_empty_domains);
+  frag_first_array_tile_idx_ = std::move(frag_first_array_tile_idx);
   compute_array_tile_indexes_for_ranges<IndexType>();
+
+  // Make sure there are no holes in the written index data.
+  ensure_continuous_domain_written<IndexType>(non_empty_domains_);
+
+  // Validate order of the label data.
+  validate_attribute_order<IndexType>(
+      label_type_,
+      label_name_,
+      increasing_labels_,
+      non_empty_domain_,
+      non_empty_domains_,
+      frag_first_array_tile_idx_);
 
   // Save the offsets into the user buffer if we make more than one iteration
   // because of memory budgetting.
@@ -305,51 +317,18 @@ void OrderedDimLabelReader::label_read() {
 }
 
 template <typename IndexType>
-void OrderedDimLabelReader::compute_non_empty_domain() {
-  auto timer_se = stats_->start_timer("compute_non_empty_domain");
-
-  IndexType min = std::numeric_limits<IndexType>::max();
-  IndexType max = std::numeric_limits<IndexType>::min();
-
-  for (unsigned f = 0; f < fragment_metadata_.size(); f++) {
-    non_empty_domains_[f] = fragment_metadata_[f]->non_empty_domain()[0].data();
-    auto frag_non_empty_domain =
-        static_cast<const IndexType*>(non_empty_domains_[f]);
-    min = std::min(min, frag_non_empty_domain[0]);
-    max = std::max(max, frag_non_empty_domain[1]);
-  }
-
-  non_empty_domain_ = Range(&min, &max, sizeof(IndexType));
+void OrderedDimLabelReader::compute_array_tile_indexes_for_ranges() {
+  auto timer_se = stats_->start_timer("compute_array_tile_indexes_for_ranges");
 
   // Save the minimum/maximum tile indexes (in the full domain) to be used
   // later.
   auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
-  const IndexType* dim_dom =
-      static_cast<const IndexType*>(index_dim_->domain().data());
-  tile_idx_min_ = index_dim_->tile_idx(min, dim_dom[0], tile_extent);
-  tile_idx_max_ = index_dim_->tile_idx(max, dim_dom[0], tile_extent);
-}
-
-template <typename IndexType>
-void OrderedDimLabelReader::compute_array_tile_indexes_for_ranges() {
-  auto timer_se = stats_->start_timer("compute_array_tile_indexes_for_ranges");
-
-  // Compute the tile index (inside of the full domain) of the first tile for
-  // each fragments.
-  auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
-  const IndexType* dim_dom =
-      static_cast<const IndexType*>(index_dim_->domain().data());
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      fragment_metadata_.size(),
-      [&](uint64_t f) {
-        const IndexType* non_empty_domain =
-            static_cast<const IndexType*>(non_empty_domains_[f]);
-        frag_first_array_tile_idx_[f] = index_dim_->tile_idx<IndexType>(
-            non_empty_domain[0], dim_dom[0], tile_extent);
-        return Status::Ok();
-      }));
+  const IndexType* dim_dom = index_dim_->domain().typed_data<IndexType>();
+  auto array_non_empty_domain = non_empty_domain_.typed_data<IndexType>();
+  auto tile_idx_min =
+      index_dim_->tile_idx(array_non_empty_domain[0], dim_dom[0], tile_extent);
+  auto tile_idx_max =
+      index_dim_->tile_idx(array_non_empty_domain[1], dim_dom[0], tile_extent);
 
   // Compute the tile (by index) where the label values include each range
   // start and end. This is stored in the following value, by fragment/range.
@@ -376,7 +355,7 @@ void OrderedDimLabelReader::compute_array_tile_indexes_for_ranges() {
   throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, ranges_.size(), [&](uint64_t r) {
         per_range_array_tile_indexes_[r] = RangeTileIndexes(
-            tile_idx_min_, tile_idx_max_, per_range_array_tile_indexes[r]);
+            tile_idx_min, tile_idx_max, per_range_array_tile_indexes[r]);
         return Status::Ok();
       }));
 }
@@ -594,8 +573,7 @@ uint64_t OrderedDimLabelReader::create_result_tiles() {
 
   uint64_t max_range = 0;
   uint64_t total_mem_used = 0;
-  const IndexType* dim_dom =
-      static_cast<const IndexType*>(index_dim_->domain().data());
+  const IndexType* dim_dom = index_dim_->domain().typed_data<IndexType>();
   auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
 
   // Set of covered tiles, per fragment. The unordered set is for tile
@@ -652,24 +630,7 @@ template <typename LabelType>
 LabelType OrderedDimLabelReader::get_label_value(
     const unsigned f, const uint64_t tile_idx, const uint64_t cell_idx) {
   auto& rt = result_tiles_[f].at(tile_idx);
-  const auto label_data =
-      rt.tile_tuple(label_name_)->fixed_tile().template data_as<LabelType>();
-  return label_data[cell_idx];
-}
-
-template <>
-std::string_view OrderedDimLabelReader::get_label_value<std::string_view>(
-    const unsigned f, const uint64_t tile_idx, const uint64_t cell_idx) {
-  auto& rt = result_tiles_[f][tile_idx];
-  auto tile_tuple = rt.tile_tuple(label_name_);
-  auto offsets_data = tile_tuple->fixed_tile().template data_as<uint64_t>();
-  auto& var_tile = tile_tuple->var_tile();
-  auto offset = offsets_data[cell_idx];
-
-  auto size = static_cast<size_t>(cell_idx) == rt.cell_num() - 1 ?
-                  var_tile.size() - offset :
-                  offsets_data[cell_idx + 1] - offset;
-  return std::string_view(&var_tile.template data_as<char>()[offset], size);
+  return rt.attribute_value<LabelType>(label_name_, cell_idx);
 }
 
 template <typename IndexType, typename LabelType>
@@ -727,8 +688,7 @@ IndexType OrderedDimLabelReader::search_for_range(
   LabelType value = get_range_as<LabelType>(r, range_index);
 
   // Minimum index to look into.
-  auto non_empty_domain =
-      static_cast<const IndexType*>(non_empty_domain_.data());
+  auto non_empty_domain = non_empty_domain_.typed_data<IndexType>();
   auto t_min = per_range_array_tile_indexes_[r].min(range_index);
   auto left_index = std::max(
       index_dim_->tile_coord_low(t_min, domain_low, tile_extent),
@@ -776,10 +736,8 @@ void OrderedDimLabelReader::compute_and_copy_range_indexes(
     IndexType* dest, uint64_t r) {
   // For easy reference.
   auto tile_extent = index_dim_->tile_extent().rvalue_as<IndexType>();
-  const IndexType* dim_dom =
-      static_cast<const IndexType*>(index_dim_->domain().data());
-  auto non_empty_domain =
-      static_cast<const IndexType*>(non_empty_domain_.data());
+  const IndexType* dim_dom = index_dim_->domain().typed_data<IndexType>();
+  auto non_empty_domain = non_empty_domain_.typed_data<IndexType>();
 
   // Set the results.
   if (increasing_labels_) {

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -264,9 +264,6 @@ void OrderedDimLabelReader::label_read() {
   frag_first_array_tile_idx_ = std::move(frag_first_array_tile_idx);
   compute_array_tile_indexes_for_ranges<IndexType>();
 
-  // Make sure there are no holes in the written index data.
-  ensure_continuous_domain_written<IndexType>(non_empty_domains_);
-
   // Validate order of the label data.
   validate_attribute_order<IndexType>(
       label_type_,

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -326,12 +326,6 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   /** Non empty domain for the array. */
   Range non_empty_domain_;
 
-  /** Minimum array tile index of the non-empty domain. */
-  uint64_t tile_idx_min_;
-
-  /** Maximum array tile index of the non-empty domain. */
-  uint64_t tile_idx_max_;
-
   /**
    * Per fragment map to hold the result tiles. The key for the maps is the
    * tile index.
@@ -366,16 +360,6 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    */
   template <typename IndexType>
   void label_read();
-
-  /**
-   * Compute the non empty domain for the index dimension. Also caches the non
-   * empty domain of each fragments for future use and saves the non empty
-   * domain in tile indexes in `tile_idx_min_` and `tile_idx_max_`.
-   *
-   * @tparam The index type.
-   */
-  template <typename IndexType>
-  void compute_non_empty_domain();
 
   /**
    * Compute the tile indexes (min/max) that can potentially contain the label

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -1835,33 +1835,6 @@ ReaderBase::cache_dimension_label_data() {
           std::move(frag_first_array_tile_idx)};
 }
 
-template <typename IndexType>
-void ReaderBase::ensure_continuous_domain_written(
-    std::vector<const void*>& non_empty_domains) {
-  // Store the non empty domains in a vector and sort them by min.
-  std::vector<std::pair<IndexType, IndexType>> sorted_non_empty_domains(
-      fragment_metadata_.size());
-  for (uint64_t f = 0; f < fragment_metadata_.size(); f++) {
-    auto ned = static_cast<const IndexType*>(non_empty_domains[f]);
-    sorted_non_empty_domains[f] = std::make_pair(ned[0], ned[1]);
-  }
-  std::sort(sorted_non_empty_domains.begin(), sorted_non_empty_domains.end());
-
-  // Go through the sorted non empty domains and make sure there is no holes.
-  IndexType max_value = sorted_non_empty_domains[0].second;
-  for (auto& non_empty_domain : sorted_non_empty_domains) {
-    // If the start is greater than the current max, there is a
-    // discountinuity.
-    if (non_empty_domain.first > max_value + 1) {
-      throw ReaderBaseStatusException("Discontiuity found in array domain");
-    }
-
-    // Adjust the max. Since the non empty domains are sorted, the min never
-    // changes.
-    max_value = std::max(max_value, non_empty_domain.second);
-  }
-}
-
 template <typename IndexType, typename AttributeType>
 void ReaderBase::validate_attribute_order(
     std::string& attribute_name,
@@ -2195,22 +2168,6 @@ template tuple<Range, std::vector<const void*>, std::vector<uint64_t>>
 ReaderBase::cache_dimension_label_data<int64_t>();
 template tuple<Range, std::vector<const void*>, std::vector<uint64_t>>
 ReaderBase::cache_dimension_label_data<uint64_t>();
-template void ReaderBase::ensure_continuous_domain_written<int8_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<uint8_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<int16_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<uint16_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<int32_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<uint32_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<int64_t>(
-    std::vector<const void*>&);
-template void ReaderBase::ensure_continuous_domain_written<uint64_t>(
-    std::vector<const void*>&);
 template void ReaderBase::validate_attribute_order<int8_t>(
     Datatype,
     std::string&,

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -1888,6 +1888,7 @@ void ReaderBase::validate_attribute_order(
     auto tiles_to_load = validator.tiles_to_load();
     throw_if_not_ok(read_attribute_tiles({attribute_name}, tiles_to_load));
     throw_if_not_ok(unfilter_tiles(attribute_name, tiles_to_load));
+
     // Validate bounds not validated using tile data.
     throw_if_not_ok(parallel_for(
         storage_manager_->compute_tp(),

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -753,18 +753,6 @@ class ReaderBase : public StrategyBase {
   cache_dimension_label_data();
 
   /**
-   * Ensures a continuous (with no holes) domain is written. Compute non empty
-   * domain at the same time.
-   *
-   * @tparam Index type.
-   * @param non_empty_domains Vector of pointers to the non empty domains for
-   * each fragments.
-   */
-  template <typename IndexType>
-  void ensure_continuous_domain_written(
-      std::vector<const void*>& non_empty_domains);
-
-  /**
    * Validate the attribute order using the tile min/max. The list of tiles to
    * load to process the remaining bounds is returned in
    * AttributeOrderValidationData with the list of bounds that are already

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -103,149 +103,6 @@ class ReaderBase : public StrategyBase {
     }
   };
 
-  class AttributeOrderValidationData {
-   public:
-    /* ********************************* */
-    /*     CONSTRUCTORS & DESTRUCTORS    */
-    /* ********************************* */
-    AttributeOrderValidationData() = delete;
-
-    /**
-     * Construct a new Order Validation Data object.
-     *
-     * @param num_frags Number of fragments.
-     */
-    AttributeOrderValidationData(uint64_t num_frags)
-        : result_tiles_to_load_(num_frags)
-        , value_validated_(num_frags)
-        , tile_to_compare_against_(num_frags) {
-    }
-
-    /* ********************************* */
-    /*                 API               */
-    /* ********************************* */
-
-    /**
-     * Add a tile to compare against when running the order validation against
-     * tile data.
-     *
-     * @param f Current fragment index.
-     * @param is_lower_bound Is this for the lower bound or upper bound.
-     * @param f_to_compare Fragment index of the tile to compare against.
-     * @param t_to_compare Tile index of the tile to compare against.
-     * @param schema Array schema.
-     */
-    inline void add_tile_to_load(
-        unsigned f,
-        bool is_lower_bound,
-        uint64_t f_to_compare,
-        uint64_t t_to_compare,
-        const ArraySchema& schema) {
-      auto it = result_tiles_to_load_[f].find(t_to_compare);
-      if (it == result_tiles_to_load_[f].end()) {
-        result_tiles_to_load_[f].emplace(
-            std::piecewise_construct,
-            std::forward_as_tuple(t_to_compare),
-            std::forward_as_tuple(f_to_compare, t_to_compare, schema));
-      }
-
-      if (is_lower_bound) {
-        tile_to_compare_against_[f].first = t_to_compare;
-      } else {
-        tile_to_compare_against_[f].second = t_to_compare;
-      }
-    }
-
-    /**
-     * Return the min validated value for a fragment.
-     *
-     * @param f Fragment index.
-     * @return reference to the min validated value.
-     */
-    inline bool& min_validated(unsigned f) {
-      return value_validated_[f].first;
-    }
-
-    /**
-     * Return the max validated value for a fragment.
-     *
-     * @param f Fragment index.
-     * @return reference to the max validated value.
-     */
-    inline bool& max_validated(unsigned f) {
-      return value_validated_[f].second;
-    }
-
-    /**
-     * Return the tile, for the fragment min, to compare against.
-     *
-     * @param f Fragment index.
-     * @return Tile to compare against.
-     */
-    inline ResultTile* min_tile_to_compare_against(unsigned f) {
-      return &result_tiles_to_load_[f][tile_to_compare_against_[f].first];
-    }
-
-    /**
-     * Return the tile, for the fragment max, to compare against.
-     *
-     * @param f Fragment index.
-     * @return Tile to compare against.
-     */
-    inline ResultTile* max_tile_to_compare_against(unsigned f) {
-      return &result_tiles_to_load_[f][tile_to_compare_against_[f].second];
-    }
-
-    /** Returns 'true' if tiles need to be loaded. */
-    inline bool need_to_load_tiles() {
-      for (auto& rt_map : result_tiles_to_load_) {
-        if (!rt_map.empty()) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    /** Returns a vector of pointers to tiles to load. */
-    std::vector<ResultTile*> tiles_to_load() {
-      std::vector<ResultTile*> ret;
-      uint64_t size = 0;
-      for (auto& rt_map : result_tiles_to_load_) {
-        size += rt_map.size();
-      }
-
-      ret.reserve(size);
-      for (auto& rt_map : result_tiles_to_load_) {
-        for (auto& rt : rt_map) {
-          ret.emplace_back(&rt.second);
-        }
-      }
-
-      return ret;
-    }
-
-   private:
-    /* ********************************* */
-    /*         PRIVATE ATTRIBUTES        */
-    /* ********************************* */
-
-    /** Map of result tiles to load, per fragments. */
-    std::vector<std::unordered_map<uint64_t, ResultTile>> result_tiles_to_load_;
-
-    /**
-     * Vector of pairs to store, per fragment, which min/max has been validated
-     * already.
-     */
-    std::vector<std::pair<bool, bool>> value_validated_;
-
-    /**
-     * Vector of pairs to store, per fragment, which tile we should compate data
-     * against for the min/max. The value is an index into
-     * `result_tiles_to_load_`.
-     */
-    std::vector<std::pair<uint64_t, uint64_t>> tile_to_compare_against_;
-  };
-
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -908,25 +765,6 @@ class ReaderBase : public StrategyBase {
       std::vector<const void*>& non_empty_domains);
 
   /**
-   * Computes, for attribute ordering check, for a fragment if the non empty
-   * domain bounds are already validated by previous fragments.
-   *
-   * @tparam Index type.
-   * @param array_min_idx Minimum index value for the array.
-   * @param array_max_idx Maximum index value for the array.
-   * @param f Fragment index.
-   * @param non_empty_domains Vector of pointers to the non empty domains for
-   * each fragments.
-   * @return Min validated, max validated.
-   */
-  template <typename IndexType>
-  std::pair<bool, bool> attribute_order_ned_bounds_already_validated(
-      IndexType array_min_idx,
-      IndexType array_max_idx,
-      uint64_t f,
-      std::vector<const void*>& non_empty_domains);
-
-  /**
    * Validate the attribute order using the tile min/max. The list of tiles to
    * load to process the remaining bounds is returned in
    * AttributeOrderValidationData with the list of bounds that are already
@@ -973,27 +811,6 @@ class ReaderBase : public StrategyBase {
       Range& array_non_empty_domain,
       std::vector<const void*>& non_empty_domains,
       std::vector<uint64_t>& frag_first_array_tile_idx);
-
-  /**
-   * Complete order validation after required tiles have been loaded by the
-   * reader.
-   *
-   * @tparam Index type
-   * @tparam Attribute type
-   * @param attribute_name Name of the attribute to validate.
-   * @param increasing_data Is the order of the data increasing?
-   * @param non_empty_domains Pointer, per fragment, to the non empty domains.
-   * @param frag_first_array_tile_idx First tile index (in full domain), per
-   * fragment.
-   * @param order_validation_data Order validation data.
-   */
-  template <typename IndexType, typename AttributeType>
-  void validate_attribute_order_with_tile_data(
-      std::string& attribute_name,
-      bool increasing_data,
-      std::vector<const void*>& non_empty_domains,
-      std::vector<uint64_t>& frag_first_array_tile_idx,
-      AttributeOrderValidationData& order_validation_data);
 
  private:
   /**

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -753,10 +753,10 @@ class ReaderBase : public StrategyBase {
   cache_dimension_label_data();
 
   /**
-   * Validate the attribute order using the tile min/max. The list of tiles to
-   * load to process the remaining bounds is returned in
-   * AttributeOrderValidationData with the list of bounds that are already
-   * validated.
+   * Validates the attribute order for all loaded fragments.
+   *
+   * Throws an error if the there is a gap between fragments or the attribute
+   * order between fragments is not maintained.
    *
    * @tparam Index type
    * @tparam Attribute type
@@ -766,7 +766,6 @@ class ReaderBase : public StrategyBase {
    * @param non_empty_domains Pointer, per fragment, to the non empty domains.
    * @param frag_first_array_tile_idx First tile index (in full domain), per
    * fragment.
-   * @return Order validation data.
    */
   template <typename IndexType, typename AttributeType>
   void validate_attribute_order(
@@ -777,10 +776,10 @@ class ReaderBase : public StrategyBase {
       std::vector<uint64_t>& frag_first_array_tile_idx);
 
   /**
-   * Validate the attribute order using the tile min/max. The list of tiles to
-   * load to process the remaining bounds is returned in
-   * AttributeOrderValidationData with the list of bounds that are already
-   * validated.
+   * Validates the attribute order for all loaded fragments.
+   *
+   * Throws an error if the there is a gap between fragments or the attribute
+   * order between fragments is not maintained.
    *
    * @tparam Index type
    * @param attribute_type Type of the attribute to validate.

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -339,7 +339,7 @@ template <typename LabelType>
 LabelType ResultTile::attribute_value(
     const std::string& label_name, const uint64_t pos) {
   const auto label_data =
-      tile_tuple(label_name)->fixed_tile().template data_as<LabelType>();
+      tile_tuple(label_name)->fixed_tile().data_as<LabelType>();
   return label_data[pos];
 }
 
@@ -347,14 +347,14 @@ template <>
 std::string_view ResultTile::attribute_value<std::string_view>(
     const std::string& label_name, const uint64_t pos) {
   auto tuple = tile_tuple(label_name);
-  auto offsets_data = tuple->fixed_tile().template data_as<uint64_t>();
+  auto offsets_data = tuple->fixed_tile().data_as<uint64_t>();
   auto& var_tile = tuple->var_tile();
   auto offset = offsets_data[pos];
 
   auto size = static_cast<size_t>(pos) == cell_num() - 1 ?
                   var_tile.size() - offset :
                   offsets_data[pos + 1] - offset;
-  return std::string_view(&var_tile.template data_as<char>()[offset], size);
+  return std::string_view(&var_tile.data_as<char>()[offset], size);
 }
 
 unsigned ResultTile::frag_idx() const {

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -335,6 +335,28 @@ uint64_t ResultTile::timestamp(uint64_t pos) {
   return tile.data_as<uint64_t>()[pos];
 }
 
+template <typename LabelType>
+LabelType ResultTile::attribute_value(
+    const std::string& label_name, const uint64_t pos) {
+  const auto label_data =
+      tile_tuple(label_name)->fixed_tile().template data_as<LabelType>();
+  return label_data[pos];
+}
+
+template <>
+std::string_view ResultTile::attribute_value<std::string_view>(
+    const std::string& label_name, const uint64_t pos) {
+  auto tuple = tile_tuple(label_name);
+  auto offsets_data = tuple->fixed_tile().template data_as<uint64_t>();
+  auto& var_tile = tuple->var_tile();
+  auto offset = offsets_data[pos];
+
+  auto size = static_cast<size_t>(pos) == cell_num() - 1 ?
+                  var_tile.size() - offset :
+                  offsets_data[pos + 1] - offset;
+  return std::string_view(&var_tile.template data_as<char>()[offset], size);
+}
+
 unsigned ResultTile::frag_idx() const {
   return frag_idx_;
 }
@@ -1348,6 +1370,28 @@ void ResultTile::set_compute_results_func() {
     }
   }
 }
+
+// Explicit template instantiations
+template int8_t ResultTile::attribute_value<int8_t>(
+    const std::string&, const uint64_t);
+template uint8_t ResultTile::attribute_value<uint8_t>(
+    const std::string&, const uint64_t);
+template int16_t ResultTile::attribute_value<int16_t>(
+    const std::string&, const uint64_t);
+template uint16_t ResultTile::attribute_value<uint16_t>(
+    const std::string&, const uint64_t);
+template int32_t ResultTile::attribute_value<int32_t>(
+    const std::string&, const uint64_t);
+template uint32_t ResultTile::attribute_value<uint32_t>(
+    const std::string&, const uint64_t);
+template int64_t ResultTile::attribute_value<int64_t>(
+    const std::string&, const uint64_t);
+template uint64_t ResultTile::attribute_value<uint64_t>(
+    const std::string&, const uint64_t);
+template float ResultTile::attribute_value<float>(
+    const std::string&, const uint64_t);
+template double ResultTile::attribute_value<double>(
+    const std::string&, const uint64_t);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -412,6 +412,13 @@ class ResultTile {
    */
   uint64_t timestamp(uint64_t pos);
 
+  /**
+   * Returns the dimension label value for the `label_name` attribute at
+   * position `pos`.
+   */
+  template <typename LabelType>
+  LabelType attribute_value(const std::string& label_name, const uint64_t pos);
+
   /** Returns the fragment id that this result tile belongs to. */
   unsigned frag_idx() const;
 


### PR DESCRIPTION
This adds attribute ordering checks to the ordered dimension label reader. The checks will later be used in consolidation, so the code has been added to `ReaderBase`. The check assumes that each fragment is already ordered by the attribute independently. The algorithm first validates that the array non-empty domain across the first dimension has no holes, meaning that every cell was written. Then, it checks each fragment's non-empty domains and sees if any bounds can be skipped. They can be skipped for the array min/max, or for bounds that were fully overwritten by new fragments. Also, if a bound is right next to another bound, we will only validate the first. Then, bounds can be validated with the tile mins/maxs. Any bound that is tile aligned or bound that is next to another can be validated using this method, which is not computationally expensive. If a bound is not tile aligned, we unfortunately need to load the tile of the next fragment that intersects this bound to read the next or previous value.

---
TYPE: IMPROVEMENT
DESC: Adding attribute ordering checks to ordered dimension label reader.
