### PR TITLE
Remove StorageManager references from GenericTileIO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,7 @@ if (TILEDB_TESTS)
   # Add cmake target for "tests" to build all unit tests executables
   add_custom_target(tests)
   add_dependencies(tests tiledb_unit)
+  add_dependencies(tests tiledb_regression)
   add_dependencies(tests test_assert)
 
   add_dependencies(tests unit_buffer unit_datum unit_dynamic_memory)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -269,6 +269,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/timer_stat.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context_resources.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/storage_manager.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/range_subset.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/subarray/subarray.cc

--- a/tiledb/api/c_api/context/CMakeLists.txt
+++ b/tiledb/api/c_api/context/CMakeLists.txt
@@ -34,6 +34,7 @@ gather_sources(${SOURCES})
 list(APPEND OTHER_SOURCES
     # We need to recompile sources that depend on StorageManager to use the stub
     ../../../sm/storage_manager/context.cc
+    ../../../sm/storage_manager/context_resources.cc
     # Source included here because it's not in object library `stats`
     ../../../sm/stats/global_stats.cc
     )

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -169,11 +169,9 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ThreadPool tp_cpu(1);
-  ThreadPool tp_io(1);
   stats::Stats stats("");
-  StorageManager sm(
-      &tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""), config);
+  ContextResources resources(1, 1, &stats);
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Register array
   tdb_unique_ptr<Array> array = x.open_array(uri, &sm);
@@ -197,11 +195,9 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ThreadPool tp_cpu(1);
-  ThreadPool tp_io(1);
   stats::Stats stats("");
