### PR TITLE
Fix exceptions thrown during webp schema validation

### DIFF
--- a/format_spec/filters/webp.md
+++ b/format_spec/filters/webp.md
@@ -4,6 +4,9 @@ title: WEBP Filter
 
 The WebP filter compresses image data using [libwebp](https://developers.google.com/speed/webp/docs/api#headers_and_libraries). The current input formats supported are `RGB`, `RGBA`, `BGR`, and `BGRA`. The colorspace format can be configured for this filter by setting the `TILEDB_WEBP_INPUT_FORMAT` filter option. Tile-based compression is determined by dimension extents. Extents equal to dimension bounds will compress the image in one pass.
 
+For attributes, the WebP filter supports only the uint8_t data type.
+Dimension data types can be any two matching integral types, such as `{uint32_t, uint32_t}` or `{int64_t, int64_t}` for example.
+
 ```
 # Data from 2x3 pixel image
 input = [[255,62,83, 149,43,67, 138,43,67]
@@ -25,7 +28,7 @@ Using the figure above from [WebP API documentation](https://developers.google.c
 The pixel `width` of the image is internally calculated based on colorspace format and tile extents.
 
 Tile extents are used to configure tile-based compression. We should note that the [maximum WebP image size](https://developers.google.com/speed/webp/faq#what_is_the_maximum_size_a_webp_image_can_be) is 16383x16383.
-Because of this, our extents can not exceed `16383` for dimension 0, and `16383 * pixel_depth` for dimension 0.
+Because of this, our extents can not exceed `16383` for dimension 0, and `16383 * pixel_depth` for dimension 1.
 `pixel_depth` is defined by our colorspace format selection. `RGB` and `BGR` images have a depth of 3, while `RGBA` and `BGRA` have a depth of 4 for the additional alpha value provided for each pixel.
 
 

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -448,8 +448,9 @@ Status ArraySchema::check() const {
   }
 
   if (array_type_ == ArrayType::SPARSE && capacity_ == 0) {
-    throw ArraySchemaStatusException("Array schema check failed; Sparse arrays "
-                                "cannot have their capacity equal to zero.");
+    throw ArraySchemaStatusException(
+        "Array schema check failed; Sparse arrays "
+        "cannot have their capacity equal to zero.");
   }
 
   RETURN_NOT_OK(check_double_delta_compressor(coords_filters()));

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -360,7 +360,7 @@ void ArraySchema::check_webp_filter() const {
       if (webp != nullptr) {
         // WebP attributes must be of type uint8_t.
         if (attr->type() != Datatype::UINT8) {
-          throw Status_ArraySchemaError(
+          throw ArraySchemaStatusException(
               "WebP filter supports only uint8 attributes");
         }
       }
@@ -370,19 +370,19 @@ void ArraySchema::check_webp_filter() const {
       return;
     }
     if (array_type_ != ArrayType::DENSE) {
-      throw Status_ArraySchemaError(
+      throw ArraySchemaStatusException(
           "WebP filter can only be applied to dense arrays");
     }
 
     // WebP filter requires at least 2 dimensions for Y, X.
     if (dim_map_.size() < 2) {
-      throw Status_ArraySchemaError(
+      throw ArraySchemaStatusException(
           "WebP filter requires at least 2 dimensions");
     }
     auto y_dim = dimension_ptr(0);
     auto x_dim = dimension_ptr(1);
     if (y_dim->type() != x_dim->type()) {
-      throw Status_ArraySchemaError(
+      throw ArraySchemaStatusException(
           "WebP filter dimensions 0, 1 should have matching integral types");
     }
 
@@ -412,7 +412,7 @@ void ArraySchema::check_webp_filter() const {
         webp->set_extents<uint64_t>(domain_->tile_extents());
         break;
       default:
-        throw Status_ArraySchemaError(
+        throw ArraySchemaStatusException(
             "WebP filter requires integral dimensions at index 0, 1");
     }
   }
@@ -448,9 +448,8 @@ Status ArraySchema::check() const {
   }
 
   if (array_type_ == ArrayType::SPARSE && capacity_ == 0) {
-    throw LOG_STATUS(
-        Status_ArraySchemaError("Array schema check failed; Sparse arrays "
-                                "cannot have their capacity equal to zero."));
+    throw ArraySchemaStatusException("Array schema check failed; Sparse arrays "
+                                "cannot have their capacity equal to zero.");
   }
 
   RETURN_NOT_OK(check_double_delta_compressor(coords_filters()));

--- a/tiledb/sm/filter/webp_filter.h
+++ b/tiledb/sm/filter/webp_filter.h
@@ -84,7 +84,10 @@ enum class WebpInputFormat : uint8_t;
  *
  * This filter expects the array to provide two dimensions for Y, X pixel
  * position. Dimensions may be defined with any name, but Y, X should be at
- * dimension index 0, 1 respectively.
+ * dimension index 0, 1 respectively. Dimension data types must use matching
+ * integral types.
+ *
+ * The WebP filter supports attribute data types of uint8 only.
  */
 class WebpFilter : public Filter {
  public:


### PR DESCRIPTION
Exceptions were being thrown with `Status_ArraySchemaError` instead of `ArraySchemaStatusException`. The former was reporting exceptions as ` unknown exception type; no further information`. I tested invalid schemas using the WebP filter against this branch in core and python and exception messages are correct. 

I also updated some of the docs around WebP to explain the data type restriction for attributes and dimensions, and will do the same for docs in TileDB-Py.

---
TYPE: BUG
DESC: Fix exceptions thrown during array schema validation for WebP filter.
