### PR TITLE
Create ContextResources class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,31 @@ set(TILEDB_EXPORT_HEADER "${TILEDB_EXPORT_HEADER_DIR}/${TILEDB_EXPORT_HEADER_NAM
 set(TILEDB_EXPORT_HEADER_LOCALINSTALL_PATH "tiledb/api/c_api/${TILEDB_EXPORT_HEADER_NAME}")
 
 ##################################
+# VFS Object Storage Configuration
+##################################
+# Create an interface library for use in passing the
+# appropriate compiler definitions for the set of
+# configured object storage backends.
+
+add_library(TILEDB_OBJECT_STORE_ILIB INTERFACE)
+
+if (TILEDB_AZURE)
+  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_AZURE)
+endif()
+
+if (TILEDB_GCS)
+  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_GCS)
+endif()
+
+if (TILEDB_HDFS)
+  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_HDFS)
+endif()
+
+if (TILEDB_S3)
+  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_S3)
+endif()
+
+##################################
 # Local install
 ##################################
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,22 +380,22 @@ set(TILEDB_EXPORT_HEADER_LOCALINSTALL_PATH "tiledb/api/c_api/${TILEDB_EXPORT_HEA
 # appropriate compiler definitions for the set of
 # configured object storage backends.
 
-add_library(TILEDB_OBJECT_STORE_ILIB INTERFACE)
+add_library(object_store_definitions INTERFACE)
 
 if (TILEDB_AZURE)
-  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_AZURE)
+  target_compile_definitions(object_store_definitions INTERFACE -DHAVE_AZURE)
 endif()
 
 if (TILEDB_GCS)
-  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_GCS)
+  target_compile_definitions(object_store_definitions INTERFACE -DHAVE_GCS)
 endif()
 
 if (TILEDB_HDFS)
-  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_HDFS)
+  target_compile_definitions(object_store_definitions INTERFACE -DHAVE_HDFS)
 endif()
 
 if (TILEDB_S3)
-  target_compile_definitions(TILEDB_OBJECT_STORE_ILIB INTERFACE -DHAVE_S3)
+  target_compile_definitions(object_store_definitions INTERFACE -DHAVE_S3)
 endif()
 
 ##################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -310,27 +310,14 @@ if (TILEDB_HDFS)
       LibJVM::libjvm
       LibJVM::libjsig
   )
-  target_compile_definitions(tiledb_unit PRIVATE -DHAVE_HDFS)
   target_include_directories(tiledb_unit PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/../external/include"
     )
 endif()
 
-if (TILEDB_S3)
-  target_compile_definitions(tiledb_unit PRIVATE -DHAVE_S3)
-endif()
-
 if (TILEDB_TESTS_AWS_S3_CONFIG)
   message(STATUS "Tests built with AWS S3 config")
   target_compile_definitions(tiledb_unit PRIVATE -DTILEDB_TESTS_AWS_S3_CONFIG)
-endif()
-
-if (TILEDB_AZURE)
-  target_compile_definitions(tiledb_unit PRIVATE -DHAVE_AZURE)
-endif()
-
-if (TILEDB_GCS)
-  target_compile_definitions(tiledb_unit PRIVATE -DHAVE_GCS)
 endif()
 
 if (TILEDB_SERIALIZATION)

--- a/test/support/CMakeLists.txt
+++ b/test/support/CMakeLists.txt
@@ -72,27 +72,14 @@ target_include_directories(
 )
 
 if (TILEDB_HDFS)
-  target_compile_definitions(tiledb_test_support_lib PRIVATE -DHAVE_HDFS)
   target_include_directories(tiledb_test_support_lib PRIVATE
     "${CMAKE_SOURCE_DIR}/external/include"
     )
 endif()
 
-if (TILEDB_S3)
-  target_compile_definitions(tiledb_test_support_lib PRIVATE -DHAVE_S3)
-endif()
-
 if (TILEDB_TESTS_AWS_S3_CONFIG)
   message(STATUS "Tests built with AWS S3 config")
   target_compile_definitions(tiledb_test_support_lib PRIVATE -DTILEDB_TESTS_AWS_S3_CONFIG)
-endif()
-
-if (TILEDB_AZURE)
-  target_compile_definitions(tiledb_test_support_lib PRIVATE -DHAVE_AZURE)
-endif()
-
-if (TILEDB_GCS)
-  target_compile_definitions(tiledb_test_support_lib PRIVATE -DHAVE_GCS)
 endif()
 
 if (TILEDB_SERIALIZATION)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -268,6 +268,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/global_stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context_resources.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/storage_manager.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/range_subset.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/relevant_fragment_generator.cc
@@ -380,7 +381,7 @@ add_library(TILEDB_CORE_OBJECTS OBJECT
 # Use BUILD_INTERFACE generator to work around
 #   https://gitlab.kitware.com/cmake/cmake/-/issues/20736
 target_link_libraries(TILEDB_CORE_OBJECTS PRIVATE $<BUILD_INTERFACE:common>)
-target_link_libraries(TILEDB_CORE_OBJECTS INTERFACE TILEDB_OBJECT_STORE_ILIB)
+target_link_libraries(TILEDB_CORE_OBJECTS INTERFACE object_store_definitions)
 
 ############################################################
 # provide actions/target for preparation of magic.mgc data for embedding/build
@@ -501,7 +502,7 @@ endif()
 add_library(TILEDB_CORE_OBJECTS_ILIB INTERFACE)
 
 # Object Store Configuration
-target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE TILEDB_OBJECT_STORE_ILIB)
+target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE object_store_definitions)
 
 # blosc link dependencies
 target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE ${TileDB_blosc_LINK_OPTIONS})
@@ -1081,7 +1082,7 @@ if (TILEDB_STATIC)
   list(APPEND TILEDB_INSTALL_TARGETS
     tiledb_static
     TILEDB_CORE_OBJECTS_ILIB
-    TILEDB_OBJECT_STORE_ILIB
+    object_store_definitions
   )
 endif()
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -380,6 +380,7 @@ add_library(TILEDB_CORE_OBJECTS OBJECT
 # Use BUILD_INTERFACE generator to work around
 #   https://gitlab.kitware.com/cmake/cmake/-/issues/20736
 target_link_libraries(TILEDB_CORE_OBJECTS PRIVATE $<BUILD_INTERFACE:common>)
+target_link_libraries(TILEDB_CORE_OBJECTS INTERFACE TILEDB_OBJECT_STORE_ILIB)
 
 ############################################################
 # provide actions/target for preparation of magic.mgc data for embedding/build
@@ -499,6 +500,9 @@ endif()
 # so we can use the targets created by the calls to find_package().
 add_library(TILEDB_CORE_OBJECTS_ILIB INTERFACE)
 
+# Object Store Configuration
+target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE TILEDB_OBJECT_STORE_ILIB)
+
 # blosc link dependencies
 target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE ${TileDB_blosc_LINK_OPTIONS})
 
@@ -520,7 +524,6 @@ if (TILEDB_S3)
       AWSSDK::aws-c-common
       AWSSDK::aws-cpp-sdk-identity-management
       AWSSDK::aws-cpp-sdk-sts)
-  add_definitions(-DHAVE_S3)
 endif()
 
 # Azure dependencies
@@ -531,7 +534,6 @@ if (TILEDB_AZURE)
     INTERFACE
       AzureSDK::AzureSDK
   )
-  add_definitions(-DHAVE_AZURE)
 
   if(MSVC)
     if (TILEDB_CURL_EP_BUILT)
@@ -550,7 +552,6 @@ if (TILEDB_GCS)
     INTERFACE
        storage_client
   )
-  add_definitions(-DHAVE_GCS)
 
   # work around for GCS finding the shared version of zlib: we will see the Zlib::Zlib
   # transitive linkage later, and we can use the correct version there.
@@ -588,7 +589,6 @@ if (TILEDB_HDFS)
     message(FATAL_ERROR "TileDB HDFS backend is not supported for Windows builds currently")
   else()
     message(STATUS "The TileDB library is compiled with HDFS support.")
-    add_definitions(-DHAVE_HDFS)
   endif()
 endif()
 
@@ -1081,6 +1081,7 @@ if (TILEDB_STATIC)
   list(APPEND TILEDB_INSTALL_TARGETS
     tiledb_static
     TILEDB_CORE_OBJECTS_ILIB
+    TILEDB_OBJECT_STORE_ILIB
   )
 endif()
 

