### PR TITLE
Let ConsolidationPlan::dump() produce valid JSON

### DIFF
--- a/tiledb/sm/consolidation_plan/consolidation_plan.cc
+++ b/tiledb/sm/consolidation_plan/consolidation_plan.cc
@@ -61,7 +61,7 @@ std::string ConsolidationPlan::dump() const {
     for (uint64_t u = 0; u < node.size(); u++) {
       auto uri = node[u];
       ret += "        {\n";
-      ret += "           \"uri\" : " + uri + "\n";
+      ret += "           \"uri\" : \"" + uri + "\"\n";
       if (u != node.size() - 1) {
         ret += "        },\n";
       } else {


### PR DESCRIPTION
One of the beautiful things about the consolidation planner is that it opens the door to distributed consolidation: one node can prepare the plan, then distribute it to a number of workers.

The distribution part will be facilitated if we can have the C++ planner dump out valid JSON which a Python (or whatever) delegator script can parse and delegate the work to other nodes.

To test: just run `consolidation_plan.dump()` output through `jq .` at the shell.

---
TYPE: BUG
DESC: Let ConsolidationPlan::dump() produce valid JSON
