### PR TITLE
Move new fragment timestamp to Query

### DIFF
--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
@@ -62,6 +62,7 @@ class DeletesAndUpdates : public StrategyBase, public IQueryStrategy {
       Layout layout,
       QueryCondition& condition,
       std::vector<UpdateValue>& update_values,
+      uint64_t fragment_timestamp,
       bool skip_checks_serialization = false);
 
   /** Destructor. */
@@ -106,6 +107,9 @@ class DeletesAndUpdates : public StrategyBase, public IQueryStrategy {
 
   /** The update values, owned by the query. */
   std::vector<UpdateValue>& update_values_;
+
+  /** The timestamp to use for the new fragment. */
+  uint64_t fragment_timestamp_;
 
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -55,16 +55,17 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
     const std::unordered_map<std::string, QueryBuffer>& array_buffers,
-    const optional<std::string>& fragment_name)
+    const optional<std::string>& fragment_name,
+    optional<uint64_t> fragment_timestamp)
     : storage_manager_(storage_manager)
     , label_range_queries_by_dim_idx_(subarray.dim_num(), nullptr)
     , label_data_queries_by_dim_idx_(subarray.dim_num())
-    , range_query_status_{QueryStatus::UNINITIALIZED}
-    , fragment_name_{fragment_name} {
+    , range_query_status_{QueryStatus::UNINITIALIZED} {
   switch (array->get_query_type()) {
     case (QueryType::READ):
       // Add dimension label queries for parent array open for reading.
-      add_read_queries(array, subarray, label_buffers, array_buffers);
+      add_read_queries(
+          array, subarray, label_buffers, fragment_name, fragment_timestamp);
       break;
 
     case (QueryType::WRITE):
@@ -72,7 +73,8 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
       // If no label buffers, then we are reading index ranges from label ranges
       // for writing to the main array.
       if (label_buffers.empty()) {
-        add_read_queries(array, subarray, label_buffers, array_buffers);
+        add_read_queries(
+            array, subarray, label_buffers, fragment_name, fragment_timestamp);
         break;
 
       } else {
@@ -83,20 +85,14 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
               "buffer and label range on a write query.");
         }
 
-        // If fragment name is not set, set it.
-        // TODO: As implemented, the timestamp for the dimension label fragment
-        // may be different than the main array. This should be updated to
-        // either always get the fragment name from the parent array on writes
-        // or to get the timestamp_end from the parent array. This fix is
-        // blocked by current discussion on a timestamp refactor design.
-        if (!fragment_name_.has_value()) {
-          fragment_name_ = storage_format::generate_fragment_name(
-              array->timestamp_end_opened_at(),
-              array->array_schema_latest().write_version());
-        }
-
         // Add dimension label queries for parent array open for writing.
-        add_write_queries(array, subarray, label_buffers, array_buffers);
+        add_write_queries(
+            array,
+            subarray,
+            label_buffers,
+            array_buffers,
+            fragment_name,
+            fragment_timestamp);
         break;
       }
 
@@ -195,7 +191,8 @@ void ArrayDimensionLabelQueries::add_read_queries(
     Array* array,
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
-    const std::unordered_map<std::string, QueryBuffer>&) {
+    const optional<std::string>& fragment_name,
+    optional<uint64_t> fragment_timestamp) {
   // Add queries for the dimension labels that have ranges added to the
   // subarray.
   for (ArraySchema::dimension_size_type dim_idx{0};
@@ -266,7 +263,8 @@ void ArrayDimensionLabelQueries::add_read_queries(
           subarray,
           label_buffer,
           QueryBuffer(),
-          nullopt));
+          fragment_name,
+          fragment_timestamp));
       label_data_queries_by_dim_idx_[dim_label_ref.dimension_index()].push_back(
           data_queries_.back().get());
     } catch (...) {
@@ -281,7 +279,9 @@ void ArrayDimensionLabelQueries::add_write_queries(
     Array* array,
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
-    const std::unordered_map<std::string, QueryBuffer>& array_buffers) {
+    const std::unordered_map<std::string, QueryBuffer>& array_buffers,
+    const optional<std::string>& fragment_name,
+    optional<uint64_t> fragment_timestamp) {
   // Add queries to write data to dimension labels.
   for (const auto& [label_name, label_buffer] : label_buffers) {
     try {
@@ -319,7 +319,8 @@ void ArrayDimensionLabelQueries::add_write_queries(
           (index_buffer_pair == array_buffers.end()) ?
               QueryBuffer() :
               index_buffer_pair->second,
-          fragment_name_));
+          fragment_name,
+          fragment_timestamp));
       label_data_queries_by_dim_idx_[dim_label_ref.dimension_index()].push_back(
           data_queries_.back().get());
     } catch (...) {

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -75,6 +75,8 @@ class ArrayDimensionLabelQueries {
    * @param array_bufffers A map of query buffers containing dimension and
    *     attribute data for the parent array.
    * @param fragment_name Optional fragment name for writing fragments.
+   * @param fragment_timestamp Timestamp to use for new fragments if
+   *     fragment_name is not set.
    */
   ArrayDimensionLabelQueries(
       StorageManager* storage_manager,
@@ -82,7 +84,8 @@ class ArrayDimensionLabelQueries {
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
       const std::unordered_map<std::string, QueryBuffer>& array_buffers,
-      const optional<std::string>& fragment_name);
+      const optional<std::string>& fragment_name,
+      optional<uint64_t> fragment_timestamp);
 
   /** Disable copy and move. */
   DISABLE_COPY_AND_COPY_ASSIGN(ArrayDimensionLabelQueries);
@@ -167,26 +170,21 @@ class ArrayDimensionLabelQueries {
   QueryStatus range_query_status_;
 
   /**
-   * The name of the new fragment to be created for writes.
-   *
-   * If not set, the fragment will be created using the latest array timestamp
-   * and a generated UUID.
-   */
-  optional<std::string> fragment_name_;
-
-  /**
    * Initializes read queries.
    *
    * @param array Array for the parent query.
    * @param subarray Subarray for the parent query.
    * @param label_buffers A map of query buffers with label buffers.
-   * @param array_buffers Non-label buffers set on the parent query.
+   * @param fragment_name Optional fragment name for writing fragments.
+   * @param fragment_timestamp Timestamp to use for new fragments if
+   *     fragment_name is not set.
    */
   void add_read_queries(
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
-      const std::unordered_map<std::string, QueryBuffer>& array_buffers);
+      const optional<std::string>& fragment_name,
+      optional<uint64_t> fragment_timestamp);
 
   /**
    * Initializes write queries.
@@ -195,12 +193,17 @@ class ArrayDimensionLabelQueries {
    * @param subarray Subarray for the parent query.
    * @param label_buffers A map of query buffers with label buffers.
    * @param array_buffers Non-label buffers set on the parent query.
+   * @param fragment_name Optional fragment name for writing fragments.
+   * @param fragment_timestamp Timestamp to use for new fragments if
+   *     fragment_name is not set.
    */
   void add_write_queries(
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
-      const std::unordered_map<std::string, QueryBuffer>& array_buffers);
+      const std::unordered_map<std::string, QueryBuffer>& array_buffers,
+      const optional<std::string>& fragment_name,
+      optional<uint64_t> fragment_timestamp);
 
   /**
    * Opens a dimension label.

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -56,8 +56,9 @@ DimensionLabelQuery::DimensionLabelQuery(
     const Subarray& parent_subarray,
     const QueryBuffer& label_buffer,
     const QueryBuffer& index_buffer,
-    optional<std::string> fragment_name)
-    : Query(storage_manager, dim_label, fragment_name)
+    const optional<std::string>& fragment_name,
+    optional<uint64_t> fragment_timestamp)
+    : Query(storage_manager, dim_label, fragment_name, fragment_timestamp)
     , dim_label_name_{dim_label_ref.name()} {
   switch (dim_label->get_query_type()) {
     case (QueryType::READ):

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -74,6 +74,8 @@ class DimensionLabelQuery : public Query {
    * @param index_buffer Query buffer for the index data. May be empty if no
    *     index buffer is set.
    * @param fragment_name Name to use when writing the fragment.
+   * @param fragment_timestamp Timestamp to use for new fragments if fragment
+   *     name isn't set.
    */
   DimensionLabelQuery(
       StorageManager* storage_manager,
@@ -82,7 +84,8 @@ class DimensionLabelQuery : public Query {
       const Subarray& parent_subarray,
       const QueryBuffer& label_buffer,
       const QueryBuffer& index_buffer,
-      optional<std::string> fragment_name);
+      const optional<std::string>& fragment_name,
+      optional<uint64_t> fragment_timestamp);
 
   /**
    * Constructor for range queries.

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1152,7 +1152,6 @@ Status Query::reset_strategy_with_layout(
     dynamic_cast<StrategyBase*>(strategy_.get())->stats()->reset();
     strategy_ = nullptr;
   }
-  // TODO: Check if this happens before or after initialization
   layout_ = layout;
   subarray_.set_layout(layout);
   RETURN_NOT_OK(create_strategy(true));

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -107,8 +107,7 @@ Query::Query(
     , consolidation_with_timestamps_(false)
     , force_legacy_reader_(false)
     , fragment_name_(fragment_name)
-    , default_fragment_timestamp_(fragment_timestamp)
-    , current_fragment_timestamp_(nullopt)
+    , fragment_timestamp_(fragment_timestamp)
     , remote_query_(false)
     , is_dimension_label_ordered_read_(false)
     , dimension_label_increasing_(true)
@@ -135,6 +134,29 @@ Query::Query(
   throw_if_not_ok(subarray_.set_config(config_));
 
   rest_scratch_ = make_shared<Buffer>(HERE());
+
+  // If provided, update the fragment timestamp to match that given by the
+  // fragment name.
+  // TODO: Handle ranges.
+  // TODO: If this is appropriate, create a new function in parse_uri.cc that
+  // takes just the fragment name, not the URI.
+  if (fragment_name_.has_value()) {
+    std::pair<uint64_t, uint64_t> timestamp_range;
+    throw_if_not_ok(utils::parse::get_timestamp_range(
+        URI(fragment_name_.value()), &timestamp_range));
+    if (fragment_timestamp_.has_value()) {
+      // Fragment timestamp was also set. Make sure the timestamps match.
+      if (fragment_timestamp_.value() != timestamp_range.first) {
+        throw QueryStatusException(
+            "Cannot create query; Mismatched values provided for the fragment "
+            "name and fragment timestamp.");
+      }
+
+    } else {
+      // Set the fragment timestamp.
+      fragment_timestamp_ = timestamp_range.first;
+    }
+  }
 }
 
 Query::~Query() {
@@ -474,7 +496,7 @@ Status Query::submit_and_finalize() {
                             "with no rest client."));
 
     if (status_ == QueryStatus::UNINITIALIZED) {
-      RETURN_NOT_OK(create_strategy());
+      RETURN_NOT_OK(create_strategy(get_fragment_timestamp()));
     }
     return rest_client->submit_and_finalize_query_to_rest(
         array_->array_uri(), this);
@@ -979,11 +1001,9 @@ Status Query::init() {
     // Check the buffer names.
     RETURN_NOT_OK(check_buffer_names());
 
-    // Set the timestamp to use for new fragments if the query type is write,
-    // modify exclusive, update or delete (any type but read).
-    if (type_ != QueryType::READ) {
-      set_current_fragment_timestamp();
-    }
+    // Set the timestamp to use for new fragments. This is a no-op if the
+    // fragment timestamp is already set or the query is a read.
+    fragment_timestamp_ = get_fragment_timestamp();
 
     // Create dimension label queries and remove labels from subarray.
     if (uses_dimension_labels()) {
@@ -1015,13 +1035,13 @@ Status Query::init() {
           label_buffers_,
           buffers_,
           fragment_name_,
-          current_fragment_timestamp_));
+          fragment_timestamp_));
     }
 
     // Create the query strategy if querying main array and the Subarray does
     // not need to be updated.
     if (!only_dim_label_query() && !subarray_.has_label_ranges()) {
-      RETURN_NOT_OK(create_strategy());
+      RETURN_NOT_OK(create_strategy(fragment_timestamp_));
     }
   }
 
@@ -1097,7 +1117,7 @@ Status Query::process() {
         dynamic_cast<StrategyBase*>(strategy_.get())->stats()->reset();
         strategy_ = nullptr;
       }
-      throw_if_not_ok(create_strategy(true));
+      throw_if_not_ok(create_strategy(fragment_timestamp_, true));
     }
   }
 
@@ -1140,12 +1160,16 @@ Status Query::process() {
 
 IQueryStrategy* Query::strategy(bool skip_checks_serialization) {
   if (strategy_ == nullptr) {
-    throw_if_not_ok(create_strategy(skip_checks_serialization));
+    // Create the strategy. If this is not a read and the query is writing data
+    // to the current time, the timestamp in this strategy may differ from that
+    // used in the actual query.
+    throw_if_not_ok(
+        create_strategy(get_fragment_timestamp(), skip_checks_serialization));
   }
   return strategy_.get();
 }
 
-Status Query::reset_strategy_with_layout(
+void Query::reset_strategy_with_layout(
     Layout layout, bool force_legacy_reader) {
   force_legacy_reader_ = force_legacy_reader;
   if (strategy_ != nullptr) {
@@ -1154,9 +1178,17 @@ Status Query::reset_strategy_with_layout(
   }
   layout_ = layout;
   subarray_.set_layout(layout);
-  RETURN_NOT_OK(create_strategy(true));
+  throw_if_not_ok(create_strategy(get_fragment_timestamp(), true));
+}
 
-  return Status::Ok();
+std::optional<uint64_t> Query::get_fragment_timestamp() const {
+  if (type_ == QueryType::READ) {
+    return nullopt;
+  }
+  auto timestamp_opened = array_->timestamp_end_opened_at();
+  return fragment_timestamp_.value_or(
+      timestamp_opened == 0 ? sm::utils::time::timestamp_now_ms() :
+                              timestamp_opened);
 }
 
 bool Query::uses_dimension_labels() const {
@@ -1242,13 +1274,13 @@ Status Query::check_buffer_names() {
   return Status::Ok();
 }
 
-Status Query::create_strategy(bool skip_checks_serialization) {
+Status Query::create_strategy(
+    optional<uint64_t> timestamp, bool skip_checks_serialization) {
   if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
     // Set the fragment timestamp if it has not yet been set.
-    if (!current_fragment_timestamp_.has_value()) {
-      set_current_fragment_timestamp();
+    if (!timestamp.has_value()) {
+      throw std::logic_error("Missing value for the fragment timestamp");
     }
-    auto timestamp = current_fragment_timestamp_.value();
 
     if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
       if (!array_schema_->dense()) {
@@ -1269,7 +1301,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           written_fragment_info_,
           coords_info_,
           remote_query_,
-          timestamp,
+          timestamp.value(),
           fragment_name_,
           skip_checks_serialization));
     } else if (layout_ == Layout::UNORDERED) {
@@ -1291,7 +1323,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           written_fragment_info_,
           coords_info_,
           remote_query_,
-          timestamp,
+          timestamp.value(),
           fragment_name_,
           skip_checks_serialization));
     } else if (layout_ == Layout::GLOBAL_ORDER) {
@@ -1311,7 +1343,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           processed_conditions_,
           coords_info_,
           remote_query_,
-          timestamp,
+          timestamp.value(),
           fragment_name_,
           skip_checks_serialization));
     } else {
@@ -1437,9 +1469,9 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           skip_checks_serialization));
     }
   } else if (type_ == QueryType::DELETE || type_ == QueryType::UPDATE) {
-    // Set the fragment timestamp if it has not yet been set.
-    if (!current_fragment_timestamp_.has_value()) {
-      set_current_fragment_timestamp();
+    // Check the fragment timestamp is provided.
+    if (!timestamp.has_value()) {
+      throw std::logic_error("Missing value for the fragment timestamp");
     }
 
     strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
@@ -1454,7 +1486,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
         layout_,
         condition_,
         update_values_,
-        current_fragment_timestamp_.value(),
+        timestamp.value(),
         skip_checks_serialization));
   } else {
     return logger_->status(
@@ -2458,14 +2490,6 @@ bool Query::only_dim_label_query() const {
          coord_offsets_buffer_is_set_))));
 }
 
-void Query::set_current_fragment_timestamp() {
-  // Set the fragment timestamp.
-  auto timestamp_opened = array_->timestamp_end_opened_at();
-  current_fragment_timestamp_ = default_fragment_timestamp_.value_or(
-      timestamp_opened == 0 ? sm::utils::time::timestamp_now_ms() :
-                              timestamp_opened);
-}
-
 Status Query::submit() {
   // Do not resubmit completed reads.
   if (type_ == QueryType::READ && status_ == QueryStatus::COMPLETED) {
@@ -2489,7 +2513,7 @@ Status Query::submit() {
           "Error in query submission; remote array with no rest client."));
 
     if (status_ == QueryStatus::UNINITIALIZED) {
-      RETURN_NOT_OK(create_strategy());
+      RETURN_NOT_OK(create_strategy(get_fragment_timestamp()));
     }
 
     // Check that input buffers are tile-aligned for remote global order

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1014,7 +1014,8 @@ Status Query::init() {
           subarray_,
           label_buffers_,
           buffers_,
-          fragment_name_));
+          fragment_name_,
+          current_fragment_timestamp_));
     }
 
     // Create the query strategy if querying main array and the Subarray does

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -41,6 +41,7 @@
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parse_argument.h"
+#include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/query/deletes_and_updates/deletes_and_updates.h"
 #include "tiledb/sm/query/dimension_label/array_dimension_label_queries.h"
 #include "tiledb/sm/query/legacy/reader.h"
@@ -81,7 +82,8 @@ class QueryStatusException : public StatusException {
 Query::Query(
     StorageManager* storage_manager,
     shared_ptr<Array> array,
-    optional<std::string> fragment_name)
+    optional<std::string> fragment_name,
+    optional<uint64_t> fragment_timestamp)
     : array_shared_(array)
     , array_(array_shared_.get())
     , array_schema_(array->array_schema_latest_ptr())
@@ -105,6 +107,8 @@ Query::Query(
     , consolidation_with_timestamps_(false)
     , force_legacy_reader_(false)
     , fragment_name_(fragment_name)
+    , default_fragment_timestamp_(fragment_timestamp)
+    , current_fragment_timestamp_(nullopt)
     , remote_query_(false)
     , is_dimension_label_ordered_read_(false)
     , dimension_label_increasing_(true)
@@ -956,9 +960,10 @@ Status Query::init() {
   // Only if the query has not been initialized before
   if (status_ == QueryStatus::UNINITIALIZED) {
     // Check if the array got closed
-    if (array_ == nullptr || !array_->is_open())
+    if (array_ == nullptr || !array_->is_open()) {
       return logger_->status(Status_QueryError(
           "Cannot init query; The associated array is not open"));
+    }
 
     // Check if the array got re-opened with a different query type
     QueryType array_query_type{array_->get_query_type()};
@@ -971,7 +976,14 @@ Status Query::init() {
       return logger_->status(Status_QueryError(errmsg.str()));
     }
 
+    // Check the buffer names.
     RETURN_NOT_OK(check_buffer_names());
+
+    // Set the timestamp to use for new fragments if the query type is write,
+    // modify exclusive, update or delete (any type but read).
+    if (type_ != QueryType::READ) {
+      set_current_fragment_timestamp();
+    }
 
     // Create dimension label queries and remove labels from subarray.
     if (uses_dimension_labels()) {
@@ -1139,6 +1151,7 @@ Status Query::reset_strategy_with_layout(
     dynamic_cast<StrategyBase*>(strategy_.get())->stats()->reset();
     strategy_ = nullptr;
   }
+  // TODO: Check if this happens before or after initialization
   layout_ = layout;
   subarray_.set_layout(layout);
   RETURN_NOT_OK(create_strategy(true));
@@ -1231,6 +1244,12 @@ Status Query::check_buffer_names() {
 
 Status Query::create_strategy(bool skip_checks_serialization) {
   if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
+    // Set the fragment timestamp if it has not yet been set.
+    if (!current_fragment_timestamp_.has_value()) {
+      set_current_fragment_timestamp();
+    }
+    auto timestamp = current_fragment_timestamp_.value();
+
     if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
       if (!array_schema_->dense()) {
         return Status_QueryError(
@@ -1250,6 +1269,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           written_fragment_info_,
           coords_info_,
           remote_query_,
+          timestamp,
           fragment_name_,
           skip_checks_serialization));
     } else if (layout_ == Layout::UNORDERED) {
@@ -1271,6 +1291,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           written_fragment_info_,
           coords_info_,
           remote_query_,
+          timestamp,
           fragment_name_,
           skip_checks_serialization));
     } else if (layout_ == Layout::GLOBAL_ORDER) {
@@ -1290,6 +1311,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           processed_conditions_,
           coords_info_,
           remote_query_,
+          timestamp,
           fragment_name_,
           skip_checks_serialization));
     } else {
@@ -1415,6 +1437,11 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           skip_checks_serialization));
     }
   } else if (type_ == QueryType::DELETE || type_ == QueryType::UPDATE) {
+    // Set the fragment timestamp if it has not yet been set.
+    if (!current_fragment_timestamp_.has_value()) {
+      set_current_fragment_timestamp();
+    }
+
     strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
         DeletesAndUpdates,
         stats_->create_child("Deletes"),
@@ -1427,6 +1454,7 @@ Status Query::create_strategy(bool skip_checks_serialization) {
         layout_,
         condition_,
         update_values_,
+        current_fragment_timestamp_.value(),
         skip_checks_serialization));
   } else {
     return logger_->status(
@@ -2294,7 +2322,7 @@ void Query::set_subarray(const void* subarray) {
           query_type_str(type_) + "'.");
   }
 
-  // Check this isn't an already initialized query using dimension labels.
+  // Check this isn't an already initialized query.
   if (status_ != QueryStatus::UNINITIALIZED) {
     throw QueryStatusException(
         "Cannot set subarray; Setting a subarray on an already initialized  "
@@ -2428,6 +2456,14 @@ bool Query::only_dim_label_query() const {
        (buffers_.size() == 1 &&
         (coord_buffer_is_set_ || coord_data_buffer_is_set_ ||
          coord_offsets_buffer_is_set_))));
+}
+
+void Query::set_current_fragment_timestamp() {
+  // Set the fragment timestamp.
+  auto timestamp_opened = array_->timestamp_end_opened_at();
+  current_fragment_timestamp_ = default_fragment_timestamp_.value_or(
+      timestamp_opened == 0 ? sm::utils::time::timestamp_now_ms() :
+                              timestamp_opened);
 }
 
 Status Query::submit() {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -132,22 +132,21 @@ class Query {
 
   /**
    * Constructor. The query type is inherited from the query type of the
-   * input array. An optional fragment URI is given as input in
-   * case the query will be used as writes and the given URI should be used
-   * for the name of the new fragment to be created.
+   * input array.
    *
    * @note Array must be a properly opened array.
    *
+   * @param storage_manager The storage manager object.
    * @param array The array that is being queried.
-   * @param fragment_uri The full URI for the new fragment. Only used for
-   * writes.
-   * @param fragment_base_uri Optional base name for new fragment. Only used for
-   *     writes and only if fragment_uri is empty.
+   * @param fragment_name If set, the name to use for new fragments.
+   * @param fragment_timestamp If set and ``fragment_name`` is not, the
+   *     timestamp to use when generating fragment names.
    */
   Query(
       StorageManager* storage_manager,
       shared_ptr<Array> array,
-      optional<std::string> fragment_name = nullopt);
+      optional<std::string> fragment_name = nullopt,
+      optional<uint64_t> fragment_timestamp = nullopt);
 
   /** Destructor. */
   virtual ~Query();
