### PR TITLE
Remove deprecated C API tiledb_fragment_info_load_with_key()

### DIFF
--- a/tiledb/doxygen/source/c-api.rst
+++ b/tiledb/doxygen/source/c-api.rst
@@ -692,8 +692,6 @@ Fragment Info
     :project: TileDB-C
 .. doxygenfunction:: tiledb_fragment_info_load
     :project: TileDB-C
-.. doxygenfunction:: tiledb_fragment_info_load_with_key
-    :project: TileDB-C
 .. doxygenfunction:: tiledb_fragment_info_get_fragment_name
     :project: TileDB-C
 .. doxygenfunction:: tiledb_fragment_info_get_fragment_num

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -6251,30 +6251,6 @@ TILEDB_EXPORT int32_t tiledb_fragment_info_load(
     tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info) TILEDB_NOEXCEPT;
 
 /**
- * Loads the fragment info from an encrypted array.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_fragment_info_load_with_key(
- *     ctx, fragment_info, TILEDB_AES_256_GCM, key, sizeof(key));
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param fragment_info The fragment info object.
- * @param encryption_type The encryption type to use.
- * @param encryption_key The encryption key to use.
- * @param key_length Length in bytes of the encryption key.
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_DEPRECATED_EXPORT int32_t tiledb_fragment_info_load_with_key(
-    tiledb_ctx_t* ctx,
-    tiledb_fragment_info_t* fragment_info,
-    tiledb_encryption_type_t encryption_type,
-    const void* encryption_key,
-    uint32_t key_length) TILEDB_NOEXCEPT;
-
-/**
  * Gets a fragment name.
  *
  * **Example:**

--- a/tiledb/sm/cpp_api/fragment_info.h
+++ b/tiledb/sm/cpp_api/fragment_info.h
@@ -82,20 +82,6 @@ class FragmentInfo {
         tiledb_fragment_info_load(ctx.ptr().get(), fragment_info_.get()));
   }
 
-  /** Loads the fragment info from an encrypted array. */
-  TILEDB_DEPRECATED
-  void load(
-      tiledb_encryption_type_t encryption_type,
-      const std::string& encryption_key) const {
-    auto& ctx = ctx_.get();
-    ctx.handle_error(tiledb_fragment_info_load_with_key(
-        ctx.ptr().get(),
-        fragment_info_.get(),
-        encryption_type,
-        encryption_key.data(),
-        (uint32_t)encryption_key.size()));
-  }
-
   /** Returns the URI of the fragment with the given index. */
   std::string fragment_uri(uint32_t fid) const {
     auto& ctx = ctx_.get();


### PR DESCRIPTION
Remove deprecated C API tiledb_fragment_info_load_with_key(). Remove deprecated C++ API `Array::load` with key arguments in signature.

---
TYPE: C_API
DESC: Remove deprecated C API tiledb_fragment_info_load_with_key()
