### PR TITLE
Remove StorageManager references from GenericTileIO

### DIFF
--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -174,7 +174,7 @@ Status FragmentMetaConsolidator::consolidate(
   EncryptionKey enc_key;
   RETURN_NOT_OK(enc_key.set_key(encryption_type, encryption_key, key_length));
 
-  GenericTileIO tile_io(storage_manager_, uri);
+  GenericTileIO tile_io(storage_manager_->resources(), uri);
   uint64_t nbytes = 0;
   RETURN_NOT_OK(tile_io.write_generic(&tile, enc_key, &nbytes));
   (void)nbytes;

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3568,7 +3568,7 @@ Status FragmentMetadata::load_v1_v2(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(storage_manager_->resources(), fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(0, encryption_key, storage_manager_->config());
   RETURN_NOT_OK(st);
@@ -3918,7 +3918,7 @@ tuple<Status, optional<Tile>> FragmentMetadata::read_generic_tile_from_file(
       std::string(constants::fragment_metadata_filename));
 
   // Read metadata
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(storage_manager_->resources(), fragment_metadata_uri);
   auto&& [st, tile_opt] =
       tile_io.read_generic(offset, encryption_key, storage_manager_->config());
   RETURN_NOT_OK_TUPLE(st, nullopt);
@@ -3964,7 +3964,7 @@ Status FragmentMetadata::write_generic_tile_to_file(
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
 
-  GenericTileIO tile_io(storage_manager_, fragment_metadata_uri);
+  GenericTileIO tile_io(storage_manager_->resources(), fragment_metadata_uri);
   RETURN_NOT_OK(tile_io.write_generic(&tile, encryption_key, nbytes));
 
   return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1277,10 +1277,9 @@ Status StorageManagerCanonical::array_get_encryption(
   const URI& schema_uri = array_dir.latest_array_schema_uri();
 
   // Read tile header
-  auto&& [st, header] =
-      GenericTileIO::read_generic_tile_header(this, schema_uri, 0);
-  RETURN_NOT_OK(st);
-  *encryption_type = static_cast<EncryptionType>(header->encryption_type);
+  auto&& header = GenericTileIO::read_generic_tile_header(
+      resources_, schema_uri, 0);
+  *encryption_type = static_cast<EncryptionType>(header.encryption_type);
 
   return Status::Ok();
 }
@@ -2053,7 +2052,7 @@ Status StorageManagerCanonical::store_metadata(
 
 Status StorageManagerCanonical::store_data_to_generic_tile(
     Tile& tile, const URI& uri, const EncryptionKey& encryption_key) {
-  GenericTileIO tile_io(this, uri);
+  GenericTileIO tile_io(resources_, uri);
   uint64_t nbytes = 0;
   Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);
 
@@ -2246,7 +2245,7 @@ void StorageManagerCanonical::load_group_metadata(
 tuple<Status, optional<Tile>>
 StorageManagerCanonical::load_data_from_generic_tile(
     const URI& uri, uint64_t offset, const EncryptionKey& encryption_key) {
-  GenericTileIO tile_io(this, uri);
+  GenericTileIO tile_io(resources_, uri);
 
   // Get encryption key from config
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -38,7 +38,6 @@
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/filter/encryption_aes256gcm_filter.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
@@ -50,8 +49,8 @@ namespace sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-GenericTileIO::GenericTileIO(StorageManager* storage_manager, const URI& uri)
-    : storage_manager_(storage_manager)
+GenericTileIO::GenericTileIO(ContextResources& resources, const URI& uri)
+    : resources_(resources)
     , uri_(uri) {
 }
 
@@ -63,10 +62,8 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
-  auto&& [st, header_opt] =
-      read_generic_tile_header(storage_manager_, uri_, file_offset);
-  RETURN_NOT_OK_TUPLE(st, nullopt);
-  auto& header = *header_opt;
+
+  auto&& header = read_generic_tile_header(resources_, uri_, file_offset);
 
   if (encryption_key.encryption_type() !=
       (EncryptionType)header.encryption_type) {
@@ -94,7 +91,7 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
 
   // Read the tile.
   RETURN_NOT_OK_TUPLE(
-      storage_manager_->read(
+      resources_.vfs().read(
           uri_,
           file_offset + tile_data_offset,
           tile.filtered_buffer().data(),
@@ -105,10 +102,10 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   assert(tile.filtered());
   RETURN_NOT_OK_TUPLE(
       header.filters.run_reverse(
-          storage_manager_->stats(),
+          &resources_.stats(),
           &tile,
           nullptr,
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           config,
           nullptr),
       nullopt);
@@ -117,51 +114,45 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
   return {Status::Ok(), std::move(tile)};
 }
 
-tuple<Status, optional<GenericTileIO::GenericTileHeader>>
+GenericTileIO::GenericTileHeader
 GenericTileIO::read_generic_tile_header(
-    const StorageManager* sm, const URI& uri, uint64_t file_offset) {
+    ContextResources& resources, const URI& uri, uint64_t file_offset) {
   GenericTileHeader header;
 
-  // Read the fixed-sized part of the header from file
-  tdb_unique_ptr<Buffer> header_buff(tdb_new(Buffer));
-  RETURN_NOT_OK_TUPLE(
-      sm->read(
-          uri, file_offset, header_buff.get(), GenericTileHeader::BASE_SIZE),
-      nullopt);
+  std::vector<uint8_t> base_buf(GenericTileHeader::BASE_SIZE);
 
-  // Read header individual values
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.version_number, sizeof(uint32_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.persisted_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.tile_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.datatype, sizeof(uint8_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.cell_size, sizeof(uint64_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.encryption_type, sizeof(uint8_t)), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      header_buff->read(&header.filter_pipeline_size, sizeof(uint32_t)),
-      nullopt);
+  throw_if_not_ok(resources.vfs().read(
+      uri,
+      file_offset,
+      base_buf.data(),
+      base_buf.size()));
+
+  Deserializer base_deserializer(base_buf.data(), base_buf.size());
+
+  header.version_number = base_deserializer.read<uint32_t>();
+  header.persisted_size = base_deserializer.read<uint64_t>();
+  header.tile_size = base_deserializer.read<uint64_t>();
+  header.datatype = base_deserializer.read<uint8_t>();
+  header.cell_size = base_deserializer.read<uint64_t>();
+  header.encryption_type = base_deserializer.read<uint8_t>();
+  header.filter_pipeline_size = base_deserializer.read<uint32_t>();
 
   // Read header filter pipeline.
-  header_buff->reset_size();
-  header_buff->reset_offset();
-  RETURN_NOT_OK_TUPLE(
-      sm->read(
-          uri,
-          file_offset + GenericTileHeader::BASE_SIZE,
-          header_buff.get(),
-          header.filter_pipeline_size),
-      nullopt);
-  Deserializer deserializer(header_buff->data(), header_buff->size());
+  std::vector<uint8_t> filter_pipeline_buf(header.filter_pipeline_size);
+  throw_if_not_ok(resources.vfs().read(
+      uri,
+      file_offset + GenericTileHeader::BASE_SIZE,
+      filter_pipeline_buf.data(),
+      filter_pipeline_buf.size()));
+
+  Deserializer filter_pipeline_deserializer(
+      filter_pipeline_buf.data(), filter_pipeline_buf.size());
   auto filterpipeline{
-      FilterPipeline::deserialize(deserializer, header.version_number)};
+      FilterPipeline::deserialize(
+          filter_pipeline_deserializer, header.version_number)};
   header.filters = std::move(filterpipeline);
 
-  return {Status::Ok(), header};
+  return header;
 }
 
 Status GenericTileIO::write_generic(
@@ -173,16 +164,16 @@ Status GenericTileIO::write_generic(
   // Filter tile
   assert(!tile->filtered());
   RETURN_NOT_OK(header.filters.run_forward(
-      storage_manager_->stats(),
+      &resources_.stats(),
       tile,
       nullptr,
-      storage_manager_->compute_tp()));
+      &resources_.compute_tp()));
   header.persisted_size = tile->filtered_buffer().size();
   assert(tile->filtered());
 
   RETURN_NOT_OK(write_generic_tile_header(&header));
 
-  RETURN_NOT_OK(storage_manager_->write(
+  RETURN_NOT_OK(resources_.vfs().write(
       uri_, tile->filtered_buffer().data(), tile->filtered_buffer().size()));
 
   *nbytes = GenericTileIO::GenericTileHeader::BASE_SIZE +
@@ -217,9 +208,9 @@ Status GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
   serialize_generic_tile_header(serializer, *header);
 
   // Write buffer to file
-  Status st = storage_manager_->write(uri_, data.data(), data.size());
+  RETURN_NOT_OK(resources_.vfs().write(uri_, data.data(), data.size()));
 
-  return st;
+  return Status::Ok();
 }
 
 Status GenericTileIO::configure_encryption_filter(

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -37,7 +37,8 @@
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
+#include "tiledb/sm/stats/stats.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 
 using namespace tiledb::common;
 
@@ -99,10 +100,10 @@ class GenericTileIO {
   /**
    * Constructor.
    *
-   * @param storage_manager The storage manager.
+   * @param resources The ContextResources to use
    * @param uri The name of the file that stores data.
    */
-  GenericTileIO(StorageManager* storage_manager, const URI& uri);
+  GenericTileIO(ContextResources& resources, const URI& uri);
 
   GenericTileIO() = delete;
   DISABLE_COPY_AND_COPY_ASSIGN(GenericTileIO);
@@ -135,15 +136,15 @@ class GenericTileIO {
   /**
    * Reads the generic tile header from the file.
    *
-   * @param sm The StorageManager instance to use for reading.
+   * @param resources The ContextResources instance to use for reading.
    * @param uri The URI of the generic tile.
    * @param file_offset The offset where the header read will begin.
    * @param encryption_key If the array is encrypted, the private encryption
    *    key. For unencrypted arrays, pass `nullptr`.
    * @return Status, Header
    */
-  static tuple<Status, optional<GenericTileHeader>> read_generic_tile_header(
-      const StorageManager* sm, const URI& uri, uint64_t file_offset);
+  static GenericTileHeader read_generic_tile_header(
+      ContextResources& resources, const URI& uri, uint64_t file_offset);
 
   /**
    * Writes a tile generically to the file. This means that a header will be
@@ -181,8 +182,8 @@ class GenericTileIO {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The storage manager object. */
-  StorageManager* storage_manager_;
+  /** The ContextResources object. */
+  ContextResources& resources_;
 
   /** The file URI. */
   URI uri_;


### PR DESCRIPTION
This is a pretty basic removal of the StorageManager dependency by passing the required vfs, stats, and compute_tp pointers directly. The only subtlety is that it required moving the StorageManager::read variant for buffers into VFS as well.

---
TYPE: IMPROVEMENT
DESC: Remove StorageManager from GenericTileIO
