### PR TITLE
Update checkout and upload actions to v3

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the Dockerfile
         run: docker build -f examples/Dockerfile/Dockerfile -t tiledb:dev .

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 90
     name: Build Docs
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Prepare git
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - name: Building TileDB with Rtools40
@@ -29,7 +29,7 @@ jobs:
           MINGW_INSTALLS: ${{ matrix.msystem }}
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
       - name: "Upload binaries"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: mingw-w64-${{ matrix.msystem }}-tiledb
           path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*

--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 120
     name: Build tiledb_unit
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Print env'
         run: ./scripts/ci/posix/print-env.sh
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.tiledb_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download a single artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -103,7 +103,7 @@ jobs:
           fi
       - name: Prepare git
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: core tiledb windows build
         run: |
           $ErrorView = "NormalView"
@@ -406,7 +406,7 @@ jobs:
 
       - name: 'upload dumpfile artifacts' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ always() == true && startsWith(matrix.os, 'windows-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{matrix.environ}}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 90
     name: Check Clang Format
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"

--- a/.github/workflows/check-heap-memory-api-violations.yml
+++ b/.github/workflows/check-heap-memory-api-violations.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 90
     name: Check Heap Memory Violations
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"

--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run PR body checker
         run: |
           cat <<'EOF' | scripts/parse_pr.py

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout || 90 }}
     name: ${{matrix.os}} - ${{ inputs.ci_backend }}${{ inputs.ci_option }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: 'Ubuntu Prelim'
         if: ${{ startsWith(matrix.os, 'ubuntu-') == true }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -24,7 +24,7 @@ jobs:
         run: printenv
 
       - name: Checkout TileDB `dev`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure TileDB CMake
         run: |
@@ -44,7 +44,7 @@ jobs:
     if: failure() || cancelled()
     steps:
       - name: Checkout TileDB `dev`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create Issue if Build Fails
         uses: JasonEtco/create-an-issue@v2
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -26,7 +26,7 @@ jobs:
   quarto-render-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Quarto
       uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
     name: Build - ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"


### PR DESCRIPTION
GitHub currently nags about older and to-be-deprecated actions due to upcoming `node` changes.  This PR updates
- all checkout actions from v2 to v3 (which has worked flawlessly in dozens of other repos)
- all but one update-action from v2 to v3 (as one already had it)

We can update remaining actions in another PR as they are flagged.

---
TYPE: NO_HISTORY 
DESC: Update GitHub Actions
