### PR TITLE
Remove non owning tile constructor.

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1531,8 +1531,7 @@ class FragmentMetadata {
   /**
    * Loads the bounding coordinates from the fragment metadata buffer.
    *
-   * @param buff Metadata buffer.
-   * @return Status
+   * @param deserializer Deserializer to get data from.
    */
   void load_bounding_coords(Deserializer& deserializer);
 
@@ -1575,32 +1574,28 @@ class FragmentMetadata {
   /**
    * Loads the cell number of the last tile from the fragment metadata buffer.
    *
-   * @param buff Metadata buffer.
-   * @return Status
+   * @param deserializer Deserializer to get data from.
    */
   void load_last_tile_cell_num(Deserializer& deserializer);
 
   /**
    * Loads the `has_timestamps_` field from the buffer.
    *
-   * @param buff Metadata buffer.
-   * @return Status
+   * @param deserializer Deserializer to get data from.
    */
   void load_has_timestamps(Deserializer& deserializer);
 
   /**
    * Loads the `has_delete_meta_` field from the buffer.
    *
-   * @param buff Metadata buffer.
-   * @return Status
+   * @param deserializer Deserializer to get data from.
    */
   void load_has_delete_meta(Deserializer& deserializer);
 
   /**
    * Loads the MBRs from the fragment metadata buffer.
    *
-   * @param buff Metadata buffer.
-   * @return Status
+   * @param deserializer Deserializer to get data from.
    */
   void load_mbrs(Deserializer& deserializer);
 
@@ -1843,14 +1838,14 @@ class FragmentMetadata {
    * offsets.
    * @return Status
    */
-  Status store_tile_validity_offsets(
+  void store_tile_validity_offsets(
       unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
 
   /**
    * Writes the validity tile offsets of the input attribute idx to the
    * input buffer.
    */
-  Status write_tile_validity_offsets(unsigned idx, Buffer* buff);
+  void write_tile_validity_offsets(unsigned idx, Serializer& serializer);
 
   /**
    * Writes the mins of the input attribute to storage.
@@ -1858,7 +1853,6 @@ class FragmentMetadata {
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the mins.
-   * @return Status
    */
   void store_tile_mins(
       unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
@@ -1874,7 +1868,6 @@ class FragmentMetadata {
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the maxs.
-   * @return Status
    */
   void store_tile_maxs(
       unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
@@ -1890,7 +1883,6 @@ class FragmentMetadata {
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the sums.
-   * @return Status
    */
   void store_tile_sums(
       unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
@@ -1906,7 +1898,6 @@ class FragmentMetadata {
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the null counts.
-   * @return Status
    */
   void store_tile_null_counts(
       unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
@@ -1931,7 +1922,6 @@ class FragmentMetadata {
    *
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written.
-   * @return Status
    */
   void store_processed_conditions(
       const EncryptionKey& encryption_key, uint64_t* nbytes);
@@ -1984,20 +1974,6 @@ class FragmentMetadata {
       std::shared_ptr<Tile>& tile,
       uint64_t* footer_offset,
       uint64_t* footer_size) const;
-
-  /**
-   * Writes the contents of the input buffer as a separate
-   * generic tile to the metadata file.
-   *
-   * @param encryption_key The encryption key.
-   * @param buff The buffer whose contents the function will write.
-   * @param nbytes The total number of bytes written to the file.
-   * @return Status
-   */
-  Status write_generic_tile_to_file(
-      const EncryptionKey& encryption_key,
-      Buffer& buff,
-      uint64_t* nbytes) const;
 
   /**
    * Writes the contents of the input tile as a separate

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -93,15 +93,14 @@ storage_size_t get_serialized_condition_size(
   return size_computation_serializer.size();
 }
 
-std::vector<uint8_t> serialize_condition(
-    const QueryCondition& query_condition) {
-  std::vector<uint8_t> ret(
-      get_serialized_condition_size(query_condition.ast()));
+Tile serialize_condition(const QueryCondition& query_condition) {
+  Tile tile{
+      Tile::from_generic(get_serialized_condition_size(query_condition.ast()))};
 
-  Serializer serializer(ret.data(), ret.size());
+  Serializer serializer(tile.data(), tile.size());
   serialize_condition_impl(query_condition.ast(), serializer);
 
-  return ret;
+  return tile;
 }
 
 tdb_unique_ptr<ASTNode> deserialize_condition_impl(Deserializer& deserializer) {
@@ -179,17 +178,17 @@ storage_size_t get_serialized_update_condition_and_values_size(
   return size_computation_serializer.size();
 }
 
-std::vector<uint8_t> serialize_update_condition_and_values(
+Tile serialize_update_condition_and_values(
     const QueryCondition& query_condition,
     const std::vector<UpdateValue>& update_values) {
-  std::vector<uint8_t> ret(get_serialized_update_condition_and_values_size(
-      query_condition.ast(), update_values));
+  Tile tile{Tile::from_generic(get_serialized_update_condition_and_values_size(
+      query_condition.ast(), update_values))};
 
-  Serializer serializer(ret.data(), ret.size());
+  Serializer serializer(tile.data(), tile.size());
   serialize_condition_impl(query_condition.ast(), serializer);
   serialize_update_values_impl(update_values, serializer);
 
-  return ret;
+  return tile;
 }
 std::vector<UpdateValue> deserialize_update_values_impl(
     Deserializer& deserializer) {

--- a/tiledb/sm/query/deletes_and_updates/serialization.h
+++ b/tiledb/sm/query/deletes_and_updates/serialization.h
@@ -46,9 +46,9 @@ enum class NodeType : uint8_t { EXPRESSION = 0, VALUE };
  * Serializes the condition.
  *
  * @param query_condition Query condition to serialize.
- * @return Serialized query condition.
+ * @return Serialized query condition tile.
  */
-std::vector<uint8_t> serialize_condition(const QueryCondition& query_condition);
+Tile serialize_condition(const QueryCondition& query_condition);
 
 /**
  * Deserializes the condition.
@@ -71,9 +71,9 @@ QueryCondition deserialize_condition(
  *
  * @param query_condition Query condition to serialize.
  * @param update_values Update values to serialize.
- * @return Serialized condition and update values.
+ * @return Serialized condition and update values tile.
  */
-std::vector<uint8_t> serialize_update_condition_and_values(
+Tile serialize_update_condition_and_values(
     const QueryCondition& query_condition,
     const std::vector<UpdateValue>& update_values);
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -2026,8 +2026,8 @@ Status StorageManagerCanonical::store_group_detail(
   if (!group_detail_dir_exists)
     RETURN_NOT_OK(create_dir(group_detail_folder_uri));
 
-  RETURN_NOT_OK(store_data_to_generic_tile(
-      tile.data(), tile.size(), *group_detail_uri, encryption_key));
+  RETURN_NOT_OK(
+      store_data_to_generic_tile(tile, *group_detail_uri, encryption_key));
 
   return st;
 }
@@ -2094,25 +2094,9 @@ Status StorageManagerCanonical::store_metadata(
   URI metadata_uri;
   RETURN_NOT_OK(metadata->get_uri(uri, &metadata_uri));
 
-  RETURN_NOT_OK(store_data_to_generic_tile(
-      tile.data(), tile.size(), metadata_uri, encryption_key));
+  RETURN_NOT_OK(store_data_to_generic_tile(tile, metadata_uri, encryption_key));
 
   return Status::Ok();
-}
-
-Status StorageManagerCanonical::store_data_to_generic_tile(
-    void* data,
-    const size_t size,
-    const URI& uri,
-    const EncryptionKey& encryption_key) {
-  Tile tile(
-      constants::generic_tile_datatype,
-      constants::generic_tile_cell_size,
-      0,
-      data,
-      size);
-
-  return store_data_to_generic_tile(tile, uri, encryption_key);
 }
 
 Status StorageManagerCanonical::store_data_to_generic_tile(

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -1028,21 +1028,6 @@ class StorageManagerCanonical {
   /**
    * Stores data into persistent storage.
    *
-   * @param data Data to store.
-   * @param size Size of the data.
-   * @param uri The object URI.
-   * @param encryption_key The encryption key to use.
-   * @return Status
-   */
-  Status store_data_to_generic_tile(
-      void* data,
-      const size_t size,
-      const URI& uri,
-      const EncryptionKey& encryption_key);
-
-  /**
-   * Stores data into persistent storage.
-   *
    * @param tile Tile to store.
    * @param uri The object URI.
    * @param encryption_key The encryption key to use.

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -49,9 +49,6 @@ class TileStatusException : public StatusException {
   }
 };
 
-void nop_free(void* const) {
-}
-
 /* ****************************** */
 /*           STATIC INIT          */
 /* ****************************** */
@@ -112,21 +109,6 @@ Tile::Tile(
     , format_version_(format_version)
     , type_(type)
     , filtered_buffer_(filtered_size) {
-}
-
-Tile::Tile(
-    const Datatype type,
-    const uint64_t cell_size,
-    const unsigned int zipped_coords_dim_num,
-    void* const buffer,
-    uint64_t size)
-    : data_(static_cast<char*>(buffer), nop_free)
-    , size_(size)
-    , cell_size_(cell_size)
-    , zipped_coords_dim_num_(zipped_coords_dim_num)
-    , format_version_(0)
-    , type_(type)
-    , filtered_buffer_(0) {
 }
 
 Tile::Tile(Tile&& tile)

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -106,24 +106,6 @@ class Tile {
       const uint64_t size,
       const uint64_t filtered_size);
 
-  /**
-   * Constructor.
-   *
-   * @param type The type of the data to be stored.
-   * @param cell_size The cell size.
-   * @param dim_num The number of dimensions in case the tile stores
-   *      coordinates.
-   * @param buffer The buffer to be encapsulated by the tile object. The
-   *      tile will not take ownership of the buffer.
-   * @param size The buffer size.
-   */
-  Tile(
-      Datatype type,
-      uint64_t cell_size,
-      unsigned int dim_num,
-      void* buffer,
-      uint64_t size);
-
   /** Move constructor. */
   Tile(Tile&& tile);
 


### PR DESCRIPTION
Now that epic #19497 is completed, we can remove the non owning tile constructor. This also cleans up the StorageManager::store_data_to_generic_tile version taking in a void* argument.

---
TYPE: IMPROVEMENT
DESC: Remove non owning tile constructor.
