### PR TITLE
Extract CA Cert file and libcurl initialization

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -137,6 +137,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/stdx_string.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/interval/interval.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/common/types/dynamic_typed_datum.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/platform/cert_file.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array_directory.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/consistency.cc

--- a/tiledb/platform/cert_file.cc
+++ b/tiledb/platform/cert_file.cc
@@ -1,11 +1,11 @@
 /**
- * @file   libcurl_state.h
+ * @file cert_file.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,16 @@
  *
  * @section DESCRIPTION
  *
- * This file initializes the libcurl state, if libcurl is present.
+ * Platform/machine config of the TileDB library.
  */
 
-#ifndef TILEDB_LIBCURL_STATE_H
-#define TILEDB_LIBCURL_STATE_H
+#include "tiledb/platform/cert_file.h"
 
-namespace tiledb::sm::global_state {
+namespace tiledb::platform {
 
-/**
- * A sentry class for ensuring that libcurl has
- * been initialized for any classes that use it.
- */
-class LibCurlInitializer {
- public:
-  /**
-   * Construct an instance of LibCurlInitializer which
-   * has the side effect of ensuring that libcurl has
-   * been initialized for use.
-   */
-  LibCurlInitializer();
-};
-
-}  // namespace tiledb::sm::global_state
-
+#if defined(__linux__)
+std::once_flag CertFileTraits<LinuxOS>::cert_file_initialized_;
+std::string CertFileTraits<LinuxOS>::cert_file_;
 #endif
+
+} // namespce tiledb::platform

--- a/tiledb/platform/cert_file.h
+++ b/tiledb/platform/cert_file.h
@@ -1,0 +1,145 @@
+/**
+ * @file   tiledb/platform/cert_file.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Platform/machine config of the TileDB library.
+ */
+
+#ifndef TILEDB_CERT_FILE_H
+#define TILEDB_CERT_FILE_H
+
+#include <array>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <system_error>
+
+#include "tiledb/common/logger.h"
+#include "tiledb/platform/os.h"
+
+namespace tiledb::platform {
+
+/**
+ * A base traits class for determining whether the current
+ * platform might have a CA Cert file on disk in a well
+ * known location.
+ */
+template <class T>
+class CertFileTraits {
+  CertFileTraits() = delete;
+};
+
+/**
+ * A platform dependent alias to the appropriate
+ * certficate file trait.
+ */
+using PlatformCertFile = CertFileTraits<PlatformOS>;
+
+/**
+ * A trait specialization for when the current platform does
+ * not have a certificate file in a well known location.
+ */
+template <>
+class CertFileTraits<BaseOS> {
+ public:
+  /**
+   * A boolean flag indicating that the current platform does
+   * not have a certificate file in a well known location.
+   */
+  static constexpr bool enabled = false;
+
+  /**
+   * Unconditionally returns an empty string for platforms
+   * that do not have a certificate file in a well known
+   * location.
+   *
+   * \return An empty string.
+   */
+  static std::string get() {
+    return {};
+  }
+};
+
+/**
+ * A trait specialization for when the current platform might
+ * have a certificate file in a well known location.
+ */
+template <>
+class CertFileTraits<LinuxOS> {
+ public:
+  /**
+   * A boolean flag indicating that the current platform has
+   * a certficate file in a well known location.
+   */
+  static constexpr bool enabled = true;
+
+  /**
+   * An instance of `std::once_flag` to search for a
+   * certificate file at most once per process lifetime.
+   */
+  static std::once_flag cert_file_initialized_;
+
+  /**
+   * The cached certificate file location.
+   */
+  static std::string cert_file_;
+
+  /**
+   * Return the possibly cached certificate file location. Only
+   * the first call to this function actually performs the search.
+   * All subsequent calls return the cached location.
+   *
+   * \return The path to a well known certificate file path or
+   * an empty string if no such file is found.
+   */
+  static std::string get() {
+    std::call_once(cert_file_initialized_, []() {
+      const std::array<std::string, 6> cert_files = {
+          "/etc/ssl/certs/ca-certificates.crt",  // Debian/Ubuntu/Gentoo etc.
+          "/etc/pki/tls/certs/ca-bundle.crt",    // Fedora/RHEL 6
+          "/etc/ssl/ca-bundle.pem",              // OpenSUSE
+          "/etc/pki/tls/cacert.pem",             // OpenELEC
+          "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // CentOS/RHEL 7
+          "/etc/ssl/cert.pem"                                   // Alpine Linux
+      };
+
+      for (const std::string& cert : cert_files) {
+        std::error_code ec;
+        if (std::filesystem::exists(cert, ec)) {
+          cert_file_ = cert;
+          return;
+        }
+      }
+    });
+
+    return cert_file_;
+  }
+};
+
+}  // namespace tiledb::platform
+#endif  // TILEDB_CERT_FILE_H

