### PR TITLE
Move attribute order check from dim label query to writer base

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,6 +110,8 @@ set(TILEDB_UNIT_TEST_SOURCES
   support/src/ast_helpers.h
   support/src/helpers.h
   support/src/helpers-dimension.h
+  src/test-capi-array-write-ordered-attr-fixed.cc
+  src/test-capi-array-write-ordered-attr-var.cc
   src/test-capi-consolidation-plan.cc
   src/test-capi-query-error-handling.cc
   src/test-cppapi-consolidation-plan.cc

--- a/test/src/test-capi-array-many-dimension-labels.cc
+++ b/test/src/test-capi-array-many-dimension-labels.cc
@@ -198,6 +198,7 @@ class ExampleArray : public TemporaryDirectoryFixture {
     REQUIRE(query_status == TILEDB_COMPLETED);
 
     // Clean-up.
+    tiledb_subarray_free(&subarray);
     tiledb_query_free(&query);
     tiledb_array_free(&array);
   }

--- a/test/src/test-capi-array-write-ordered-attr-fixed.cc
+++ b/test/src/test-capi-array-write-ordered-attr-fixed.cc
@@ -75,7 +75,7 @@ struct FixedOrderedAttributeArrayFixture {
     // exposed in the C-API yet.
     auto attr = make_shared<sm::Attribute>(HERE(), "a", type, 1, order);
     auto st = schema->array_schema_->add_attribute(attr);
-    REQUIRE_TILEDB_STATUS_OK(st);
+    REQUIRE(st.ok());
 
     // Create the array and clean-up.
     std::string base_name{"array_ordered_attr_" + datatype_str(type) + "_" +

--- a/test/src/test-capi-array-write-ordered-attr-fixed.cc
+++ b/test/src/test-capi-array-write-ordered-attr-fixed.cc
@@ -1,5 +1,5 @@
 /**
- * @file   unit-ordered-dim-label-reader.cc
+ * @file  test-capi-array-write-ordered-attr-fixed.cc
  *
  * @section LICENSE
  *
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * Tests the ordered dimension label reader.
+ * Tests sort checks for fixed length ordered attributes.
  */
 
 #include <test/support/tdb_catch.h>
@@ -175,8 +175,10 @@ struct FixedOrderedAttributeArrayFixture {
       CHECK(query_status == TILEDB_COMPLETED);
     } else {
       // Submit write query and verify if fails.
-      auto rc = tiledb_query_submit(ctx, query);
-      CHECK(rc != TILEDB_OK);
+      require_tiledb_error_with(
+          tiledb_query_submit(ctx, query),
+          "WriterBase: The data for attribute 'a' is not in the expected "
+          "order.");
     }
 
     // Clean-up.
@@ -193,6 +195,11 @@ struct FixedOrderedAttributeArrayFixture {
   /** Require a TileDB return code is ok. */
   inline void require_tiledb_ok(int rc) const {
     temp_dir_.require_tiledb_ok(rc);
+  }
+
+  /** Require a TileDB return code is an error with the given message. */
+  inline void require_tiledb_error_with(int rc, const std::string& msg) {
+    temp_dir_.require_tiledb_error_with(rc, msg);
   }
 
  protected:

--- a/test/src/test-capi-array-write-ordered-attr-fixed.cc
+++ b/test/src/test-capi-array-write-ordered-attr-fixed.cc
@@ -1,0 +1,405 @@
+/**
+ * @file   unit-ordered-dim-label-reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the ordered dimension label reader.
+ */
+
+#include <test/support/tdb_catch.h>
+#include <catch2/matchers/catch_matchers_string.hpp>
+using namespace Catch::Matchers;
+
+#include <test/support/src/helpers.h>
+#include <test/support/src/vfs_helpers.h>
+#include <test/support/tdb_catch.h>
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+
+#include <numeric>
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+template <typename T, Datatype type, DataOrder order>
+struct FixedOrderedAttributeArrayFixture {
+ public:
+  FixedOrderedAttributeArrayFixture()
+      : temp_dir_{}
+      , ctx{temp_dir_.get_ctx()} {
+    // Allocate array schema.
+    tiledb_array_schema_t* schema{nullptr};
+    require_tiledb_ok(tiledb_array_schema_alloc(ctx, TILEDB_DENSE, &schema));
+
+    // Set the domian.
+    uint32_t dim_domain_data[2]{0, 31};
+    uint32_t tile{32};
+    tiledb_dimension_t* dim;
+    tiledb_dimension_alloc(
+        ctx, "x", TILEDB_INT32, &dim_domain_data[0], &tile, &dim);
+    tiledb_domain_t* domain;
+    tiledb_domain_alloc(ctx, &domain);
+    tiledb_domain_add_dimension(ctx, domain, dim);
+    tiledb_array_schema_set_domain(ctx, schema, domain);
+    tiledb_dimension_free(&dim);
+    tiledb_domain_free(&domain);
+
+    // Define the attribute: skip C-API since ordered attributes aren't
+    // exposed in the C-API yet.
+    auto attr = make_shared<sm::Attribute>(HERE(), "a", type, 1, order);
+    auto st = schema->array_schema_->add_attribute(attr);
+    REQUIRE_TILEDB_STATUS_OK(st);
+
+    // Create the array and clean-up.
+    std::string base_name{"array_ordered_attr_" + datatype_str(type) + "_" +
+                          data_order_str(order)};
+    array_name = temp_dir_.create_temporary_array(std::move(base_name), schema);
+    tiledb_array_schema_free(&schema);
+  }
+
+  /**
+   * Read back data from an array and verify it matches the expected data.
+   *
+   * @param min_index Lower bound for range to read data from.
+   * @param max_index Upper bound for range to read data from.
+   * @param expected_data The expected output data.
+   */
+  void check_array_data(
+      uint32_t min_index,
+      uint32_t max_index,
+      const std::vector<T>& expected_data) {
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Define sizes for setting buffers.
+    uint64_t attr_data_size{expected_data.size() * sizeof(T)};
+    std::vector<T> output_data(expected_data.size());
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &min_index, &max_index, nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "a", output_data.data(), &attr_data_size));
+
+    // Submit read query and verify it is successful.
+    check_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    check_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    CHECK(query_status == TILEDB_COMPLETED);
+
+    CHECK(output_data == expected_data);
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /**
+   * Write data to the ordered attribute.
+   *
+   * @param min_index Lower bound for range to write data to.
+   * @param max_index Upper bound for range to write data to.
+   * @param data Data to write to the attribute.
+   * @param valid If ``true`` the write should succeed, otherwise the write
+   *     should fail.
+   */
+  void write_fragment(
+      uint32_t min_index,
+      uint32_t max_index,
+      std::vector<T>& data,
+      bool valid = true) {
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+    // Define sizes for setting buffers.
+    uint64_t attr_data_size{data.size() * sizeof(T)};
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &min_index, &max_index, nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "a", data.data(), &attr_data_size));
+
+    // Submit query.
+    if (valid) {
+      // Submit write query and verify it is successful.
+      check_tiledb_ok(tiledb_query_submit(ctx, query));
+      tiledb_query_status_t query_status;
+      check_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+      CHECK(query_status == TILEDB_COMPLETED);
+    } else {
+      // Submit write query and verify if fails.
+      auto rc = tiledb_query_submit(ctx, query);
+      CHECK(rc != TILEDB_OK);
+    }
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /** Check a TileDB return code is ok. */
+  inline void check_tiledb_ok(int rc) const {
+    temp_dir_.check_tiledb_ok(rc);
+  }
+
+  /** Require a TileDB return code is ok. */
+  inline void require_tiledb_ok(int rc) const {
+    temp_dir_.require_tiledb_ok(rc);
+  }
+
+ protected:
+  /** Temporary directory and virtual file system. */
+  test::TemporaryDirectoryFixture temp_dir_;
+
+  /**
+   * TileDB context.
+   *
+   * This context in managed by the above temporary directory fixture.
+   */
+  tiledb_ctx_t* ctx;
+
+  /** Name of the array. */
+  std::string array_name;
+};
+
+TEMPLATE_TEST_CASE_SIG(
+    "Write to increasing attributes with fixed length: valid",
+    "[ordered-writer][fixed][ordered-data]",
+    ((typename T, sm::Datatype datatype), T, datatype),
+    (uint8_t, Datatype::UINT8),
+    (int8_t, Datatype::INT8),
+    (uint16_t, Datatype::UINT16),
+    (int16_t, Datatype::INT16),
+    (uint32_t, Datatype::UINT32),
+    (int32_t, Datatype::INT32),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::INT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  auto fixture = FixedOrderedAttributeArrayFixture<
+      T,
+      datatype,
+      sm::DataOrder::INCREASING_DATA>{};
+  std::vector<T> data{3, 4, 5, 6, 7, 8};
+  fixture.write_fragment(2, 7, data);
+  fixture.check_array_data(2, 7, data);
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "Write to decreasing attributes with fixed length: valid",
+    "[ordered-writer][fixed][ordered-data]",
+    ((typename T, sm::Datatype datatype), T, datatype),
+    (uint8_t, Datatype::UINT8),
+    (int8_t, Datatype::INT8),
+    (uint16_t, Datatype::UINT16),
+    (int16_t, Datatype::INT16),
+    (uint32_t, Datatype::UINT32),
+    (int32_t, Datatype::INT32),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::INT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  auto fixture = FixedOrderedAttributeArrayFixture<
+      T,
+      datatype,
+      sm::DataOrder::DECREASING_DATA>{};
+  std::vector<T> data{8, 7, 6, 5, 4, 3};
+  fixture.write_fragment(2, 7, data);
+  fixture.check_array_data(2, 7, data);
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "Write to increasing attributes with fixed length: Invalid order",
+    "[ordered-writer][fixed][ordered-data]",
+    ((typename T, sm::Datatype datatype), T, datatype),
+    (uint8_t, Datatype::UINT8),
+    (int8_t, Datatype::INT8),
+    (uint16_t, Datatype::UINT16),
+    (int16_t, Datatype::INT16),
+    (uint32_t, Datatype::UINT32),
+    (int32_t, Datatype::INT32),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::INT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  auto fixture = FixedOrderedAttributeArrayFixture<
+      T,
+      datatype,
+      sm::DataOrder::INCREASING_DATA>{};
+  // Write initial data.
+  std::vector<T> valid_data{1, 2, 3, 4};
+  fixture.write_fragment(4, 7, valid_data);
+
+  // Try writing invalid data.
+  std::vector<T> invalid_data{10, 10, 11, 12};
+  fixture.write_fragment(4, 7, invalid_data, false);
+
+  // Verify array data is unchanged for bad write.
+  fixture.check_array_data(4, 7, valid_data);
+}
+
+TEMPLATE_TEST_CASE_SIG(
+    "Write to decreasing attributes with fixed length: Invalid order",
+    "[ordered-writer][fixed][ordered-data]",
+    ((typename T, sm::Datatype datatype), T, datatype),
+    (uint8_t, Datatype::UINT8),
+    (int8_t, Datatype::INT8),
+    (uint16_t, Datatype::UINT16),
+    (int16_t, Datatype::INT16),
+    (uint32_t, Datatype::UINT32),
+    (int32_t, Datatype::INT32),
+    (uint64_t, Datatype::UINT64),
+    (int64_t, Datatype::INT64),
+    (int64_t, Datatype::DATETIME_YEAR),
+    (int64_t, Datatype::DATETIME_MONTH),
+    (int64_t, Datatype::DATETIME_WEEK),
+    (int64_t, Datatype::DATETIME_DAY),
+    (int64_t, Datatype::DATETIME_HR),
+    (int64_t, Datatype::DATETIME_MIN),
+    (int64_t, Datatype::DATETIME_SEC),
+    (int64_t, Datatype::DATETIME_MS),
+    (int64_t, Datatype::DATETIME_US),
+    (int64_t, Datatype::DATETIME_NS),
+    (int64_t, Datatype::DATETIME_PS),
+    (int64_t, Datatype::DATETIME_FS),
+    (int64_t, Datatype::DATETIME_AS),
+    (int64_t, Datatype::TIME_HR),
+    (int64_t, Datatype::TIME_MIN),
+    (int64_t, Datatype::TIME_SEC),
+    (int64_t, Datatype::TIME_MS),
+    (int64_t, Datatype::TIME_US),
+    (int64_t, Datatype::TIME_NS),
+    (int64_t, Datatype::TIME_PS),
+    (int64_t, Datatype::TIME_FS),
+    (int64_t, Datatype::TIME_AS),
+    (float, Datatype::FLOAT32),
+    (double, Datatype::FLOAT64)) {
+  auto fixture = FixedOrderedAttributeArrayFixture<
+      T,
+      datatype,
+      sm::DataOrder::DECREASING_DATA>{};
+  // Write initial data.
+  std::vector<T> valid_data{4, 3, 2, 1};
+  fixture.write_fragment(4, 7, valid_data);
+
+  // Try writing invalid data.
+  std::vector<T> invalid_data{12, 11, 10, 10};
+  fixture.write_fragment(4, 7, invalid_data, false);
+
+  // Verify array data is unchanged for bad write.
+  fixture.check_array_data(4, 7, valid_data);
+}

--- a/test/src/test-capi-array-write-ordered-attr-var.cc
+++ b/test/src/test-capi-array-write-ordered-attr-var.cc
@@ -1,0 +1,280 @@
+/**
+ * @file   unit-ordered-dim-label-reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the ordered dimension label reader.
+ */
+
+#include <test/support/tdb_catch.h>
+#include <catch2/matchers/catch_matchers_string.hpp>
+using namespace Catch::Matchers;
+
+#include <test/support/src/helpers.h>
+#include <test/support/src/vfs_helpers.h>
+#include <test/support/tdb_catch.h>
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+
+#include <numeric>
+
+using namespace tiledb;
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+template <DataOrder order>
+struct VarOrderedAttributeArrayFixture {
+ public:
+  VarOrderedAttributeArrayFixture()
+      : temp_dir_{}
+      , ctx{temp_dir_.get_ctx()} {
+    // Allocate array schema.
+    tiledb_array_schema_t* schema{nullptr};
+    require_tiledb_ok(tiledb_array_schema_alloc(ctx, TILEDB_DENSE, &schema));
+
+    // Set the domian.
+    uint32_t dim_domain_data[2]{0, 31};
+    uint32_t tile{32};
+    tiledb_dimension_t* dim;
+    tiledb_dimension_alloc(
+        ctx, "x", TILEDB_INT32, &dim_domain_data[0], &tile, &dim);
+    tiledb_domain_t* domain;
+    tiledb_domain_alloc(ctx, &domain);
+    tiledb_domain_add_dimension(ctx, domain, dim);
+    tiledb_array_schema_set_domain(ctx, schema, domain);
+    tiledb_dimension_free(&dim);
+    tiledb_domain_free(&domain);
+
+    // Define the attribute: skip C-API since ordered attributes aren't
+    // exposed in the C-API yet.
+    auto attr = make_shared<sm::Attribute>(
+        HERE(), "a", Datatype::STRING_ASCII, constants::var_num, order);
+    auto st = schema->array_schema_->add_attribute(attr);
+    REQUIRE_TILEDB_STATUS_OK(st);
+
+    // Create the array and clean-up.
+    std::string base_name{"array_ordered_attr_ascii_" + data_order_str(order)};
+    array_name = temp_dir_.create_temporary_array(std::move(base_name), schema);
+    tiledb_array_schema_free(&schema);
+  }
+
+  /**
+   * Read back data from an array and verify it matches the expected data.
+   *
+   * @param min_index Lower bound for range to read data from.
+   * @param max_index Upper bound for range to read data from.
+   * @param expected_data The expected output data.
+   * @param expected_offsets The expected output offsets.
+   */
+  void check_array_data(
+      uint32_t min_index,
+      uint32_t max_index,
+      const std::string& expected_data,
+      const std::vector<uint64_t> expected_offsets) {
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
+
+    // Define sizes for setting buffers.
+    uint64_t data_size{expected_data.size() * sizeof(char)};
+    uint64_t offsets_size{expected_offsets.size() * sizeof(uint64_t)};
+    std::string output_data(expected_data.size(), ' ');
+    std::vector<uint64_t> output_offsets(expected_offsets.size());
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &min_index, &max_index, nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(tiledb_query_set_data_buffer(
+        ctx, query, "a", output_data.data(), &data_size));
+    require_tiledb_ok(tiledb_query_set_offsets_buffer(
+        ctx, query, "a", output_offsets.data(), &offsets_size));
+
+    // Submit read query and verify it is successful.
+    check_tiledb_ok(tiledb_query_submit(ctx, query));
+    tiledb_query_status_t query_status;
+    check_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+    CHECK(query_status == TILEDB_COMPLETED);
+
+    CHECK(output_data == expected_data);
+    CHECK(output_offsets == expected_offsets);
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /**
+   * Write data to the ordered attribute.
+   *
+   * @param min_index Lower bound for range to write data to.
+   * @param max_index Upper bound for range to write data to.
+   * @param data Data to write to the attribute.
+   * @param offsets Offsets for the variable length data to write to the
+   *     attribute.
+   * @param valid If ``true`` the write should succeed, otherwise the write
+   *     should fail.
+   */
+  void write_fragment(
+      uint32_t min_index,
+      uint32_t max_index,
+      std::string& data,
+      std::vector<uint64_t>& offsets,
+      bool valid = true) {
+    tiledb_array_t* array;
+    require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+    require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_WRITE));
+
+    // Define sizes for setting buffers.
+    uint64_t data_size{data.size() * sizeof(char)};
+    uint64_t offsets_size{offsets.size() * sizeof(uint64_t)};
+
+    // Create subarray.
+    tiledb_subarray_t* subarray;
+    require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
+    require_tiledb_ok(tiledb_subarray_add_range(
+        ctx, subarray, 0, &min_index, &max_index, nullptr));
+
+    // Create write query.
+    tiledb_query_t* query;
+    require_tiledb_ok(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query));
+    require_tiledb_ok(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR));
+    require_tiledb_ok(tiledb_query_set_subarray_t(ctx, query, subarray));
+    require_tiledb_ok(
+        tiledb_query_set_data_buffer(ctx, query, "a", data.data(), &data_size));
+    require_tiledb_ok(tiledb_query_set_offsets_buffer(
+        ctx, query, "a", offsets.data(), &offsets_size));
+
+    // Submit query.
+    if (valid) {
+      // Submit write query and verify it is successful.
+      check_tiledb_ok(tiledb_query_submit(ctx, query));
+      tiledb_query_status_t query_status;
+      check_tiledb_ok(tiledb_query_get_status(ctx, query, &query_status));
+      CHECK(query_status == TILEDB_COMPLETED);
+    } else {
+      // Submit write query and verify if fails.
+      auto rc = tiledb_query_submit(ctx, query);
+      CHECK(rc != TILEDB_OK);
+    }
+
+    // Clean-up.
+    tiledb_subarray_free(&subarray);
+    tiledb_query_free(&query);
+    tiledb_array_free(&array);
+  }
+
+  /** Check a TileDB return code is ok. */
+  inline void check_tiledb_ok(int rc) const {
+    temp_dir_.check_tiledb_ok(rc);
+  }
+
+  /** Require a TileDB return code is ok. */
+  inline void require_tiledb_ok(int rc) const {
+    temp_dir_.require_tiledb_ok(rc);
+  }
+
+ protected:
+  /** Temporary directory and virtual file system. */
+  test::TemporaryDirectoryFixture temp_dir_;
+
+  /**
+   * TileDB context.
+   *
+   * This context in managed by the above temporary directory fixture.
+   */
+  tiledb_ctx_t* ctx;
+
+  /** Name of the array. */
+  std::string array_name;
+};
+
+TEST_CASE_METHOD(
+    VarOrderedAttributeArrayFixture<DataOrder::INCREASING_DATA>,
+    "Write to increasing attributes with fixed length: valid",
+    "[ordered-writer][var][ordered-data]") {
+  std::string data{"aabbbccddd"};
+  std::vector<uint64_t> offsets{0, 2, 5, 7};
+  write_fragment(2, 5, data, offsets);
+  check_array_data(2, 5, data, offsets);
+}
+
+TEST_CASE_METHOD(
+    VarOrderedAttributeArrayFixture<DataOrder::DECREASING_DATA>,
+    "Write to decreasing attributes with fixed length: valid",
+    "[ordered-writer][var][ordered-data]") {
+  std::string data{"zzyyyxxwww"};
+  std::vector<uint64_t> offsets{0, 2, 5, 7};
+  write_fragment(2, 5, data, offsets);
+  check_array_data(2, 5, data, offsets);
+}
+
+TEST_CASE_METHOD(
+    VarOrderedAttributeArrayFixture<DataOrder::INCREASING_DATA>,
+    "Write to increasing attributes with variable length: Invalid order",
+    "[ordered-writer][var][ordered-data]") {
+  // Write initial data.
+  std::string valid_data{"abcd"};
+  std::vector<uint64_t> valid_offsets{0, 1, 2, 3};
+  write_fragment(4, 7, valid_data, valid_offsets);
+
+  // Try writing invalid data.
+  std::string invalid_data{"aabbaadd"};
+  std::vector<uint64_t> invalid_offsets{0, 2, 4, 6};
+  write_fragment(4, 7, invalid_data, invalid_offsets, false);
+
+  // Verify array data is unchanged for bad write.
+  check_array_data(4, 7, valid_data, valid_offsets);
+}
+
+TEST_CASE_METHOD(
+    VarOrderedAttributeArrayFixture<DataOrder::DECREASING_DATA>,
+    "Write to decreasing attributes with variable length: Invalid order",
+    "[ordered-writer][var][ordered-data]") {
+  // Write initial data.
+  std::string valid_data{"zzyyxxww"};
+  std::vector<uint64_t> valid_offsets{0, 2, 4, 6};
+  write_fragment(4, 7, valid_data, valid_offsets);
+
+  // Try writing invalid data.
+  std::string invalid_data{"zzyx"};
+  std::vector<uint64_t> invalid_offsets{0, 1, 2, 3};
+  write_fragment(4, 7, invalid_data, invalid_offsets, false);
+
+  // Verify array data is unchanged for bad write.
+  check_array_data(4, 7, valid_data, valid_offsets);
+}

