### PR TITLE
Remove deprecated C API function `tiledb_coords`

### DIFF
--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -894,7 +894,7 @@ TEST_CASE_METHOD(
     check_read_stats(query);
 
     auto result_el = query.result_buffer_elements_nullable();
-    REQUIRE(std::get<1>(result_el[TILEDB_COORDS]) == 20);
+    REQUIRE(std::get<1>(result_el[tiledb::test::TILEDB_COORDS]) == 20);
     REQUIRE(std::get<1>(result_el["a1"]) == 10);
     REQUIRE(std::get<1>(result_el["a2"]) == 20);
     REQUIRE(std::get<2>(result_el["a2"]) == 10);

--- a/test/src/unit-capi-serialized_queries_using_subarray.cc
+++ b/test/src/unit-capi-serialized_queries_using_subarray.cc
@@ -391,7 +391,7 @@ struct SerializationFx {
     ctx.handle_error(tiledb_query_get_data_buffer(
         ctx.ptr().get(),
         query->ptr().get(),
-        TILEDB_COORDS,
+        tiledb::test::TILEDB_COORDS,
         &unused1,
         &coords_size));
 
@@ -433,7 +433,7 @@ struct SerializationFx {
       ctx.handle_error(tiledb_query_set_data_buffer(
           ctx.ptr().get(),
           query->ptr().get(),
-          TILEDB_COORDS,
+          tiledb::test::TILEDB_COORDS,
           buff,
           coords_size));
       to_free.push_back(buff);
@@ -813,7 +813,7 @@ TEST_CASE_METHOD(
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
     auto result_el = query.result_buffer_elements_nullable();
-    REQUIRE(std::get<1>(result_el[TILEDB_COORDS]) == 20);
+    REQUIRE(std::get<1>(result_el[tiledb::test::TILEDB_COORDS]) == 20);
     REQUIRE(std::get<1>(result_el["a1"]) == 10);
     REQUIRE(std::get<1>(result_el["a2"]) == 20);
     REQUIRE(std::get<2>(result_el["a2"]) == 10);

--- a/test/src/unit-cppapi-checksum.cc
+++ b/test/src/unit-cppapi-checksum.cc
@@ -30,9 +30,9 @@
  * Tests the C++ API for checksum validation.
  */
 
-#include "test/support/src/coords_workaround.h"
 #include <test/support/tdb_catch.h>
 #include <fstream>
+#include "test/support/src/coords_workaround.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
 static void check_filters(

--- a/test/src/unit-cppapi-checksum.cc
+++ b/test/src/unit-cppapi-checksum.cc
@@ -30,6 +30,7 @@
  * Tests the C++ API for checksum validation.
  */
 
+#include "test/support/src/coords_workaround.h"
 #include <test/support/tdb_catch.h>
 #include <fstream>
 #include "tiledb/sm/cpp_api/tiledb"
@@ -112,7 +113,7 @@ static void run_checksum_test(tiledb_filter_type_t filter_type) {
   Query query_r(ctx2, array);
   query_r.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
-      .set_data_buffer(tiledb_coords(), coords_read)
+      .set_data_buffer(tiledb::test::TILEDB_COORDS, coords_read)
       .set_data_buffer("a1", a1_read)
       .set_data_buffer("a2", a2_read_data)
       .set_offsets_buffer("a2", a2_read_off);
@@ -183,7 +184,7 @@ static void run_checksum_test(tiledb_filter_type_t filter_type) {
   Query query_r2(ctx, array);
   query_r2.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
-      .set_data_buffer(tiledb_coords(), coords_read2)
+      .set_data_buffer(tiledb::test::TILEDB_COORDS, coords_read2)
       .set_data_buffer("a1", a1_read2)
       .set_data_buffer("a2", a2_read_data2)
       .set_offsets_buffer("a2", a2_read_off2);

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -30,6 +30,7 @@
  * Tests the C++ API for schema related functions.
  */
 
+#include "test/support/src/coords_workaround.h"
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/cpp_api/tiledb_experimental"
@@ -253,7 +254,7 @@ TEST_CASE(
   Query query(ctx, array, TILEDB_READ);
   CHECK_THROWS(query.set_subarray(subarray));
   std::vector<int32_t> buff = {1, 2, 4};
-  CHECK_THROWS(query.set_data_buffer(TILEDB_COORDS, buff));
+  CHECK_THROWS(query.set_data_buffer(tiledb::test::TILEDB_COORDS, buff));
 
   // Close array
   array.close();

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -30,8 +30,8 @@
  * Tests the C++ API for schema related functions.
  */
 
-#include "test/support/src/coords_workaround.h"
 #include <test/support/tdb_catch.h>
+#include "test/support/src/coords_workaround.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/cpp_api/tiledb_experimental"
 #include "tiledb/sm/misc/constants.h"

--- a/test/support/src/coords_workaround.h
+++ b/test/support/src/coords_workaround.h
@@ -35,22 +35,22 @@
 #define TILEDB_TEST_COORDS_WORKAROUND_H
 
 namespace tiledb::test {
-  /**
-   * This symbol TILEDB_COORDS used to be defined as a preprocessor definition
-   * that called a now-removed C API function that returned a constant string.
-   * At the time the API function was removed there remained a large number of
-   * internal uses of the symbol for testing. This symbol was used for a
-   * particular buffer layout for query results ("zipped coordinates") that was
-   * long ago deprecated. The tests were never updated.
-   *
-   * This symbol is defined here to allow tests to continue to compile for the
-   * interim until the tests have been rewritten to eliminate its appearance
-   * entirely. New code must not use this symbol.
-   *
-   * This definition duplicates that in `tiledb::sm::constants::coords`. This is
-   * intentional, since it simplifies linking by avoiding an object file.
-   */
-  constexpr auto TILEDB_COORDS = "__coords";
+/**
+ * This symbol TILEDB_COORDS used to be defined as a preprocessor definition
+ * that called a now-removed C API function that returned a constant string.
+ * At the time the API function was removed there remained a large number of
+ * internal uses of the symbol for testing. This symbol was used for a
+ * particular buffer layout for query results ("zipped coordinates") that was
+ * long ago deprecated. The tests were never updated.
+ *
+ * This symbol is defined here to allow tests to continue to compile for the
+ * interim until the tests have been rewritten to eliminate its appearance
+ * entirely. New code must not use this symbol.
+ *
+ * This definition duplicates that in `tiledb::sm::constants::coords`. This is
+ * intentional, since it simplifies linking by avoiding an object file.
+ */
+constexpr auto TILEDB_COORDS = "__coords";
 }  // End of namespace tiledb::test
 
 #endif

--- a/test/support/src/coords_workaround.h
+++ b/test/support/src/coords_workaround.h
@@ -1,0 +1,56 @@
+/**
+ * @file /test/support/src/coords_workaround.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the symbol TILEDB_COORDS, a legacy symbol that used to be
+ * exposed through the API.
+ */
+
+#ifndef TILEDB_TEST_COORDS_WORKAROUND_H
+#define TILEDB_TEST_COORDS_WORKAROUND_H
+
+namespace tiledb::test {
+  /**
+   * This symbol TILEDB_COORDS used to be defined as a preprocessor definition
+   * that called a now-removed C API function that returned a constant string.
+   * At the time the API function was removed there remained a large number of
+   * internal uses of the symbol for testing. This symbol was used for a
+   * particular buffer layout for query results ("zipped coordinates") that was
+   * long ago deprecated. The tests were never updated.
+   *
+   * This symbol is defined here to allow tests to continue to compile for the
+   * interim until the tests have been rewritten to eliminate its appearance
+   * entirely. New code must not use this symbol.
+   *
+   * This definition duplicates that in `tiledb::sm::constants::coords`. This is
+   * intentional, since it simplifies linking by avoiding an object file.
+   */
+  constexpr auto TILEDB_COORDS = "__coords";
+}  // End of namespace tiledb::test
+
+#endif

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -34,6 +34,7 @@
 #define TILEDB_TEST_HELPERS_H
 
 #include <tiledb/common/logger_public.h>
+#include "test/support/src/coords_workaround.h"
 #include "tiledb.h"
 #include "tiledb/common/common.h"
 #include "tiledb/sm/array/array.h"

--- a/tiledb/doxygen/source/c-api.rst
+++ b/tiledb/doxygen/source/c-api.rst
@@ -51,8 +51,6 @@ Return Codes
 
 Constants
 ---------
-.. doxygendefine:: TILEDB_COORDS
-    :project: TileDB-C
 .. doxygendefine:: TILEDB_VAR_NUM
     :project: TileDB-C
 .. doxygendefine:: TILEDB_MAX_PATH
@@ -60,8 +58,6 @@ Constants
 .. doxygendefine:: TILEDB_OFFSET_SIZE
     :project: TileDB-C
 .. doxygendefine:: TILEDB_TIMESTAMPS
-    :project: TileDB-C
-.. doxygenfunction:: tiledb_coords
     :project: TileDB-C
 .. doxygenfunction:: tiledb_var_num
     :project: TileDB-C

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -6263,10 +6263,6 @@ int32_t tiledb_vfs_mode_from_str(
 /*            CONSTANTS           */
 /* ****************************** */
 
-const char* tiledb_coords() noexcept {
-  return tiledb::sm::constants::coords.c_str();
-}
-
 uint32_t tiledb_var_num() noexcept {
   return tiledb::sm::constants::var_num;
 }

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -260,15 +260,6 @@ TILEDB_EXPORT int32_t tiledb_vfs_mode_from_str(
 /*            CONSTANTS           */
 /* ****************************** */
 
-/**
- * Returns a special name indicating the coordinates attribute.
- *
- * The coordinate buffer has been deprecated. Set the coordinates for
- * each individual dimension with the `set_buffer` API. Consult the current
- * documentation for more information.
- */
-TILEDB_DEPRECATED_EXPORT const char* tiledb_coords(void) TILEDB_NOEXCEPT;
-
 /** Returns a special value indicating a variable number of elements. */
 TILEDB_EXPORT uint32_t tiledb_var_num(void) TILEDB_NOEXCEPT;
 
@@ -291,8 +282,6 @@ TILEDB_EXPORT const char* tiledb_timestamps(void) TILEDB_NOEXCEPT;
  * @name Constants wrapping special functions
  */
 /**@{*/
-/** A special name indicating the coordinates attribute. */
-#define TILEDB_COORDS tiledb_coords()
 /** A special value indicating a variable number of elements. */
 #define TILEDB_VAR_NUM tiledb_var_num()
 /** The maximum path length on the current platform. */


### PR DESCRIPTION
Remove deprecated C API function `tiledb_coords` and a macro `TILEDB_COORDS` that calls it. This PR accomplishes the narrow purpose of removing these symbols from the API as part of the removal process. It does not complete the removal process.

Reintroduce `TILEDB_COORDS` in `tiledb::test` only for test purposes. The symbol `TILEDB_COORDS` continues to be used extensively in test code. This PR moves the symbol into the namespace `tiledb::test` and adjusts a few things to allow the tests to continue to compile. This is a transitional measure only; it's on the road to complete removal, but does not arrive there. 

---
TYPE: C_API
DESC: Remove deprecated C API function `tiledb_coords`