--- a/tiledb/platform/os.h
+++ b/tiledb/platform/os.h
@@ -1,11 +1,11 @@
 /**
- * @file   libcurl_state.h
+ * @file   tiledb/platform/platform.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,22 @@
  *
  * @section DESCRIPTION
  *
- * This file initializes the libcurl state, if libcurl is present.
+ * Platform/machine config of the TileDB library.
  */
 
-#ifndef TILEDB_LIBCURL_STATE_H
-#define TILEDB_LIBCURL_STATE_H
+#ifndef TILEDB_PLATFORM_OS_H
+#define TILEDB_PLATFORM_OS_H
 
-namespace tiledb::sm::global_state {
+namespace tiledb::platform {
 
-/**
- * A sentry class for ensuring that libcurl has
- * been initialized for any classes that use it.
- */
-class LibCurlInitializer {
- public:
-  /**
-   * Construct an instance of LibCurlInitializer which
-   * has the side effect of ensuring that libcurl has
-   * been initialized for use.
-   */
-  LibCurlInitializer();
-};
+class BaseOS;
+class LinuxOS;
 
-}  // namespace tiledb::sm::global_state
+#if defined(__linux__)
+using PlatformOS = LinuxOS;
+#else
+using PlatformOS = BaseOS;
+#endif  // if defined(__linux_)
 
-#endif
+}  // namespace tiledb::platform
+#endif  // TILEDB_PLATFORM_OS_H

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -41,8 +41,8 @@
 #include "tiledb/common/common.h"
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/logger_public.h"
+#include "tiledb/platform/cert_file.h"
 #include "tiledb/sm/filesystem/azure.h"
-#include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/utils.h"
@@ -158,18 +158,18 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
   // 'curl_easy_init'. This ensures that our 'thread_pool_' threads
   // will not block on the blob client's internal request queue
   // unless the user is performing concurrent I/O on this instance.
-#ifdef __linux__
+
   // Get CA Cert bundle file from global state. This is initialized and cached
   // if detected. We have only had issues with finding the certificate path on
   // Linux.
