### PR TITLE
Consolidation plan: implementation for creating a plan using MBRs.

### DIFF
--- a/test/src/test-capi-consolidation-plan.cc
+++ b/test/src/test-capi-consolidation-plan.cc
@@ -186,7 +186,7 @@ void ConsolidationPlanFx::check_last_error(std::string expected) {
 TEST_CASE_METHOD(
     ConsolidationPlanFx,
     "CAPI: Consolidation plan",
-    "[capi][consolidation_plan]") {
+    "[capi][consolidation-plan]") {
   create_sparse_array();
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
 
@@ -229,7 +229,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     ConsolidationPlanFx,
     "CAPI: Consolidation plan dump",
-    "[capi][consolidation_plan][dump]") {
+    "[capi][consolidation-plan][dump]") {
   create_sparse_array();
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1);
 

--- a/test/src/test-capi-consolidation-plan.cc
+++ b/test/src/test-capi-consolidation-plan.cc
@@ -249,7 +249,7 @@ TEST_CASE_METHOD(
       ctx_.ptr().get(), consolidation_plan, &str);
 
   std::string plan(str);
-  CHECK(plan == "Not implemented\n");
+  CHECK(plan == "{\n  \"nodes\": [\n  ]\n}\n");
 
   tiledb_consolidation_plan_free_json_str(&str);
   tiledb_consolidation_plan_free(&consolidation_plan);

--- a/tiledb/sm/consolidation_plan/consolidation_plan.h
+++ b/tiledb/sm/consolidation_plan/consolidation_plan.h
@@ -90,7 +90,7 @@ class ConsolidationPlan {
           "Trying to access a node that doesn't exists");
     }
 
-    return fragment_uris_[node_idx].size();
+    return fragment_uris_per_node_[node_idx].size();
   }
 
   /**
@@ -109,12 +109,12 @@ class ConsolidationPlan {
     }
 
     if (fragment_idx == std::numeric_limits<uint64_t>::max() ||
-        fragment_idx + 1 > fragment_uris_[node_idx].size()) {
+        fragment_idx + 1 > fragment_uris_per_node_[node_idx].size()) {
       throw ConsolidationPlanStatusException(
           "Trying to access a fragment that doesn't exists");
     }
 
-    return fragment_uris_[node_idx][fragment_idx].c_str();
+    return fragment_uris_per_node_[node_idx][fragment_idx].c_str();
   }
 
   /** @return the consolidation plan in JSON format. */
@@ -227,9 +227,9 @@ class ConsolidationPlan {
   uint64_t num_nodes_;
 
   /** Fragment uris, per node. */
-  std::vector<std::vector<std::string>> fragment_uris_;
+  std::vector<std::vector<std::string>> fragment_uris_per_node_;
 
-  /** Desired fragment size. */
+  /** Desired fragment size, in bytes. */
   storage_size_t desired_fragment_size_;
 
   /* ********************************* */


### PR DESCRIPTION
This is an implementation for the consolidation plan using the MBRs. We first batch all fragments that intersect together. Then we take small fragments and combine them is the union of their MBRs don't intersect any other fragments. Finally, we take fragments that are too large according to the passed in desired size and add them to their own node so they get split up.

---
TYPE: IMPROVEMENT
DESC: Consolidation plan: implementation for creating a plan using MBRs.
