### PR TITLE
Fragment consolidator: stop consolidation if no progress can be made.

### DIFF
--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -50,6 +50,13 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+class FragmentConsolidatorStatusException : public StatusException {
+ public:
+  explicit FragmentConsolidatorStatusException(const std::string& message)
+      : StatusException("FragmentConsolidator", message) {
+  }
+};
+
 /* ****************************** */
 /*          CONSTRUCTOR           */
 /* ****************************** */
@@ -512,6 +519,12 @@ Status FragmentConsolidator::copy_array(
   do {
     // READ
     RETURN_NOT_OK(query_r->submit());
+
+    // If Consolidation cannot make any progress, throw.
+    if (buffer_sizes->at(0) == 0) {
+      throw FragmentConsolidatorStatusException(
+          "Consolidation read 0 cells, no progress can be made");
+    }
 
     // Set explicitly the write query buffers, as the sizes may have
     // been altered by the read query.

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -520,7 +520,10 @@ Status FragmentConsolidator::copy_array(
     // READ
     RETURN_NOT_OK(query_r->submit());
 
-    // If Consolidation cannot make any progress, throw.
+    // If Consolidation cannot make any progress, throw. The first buffer will
+    // always contain fixed size data, wether it is tile offsets for var size
+    // attribute/dimension or the actual fixed size data so we can use its size
+    // to know if any cells were written or not.
     if (buffer_sizes->at(0) == 0) {
       throw FragmentConsolidatorStatusException(
           "Consolidation read 0 cells, no progress can be made");
@@ -777,6 +780,10 @@ Status FragmentConsolidator::set_query_buffers(
   auto dense = array_schema.dense();
   auto attributes = array_schema.attributes();
   unsigned bid = 0;
+
+  // Here the first buffer should always be the fixed buffer (either offsets or
+  // fixed data) as we use the first buffer size to determine if any cells were
+  // written or not.
   for (const auto& attr : attributes) {
     if (!attr->var_size()) {
       if (!attr->nullable()) {


### PR DESCRIPTION
This change fixes an issue when the fragment consolidator loops forever when no progress can be made.

---
TYPE: IMPROVEMENT
DESC: Fragment consolidator: stop consolidation if no progress can be made.
