### PR TITLE
Fix parsing of multiple enable= arguments to bootstrap script

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -141,7 +141,7 @@ while test $# != 0; do
     --enable-abseil) tiledb_build_abseil="ON";;
     --enable-experimental-features) tiledb_experimental_features="ON";;
     --enable=*) s=`arg "$1"`
-                enable_multiple="$s";;
+                enable_multiple+="$s,";;
     --help) usage ;;
     *) die "Unknown option: $1" ;;
     esac

--- a/bootstrap
+++ b/bootstrap
@@ -141,7 +141,7 @@ while test $# != 0; do
     --enable-abseil) tiledb_build_abseil="ON";;
     --enable-experimental-features) tiledb_experimental_features="ON";;
     --enable=*) s=`arg "$1"`
-                enable_multiple+="$s,";;
+                enable_multiple+="${enable_multiple:+,}${s}";;
     --help) usage ;;
     *) die "Unknown option: $1" ;;
     esac


### PR DESCRIPTION
The following bootstrap invocation did not work correctly. Prior to this PR, only the `--enable=verbose` argument is handled, because the handler loop resets the `enable_multiple` internal variable when it encounters the second `enable=`:
```
bootstrap --enable=s3,serialization,tools --enable-release-symbols --enable=verbose
```
Fix by appending multiple `enable=` argument-sets together.

---
TYPE: BUG
DESC: Fix parsing of multiple enable= arguments to bootstrap script
