### PR TITLE
Correct Minor Typo In `subarray_partitioner.cc`

### DIFF
--- a/test/src/unit-SubarrayPartitioner-dense.cc
+++ b/test/src/unit-SubarrayPartitioner-dense.cc
@@ -378,7 +378,7 @@ void SubarrayPartitionerDenseFx::read_array_default_1d_array(
     // Make sure we get the right message on failure
     CHECK(
         message ==
-        "SubarrayPertitioner: Trying to partition a unary range because of "
+        "SubarrayPartitioner: Trying to partition a unary range because of "
         "memory budget, this will cause the query to run very slow. Increase "
         "`sm.memory_budget` and `sm.memory_budget_var` through the "
         "configuration settings to avoid this issue. To override and run the "

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -48,7 +48,7 @@
 class SubarrayPartitionerStatusException : public StatusException {
  public:
   explicit SubarrayPartitionerStatusException(const std::string& message)
-      : StatusException("SubarrayPertitioner", message) {
+      : StatusException("SubarrayPartitioner", message) {
   }
 };
 


### PR DESCRIPTION
Correct `SubarrayPertitioner` to `SubarrayPartitioner` in `subarray_partitioner.cc`.

---
TYPE: FORMAT
DESC: Correct Minor Typo In `subarray_partitioner.cc`
