### PR TITLE
Remove StorageManager dep from GenericTileIO

### DIFF
--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -168,7 +168,11 @@ Status FragmentMetaConsolidator::consolidate(
       buff.data(),
       buff.size());
 
-  GenericTileIO tile_io(storage_manager_, uri);
+  GenericTileIO tile_io(
+          storage_manager_->vfs(),
+          storage_manager_->stats(),
+          storage_manager_->compute_tp(),
+          uri);
   uint64_t nbytes = 0;
   RETURN_NOT_OK_ELSE(
       tile_io.write_generic(&tile, enc_key, &nbytes), buff.clear());

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1189,6 +1189,19 @@ Status VFS::read(
   }
 }
 
+Status VFS::read(
+    const URI& uri,
+    uint64_t offset,
+    Buffer* buffer,
+    uint64_t nbytes) {
+  RETURN_NOT_OK(buffer->realloc(nbytes));
+  RETURN_NOT_OK(read(uri, offset, buffer->data(), nbytes));
+  buffer->set_size(nbytes);
+  buffer->reset_offset();
+
+  return Status::Ok();
+}
+
 Status VFS::read_impl(
     const URI& uri,
     const uint64_t offset,

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -382,6 +382,18 @@ class VFS {
       bool use_read_ahead = true);
 
   /**
+   * Reads from a file into the input buffer.
+   *
+   * @param uri The URI file to read from.
+   * @param offset The offset in the file the read will start from.
+   * @param buffer The buffer to write into. The function reallocates memory
+   *     for the buffer, sets its size to *nbytes* and resets its offset.
+   * @param nbytes The number of bytes to read.
+   * @return Status.
+   */
+  Status read(const URI& uri, uint64_t offset, Buffer* buffer, uint64_t nbytes);
+
+  /**
    * Reads multiple regions from a file.
    *
    * @param uri The URI of the file.

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3736,7 +3736,11 @@ Status FragmentMetadata::load_v1_v2(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+          storage_manager_->vfs(),
+          storage_manager_->stats(),
+          storage_manager_->compute_tp(),
+          fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(0, encryption_key, storage_manager_->config());
   RETURN_NOT_OK(st);
@@ -4172,7 +4176,11 @@ tuple<Status, optional<Tile>> FragmentMetadata::read_generic_tile_from_file(
       std::string(constants::fragment_metadata_filename));
 
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+          storage_manager_->vfs(),
+          storage_manager_->stats(),
+          storage_manager_->compute_tp(),
+          fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(offset, encryption_key, storage_manager_->config());
   RETURN_NOT_OK_TUPLE(st, nullopt);
@@ -4217,7 +4225,11 @@ Status FragmentMetadata::write_generic_tile_to_file(
       buff.data(),
       buff.size());
 
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+          storage_manager_->vfs(),
+          storage_manager_->stats(),
+          storage_manager_->compute_tp(),
+          fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
   return Status::Ok();
@@ -4228,7 +4240,11 @@ Status FragmentMetadata::write_generic_tile_to_file(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
 
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+          storage_manager_->vfs(),
+          storage_manager_->stats(),
+          storage_manager_->compute_tp(),
+          fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
   return Status::Ok();

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -33,11 +33,13 @@
 #ifndef TILEDB_GENERIC_TILE_IO_H
 #define TILEDB_GENERIC_TILE_IO_H
 
+#include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
+#include "tiledb/sm/stats/stats.h"
 
 using namespace tiledb::common;
 
@@ -99,10 +101,13 @@ class GenericTileIO {
   /**
    * Constructor.
    *
-   * @param storage_manager The storage manager.
+   * @param vfs The VFS instance to use for IO
+   * @param stats The stats instance to use
+   * @param compute_tp The thread pool instance to use for filters
    * @param uri The name of the file that stores data.
    */
-  GenericTileIO(StorageManager* storage_manager, const URI& uri);
+  GenericTileIO(
+      VFS* vfs, stats::Stats* stats, ThreadPool* compute_tp, const URI& uri);
 
   GenericTileIO() = delete;
   DISABLE_COPY_AND_COPY_ASSIGN(GenericTileIO);
@@ -135,7 +140,7 @@ class GenericTileIO {
   /**
    * Reads the generic tile header from the file.
    *
-   * @param sm The StorageManager instance to use for reading.
+   * @param vfs The VFS instance to use for reading.
    * @param uri The URI of the generic tile.
    * @param file_offset The offset where the header read will begin.
    * @param encryption_key If the array is encrypted, the private encryption
@@ -143,7 +148,7 @@ class GenericTileIO {
    * @return Status, Header
    */
   static tuple<Status, optional<GenericTileHeader>> read_generic_tile_header(
-      const StorageManager* sm, const URI& uri, uint64_t file_offset);
+      VFS* vfs, const URI& uri, uint64_t file_offset);
 
   /**
    * Writes a tile generically to the file. This means that a header will be
@@ -181,8 +186,14 @@ class GenericTileIO {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The storage manager object. */
-  StorageManager* storage_manager_;
+  /** The VFS object. */
+  VFS* vfs_;
+
+  /** The stats object. */
+  stats::Stats* stats_;
+
+  /** The compute threadpool object. */
+  ThreadPool* compute_tp_;
 
   /** The file URI. */
   URI uri_;


### PR DESCRIPTION
This is a pretty basic removal of the StorageManager dependency by passing the required vfs, stats, and compute_tp pointers directly. The only subtlety is that it required moving the StorageManager::read variant for buffers into VFS as well.

---
TYPE: IMPROVEMENT
DESC: Remove StorageManager dependency from GenericTileIO
