### PR TITLE
Show array version in tool output [trivial]

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -593,6 +593,7 @@ void ArraySchema::dump(FILE* out) const {
     out = stdout;
 
   std::stringstream ss;
+  ss << "- Version: " << version_ << "\n";
   ss << "- Array type: " << array_type_str(array_type_) << "\n";
   ss << "- Cell order: " << layout_str(cell_order_) << "\n";
   ss << "- Tile order: " << layout_str(tile_order_) << "\n";


### PR DESCRIPTION
Makes the array-schema version information visible

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: Makes the array-schema version information visible

