### PR TITLE
Sparse global order reader: fix tile cleanup when ending an iteration.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -2036,7 +2036,7 @@ Status SparseGlobalOrderReader<BitmapType>::end_iteration() {
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
         while (!result_tiles_[f].empty() &&
-               result_tiles_[f].front().tile_idx() !=
+               result_tiles_[f].front().tile_idx() <
                    read_state_.frag_idx_[f].tile_idx_) {
           RETURN_NOT_OK(remove_result_tile(f, result_tiles_[f].begin()));
         }


### PR DESCRIPTION
This change fixes the tile cleanup code when an iteration is done. When the user sets ranges, the first tile for a fragment might not have index 0. The tile index in the read state (initialized at 0) for a fragment might not be touched if an iteration doesn't merge any cells from that fragment, so it might stay 0. As the cleanup code was looking for an exact match on the tile index before stopping cleanup, this would clean up every tiles. The cleanup now cleans up tiles with an index smaller than the index in the read state which fixes this case.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: fix tile cleanup when ending an iteration.