@@ -1044,6 +1043,17 @@ class Query {
    */
   optional<std::string> fragment_name_;
 
+  /** If set, use this timestamp when creating a new fragment. */
+  optional<uint64_t> default_fragment_timestamp_;
+
+  /**
+   * The current timestamp to use for new fragments.
+   *
+   * This is only set once query is initialized or the strategy is created.
+   * Before it is initialized, it is set to nullopt.
+   */
+  optional<uint64_t> current_fragment_timestamp_;
+
   /** It tracks if this is a remote query */
   bool remote_query_;
 
@@ -1099,6 +1109,9 @@ class Query {
    * 3. At least one label buffer is set.
    */
   bool only_dim_label_query() const;
+
+  /** Sets the timestamp to use for new fragments. */
+  void set_current_fragment_timestamp();
 
   /**
    * This is a deprecated API.

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -459,11 +459,18 @@ class Query {
    * Switch the strategy depending on layout. Used by serialization.
    *
    * @param layout New layout
+   * @param fragment_timestamp The timestamp to use for new fragment names.
    * @param force_legacy_reader Force use of the legacy reader if the client
    *    requested it.
-   * @return Status
    */
-  Status reset_strategy_with_layout(Layout layout, bool force_legacy_reader);
+  void reset_strategy_with_layout(Layout layout, bool force_legacy_reader);
+
+  /**
+   * Get the fragment timestamp to use for writes.
+   *
+   * TODO: Add details
+   */
+  std::optional<uint64_t> get_fragment_timestamp() const;
 
   /**
    * Disables checking the global order and coordinate duplicates. Applicable
@@ -1043,16 +1050,12 @@ class Query {
    */
   optional<std::string> fragment_name_;
 
-  /** If set, use this timestamp when creating a new fragment. */
-  optional<uint64_t> default_fragment_timestamp_;
-
   /**
-   * The current timestamp to use for new fragments.
+   * The timestamp to use for new fragments.
    *
-   * This is only set once query is initialized or the strategy is created.
-   * Before it is initialized, it is set to nullopt.
+   * This is only used if `fragment_name_` is not set.
    */
-  optional<uint64_t> current_fragment_timestamp_;
+  optional<uint64_t> fragment_timestamp_;
 
   /** It tracks if this is a remote query */
   bool remote_query_;
@@ -1082,10 +1085,12 @@ class Query {
 
   /**
    * Create the strategy.
-   *
+   * @param timestamp Timestamp for new fragments. Must be set unless this is
+   *     a read query.
    * @param skip_checks_serialization Skip checks during serialization.
    */
-  Status create_strategy(bool skip_checks_serialization = false);
+  Status create_strategy(
+      optional<uint64_t> timestamp, bool skip_checks_serialization = false);
 
   Status check_set_fixed_buffer(const std::string& name);
 
@@ -1109,9 +1114,6 @@ class Query {
    * 3. At least one label buffer is set.
    */
   bool only_dim_label_query() const;
-
-  /** Sets the timestamp to use for new fragments. */
-  void set_current_fragment_timestamp();
 
   /**
    * This is a deprecated API.

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -87,6 +87,7 @@ GlobalOrderWriter::GlobalOrderWriter(
     std::vector<std::string>& processed_conditions,
     Query::CoordsInfo& coords_info,
     bool remote_query,
+    uint64_t fragment_timestamp,
     optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : WriterBase(
@@ -102,6 +103,7 @@ GlobalOrderWriter::GlobalOrderWriter(
           disable_checks_consolidation,
           coords_info,
           remote_query,
+          fragment_timestamp,
           fragment_name,
           skip_checks_serialization)
     , processed_conditions_(processed_conditions)
@@ -1429,11 +1431,11 @@ Status GlobalOrderWriter::start_new_fragment() {
   const auto write_version = array_->array_schema_latest().write_version();
   auto frag_dir_uri =
       array_->array_directory().get_fragments_dir(write_version);
-  auto new_fragment_str = storage_format::generate_uri(
+  auto new_fragment_name = storage_format::generate_uri(
       fragment_timestamp_range_.first,
       fragment_timestamp_range_.second,
       write_version);
-  fragment_uri_ = frag_dir_uri.join_path(new_fragment_str);
+  fragment_uri_ = frag_dir_uri.join_path(new_fragment_name);
 
   // Create a new fragment.
   current_fragment_size_ = 0;

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -120,6 +120,7 @@ class GlobalOrderWriter : public WriterBase {
       std::vector<std::string>& processed_conditions,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
+      uint64_t fragment_timestamp,
       optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -77,6 +77,7 @@ OrderedWriter::OrderedWriter(
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
     bool remote_query,
+    uint64_t fragment_timestamp,
     optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : WriterBase(
@@ -92,6 +93,7 @@ OrderedWriter::OrderedWriter(
           false,
           coords_info,
           remote_query,
+          fragment_timestamp,
           fragment_name,
           skip_checks_serialization)
     , frag_uri_(std::nullopt) {

--- a/tiledb/sm/query/writers/ordered_writer.h
+++ b/tiledb/sm/query/writers/ordered_writer.h
@@ -64,6 +64,7 @@ class OrderedWriter : public WriterBase {
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
+      uint64_t fragment_timestamp,
       optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -84,6 +84,7 @@ UnorderedWriter::UnorderedWriter(
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
     bool remote_query,
+    uint64_t fragment_timestamp,
     optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : WriterBase(
@@ -99,6 +100,7 @@ UnorderedWriter::UnorderedWriter(
           false,
           coords_info,
           remote_query,
+          fragment_timestamp,
           fragment_name,
           skip_checks_serialization)
     , frag_uri_(std::nullopt) {

--- a/tiledb/sm/query/writers/unordered_writer.h
+++ b/tiledb/sm/query/writers/unordered_writer.h
@@ -64,6 +64,7 @@ class UnorderedWriter : public WriterBase {
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
+      uint64_t fragment_timestamp,
       optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -88,6 +88,7 @@ WriterBase::WriterBase(
     bool disable_checks_consolidation,
     Query::CoordsInfo& coords_info,
     bool remote_query,
+    uint64_t fragment_timestamp,
     optional<std::string> fragment_name,
     bool skip_checks_serialization)
     : StrategyBase(
@@ -217,15 +218,14 @@ WriterBase::WriterBase(
   check_var_attr_offsets();
 
   // Get the timestamp the array was opened and the array write version.
-  uint64_t timestamp = array_->timestamp_end_opened_at();
   auto write_version = array_->array_schema_latest().write_version();
 
   // Set the fragment URI using either the provided fragment name or a generated
   // fragment name.
-  auto new_fragment_str =
-      fragment_name.has_value() ?
-          fragment_name.value() :
-          storage_format::generate_fragment_name(timestamp, write_version);
+  auto new_fragment_str = fragment_name.has_value() ?
+                              fragment_name.value() :
+                              storage_format::generate_fragment_name(
+                                  fragment_timestamp, write_version);
   auto frag_dir_uri =
       array_->array_directory().get_fragments_dir(write_version);
   fragment_uri_ = frag_dir_uri.join_path(new_fragment_str);

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -80,6 +80,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
       bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
+      uint64_t fragment_timestamp,
       optional<std::string> fragment_name = nullopt,
       bool skip_checks_serialization = false);
 

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1448,7 +1448,7 @@ Status query_from_capnp(
   // Make sure we have the right query strategy in place.
   bool force_legacy_reader =
       query_type == QueryType::READ && query_reader.hasReader();
-  RETURN_NOT_OK(query->reset_strategy_with_layout(layout, force_legacy_reader));
+  query->reset_strategy_with_layout(layout, force_legacy_reader);
 
   // Deserialize Config
   if (query_reader.hasConfig()) {


### PR DESCRIPTION
Rather than creating fragment timestamp inside of the fragment name generation inside strategies and dimension labels, this change initializes the fragment timestamp when the Query is initialized. This isolates the timestamp creation to a single place that can be passed between the strategies and dimension labels.

---
TYPE: IMPROVEMENT
DESC: Move new fragment timestamp to Query