-  const std::string cert_file =
-      global_state::GlobalState::GetGlobalState().cert_file();
-  client_ = make_shared<azure::storage_lite::blob_client>(
-      HERE(), account, thread_pool_->concurrency_level(), cert_file);
-#else
-  client_ = make_shared<azure::storage_lite::blob_client>(
+  if constexpr (tiledb::platform::PlatformCertFile::enabled) {
+    const std::string cert_file = tiledb::platform::PlatformCertFile::get();
+    client_ = make_shared<azure::storage_lite::blob_client>(
+        HERE(), account, thread_pool_->concurrency_level(), cert_file);
+  } else {
+    client_ = make_shared<azure::storage_lite::blob_client>(
       HERE(), account, static_cast<int>(thread_pool_->concurrency_level()));
-#endif
+  }
 
   // The Azure SDK does not provide a way to configure the retry
   // policy or construct a client with our own retry policy. This

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -39,6 +39,7 @@
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/global_state/libcurl_state.h"
 #include "tiledb/sm/misc/constants.h"
 #include "uri.h"
 
@@ -450,6 +451,13 @@ class Azure {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  global_state::LibCurlInitializer curl_inited_;
 
   /** The VFS thread pool. */
   ThreadPool* thread_pool_;

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -44,8 +44,8 @@
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/common/unique_rwlock.h"
+#include "tiledb/platform/cert_file.h"
 #include "tiledb/sm/filesystem/gcs.h"
-#include "tiledb/sm/global_state/global_state.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/utils.h"
@@ -121,13 +121,12 @@ Status GCS::init_client() const {
 
   google::cloud::storage::ChannelOptions channel_options;
 
-#ifdef __linux__
-  const std::string cert_file =
-      global_state::GlobalState::GetGlobalState().cert_file();
-  if (!cert_file.empty()) {
-    channel_options.set_ssl_root_path(cert_file);
+  if constexpr (tiledb::platform::PlatformCertFile::enabled) {
+    const std::string cert_file = tiledb::platform::PlatformCertFile::get();
+    if (!cert_file.empty()) {
+      channel_options.set_ssl_root_path(cert_file);
+    }
   }
-#endif
 
   // Note that the order here is *extremely important*
   // We must call ::GoogleDefaultCredentials *with* a channel_options

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -42,6 +42,7 @@
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/global_state/libcurl_state.h"
 #include "tiledb/sm/misc/constants.h"
 #include "uri.h"
 
@@ -389,6 +390,13 @@ class GCS {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  global_state::LibCurlInitializer curl_inited_;
 
   /** The current state. */
   State state_;

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -41,6 +41,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/s3_thread_pool_executor.h"
+#include "tiledb/sm/global_state/libcurl_state.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/stats/stats.h"
@@ -603,6 +604,13 @@ class S3 {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  global_state::LibCurlInitializer curl_inited_;
 
   /** The class stats. */
   stats::Stats* stats_;

--- a/tiledb/sm/global_state/global_state.h
+++ b/tiledb/sm/global_state/global_state.h
@@ -88,13 +88,6 @@ class GlobalState {
    */
   std::set<StorageManager*> storage_managers();
 
-  /**
-   * Getter for cert file
-   * @return detected cert file or empty if no cert file detected. Always empty
-   * string on non-linux platforms
-   */
-  const std::string& cert_file();
-
  private:
   /** The TileDB configuration parameters. */
   Config config_;
@@ -110,9 +103,6 @@ class GlobalState {
 
   /** Mutex protecting list of StorageManagers. */
   std::mutex storage_managers_mtx_;
-
-  /** Detected certificate file, currently only used on linux */
-  std::string cert_file_;
 
   /** Constructor. */
   GlobalState();

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -808,21 +808,6 @@ const void* fill_value(Datatype type) {
   return nullptr;
 }
 
-#ifdef __linux__
-/** Possible certificate files; stop after finding one.
- * inspired by
- * https://github.com/golang/go/blob/f0e940ebc985661f54d31c8d9ba31a553b87041b/src/crypto/x509/root_linux.go
- */
-const std::array<std::string, 6> cert_files_linux = {
-    "/etc/ssl/certs/ca-certificates.crt",  // Debian/Ubuntu/Gentoo etc.
-    "/etc/pki/tls/certs/ca-bundle.crt",    // Fedora/RHEL 6
-    "/etc/ssl/ca-bundle.pem",              // OpenSUSE
-    "/etc/pki/tls/cacert.pem",             // OpenELEC
-    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // CentOS/RHEL 7
-    "/etc/ssl/cert.pem"                                   // Alpine Linux
-};
-#endif
-
 const std::string config_delimiter = ",";
 }  // namespace constants
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -687,11 +687,6 @@ const void* fill_value(Datatype type);
 /** The redirection header key in REST response. */
 extern const std::string redirection_header_key;
 
-#ifdef __linux__
-/** List of possible certificates files for libcurl */
-extern const std::array<std::string, 6> cert_files_linux;
-#endif
-
 /** Delimiter for lists passed as config parameter */
 extern const std::string config_delimiter;
 

--- a/tiledb/sm/misc/utils.cc
+++ b/tiledb/sm/misc/utils.cc
@@ -53,22 +53,6 @@ namespace sm {
 
 namespace utils {
 
-#ifdef __linux__
-namespace https {
-std::string find_ca_certs_linux(const Posix& posix) {
-  // Check ever cert file location to see if the certificate exists
-  for (const std::string& cert : constants::cert_files_linux) {
-    // Check if the file exists, any errors are treated as the file not existing
-    if (posix.is_file(cert)) {
-      return cert;
-    }
-  }
-  // Could not find the ca bundle
-  return "";
-}
-}  // namespace https
-#endif
-
 /* ****************************** */
 /*         TYPE FUNCTIONS         */
 /* ****************************** */

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -57,18 +57,6 @@ enum class SerializationType : uint8_t;
 
 namespace utils {
 
-#ifdef __linux__
-namespace https {
-/**
- * Check hard coded paths for possible ca certificates to set for curl
- *
- * @param vfs to use to check if cert paths exist
- * @return ca cert bundle path or empty string if ca cert bundle was not found
- */
-std::string find_ca_certs_linux(const Posix& posix);
-}  // namespace https
-#endif
-
 /* ********************************* */
 /*          TYPE FUNCTIONS           */
 /* ********************************* */

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -53,6 +53,7 @@
 #include "tiledb/sm/buffer/buffer_list.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/global_state/libcurl_state.h"
 #include "tiledb/sm/stats/stats.h"
 
 using namespace tiledb::common;
@@ -335,6 +336,13 @@ class Curl {
   tuple<Status, optional<long>> last_http_status_code();
 
  private:
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  global_state::LibCurlInitializer curl_inited_;
+
   /** TileDB config parameters. */
   const Config* config_;
 


### PR DESCRIPTION
This separates out the global initialization of TileDB from the rest of GlobalState which handles registration of StorageManager instances to help process termination.

The motivation for separating these two aspects is to remove the StorageManager dependency from VFS instances as StorageManager and GlobalState have a cyclic dependnecy chain.

---
TYPE: IMPROVEMENT
DESC: Extract CA Cert and libcurl from GlobalState initialization
