### PR TITLE
Neaten a logging message

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -761,7 +761,7 @@ Status Curl::post_data_common(
   } else {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data->total_size());
   }
-  logger_->debug("posting {} bytes to", data->total_size());
+  logger_->debug("posting {} bytes", data->total_size());
 
   // Set auth and content-type for request
   *headers = nullptr;


### PR DESCRIPTION
Messages print like

```
[2022-11-30 16:42:45.488] [Process: 235579] [debug] [1669826563297183185-Context: 1] [curl : 1] [curl : 5] posting 12336 bytes to
```

which looks like we left something out, or like the server URL was blank.

We should just say

```
[2022-11-30 16:42:45.488] [Process: 235579] [debug] [1669826563297183185-Context: 1] [curl : 1] [curl : 5] posting 12336 bytes
```

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: Neaten debug-level logging message
