### PR TITLE
Don't retry curl errors for REST

### DIFF
--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -501,7 +501,7 @@ class Curl {
    * @param retry true if the http code matches the retry list
    * @return Status
    */
-  Status should_retry(bool* retry) const;
+  Status should_retry_based_on_http_status(bool* retry) const;
 };
 
 }  // namespace sm


### PR DESCRIPTION
If we received a curl error we should not resubmit the original request. There are some curl errors that can occur after we have received partial results and we might have already deserialized and copied data into the user buffer. Retries resubmit the initial request not accounting for any partial state.


---
TYPE: IMPROVEMENT
DESC: Do not resubmit http requests for curl errors for REST requests
