### PR TITLE
Document `tiledb_array_vacuum`, and fix documentation of `tiledb_array_consolidate_fragments`.

### DIFF
--- a/tiledb/doxygen/source/c-api.rst
+++ b/tiledb/doxygen/source/c-api.rst
@@ -243,6 +243,8 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_consolidate_with_key
     :project: TileDB-C
+.. doxygenfunction:: tiledb_array_vacuum
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_array_get_schema
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_get_query_type

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -4779,7 +4779,7 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_create_with_key(
  * @param array_uri The name of the TileDB array whose metadata will
  *     be consolidated.
  * @param config Configuration parameters for the consolidation
- *     (`nullptr` means default, which will use the config from `ctx`).
+ *     (`nullptr` means default, which will use the config from \p ctx).
  *     The `sm.consolidation.mode` parameter determines which type of
  *     consolidation to perform.
  *
@@ -4838,7 +4838,7 @@ TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_with_key(
  * @param ctx The TileDB context.
  * @param array_uri The name of the TileDB array to vacuum.
  * @param config Configuration parameters for the vacuuming
- *     (`nullptr` means default, which will use the config from `ctx`).
+ *     (`nullptr` means default, which will use the config from \p ctx).
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */
 TILEDB_EXPORT int32_t tiledb_array_vacuum(

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -441,7 +441,7 @@ TILEDB_EXPORT capi_return_t tiledb_ctx_alloc_with_error(
 
  * const char* uris[2]={"__0_0_0807b1428b6c4ff48b3cdb3283ca7903_10",
  *                      "__1_1_d9d965753d224194965575c1e9cdeeda_10"};
- * tiledb_array_consolidate(ctx, "my_array", uris, 2);
+ * tiledb_array_consolidate_fragments(ctx, "my_array", uris, 2, nullptr);
  * @endcode
  *
  * @param[in] ctx The TileDB context.
@@ -449,8 +449,8 @@ TILEDB_EXPORT capi_return_t tiledb_ctx_alloc_with_error(
  *     be consolidated.
  * @param[in] fragment_uris URIs of the fragments to consolidate.
  * @param[in] num_fragments Number of URIs to consolidate.
- * @param[in] config Config object to apply to this operation (overrides Context
- config).
+ * @param config Configuration parameters for the consolidation
+ *     (`nullptr` means default, which will use the config from \p ctx).
  *
  * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
  */


### PR DESCRIPTION
---
TYPE: NO_HISTORY