### PR TITLE
[Backport release-2.12] Sparse globalorder reader: prevent unused tiles from being loaded again.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -767,7 +767,10 @@ bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
         if (rc.same_coords(rc2)) {
           // Remove the current tile if not used.
           if (!rc.tile_->used()) {
-            remove_result_tile(frag_idx, result_tiles_it[frag_idx]);
+            ignored_tiles_.emplace(
+                frag_idx, result_tiles_it[frag_idx]->tile_idx());
+            throw_if_not_ok(
+                remove_result_tile(frag_idx, result_tiles_it[frag_idx]));
           }
 
           result_tiles_it[frag_idx] = next_tile;
@@ -804,7 +807,8 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
 
     // Remove the tile from result tiles if it wasn't used at all.
     if (!rc.tile_->used()) {
-      remove_result_tile(frag_idx, to_delete);
+      ignored_tiles_.emplace(frag_idx, to_delete->tile_idx());
+      throw_if_not_ok(remove_result_tile(frag_idx, to_delete));
     }
 
     // Try to find a new tile.


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/c16a38af2836b1eb361786c1b636bcc3115b3345 from https://github.com/TileDB-Inc/TileDB/pull/3710

---
TYPE: NO_HISTORY
