### PR TITLE
Throw error when memory budget leads to splitting to unary range.

### DIFF
--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -317,7 +317,7 @@ void SubarrayPartitionerDenseFx::read_array_default_1d_array(
     std::string memory_budget,
     std::string skip_unary_partitioning_budget_check,
     bool expect_failure) {
-  // Create TileDB context
+  // Create TileDB context, set sm.skip_unary_partitioning_budget_check to true.
   tiledb_config_t* config;
   tiledb_error_t* error = nullptr;
   int rc = tiledb_config_alloc(&config, &error);
@@ -375,10 +375,15 @@ void SubarrayPartitionerDenseFx::read_array_default_1d_array(
     tiledb_error_message(err, &msg);
     std::string message(msg);
 
+    // Make sure we get the right message on failure
     CHECK(
         message ==
         "SubarrayPertitioner: Trying to partition a unary range because of "
-        "memory budget");
+        "memory budget, this will cause the query to run very slow. Increase "
+        "`sm.memory_budget` and `sm.memory_budget_var` through the "
+        "configuration settings to avoid this issue. To override and run the "
+        "query with the same budget, set "
+        "`sm.skip_unary_partitioning_budget_check` to `true`.");
   } else {
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_query_finalize(ctx, query);

--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -86,6 +86,12 @@ struct SubarrayPartitionerDenseFx {
   /** Helper function that writes to the default 2D array. */
   void write_default_2d_array();
 
+  /** Helper function that writes to the default 1D array. */
+  void read_array_default_1d_array(
+      std::string memory_budget,
+      std::string skip_unary_partitioning_budget_check,
+      bool expect_failure = false);
+
   /**
    * Helper function to test the subarray partitioner for the given arguments.
    */
@@ -305,6 +311,88 @@ void SubarrayPartitionerDenseFx::test_subarray_partitioner(
   CHECK(st.ok());
 
   check_partitions(subarray_partitioner, partitions, unsplittable);
+}
+
+void SubarrayPartitionerDenseFx::read_array_default_1d_array(
+    std::string memory_budget,
+    std::string skip_unary_partitioning_budget_check,
+    bool expect_failure) {
+  // Create TileDB context
+  tiledb_config_t* config;
+  tiledb_error_t* error = nullptr;
+  int rc = tiledb_config_alloc(&config, &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.memory_budget", memory_budget.c_str(), &error);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config,
+      "sm.skip_unary_partitioning_budget_check",
+      skip_unary_partitioning_budget_check.c_str(),
+      &error);
+  REQUIRE(error == nullptr);
+
+  tiledb_ctx_t* ctx;
+  rc = tiledb_ctx_alloc(config, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Open array
+  tiledb_array_t* array;
+  rc = tiledb_array_alloc(ctx, array_name_.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Compute max buffer sizes
+  uint64_t subarray[] = {1, 10};
+
+  // Prepare cell buffers
+  std::vector<int> a(10);
+  uint64_t a_size = 10 * sizeof(int);
+
+  // Create query
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx, query, "a", a.data(), &a_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray(ctx, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query
+  rc = tiledb_query_submit(ctx, query);
+
+  if (expect_failure) {
+    REQUIRE(rc == TILEDB_ERR);
+
+    // Retrieve the last error that occurred
+    tiledb_error_t* err = NULL;
+    tiledb_ctx_get_last_error(ctx, &err);
+    const char* msg;
+    tiledb_error_message(err, &msg);
+    std::string message(msg);
+
+    CHECK(
+        message ==
+        "SubarrayPertitioner: Trying to partition a unary range because of "
+        "memory budget");
+  } else {
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_query_finalize(ctx, query);
+    REQUIRE(rc == TILEDB_OK);
+  }
+
+  // Close array
+  rc = tiledb_array_close(ctx, array);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
 }
 
 /* ********************************* */
@@ -2024,6 +2112,19 @@ TEST_CASE_METHOD(
     test_subarray_partitioner(
         subarray_layout, ranges, partitions, attr, budget, unsplittable);
   }
+
+  close_array(ctx_, array_);
+}
+
+TEST_CASE_METHOD(
+    SubarrayPartitionerDenseFx,
+    "SubarrayPartitioner (Dense): 1D, single-range, memory budget unary range "
+    "split",
+    "[SubarrayPartitioner][dense][memory-budget-unary-range-split]") {
+  create_default_1d_array(TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR);
+  write_default_1d_array();
+  read_array_default_1d_array("1", "false", true);
+  read_array_default_1d_array("1", "true", false);
 
   close_array(ctx_, array_);
 }

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -285,6 +285,7 @@ void check_save_to_file() {
   ss << "sm.read_range_oob warn\n";
   ss << "sm.skip_checksum_validation false\n";
   ss << "sm.skip_est_size_partitioning false\n";
+  ss << "sm.skip_unary_partitioning_budget_check false\n";
   ss << "sm.tile_cache_size 10000000\n";
   ss << "sm.vacuum.mode fragments\n";
   ss << "sm.var_offsets.bitsize 64\n";
@@ -599,6 +600,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.check_global_order"] = "true";
   all_param_values["sm.tile_cache_size"] = "100";
   all_param_values["sm.skip_est_size_partitioning"] = "false";
+  all_param_values["sm.skip_unary_partitioning_budget_check"] = "false";
   all_param_values["sm.memory_budget"] = "5368709120";
   all_param_values["sm.memory_budget_var"] = "10737418240";
   all_param_values["sm.query.dense.qc_coords_mode"] = "false";

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -3275,6 +3275,12 @@ void DenseArrayFx::set_small_memory_budget() {
       tiledb_config_set(config, "sm.memory_budget", "10", &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
+  REQUIRE(
+      tiledb_config_set(
+          config, "sm.skip_unary_partitioning_budget_check", "true", &error) ==
+      TILEDB_OK);
+  REQUIRE(error == nullptr);
+
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
   REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -87,6 +87,7 @@ const std::string Config::SM_READ_RANGE_OOB = "warn";
 const std::string Config::SM_CHECK_GLOBAL_ORDER = "true";
 const std::string Config::SM_TILE_CACHE_SIZE = "10000000";
 const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
+const std::string Config::SM_SKIP_UNARY_PARTITIONING_BUDGET_CHECK = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
 const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
 const std::string Config::SM_QUERY_DENSE_QC_COORDS_MODE = "false";
@@ -263,6 +264,8 @@ Config::Config() {
   param_values_["sm.tile_cache_size"] = SM_TILE_CACHE_SIZE;
   param_values_["sm.skip_est_size_partitioning"] =
       SM_SKIP_EST_SIZE_PARTITIONING;
+  param_values_["sm.skip_unary_partitioning_budget_check"] =
+      SM_SKIP_UNARY_PARTITIONING_BUDGET_CHECK;
   param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
   param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
   param_values_["sm.query.dense.qc_coords_mode"] =

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -168,6 +168,9 @@ class Config {
   /** If `true`, bypass partitioning on estimated result sizes. */
   static const std::string SM_SKIP_EST_SIZE_PARTITIONING;
 
+  /** If `true`, bypass partitioning budget check for unary ranges. */
+  static const std::string SM_SKIP_UNARY_PARTITIONING_BUDGET_CHECK;
+
   /**
    * The maximum memory budget for producing the result (in bytes)
    * for a fixed-sized attribute or the offsets of a var-sized attribute.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -258,8 +258,10 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Are dimensions var sized. */
   std::vector<bool> is_dim_var_size_;
 
-  /** Reverse sorted vector, per fragments, of tiles ranges in the subarray, if
-   * set. */
+  /**
+   * Reverse sorted vector, per fragments, of tiles ranges in the subarray, if
+   * set.
+   */
   std::vector<std::vector<std::pair<uint64_t, uint64_t>>> result_tile_ranges_;
 
   /** Total memory budget. */

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -1221,12 +1221,21 @@ bool SubarrayPartitioner::must_split(Subarray* partition) {
       }
     }
 
+    // If we try to split a unary range because of memory budgets, throw an
+    // error. This can happen when the memory budget cannot fit even one tile.
+    // It will cause the reader to process the query cell by cell, which will
+    // make it very slow.
     if (!skip_unary_partitioning_budget_check_ &&
         (mem_size_fixed > memory_budget_ || mem_size_var > memory_budget_var_ ||
          mem_size_validity > memory_budget_validity_)) {
       if (partition->is_unary()) {
         throw SubarrayPartitionerStatusException(
-            "Trying to partition a unary range because of memory budget");
+            "Trying to partition a unary range because of memory budget, this "
+            "will cause the query to run very slow. Increase "
+            "`sm.memory_budget` and `sm.memory_budget_var` through the "
+            "configuration settings to avoid this issue. To override and run "
+            "the query with the same budget, set "
+            "`sm.skip_unary_partitioning_budget_check` to `true`.");
       }
     }
 

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -45,6 +45,13 @@
 
 #include <iomanip>
 
+class SubarrayPartitionerStatusException : public StatusException {
+ public:
+  explicit SubarrayPartitionerStatusException(const std::string& message)
+      : StatusException("SubarrayPertitioner", message) {
+  }
+};
+
 /* ****************************** */
 /*             MACROS             */
 /* ****************************** */
@@ -88,6 +95,12 @@ SubarrayPartitioner::SubarrayPartitioner(
   bool found = false;
   throw_if_not_ok(config_->get<bool>(
       "sm.skip_est_size_partitioning", &skip_split_on_est_size_, &found));
+  assert(found);
+
+  throw_if_not_ok(config_->get<bool>(
+      "sm.skip_unary_partitioning_budget_check",
+      &skip_unary_partitioning_budget_check_,
+      &found));
   (void)found;
   assert(found);
 }
@@ -767,6 +780,8 @@ SubarrayPartitioner SubarrayPartitioner::clone() const {
   clone.memory_budget_var_ = memory_budget_var_;
   clone.memory_budget_validity_ = memory_budget_validity_;
   clone.skip_split_on_est_size_ = skip_split_on_est_size_;
+  clone.skip_unary_partitioning_budget_check_ =
+      skip_unary_partitioning_budget_check_;
   clone.compute_tp_ = compute_tp_;
 
   return clone;
@@ -1206,6 +1221,15 @@ bool SubarrayPartitioner::must_split(Subarray* partition) {
       }
     }
 
+    if (!skip_unary_partitioning_budget_check_ &&
+        (mem_size_fixed > memory_budget_ || mem_size_var > memory_budget_var_ ||
+         mem_size_validity > memory_budget_validity_)) {
+      if (partition->is_unary()) {
+        throw SubarrayPartitionerStatusException(
+            "Trying to partition a unary range because of memory budget");
+      }
+    }
+
     // Check for budget overflow
     if ((!skip_split_on_est_size_ &&
          (size_fixed > b.second.size_fixed_ || size_var > b.second.size_var_ ||
@@ -1371,6 +1395,9 @@ void SubarrayPartitioner::swap(SubarrayPartitioner& partitioner) {
   std::swap(memory_budget_var_, partitioner.memory_budget_var_);
   std::swap(memory_budget_validity_, partitioner.memory_budget_validity_);
   std::swap(skip_split_on_est_size_, partitioner.skip_split_on_est_size_);
+  std::swap(
+      skip_unary_partitioning_budget_check_,
+      partitioner.skip_unary_partitioning_budget_check_);
   std::swap(compute_tp_, partitioner.compute_tp_);
 }
 

--- a/tiledb/sm/subarray/subarray_partitioner.h
+++ b/tiledb/sm/subarray/subarray_partitioner.h
@@ -382,6 +382,12 @@ class SubarrayPartitioner {
    */
   bool skip_split_on_est_size_;
 
+  /**
+   * If true, do not consider a memory budget overflow an error when the
+   * partition is a unary range.
+   */
+  bool skip_unary_partitioning_budget_check_;
+
   /** The thread pool for compute-bound tasks. */
   ThreadPool* compute_tp_;
 


### PR DESCRIPTION
This changes the subarray partitioner to throw an error when a single tile cannot fit the memory budget, which will lead to processing a single cell at a time and a very slow query. The change also includes a setting that allows the query to proceed without throwing an error if this condition occurs.

---
TYPE: IMPROVEMENT
DESC: Throw error when memory budget leads to splitting to unary range.