--- a/test/src/test-capi-array-write-ordered-attr-var.cc
+++ b/test/src/test-capi-array-write-ordered-attr-var.cc
@@ -1,5 +1,5 @@
 /**
- * @file   unit-ordered-dim-label-reader.cc
+ * @file  test-capi-array-write-ordered-array-var.cc
  *
  * @section LICENSE
  *
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * Tests the ordered dimension label reader.
+ * Tests sort checks for writing variable length ordered attributes.
  */
 
 #include <test/support/tdb_catch.h>
@@ -188,8 +188,10 @@ struct VarOrderedAttributeArrayFixture {
       CHECK(query_status == TILEDB_COMPLETED);
     } else {
       // Submit write query and verify if fails.
-      auto rc = tiledb_query_submit(ctx, query);
-      CHECK(rc != TILEDB_OK);
+      require_tiledb_error_with(
+          tiledb_query_submit(ctx, query),
+          "WriterBase: The data for attribute 'a' is not in the expected "
+          "order.");
     }
 
     // Clean-up.
@@ -206,6 +208,11 @@ struct VarOrderedAttributeArrayFixture {
   /** Require a TileDB return code is ok. */
   inline void require_tiledb_ok(int rc) const {
     temp_dir_.require_tiledb_ok(rc);
+  }
+
+  /** Require a TileDB return code is an error with the given message. */
+  inline void require_tiledb_error_with(int rc, const std::string& msg) {
+    temp_dir_.require_tiledb_error_with(rc, msg);
   }
 
  protected:

--- a/test/src/test-capi-array-write-ordered-attr-var.cc
+++ b/test/src/test-capi-array-write-ordered-attr-var.cc
@@ -76,7 +76,7 @@ struct VarOrderedAttributeArrayFixture {
     auto attr = make_shared<sm::Attribute>(
         HERE(), "a", Datatype::STRING_ASCII, constants::var_num, order);
     auto st = schema->array_schema_->add_attribute(attr);
-    REQUIRE_TILEDB_STATUS_OK(st);
+    REQUIRE(st.ok());
 
     // Create the array and clean-up.
     std::string base_name{"array_ordered_attr_ascii_" + data_order_str(order)};

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -156,6 +156,7 @@ class ArrayExample : public TemporaryDirectoryFixture {
 
     // Clean-up.
     tiledb_query_free(&query);
+    tiledb_subarray_free(&subarray);
     tiledb_array_free(&array);
   }
 

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -158,6 +158,7 @@ class DenseArrayExample1 : public TemporaryDirectoryFixture {
     }
 
     // Clean-up.
+    tiledb_subarray_free(&subarray);
     tiledb_query_free(&query);
     tiledb_array_free(&array);
   }
@@ -221,6 +222,7 @@ class DenseArrayExample1 : public TemporaryDirectoryFixture {
 
     // Clean-up.
     tiledb_query_free(&query);
+    tiledb_subarray_free(&subarray);
     tiledb_array_free(&array);
   }
 

--- a/test/src/test-capi-dimension_labels.cc
+++ b/test/src/test-capi-dimension_labels.cc
@@ -127,11 +127,11 @@ std::string DimensionLabelTestFixture::create_single_label_array(
       4096,
       false);
 
-  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
+  require_tiledb_ok(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "x", TILEDB_INCREASING_DATA, label_type));
 
   // Check array schema and number of dimension labels.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_check(ctx, array_schema));
