### PR TITLE
[trivial] Fix a typo in a comment

### DIFF
--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -246,7 +246,7 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Read state. */
   ReadState read_state_;
 
-  /** Have we loaded all thiles for this fragment. */
+  /** Have we loaded all tiles for this fragment. */
   std::vector<uint8_t> all_tiles_loaded_;
 
   /** Include coordinates when loading tiles. */


### PR DESCRIPTION
From `thiles` to `tiles` in a comment

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: Fix a typo in a comment
