### PR TITLE
Remove StorageManager::array_close_for_* methods

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -157,25 +157,6 @@ StorageManagerCanonical::~StorageManagerCanonical() {
 /*               API              */
 /* ****************************** */
 
-Status StorageManagerCanonical::array_close_for_reads(Array*) {
-  return Status::Ok();
-}
-
-Status StorageManagerCanonical::array_close_for_writes(Array* array) {
-  // Flush the array metadata
-  RETURN_NOT_OK(store_metadata(
-      array->array_uri(), *array->encryption_key(), array->unsafe_metadata()));
-  return Status::Ok();
-}
-
-Status StorageManagerCanonical::array_close_for_deletes(Array*) {
-  return Status::Ok();
-}
-
-Status StorageManagerCanonical::array_close_for_updates(Array*) {
-  return Status::Ok();
-}
-
 Status StorageManagerCanonical::group_close_for_reads(Group* group) {
   assert(open_groups_.find(group) != open_groups_.end());
 

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -151,38 +151,6 @@ class StorageManagerCanonical {
   /* ********************************* */
 
   /**
-   * Closes an array opened for reads.
-   *
-   * @param array The array to be closed.
-   * @return Status
-   */
-  Status array_close_for_reads(Array* array);
-
-  /**
-   * Closes an array opened for writes.
-   *
-   * @param array The array to be closed.
-   * @return Status
-   */
-  Status array_close_for_writes(Array* array);
-
-  /**
-   * Closes an array opened for deletes.
-   *
-   * @param array The array to be closed.
-   * @return Status
-   */
-  Status array_close_for_deletes(Array* array);
-
-  /**
-   * Closes an array opened for updates.
-   *
-   * @param array The array to be closed.
-   * @return Status
-   */
-  Status array_close_for_updates(Array* array);
-
-  /**
    * Closes an group opened for reads.
    *
    * @param group The group to be closed.


### PR DESCRIPTION
After removing the open_arrays_ variable in StorageManager this group of functions effectively become no-ops except for the close for write method that flushes the metadata before closing. This commit just removes the functions and flushes the metadata directly in array.cc

---
TYPE: IMPROVEMENT
DESC: Remove StorageManager::array_close_for_$type methods
