### PR TITLE
tiledb/sm/subarray/cell_slab.h: add missing <cstdint> header

### DIFF
--- a/tiledb/sm/subarray/cell_slab.h
+++ b/tiledb/sm/subarray/cell_slab.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_CELL_SLAB_H
 #define TILEDB_CELL_SLAB_H
 
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
Without the change build fails on weekly `gcc-13` as:

    In file included from sm/subarray/cell_slab_iter.h:36,
                     from sm/subarray/cell_slab_iter.cc:33:
    sm/subarray/cell_slab.h:56:3: error: 'uint64_t' does not name a type
       56 |   uint64_t length_ = UINT64_MAX;
          |   ^~~~~~~~
    sm/subarray/cell_slab.h:39:1:
      note: 'uint64_t' is defined in header '<cstdint>';
        did you forget to '#include <cstdint>'?
       38 | #include <vector>
      +++ |+#include <cstdint>

<long description>

---
TYPE: BUG
DESC: fix build on upcoming gcc-13
