### PR TITLE
Add Attribute data order constructor and checks

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -53,6 +53,7 @@
 #include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/storage_format/uri/parse_uri.h"
 
+#include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <set>
@@ -392,6 +393,19 @@ Status ArraySchema::check() const {
   check_attribute_dimension_label_names();
   check_webp_filter();
 
+  // Check for ordered attributes on sparse arrays and arrays with more than one
+  // dimension.
+  if (array_type_ == ArrayType::SPARSE || this->dim_num() != 1) {
+    if (std::any_of(
+            attributes_.cbegin(), attributes_.cend(), [](const auto& attr) {
+              return attr->order() != DataOrder::UNORDERED_DATA;
+            })) {
+      throw ArraySchemaStatusException(
+          "Array schema check failed; Ordered attributes are only supported on "
+          "dense arrays with 1 dimension.");
+    }
+  }
+
   // Check all internal dimension labels have a schema set and the schema is
   // compatible with the definition of the array it was added to.
   //
@@ -715,9 +729,10 @@ bool ArraySchema::var_size(const std::string& name) const {
 Status ArraySchema::add_attribute(
     shared_ptr<const Attribute> attr, bool check_special) {
   // Sanity check
-  if (attr == nullptr)
+  if (attr == nullptr) {
     return LOG_STATUS(Status_ArraySchemaError(
         "Cannot add attribute; Input attribute is null"));
+  }
 
   // Do not allow attributes with special names
   if (check_special && attr->name().find(constants::special_name_prefix) == 0) {

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -71,6 +71,28 @@ Attribute::Attribute(
 Attribute::Attribute(
     const std::string& name,
     Datatype type,
+    uint32_t cell_val_num,
+    DataOrder order)
+    : cell_val_num_(cell_val_num)
+    , nullable_(false)
+    , name_(name)
+    , type_(type)
+    , order_(order) {
+  set_default_fill_value();
+
+  if (order_ != DataOrder::UNORDERED_DATA) {
+    ensure_ordered_attribute_datatype_is_valid(type_);
+    if (cell_val_num_ != 1 && type != Datatype::STRING_ASCII) {
+      throw std::invalid_argument(
+          "Ordered attributes with datatype '" + datatype_str(type_) +
+          "' must have cell_val_num=1.");
+    }
+  }
+}
+
+Attribute::Attribute(
+    const std::string& name,
+    Datatype type,
     bool nullable,
     uint32_t cell_val_num,
     const FilterPipeline& filter_pipeline,

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -81,6 +81,20 @@ class Attribute {
    *
    * @param name The name of the attribute.
    * @param type The type of the attribute.
+   * @param cell_val_num The cell number of the attribute.
+   * @param order The ordering of the attribute.
+   */
+  Attribute(
+      const std::string& name,
+      Datatype type,
+      uint32_t cell_val_num,
+      DataOrder order);
+
+  /**
+   * Constructor.
+   *
+   * @param name The name of the attribute.
+   * @param type The type of the attribute.
    * @param nullable The nullable of the attribute.
    * @param cell_val_num The cell number of the attribute.
    * @param filter_pipeline The filters of the attribute.

--- a/tiledb/sm/array_schema/dimension_label_schema.cc
+++ b/tiledb/sm/array_schema/dimension_label_schema.cc
@@ -46,8 +46,7 @@ DimensionLabelSchema::DimensionLabelSchema(
     Datatype index_type,
     const void* index_domain,
     const void* index_tile_extent)
-    : label_order_(label_order)
-    , indexed_array_schema_(make_shared<ArraySchema>(
+    : indexed_array_schema_(make_shared<ArraySchema>(
           HERE(),
           label_order == DataOrder::UNORDERED_DATA ? ArrayType::SPARSE :
                                                      ArrayType::DENSE))
@@ -70,27 +69,28 @@ DimensionLabelSchema::DimensionLabelSchema(
         " is not a valid dimension datatype."));
   }
 
-  // Create indexed array.
-  if (label_order == DataOrder::UNORDERED_DATA) {
-    throw_if_not_ok(indexed_array_schema_->set_allows_dups(true));
-  }
+  // Create and set dimension label domain.
   std::vector<shared_ptr<Dimension>> index_dims{
       make_shared<Dimension>(HERE(), "index", index_type)};
   throw_if_not_ok(index_dims.back()->set_domain(index_domain));
   throw_if_not_ok(index_dims.back()->set_tile_extent(index_tile_extent));
   throw_if_not_ok(indexed_array_schema_->set_domain(make_shared<Domain>(
       HERE(), Layout::ROW_MAJOR, index_dims, Layout::ROW_MAJOR)));
-  auto label_attr = make_shared<Attribute>(HERE(), "label", label_type);
-  if (label_type == Datatype::STRING_ASCII)
-    throw_if_not_ok(label_attr->set_cell_val_num(constants::var_num));
+
+  // Create and set dimension label attribute.
+  uint32_t label_cell_val_num =
+      label_type == Datatype::STRING_ASCII ? constants::var_num : 1;
+  auto label_attr = make_shared<Attribute>(
+      HERE(), "label", label_type, label_cell_val_num, label_order);
   throw_if_not_ok(indexed_array_schema_->add_attribute(label_attr));
+
+  // Check the array schema is valid.
   throw_if_not_ok(indexed_array_schema_->check());
 }
 
 DimensionLabelSchema::DimensionLabelSchema(
-    DataOrder label_order, shared_ptr<ArraySchema> indexed_array_schema)
-    : label_order_(label_order)
-    , indexed_array_schema_(indexed_array_schema)
+    DataOrder, shared_ptr<ArraySchema> indexed_array_schema)
+    : indexed_array_schema_(indexed_array_schema)
     , label_domain_{} {
   // Check arrays have one dimension and one attribute
   if (indexed_array_schema->dim_num() != 1)
@@ -113,7 +113,6 @@ DimensionLabelSchema::DimensionLabelSchema(
 
 DimensionLabelSchema::DimensionLabelSchema(
     const DimensionLabelSchema* dim_label) {
-  label_order_ = dim_label->label_order_;
   indexed_array_schema_ =
       make_shared<ArraySchema>(HERE(), *dim_label->indexed_array_schema_);
   label_domain_ = dim_label->label_domain_;
@@ -123,17 +122,14 @@ const Dimension* DimensionLabelSchema::index_dimension() const {
   return indexed_array_schema_->dimension_ptr(0);
 }
 
-/** Returns the number of values per cell for the index. */
 uint32_t DimensionLabelSchema::index_cell_val_num() const {
   return index_dimension()->cell_val_num();
 }
 
-/** Returns a reference to the index domain. */
 const Range& DimensionLabelSchema::index_domain() const {
   return index_dimension()->domain();
 }
 
-/** Returns the index datatype. */
 Datatype DimensionLabelSchema::index_type() const {
   return index_dimension()->type();
 }
@@ -149,17 +145,18 @@ const Attribute* DimensionLabelSchema::label_attribute() const {
   return indexed_array_schema_->attribute(0);
 }
 
-/** Returns the number of values per cell for the index. */
 uint32_t DimensionLabelSchema::label_cell_val_num() const {
   return label_attribute()->cell_val_num();
 }
 
-/** Returns a reference to the index domain. */
 const Range& DimensionLabelSchema::label_domain() const {
   return label_domain_;
 }
 
-/** Returns the index datatype. */
+DataOrder DimensionLabelSchema::label_order() const {
+  return label_attribute()->order();
+}
+
 Datatype DimensionLabelSchema::label_type() const {
   return label_attribute()->type();
 }

--- a/tiledb/sm/array_schema/dimension_label_schema.h
+++ b/tiledb/sm/array_schema/dimension_label_schema.h
@@ -146,14 +146,9 @@ class DimensionLabelSchema {
   Datatype label_type() const;
 
   /** Returns the label order type of this dimension label. */
-  inline DataOrder label_order() const {
-    return label_order_;
-  }
+  DataOrder label_order() const;
 
  private:
-  /** Order of the labels relative to the indices. */
-  DataOrder label_order_;
-
   /** Schema for the array with indices defined on the dimension. */
   shared_ptr<ArraySchema> indexed_array_schema_;
 

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -392,6 +392,7 @@ inline void ensure_datatype_is_valid(const std::string& datatype_str) {
   ensure_datatype_is_valid(datatype_type);
 }
 
+/** Throws an error if the input type is not supported on dimenions. */
 inline void ensure_dimension_datatype_is_valid(Datatype type) {
   switch (type) {
     case Datatype::INT32:
@@ -432,6 +433,53 @@ inline void ensure_dimension_datatype_is_valid(Datatype type) {
       throw std::runtime_error(
           "Datatype '" + datatype_str(type) +
           "' is not a valid dimension datatype.");
+  }
+}
+
+/**
+ * Throws and error if the input type is not supported on attributes with
+ * increasing or decreasing order.
+ */
+inline void ensure_ordered_attribute_datatype_is_valid(Datatype type) {
+  switch (type) {
+    case Datatype::INT32:
+    case Datatype::INT64:
+    case Datatype::FLOAT32:
+    case Datatype::FLOAT64:
+    case Datatype::INT8:
+    case Datatype::UINT8:
+    case Datatype::INT16:
+    case Datatype::UINT16:
+    case Datatype::UINT32:
+    case Datatype::UINT64:
+    case Datatype::STRING_ASCII:
+    case Datatype::DATETIME_YEAR:
+    case Datatype::DATETIME_MONTH:
+    case Datatype::DATETIME_WEEK:
+    case Datatype::DATETIME_DAY:
+    case Datatype::DATETIME_HR:
+    case Datatype::DATETIME_MIN:
+    case Datatype::DATETIME_SEC:
+    case Datatype::DATETIME_MS:
+    case Datatype::DATETIME_US:
+    case Datatype::DATETIME_NS:
+    case Datatype::DATETIME_PS:
+    case Datatype::DATETIME_FS:
+    case Datatype::DATETIME_AS:
+    case Datatype::TIME_HR:
+    case Datatype::TIME_MIN:
+    case Datatype::TIME_SEC:
+    case Datatype::TIME_MS:
+    case Datatype::TIME_US:
+    case Datatype::TIME_NS:
+    case Datatype::TIME_PS:
+    case Datatype::TIME_FS:
+    case Datatype::TIME_AS:
+      return;
+    default:
+      throw std::runtime_error(
+          "Datatype '" + datatype_str(type) +
+          "' is not a valid datatype for an ordered attribute.");
   }
 }
 

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -392,7 +392,7 @@ inline void ensure_datatype_is_valid(const std::string& datatype_str) {
   ensure_datatype_is_valid(datatype_type);
 }
 
-/** Throws an error if the input type is not supported on dimenions. */
+/** Throws an error if the input type is not supported for dimensions. */
 inline void ensure_dimension_datatype_is_valid(Datatype type) {
   switch (type) {
     case Datatype::INT32:


### PR DESCRIPTION
Add a constructor for `Attribute` with the `DataOrder`. Add verifying data order to `Array::check`. Replace `label_order_` in `DimensionLabelSchema` with accessing value from the attribute.

---
TYPE: IMPROVEMENT
DESC: Add Attribute data order constructor and checks