### PR TITLE
Query condition: fix when attribute condition is not in user buffers.

### DIFF
--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -416,7 +416,12 @@ Status DenseReader::dense_read() {
 
   // Process attributes.
   std::vector<std::string> to_read(1);
-  for (auto& name : names) {
+  for (auto& buff : buffers_) {
+    auto& name = buff.first;
+    if (name == constants::coords || array_schema_.is_dim(name)) {
+      continue;
+    }
+
     if (condition_.field_names().count(name) == 0) {
       // Read and unfilter tiles.
       to_read[0] = name;

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -386,8 +386,13 @@ Status SparseIndexReaderBase::load_initial_data() {
   }
 
   qc_loaded_attr_names_.reserve(qc_loaded_attr_names_set_.size());
+  std::vector<std::string> var_size_to_load;
   for (auto& name : qc_loaded_attr_names_set_) {
     qc_loaded_attr_names_.emplace_back(name);
+
+    if (array_schema_.var_size(name)) {
+      var_size_to_load.emplace_back(name);
+    }
   }
 
   // Make sure there is enough space for tiles data.
@@ -430,12 +435,13 @@ Status SparseIndexReaderBase::load_initial_data() {
   }
 
   // Compute tile offsets to load and var size to load for attributes.
-  std::vector<std::string> var_size_to_load;
-  std::vector<std::string> attr_tile_offsets_to_load;
+  std::vector<std::string> attr_tile_offsets_to_load(qc_loaded_attr_names_);
   for (auto& it : buffers_) {
     const auto& name = it.first;
-    if (array_schema_.is_dim(name))
+    if (array_schema_.is_dim(name) ||
+        qc_loaded_attr_names_set_.count(name) != 0) {
       continue;
+    }
 
     attr_tile_offsets_to_load.emplace_back(name);
 


### PR DESCRIPTION
This fixes the sparse readers and dense reader to be able to run queries where an attribute that is in the query condition is not in the user buffers.

---
TYPE: IMPROVEMENT
DESC: Query condition: fix when attribute condition is not in user buffers.