### PR TITLE
Add Boolean Support For Sparse Query Conditions

### DIFF
--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1933,6 +1933,7 @@ void QueryCondition::apply_ast_node_sparse(
       apply_ast_node_sparse<int8_t, BitmapType, CombinationOp>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
+    case Datatype::BOOL:
     case Datatype::UINT8: {
       apply_ast_node_sparse<uint8_t, BitmapType, CombinationOp>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);


### PR DESCRIPTION
* This is supported in the dense case here: https://github.com/TileDB-Inc/TileDB/blob/dev/tiledb/sm/query/query_condition.cc#L1234-L1235 But missing for the sparse case
---
TYPE: BUG
DESC: Add Boolean Support For Sparse Query Conditions
