### PR TITLE
Adding size computation for tile offsets to sparse readers.

### DIFF
--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -383,7 +383,11 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   std::string error_str(msg);
-  CHECK(error_str.find("Cannot load tile offsets") != std::string::npos);
+  CHECK(
+      error_str.find(
+          "SparseIndexReaderBase: Cannot load tile offsets, computed size (48) "
+          "is larger than memory budget for array data (10).") !=
+      std::string::npos);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -728,7 +728,11 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
 
   std::string error_str(msg);
-  CHECK(error_str.find("Cannot load tile offsets") != std::string::npos);
+  CHECK(
+      error_str.find(
+          "SparseIndexReaderBase: Cannot load tile offsets, computed size (48) "
+          "is larger than memory budget for array data (10).") !=
+      std::string::npos);
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -41,6 +41,8 @@ namespace sm {
 
 class MemoryTracker {
  public:
+  enum class MemoryType { RTREE, FOOTER, TILE_OFFSETS, MIN_MAX_SUM_NULL_COUNT };
+
   /** Constructor. */
   MemoryTracker() {
     memory_usage_ = 0;
@@ -59,10 +61,11 @@ class MemoryTracker {
    * @param size The memory size.
    * @return true if the memory is available, false otherwise.
    */
-  bool take_memory(uint64_t size) {
+  bool take_memory(uint64_t size, MemoryType mem_type) {
     std::lock_guard<std::mutex> lg(mutex_);
     if (memory_usage_ + size <= memory_budget_) {
       memory_usage_ += size;
+      memory_usage_by_type_[mem_type] += size;
       return true;
     }
 
@@ -74,19 +77,26 @@ class MemoryTracker {
    *
    * @param size The memory size.
    */
-  void release_memory(uint64_t size) {
+  void release_memory(uint64_t size, MemoryType mem_type) {
     std::lock_guard<std::mutex> lg(mutex_);
     memory_usage_ -= size;
+    memory_usage_by_type_[mem_type] -= size;
   }
 
   /**
    * Set the memory budget.
    *
    * @param size The memory budget size.
+   * @return true if the budget can be set, false otherwise.
    */
-  void set_budget(uint64_t size) {
+  bool set_budget(uint64_t size) {
     std::lock_guard<std::mutex> lg(mutex_);
+    if (memory_usage_ > size) {
+      return false;
+    }
+
     memory_budget_ = size;
+    return true;
   }
 
   /**
@@ -95,6 +105,14 @@ class MemoryTracker {
   uint64_t get_memory_usage() {
     std::lock_guard<std::mutex> lg(mutex_);
     return memory_usage_;
+  }
+
+  /**
+   * Get the memory usage by type.
+   */
+  uint64_t get_memory_usage(MemoryType mem_type) {
+    std::lock_guard<std::mutex> lg(mutex_);
+    return memory_usage_by_type_[mem_type];
   }
 
   /**
@@ -124,6 +142,9 @@ class MemoryTracker {
 
   /** Memory budget. */
   uint64_t memory_budget_;
+
+  /** Memory usage by type. */
+  std::unordered_map<MemoryType, uint64_t> memory_usage_by_type_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2000,7 +2000,8 @@ Status FragmentMetadata::load_rtree(const EncryptionKey& encryption_key) {
 
   // Use the serialized buffer size to approximate memory usage of the rtree.
   if (memory_tracker_ != nullptr &&
-      !memory_tracker_->take_memory(tile.size())) {
+      !memory_tracker_->take_memory(
+          tile.size(), MemoryTracker::MemoryType::RTREE)) {
     return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load R-tree; Insufficient memory budget; Needed " +
         std::to_string(tile.size()) + " but only had " +
@@ -2020,7 +2021,7 @@ Status FragmentMetadata::load_rtree(const EncryptionKey& encryption_key) {
 void FragmentMetadata::free_rtree() {
   auto freed = rtree_.free_memory();
   if (memory_tracker_ != nullptr)
-    memory_tracker_->release_memory(freed);
+    memory_tracker_->release_memory(freed, MemoryTracker::MemoryType::RTREE);
   loaded_metadata_.rtree_ = false;
 }
 
@@ -2867,7 +2868,9 @@ void FragmentMetadata::load_tile_offsets(Deserializer& deserializer) {
       continue;
 
     auto size = tile_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
           "Cannot load tile offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -2895,7 +2898,9 @@ void FragmentMetadata::load_tile_offsets(
   // Get tile offsets
   if (tile_offsets_num != 0) {
     auto size = tile_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
           "Cannot load tile offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -2935,7 +2940,9 @@ void FragmentMetadata::load_tile_var_offsets(Deserializer& deserializer) {
       continue;
 
     auto size = tile_var_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
           "Cannot load tile var offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -2963,7 +2970,9 @@ void FragmentMetadata::load_tile_var_offsets(
   // Get variable tile offsets
   if (tile_var_offsets_num != 0) {
     auto size = tile_var_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
           "Cannot load tile var offsets; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -3001,7 +3010,9 @@ void FragmentMetadata::load_tile_var_sizes(Deserializer& deserializer) {
       continue;
 
     auto size = tile_var_sizes_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
           "Cannot load tile var sizes; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -3028,7 +3039,9 @@ void FragmentMetadata::load_tile_var_sizes(
   // Get variable tile sizes
   if (tile_var_sizes_num != 0) {
     auto size = tile_var_sizes_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
           "Cannot load tile var sizes; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -3059,7 +3072,9 @@ Status FragmentMetadata::load_tile_validity_offsets(
   // Get tile offsets
   if (tile_validity_offsets_num != 0) {
     auto size = tile_validity_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       return LOG_STATUS(Status_FragmentMetadataError(
           "Cannot load tile validity offsets; Insufficient memory budget; "
           "Needed " +
@@ -3107,7 +3122,9 @@ void FragmentMetadata::load_tile_min_values(
   // Get tile mins
   if (buffer_size != 0) {
     auto size = buffer_size + var_buffer_size;
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::MIN_MAX_SUM_NULL_COUNT)) {
       throw FragmentMetadataStatusException(
           "Cannot load min values; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -3151,7 +3168,9 @@ void FragmentMetadata::load_tile_max_values(
   // Get tile maxs
   if (buffer_size != 0) {
     auto size = buffer_size + var_buffer_size;
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::MIN_MAX_SUM_NULL_COUNT)) {
       throw FragmentMetadataStatusException(
           "Cannot load max values; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -3187,7 +3206,9 @@ void FragmentMetadata::load_tile_sum_values(
   // Get tile sums
   if (tile_sum_num != 0) {
     auto size = tile_sum_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::MIN_MAX_SUM_NULL_COUNT)) {
       throw FragmentMetadataStatusException(
           "Cannot load sum values; Insufficient memory budget; Needed " +
           std::to_string(size) + " but only had " +
@@ -3218,7 +3239,9 @@ void FragmentMetadata::load_tile_null_count_values(
   // Get tile null count
   if (tile_null_count_num != 0) {
     auto size = tile_null_count_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr && !memory_tracker_->take_memory(size)) {
+    if (memory_tracker_ != nullptr &&
+        !memory_tracker_->take_memory(
+            size, MemoryTracker::MemoryType::MIN_MAX_SUM_NULL_COUNT)) {
       throw FragmentMetadataStatusException(
           "Cannot load null count values; Insufficient memory budget; "
           "Needed " +
@@ -3918,7 +3941,8 @@ Status FragmentMetadata::read_file_footer(
   storage_manager_->stats()->add_counter("read_frag_meta_size", *footer_size);
 
   if (memory_tracker_ != nullptr &&
-      !memory_tracker_->take_memory(*footer_size)) {
+      !memory_tracker_->take_memory(
+          *footer_size, MemoryTracker::MemoryType::FOOTER)) {
     return LOG_STATUS(Status_FragmentMetadataError(
         "Cannot load file footer; Insufficient memory budget; Needed " +
         std::to_string(*footer_size) + " but only had " +

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -315,6 +315,13 @@ class SparseIndexReaderBase : public ReaderBase {
   /* ********************************* */
 
   /**
+   * Computes the required size for loading tile offsets, per fragments.
+   *
+   * @return Required memory for loading tile offsets, per fragments.
+   */
+  std::vector<uint64_t> tile_offset_sizes();
+
+  /**
    * Returns if there is any condition to be applied post deduplication. This
    * will return true if we have:
    *   A query condition.


### PR DESCRIPTION
This adds a function to compute the size required for loading tile offsets before loading them. This should allow to do early detection of insufficient budget and issue a more relevant error than before.

More, it prepares for future work where we will only load some tile offsets when the memory budget is too small to load all so queries can succeed anyway.

It also fixes an issue where we could set the budget smaller than the usage on the memory tracker and would issue errors with an available memory number that underflowed.

Finally, the memory tracker now split the memory consumption into different buckets to make debugging of issues easier.

---
TYPE: IMPROVEMENT
DESC: Adding size computation for tile offsets to sparse readers.
