### PR TITLE
Sparse unordered w/dups reader: allow partial tile offsets loading.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -278,6 +278,7 @@ void check_save_to_file() {
   ss << "sm.mem.total_budget 10737418240\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
+  ss << "sm.partial_tile_offsets_loading false\n";
   ss << "sm.query.dense.qc_coords_mode false\n";
   ss << "sm.query.dense.reader refactored\n";
   ss << "sm.query.sparse_global_order.reader refactored\n";
@@ -595,6 +596,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.encryption_key"] = "";
   all_param_values["sm.encryption_type"] = "NO_ENCRYPTION";
   all_param_values["sm.dedup_coords"] = "false";
+  all_param_values["sm.partial_tile_offsets_loading"] = "false";
   all_param_values["sm.check_coord_dups"] = "true";
   all_param_values["sm.check_coord_oob"] = "true";
   all_param_values["sm.check_global_order"] = "true";
@@ -653,6 +655,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.var_offsets.mode"] = "elements";
   all_param_values["sm.max_tile_overlap_size"] = "314572800";
   all_param_values["sm.fragment_info.preload_mbrs"] = "true";
+  all_param_values["sm.partial_tile_offsets_loading"] = "false";
 
   all_param_values["vfs.disable_batching"] = "false";
   all_param_values["vfs.max_batch_size"] = std::to_string(UINT64_MAX);

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -177,7 +177,7 @@ void CSparseGlobalOrderFx::update_config() {
 }
 
 void CSparseGlobalOrderFx::create_default_array_1d(bool allow_dups) {
-  int domain[] = {1, 20};
+  int domain[] = {1, 200};
   int tile_extent = 2;
   create_array(
       ctx_,
@@ -353,16 +353,20 @@ TEST_CASE_METHOD(
   create_default_array_1d();
 
   // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
+  std::vector<int> coords(200);
+  std::iota(coords.begin(), coords.end(), 1);
+  uint64_t coords_size = coords.size() * sizeof(int);
 
-  // We should have 3 tiles (tile offset size 24) which will be bigger than
-  // budget (10).
-  total_budget_ = "1000";
-  ratio_array_data_ = "0.01";
+  std::vector<int> data(200);
+  std::iota(data.begin(), data.end(), 1);
+  uint64_t data_size = data.size() * sizeof(int);
+
+  write_1d_fragment(coords.data(), &coords_size, data.data(), &data_size);
+
+  // We should have 100 tiles (tile offset size 800) which will be bigger than
+  // leftover budget.
+  total_budget_ = "3000";
+  ratio_array_data_ = "0.5";
   update_config();
 
   // Try to read.
@@ -385,8 +389,7 @@ TEST_CASE_METHOD(
   std::string error_str(msg);
   CHECK(
       error_str.find(
-          "SparseIndexReaderBase: Cannot load tile offsets, computed size (48) "
-          "is larger than memory budget for array data (10).") !=
+          "SparseGlobalOrderReader: Cannot load tile offsets, computed size") !=
       std::string::npos);
 }
 

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -272,10 +272,20 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    The end timestamp used for opening the group. <br>
  *    Also used for the write timestamp if set. <br>
  *    **Default**: UINT64_MAX
+ * -  `sm.partial_tile_offsets_loading`
+ *    **Experimental** <br>
+ *    If `true` tile offsets can be partially loaded and unloaded by the
+ *    readers. <br>
+ *    **Default**: false
  * - `sm.fragment_info.preload_mbrs` <br>
  *    If `true` MBRs will be loaded at the same time as the rest of fragment
  *    info, otherwise they will be loaded lazily when some info related to MBRs
  *    is requested by the user. <br>
+ *    **Default**: false
+ * -  `sm.partial_tile_offset_loading`
+ *    **Experimental** <br>
+ *    If `true` tile offsets can be partially loaded and unloaded by the
+ *    readers. <br>
  *    **Default**: false
  * -  `vfs.read_ahead_cache_size` <br>
  *    The the total maximum size of the read-ahead cache, which is an LRU. <br>

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -324,7 +324,7 @@ int32_t tiledb_buffer_list_flatten(
   // Resize the dest buffer
   const auto nbytes = buffer_list->buffer_list_->total_size();
   auto st = buf->buffer().realloc(nbytes);
-  if(!st.ok()) {
+  if (!st.ok()) {
     tiledb_buffer_handle_t::break_handle(buf);
     throw StatusException(st);
   }
@@ -332,7 +332,7 @@ int32_t tiledb_buffer_list_flatten(
   // Read all into the dest buffer
   buffer_list->buffer_list_->reset_offset();
   st = buffer_list->buffer_list_->read(buf->buffer().data(), nbytes);
-  if(!st.ok()) {
+  if (!st.ok()) {
     tiledb_buffer_handle_t::break_handle(buf);
     throw StatusException(st);
   }
@@ -2531,7 +2531,9 @@ int32_t tiledb_query_get_relevant_fragment_num(
     return TILEDB_ERR;
 
   *relevant_fragment_num =
-      query->query_->subarray()->relevant_fragments()->size();
+      query->query_->subarray()->relevant_fragments().has_value() ?
+          query->query_->subarray()->relevant_fragments()->size() :
+          0;
 
   return TILEDB_OK;
 }
@@ -4923,8 +4925,7 @@ int32_t tiledb_deserialize_query(
     int32_t client_side,
     tiledb_query_t* query) {
   // Sanity check
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, query) == TILEDB_ERR)
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
   api::ensure_buffer_is_valid(buffer);
@@ -4986,8 +4987,7 @@ int32_t tiledb_deserialize_array_nonempty_domain(
   (void)client_side;
 
   // Sanity check
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, array) == TILEDB_ERR)
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
 
   api::ensure_buffer_is_valid(buffer);
@@ -5045,8 +5045,7 @@ int32_t tiledb_deserialize_array_non_empty_domain_all_dimensions(
   (void)client_side;
 
   // Sanity check
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, array) == TILEDB_ERR)
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
 
   api::ensure_buffer_is_valid(buffer);
@@ -5128,8 +5127,7 @@ int32_t tiledb_deserialize_array_metadata(
     tiledb_serialization_type_t serialize_type,
     const tiledb_buffer_t* buffer) {
   // Sanity check
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, array) == TILEDB_ERR)
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
 
   api::ensure_buffer_is_valid(buffer);
@@ -5178,8 +5176,7 @@ int32_t tiledb_deserialize_query_est_result_sizes(
     int32_t client_side,
     const tiledb_buffer_t* buffer) {
   // Sanity check
-  if (sanity_check(ctx) == TILEDB_ERR ||
-      sanity_check(ctx, query) == TILEDB_ERR)
+  if (sanity_check(ctx) == TILEDB_ERR || sanity_check(ctx, query) == TILEDB_ERR)
     return TILEDB_ERR;
 
   api::ensure_buffer_is_valid(buffer);

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -139,6 +139,7 @@ const std::string Config::SM_MAX_TILE_OVERLAP_SIZE = "314572800";  // 300MiB
 const std::string Config::SM_GROUP_TIMESTAMP_START = "0";
 const std::string Config::SM_GROUP_TIMESTAMP_END = std::to_string(UINT64_MAX);
 const std::string Config::SM_FRAGMENT_INFO_PRELOAD_MBRS = "false";
+const std::string Config::SM_PARTIAL_TILE_OFFSETS_LOADING = "false";
 const std::string Config::VFS_MIN_PARALLEL_SIZE = "10485760";
 const std::string Config::VFS_MAX_BATCH_SIZE = std::to_string(UINT64_MAX);
 const std::string Config::VFS_MIN_BATCH_GAP = "512000";
@@ -203,6 +204,233 @@ const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
 const std::string Config::FILESTORE_BUFFER_SIZE = "104857600";
+
+const std::map<std::string, std::string> default_config_values = {
+    std::make_pair("rest.server_address", Config::REST_SERVER_DEFAULT_ADDRESS),
+    std::make_pair(
+        "rest.server_serialization_format",
+        Config::REST_SERIALIZATION_DEFAULT_FORMAT),
+    std::make_pair(
+        "rest.http_compressor", Config::REST_SERVER_DEFAULT_HTTP_COMPRESSOR),
+    std::make_pair("rest.retry_http_codes", Config::REST_RETRY_HTTP_CODES),
+    std::make_pair("rest.retry_count", Config::REST_RETRY_COUNT),
+    std::make_pair(
+        "rest.retry_initial_delay_ms", Config::REST_RETRY_INITIAL_DELAY_MS),
+    std::make_pair("rest.retry_delay_factor", Config::REST_RETRY_DELAY_FACTOR),
+    std::make_pair("rest.curl.buffer_size", Config::REST_CURL_BUFFER_SIZE),
+    std::make_pair("rest.curl.verbose", Config::REST_CURL_VERBOSE),
+    std::make_pair(
+        "rest.load_metadata_on_array_open",
+        Config::REST_LOAD_METADATA_ON_ARRAY_OPEN),
+    std::make_pair(
+        "rest.load_non_empty_domain_on_array_open",
+        Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN),
+    std::make_pair(
+        "rest.use_refactored_array_open",
+        Config::REST_USE_REFACTORED_ARRAY_OPEN),
+    std::make_pair(
+        "config.env_var_prefix", Config::CONFIG_ENVIRONMENT_VARIABLE_PREFIX),
+    std::make_pair("config.logging_level", Config::CONFIG_LOGGING_LEVEL),
+    std::make_pair(
+        "config.logging_format", Config::CONFIG_LOGGING_DEFAULT_FORMAT),
+    std::make_pair(
+        "sm.allow_updates_experimental", Config::SM_ALLOW_UPDATES_EXPERIMENTAL),
+    std::make_pair("sm.encryption_key", Config::SM_ENCRYPTION_KEY),
+    std::make_pair("sm.encryption_type", Config::SM_ENCRYPTION_TYPE),
+    std::make_pair("sm.dedup_coords", Config::SM_DEDUP_COORDS),
+    std::make_pair("sm.check_coord_dups", Config::SM_CHECK_COORD_DUPS),
+    std::make_pair("sm.check_coord_oob", Config::SM_CHECK_COORD_OOB),
+    std::make_pair("sm.read_range_oob", Config::SM_READ_RANGE_OOB),
+    std::make_pair("sm.check_global_order", Config::SM_CHECK_GLOBAL_ORDER),
+    std::make_pair("sm.tile_cache_size", Config::SM_TILE_CACHE_SIZE),
+    std::make_pair(
+        "sm.skip_est_size_partitioning", Config::SM_SKIP_EST_SIZE_PARTITIONING),
+    std::make_pair(
+        "sm.skip_unary_partitioning_budget_check",
+        Config::SM_SKIP_UNARY_PARTITIONING_BUDGET_CHECK),
+    std::make_pair("sm.memory_budget", Config::SM_MEMORY_BUDGET),
+    std::make_pair("sm.memory_budget_var", Config::SM_MEMORY_BUDGET_VAR),
+    std::make_pair(
+        "sm.query.dense.qc_coords_mode", Config::SM_QUERY_DENSE_QC_COORDS_MODE),
+    std::make_pair("sm.query.dense.reader", Config::SM_QUERY_DENSE_READER),
+    std::make_pair(
+        "sm.query.sparse_global_order.reader",
+        Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER),
+    std::make_pair(
+        "sm.query.sparse_unordered_with_dups.reader",
+        Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER),
+    std::make_pair("sm.mem.malloc_trim", Config::SM_MEM_MALLOC_TRIM),
+    std::make_pair("sm.mem.total_budget", Config::SM_MEM_TOTAL_BUDGET),
+    std::make_pair(
+        "sm.mem.reader.sparse_global_order.ratio_coords",
+        Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS),
+    std::make_pair(
+        "sm.mem.reader.sparse_global_order.ratio_query_condition",
+        Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION),
+    std::make_pair(
+        "sm.mem.reader.sparse_global_order.ratio_tile_ranges",
+        Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES),
+    std::make_pair(
+        "sm.mem.reader.sparse_global_order.ratio_array_data",
+        Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA),
+    std::make_pair(
+        "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
+        Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS),
+    std::make_pair(
+        "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition",
+        Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION),
+    std::make_pair(
+        "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges",
+        Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES),
+    std::make_pair(
+        "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data",
+        Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA),
+    std::make_pair(
+        "sm.enable_signal_handlers", Config::SM_ENABLE_SIGNAL_HANDLERS),
+    std::make_pair(
+        "sm.compute_concurrency_level", Config::SM_COMPUTE_CONCURRENCY_LEVEL),
+    std::make_pair("sm.io_concurrency_level", Config::SM_IO_CONCURRENCY_LEVEL),
+    std::make_pair(
+        "sm.skip_checksum_validation", Config::SM_SKIP_CHECKSUM_VALIDATION),
+    std::make_pair(
+        "sm.consolidation.amplification",
+        Config::SM_CONSOLIDATION_AMPLIFICATION),
+    std::make_pair(
+        "sm.consolidation.buffer_size", Config::SM_CONSOLIDATION_BUFFER_SIZE),
+    std::make_pair(
+        "sm.consolidation.max_fragment_size",
+        Config::SM_CONSOLIDATION_MAX_FRAGMENT_SIZE),
+    std::make_pair(
+        "sm.consolidation.purge_deleted_cells",
+        Config::SM_CONSOLIDATION_PURGE_DELETED_CELLS),
+    std::make_pair(
+        "sm.consolidation.step_min_frags",
+        Config::SM_CONSOLIDATION_STEP_MIN_FRAGS),
+    std::make_pair(
+        "sm.consolidation.step_max_frags",
+        Config::SM_CONSOLIDATION_STEP_MAX_FRAGS),
+    std::make_pair(
+        "sm.consolidation.step_size_ratio",
+        Config::SM_CONSOLIDATION_STEP_SIZE_RATIO),
+    std::make_pair("sm.consolidation.steps", Config::SM_CONSOLIDATION_STEPS),
+    std::make_pair("sm.consolidation.mode", Config::SM_CONSOLIDATION_MODE),
+    std::make_pair(
+        "sm.consolidation.timestamp_start",
+        Config::SM_CONSOLIDATION_TIMESTAMP_START),
+    std::make_pair(
+        "sm.consolidation.timestamp_end",
+        Config::SM_CONSOLIDATION_TIMESTAMP_END),
+    std::make_pair("sm.vacuum.mode", Config::SM_VACUUM_MODE),
+    std::make_pair("sm.var_offsets.bitsize", Config::SM_OFFSETS_BITSIZE),
+    std::make_pair(
+        "sm.var_offsets.extra_element", Config::SM_OFFSETS_EXTRA_ELEMENT),
+    std::make_pair("sm.var_offsets.mode", Config::SM_OFFSETS_FORMAT_MODE),
+    std::make_pair(
+        "sm.max_tile_overlap_size", Config::SM_MAX_TILE_OVERLAP_SIZE),
+    std::make_pair(
+        "sm.group.timestamp_start", Config::SM_GROUP_TIMESTAMP_START),
+    std::make_pair("sm.group.timestamp_end", Config::SM_GROUP_TIMESTAMP_END),
+    std::make_pair(
+        "sm.fragment_info.preload_mbrs", Config::SM_FRAGMENT_INFO_PRELOAD_MBRS),
+    std::make_pair(
+        "sm.partial_tile_offsets_loading",
+        Config::SM_PARTIAL_TILE_OFFSETS_LOADING),
+    std::make_pair("vfs.min_parallel_size", Config::VFS_MIN_PARALLEL_SIZE),
+    std::make_pair("vfs.max_batch_size", Config::VFS_MAX_BATCH_SIZE),
+    std::make_pair("vfs.min_batch_gap", Config::VFS_MIN_BATCH_GAP),
+    std::make_pair("vfs.min_batch_size", Config::VFS_MIN_BATCH_SIZE),
+    std::make_pair("vfs.disable_batching", Config::VFS_DISABLE_BATCHING),
+    std::make_pair("vfs.read_ahead_size", Config::VFS_READ_AHEAD_SIZE),
+    std::make_pair(
+        "vfs.read_ahead_cache_size", Config::VFS_READ_AHEAD_CACHE_SIZE),
+    std::make_pair(
+        "vfs.file.posix_file_permissions",
+        Config::VFS_FILE_POSIX_FILE_PERMISSIONS),
+    std::make_pair(
+        "vfs.file.posix_directory_permissions",
+        Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS),
+    std::make_pair(
+        "vfs.file.max_parallel_ops", Config::VFS_FILE_MAX_PARALLEL_OPS),
+    std::make_pair(
+        "vfs.azure.storage_account_name",
+        Config::VFS_AZURE_STORAGE_ACCOUNT_NAME),
+    std::make_pair(
+        "vfs.azure.storage_account_key", Config::VFS_AZURE_STORAGE_ACCOUNT_KEY),
+    std::make_pair(
+        "vfs.azure.storage_sas_token", Config::VFS_AZURE_STORAGE_SAS_TOKEN),
+    std::make_pair("vfs.azure.blob_endpoint", Config::VFS_AZURE_BLOB_ENDPOINT),
+    std::make_pair("vfs.azure.use_https", Config::VFS_AZURE_USE_HTTPS),
+    std::make_pair(
+        "vfs.azure.max_parallel_ops", Config::VFS_AZURE_MAX_PARALLEL_OPS),
+    std::make_pair(
+        "vfs.azure.block_list_block_size",
+        Config::VFS_AZURE_BLOCK_LIST_BLOCK_SIZE),
+    std::make_pair(
+        "vfs.azure.use_block_list_upload",
+        Config::VFS_AZURE_USE_BLOCK_LIST_UPLOAD),
+    std::make_pair("vfs.gcs.project_id", Config::VFS_GCS_PROJECT_ID),
+    std::make_pair(
+        "vfs.gcs.max_parallel_ops", Config::VFS_GCS_MAX_PARALLEL_OPS),
+    std::make_pair("vfs.gcs.multi_part_size", Config::VFS_GCS_MULTI_PART_SIZE),
+    std::make_pair(
+        "vfs.gcs.use_multi_part_upload", Config::VFS_GCS_USE_MULTI_PART_UPLOAD),
+    std::make_pair(
+        "vfs.gcs.request_timeout_ms", Config::VFS_GCS_REQUEST_TIMEOUT_MS),
+    std::make_pair("vfs.s3.region", Config::VFS_S3_REGION),
+    std::make_pair(
+        "vfs.s3.aws_access_key_id", Config::VFS_S3_AWS_ACCESS_KEY_ID),
+    std::make_pair(
+        "vfs.s3.aws_secret_access_key", Config::VFS_S3_AWS_SECRET_ACCESS_KEY),
+    std::make_pair(
+        "vfs.s3.aws_session_token", Config::VFS_S3_AWS_SESSION_TOKEN),
+    std::make_pair("vfs.s3.aws_role_arn", Config::VFS_S3_AWS_ROLE_ARN),
+    std::make_pair("vfs.s3.aws_external_id", Config::VFS_S3_AWS_EXTERNAL_ID),
+    std::make_pair(
+        "vfs.s3.aws_load_frequency", Config::VFS_S3_AWS_LOAD_FREQUENCY),
+    std::make_pair("vfs.s3.aws_session_name", Config::VFS_S3_AWS_SESSION_NAME),
+    std::make_pair("vfs.s3.scheme", Config::VFS_S3_SCHEME),
+    std::make_pair(
+        "vfs.s3.endpoint_override", Config::VFS_S3_ENDPOINT_OVERRIDE),
+    std::make_pair(
+        "vfs.s3.use_virtual_addressing", Config::VFS_S3_USE_VIRTUAL_ADDRESSING),
+    std::make_pair("vfs.s3.skip_init", Config::VFS_S3_SKIP_INIT),
+    std::make_pair(
+        "vfs.s3.use_multipart_upload", Config::VFS_S3_USE_MULTIPART_UPLOAD),
+    std::make_pair("vfs.s3.max_parallel_ops", Config::VFS_S3_MAX_PARALLEL_OPS),
+    std::make_pair(
+        "vfs.s3.multipart_part_size", Config::VFS_S3_MULTIPART_PART_SIZE),
+    std::make_pair("vfs.s3.ca_file", Config::VFS_S3_CA_FILE),
+    std::make_pair("vfs.s3.ca_path", Config::VFS_S3_CA_PATH),
+    std::make_pair(
+        "vfs.s3.connect_timeout_ms", Config::VFS_S3_CONNECT_TIMEOUT_MS),
+    std::make_pair(
+        "vfs.s3.connect_max_tries", Config::VFS_S3_CONNECT_MAX_TRIES),
+    std::make_pair(
+        "vfs.s3.connect_scale_factor", Config::VFS_S3_CONNECT_SCALE_FACTOR),
+    std::make_pair("vfs.s3.sse", Config::VFS_S3_SSE),
+    std::make_pair("vfs.s3.sse_kms_key_id", Config::VFS_S3_SSE_KMS_KEY_ID),
+    std::make_pair(
+        "vfs.s3.request_timeout_ms", Config::VFS_S3_REQUEST_TIMEOUT_MS),
+    std::make_pair("vfs.s3.requester_pays", Config::VFS_S3_REQUESTER_PAYS),
+    std::make_pair("vfs.s3.proxy_scheme", Config::VFS_S3_PROXY_SCHEME),
+    std::make_pair("vfs.s3.proxy_host", Config::VFS_S3_PROXY_HOST),
+    std::make_pair("vfs.s3.proxy_port", Config::VFS_S3_PROXY_PORT),
+    std::make_pair("vfs.s3.proxy_username", Config::VFS_S3_PROXY_USERNAME),
+    std::make_pair("vfs.s3.proxy_password", Config::VFS_S3_PROXY_PASSWORD),
+    std::make_pair("vfs.s3.logging_level", Config::VFS_S3_LOGGING_LEVEL),
+    std::make_pair("vfs.s3.verify_ssl", Config::VFS_S3_VERIFY_SSL),
+    std::make_pair(
+        "vfs.s3.bucket_canned_acl", Config::VFS_S3_BUCKET_CANNED_ACL),
+    std::make_pair(
+        "vfs.s3.object_canned_acl", Config::VFS_S3_OBJECT_CANNED_ACL),
+    std::make_pair("vfs.hdfs.name_node_uri", Config::VFS_HDFS_NAME_NODE_URI),
+    std::make_pair("vfs.hdfs.username", Config::VFS_HDFS_USERNAME),
+    std::make_pair(
+        "vfs.hdfs.kerb_ticket_cache_path",
+        Config::VFS_HDFS_KERB_TICKET_CACHE_PATH),
+    std::make_pair("filestore.buffer_size", Config::FILESTORE_BUFFER_SIZE),
+};
+
 /* ****************************** */
 /*        PRIVATE CONSTANTS       */
 /* ****************************** */
@@ -233,168 +461,7 @@ const std::set<std::string> Config::unserialized_params_ = {
 
 Config::Config() {
   // Set config values
-  param_values_["rest.server_address"] = REST_SERVER_DEFAULT_ADDRESS;
-  param_values_["rest.server_serialization_format"] =
-      REST_SERIALIZATION_DEFAULT_FORMAT;
-  param_values_["rest.http_compressor"] = REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
-  param_values_["rest.retry_http_codes"] = REST_RETRY_HTTP_CODES;
-  param_values_["rest.retry_count"] = REST_RETRY_COUNT;
-  param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
-  param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
-  param_values_["rest.curl.buffer_size"] = REST_CURL_BUFFER_SIZE;
-  param_values_["rest.curl.verbose"] = REST_CURL_VERBOSE;
-  param_values_["rest.load_metadata_on_array_open"] =
-      REST_LOAD_METADATA_ON_ARRAY_OPEN;
-  param_values_["rest.load_non_empty_domain_on_array_open"] =
-      REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN;
-  param_values_["rest.use_refactored_array_open"] =
-      REST_USE_REFACTORED_ARRAY_OPEN;
-  param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
-  param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
-  param_values_["config.logging_format"] = CONFIG_LOGGING_DEFAULT_FORMAT;
-  param_values_["sm.allow_updates_experimental"] =
-      SM_ALLOW_UPDATES_EXPERIMENTAL;
-  param_values_["sm.encryption_key"] = SM_ENCRYPTION_KEY;
-  param_values_["sm.encryption_type"] = SM_ENCRYPTION_TYPE;
-  param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
-  param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
-  param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
-  param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
-  param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
-  param_values_["sm.tile_cache_size"] = SM_TILE_CACHE_SIZE;
-  param_values_["sm.skip_est_size_partitioning"] =
-      SM_SKIP_EST_SIZE_PARTITIONING;
-  param_values_["sm.skip_unary_partitioning_budget_check"] =
-      SM_SKIP_UNARY_PARTITIONING_BUDGET_CHECK;
-  param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
-  param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
-  param_values_["sm.query.dense.qc_coords_mode"] =
-      SM_QUERY_DENSE_QC_COORDS_MODE;
-  param_values_["sm.query.dense.reader"] = SM_QUERY_DENSE_READER;
-  param_values_["sm.query.sparse_global_order.reader"] =
-      SM_QUERY_SPARSE_GLOBAL_ORDER_READER;
-  param_values_["sm.query.sparse_unordered_with_dups.reader"] =
-      SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
-  param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
-  param_values_["sm.mem.total_budget"] = SM_MEM_TOTAL_BUDGET;
-  param_values_["sm.mem.reader.sparse_global_order.ratio_coords"] =
-      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS;
-  param_values_["sm.mem.reader.sparse_global_order.ratio_query_condition"] =
-      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION;
-  param_values_["sm.mem.reader.sparse_global_order.ratio_tile_ranges"] =
-      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES;
-  param_values_["sm.mem.reader.sparse_global_order.ratio_array_data"] =
-      SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
-  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
-      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
-  param_values_
-      ["sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition"] =
-          SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION;
-  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] =
-      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES;
-  param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_array_data"] =
-      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA;
-  param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
-  param_values_["sm.compute_concurrency_level"] = SM_COMPUTE_CONCURRENCY_LEVEL;
-  param_values_["sm.io_concurrency_level"] = SM_IO_CONCURRENCY_LEVEL;
-  param_values_["sm.skip_checksum_validation"] = SM_SKIP_CHECKSUM_VALIDATION;
-  param_values_["sm.consolidation.amplification"] =
-      SM_CONSOLIDATION_AMPLIFICATION;
-  param_values_["sm.consolidation.buffer_size"] = SM_CONSOLIDATION_BUFFER_SIZE;
-  param_values_["sm.consolidation.max_fragment_size"] =
-      SM_CONSOLIDATION_MAX_FRAGMENT_SIZE;
-  param_values_["sm.consolidation.purge_deleted_cells"] =
-      SM_CONSOLIDATION_PURGE_DELETED_CELLS;
-  param_values_["sm.consolidation.step_min_frags"] =
-      SM_CONSOLIDATION_STEP_MIN_FRAGS;
-  param_values_["sm.consolidation.step_max_frags"] =
-      SM_CONSOLIDATION_STEP_MAX_FRAGS;
-  param_values_["sm.consolidation.step_size_ratio"] =
-      SM_CONSOLIDATION_STEP_SIZE_RATIO;
-  param_values_["sm.consolidation.steps"] = SM_CONSOLIDATION_STEPS;
-  param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
-  param_values_["sm.consolidation.timestamp_start"] =
-      SM_CONSOLIDATION_TIMESTAMP_START;
-  param_values_["sm.consolidation.timestamp_end"] =
-      SM_CONSOLIDATION_TIMESTAMP_END;
-  param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
-  param_values_["sm.var_offsets.extra_element"] = SM_OFFSETS_EXTRA_ELEMENT;
-  param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
-  param_values_["sm.max_tile_overlap_size"] = SM_MAX_TILE_OVERLAP_SIZE;
-  param_values_["sm.group.timestamp_start"] = SM_GROUP_TIMESTAMP_START;
-  param_values_["sm.group.timestamp_end"] = SM_GROUP_TIMESTAMP_END;
-  param_values_["sm.fragment_info.preload_mbrs"] =
-      SM_FRAGMENT_INFO_PRELOAD_MBRS;
-  param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
-  param_values_["vfs.max_batch_size"] = VFS_MAX_BATCH_SIZE;
-  param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
-  param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
-  param_values_["vfs.disable_batching"] = VFS_DISABLE_BATCHING;
-  param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
-  param_values_["vfs.read_ahead_cache_size"] = VFS_READ_AHEAD_CACHE_SIZE;
-  param_values_["vfs.file.posix_file_permissions"] =
-      VFS_FILE_POSIX_FILE_PERMISSIONS;
-  param_values_["vfs.file.posix_directory_permissions"] =
-      VFS_FILE_POSIX_DIRECTORY_PERMISSIONS;
-  param_values_["vfs.file.max_parallel_ops"] = VFS_FILE_MAX_PARALLEL_OPS;
-  param_values_["vfs.azure.storage_account_name"] =
-      VFS_AZURE_STORAGE_ACCOUNT_NAME;
-  param_values_["vfs.azure.storage_account_key"] =
-      VFS_AZURE_STORAGE_ACCOUNT_KEY;
-  param_values_["vfs.azure.storage_sas_token"] = VFS_AZURE_STORAGE_SAS_TOKEN;
-  param_values_["vfs.azure.blob_endpoint"] = VFS_AZURE_BLOB_ENDPOINT;
-  param_values_["vfs.azure.use_https"] = VFS_AZURE_USE_HTTPS;
-  param_values_["vfs.azure.max_parallel_ops"] = VFS_AZURE_MAX_PARALLEL_OPS;
-  param_values_["vfs.azure.block_list_block_size"] =
-      VFS_AZURE_BLOCK_LIST_BLOCK_SIZE;
-  param_values_["vfs.azure.use_block_list_upload"] =
-      VFS_AZURE_USE_BLOCK_LIST_UPLOAD;
-  param_values_["vfs.gcs.project_id"] = VFS_GCS_PROJECT_ID;
-  param_values_["vfs.gcs.max_parallel_ops"] = VFS_GCS_MAX_PARALLEL_OPS;
-  param_values_["vfs.gcs.multi_part_size"] = VFS_GCS_MULTI_PART_SIZE;
-  param_values_["vfs.gcs.use_multi_part_upload"] =
-      VFS_GCS_USE_MULTI_PART_UPLOAD;
-  param_values_["vfs.gcs.request_timeout_ms"] = VFS_GCS_REQUEST_TIMEOUT_MS;
-  param_values_["vfs.s3.region"] = VFS_S3_REGION;
-  param_values_["vfs.s3.aws_access_key_id"] = VFS_S3_AWS_ACCESS_KEY_ID;
-  param_values_["vfs.s3.aws_secret_access_key"] = VFS_S3_AWS_SECRET_ACCESS_KEY;
-  param_values_["vfs.s3.aws_session_token"] = VFS_S3_AWS_SESSION_TOKEN;
-  param_values_["vfs.s3.aws_role_arn"] = VFS_S3_AWS_ROLE_ARN;
-  param_values_["vfs.s3.aws_external_id"] = VFS_S3_AWS_EXTERNAL_ID;
-  param_values_["vfs.s3.aws_load_frequency"] = VFS_S3_AWS_LOAD_FREQUENCY;
-  param_values_["vfs.s3.aws_session_name"] = VFS_S3_AWS_SESSION_NAME;
-  param_values_["vfs.s3.scheme"] = VFS_S3_SCHEME;
-  param_values_["vfs.s3.endpoint_override"] = VFS_S3_ENDPOINT_OVERRIDE;
-  param_values_["vfs.s3.use_virtual_addressing"] =
-      VFS_S3_USE_VIRTUAL_ADDRESSING;
-  param_values_["vfs.s3.skip_init"] = VFS_S3_SKIP_INIT;
-  param_values_["vfs.s3.use_multipart_upload"] = VFS_S3_USE_MULTIPART_UPLOAD;
-  param_values_["vfs.s3.max_parallel_ops"] = VFS_S3_MAX_PARALLEL_OPS;
-  param_values_["vfs.s3.multipart_part_size"] = VFS_S3_MULTIPART_PART_SIZE;
-  param_values_["vfs.s3.ca_file"] = VFS_S3_CA_FILE;
-  param_values_["vfs.s3.ca_path"] = VFS_S3_CA_PATH;
-  param_values_["vfs.s3.connect_timeout_ms"] = VFS_S3_CONNECT_TIMEOUT_MS;
-  param_values_["vfs.s3.connect_max_tries"] = VFS_S3_CONNECT_MAX_TRIES;
-  param_values_["vfs.s3.connect_scale_factor"] = VFS_S3_CONNECT_SCALE_FACTOR;
-  param_values_["vfs.s3.sse"] = VFS_S3_SSE;
-  param_values_["vfs.s3.sse_kms_key_id"] = VFS_S3_SSE_KMS_KEY_ID;
-  param_values_["vfs.s3.request_timeout_ms"] = VFS_S3_REQUEST_TIMEOUT_MS;
-  param_values_["vfs.s3.requester_pays"] = VFS_S3_REQUESTER_PAYS;
-  param_values_["vfs.s3.proxy_scheme"] = VFS_S3_PROXY_SCHEME;
-  param_values_["vfs.s3.proxy_host"] = VFS_S3_PROXY_HOST;
-  param_values_["vfs.s3.proxy_port"] = VFS_S3_PROXY_PORT;
-  param_values_["vfs.s3.proxy_username"] = VFS_S3_PROXY_USERNAME;
-  param_values_["vfs.s3.proxy_password"] = VFS_S3_PROXY_PASSWORD;
-  param_values_["vfs.s3.logging_level"] = VFS_S3_LOGGING_LEVEL;
-  param_values_["vfs.s3.verify_ssl"] = VFS_S3_VERIFY_SSL;
-  param_values_["vfs.s3.bucket_canned_acl"] = VFS_S3_BUCKET_CANNED_ACL;
-  param_values_["vfs.s3.object_canned_acl"] = VFS_S3_OBJECT_CANNED_ACL;
-  param_values_["vfs.hdfs.name_node_uri"] = VFS_HDFS_NAME_NODE_URI;
-  param_values_["vfs.hdfs.username"] = VFS_HDFS_USERNAME;
-  param_values_["vfs.hdfs.kerb_ticket_cache_path"] =
-      VFS_HDFS_KERB_TICKET_CACHE_PATH;
-  param_values_["filestore.buffer_size"] = FILESTORE_BUFFER_SIZE;
+  param_values_ = default_config_values;
 }
 
 Config::~Config() = default;
@@ -539,294 +606,9 @@ const std::set<std::string>& Config::set_params() const {
 
 Status Config::unset(const std::string& param) {
   // Set back to default
-  if (param == "rest.server_address") {
-    param_values_["rest.server_address"] = REST_SERVER_DEFAULT_ADDRESS;
-  } else if (param == "rest.server_serialization_format") {
-    param_values_["rest.server_serialization_format"] =
-        REST_SERIALIZATION_DEFAULT_FORMAT;
-  } else if (param == "rest.http_compressor") {
-    param_values_["rest.http_compressor"] = REST_SERVER_DEFAULT_HTTP_COMPRESSOR;
-  } else if (param == "rest.retry_http_codes") {
-    param_values_["rest.retry_http_codes"] = REST_RETRY_HTTP_CODES;
-  } else if (param == "rest.retry_count") {
-    param_values_["rest.retry_count"] = REST_RETRY_COUNT;
-  } else if (param == "rest.retry_initial_delay_ms") {
-    param_values_["rest.retry_initial_delay_ms"] = REST_RETRY_INITIAL_DELAY_MS;
-  } else if (param == "rest.retry_delay_factor") {
-    param_values_["rest.retry_delay_factor"] = REST_RETRY_DELAY_FACTOR;
-  } else if (param == "rest.curl.buffer_size") {
-    param_values_["rest.curl.buffer_size"] = REST_CURL_BUFFER_SIZE;
-  } else if (param == "rest.curl.verbose") {
-    param_values_["rest.curl.verbose"] = REST_CURL_VERBOSE;
-  } else if (param == "rest.load_metadata_on_array_open") {
-    param_values_["rest.load_metadata_on_array_open"] =
-        REST_LOAD_METADATA_ON_ARRAY_OPEN;
-  } else if (param == "rest.load_non_empty_domain_on_array_open") {
-    param_values_["rest.load_non_empty_domain_on_array_open"] =
-        REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN;
-  } else if (param == "rest.use_refactored_array_open") {
-    param_values_["rest.use_refactored_array_open"] =
-        REST_USE_REFACTORED_ARRAY_OPEN;
-  } else if (param == "config.env_var_prefix") {
-    param_values_["config.env_var_prefix"] = CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
-  } else if (param == "config.logging_level") {
-    param_values_["config.logging_level"] = CONFIG_LOGGING_LEVEL;
-  } else if (param == "config.logging_format") {
-    param_values_["config.logging_format"] = CONFIG_LOGGING_DEFAULT_FORMAT;
-  } else if (param == "sm.allow_updates_experimental") {
-    param_values_["sm.allow_updates_experimental"] =
-        SM_ALLOW_UPDATES_EXPERIMENTAL;
-  } else if (param == "sm.encryption_key") {
-    param_values_["sm.encryption_key"] = SM_ENCRYPTION_KEY;
-  } else if (param == "sm.encryption_type") {
-    param_values_["sm.encryption_type"] = SM_ENCRYPTION_TYPE;
-  } else if (param == "sm.dedup_coords") {
-    param_values_["sm.dedup_coords"] = SM_DEDUP_COORDS;
-  } else if (param == "sm.check_coord_dups") {
-    param_values_["sm.check_coord_dups"] = SM_CHECK_COORD_DUPS;
-  } else if (param == "sm.check_coord_oob") {
-    param_values_["sm.check_coord_oob"] = SM_CHECK_COORD_OOB;
-  } else if (param == "sm.read_range_oob") {
-    param_values_["sm.read_range_oob"] = SM_READ_RANGE_OOB;
-  } else if (param == "sm.check_global_order") {
-    param_values_["sm.check_global_order"] = SM_CHECK_GLOBAL_ORDER;
-  } else if (param == "sm.tile_cache_size") {
-    param_values_["sm.tile_cache_size"] = SM_TILE_CACHE_SIZE;
-  } else if (param == "sm.memory_budget") {
-    param_values_["sm.memory_budget"] = SM_MEMORY_BUDGET;
-  } else if (param == "sm.memory_budget_var") {
-    param_values_["sm.memory_budget_var"] = SM_MEMORY_BUDGET_VAR;
-  } else if (param == "sm.query.dense.qc_coords_mode") {
-    param_values_["sm.query.dense.qc_coords_mode"] =
-        SM_QUERY_DENSE_QC_COORDS_MODE;
-  } else if (param == "sm.query.dense.reader") {
-    param_values_["sm.query.dense.reader"] = SM_QUERY_DENSE_READER;
-  } else if (param == "sm.query.sparse_global_order.reader") {
-    param_values_["sm.query.sparse_global_order.reader"] =
-        SM_QUERY_SPARSE_GLOBAL_ORDER_READER;
-  } else if (param == "sm.query.sparse_unordered_with_dups.reader") {
-    param_values_["sm.query.sparse_unordered_with_dups.reader"] =
-        SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER;
-  } else if (param == "sm.mem.malloc_trim") {
-    param_values_["sm.mem.malloc_trim"] = SM_MEM_MALLOC_TRIM;
-  } else if (param == "sm.mem.total_budget") {
-    param_values_["sm.mem.total_budget"] = SM_MEM_TOTAL_BUDGET;
-  } else if (param == "sm.mem.reader.sparse_global_order.ratio_coords") {
-    param_values_["sm.mem.reader.sparse_global_order.ratio_coords"] =
-        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS;
-  } else if (
-      param == "sm.mem.reader.sparse_global_order.ratio_query_condition") {
-    param_values_["sm.mem.reader.sparse_global_order.ratio_query_condition"] =
-        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION;
-  } else if (param == "sm.mem.reader.sparse_global_order.ratio_tile_ranges") {
-    param_values_["sm.mem.reader.sparse_global_order.ratio_tile_ranges"] =
-        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES;
-  } else if (param == "sm.mem.reader.sparse_global_order.ratio_array_data") {
-    param_values_["sm.mem.reader.sparse_global_order.ratio_array_data"] =
-        SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA;
-  } else if (param == "sm.mem.reader.sparse_unordered_with_dups.ratio_coords") {
-    param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
-        SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
-  } else if (
-      param ==
-      "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition") {
-    param_values_
-        ["sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition"] =
-            SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION;
-  } else if (
-      param == "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges") {
-    param_values_
-        ["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] =
-            SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES;
-  } else if (
-      param == "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data") {
-    param_values_["sm.mem.reader.sparse_unordered_with_dups.ratio_array_data"] =
-        SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA;
-  } else if (param == "sm.enable_signal_handlers") {
-    param_values_["sm.enable_signal_handlers"] = SM_ENABLE_SIGNAL_HANDLERS;
-  } else if (param == "sm.compute_concurrency_level") {
-    param_values_["sm.compute_concurrency_level"] =
-        SM_COMPUTE_CONCURRENCY_LEVEL;
-  } else if (param == "sm.io_concurrency_level") {
-    param_values_["sm.io_concurrency_level"] = SM_IO_CONCURRENCY_LEVEL;
-  } else if (param == "sm.consolidation.amplification") {
-    param_values_["sm.consolidation.amplification"] =
-        SM_CONSOLIDATION_AMPLIFICATION;
-  } else if (param == "sm.consolidation.buffer_size") {
-    param_values_["sm.consolidation.buffer_size"] =
-        SM_CONSOLIDATION_BUFFER_SIZE;
-  } else if (param == "sm.consolidation.max_fragment_size") {
-    param_values_["sm.consolidation.max_fragment_size"] =
-        SM_CONSOLIDATION_MAX_FRAGMENT_SIZE;
-  } else if (param == "sm.consolidation.purge_deleted_cells") {
-    param_values_["sm.consolidation.steps"] =
-        SM_CONSOLIDATION_PURGE_DELETED_CELLS;
-  } else if (param == "sm.consolidation.steps") {
-    param_values_["sm.consolidation.steps"] = SM_CONSOLIDATION_STEPS;
-  } else if (param == "sm.consolidation.step_min_frags") {
-    param_values_["sm.consolidation.step_min_frags"] =
-        SM_CONSOLIDATION_STEP_MIN_FRAGS;
-  } else if (param == "sm.consolidation.step_max_frags") {
-    param_values_["sm.consolidation.step_max_frags"] =
-        SM_CONSOLIDATION_STEP_MAX_FRAGS;
-  } else if (param == "sm.consolidation.step_size_ratio") {
-    param_values_["sm.consolidation.step_size_ratio"] =
-        SM_CONSOLIDATION_STEP_SIZE_RATIO;
-  } else if (param == "sm.consolidation.mode") {
-    param_values_["sm.consolidation.mode"] = SM_CONSOLIDATION_MODE;
-  } else if (param == "sm.consolidation.timestamp_start") {
-    param_values_["sm.consolidation.timestamp_start"] =
-        SM_CONSOLIDATION_TIMESTAMP_START;
-  } else if (param == "sm.consolidation.timestamp_end") {
-    param_values_["sm.consolidation.timestamp_end"] =
-        SM_CONSOLIDATION_TIMESTAMP_END;
-  } else if (param == "sm.vacuum.mode") {
-    param_values_["sm.vacuum.mode"] = SM_VACUUM_MODE;
-  } else if (param == "sm.var_offsets.bitsize") {
-    param_values_["sm.var_offsets.bitsize"] = SM_OFFSETS_BITSIZE;
-  } else if (param == "sm.var_offsets.extra_element") {
-    param_values_["sm.var_offsets.extra_element"] = SM_OFFSETS_EXTRA_ELEMENT;
-  } else if (param == "sm.var_offsets.mode") {
-    param_values_["sm.var_offsets.mode"] = SM_OFFSETS_FORMAT_MODE;
-  } else if (param == "sm.max_tile_overlap_size") {
-    param_values_["sm.max_tile_overlap_size"] = SM_MAX_TILE_OVERLAP_SIZE;
-  } else if (param == "sm.group.timestamp_start") {
-    param_values_["sm.group.timestamp_start"] = SM_GROUP_TIMESTAMP_START;
-  } else if (param == "sm.group.timestamp_end") {
-    param_values_["sm.group.timestamp_end"] = SM_GROUP_TIMESTAMP_END;
-  } else if (param == "sm.fragment_info.preload_mbrs") {
-    param_values_["sm.fragment_info.preload_mbrs"] =
-        SM_FRAGMENT_INFO_PRELOAD_MBRS;
-  } else if (param == "vfs.min_parallel_size") {
-    param_values_["vfs.min_parallel_size"] = VFS_MIN_PARALLEL_SIZE;
-  } else if (param == "vfs.max_batch_size") {
-    param_values_["vfs.max_batch_size"] = VFS_MAX_BATCH_SIZE;
-  } else if (param == "vfs.min_batch_gap") {
-    param_values_["vfs.min_batch_gap"] = VFS_MIN_BATCH_GAP;
-  } else if (param == "vfs.min_batch_size") {
-    param_values_["vfs.min_batch_size"] = VFS_MIN_BATCH_SIZE;
-  } else if (param == "vfs.disable_batching") {
-    param_values_["vfs.disable_batching"] = VFS_DISABLE_BATCHING;
-  } else if (param == "vfs.read_ahead_size") {
-    param_values_["vfs.read_ahead_size"] = VFS_READ_AHEAD_SIZE;
-  } else if (param == "vfs.read_ahead_cache_size") {
-    param_values_["vfs.read_ahead_cache_size"] = VFS_READ_AHEAD_CACHE_SIZE;
-  } else if (param == "vfs.file.posix_file_permissions") {
-    param_values_["vfs.file.posix_file_permissions"] =
-        VFS_FILE_POSIX_FILE_PERMISSIONS;
-  } else if (param == "vfs.file.posix_directory_permissions") {
-    param_values_["vfs.file.posix_directory_permissions"] =
-        VFS_FILE_POSIX_DIRECTORY_PERMISSIONS;
-  } else if (param == "vfs.file.max_parallel_ops") {
-    param_values_["vfs.file.max_parallel_ops"] = VFS_FILE_MAX_PARALLEL_OPS;
-  } else if (param == "vfs.azure.storage_account_name") {
-    param_values_["vfs.azure.storage_account_name"] =
-        VFS_AZURE_STORAGE_ACCOUNT_NAME;
-  } else if (param == "vfs.azure.storage_account_key") {
-    param_values_["vfs.azure.storage_account_key"] =
-        VFS_AZURE_STORAGE_ACCOUNT_KEY;
-  } else if (param == "vfs.azure.storage_sas_token") {
-    param_values_["vfs.azure.storage_sas_token"] = VFS_AZURE_STORAGE_SAS_TOKEN;
-  } else if (param == "vfs.azure.blob_endpoint") {
-    param_values_["vfs.azure.blob_endpoint"] = VFS_AZURE_BLOB_ENDPOINT;
-  } else if (param == "vfs.azure.use_https") {
-    param_values_["vfs.azure.use_https"] = VFS_AZURE_USE_HTTPS;
-  } else if (param == "vfs.azure.max_parallel_ops") {
-    param_values_["vfs.azure.max_parallel_ops"] = VFS_AZURE_MAX_PARALLEL_OPS;
-  } else if (param == "vfs.azure.block_list_block_size") {
-    param_values_["vfs.azure.block_list_block_size"] =
-        VFS_AZURE_BLOCK_LIST_BLOCK_SIZE;
-  } else if (param == "vfs.azure.use_block_list_upload") {
-    param_values_["vfs.azure.use_block_list_upload"] =
-        VFS_AZURE_USE_BLOCK_LIST_UPLOAD;
-  } else if (param == "vfs.gcs.project_id") {
-    param_values_["vfs.gcs.project_id"] = VFS_GCS_PROJECT_ID;
-  } else if (param == "vfs.gcs.max_parallel_ops") {
-    param_values_["vfs.gcs.max_parallel_ops"] = VFS_GCS_MAX_PARALLEL_OPS;
-  } else if (param == "vfs.gcs.multi_part_size") {
-    param_values_["vfs.gcs.multi_part_size"] = VFS_GCS_MULTI_PART_SIZE;
-  } else if (param == "vfs.gcs.use_multi_part_upload") {
-    param_values_["vfs.gcs.use_multi_part_upload"] =
-        VFS_GCS_USE_MULTI_PART_UPLOAD;
-  } else if (param == "vfs.gcs.request_timeout_ms") {
-    param_values_["vfs.gcs.request_timeout_ms"] = VFS_GCS_REQUEST_TIMEOUT_MS;
-  } else if (param == "vfs.s3.region") {
-    param_values_["vfs.s3.region"] = VFS_S3_REGION;
-  } else if (param == "vfs.s3.aws_access_key_id") {
-    param_values_["vfs.s3.aws_access_key_id"] = VFS_S3_AWS_ACCESS_KEY_ID;
-  } else if (param == "vfs.s3.aws_secret_access_key") {
-    param_values_["vfs.s3.aws_secret_access_key"] =
-        VFS_S3_AWS_SECRET_ACCESS_KEY;
-  } else if (param == "vfs.s3.aws_session_token") {
-    param_values_["vfs.s3.aws_session_token"] = VFS_S3_AWS_SESSION_TOKEN;
-  } else if (param == "vfs.s3.aws_role_arn") {
-    param_values_["vfs.s3.aws_role_arn"] = VFS_S3_AWS_ROLE_ARN;
-  } else if (param == "vfs.s3.aws_external_id") {
-    param_values_["vfs.s3.aws_external_id"] = VFS_S3_AWS_EXTERNAL_ID;
-  } else if (param == "vfs.s3.aws_load_frequency") {
-    param_values_["vfs.s3.aws_load_frequency"] = VFS_S3_AWS_LOAD_FREQUENCY;
-  } else if (param == "vfs.s3.aws_session_name") {
-    param_values_["vfs.s3.aws_session_name"] = VFS_S3_AWS_SESSION_NAME;
-  } else if (param == "vfs.s3.logging_level") {
-    param_values_["vfs.s3.logging_level"] = VFS_S3_LOGGING_LEVEL;
-  } else if (param == "vfs.s3.scheme") {
-    param_values_["vfs.s3.scheme"] = VFS_S3_SCHEME;
-  } else if (param == "vfs.s3.endpoint_override") {
-    param_values_["vfs.s3.endpoint_override"] = VFS_S3_ENDPOINT_OVERRIDE;
-  } else if (param == "vfs.s3.use_virtual_addressing") {
-    param_values_["vfs.s3.use_virtual_addressing"] =
-        VFS_S3_USE_VIRTUAL_ADDRESSING;
-  } else if (param == "vfs.s3.skip_init") {
-    param_values_["vfs.s3.skip_init"] = VFS_S3_SKIP_INIT;
-  } else if (param == "vfs.s3.use_multipart_upload") {
-    param_values_["vfs.s3.use_multipart_upload"] = VFS_S3_USE_MULTIPART_UPLOAD;
-  } else if (param == "vfs.s3.max_parallel_ops") {
-    param_values_["vfs.s3.max_parallel_ops"] = VFS_S3_MAX_PARALLEL_OPS;
-  } else if (param == "vfs.s3.multipart_part_size") {
-    param_values_["vfs.s3.multipart_part_size"] = VFS_S3_MULTIPART_PART_SIZE;
-  } else if (param == "vfs.s3.ca_file") {
-    param_values_["vfs.s3.ca_file"] = VFS_S3_CA_FILE;
-  } else if (param == "vfs.s3.ca_path") {
-    param_values_["vfs.s3.ca_path"] = VFS_S3_CA_PATH;
-  } else if (param == "vfs.s3.connect_timeout_ms") {
-    param_values_["vfs.s3.connect_timeout_ms"] = VFS_S3_CONNECT_TIMEOUT_MS;
-  } else if (param == "vfs.s3.connect_max_tries") {
-    param_values_["vfs.s3.connect_max_tries"] = VFS_S3_CONNECT_MAX_TRIES;
-  } else if (param == "vfs.s3.connect_scale_factor") {
-    param_values_["vfs.s3.connect_scale_factor"] = VFS_S3_CONNECT_SCALE_FACTOR;
-  } else if (param == "vfs.s3.sse") {
-    param_values_["vfs.s3.sse"] = VFS_S3_SSE;
-  } else if (param == "vfs.s3.sse_kms_key_id") {
-    param_values_["vfs.s3.sse_kms_key_id"] = VFS_S3_SSE_KMS_KEY_ID;
-  } else if (param == "vfs.s3.request_timeout_ms") {
-    param_values_["vfs.s3.request_timeout_ms"] = VFS_S3_REQUEST_TIMEOUT_MS;
-  } else if (param == "vfs.s3.requester_pays") {
-    param_values_["vfs.s3.requester_pays"] = VFS_S3_REQUESTER_PAYS;
-  } else if (param == "vfs.s3.proxy_scheme") {
-    param_values_["vfs.s3.proxy_scheme"] = VFS_S3_PROXY_SCHEME;
-  } else if (param == "vfs.s3.proxy_host") {
-    param_values_["vfs.s3.proxy_host"] = VFS_S3_PROXY_HOST;
-  } else if (param == "vfs.s3.proxy_port") {
-    param_values_["vfs.s3.proxy_port"] = VFS_S3_PROXY_PORT;
-  } else if (param == "vfs.s3.proxy_username") {
-    param_values_["vfs.s3.proxy_username"] = VFS_S3_PROXY_USERNAME;
-  } else if (param == "vfs.s3.proxy_password") {
-    param_values_["vfs.s3.proxy_password"] = VFS_S3_PROXY_PASSWORD;
-  } else if (param == "vfs.s3.verify_ssl") {
-    param_values_["vfs.s3.verify_ssl"] = VFS_S3_VERIFY_SSL;
-  } else if (param == "vfs.s3.bucket_canned_acl") {
-    param_values_["vfs.s3.bucket_canned_acl"] = VFS_S3_BUCKET_CANNED_ACL;
-  } else if (param == "vfs.s3.object_canned_acl") {
-    param_values_["vfs.s3.object_canned_acl"] = VFS_S3_OBJECT_CANNED_ACL;
-  } else if (param == "vfs.hdfs.name_node_uri") {
-    param_values_["vfs.hdfs.name_node_uri"] = VFS_HDFS_NAME_NODE_URI;
-  } else if (param == "vfs.hdfs.username") {
-    param_values_["vfs.hdfs.username"] = VFS_HDFS_USERNAME;
-  } else if (param == "vfs.hdfs.kerb_ticket_cache_path") {
-    param_values_["vfs.hdfs.kerb_ticket_cache_path"] =
-        VFS_HDFS_KERB_TICKET_CACHE_PATH;
-  } else if (param == "filestore.buffer_size") {
-    param_values_["filestore.buffer_size"] = FILESTORE_BUFFER_SIZE;
+  auto it = default_config_values.find(param);
+  if (it != default_config_values.end()) {
+    param_values_[param] = it->second;
   } else {
     param_values_.erase(param);
   }

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -365,6 +365,9 @@ class Config {
    */
   static const std::string SM_FRAGMENT_INFO_PRELOAD_MBRS;
 
+  /** If `true` the readers might partially load/unload tile offsets. */
+  static const std::string SM_PARTIAL_TILE_OFFSETS_LOADING;
+
   /** The default minimum number of bytes in a parallel VFS operation. */
   static const std::string VFS_MIN_PARALLEL_SIZE;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -466,6 +466,11 @@ class Config {
    *    info, otherwise they will be loaded lazily when some info related to
    *    MBRs is requested by the user. <br>
    *    **Default**: false
+   * -  `sm.partial_tile_offsets_loading`
+   *    **Experimental** <br>
+   *    If `true` tile offsets can be partially loaded and unloaded by the
+   *    readers. <br>
+   *    **Default**: false
    * -  `vfs.read_ahead_cache_size` <br>
    *    The the total maximum size of the read-ahead cache, which is an LRU.
    *    <br>

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2020,9 +2020,67 @@ Status FragmentMetadata::load_rtree(const EncryptionKey& encryption_key) {
 
 void FragmentMetadata::free_rtree() {
   auto freed = rtree_.free_memory();
-  if (memory_tracker_ != nullptr)
+  if (memory_tracker_ != nullptr) {
     memory_tracker_->release_memory(freed, MemoryTracker::MemoryType::RTREE);
+  }
   loaded_metadata_.rtree_ = false;
+}
+
+void FragmentMetadata::free_tile_offsets() {
+  for (uint64_t i = 0; i < tile_offsets_.size(); i++) {
+    std::lock_guard<std::mutex> lock(tile_offsets_mtx_[i]);
+    if (memory_tracker_ != nullptr) {
+      memory_tracker_->release_memory(
+          tile_offsets_[i].size() * sizeof(uint64_t),
+          MemoryTracker::MemoryType::TILE_OFFSETS);
+    }
+    tile_offsets_[i].clear();
+    loaded_metadata_.tile_offsets_[i] = false;
+  }
+
+  for (uint64_t i = 0; i < tile_var_offsets_.size(); i++) {
+    std::lock_guard<std::mutex> lock(tile_var_offsets_mtx_[i]);
+    if (memory_tracker_ != nullptr) {
+      memory_tracker_->release_memory(
+          tile_var_offsets_[i].size() * sizeof(uint64_t),
+          MemoryTracker::MemoryType::TILE_OFFSETS);
+    }
+    tile_var_offsets_[i].clear();
+    loaded_metadata_.tile_var_offsets_[i] = false;
+  }
+
+  for (uint64_t i = 0; i < tile_offsets_.size(); i++) {
+    std::lock_guard<std::mutex> lock(tile_offsets_mtx_[i]);
+    if (memory_tracker_ != nullptr) {
+      memory_tracker_->release_memory(
+          tile_offsets_[i].size() * sizeof(uint64_t),
+          MemoryTracker::MemoryType::TILE_OFFSETS);
+    }
+    tile_offsets_[i].clear();
+    loaded_metadata_.tile_offsets_[i] = false;
+  }
+
+  for (uint64_t i = 0; i < tile_validity_offsets_.size(); i++) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (memory_tracker_ != nullptr) {
+      memory_tracker_->release_memory(
+          tile_validity_offsets_[i].size() * sizeof(uint64_t),
+          MemoryTracker::MemoryType::TILE_OFFSETS);
+    }
+    tile_validity_offsets_[i].clear();
+    loaded_metadata_.tile_validity_offsets_[i] = false;
+  }
+
+  for (uint64_t i = 0; i < tile_var_sizes_.size(); i++) {
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (memory_tracker_ != nullptr) {
+      memory_tracker_->release_memory(
+          tile_var_sizes_[i].size() * sizeof(uint64_t),
+          MemoryTracker::MemoryType::TILE_OFFSETS);
+    }
+    tile_var_sizes_[i].clear();
+    loaded_metadata_.tile_var_sizes_[i] = false;
+  }
 }
 
 Status FragmentMetadata::load_tile_var_sizes(
@@ -2790,7 +2848,8 @@ void FragmentMetadata::load_non_empty_domain_v3_v4(Deserializer& deserializer) {
   // Get non-empty domain
   if (!null_non_empty_domain) {
     auto dim_num = array_schema_->dim_num();
-    // Note: These versions supports only dimensions domains with the same type
+    // Note: These versions supports only dimensions domains with the same
+    // type
     auto coord_size_0{array_schema_->domain().dimension_ptr(0)->coord_size()};
     auto domain_size = 2 * dim_num * coord_size_0;
     std::vector<uint8_t> temp(domain_size);
@@ -2815,7 +2874,8 @@ void FragmentMetadata::load_non_empty_domain_v3_v4(Deserializer& deserializer) {
 // ===== FORMAT =====
 // null_non_empty_domain
 // fix-sized: range(void*)
-// var-sized: range_size(uint64_t) | start_range_size(uint64_t) | range(void*)
+// var-sized: range_size(uint64_t) | start_range_size(uint64_t) |
+// range(void*)
 void FragmentMetadata::load_non_empty_domain_v5_or_higher(
     Deserializer& deserializer) {
   // Get null non-empty domain
@@ -2916,7 +2976,8 @@ void FragmentMetadata::load_tile_offsets(
 
 // ===== FORMAT =====
 // tile_var_offsets_attr#0_num (uint64_t)
-// tile_var_offsets_attr#0_#1 (uint64_t) tile_var_offsets_attr#0_#2 (uint64_t)
+// tile_var_offsets_attr#0_#1 (uint64_t) tile_var_offsets_attr#0_#2
+// (uint64_t)
 // ...
 // ...
 // tile_var_offsets_attr#<attribute_num-1>_num(uint64_t)
@@ -2944,7 +3005,8 @@ void FragmentMetadata::load_tile_var_offsets(Deserializer& deserializer) {
         !memory_tracker_->take_memory(
             size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
-          "Cannot load tile var offsets; Insufficient memory budget; Needed " +
+          "Cannot load tile var offsets; Insufficient memory budget; "
+          "Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker_->get_memory_available()) +
           " from budget " +
@@ -2974,7 +3036,8 @@ void FragmentMetadata::load_tile_var_offsets(
         !memory_tracker_->take_memory(
             size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
-          "Cannot load tile var offsets; Insufficient memory budget; Needed " +
+          "Cannot load tile var offsets; Insufficient memory budget; "
+          "Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker_->get_memory_available()) +
           " from budget " +
@@ -3014,7 +3077,8 @@ void FragmentMetadata::load_tile_var_sizes(Deserializer& deserializer) {
         !memory_tracker_->take_memory(
             size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
-          "Cannot load tile var sizes; Insufficient memory budget; Needed " +
+          "Cannot load tile var sizes; Insufficient memory budget; "
+          "Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker_->get_memory_available()) +
           " from budget " +
@@ -3043,7 +3107,8 @@ void FragmentMetadata::load_tile_var_sizes(
         !memory_tracker_->take_memory(
             size, MemoryTracker::MemoryType::TILE_OFFSETS)) {
       throw FragmentMetadataStatusException(
-          "Cannot load tile var sizes; Insufficient memory budget; Needed " +
+          "Cannot load tile var sizes; Insufficient memory budget; "
+          "Needed " +
           std::to_string(size) + " but only had " +
           std::to_string(memory_tracker_->get_memory_available()) +
           " from budget " +
@@ -3191,7 +3256,8 @@ void FragmentMetadata::load_tile_max_values(
 
 // ===== FORMAT =====
 // tile_sum_values_attr#0_num (uint64_t)
-// tile_sum_value_attr#0_#1 (uint64_t) tile_sum_value_attr#0_#2 (uint64_t) ...
+// tile_sum_value_attr#0_#1 (uint64_t) tile_sum_value_attr#0_#2 (uint64_t)
+// ...
 // ...
 // tile_sum_values_attr#<attribute_num-1>_num (uint64_t)
 // tile_sum_value_attr#<attribute_num-1>_#1 (uint64_t)
@@ -3723,8 +3789,8 @@ Status FragmentMetadata::load_footer(
 
   loaded_metadata_.footer_ = true;
 
-  // If the footer_size is not set lets calculate from how much of the buffer we
-  // read
+  // If the footer_size is not set lets calculate from how much of the
+  // buffer we read
   if (footer_size_ == 0) {
     footer_size_ = starting_deserializer_size - deserializer.size();
   }
@@ -3875,7 +3941,8 @@ Tile FragmentMetadata::write_rtree() {
 // ===== FORMAT =====
 // null_non_empty_domain(char)
 // fix-sized: range(void*)
-// var-sized: range_size(uint64_t) | start_range_size(uint64_t) | range(void*)
+// var-sized: range_size(uint64_t) | start_range_size(uint64_t) |
+// range(void*)
 // ...
 void FragmentMetadata::write_non_empty_domain(Serializer& serializer) const {
   // Write null_non_empty_domain

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -877,6 +877,9 @@ class FragmentMetadata {
   /** Frees the memory associated with the rtree. */
   void free_rtree();
 
+  /** Frees the memory associated with tile_offsets. */
+  void free_tile_offsets();
+
   /**
    * Loads the variable tile sizes for the input attribute or dimension idx
    * from storage.

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -391,10 +391,10 @@ Status DenseReader::dense_read() {
 
   // Pre-load all attribute offsets into memory for attributes
   // in query condition to be read.
-  RETURN_CANCEL_OR_ERROR(
-      load_tile_var_sizes(read_state_.partitioner_.subarray(), var_names));
-  RETURN_CANCEL_OR_ERROR(
-      load_tile_offsets(read_state_.partitioner_.subarray(), names));
+  RETURN_CANCEL_OR_ERROR(load_tile_var_sizes(
+      read_state_.partitioner_.subarray().relevant_fragments(), var_names));
+  RETURN_CANCEL_OR_ERROR(load_tile_offsets(
+      read_state_.partitioner_.subarray().relevant_fragments(), names));
 
   auto&& [st, qc_result] = apply_query_condition<DimType, OffType>(
       subarray,

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -183,8 +183,8 @@ Status OrderedDimLabelReader::dowork() {
   // `tile_var_offsets_`, `tile_validity_offsets_` and `tile_var_sizes_` in
   // `fragment_metadata_`.
   std::vector<std::string> names = {label_name_};
-  RETURN_NOT_OK(load_tile_offsets(subarray_, names));
-  RETURN_NOT_OK(load_tile_var_sizes(subarray_, names));
+  RETURN_NOT_OK(load_tile_offsets(subarray_.relevant_fragments(), names));
+  RETURN_NOT_OK(load_tile_var_sizes(subarray_.relevant_fragments(), names));
 
   // Load the dimension labels min/max values.
   load_label_min_max_values();

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -322,20 +322,22 @@ class ReaderBase : public StrategyBase {
    * Loads tile offsets for each attribute/dimension name into
    * their associated element in `fragment_metadata_`.
    *
-   * @param subarray The subarray to load tiles for.
+   * @param relevant_fragments Optional list of relevant fragments.
    * @param names The attribute/dimension names.
    * @return Status
    */
   Status load_tile_offsets(
-      Subarray& subarray, const std::vector<std::string>& names);
+      const optional<std::vector<unsigned>>& relevant_fragments,
+      const std::vector<std::string>& names);
 
   /**
    * Checks if at least one fragment overlaps partially with the
    * time at which the read is taking place.
    *
+   * @param subarray Subarray to use.
    * @return True if at least one fragment partially overlaps.
    */
-  bool partial_consolidated_fragment_overlap() const;
+  bool partial_consolidated_fragment_overlap(Subarray& subarray) const;
 
   /**
    * Add a condition for partial time overlap based on array open and
@@ -353,12 +355,13 @@ class ReaderBase : public StrategyBase {
    * Loads tile var sizes for each attribute/dimension name into
    * their associated element in `fragment_metadata_`.
    *
-   * @param subarray The subarray to load tiles for.
+   * @param relevant_fragments Optional list of relevant fragments.
    * @param names The attribute/dimension names.
    * @return Status
    */
   Status load_tile_var_sizes(
-      Subarray& subarray, const std::vector<std::string>& names);
+      const optional<std::vector<unsigned>>& relevant_fragments,
+      const std::vector<std::string>& names);
 
   /**
    * Loads processed conditions from fragment metadata.

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -177,6 +177,9 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   // before to be purged.
   bool purge_deletes_no_dups_mode_;
 
+  /** Are tile offsets loaded? */
+  bool tile_offsets_loaded_;
+
   /* ********************************* */
   /*       PRIVATE DECLARATIONS        */
   /* ********************************* */
@@ -195,6 +198,9 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /** Load all tile offsets required for the read operation. */
+  void load_all_tile_offsets();
 
   /**
    * Get the coordinate tiles size for a dimension.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -312,6 +312,18 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Optional string for a bitsort attribute. */
   std::optional<std::string> bitsort_attribute_;
 
+  /** Do we allo partial tile offset loading for this query? */
+  bool partial_tile_offsets_loading_;
+
+  /** Var dimensions/attributes for which to load tile var sizes. */
+  std::vector<std::string> var_size_to_load_;
+
+  /** Attributes for which to load tile offsets. */
+  std::vector<std::string> attr_tile_offsets_to_load_;
+
+  /** Per fragment tile offsets memory usage. */
+  std::vector<uint64_t> per_frag_tile_offsets_usage_;
+
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
@@ -358,11 +370,30 @@ class SparseIndexReaderBase : public ReaderBase {
       unsigned dim_num, unsigned f, uint64_t t);
 
   /**
-   * Load tile offsets and result tile ranges.
+   * Load result tile ranges and dimension/attributes to load tile offsets for.
    *
    * @return Status.
    */
   Status load_initial_data();
+
+  /**
+   * Returns the tile offset size for the list of relevant fragments.
+   *
+   * @param relevant_fragments Relevant fragments to load offsets for or
+   * nullopt to load for all fragments.
+   * @return Total in memory size.
+   */
+  uint64_t tile_offsets_size(
+      const optional<std::vector<unsigned>>& relevant_fragments);
+
+  /**
+   * Load all tile offsets.
+   *
+   * @param relevant_fragments Relevant fragments to load offsets for or
+   * nullopt to load for all fragments.
+   */
+  void load_tile_offsets_for_fragments(
+      const optional<std::vector<unsigned>>& relevant_fragments);
 
   /**
    * Read and unfilter coord tiles.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -164,9 +164,18 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   /** Result tiles currently loaded. */
   std::list<UnorderedWithDupsResultTile<BitmapType>> result_tiles_;
 
+  /** Minimum fragment index for loaded tile offsets data. */
+  unsigned tile_offsets_min_frag_idx_;
+
+  /** Maximum fragment index for loaded tile offsets data. */
+  unsigned tile_offsets_max_frag_idx_;
+
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /** Loads as much tile offset data in memory as possible. */
+  void load_tile_offsets_data();
 
   /**
    * Get the coordinate tiles size for a dimension.

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -175,7 +175,8 @@ Status subarray_to_capnp(
     RETURN_NOT_OK(stats_to_capnp(*stats, &stats_builder));
   }
 
-  if (subarray->relevant_fragments()->size() > 0) {
+  if (subarray->relevant_fragments().has_value() &&
+      subarray->relevant_fragments()->size() > 0) {
     auto relevant_fragments_builder =
         builder->initRelevantFragments(subarray->relevant_fragments()->size());
     for (size_t i = 0; i < subarray->relevant_fragments()->size(); ++i) {
@@ -239,6 +240,7 @@ Status subarray_from_capnp(
   if (reader.hasRelevantFragments()) {
     auto relevant_fragments = reader.getRelevantFragments();
     size_t count = relevant_fragments.size();
+    subarray->relevant_fragments() = std::vector<unsigned>();
     subarray->relevant_fragments()->reserve(count);
     for (size_t i = 0; i < count; i++) {
       subarray->relevant_fragments()->emplace_back(relevant_fragments[i]);

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -1129,12 +1129,12 @@ class Subarray {
   /**
    * Return relevant fragments as computed
    */
-  const std::vector<unsigned>* relevant_fragments() const;
+  const optional<std::vector<unsigned>>& relevant_fragments() const;
 
   /**
    * Return relevant fragments as computed
    */
-  std::vector<unsigned>* relevant_fragments();
+  optional<std::vector<unsigned>>& relevant_fragments();
 
   /**
    * For flattened ("total order") start/end range indexes,
@@ -1334,7 +1334,7 @@ class Subarray {
    * The array fragment ids whose non-empty domain intersects at
    * least one subarray range.
    */
-  std::vector<unsigned> relevant_fragments_;
+  optional<std::vector<unsigned>> relevant_fragments_;
 
   /**
    * The precomputed tile overlap state. Is not guaranteed to be


### PR DESCRIPTION
This change allows to partially load tile offsets for sparse unordered with duplicates queries. The behavior is enabled, for now, through a configuration setting `sm.partial_tile_offsets_loading` that also means that the user guarantees that the opened array will only process one query at a time.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/dups reader: allow partial tile offsets loading.
