### PR TITLE
Show URL in logger trace before results are returned

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -716,7 +716,7 @@ Status Curl::post_data(
     Buffer* const returned_data,
     const std::string& res_uri) {
   struct curl_slist* headers;
-  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers));
+  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers, url));
 
   CURLcode ret;
   headerData.uri = &res_uri;
@@ -739,7 +739,7 @@ Status Curl::post_data(
     PostResponseCb&& cb,
     const std::string& res_uri) {
   struct curl_slist* headers;
-  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers));
+  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers, url));
 
   CURLcode ret;
   headerData.uri = &res_uri;
@@ -756,7 +756,8 @@ Status Curl::post_data(
 Status Curl::post_data_common(
     const SerializationType serialization_type,
     const BufferList* data,
-    struct curl_slist** headers) {
+    struct curl_slist** headers,
+    const std::string& url) {
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
@@ -769,7 +770,7 @@ Status Curl::post_data_common(
   } else {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data->total_size());
   }
-  logger_->debug("posting {} bytes", data->total_size());
+  logger_->debug("posting {} bytes to {}", data->total_size(), url);
 
   // Set auth and content-type for request
   *headers = nullptr;

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -718,6 +718,8 @@ Status Curl::post_data(
   struct curl_slist* headers;
   RETURN_NOT_OK(post_data_common(serialization_type, data, &headers));
 
+  logger_->debug("posting {} bytes to {}", data->total_size(), url);
+
   CURLcode ret;
   headerData.uri = &res_uri;
   auto st = make_curl_request(stats, url.c_str(), &ret, returned_data);
@@ -769,7 +771,6 @@ Status Curl::post_data_common(
   } else {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data->total_size());
   }
-  logger_->debug("posting {} bytes", data->total_size());
 
   // Set auth and content-type for request
   *headers = nullptr;

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -716,7 +716,7 @@ Status Curl::post_data(
     Buffer* const returned_data,
     const std::string& res_uri) {
   struct curl_slist* headers;
-  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers, url));
+  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers));
 
   CURLcode ret;
   headerData.uri = &res_uri;
@@ -739,7 +739,7 @@ Status Curl::post_data(
     PostResponseCb&& cb,
     const std::string& res_uri) {
   struct curl_slist* headers;
-  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers, url));
+  RETURN_NOT_OK(post_data_common(serialization_type, data, &headers));
 
   CURLcode ret;
   headerData.uri = &res_uri;
@@ -756,8 +756,7 @@ Status Curl::post_data(
 Status Curl::post_data_common(
     const SerializationType serialization_type,
     const BufferList* data,
-    struct curl_slist** headers,
-    const std::string& url) {
+    struct curl_slist** headers) {
   CURL* curl = curl_.get();
   if (curl == nullptr)
     return LOG_STATUS(
@@ -770,7 +769,7 @@ Status Curl::post_data_common(
   } else {
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, data->total_size());
   }
-  logger_->debug("posting {} bytes to {}", data->total_size(), url);
+  logger_->debug("posting {} bytes", data->total_size());
 
   // Set auth and content-type for request
   *headers = nullptr;

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -286,14 +286,12 @@ class Curl {
    * @param headers Request headers that must be freed after the curl
    *    request is complete. If this routine returns a non-OK status,
    *    the value returned through this parameter should be ignored.
-   * @param url URL (for debug-logging)
    * @return Status
    */
   Status post_data_common(
       SerializationType serialization_type,
       const BufferList* data,
-      struct curl_slist** headers,
-      const std::string& url);
+      struct curl_slist** headers);
 
   /**
    * Simple wrapper for getting data from server

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -286,12 +286,14 @@ class Curl {
    * @param headers Request headers that must be freed after the curl
    *    request is complete. If this routine returns a non-OK status,
    *    the value returned through this parameter should be ignored.
+   * @param url URL (for debug-logging)
    * @return Status
    */
   Status post_data_common(
       SerializationType serialization_type,
       const BufferList* data,
-      struct curl_slist** headers);
+      struct curl_slist** headers,
+      const std::string& url);
 
   /**
    * Simple wrapper for getting data from server


### PR DESCRIPTION
For perf analysis, log analysis, etc. it's often useful to have a REST URL available before the HTTP request returns. cc @snagles and @Shelnutt2.

---
TYPE: IMPROVEMENT
DESC: Show URL in logger trace before results are returned<short description