### PR TITLE
Extract libcurl initialization from GlobalState

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -175,6 +175,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/encryption_key_validation.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_openssl.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/crypto/crypto_win32.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/curl/curl_init.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/azure.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/gcs.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/mem_filesystem.cc
@@ -208,7 +209,6 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/fragment/fragment_info.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/fragment/fragment_metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/global_state.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/libcurl_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/signal_handlers.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/global_state/watchdog.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/group/group.cc

--- a/tiledb/sm/curl/curl_init.h
+++ b/tiledb/sm/curl/curl_init.h
@@ -1,5 +1,5 @@
 /**
- * @file   libcurl_state.cc
+ * @file curl_init.h
  *
  * @section LICENSE
  *
@@ -27,34 +27,28 @@
  *
  * @section DESCRIPTION
  *
- This file initializes the libcurl state, if libcurl is present.
+ * This file initializes the libcurl state, if libcurl is present.
  */
 
-#include "tiledb/sm/global_state/libcurl_state.h"
-#include "tiledb/common/logger.h"
+#ifndef TILEDB_CURL_INIT_H
+#define TILEDB_CURL_INIT_H
 
-#ifdef TILEDB_SERIALIZATION
-#include <curl/curl.h>
+namespace tiledb::sm::curl {
+
+/**
+ * A sentry class for ensuring that libcurl has
+ * been initialized for any classes that use it.
+ */
+class LibCurlInitializer {
+ public:
+  /**
+   * Construct an instance of LibCurlInitializer which
+   * has the side effect of ensuring that libcurl has
+   * been initialized for use.
+   */
+  LibCurlInitializer();
+};
+
+}  // namespace tiledb::sm::curl
+
 #endif
-
-using namespace tiledb::common;
-
-namespace tiledb {
-namespace sm {
-namespace global_state {
-
-Status init_libcurl() {
-#ifdef TILEDB_SERIALIZATION
-  auto rc = curl_global_init(CURL_GLOBAL_DEFAULT);
-  if (rc != 0)
-    return LOG_STATUS(Status_Error(
-        "Cannot initialize libcurl global state: got non-zero return code " +
-        std::to_string(rc)));
-#endif
-
-  return Status::Ok();
-}
-
-}  // namespace global_state
-}  // namespace sm
-}  // namespace tiledb

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -39,6 +39,7 @@
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/curl/curl_init.h"
 #include "tiledb/sm/misc/constants.h"
 #include "uri.h"
 
@@ -450,6 +451,13 @@ class Azure {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  tiledb::sm::curl::LibCurlInitializer curl_inited_;
 
   /** The VFS thread pool. */
   ThreadPool* thread_pool_;

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -42,6 +42,7 @@
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/curl/curl_init.h"
 #include "tiledb/sm/misc/constants.h"
 #include "uri.h"
 
@@ -389,6 +390,13 @@ class GCS {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  tiledb::sm::curl::LibCurlInitializer curl_inited_;
 
   /** The current state. */
   State state_;

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -40,6 +40,7 @@
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/curl/curl_init.h"
 #include "tiledb/sm/filesystem/s3_thread_pool_executor.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/stats/global_stats.h"
@@ -603,6 +604,13 @@ class S3 {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  tiledb::sm::curl::LibCurlInitializer curl_inited_;
 
   /** The class stats. */
   stats::Stats* stats_;

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -31,7 +31,6 @@
  */
 
 #include "tiledb/sm/global_state/global_state.h"
-#include "tiledb/sm/global_state/libcurl_state.h"
 #include "tiledb/sm/global_state/signal_handlers.h"
 #include "tiledb/sm/global_state/watchdog.h"
 #include "tiledb/sm/misc/constants.h"
@@ -79,7 +78,6 @@ Status GlobalState::init(const Config& config) {
       RETURN_NOT_OK(SignalHandlers::GetSignalHandlers().initialize());
     }
     RETURN_NOT_OK(Watchdog::GetWatchdog().initialize());
-    RETURN_NOT_OK(init_libcurl());
 
     initialized_ = true;
   }

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -52,6 +52,7 @@
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/buffer_list.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/curl/curl_init.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/stats/stats.h"
 
@@ -335,6 +336,13 @@ class Curl {
   tuple<Status, optional<long>> last_http_status_code();
 
  private:
+  /**
+   * A libcurl initializer instance. This should remain
+   * the first member variable to ensure that libcurl is
+   * initialized before any calls that may require it.
+   */
+  tiledb::sm::curl::LibCurlInitializer curl_inited_;
+
   /** TileDB config parameters. */
   const Config* config_;
 


### PR DESCRIPTION
This is a second step to removing the cyclic dependency between GlobalState and StorageManager.

This moves libcurl initialization logic out of GlobalState and into its own specialized class that can be reused in just the four places its required.

---
TYPE: IMPROVEMENT
DESC: Extract libcurl initialization from GlobalState