+  require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
   auto dim_label_num = array_schema->array_schema_->dim_label_num();
   REQUIRE(dim_label_num == 1);
 
@@ -163,13 +163,13 @@ std::string DimensionLabelTestFixture::create_multi_label_array(
       false);
 
   // Add dimension labels.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
+  require_tiledb_ok(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "x", TILEDB_INCREASING_DATA, TILEDB_FLOAT64));
-  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
+  require_tiledb_ok(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "id", TILEDB_INCREASING_DATA, TILEDB_STRING_ASCII));
 
   // Check array schema and number of dimension labels.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_check(ctx, array_schema));
+  require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
   auto dim_label_num = array_schema->array_schema_->dim_label_num();
   REQUIRE(dim_label_num == 2);
 
@@ -190,12 +190,12 @@ TEST_CASE_METHOD(
 
   // Load array schema and check number of labels.
   tiledb_array_schema_t* loaded_array_schema{nullptr};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_array_schema_load(ctx, array_name.c_str(), &loaded_array_schema));
 
   // Check the array schema has the expected dimension label.
   int32_t has_label;
-  CHECK_TILEDB_OK(tiledb_array_schema_has_dimension_label(
+  check_tiledb_ok(tiledb_array_schema_has_dimension_label(
       ctx, loaded_array_schema, "x", &has_label));
   CHECK(has_label == 1);
 
@@ -242,25 +242,25 @@ TEST_CASE_METHOD(
       false);
 
   // Add dimension label.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
+  require_tiledb_ok(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "x", TILEDB_INCREASING_DATA, label_type));
 
   // Set filter.
   tiledb_filter_list_t* filter_list;
-  REQUIRE_TILEDB_OK(tiledb_filter_list_alloc(ctx, &filter_list));
+  require_tiledb_ok(tiledb_filter_list_alloc(ctx, &filter_list));
   tiledb_filter_t* filter;
   int32_t level = 6;
-  REQUIRE_TILEDB_OK(tiledb_filter_alloc(ctx, TILEDB_FILTER_BZIP2, &filter));
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(tiledb_filter_alloc(ctx, TILEDB_FILTER_BZIP2, &filter));
+  require_tiledb_ok(
       tiledb_filter_set_option(ctx, filter, TILEDB_COMPRESSION_LEVEL, &level));
-  REQUIRE_TILEDB_OK(tiledb_filter_list_add_filter(ctx, filter_list, filter));
-  REQUIRE_TILEDB_OK(tiledb_array_schema_set_dimension_label_filter_list(
+  require_tiledb_ok(tiledb_filter_list_add_filter(ctx, filter_list, filter));
+  require_tiledb_ok(tiledb_array_schema_set_dimension_label_filter_list(
       ctx, array_schema, "x", filter_list));
   tiledb_filter_free(&filter);
   tiledb_filter_list_free(&filter_list);
 
   // Check array schema and number of dimension labels.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_check(ctx, array_schema));
+  require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
   auto dim_label_num = array_schema->array_schema_->dim_label_num();
   REQUIRE(dim_label_num == 1);
 
@@ -272,41 +272,44 @@ TEST_CASE_METHOD(
 
   // Get the schema for array containing the dimension label.
   tiledb_array_schema_t* loaded_array_schema{nullptr};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_array_schema_load(ctx, array_uri.c_str(), &loaded_array_schema));
   auto dim_label_ref =
       loaded_array_schema->array_schema_->dimension_label_reference("x");
   auto dim_label_uri = dim_label_ref.uri(array_uri);
   tiledb_array_schema_t* loaded_dim_label_array_schema{nullptr};
-  REQUIRE_TILEDB_OK(tiledb_array_schema_load(
+  require_tiledb_ok(tiledb_array_schema_load(
       ctx, dim_label_uri.c_str(), &loaded_dim_label_array_schema));
   tiledb_array_schema_free(&loaded_array_schema);
 
   // Check the filter on the label attribute.
   tiledb_attribute_t* label_attr;
-  REQUIRE_TILEDB_OK(tiledb_array_schema_get_attribute_from_index(
+  require_tiledb_ok(tiledb_array_schema_get_attribute_from_index(
       ctx, loaded_dim_label_array_schema, 0, &label_attr));
   tiledb_filter_list_t* loaded_filter_list;
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_attribute_get_filter_list(ctx, label_attr, &loaded_filter_list));
   uint32_t nfilters;
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_filter_list_get_nfilters(ctx, loaded_filter_list, &nfilters));
   CHECK(nfilters == 1);
   tiledb_filter_t* loaded_filter;
-  REQUIRE_TILEDB_OK(tiledb_filter_list_get_filter_from_index(
+  require_tiledb_ok(tiledb_filter_list_get_filter_from_index(
       ctx, loaded_filter_list, 0, &loaded_filter));
   REQUIRE(loaded_filter != nullptr);
   tiledb_filter_type_t loaded_filter_type{};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_filter_get_type(ctx, loaded_filter, &loaded_filter_type));
   CHECK(loaded_filter_type == TILEDB_FILTER_BZIP2);
   int32_t loaded_level{};
-  REQUIRE_TILEDB_OK(tiledb_filter_get_option(
+  require_tiledb_ok(tiledb_filter_get_option(
       ctx, loaded_filter, TILEDB_COMPRESSION_LEVEL, &loaded_level));
   CHECK(loaded_level == level);
+  tiledb_attribute_free(&label_attr);
+  tiledb_filter_free(&loaded_filter);
+  tiledb_filter_list_free(&loaded_filter_list);
 
-  // Free remaining resources
+  // Free remaining resources.
   tiledb_array_schema_free(&loaded_dim_label_array_schema);
 }
 
@@ -340,16 +343,16 @@ TEST_CASE_METHOD(
       false);
 
   // Add dimension label.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_add_dimension_label(
+  require_tiledb_ok(tiledb_array_schema_add_dimension_label(
       ctx, array_schema, 0, "x", TILEDB_INCREASING_DATA, label_type));
 
   // Set tile.
   uint64_t tile_extent{8};
-  REQUIRE_TILEDB_OK(tiledb_array_schema_set_dimension_label_tile_extent(
+  require_tiledb_ok(tiledb_array_schema_set_dimension_label_tile_extent(
       ctx, array_schema, "x", TILEDB_UINT64, &tile_extent));
 
   // Check array schema and number of dimension labels.
-  REQUIRE_TILEDB_OK(tiledb_array_schema_check(ctx, array_schema));
+  require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
   auto dim_label_num = array_schema->array_schema_->dim_label_num();
   REQUIRE(dim_label_num == 1);
 
@@ -361,7 +364,7 @@ TEST_CASE_METHOD(
 
   // Get the URI for the dimension label array schema.
   tiledb_array_schema_t* loaded_array_schema{nullptr};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_array_schema_load(ctx, array_uri.c_str(), &loaded_array_schema));
   auto dim_label_ref =
       loaded_array_schema->array_schema_->dimension_label_reference("x");
@@ -369,7 +372,7 @@ TEST_CASE_METHOD(
 
   // Open the dimension label array schema and check the tile extent.
   tiledb_array_schema_t* loaded_dim_label_array_schema{nullptr};
-  REQUIRE_TILEDB_OK(tiledb_array_schema_load(
+  require_tiledb_ok(tiledb_array_schema_load(
       ctx, dim_label_uri.c_str(), &loaded_dim_label_array_schema));
   uint64_t loaded_tile_extent{
       loaded_dim_label_array_schema->array_schema_->dimension_ptr(0)
@@ -390,34 +393,34 @@ TEST_CASE_METHOD(
 
   // Create array and subarray.
   tiledb_array_t* array;
-  REQUIRE_TILEDB_OK(tiledb_array_alloc(ctx, array_name.c_str(), &array));
-  REQUIRE_TILEDB_OK(tiledb_array_open(ctx, array, TILEDB_READ));
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
   tiledb_subarray_t* subarray;
-  REQUIRE_TILEDB_OK(tiledb_subarray_alloc(ctx, array, &subarray));
+  require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
 
   // Check label range num is zero for all labels.
   uint64_t range_num{0};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "x", &range_num));
   CHECK(range_num == 0);
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "id", &range_num));
   CHECK(range_num == 0);
 
   // Add fixed ranges
   double r1[2]{-1.0, 1.0};
-  REQUIRE_TILEDB_OK(tiledb_subarray_add_label_range(
+  require_tiledb_ok(tiledb_subarray_add_label_range(
       ctx, subarray, "x", &r1[0], &r1[1], nullptr));
   // Check no regular ranges set.
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_range_num(ctx, subarray, 0, &range_num));
   CHECK(range_num == 0);
   // Check 1 label range set by name.
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "x", &range_num));
   CHECK(range_num == 1);
   // Check 0 label range set by name to other label on dim.
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "id", &range_num));
   CHECK(range_num == 0);
 
@@ -425,7 +428,7 @@ TEST_CASE_METHOD(
   const void* r1_start{};
   const void* r1_end{};
   const void* r1_stride{};
-  REQUIRE_TILEDB_OK(tiledb_subarray_get_label_range(
+  require_tiledb_ok(tiledb_subarray_get_label_range(
       ctx, subarray, "x", 0, &r1_start, &r1_end, &r1_stride));
   CHECK(r1_stride == nullptr);
   CHECK(*static_cast<const double*>(r1_start) == r1[0]);
@@ -443,6 +446,10 @@ TEST_CASE_METHOD(
   rc = tiledb_subarray_add_label_range_var(
       ctx, subarray, "id", start.data(), start.size(), end.data(), end.size());
   CHECK(rc != TILEDB_OK);
+
+  // Free resources.
+  tiledb_array_free(&array);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -453,46 +460,46 @@ TEST_CASE_METHOD(
 
   // Create array and subarray.
   tiledb_array_t* array;
-  REQUIRE_TILEDB_OK(tiledb_array_alloc(ctx, array_name.c_str(), &array));
-  REQUIRE_TILEDB_OK(tiledb_array_open(ctx, array, TILEDB_READ));
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
   tiledb_subarray_t* subarray;
-  REQUIRE_TILEDB_OK(tiledb_subarray_alloc(ctx, array, &subarray));
+  require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
 
   // Check label range num is zero for all labels.
   uint64_t range_num{0};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "x", &range_num));
   CHECK(range_num == 0);
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "id", &range_num));
   CHECK(range_num == 0);
 
   // Set range.
   std::string start{"alpha"};
   std::string end{"beta"};
-  REQUIRE_TILEDB_OK(tiledb_subarray_add_label_range_var(
+  require_tiledb_ok(tiledb_subarray_add_label_range_var(
       ctx, subarray, "id", start.data(), start.size(), end.data(), end.size()));
   // Check no regular ranges set.
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_range_num(ctx, subarray, 0, &range_num));
   CHECK(range_num == 0);
   // Check 1 label range set by name.
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "id", &range_num));
   CHECK(range_num == 1);
   // Check 0 label range set by name to other label on dim.
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "x", &range_num));
   CHECK(range_num == 0);
 
   // Check getting the range back from the subarray.
   uint64_t start_size{0};
   uint64_t end_size{0};
-  REQUIRE_TILEDB_OK(tiledb_subarray_get_label_range_var_size(
+  require_tiledb_ok(tiledb_subarray_get_label_range_var_size(
       ctx, subarray, "id", 0, &start_size, &end_size));
   std::vector<char> start_data(start_size);
   std::vector<char> end_data(end_size);
-  REQUIRE_TILEDB_OK(tiledb_subarray_get_label_range_var(
+  require_tiledb_ok(tiledb_subarray_get_label_range_var(
       ctx, subarray, "id", 0, start_data.data(), end_data.data()));
   CHECK(std::string(start_data.data(), start_data.size()) == start);
   CHECK(std::string(end_data.data(), end_data.size()) == end);
@@ -508,6 +515,10 @@ TEST_CASE_METHOD(
   rc = tiledb_subarray_add_label_range(
       ctx, subarray, "x", &r1[0], &r1[1], nullptr);
   CHECK(rc != TILEDB_OK);
+
+  // Free resources.
+  tiledb_subarray_free(&subarray);
+  tiledb_array_free(&array);
 }
 
 TEST_CASE_METHOD(
@@ -518,17 +529,17 @@ TEST_CASE_METHOD(
 
   // Create array and subarray.
   tiledb_array_t* array;
-  REQUIRE_TILEDB_OK(tiledb_array_alloc(ctx, array_name.c_str(), &array));
-  REQUIRE_TILEDB_OK(tiledb_array_open(ctx, array, TILEDB_READ));
+  require_tiledb_ok(tiledb_array_alloc(ctx, array_name.c_str(), &array));
+  require_tiledb_ok(tiledb_array_open(ctx, array, TILEDB_READ));
   tiledb_subarray_t* subarray;
-  REQUIRE_TILEDB_OK(tiledb_subarray_alloc(ctx, array, &subarray));
+  require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
 
   // Check label range num is zero for all labels.
   uint64_t range_num{0};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "x", &range_num));
   CHECK(range_num == 0);
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "id", &range_num));
   CHECK(range_num == 0);
 
@@ -552,7 +563,7 @@ TEST_CASE_METHOD(
   // Check cannot add dimension label range to dimension with standard ranges
   // explicitly set
   uint64_t r1[2]{1, 10};
-  REQUIRE_TILEDB_OK(
+  require_tiledb_ok(
       tiledb_subarray_add_range(ctx, subarray, 0, &r1[0], &r1[1], nullptr));
   // Check cannot set dimension range to another label on same dimension
   double r2[2]{-1.0, 1.0};

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -66,31 +66,6 @@ extern std::mutex catch2_macro_mutex;
     REQUIRE(a);                                           \
   }
 
-// A variant of the CHECK macro for checking C API return value equals
-// TILEDB_OK.
-#define CHECK_TILEDB_OK(a) \
-  { CHECK(a == TILEDB_OK); }
-
-// A variant of the REQUIRE macro for checking C API return value equals
-// TILEDB_OK.
-#define REQUIRE_TILEDB_OK(a) \
-  { REQUIRE(a == TILEDB_OK); }
-
-// A variant of the CHECK macro for checking a Status object is okay.
-#define CHECK_TILEDB_STATUS_OK(status)   \
-  {                                      \
-    if (!status.ok())                    \
-      UNSCOPED_INFO(status.to_string()); \
-    CHECK(status.ok());                  \
-  }
-
-// A variant of the REQUIRE macro for checking a Status objects is okay.
-#define REQUIRE_TILEDB_STATUS_OK(status) \
-  {                                      \
-    if (!status.ok())                    \
-      UNSCOPED_INFO(status.to_string()); \
-    REQUIRE(status.ok());                \
-  }
 namespace tiledb {
 
 namespace sm {

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -366,6 +366,7 @@ void TemporaryDirectoryFixture::check_tiledb_ok(int rc) const {
     const char* msg;
     tiledb_error_message(err, &msg);
     UNSCOPED_INFO(msg);
+    tiledb_error_free(&err);
   }
   CHECK(rc == TILEDB_OK);
 }
@@ -377,8 +378,29 @@ void TemporaryDirectoryFixture::require_tiledb_ok(int rc) const {
     const char* msg;
     tiledb_error_message(err, &msg);
     UNSCOPED_INFO(msg);
+    tiledb_error_free(&err);
   }
   REQUIRE(rc == TILEDB_OK);
+}
+
+void TemporaryDirectoryFixture::require_tiledb_error_with(
+    int rc, const std::string& expected_msg) const {
+  REQUIRE(rc == TILEDB_ERR);
+  tiledb_error_t* err{nullptr};
+  tiledb_ctx_get_last_error(ctx, &err);
+  if (err == nullptr) {
+    INFO("No message returned. Expected message: " + expected_msg);
+    REQUIRE(false);
+  }
+  const char* raw_msg;
+  tiledb_error_message(err, &raw_msg);
+  if (raw_msg == nullptr) {
+    INFO("No message returned. Expected message: " + expected_msg);
+    REQUIRE(false);
+  }
+  std::string err_msg{raw_msg};
+  REQUIRE(err_msg == expected_msg);
+  tiledb_error_free(&err);
 }
 
 }  // End of namespace test

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -359,7 +359,7 @@ std::string SupportedFsMem::temp_dir() {
   return temp_dir_;
 }
 
-void TemporaryDirectoryFixture::check_tiledb_ok(int rc) {
+void TemporaryDirectoryFixture::check_tiledb_ok(int rc) const {
   if (rc != TILEDB_OK) {
     tiledb_error_t* err = NULL;
     tiledb_ctx_get_last_error(ctx, &err);
@@ -370,7 +370,7 @@ void TemporaryDirectoryFixture::check_tiledb_ok(int rc) {
   CHECK(rc == TILEDB_OK);
 }
 
-void TemporaryDirectoryFixture::require_tiledb_ok(int rc) {
+void TemporaryDirectoryFixture::require_tiledb_ok(int rc) const {
   if (rc != TILEDB_OK) {
     tiledb_error_t* err = NULL;
     tiledb_ctx_get_last_error(ctx, &err);

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -620,6 +620,16 @@ struct TemporaryDirectoryFixture {
    */
   void require_tiledb_ok(int rc) const;
 
+  /**
+   * Require the return code for a TileDB C-API function is TILEDB_ERR and
+   * compare the last error message from the local TileDB context to an expected
+   * error message.
+   *
+   * @param rc Return code from a TileDB C-API function.
+   * @param expected_msg The expected message from the last error.
+   */
+  void require_tiledb_error_with(int rc, const std::string& expected_msg) const;
+
  protected:
   /** TileDB context */
   tiledb_ctx_t* ctx;

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -589,8 +589,8 @@ struct TemporaryDirectoryFixture {
   std::string create_temporary_array(
       std::string&& name, tiledb_array_schema_t* array_schema) {
     auto array_uri = fullpath(std::move(name));
-    REQUIRE_TILEDB_OK(tiledb_array_schema_check(ctx, array_schema));
-    REQUIRE_TILEDB_OK(
+    require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
+    require_tiledb_ok(
         tiledb_array_create(ctx, array_uri.c_str(), array_schema));
     return array_uri;
   };
@@ -602,7 +602,14 @@ struct TemporaryDirectoryFixture {
    *
    * @param rc Return code from a TileDB C-API function.
    */
-  void check_tiledb_ok(int rc);
+  void check_tiledb_ok(int rc) const;
+
+  /**
+   * Returns the context pointer object.
+   */
+  inline tiledb_ctx_t* get_ctx() {
+    return ctx;
+  }
 
   /**
    * Requires the return code for a TileDB C-API function is TILEDB_OK. If not,
@@ -611,7 +618,7 @@ struct TemporaryDirectoryFixture {
    *
    * @param rc Return code from a TileDB C-API function.
    */
-  void require_tiledb_ok(int rc);
+  void require_tiledb_ok(int rc) const;
 
  protected:
   /** TileDB context */

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -461,10 +461,7 @@ Status ArraySchema::check() const {
   // Check for ordered attributes on sparse arrays and arrays with more than one
   // dimension.
   if (array_type_ == ArrayType::SPARSE || this->dim_num() != 1) {
-    if (std::any_of(
-            attributes_.cbegin(), attributes_.cend(), [](const auto& attr) {
-              return attr->order() != DataOrder::UNORDERED_DATA;
-            })) {
+    if (has_ordered_attributes()) {
       throw ArraySchemaStatusException(
           "Array schema check failed; Ordered attributes are only supported on "
           "dense arrays with 1 dimension.");
@@ -702,6 +699,13 @@ Status ArraySchema::has_attribute(
   }
 
   return Status::Ok();
+}
+
+bool ArraySchema::has_ordered_attributes() const {
+  return std::any_of(
+      attributes_.cbegin(), attributes_.cend(), [](const auto& attr) {
+        return attr->order() != DataOrder::UNORDERED_DATA;
+      });
 }
 
 bool ArraySchema::is_attr(const std::string& name) const {

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -286,6 +286,8 @@ class ArraySchema {
    */
   Status has_attribute(const std::string& name, bool* has_attr) const;
 
+  bool has_ordered_attributes() const;
+
   /** Returns true if the input name is an attribute. */
   bool is_attr(const std::string& name) const;
 

--- a/tiledb/sm/array_schema/test/unit_array_schema.cc
+++ b/tiledb/sm/array_schema/test/unit_array_schema.cc
@@ -237,3 +237,28 @@ TEST_CASE(
       zref.uri().to_string() ==
       constants::array_dimension_labels_dir_name + "/l2");
 }
+
+TEST_CASE(
+    "Test ArraySchema::has_ordered_attributes with no ordered attributes"
+    "[array_schema]") {
+  std::vector<shared_ptr<Dimension>> dims{
+      test::make_dimension<uint64_t>("x", Datatype::UINT64, 1, 0, 15, 16)};
+  std::vector<shared_ptr<Attribute>> attrs{
+      test::make_attribute<float>("a", Datatype::UINT64, false, 1, 0),
+      test::make_attribute<float>("b", Datatype::FLOAT64, false, 1, 0)};
+  auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
+  REQUIRE(!schema->has_ordered_attributes());
+}
+
+TEST_CASE(
+    "Test ArraySchema::has_ordered_attributes with ordered attributes"
+    "[array_schema]") {
+  std::vector<shared_ptr<Dimension>> dims{
+      test::make_dimension<uint64_t>("x", Datatype::UINT64, 1, 0, 15, 16)};
+  std::vector<shared_ptr<Attribute>> attrs{
+      test::make_attribute<float>("a", Datatype::UINT64, false, 1, 0),
+      make_shared<Attribute>(
+          HERE(), "b", Datatype::FLOAT64, 1, DataOrder::INCREASING_DATA)};
+  auto schema = test::make_array_schema(ArrayType::DENSE, dims, attrs);
+  REQUIRE(schema->has_ordered_attributes());
+}

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -51,14 +51,12 @@ namespace tiledb::sm {
 
 ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
     StorageManager* storage_manager,
-    stats::Stats* stats,
     Array* array,
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
     const std::unordered_map<std::string, QueryBuffer>& array_buffers,
     const optional<std::string>& fragment_name)
     : storage_manager_(storage_manager)
-    , stats_(stats)
     , label_range_queries_by_dim_idx_(subarray.dim_num(), nullptr)
     , label_data_queries_by_dim_idx_(subarray.dim_num())
     , range_query_status_{QueryStatus::UNINITIALIZED}
@@ -263,7 +261,6 @@ void ArrayDimensionLabelQueries::add_read_queries(
       data_queries_.emplace_back(tdb_new(
           DimensionLabelQuery,
           storage_manager_,
-          stats_->create_child("DimensionLabelQuery"),
           dim_label,
           dim_label_ref,
           subarray,
@@ -315,7 +312,6 @@ void ArrayDimensionLabelQueries::add_write_queries(
       data_queries_.emplace_back(tdb_new(
           DimensionLabelQuery,
           storage_manager_,
-          stats_->create_child("DimensionLabelQuery"),
           dim_label,
           dim_label_ref,
           subarray,

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -36,7 +36,6 @@
 #include "tiledb/common/common.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/query/dimension_label/dimension_label_query.h"
-#include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
 #include <unordered_map>
@@ -79,7 +78,6 @@ class ArrayDimensionLabelQueries {
    */
   ArrayDimensionLabelQueries(
       StorageManager* storage_manager,
-      stats::Stats* stats,
       Array* array,
       const Subarray& subarray,
       const std::unordered_map<std::string, QueryBuffer>& label_buffers,
@@ -132,9 +130,6 @@ class ArrayDimensionLabelQueries {
  private:
   /** The storage manager. */
   StorageManager* storage_manager_;
-
-  /** Class stats object for timing. */
-  stats::Stats* stats_;
 
   /** Map from label name to dimension label opened by this query. */
   std::unordered_map<std::string, shared_ptr<Array>> dimension_labels_;

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -67,7 +67,6 @@ class DimensionLabelQuery : public Query {
    * Constructor for queries to read or write label data.
    *
    * @param storage_manager Storage manager object.
-   * @param stats Stats object for the dimension label query.
    * @param dim_label Opened dimension label for the query.
    * @param dim_label_ref Description of the dimension label.
    * @param parent_subarray Subarray of the parent array.
@@ -78,7 +77,6 @@ class DimensionLabelQuery : public Query {
    */
   DimensionLabelQuery(
       StorageManager* storage_manager,
-      stats::Stats* stats,
       shared_ptr<Array> dim_label,
       const DimensionLabelReference& dim_label_ref,
       const Subarray& parent_subarray,
@@ -150,7 +148,6 @@ class DimensionLabelQuery : public Query {
    *
    * This should only be called inside constructors.
    *
-   * @param stats Statistics object for performing timing.
    * @param dim_label_schema Array schema for the opened dimension label.
    * @param parent_subarray Subarray of the parent array.
    * @param label_attr_name Name of the attribute storing label data.
@@ -161,7 +158,6 @@ class DimensionLabelQuery : public Query {
    *     label is for.
    */
   void initialize_ordered_write_query(
-      stats::Stats* stats,
       const Subarray& parent_subarray,
       const std::string& label_attr_name,
       const QueryBuffer& label_buffer,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -990,7 +990,6 @@ Status Query::init() {
       dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
           ArrayDimensionLabelQueries,
           storage_manager_,
-          stats_->create_child("ArrayDimensionLabelQueries"),
           array_,
           subarray_,
           label_buffers_,

--- a/tiledb/sm/query/query_buffer.h
+++ b/tiledb/sm/query/query_buffer.h
@@ -287,7 +287,7 @@ class QueryBuffer {
     for (uint64_t index{0}; index < num_offset_values - 1; ++index) {
       uint64_t i0 = offsets[index];
       uint64_t i1 = offsets[index + 1];
-      uint64_t i2 = index + 1 < num_offset_values ? offsets[index + 2] :
+      uint64_t i2 = index + 2 < num_offset_values ? offsets[index + 2] :
                                                     last_offset_value;
       if (compare(
               std::string_view(&data[i1], i2 - i1),

--- a/tiledb/sm/query/query_buffer.h
+++ b/tiledb/sm/query/query_buffer.h
@@ -280,15 +280,15 @@ class QueryBuffer {
     auto offsets = offsets_buffer();
     auto data = data_buffer_as<char>();
     uint64_t num_offset_values = *buffer_size_ / sizeof(uint64_t);
-    uint64_t num_data_values = *buffer_var_size_ / sizeof(char);
+    uint64_t last_offset_value = *buffer_var_size_ / sizeof(char);
 
     // Check the sort.
     Op compare;
     for (uint64_t index{0}; index < num_offset_values - 1; ++index) {
       uint64_t i0 = offsets[index];
       uint64_t i1 = offsets[index + 1];
-      uint64_t i2 =
-          index + 1 < num_offset_values ? offsets[index + 2] : num_data_values;
+      uint64_t i2 = index + 1 < num_offset_values ? offsets[index + 2] :
+                                                    last_offset_value;
       if (compare(
               std::string_view(&data[i1], i2 - i1),
               std::string_view(&data[i0], i1 - i0))) {

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -107,10 +107,18 @@ GlobalOrderWriter::GlobalOrderWriter(
     , processed_conditions_(processed_conditions)
     , fragment_size_(fragment_size)
     , current_fragment_size_(0) {
+  // Check the layout is global order.
   if (layout != Layout::GLOBAL_ORDER) {
     throw GlobalOrderWriterStatusException(
         "Failed to initialize global order writer. Layout " +
         layout_str(layout) + " is not global order.");
+  }
+
+  // Check no ordered attributes.
+  if (array_schema_.has_ordered_attributes()) {
+    throw GlobalOrderWriterStatusException(
+        "Failed to initialize global order writer. Global order writes to "
+        "ordered attributes are not yet supported.");
   }
 }
 
@@ -125,8 +133,6 @@ Status GlobalOrderWriter::dowork() {
   get_dim_attr_stats();
 
   auto timer_se = stats_->start_timer("write");
-
-  check_attr_order();
 
   // In case the user has provided a coordinates buffer
   RETURN_NOT_OK(split_coords_buffer());

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -126,6 +126,8 @@ Status GlobalOrderWriter::dowork() {
 
   auto timer_se = stats_->start_timer("write");
 
+  check_attr_order();
+
   // In case the user has provided a coordinates buffer
   RETURN_NOT_OK(split_coords_buffer());
 

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -121,6 +121,8 @@ Status OrderedWriter::dowork() {
 
   auto timer_se = stats_->start_timer("write");
 
+  check_attr_order();
+
   // In case the user has provided a coordinates buffer
   RETURN_NOT_OK(split_coords_buffer());
 

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -223,7 +223,15 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    */
   void check_var_attr_offsets() const;
 
-  /** Throws an error if data is not sorted on an ordered attribute. */
+  /**
+   * Throws an error if ordered data buffers do not have the expected sort.
+   *
+   * This method only checks currently loaded data. It does not check the
+   * sort of data in subsequent writes for the global order writer.
+   *
+   * For unordered writes, this method will need to be modified to take into
+   * account the sort order.
+   */
   void check_attr_order() const;
 
   /**

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -223,6 +223,9 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    */
   void check_var_attr_offsets() const;
 
+  /** Throws an error if data is not sorted on an ordered attribute. */
+  void check_attr_order() const;
+
   /**
    * Cleans up the coordinate buffers. Applicable only if the coordinate
    * buffers were allocated by TileDB (not the user)


### PR DESCRIPTION
Move check that the provided data for a write on an attribute from dimension (special case) to the writer base (general case). This will make it safe for a user to write directly to a dimension label using the array API.

---
TYPE: IMPROVEMENT
DESC: Move attribute order check to writer base