### PR TITLE
Remove C API functions `tiledb_array_consolidate_metadata` and `tiledb_array_consolidate_metadata_with_key`

### DIFF
--- a/tiledb/doxygen/source/c-api.rst
+++ b/tiledb/doxygen/source/c-api.rst
@@ -265,10 +265,6 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_delete_metadata
     :project: TileDB-C
-.. doxygenfunction:: tiledb_array_consolidate_metadata
-    :project: TileDB-C
-.. doxygenfunction:: tiledb_array_consolidate_metadata_with_key
-    :project: TileDB-C
 
 Array Schema
 ------------

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3817,45 +3817,6 @@ int32_t tiledb_array_has_metadata_key(
   return TILEDB_OK;
 }
 
-int32_t tiledb_array_consolidate_metadata(
-    tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
-  // Sanity checks
-  if (sanity_check(ctx) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  throw_if_not_ok(ctx->storage_manager()->array_metadata_consolidate(
-      array_uri,
-      static_cast<tiledb::sm::EncryptionType>(TILEDB_NO_ENCRYPTION),
-      nullptr,
-      0,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
-
-  return TILEDB_OK;
-}
-
-int32_t tiledb_array_consolidate_metadata_with_key(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_encryption_type_t encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    tiledb_config_t* config) {
-  // Sanity checks
-  if (sanity_check(ctx) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  throw_if_not_ok(ctx->storage_manager()->array_metadata_consolidate(
-      array_uri,
-      static_cast<tiledb::sm::EncryptionType>(encryption_type),
-      encryption_key,
-      key_length,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
-
-  return TILEDB_OK;
-}
-
 int32_t tiledb_array_evolve(
     tiledb_ctx_t* ctx,
     const char* array_uri,
@@ -8047,25 +8008,6 @@ int32_t tiledb_array_has_metadata_key(
     int32_t* has_key) noexcept {
   return api_entry<tiledb::api::tiledb_array_has_metadata_key>(
       ctx, array, key, value_type, has_key);
-}
-
-int32_t tiledb_array_consolidate_metadata(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_config_t* config) noexcept {
-  return api_entry<tiledb::api::tiledb_array_consolidate_metadata>(
-      ctx, array_uri, config);
-}
-
-int32_t tiledb_array_consolidate_metadata_with_key(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_encryption_type_t encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    tiledb_config_t* config) noexcept {
-  return api_entry<tiledb::api::tiledb_array_consolidate_metadata_with_key>(
-      ctx, array_uri, encryption_type, encryption_key, key_length, config);
 }
 
 int32_t tiledb_array_evolve(

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5250,58 +5250,6 @@ TILEDB_EXPORT int32_t tiledb_array_has_metadata_key(
     tiledb_datatype_t* value_type,
     int32_t* has_key) TILEDB_NOEXCEPT;
 
-/**
- * Consolidates the array metadata into a single array metadata file.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_array_consolidate_metadata(
- *     ctx, "hdfs:///tiledb_arrays/my_array", nullptr);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_uri The name of the TileDB array whose metadata will
- *     be consolidated.
- * @param config Configuration parameters for the consolidation
- *     (`nullptr` means default, which will use the config from `ctx`).
- * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
- */
-TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_config_t* config) TILEDB_NOEXCEPT;
-
-/**
- * Consolidates the array metadata of an encrypted array into a single file.
- *
- * **Example:**
- *
- * @code{.c}
- * uint8_t key[32] = ...;
- * tiledb_array_consolidate_metadata_with_key(
- *     ctx, "hdfs:///tiledb_arrays/my_array",
- *     TILEDB_AES_256_GCM, key, sizeof(key), nullptr);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_uri The name of the TileDB array to be consolidated.
- * @param encryption_type The encryption type to use.
- * @param encryption_key The encryption key to use.
- * @param key_length Length in bytes of the encryption key.
- * @param config Configuration parameters for the consolidation
- *     (`nullptr` means default, which will use the config from `ctx`).
- *
- * @return `TILEDB_OK` on success, and `TILEDB_ERR` on error.
- */
-TILEDB_DEPRECATED_EXPORT int32_t tiledb_array_consolidate_metadata_with_key(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_encryption_type_t encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    tiledb_config_t* config) TILEDB_NOEXCEPT;
-
 /* ********************************* */
 /*          OBJECT MANAGEMENT        */
 /* ********************************* */


### PR DESCRIPTION
Remove C API functions `tiledb_array_consolidate_metadata` and `tiledb_array_consolidate_metadata_with_key`.

---
TYPE: C_API
DESC: Remove C API functions `tiledb_array_consolidate_metadata` and `tiledb_array_consolidate_metadata_with_key`