--- a/tiledb/api/c_api/context/CMakeLists.txt
+++ b/tiledb/api/c_api/context/CMakeLists.txt
@@ -34,6 +34,7 @@ gather_sources(${SOURCES})
 list(APPEND OTHER_SOURCES
     # We need to recompile sources that depend on StorageManager to use the stub
     ../../../sm/storage_manager/context.cc
+    ../../../sm/storage_manager/context_resources.cc
     # Source included here because it's not in object library `stats`
     ../../../sm/stats/global_stats.cc
     )

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -70,7 +70,7 @@ capi_return_t tiledb_ctx_get_stats(
     tiledb_ctx_handle_t* ctx, char** stats_json) {
   ensure_output_pointer_is_valid(stats_json);
 
-  const std::string str = ctx->context().stats()->dump(2, 0);
+  const std::string str = ctx->context().resources().stats().dump(2, 0);
 
   *stats_json = static_cast<char*>(std::malloc(str.size() + 1));
   if (*stats_json == nullptr)

--- a/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
+++ b/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
@@ -35,6 +35,7 @@
 
 #include <memory>
 #include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 
 namespace tiledb::common {
 class ThreadPool;
@@ -53,11 +54,7 @@ class StorageManagerStub {
  public:
   static constexpr bool is_overriding_class = true;
   StorageManagerStub(
-      common::ThreadPool*,
-      common::ThreadPool*,
-      stats::Stats*,
-      std::shared_ptr<common::Logger>,
-      const Config& config)
+      ContextResources&, std::shared_ptr<common::Logger>, const Config& config)
       : config_(config) {
   }
 

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -169,11 +169,8 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ThreadPool tp_cpu(1);
-  ThreadPool tp_io(1);
-  stats::Stats stats("");
-  StorageManager sm(
-      &tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""), config);
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Register array
   tdb_unique_ptr<Array> array = x.open_array(uri, &sm);
@@ -197,11 +194,8 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ThreadPool tp_cpu(1);
-  ThreadPool tp_io(1);
-  stats::Stats stats("");
-  StorageManager sm(
-      &tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""), config);
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   std::vector<tdb_unique_ptr<Array>> arrays;
   std::vector<URI> uris = {URI("whitebox_array_vector_1"),
@@ -242,11 +236,8 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ThreadPool tp_cpu(1);
-  ThreadPool tp_io(1);
-  stats::Stats stats("");
-  StorageManager sm(
-      &tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""), config);
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Create an array
   tdb_unique_ptr<Array> array = x.create_array(uri, &sm);

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -174,7 +174,7 @@ Status FragmentMetaConsolidator::consolidate(
   EncryptionKey enc_key;
   RETURN_NOT_OK(enc_key.set_key(encryption_type, encryption_key, key_length));
 
-  GenericTileIO tile_io(storage_manager_, uri);
+  GenericTileIO tile_io(storage_manager_->resources(), uri);
   uint64_t nbytes = 0;
   RETURN_NOT_OK(tile_io.write_generic(&tile, enc_key, &nbytes));
   (void)nbytes;

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3634,7 +3634,7 @@ Status FragmentMetadata::load_v1_v2(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(storage_manager_->resources(), fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(0, encryption_key, storage_manager_->config());
   RETURN_NOT_OK(st);
@@ -3985,7 +3985,7 @@ tuple<Status, optional<Tile>> FragmentMetadata::read_generic_tile_from_file(
       std::string(constants::fragment_metadata_filename));
 
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(storage_manager_->resources(), fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(offset, encryption_key, storage_manager_->config());
   RETURN_NOT_OK_TUPLE(st, nullopt);
@@ -4031,7 +4031,7 @@ Status FragmentMetadata::write_generic_tile_to_file(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
 
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(storage_manager_->resources(), fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -51,14 +51,13 @@ Context::Context(const Config& config)
     , logger_(make_shared<Logger>(
           HERE(), logger_prefix_ + std::to_string(++logger_id_)))
     , resources_(
-        config,
-        get_compute_thread_count(config),
-        get_io_thread_count(config),
-        // TODO: Remove `.StorageManager` from statistic names
-        // We're sticking with `Context.StorageManager` here because
-        // it is part of the public facing API.
-        "Context.StorageManager"
-      )
+          config,
+          get_compute_thread_count(config),
+          get_io_thread_count(config),
+          // TODO: Remove `.StorageManager` from statistic names
+          // We're sticking with `Context.StorageManager` here because
+          // it is part of the public facing API.
+          "Context.StorageManager")
     , storage_manager_{resources_, logger_, config} {
   /*
    * Logger class is not yet C.41-compliant

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -50,18 +50,20 @@ Context::Context(const Config& config)
     : last_error_(nullopt)
     , logger_(make_shared<Logger>(
           HERE(), logger_prefix_ + std::to_string(++logger_id_)))
-    , compute_tp_(get_compute_thread_count(config))
-    , io_tp_(get_io_thread_count(config))
-    , stats_(make_shared<stats::Stats>(HERE(), "Context"))
-    , storage_manager_{&compute_tp_, &io_tp_, stats_.get(), logger_, config} {
+    , resources_(
+        config,
+        get_compute_thread_count(config),
+        get_io_thread_count(config),
+        // TODO: Remove `.StorageManager` from statistic names
+        // We're sticking with `Context.StorageManager` here because
+        // it is part of the public facing API.
+        "Context.StorageManager"
+      )
+    , storage_manager_{resources_, logger_, config} {
   /*
    * Logger class is not yet C.41-compliant
    */
   throw_if_not_ok(init_loggers(config));
-  /*
-   * Explicitly register our `stats` object with the global.
-   */
-  stats::all_stats.register_stats(stats_);
 }
 
 /* ****************************** */
@@ -81,18 +83,6 @@ void Context::save_error(const Status& st) {
 void Context::save_error(const StatusException& st) {
   std::lock_guard<std::mutex> lock(mtx_);
   last_error_ = st.what();
-}
-
-ThreadPool* Context::compute_tp() const {
-  return &compute_tp_;
-}
-
-ThreadPool* Context::io_tp() const {
-  return &io_tp_;
-}
-
-stats::Stats* Context::stats() const {
-  return stats_.get();
 }
 
 Status Context::get_config_thread_count(

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -37,6 +37,7 @@
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <mutex>
@@ -93,14 +94,19 @@ class Context {
     return &storage_manager_;
   }
 
+  [[nodiscard]] inline ContextResources& resources() const {
+    return resources_;
+  }
+
   /** Returns the thread pool for compute-bound tasks. */
-  ThreadPool* compute_tp() const;
+  [[nodiscard]] inline ThreadPool* compute_tp() const {
+    return &(resources_.compute_tp());
+  }
 
   /** Returns the thread pool for io-bound tasks. */
-  ThreadPool* io_tp() const;
-
-  /** Returns the internal stats object. */
-  stats::Stats* stats() const;
+  [[nodiscard]] inline ThreadPool* io_tp() const {
+    return &(resources_.io_tp());
+  }
 
  private:
   /* ********************************* */
@@ -130,14 +136,8 @@ class Context {
    */
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
-  /** The thread pool for compute-bound tasks. */
-  mutable ThreadPool compute_tp_;
-
-  /** The thread pool for io-bound tasks. */
-  mutable ThreadPool io_tp_;
-
-  /** The class stats. */
-  shared_ptr<stats::Stats> stats_;
+  /** The class resources. */
+  mutable ContextResources resources_;
 
   /**
    * The storage manager.

--- a/tiledb/sm/storage_manager/context_resources.cc
+++ b/tiledb/sm/storage_manager/context_resources.cc
@@ -41,15 +41,14 @@ namespace tiledb::sm {
 /* ****************************** */
 
 ContextResources::ContextResources(
-      const Config& config,
-      size_t compute_thread_count,
-      size_t io_thread_count,
-      std::string stats_name)
+    const Config& config,
+    size_t compute_thread_count,
+    size_t io_thread_count,
+    std::string stats_name)
     : compute_tp_(compute_thread_count)
     , io_tp_(io_thread_count)
     , stats_(make_shared<stats::Stats>(HERE(), stats_name))
     , vfs_(stats_.get(), &compute_tp_, &io_tp_, config) {
-
   /*
    * Explicitly register our `stats` object with the global.
    */

--- a/tiledb/sm/storage_manager/context_resources.cc
+++ b/tiledb/sm/storage_manager/context_resources.cc
@@ -1,0 +1,59 @@
+/**
+ * @file context_resources.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class ContextResources.
+ */
+
+#include "tiledb/sm/storage_manager/context_resources.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+/* ****************************** */
+/*   CONSTRUCTORS & DESTRUCTORS   */
+/* ****************************** */
+
+ContextResources::ContextResources(
+      const Config& config,
+      size_t compute_thread_count,
+      size_t io_thread_count,
+      std::string stats_name)
+    : compute_tp_(compute_thread_count)
+    , io_tp_(io_thread_count)
+    , stats_(make_shared<stats::Stats>(HERE(), stats_name))
+    , vfs_(stats_.get(), &compute_tp_, &io_tp_, config) {
+
+  /*
+   * Explicitly register our `stats` object with the global.
+   */
+  stats::all_stats.register_stats(stats_);
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -1,0 +1,117 @@
+/**
+ * @file context_resources.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ContextResources.
+ */
+
+#ifndef TILEDB_CONTEXT_RESOURCES_H
+#define TILEDB_CONTEXT_RESOURCES_H
+
+#include "tiledb/common/exception/exception.h"
+#include "tiledb/common/thread_pool/thread_pool.h"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/stats/global_stats.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+/**
+ * This class manages the context for the C API, wrapping a
+ * storage manager object.
+ */
+class ContextResources {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Default constructor is deleted.
+   */
+  ContextResources() = delete;
+
+  /** Constructor. */
+  explicit ContextResources(
+      const Config& config,
+      size_t compute_thread_count,
+      size_t io_thread_count,
+      std::string stats_name);
+
+  DISABLE_COPY_AND_COPY_ASSIGN(ContextResources);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(ContextResources);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the thread pool for compute-bound tasks. */
+  [[nodiscard]] inline ThreadPool& compute_tp() const {
+    return compute_tp_;
+  }
+
+  /** Returns the thread pool for io-bound tasks. */
+  [[nodiscard]] inline ThreadPool& io_tp() const {
+    return io_tp_;
+  }
+
+  /** Returns the internal stats object. */
+  [[nodiscard]] inline stats::Stats& stats() const {
+    return *(stats_.get());
+  }
+
+  [[nodiscard]] inline VFS& vfs() const {
+    return vfs_;
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The thread pool for compute-bound tasks. */
+  mutable ThreadPool compute_tp_;
+
+  /** The thread pool for io-bound tasks. */
+  mutable ThreadPool io_tp_;
+
+  /** The class stats. */
+  shared_ptr<stats::Stats> stats_;
+
+  /**
+   * Virtual filesystem handler. It directs queries to the appropriate
+   * filesystem backend. Note that this is stateful.
+   */
+  mutable VFS vfs_;
+};
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_CONTEXT_RESOURCES_H

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1277,8 +1277,8 @@ Status StorageManagerCanonical::array_get_encryption(
   const URI& schema_uri = array_dir.latest_array_schema_uri();
 
   // Read tile header
-  auto&& header = GenericTileIO::read_generic_tile_header(
-      resources_, schema_uri, 0);
+  auto&& header =
+      GenericTileIO::read_generic_tile_header(resources_, schema_uri, 0);
   *encryption_type = static_cast<EncryptionType>(header.encryption_type);
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -87,19 +87,14 @@ namespace sm {
 /* ****************************** */
 
 StorageManagerCanonical::StorageManagerCanonical(
-    ThreadPool* const compute_tp,
-    ThreadPool* const io_tp,
-    stats::Stats* const parent_stats,
+    ContextResources& resources,
     shared_ptr<Logger> logger,
     const Config& config)
-    : stats_(parent_stats->create_child("StorageManager"))
+    : resources_(resources)
     , logger_(logger)
     , cancellation_in_progress_(false)
     , config_(config)
-    , queries_in_progress_(0)
-    , compute_tp_(compute_tp)
-    , io_tp_(io_tp)
-    , vfs_(nullptr) {
+    , queries_in_progress_(0) {
   /*
    * This is a transitional version the implementation of this constructor. To
    * complete the transition, the `init` member function must disappear.
@@ -118,12 +113,9 @@ Status StorageManagerCanonical::init() {
   tile_cache_ =
       tdb_unique_ptr<BufferLRUCache>(tdb_new(BufferLRUCache, tile_cache_size));
 
-  // GlobalState must be initialized before `vfs->init` because S3::init calls
-  // GetGlobalState
   auto& global_state = global_state::GlobalState::GetGlobalState();
   RETURN_NOT_OK(global_state.init(config_));
 
-  vfs_ = tdb_new(VFS, stats_, compute_tp_, io_tp_, config_);
 #ifdef TILEDB_SERIALIZATION
   RETURN_NOT_OK(init_rest_client());
 #endif
@@ -138,10 +130,7 @@ Status StorageManagerCanonical::init() {
 StorageManagerCanonical::~StorageManagerCanonical() {
   global_state::GlobalState::GetGlobalState().unregister_storage_manager(this);
 
-  if (vfs_ != nullptr) {
-    throw_if_not_ok(cancel_all_tasks());
-    tdb_delete(vfs_);
-  }
+  throw_if_not_ok(cancel_all_tasks());
 
   bool found{false};
   bool use_malloc_trim{false};
@@ -196,7 +185,7 @@ StorageManagerCanonical::load_array_schemas_and_fragment_metadata(
     MemoryTracker* memory_tracker,
     const EncryptionKey& enc_key) {
   auto timer_se =
-      stats_->start_timer("sm_load_array_schemas_and_fragment_metadata");
+      stats()->start_timer("sm_load_array_schemas_and_fragment_metadata");
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
@@ -212,7 +201,7 @@ StorageManagerCanonical::load_array_schemas_and_fragment_metadata(
   std::vector<shared_ptr<Tile>> fragment_metadata_tiles(meta_uris.size());
   std::vector<std::vector<std::pair<std::string, uint64_t>>> offsets_vectors(
       meta_uris.size());
-  auto status = parallel_for(compute_tp_, 0, meta_uris.size(), [&](size_t i) {
+  auto status = parallel_for(compute_tp(), 0, meta_uris.size(), [&](size_t i) {
     auto&& [st, tile_opt, offsets] =
         load_consolidated_fragment_meta(meta_uris[i], enc_key);
     RETURN_NOT_OK(st);
@@ -267,7 +256,7 @@ tuple<
     optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
     optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManagerCanonical::array_open_for_reads(Array* array) {
-  auto timer_se = stats_->start_timer("array_open_for_reads");
+  auto timer_se = stats()->start_timer("array_open_for_reads");
   auto&& [st, array_schema_latest, array_schemas_all, fragment_metadata] =
       load_array_schemas_and_fragment_metadata(
           array->array_directory(),
@@ -288,7 +277,7 @@ tuple<
     optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManagerCanonical::array_open_for_reads_without_fragments(Array* array) {
   auto timer_se =
-      stats_->start_timer("sm_array_open_for_reads_without_fragments");
+      stats()->start_timer("sm_array_open_for_reads_without_fragments");
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
@@ -307,7 +296,7 @@ tuple<
     optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManagerCanonical::array_open_for_writes(Array* array) {
   // Checks
-  if (!vfs_->supports_uri_scheme(array->array_uri()))
+  if (!vfs()->supports_uri_scheme(array->array_uri()))
     return {logger_->status(Status_StorageManagerError(
                 "Cannot open array; URI scheme unsupported.")),
             nullopt,
@@ -353,7 +342,7 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
 tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManagerCanonical::array_load_fragments(
     Array* array, const std::vector<TimestampedURI>& fragments_to_load) {
-  auto timer_se = stats_->start_timer("array_load_fragments");
+  auto timer_se = stats()->start_timer("array_load_fragments");
 
   // Load the fragment metadata
   std::unordered_map<std::string, std::pair<Tile*, uint64_t>> offsets;
@@ -375,7 +364,7 @@ tuple<
     optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
     optional<std::vector<shared_ptr<FragmentMetadata>>>>
 StorageManagerCanonical::array_reopen(Array* array) {
-  auto timer_se = stats_->start_timer("read_array_open");
+  auto timer_se = stats()->start_timer("read_array_open");
   return array_open_for_reads(array);
 }
 
@@ -526,8 +515,8 @@ Status StorageManagerCanonical::write_commit_ignore_file(
   URI ignore_file_uri =
       array_dir.get_commits_dir(constants::format_version)
           .join_path(name.value() + constants::ignore_file_suffix);
-  RETURN_NOT_OK(vfs_->write(ignore_file_uri, data.c_str(), data.size()));
-  RETURN_NOT_OK(vfs_->close_file(ignore_file_uri));
+  RETURN_NOT_OK(vfs()->write(ignore_file_uri, data.c_str(), data.size()));
+  RETURN_NOT_OK(vfs()->close_file(ignore_file_uri));
 
   return Status::Ok();
 }
@@ -554,7 +543,7 @@ void StorageManagerCanonical::write_consolidated_commits_file(
     // the size variable.
     if (stdx::string::ends_with(
             uri.to_string(), constants::delete_file_suffix)) {
-      throw_if_not_ok(this->vfs()->file_size(uri, &file_sizes[i]));
+      throw_if_not_ok(vfs()->file_size(uri, &file_sizes[i]));
       total_size += file_sizes[i];
       total_size += sizeof(storage_size_t);
     }
@@ -575,8 +564,7 @@ void StorageManagerCanonical::write_consolidated_commits_file(
             uri.to_string(), constants::delete_file_suffix)) {
       memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
       file_index += sizeof(storage_size_t);
-      throw_if_not_ok(
-          this->vfs()->read(uri, 0, &data[file_index], file_sizes[i]));
+      throw_if_not_ok(vfs()->read(uri, 0, &data[file_index], file_sizes[i]));
       file_index += file_sizes[i];
     }
   }
@@ -586,8 +574,8 @@ void StorageManagerCanonical::write_consolidated_commits_file(
       array_dir.get_commits_dir(write_version)
           .join_path(name.value() + constants::con_commits_file_suffix);
   throw_if_not_ok(
-      this->vfs()->write(consolidated_commits_uri, data.data(), data.size()));
-  throw_if_not_ok(this->vfs()->close_file(consolidated_commits_uri));
+      vfs()->write(consolidated_commits_uri, data.data(), data.size()));
+  throw_if_not_ok(vfs()->close_file(consolidated_commits_uri));
 }
 
 void StorageManagerCanonical::delete_array(const char* array_name) {
@@ -601,17 +589,17 @@ void StorageManagerCanonical::delete_array(const char* array_name) {
       delete_fragments(array_name, 0, std::numeric_limits<uint64_t>::max()));
 
   auto array_dir = ArrayDirectory(
-      vfs_,
-      compute_tp_,
+      vfs(),
+      compute_tp(),
       URI(array_name),
       0,
       std::numeric_limits<uint64_t>::max());
 
   // Delete array metadata, fragment metadata and array schema files
   // Note: metadata files may not be present, try to delete anyway
-  vfs_->remove_files(compute_tp_, array_dir.array_meta_uris());
-  vfs_->remove_files(compute_tp_, array_dir.fragment_meta_uris());
-  vfs_->remove_files(compute_tp_, array_dir.array_schema_uris());
+  vfs()->remove_files(compute_tp(), array_dir.array_meta_uris());
+  vfs()->remove_files(compute_tp(), array_dir.fragment_meta_uris());
+  vfs()->remove_files(compute_tp(), array_dir.array_schema_uris());
 }
 
 Status StorageManagerCanonical::delete_fragments(
@@ -623,7 +611,7 @@ Status StorageManagerCanonical::delete_fragments(
   }
 
   auto array_dir = ArrayDirectory(
-      vfs_, compute_tp_, URI(array_name), timestamp_start, timestamp_end);
+      vfs(), compute_tp(), URI(array_name), timestamp_start, timestamp_end);
 
   // Get the fragment URIs to be deleted
   auto filtered_fragment_uris = array_dir.filtered_fragment_uris(true);
@@ -648,11 +636,11 @@ Status StorageManagerCanonical::delete_fragments(
 
   // Delete fragments and commits
   st = parallel_for(compute_tp(), 0, fragment_uris.size(), [&](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_dir(fragment_uris[i].uri_));
+    RETURN_NOT_OK(vfs()->remove_dir(fragment_uris[i].uri_));
     bool is_file = false;
-    RETURN_NOT_OK(vfs_->is_file(commit_uris_to_delete[i], &is_file));
+    RETURN_NOT_OK(vfs()->is_file(commit_uris_to_delete[i], &is_file));
     if (is_file) {
-      RETURN_NOT_OK(vfs_->remove_file(commit_uris_to_delete[i]));
+      RETURN_NOT_OK(vfs()->remove_file(commit_uris_to_delete[i]));
     }
     return Status::Ok();
   });
@@ -668,18 +656,18 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
   }
 
   auto group_dir = GroupDirectory(
-      vfs_,
-      compute_tp_,
+      vfs(),
+      compute_tp(),
       URI(group_name),
       0,
       std::numeric_limits<uint64_t>::max());
 
   // Delete the group detail, group metadata and group files
-  vfs_->remove_files(compute_tp_, group_dir.group_detail_uris());
-  vfs_->remove_files(compute_tp_, group_dir.group_meta_uris());
-  vfs_->remove_files(compute_tp_, group_dir.group_meta_uris_to_vacuum());
-  vfs_->remove_files(compute_tp_, group_dir.group_meta_vac_uris_to_vacuum());
-  vfs_->remove_files(compute_tp_, group_dir.group_file_uris());
+  vfs()->remove_files(compute_tp(), group_dir.group_detail_uris());
+  vfs()->remove_files(compute_tp(), group_dir.group_meta_uris());
+  vfs()->remove_files(compute_tp(), group_dir.group_meta_uris_to_vacuum());
+  vfs()->remove_files(compute_tp(), group_dir.group_meta_vac_uris_to_vacuum());
+  vfs()->remove_files(compute_tp(), group_dir.group_file_uris());
 }
 
 void StorageManagerCanonical::array_vacuum(
@@ -773,36 +761,36 @@ Status StorageManagerCanonical::array_create(
   RETURN_NOT_OK(array_schema->check());
 
   // Create array directory
-  RETURN_NOT_OK(vfs_->create_dir(array_uri));
+  RETURN_NOT_OK(vfs()->create_dir(array_uri));
 
   // Create array schema directory
   URI array_schema_dir_uri =
       array_uri.join_path(constants::array_schema_dir_name);
-  RETURN_NOT_OK(vfs_->create_dir(array_schema_dir_uri));
+  RETURN_NOT_OK(vfs()->create_dir(array_schema_dir_uri));
 
   // Create commit directory
   URI array_commit_uri = array_uri.join_path(constants::array_commits_dir_name);
-  RETURN_NOT_OK(vfs_->create_dir(array_commit_uri));
+  RETURN_NOT_OK(vfs()->create_dir(array_commit_uri));
 
   // Create fragments directory
   URI array_fragments_uri =
       array_uri.join_path(constants::array_fragments_dir_name);
-  RETURN_NOT_OK(vfs_->create_dir(array_fragments_uri));
+  RETURN_NOT_OK(vfs()->create_dir(array_fragments_uri));
 
   // Create array metadata directory
   URI array_metadata_uri =
       array_uri.join_path(constants::array_metadata_dir_name);
-  RETURN_NOT_OK(vfs_->create_dir(array_metadata_uri));
+  RETURN_NOT_OK(vfs()->create_dir(array_metadata_uri));
 
   // Create fragment metadata directory
   URI array_fragment_metadata_uri =
       array_uri.join_path(constants::array_fragment_meta_dir_name);
-  RETURN_NOT_OK(vfs_->create_dir(array_fragment_metadata_uri));
+  RETURN_NOT_OK(vfs()->create_dir(array_fragment_metadata_uri));
 
   if constexpr (is_experimental_build) {
     URI array_dimension_labels_uri =
         array_uri.join_path(constants::array_dimension_labels_dir_name);
-    RETURN_NOT_OK(vfs_->create_dir(array_dimension_labels_uri));
+    RETURN_NOT_OK(vfs()->create_dir(array_dimension_labels_uri));
   }
 
   // Get encryption key from config
@@ -847,7 +835,7 @@ Status StorageManagerCanonical::array_create(
 
   // Store array schema
   if (!st.ok()) {
-    throw_if_not_ok(vfs_->remove_dir(array_uri));
+    throw_if_not_ok(vfs()->remove_dir(array_uri));
     return st;
   }
 
@@ -871,8 +859,8 @@ Status StorageManager::array_evolve_schema(
 
   // Load URIs from the array directory
   tiledb::sm::ArrayDirectory array_dir{
-      this->vfs(),
-      this->io_tp(),
+      vfs(),
+      io_tp(),
       array_uri,
       0,
       UINT64_MAX,
@@ -914,8 +902,8 @@ Status StorageManagerCanonical::array_upgrade_version(
 
   // Load URIs from the array directory
   tiledb::sm::ArrayDirectory array_dir{
-      this->vfs(),
-      this->io_tp(),
+      vfs(),
+      io_tp(),
       array_uri,
       0,
       UINT64_MAX,
@@ -966,7 +954,7 @@ Status StorageManagerCanonical::array_upgrade_version(
     // Create array schema directory if necessary
     URI array_schema_dir_uri =
         array_uri.join_path(constants::array_schema_dir_name);
-    st = vfs_->create_dir(array_schema_dir_uri);
+    st = vfs()->create_dir(array_schema_dir_uri);
     RETURN_NOT_OK_ELSE(st, logger_->status_no_return_value(st));
 
     // Store array schema
@@ -977,19 +965,19 @@ Status StorageManagerCanonical::array_upgrade_version(
     URI array_commit_uri =
         array_uri.join_path(constants::array_commits_dir_name);
     RETURN_NOT_OK_ELSE(
-        vfs_->create_dir(array_commit_uri),
+        vfs()->create_dir(array_commit_uri),
         logger_->status_no_return_value(st));
 
     // Create fragments directory if necessary
     URI array_fragments_uri =
         array_uri.join_path(constants::array_fragments_dir_name);
-    st = vfs_->create_dir(array_fragments_uri);
+    st = vfs()->create_dir(array_fragments_uri);
     RETURN_NOT_OK_ELSE(st, logger_->status_no_return_value(st));
 
     // Create fragment metadata directory if necessary
     URI array_fragment_metadata_uri =
         array_uri.join_path(constants::array_fragment_meta_dir_name);
-    st = vfs_->create_dir(array_fragment_metadata_uri);
+    st = vfs()->create_dir(array_fragment_metadata_uri);
     RETURN_NOT_OK_ELSE(st, logger_->status_no_return_value(st));
   }
 
@@ -1299,7 +1287,7 @@ Status StorageManagerCanonical::array_get_encryption(
 
 Status StorageManagerCanonical::async_push_query(Query* query) {
   cancelable_tasks_.execute(
-      compute_tp_,
+      compute_tp(),
       [this, query]() {
         // Process query.
         Status st = query_submit(query);
@@ -1332,10 +1320,7 @@ Status StorageManagerCanonical::cancel_all_tasks() {
   if (handle_cancel) {
     // Cancel any queued tasks.
     cancelable_tasks_.cancel_all_tasks();
-
-    // Only call VFS cancel if the object has been constructed
-    if (vfs_ != nullptr)
-      throw_if_not_ok(vfs_->cancel_all_tasks());
+    throw_if_not_ok(resources().vfs().cancel_all_tasks());
 
     // Wait for in-progress queries to finish.
     wait_for_zero_in_progress();
@@ -1358,15 +1343,15 @@ const Config& StorageManagerCanonical::config() const {
 }
 
 Status StorageManagerCanonical::create_dir(const URI& uri) {
-  return vfs_->create_dir(uri);
+  return vfs()->create_dir(uri);
 }
 
 Status StorageManagerCanonical::is_dir(const URI& uri, bool* is_dir) const {
-  return vfs_->is_dir(uri, is_dir);
+  return vfs()->is_dir(uri, is_dir);
 }
 
 Status StorageManagerCanonical::touch(const URI& uri) {
-  return vfs_->touch(uri);
+  return vfs()->touch(uri);
 }
 
 void StorageManagerCanonical::decrement_in_progress() {
@@ -1388,7 +1373,7 @@ Status StorageManagerCanonical::object_remove(const char* path) const {
         std::string("Cannot remove object '") + path +
         "'; Invalid TileDB object"));
 
-  return vfs_->remove_dir(uri);
+  return vfs()->remove_dir(uri);
 }
 
 Status StorageManagerCanonical::object_move(
@@ -1410,7 +1395,7 @@ Status StorageManagerCanonical::object_move(
         std::string("Cannot move object '") + old_path +
         "'; Invalid TileDB object"));
 
-  return vfs_->move_dir(old_uri, new_uri);
+  return vfs()->move_dir(old_uri, new_uri);
 }
 
 const std::unordered_map<std::string, std::string>&
@@ -1442,28 +1427,20 @@ Status StorageManagerCanonical::group_create(const std::string& group_uri) {
   }
 
   // Create group directory
-  RETURN_NOT_OK(vfs_->create_dir(uri));
+  RETURN_NOT_OK(vfs()->create_dir(uri));
 
   // Create group file
   URI group_filename = uri.join_path(constants::group_filename);
-  RETURN_NOT_OK(vfs_->touch(group_filename));
+  RETURN_NOT_OK(vfs()->touch(group_filename));
 
   // Create metadata folder
   RETURN_NOT_OK(
-      vfs_->create_dir(uri.join_path(constants::group_metadata_dir_name)));
+      vfs()->create_dir(uri.join_path(constants::group_metadata_dir_name)));
 
   // Create group detail folder
   RETURN_NOT_OK(
-      vfs_->create_dir(uri.join_path(constants::group_detail_dir_name)));
+      vfs()->create_dir(uri.join_path(constants::group_detail_dir_name)));
   return Status::Ok();
-}
-
-ThreadPool* StorageManagerCanonical::compute_tp() const {
-  return compute_tp_;
-}
-
-ThreadPool* StorageManagerCanonical::io_tp() const {
-  return io_tp_;
 }
 
 RestClient* StorageManagerCanonical::rest_client() const {
@@ -1486,7 +1463,7 @@ bool StorageManagerCanonical::is_array(const URI& uri) const {
   } else {
     // Check if the schema directory exists or not
     bool dir_exists = false;
-    throw_if_not_ok(vfs_->is_dir(
+    throw_if_not_ok(vfs()->is_dir(
         uri.join_path(constants::array_schema_dir_name), &dir_exists));
 
     if (dir_exists) {
@@ -1495,7 +1472,7 @@ bool StorageManagerCanonical::is_array(const URI& uri) const {
 
     bool schema_exists = false;
     // If there is no schema directory, we check schema file
-    throw_if_not_ok(vfs_->is_file(
+    throw_if_not_ok(vfs()->is_file(
         uri.join_path(constants::array_schema_filename), &schema_exists));
     return schema_exists;
   }
@@ -1504,7 +1481,7 @@ bool StorageManagerCanonical::is_array(const URI& uri) const {
 }
 
 Status StorageManagerCanonical::is_file(const URI& uri, bool* is_file) const {
-  RETURN_NOT_OK(vfs_->is_file(uri, is_file));
+  RETURN_NOT_OK(vfs()->is_file(uri, is_file));
   return Status::Ok();
 }
 
@@ -1516,7 +1493,7 @@ Status StorageManagerCanonical::is_group(const URI& uri, bool* is_group) const {
     *is_group = *exists;
   } else {
     // Check for new group details directory
-    RETURN_NOT_OK(vfs_->is_dir(
+    RETURN_NOT_OK(vfs()->is_dir(
         uri.join_path(constants::group_detail_dir_name), is_group));
 
     if (*is_group) {
@@ -1525,7 +1502,7 @@ Status StorageManagerCanonical::is_group(const URI& uri, bool* is_group) const {
 
     // Fall back to older group file to check for legacy (pre-format 12) groups
     RETURN_NOT_OK(
-        vfs_->is_file(uri.join_path(constants::group_filename), is_group));
+        vfs()->is_file(uri.join_path(constants::group_filename), is_group));
   }
   return Status::Ok();
 }
@@ -1533,14 +1510,14 @@ Status StorageManagerCanonical::is_group(const URI& uri, bool* is_group) const {
 tuple<Status, optional<shared_ptr<ArraySchema>>>
 StorageManagerCanonical::load_array_schema_from_uri(
     const URI& schema_uri, const EncryptionKey& encryption_key) {
-  auto timer_se = stats_->start_timer("sm_load_array_schema_from_uri");
+  auto timer_se = stats()->start_timer("sm_load_array_schema_from_uri");
 
   auto&& [st, tile_opt] =
       load_data_from_generic_tile(schema_uri, 0, encryption_key);
   RETURN_NOT_OK_TUPLE(st, nullopt);
   auto& tile = *tile_opt;
 
-  stats_->add_counter("read_array_schema_size", tile.size());
+  stats()->add_counter("read_array_schema_size", tile.size());
 
   // Deserialize
   Deserializer deserializer(tile.data(), tile.size());
@@ -1557,7 +1534,7 @@ StorageManagerCanonical::load_array_schema_from_uri(
 tuple<Status, optional<shared_ptr<ArraySchema>>>
 StorageManagerCanonical::load_array_schema_latest(
     const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
-  auto timer_se = stats_->start_timer("sm_load_array_schema_latest");
+  auto timer_se = stats()->start_timer("sm_load_array_schema_latest");
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
@@ -1601,7 +1578,7 @@ tuple<
     optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
 StorageManagerCanonical::load_all_array_schemas(
     const ArrayDirectory& array_dir, const EncryptionKey& encryption_key) {
-  auto timer_se = stats_->start_timer("sm_load_all_array_schemas");
+  auto timer_se = stats()->start_timer("sm_load_all_array_schemas");
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
@@ -1621,7 +1598,7 @@ StorageManagerCanonical::load_all_array_schemas(
   schema_vector.resize(schema_num);
 
   auto status =
-      parallel_for(compute_tp_, 0, schema_num, [&](size_t schema_ith) {
+      parallel_for(compute_tp(), 0, schema_num, [&](size_t schema_ith) {
         auto& schema_uri = schema_uris[schema_ith];
         try {
           auto&& [st, array_schema] =
@@ -1649,7 +1626,7 @@ void StorageManagerCanonical::load_array_metadata(
     const ArrayDirectory& array_dir,
     const EncryptionKey& encryption_key,
     Metadata* metadata) {
-  auto timer_se = stats_->start_timer("sm_load_array_metadata");
+  auto timer_se = stats()->start_timer("sm_load_array_metadata");
 
   // Special case
   if (metadata == nullptr) {
@@ -1661,7 +1638,7 @@ void StorageManagerCanonical::load_array_metadata(
 
   auto metadata_num = array_metadata_to_load.size();
   std::vector<shared_ptr<Tile>> metadata_tiles(metadata_num);
-  throw_if_not_ok(parallel_for(compute_tp_, 0, metadata_num, [&](size_t m) {
+  throw_if_not_ok(parallel_for(compute_tp(), 0, metadata_num, [&](size_t m) {
     const auto& uri = array_metadata_to_load[m].uri_;
 
     auto&& [st, tile] = load_data_from_generic_tile(uri, 0, encryption_key);
@@ -1677,7 +1654,7 @@ void StorageManagerCanonical::load_array_metadata(
   for (const auto& t : metadata_tiles) {
     meta_size += t->size();
   }
-  stats_->add_counter("read_array_meta_size", meta_size);
+  stats()->add_counter("read_array_meta_size", meta_size);
 
   *metadata = Metadata::deserialize(metadata_tiles);
 
@@ -1694,7 +1671,7 @@ StorageManagerCanonical::load_delete_and_update_conditions(const Array& array) {
   auto conditions = std::vector<QueryCondition>(locations.size());
   auto update_values = std::vector<std::vector<UpdateValue>>(locations.size());
 
-  auto status = parallel_for(compute_tp_, 0, locations.size(), [&](size_t i) {
+  auto status = parallel_for(compute_tp(), 0, locations.size(), [&](size_t i) {
     // Get condition marker.
     auto& uri = locations[i].uri();
 
@@ -1748,7 +1725,7 @@ Status StorageManagerCanonical::object_type(
   } else if (!uri.is_tiledb()) {
     // For non public cloud backends, listing a non-directory is an error.
     bool is_dir = false;
-    RETURN_NOT_OK(vfs_->is_dir(uri, &is_dir));
+    RETURN_NOT_OK(vfs()->is_dir(uri, &is_dir));
     if (!is_dir) {
       *type = ObjectType::INVALID;
       return Status::Ok();
@@ -1781,7 +1758,7 @@ Status StorageManagerCanonical::object_iter_begin(
 
   // Get all contents of path
   std::vector<URI> uris;
-  RETURN_NOT_OK(vfs_->ls(path_uri, &uris));
+  RETURN_NOT_OK(vfs()->ls(path_uri, &uris));
 
   // Create a new object iterator
   *obj_iter = tdb_new(ObjectIter);
@@ -1813,7 +1790,7 @@ Status StorageManagerCanonical::object_iter_begin(
 
   // Get all contents of path
   std::vector<URI> uris;
-  RETURN_NOT_OK(vfs_->ls(path_uri, &uris));
+  RETURN_NOT_OK(vfs()->ls(path_uri, &uris));
 
   // Create a new object iterator
   *obj_iter = tdb_new(ObjectIter);
@@ -1865,7 +1842,7 @@ Status StorageManagerCanonical::object_iter_next_postorder(
     do {
       obj_num = obj_iter->objs_.size();
       std::vector<URI> uris;
-      RETURN_NOT_OK(vfs_->ls(obj_iter->objs_.front(), &uris));
+      RETURN_NOT_OK(vfs()->ls(obj_iter->objs_.front(), &uris));
       obj_iter->expanded_.front() = true;
 
       // Push the new TileDB objects in the front of the iterator's list
@@ -1912,7 +1889,7 @@ Status StorageManagerCanonical::object_iter_next_preorder(
 
   // Get all contents of the next URI
   std::vector<URI> uris;
-  RETURN_NOT_OK(vfs_->ls(front_uri, &uris));
+  RETURN_NOT_OK(vfs()->ls(front_uri, &uris));
 
   // Push the new TileDB objects in the front of the iterator's list
   ObjectType obj_type;
@@ -1954,7 +1931,7 @@ Status StorageManagerCanonical::read_from_cache(
 Status StorageManagerCanonical::read(
     const URI& uri, uint64_t offset, Buffer* buffer, uint64_t nbytes) const {
   RETURN_NOT_OK(buffer->realloc(nbytes));
-  RETURN_NOT_OK(vfs_->read(uri, offset, buffer->data(), nbytes));
+  RETURN_NOT_OK(vfs()->read(uri, offset, buffer->data(), nbytes));
   buffer->set_size(nbytes);
   buffer->reset_offset();
   return Status::Ok();
@@ -1962,7 +1939,7 @@ Status StorageManagerCanonical::read(
 
 Status StorageManagerCanonical::read(
     const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) const {
-  RETURN_NOT_OK(vfs_->read(uri, offset, buffer, nbytes));
+  RETURN_NOT_OK(vfs()->read(uri, offset, buffer, nbytes));
   return Status::Ok();
 }
 
@@ -1992,7 +1969,7 @@ Status StorageManagerCanonical::store_group_detail(
   Serializer serializer(tile.data(), tile.size());
   group->serialize(serializer);
 
-  stats_->add_counter("write_group_size", tile.size());
+  stats()->add_counter("write_group_size", tile.size());
 
   // Check if the array schema directory exists
   // If not create it, this is caused by a pre-v10 array
@@ -2020,13 +1997,13 @@ Status StorageManagerCanonical::store_array_schema(
   Serializer serializer(tile.data(), tile.size());
   array_schema->serialize(serializer);
 
-  stats_->add_counter("write_array_schema_size", tile.size());
+  stats()->add_counter("write_array_schema_size", tile.size());
 
   // Delete file if it exists already
   bool exists;
   RETURN_NOT_OK(is_file(schema_uri, &exists));
   if (exists)
-    RETURN_NOT_OK(vfs_->remove_file(schema_uri));
+    RETURN_NOT_OK(vfs()->remove_file(schema_uri));
 
   // Check if the array schema directory exists
   // If not create it, this is caused by a pre-v10 array
@@ -2044,7 +2021,7 @@ Status StorageManagerCanonical::store_array_schema(
 
 Status StorageManagerCanonical::store_metadata(
     const URI& uri, const EncryptionKey& encryption_key, Metadata* metadata) {
-  auto timer_se = stats_->start_timer("write_meta");
+  auto timer_se = stats()->start_timer("write_meta");
 
   // Trivial case
   if (metadata == nullptr)
@@ -2063,7 +2040,7 @@ Status StorageManagerCanonical::store_metadata(
   Serializer serializer(tile.data(), tile.size());
   metadata->serialize(serializer);
 
-  stats_->add_counter("write_meta_size", serializer.size());
+  stats()->add_counter("write_meta_size", serializer.size());
 
   // Create a metadata file name
   URI metadata_uri;
@@ -2088,15 +2065,11 @@ Status StorageManagerCanonical::store_data_to_generic_tile(
 }
 
 Status StorageManagerCanonical::close_file(const URI& uri) {
-  return vfs_->close_file(uri);
+  return vfs()->close_file(uri);
 }
 
 Status StorageManagerCanonical::sync(const URI& uri) {
-  return vfs_->sync(uri);
-}
-
-VFS* StorageManagerCanonical::vfs() const {
-  return vfs_;
+  return vfs()->sync(uri);
 }
 
 void StorageManagerCanonical::wait_for_zero_in_progress() {
@@ -2110,7 +2083,7 @@ Status StorageManagerCanonical::init_rest_client() {
   RETURN_NOT_OK(config_.get("rest.server_address", &server_address));
   if (server_address != nullptr) {
     rest_client_.reset(tdb_new(RestClient));
-    RETURN_NOT_OK(rest_client_->init(stats_, &config_, compute_tp_, logger_));
+    RETURN_NOT_OK(rest_client_->init(stats(), &config_, compute_tp(), logger_));
   }
 
   return Status::Ok();
@@ -2141,11 +2114,7 @@ Status StorageManagerCanonical::write_to_cache(
 
 Status StorageManagerCanonical::write(
     const URI& uri, void* data, uint64_t size) const {
-  return vfs_->write(uri, data, size);
-}
-
-stats::Stats* StorageManagerCanonical::stats() {
-  return stats_;
+  return vfs()->write(uri, data, size);
 }
 
 shared_ptr<Logger> StorageManagerCanonical::logger() const {
@@ -2155,13 +2124,13 @@ shared_ptr<Logger> StorageManagerCanonical::logger() const {
 tuple<Status, optional<shared_ptr<Group>>>
 StorageManagerCanonical::load_group_from_uri(
     const URI& group_uri, const URI& uri, const EncryptionKey& encryption_key) {
-  auto timer_se = stats_->start_timer("sm_load_group_from_uri");
+  auto timer_se = stats()->start_timer("sm_load_group_from_uri");
 
   auto&& [st, tile_opt] = load_data_from_generic_tile(uri, 0, encryption_key);
   RETURN_NOT_OK_TUPLE(st, nullopt);
   auto& tile = *tile_opt;
 
-  stats_->add_counter("read_group_size", tile.size());
+  stats()->add_counter("read_group_size", tile.size());
 
   // Deserialize
   Deserializer deserializer(tile.data(), tile.size());
@@ -2173,7 +2142,7 @@ tuple<Status, optional<shared_ptr<Group>>>
 StorageManagerCanonical::load_group_details(
     const shared_ptr<GroupDirectory>& group_directory,
     const EncryptionKey& encryption_key) {
-  auto timer_se = stats_->start_timer("sm_load_group_details");
+  auto timer_se = stats()->start_timer("sm_load_group_details");
   const URI& latest_group_uri = group_directory->latest_group_details_uri();
   if (latest_group_uri.is_invalid()) {
     // Returning ok because not having the latest group details means the group
@@ -2189,7 +2158,7 @@ std::tuple<
     std::optional<
         const std::unordered_map<std::string, tdb_shared_ptr<GroupMember>>>>
 StorageManagerCanonical::group_open_for_reads(Group* group) {
-  auto timer_se = stats_->start_timer("group_open_for_reads");
+  auto timer_se = stats()->start_timer("group_open_for_reads");
 
   // Load group data
   auto&& [st, group_deserialized] =
@@ -2214,7 +2183,7 @@ std::tuple<
     std::optional<
         const std::unordered_map<std::string, tdb_shared_ptr<GroupMember>>>>
 StorageManagerCanonical::group_open_for_writes(Group* group) {
-  auto timer_se = stats_->start_timer("group_open_for_writes");
+  auto timer_se = stats()->start_timer("group_open_for_writes");
 
   // Load group data
   auto&& [st, group_deserialized] =
@@ -2238,7 +2207,7 @@ void StorageManagerCanonical::load_group_metadata(
     const shared_ptr<GroupDirectory>& group_dir,
     const EncryptionKey& encryption_key,
     Metadata* metadata) {
-  auto timer_se = stats_->start_timer("sm_load_group_metadata");
+  auto timer_se = stats()->start_timer("sm_load_group_metadata");
 
   // Special case
   if (metadata == nullptr) {
@@ -2251,7 +2220,7 @@ void StorageManagerCanonical::load_group_metadata(
   auto metadata_num = group_metadata_to_load.size();
   // TBD: Might use DynamicArray when it is more capable.
   std::vector<shared_ptr<Tile>> metadata_tiles(metadata_num);
-  throw_if_not_ok(parallel_for(compute_tp_, 0, metadata_num, [&](size_t m) {
+  throw_if_not_ok(parallel_for(compute_tp(), 0, metadata_num, [&](size_t m) {
     const auto& uri = group_metadata_to_load[m].uri_;
 
     auto&& [st, tile] = load_data_from_generic_tile(uri, 0, encryption_key);
@@ -2267,7 +2236,7 @@ void StorageManagerCanonical::load_group_metadata(
   for (const auto& t : metadata_tiles) {
     meta_size += t->size();
   }
-  stats_->add_counter("read_array_meta_size", meta_size);
+  stats()->add_counter("read_array_meta_size", meta_size);
 
   // Copy the deserialized metadata into the original Metadata object
   *metadata = Metadata::deserialize(metadata_tiles);
@@ -2346,13 +2315,13 @@ StorageManagerCanonical::load_fragment_metadata(
     const std::vector<TimestampedURI>& fragments_to_load,
     const std::unordered_map<std::string, std::pair<Tile*, uint64_t>>&
         offsets) {
-  auto timer_se = stats_->start_timer("load_fragment_metadata");
+  auto timer_se = stats()->start_timer("load_fragment_metadata");
 
   // Load the metadata for each fragment
   auto fragment_num = fragments_to_load.size();
   std::vector<shared_ptr<FragmentMetadata>> fragment_metadata;
   fragment_metadata.resize(fragment_num);
-  auto status = parallel_for(compute_tp_, 0, fragment_num, [&](size_t f) {
+  auto status = parallel_for(compute_tp(), 0, fragment_num, [&](size_t f) {
     const auto& sf = fragments_to_load[f];
 
     URI coords_uri =
@@ -2368,7 +2337,7 @@ StorageManagerCanonical::load_fragment_metadata(
     shared_ptr<FragmentMetadata> metadata;
     if (f_version == 1) {  // This is equivalent to format version <=2
       bool sparse;
-      RETURN_NOT_OK(vfs_->is_file(coords_uri, &sparse));
+      RETURN_NOT_OK(vfs()->is_file(coords_uri, &sparse));
       metadata = make_shared<FragmentMetadata>(
           HERE(),
           this,
@@ -2421,7 +2390,7 @@ tuple<
     optional<std::vector<std::pair<std::string, uint64_t>>>>
 StorageManagerCanonical::load_consolidated_fragment_meta(
     const URI& uri, const EncryptionKey& enc_key) {
-  auto timer_se = stats_->start_timer("read_load_consolidated_frag_meta");
+  auto timer_se = stats()->start_timer("read_load_consolidated_frag_meta");
 
   // No consolidated fragment metadata file
   if (uri.to_string().empty())
@@ -2431,7 +2400,7 @@ StorageManagerCanonical::load_consolidated_fragment_meta(
   RETURN_NOT_OK_TUPLE(st, nullopt, nullopt);
   auto& tile = *tile_opt;
 
-  stats_->add_counter("consolidated_frag_meta_size", tile.size());
+  stats()->add_counter("consolidated_frag_meta_size", tile.size());
 
   uint32_t fragment_num;
   Deserializer deserializer(tile.data(), tile.size());

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1277,10 +1277,9 @@ Status StorageManagerCanonical::array_get_encryption(
   const URI& schema_uri = array_dir.latest_array_schema_uri();
 
   // Read tile header
-  auto&& [st, header] =
-      GenericTileIO::read_generic_tile_header(this, schema_uri, 0);
-  RETURN_NOT_OK(st);
-  *encryption_type = static_cast<EncryptionType>(header->encryption_type);
+  auto&& header = GenericTileIO::read_generic_tile_header(
+      resources_, schema_uri, 0);
+  *encryption_type = static_cast<EncryptionType>(header.encryption_type);
 
   return Status::Ok();
 }
@@ -2053,7 +2052,7 @@ Status StorageManagerCanonical::store_metadata(
 
 Status StorageManagerCanonical::store_data_to_generic_tile(
     Tile& tile, const URI& uri, const EncryptionKey& encryption_key) {
-  GenericTileIO tile_io(this, uri);
+  GenericTileIO tile_io(resources_, uri);
   uint64_t nbytes = 0;
   Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);
 
@@ -2246,7 +2245,7 @@ void StorageManagerCanonical::load_group_metadata(
 tuple<Status, optional<Tile>>
 StorageManagerCanonical::load_data_from_generic_tile(
     const URI& uri, uint64_t offset, const EncryptionKey& encryption_key) {
-  GenericTileIO tile_io(this, uri);
+  GenericTileIO tile_io(resources_, uri);
 
   // Get encryption key from config
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -38,7 +38,6 @@
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
@@ -50,8 +49,8 @@ namespace sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-GenericTileIO::GenericTileIO(StorageManager* storage_manager, const URI& uri)
-    : storage_manager_(storage_manager)
+GenericTileIO::GenericTileIO(ContextResources& resources, const URI& uri)
+    : resources_(resources)
     , uri_(uri) {
 }
 
@@ -63,10 +62,8 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
-  auto&& [st, header_opt] =
-      read_generic_tile_header(storage_manager_, uri_, file_offset);
-  RETURN_NOT_OK_TUPLE(st, nullopt);
-  auto& header = *header_opt;
+
+  auto&& header = read_generic_tile_header(resources_, uri_, file_offset);
 
   if (encryption_key.encryption_type() !=
       (EncryptionType)header.encryption_type) {
@@ -94,7 +91,7 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
 
   // Read the tile.
   RETURN_NOT_OK_TUPLE(
-      storage_manager_->read(
+      resources_.vfs().read(
           uri_,
           file_offset + tile_data_offset,
           tile.filtered_buffer().data(),
@@ -105,10 +102,10 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   assert(tile.filtered());
   RETURN_NOT_OK_TUPLE(
       header.filters.run_reverse(
-          storage_manager_->stats(),
+          &resources_.stats(),
           &tile,
           nullptr,
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           config,
           nullptr),
       nullopt);
@@ -117,51 +114,45 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   return {Status::Ok(), std::move(tile)};
 }
 
-tuple<Status, optional<GenericTileIO::GenericTileHeader>>
+GenericTileIO::GenericTileHeader
 GenericTileIO::read_generic_tile_header(
-    const StorageManager* sm, const URI& uri, uint64_t file_offset) {
+    ContextResources& resources, const URI& uri, uint64_t file_offset) {
   GenericTileHeader header;
 
-  // Read the fixed-sized part of the header from file
-  tdb_unique_ptr<Buffer> header_buff(tdb_new(Buffer));
-  RETURN_NOT_OK_TUPLE(
-      sm->read(
-          uri, file_offset, header_buff.get(), GenericTileHeader::BASE_SIZE),
-      nullopt);
+  std::vector<uint8_t> base_buf(GenericTileHeader::BASE_SIZE);
 
-  // Read header individual values
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.version_number, sizeof(uint32_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.persisted_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.tile_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.datatype, sizeof(uint8_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.cell_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.encryption_type, sizeof(uint8_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.filter_pipeline_size, sizeof(uint32_t)),
-      nullopt);
+  throw_if_not_ok(resources.vfs().read(
+      uri,
+      file_offset,
+      base_buf.data(),
+      base_buf.size()));
+
+  Deserializer base_deserializer(base_buf.data(), base_buf.size());
+
+  header.version_number = base_deserializer.read<uint32_t>();
+  header.persisted_size = base_deserializer.read<uint64_t>();
+  header.tile_size = base_deserializer.read<uint64_t>();
+  header.datatype = base_deserializer.read<uint8_t>();
+  header.cell_size = base_deserializer.read<uint64_t>();
+  header.encryption_type = base_deserializer.read<uint8_t>();
+  header.filter_pipeline_size = base_deserializer.read<uint32_t>();
 
   // Read header filter pipeline.
-  header_buff->reset_size();
-  header_buff->reset_offset();
-  RETURN_NOT_OK_TUPLE(
-      sm->read(
-          uri,
-          file_offset + GenericTileHeader::BASE_SIZE,
-          header_buff.get(),
-          header.filter_pipeline_size),
-      nullopt);
-  Deserializer deserializer(header_buff->data(), header_buff->size());
+  std::vector<uint8_t> filter_pipeline_buf(header.filter_pipeline_size);
+  throw_if_not_ok(resources.vfs().read(
+      uri,
+      file_offset + GenericTileHeader::BASE_SIZE,
+      filter_pipeline_buf.data(),
+      filter_pipeline_buf.size()));
+
+  Deserializer filter_pipeline_deserializer(
+      filter_pipeline_buf.data(), filter_pipeline_buf.size());
   auto filterpipeline{
-      FilterPipeline::deserialize(deserializer, header.version_number)};
+      FilterPipeline::deserialize(
+          filter_pipeline_deserializer, header.version_number)};
   header.filters = std::move(filterpipeline);
 
-  return {Status::Ok(), header};
+  return header;
 }
 
 Status GenericTileIO::write_generic(
@@ -173,16 +164,16 @@ Status GenericTileIO::write_generic(
   // Filter tile
   assert(!tile->filtered());
   RETURN_NOT_OK(header.filters.run_forward(
-      storage_manager_->stats(),
+      &resources_.stats(),
       tile,
       nullptr,
-      storage_manager_->compute_tp()));
+      &resources_.compute_tp()));
   header.persisted_size = tile->filtered_buffer().size();
   assert(tile->filtered());
 
   RETURN_NOT_OK(write_generic_tile_header(&header));
 
-  RETURN_NOT_OK(storage_manager_->write(
+  RETURN_NOT_OK(resources_.vfs().write(
       uri_, tile->filtered_buffer().data(), tile->filtered_buffer().size()));
 
   *nbytes = GenericTileIO::GenericTileHeader::BASE_SIZE +
@@ -217,9 +208,9 @@ Status GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
   serialize_generic_tile_header(serializer, *header);
 
   // Write buffer to file
-  Status st = storage_manager_->write(uri_, data.data(), data.size());
+  RETURN_NOT_OK(resources_.vfs().write(uri_, data.data(), data.size()));
 
-  return st;
+  return Status::Ok();
 }
 
 Status GenericTileIO::configure_encryption_filter(

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -62,7 +62,6 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
-
   auto&& header = read_generic_tile_header(resources_, uri_, file_offset);
 
   if (encryption_key.encryption_type() !=
@@ -114,18 +113,14 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   return {Status::Ok(), std::move(tile)};
 }
 
-GenericTileIO::GenericTileHeader
-GenericTileIO::read_generic_tile_header(
+GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
     ContextResources& resources, const URI& uri, uint64_t file_offset) {
   GenericTileHeader header;
 
   std::vector<uint8_t> base_buf(GenericTileHeader::BASE_SIZE);
 
-  throw_if_not_ok(resources.vfs().read(
-      uri,
-      file_offset,
-      base_buf.data(),
-      base_buf.size()));
+  throw_if_not_ok(
+      resources.vfs().read(uri, file_offset, base_buf.data(), base_buf.size()));
 
   Deserializer base_deserializer(base_buf.data(), base_buf.size());
 
@@ -147,9 +142,8 @@ GenericTileIO::read_generic_tile_header(
 
   Deserializer filter_pipeline_deserializer(
       filter_pipeline_buf.data(), filter_pipeline_buf.size());
-  auto filterpipeline{
-      FilterPipeline::deserialize(
-          filter_pipeline_deserializer, header.version_number)};
+  auto filterpipeline{FilterPipeline::deserialize(
+      filter_pipeline_deserializer, header.version_number)};
   header.filters = std::move(filterpipeline);
 
   return header;
@@ -164,10 +158,7 @@ Status GenericTileIO::write_generic(
   // Filter tile
   assert(!tile->filtered());
   RETURN_NOT_OK(header.filters.run_forward(
-      &resources_.stats(),
-      tile,
-      nullptr,
-      &resources_.compute_tp()));
+      &resources_.stats(), tile, nullptr, &resources_.compute_tp()));
   header.persisted_size = tile->filtered_buffer().size();
   assert(tile->filtered());
 

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -37,7 +37,8 @@
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
+#include "tiledb/sm/stats/stats.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 
 using namespace tiledb::common;
 
@@ -99,10 +100,10 @@ class GenericTileIO {
   /**
    * Constructor.
    *
-   * @param storage_manager The storage manager.
+   * @param resources The ContextResources to use
    * @param uri The name of the file that stores data.
    */
-  GenericTileIO(StorageManager* storage_manager, const URI& uri);
+  GenericTileIO(ContextResources& resources, const URI& uri);
 
   GenericTileIO() = delete;
   DISABLE_COPY_AND_COPY_ASSIGN(GenericTileIO);
@@ -135,15 +136,15 @@ class GenericTileIO {
   /**
    * Reads the generic tile header from the file.
    *
-   * @param sm The StorageManager instance to use for reading.
+   * @param resources The ContextResources instance to use for reading.
    * @param uri The URI of the generic tile.
    * @param file_offset The offset where the header read will begin.
    * @param encryption_key If the array is encrypted, the private encryption
    *    key. For unencrypted arrays, pass `nullptr`.
    * @return Status, Header
    */
-  static tuple<Status, optional<GenericTileHeader>> read_generic_tile_header(
-      const StorageManager* sm, const URI& uri, uint64_t file_offset);
+  static GenericTileHeader read_generic_tile_header(
+      ContextResources& resources, const URI& uri, uint64_t file_offset);
 
   /**
    * Writes a tile generically to the file. This means that a header will be
@@ -181,8 +182,8 @@ class GenericTileIO {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The storage manager object. */
-  StorageManager* storage_manager_;
+  /** The ContextResources object. */
+  ContextResources& resources_;
 
   /** The file URI. */
   URI uri_;

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -116,9 +116,9 @@ void InfoCommand::run() {
 }
 
 void InfoCommand::print_tile_sizes() const {
-  stats::Stats stats("");
-  StorageManager sm(
-      &compute_tp_, &io_tp_, &stats, make_shared<Logger>(HERE(), ""), Config());
+  Config config;
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Open the array
   URI uri(array_uri_);
@@ -186,9 +186,9 @@ void InfoCommand::print_tile_sizes() const {
 }
 
 void InfoCommand::print_schema_info() const {
-  stats::Stats stats("");
-  StorageManager sm(
-      &compute_tp_, &io_tp_, &stats, make_shared<Logger>(HERE(), ""), Config());
+  Config config;
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Open the array
   URI uri(array_uri_);
@@ -203,9 +203,9 @@ void InfoCommand::print_schema_info() const {
 }
 
 void InfoCommand::write_svg_mbrs() const {
-  stats::Stats stats("");
-  StorageManager sm(
-      &compute_tp_, &io_tp_, &stats, make_shared<Logger>(HERE(), ""), Config());
+  Config config;
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Open the array
   URI uri(array_uri_);
@@ -278,9 +278,9 @@ void InfoCommand::write_svg_mbrs() const {
 }
 
 void InfoCommand::write_text_mbrs() const {
-  stats::Stats stats("");
-  StorageManager sm(
-      &compute_tp_, &io_tp_, &stats, make_shared<Logger>(HERE(), ""), Config());
+  Config config;
+  ContextResources resources(config, 1, 1, "");
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Open the array
   URI uri(array_uri_);


### PR DESCRIPTION
Create a ContextResources container class

This new class just holds references to the compute thread pool, IO
thread pool, and stats instances. The purpose of this change is to make
removing StorageManager dependencies more ergonomic by having a single
simple instance to pass around instead of passing each of the three
resources as separate arguments.

Eventually we'll also move the StorageManager::vfs_ instance into this
class once the cyclic dependency between StorageManager and GlobalState
is removed.

---
TYPE: IMPROVEMENT
DESC: Create ContextResources container class to help remove StorageManager
