### PR TITLE
Sparse globalorder reader: prevent unused tiles from being loaded again.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -760,6 +760,8 @@ bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
         if (rc.same_coords(rc2)) {
           // Remove the current tile if not used.
           if (!rc.tile_->used()) {
+            ignored_tiles_.emplace(
+                frag_idx, result_tiles_it[frag_idx]->tile_idx());
             throw_if_not_ok(
                 remove_result_tile(frag_idx, result_tiles_it[frag_idx]));
           }
@@ -798,6 +800,7 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
 
     // Remove the tile from result tiles if it wasn't used at all.
     if (!rc.tile_->used()) {
+      ignored_tiles_.emplace(frag_idx, to_delete->tile_idx());
       throw_if_not_ok(remove_result_tile(frag_idx, to_delete));
     }
 


### PR DESCRIPTION
When the reader doesn't use a tile in the merge, it removes it from the list. It should also be added to the list of ignored cells to ensure that the tile doesn't get loaded again.

---
TYPE: IMPROVEMENT
DESC: Sparse globalorder reader: prevent unused tiles from being loaded again.