-  StorageManager sm(
-      &tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""), config);
+  ContextResources resources(1, 1, &stats);
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   std::vector<tdb_unique_ptr<Array>> arrays;
   std::vector<URI> uris = {URI("whitebox_array_vector_1"),
@@ -242,11 +238,9 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ThreadPool tp_cpu(1);
-  ThreadPool tp_io(1);
   stats::Stats stats("");
-  StorageManager sm(
-      &tp_cpu, &tp_io, &stats, make_shared<Logger>(HERE(), ""), config);
+  ContextResources resources(1, 1, &stats);
+  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Create an array
   tdb_unique_ptr<Array> array = x.create_array(uri, &sm);

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -168,7 +168,10 @@ Status FragmentMetaConsolidator::consolidate(
       buff.data(),
       buff.size());
 
-  GenericTileIO tile_io(storage_manager_, uri);
+  GenericTileIO tile_io(
+      storage_manager_->resources(),
+      storage_manager_->vfs(),
+      uri);
   uint64_t nbytes = 0;
   RETURN_NOT_OK_ELSE(
       tile_io.write_generic(&tile, enc_key, &nbytes), buff.clear());

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3743,7 +3743,10 @@ Status FragmentMetadata::load_v1_v2(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+      storage_manager_->resources(),
+      storage_manager_->vfs(),
+      fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(0, encryption_key, storage_manager_->config());
   RETURN_NOT_OK(st);
@@ -4179,7 +4182,10 @@ tuple<Status, optional<Tile>> FragmentMetadata::read_generic_tile_from_file(
       std::string(constants::fragment_metadata_filename));
 
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+      storage_manager_->resources(),
+      storage_manager_->vfs(),
+      fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(offset, encryption_key, storage_manager_->config());
   RETURN_NOT_OK_TUPLE(st, nullopt);
@@ -4224,7 +4230,10 @@ Status FragmentMetadata::write_generic_tile_to_file(
       buff.data(),
       buff.size());
 
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+      storage_manager_->resources(),
+      storage_manager_->vfs(),
+      fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
   return Status::Ok();
@@ -4235,7 +4244,10 @@ Status FragmentMetadata::write_generic_tile_to_file(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
 
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(
+      storage_manager_->resources(),
+      storage_manager_->vfs(),
+      fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -37,6 +37,7 @@
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <mutex>
@@ -93,6 +94,8 @@ class Context {
     return &storage_manager_;
   }
 
+  ContextResources& resources() const;
+
   /** Returns the thread pool for compute-bound tasks. */
   ThreadPool* compute_tp() const;
 
@@ -130,14 +133,11 @@ class Context {
    */
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
-  /** The thread pool for compute-bound tasks. */
-  mutable ThreadPool compute_tp_;
-
-  /** The thread pool for io-bound tasks. */
-  mutable ThreadPool io_tp_;
-
   /** The class stats. */
   shared_ptr<stats::Stats> stats_;
+
+  /** The class resources. */
+  mutable ContextResources resources_;
 
   /**
    * The storage manager.

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -1,0 +1,98 @@
+/**
+ * @file context_resources.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class ContextResources.
+ */
+
+#ifndef TILEDB_CONTEXT_RESOURCES_H
+#define TILEDB_CONTEXT_RESOURCES_H
+
+#include "tiledb/common/exception/exception.h"
+#include "tiledb/common/thread_pool/thread_pool.h"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/stats/global_stats.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+/**
+ * This class manages the context for the C API, wrapping a
+ * storage manager object.
+ */
+class ContextResources {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Default constructor is deleted.
+   */
+  ContextResources() = delete;
+
+  /** Constructor. */
+  explicit ContextResources(
+      size_t compute_thread_count, size_t io_thread_count, stats::Stats* stats);
+
+  DISABLE_COPY_AND_COPY_ASSIGN(ContextResources);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(ContextResources);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the thread pool for compute-bound tasks. */
+  ThreadPool* compute_tp() const;
+
+  /** Returns the thread pool for io-bound tasks. */
+  ThreadPool* io_tp() const;
+
+  /** Returns the internal stats object. */
+  stats::Stats* stats() const;
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** The thread pool for compute-bound tasks. */
+  mutable ThreadPool compute_tp_;
+
+  /** The thread pool for io-bound tasks. */
+  mutable ThreadPool io_tp_;
+
+  /** The class stats. */
+  stats::Stats* stats_;
+};
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_CONTEXT_RESOURCES_H

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1308,10 +1308,8 @@ Status StorageManagerCanonical::array_get_encryption(
   const URI& schema_uri = array_dir.latest_array_schema_uri();
 
   // Read tile header
-  auto&& [st, header] =
-      GenericTileIO::read_generic_tile_header(this, schema_uri, 0);
-  RETURN_NOT_OK(st);
-  *encryption_type = static_cast<EncryptionType>(header->encryption_type);
+  auto&& header = GenericTileIO::read_generic_tile_header(vfs_, schema_uri, 0);
+  *encryption_type = static_cast<EncryptionType>(header.encryption_type);
 
   return Status::Ok();
 }
@@ -2113,7 +2111,7 @@ Status StorageManagerCanonical::store_data_to_generic_tile(
 
 Status StorageManagerCanonical::store_data_to_generic_tile(
     Tile& tile, const URI& uri, const EncryptionKey& encryption_key) {
-  GenericTileIO tile_io(this, uri);
+  GenericTileIO tile_io(resources_, vfs_, uri);
   uint64_t nbytes = 0;
   Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);
 
@@ -2319,7 +2317,7 @@ void StorageManagerCanonical::load_group_metadata(
 tuple<Status, optional<Tile>>
 StorageManagerCanonical::load_data_from_generic_tile(
     const URI& uri, uint64_t offset, const EncryptionKey& encryption_key) {
-  GenericTileIO tile_io(this, uri);
+  GenericTileIO tile_io(resources_, vfs_, uri);
 
   // Get encryption key from config
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -56,6 +56,7 @@
 #include "tiledb/sm/misc/cancelable_tasks.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/tile/filtered_buffer.h"
 
 using namespace tiledb::common;
@@ -122,9 +123,7 @@ class StorageManagerCanonical {
    * @param config The configuration parameters.
    */
   StorageManagerCanonical(
-      ThreadPool* compute_tp,
-      ThreadPool* io_tp,
-      stats::Stats* parent_stats,
+      ContextResources& resources,
       shared_ptr<Logger> logger,
       const Config& config);
 
@@ -1057,6 +1056,8 @@ class StorageManagerCanonical {
   /** Syncs a file or directory, flushing its contents to persistent storage. */
   Status sync(const URI& uri);
 
+  ContextResources& resources() const;
+
   /** Returns the virtual filesystem object. */
   VFS* vfs() const;
 
@@ -1155,8 +1156,8 @@ class StorageManagerCanonical {
   /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
 
-  /** The class stats. */
-  stats::Stats* stats_;
+  /** Context create resources object. */
+  ContextResources& resources_;
 
   /** The class logger. */
   shared_ptr<Logger> logger_;
@@ -1194,12 +1195,6 @@ class StorageManagerCanonical {
 
   /** Guards queries_in_progress_ counter. */
   std::condition_variable queries_in_progress_cv_;
-
-  /** The thread pool for compute-bound tasks. */
-  ThreadPool* const compute_tp_;
-
-  /** The thread pool for io-bound tasks. */
-  ThreadPool* const io_tp_;
 
   /** Tracks all scheduled tasks that can be safely cancelled before execution.
    */

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -38,7 +38,6 @@
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
@@ -50,8 +49,9 @@ namespace sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-GenericTileIO::GenericTileIO(StorageManager* storage_manager, const URI& uri)
-    : storage_manager_(storage_manager)
+GenericTileIO::GenericTileIO(ContextResources& resources, VFS* vfs, const URI& uri)
+    : resources_(resources)
+    , vfs_(vfs)
     , uri_(uri) {
 }
 
@@ -63,10 +63,8 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
-  auto&& [st, header_opt] =
-      read_generic_tile_header(storage_manager_, uri_, file_offset);
-  RETURN_NOT_OK_TUPLE(st, nullopt);
-  auto& header = *header_opt;
+
+  auto&& header = read_generic_tile_header(vfs_, uri_, file_offset);
 
   if (encryption_key.encryption_type() !=
       (EncryptionType)header.encryption_type) {
@@ -94,7 +92,7 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
 
   // Read the tile.
   RETURN_NOT_OK_TUPLE(
-      storage_manager_->read(
+      vfs_->read(
           uri_,
           file_offset + tile_data_offset,
           tile.filtered_buffer().data(),
@@ -105,10 +103,10 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   assert(tile.filtered());
   RETURN_NOT_OK_TUPLE(
       header.filters.run_reverse(
-          storage_manager_->stats(),
+          resources_.stats(),
           &tile,
           nullptr,
-          storage_manager_->compute_tp(),
+          resources_.compute_tp(),
           config,
           nullptr),
       nullopt);
@@ -117,51 +115,45 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   return {Status::Ok(), std::move(tile)};
 }
 
-tuple<Status, optional<GenericTileIO::GenericTileHeader>>
+GenericTileIO::GenericTileHeader
 GenericTileIO::read_generic_tile_header(
-    const StorageManager* sm, const URI& uri, uint64_t file_offset) {
+    VFS* vfs, const URI& uri, uint64_t file_offset) {
   GenericTileHeader header;
 
-  // Read the fixed-sized part of the header from file
-  tdb_unique_ptr<Buffer> header_buff(tdb_new(Buffer));
-  RETURN_NOT_OK_TUPLE(
-      sm->read(
-          uri, file_offset, header_buff.get(), GenericTileHeader::BASE_SIZE),
-      nullopt);
+  std::vector<uint8_t> base_buf(GenericTileHeader::BASE_SIZE);
 
-  // Read header individual values
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.version_number, sizeof(uint32_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.persisted_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.tile_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.datatype, sizeof(uint8_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.cell_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.encryption_type, sizeof(uint8_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.filter_pipeline_size, sizeof(uint32_t)),
-      nullopt);
+  throw_if_not_ok(vfs->read(
+      uri,
+      file_offset,
+      base_buf.data(),
+      base_buf.size()));
+
+  Deserializer base_deserializer(base_buf.data(), base_buf.size());
+
+  header.version_number = base_deserializer.read<uint32_t>();
+  header.persisted_size = base_deserializer.read<uint64_t>();
+  header.tile_size = base_deserializer.read<uint64_t>();
+  header.datatype = base_deserializer.read<uint8_t>();
+  header.cell_size = base_deserializer.read<uint64_t>();
+  header.encryption_type = base_deserializer.read<uint8_t>();
+  header.filter_pipeline_size = base_deserializer.read<uint32_t>();
 
   // Read header filter pipeline.
-  header_buff->reset_size();
-  header_buff->reset_offset();
-  RETURN_NOT_OK_TUPLE(
-      sm->read(
-          uri,
-          file_offset + GenericTileHeader::BASE_SIZE,
-          header_buff.get(),
-          header.filter_pipeline_size),
-      nullopt);
-  Deserializer deserializer(header_buff->data(), header_buff->size());
+  std::vector<uint8_t> filter_pipeline_buf(header.filter_pipeline_size);
+  throw_if_not_ok(vfs->read(
+      uri,
+      file_offset + GenericTileHeader::BASE_SIZE,
+      filter_pipeline_buf.data(),
+      filter_pipeline_buf.size()));
+
+  Deserializer filter_pipeline_deserializer(
+      filter_pipeline_buf.data(), filter_pipeline_buf.size());
   auto filterpipeline{
-      FilterPipeline::deserialize(deserializer, header.version_number)};
+      FilterPipeline::deserialize(
+          filter_pipeline_deserializer, header.version_number)};
   header.filters = std::move(filterpipeline);
 
-  return {Status::Ok(), header};
+  return header;
 }
 
 Status GenericTileIO::write_generic(
@@ -173,16 +165,16 @@ Status GenericTileIO::write_generic(
   // Filter tile
   assert(!tile->filtered());
   RETURN_NOT_OK(header.filters.run_forward(
-      storage_manager_->stats(),
+      resources_.stats(),
       tile,
       nullptr,
-      storage_manager_->compute_tp()));
+      resources_.compute_tp()));
   header.persisted_size = tile->filtered_buffer().size();
   assert(tile->filtered());
 
   RETURN_NOT_OK(write_generic_tile_header(&header));
 
-  RETURN_NOT_OK(storage_manager_->write(
+  RETURN_NOT_OK(vfs_->write(
       uri_, tile->filtered_buffer().data(), tile->filtered_buffer().size()));
 
   *nbytes = GenericTileIO::GenericTileHeader::BASE_SIZE +
@@ -217,9 +209,9 @@ Status GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
   serialize_generic_tile_header(serializer, *header);
 
   // Write buffer to file
-  Status st = storage_manager_->write(uri_, data.data(), data.size());
+  RETURN_NOT_OK(vfs_->write(uri_, data.data(), data.size()));
 
-  return st;
+  return Status::Ok();
 }
 
 Status GenericTileIO::configure_encryption_filter(

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -33,11 +33,14 @@
 #ifndef TILEDB_GENERIC_TILE_IO_H
 #define TILEDB_GENERIC_TILE_IO_H
 
+#include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
+#include "tiledb/sm/stats/stats.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 
 using namespace tiledb::common;
 
@@ -99,10 +102,11 @@ class GenericTileIO {
   /**
    * Constructor.
    *
-   * @param storage_manager The storage manager.
+   * @param resources The ContextResources to use
+   * @param vfs The VFS instance to use for IO
    * @param uri The name of the file that stores data.
    */
-  GenericTileIO(StorageManager* storage_manager, const URI& uri);
+  GenericTileIO(ContextResources& resourcse, VFS* vfs, const URI& uri);
 
   GenericTileIO() = delete;
   DISABLE_COPY_AND_COPY_ASSIGN(GenericTileIO);
@@ -135,15 +139,15 @@ class GenericTileIO {
   /**
    * Reads the generic tile header from the file.
    *
-   * @param sm The StorageManager instance to use for reading.
+   * @param vfs The VFS instance to use for reading.
    * @param uri The URI of the generic tile.
    * @param file_offset The offset where the header read will begin.
    * @param encryption_key If the array is encrypted, the private encryption
    *    key. For unencrypted arrays, pass `nullptr`.
    * @return Status, Header
    */
-  static tuple<Status, optional<GenericTileHeader>> read_generic_tile_header(
-      const StorageManager* sm, const URI& uri, uint64_t file_offset);
+  static GenericTileHeader read_generic_tile_header(
+      VFS* vfs, const URI& uri, uint64_t file_offset);
 
   /**
    * Writes a tile generically to the file. This means that a header will be
@@ -181,8 +185,11 @@ class GenericTileIO {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The storage manager object. */
-  StorageManager* storage_manager_;
+  /** The ContextResources object. */
+  ContextResources& resources_;
+
+  /** The VFS object. */
+  VFS* vfs_;
 
   /** The file URI. */
   URI uri_;


### PR DESCRIPTION
This version of the PR is based on another draft PR that creates a ContextResources object. For the moment, this is just for comparison between the two approaches.

---
TYPE: IMPROVEMENT
DESC: Remove StorageManager references from GenericTileIO
