### PR TITLE
Fix grouping of FIND_FILES arg to 'find' command

### DIFF
--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -36,10 +36,10 @@ SOURCE_PATHS=($src/tiledb $src/test $src/examples $src/tools $src/experimental)
 FIND_FILES=(-name "*.cc" -or -name "*.c" -or -name "*.h")
 
 if [ "$APPLY_FIXES" == "1" ]; then
-  find "${SOURCE_PATHS[@]}" "${FIND_FILES[@]}" -print0 | xargs -0 -P8 $CLANG_FORMAT -i
+  find "${SOURCE_PATHS[@]}" \( "${FIND_FILES[@]}" \) -print0 | xargs -0 -P8 $CLANG_FORMAT -i
 
 else
-  NUM_CORRECTIONS=`find "${SOURCE_PATHS[@]}" "${FIND_FILES[@]}" -print0 | xargs -0 -P8 $CLANG_FORMAT -output-replacements-xml | grep offset | wc -l`
+  NUM_CORRECTIONS=`find "${SOURCE_PATHS[@]}" \( "${FIND_FILES[@]}" \) -print0 | xargs -0 -P8 $CLANG_FORMAT -output-replacements-xml | grep offset | wc -l`
 
   if [ "$NUM_CORRECTIONS" -gt "0" ]; then
     echo "clang-format suggested changes, please run 'make format'!!!!"

--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -326,20 +326,19 @@ TEST_CASE(
           Catch::Matchers::Equals(std::vector<uint8_t>{0, 1, 0, 0}));
       CHECK_THAT(
           d_data,
-          Catch::Matchers::Equals(std::vector<char>{
-              't',
-              'e',
-              's',
-              't',
-              'd',
-              't',
-              'e',
-              's',
-              't',
-              't',
-              'e',
-              's',
-              't'}));
+          Catch::Matchers::Equals(std::vector<char>{'t',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    'd',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't'}));
       CHECK_THAT(
           d_offsets,
           Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 5, 9}));
@@ -368,20 +367,19 @@ TEST_CASE(
           Catch::Matchers::Equals(std::vector<uint8_t>{0, 0, 0, 1}));
       CHECK_THAT(
           d_data,
-          Catch::Matchers::Equals(std::vector<char>{
-              't',
-              'e',
-              's',
-              't',
-              't',
-              'e',
-              's',
-              't',
-              't',
-              'e',
-              's',
-              't',
-              'd'}));
+          Catch::Matchers::Equals(std::vector<char>{'t',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    't',
+                                                    'e',
+                                                    's',
+                                                    't',
+                                                    'd'}));
       CHECK_THAT(
           d_offsets,
           Catch::Matchers::Equals(std::vector<uint64_t>{0, 4, 8, 12}));
@@ -585,23 +583,22 @@ TEST_CASE(
               0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 49, 50, 51}));
       CHECK_THAT(
           e_data,
-          Catch::Matchers::Equals(std::vector<char>{
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'n',
-              'e',
-              'e',
-              'e',
-              'e'}));
+          Catch::Matchers::Equals(std::vector<char>{'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'n',
+                                                    'e',
+                                                    'e',
+                                                    'e',
+                                                    'e'}));
       CHECK_THAT(
           e_offsets,
           Catch::Matchers::Equals(std::vector<uint64_t>{
@@ -742,12 +739,7 @@ TEST_CASE(
     //       in order to reproduce SC-23671.
     int value = 4;
     QueryCondition query_condition(ctx);
-    query_condition.init(
-      "b",
-      &value,
-      sizeof(value),
-      TILEDB_EQ
-    );
+    query_condition.init("b", &value, sizeof(value), TILEDB_EQ);
 
     // Prepare the query
     Query query(ctx, array, TILEDB_READ);
@@ -770,14 +762,10 @@ TEST_CASE(
     b_data.resize(result_num);
     d1_data.resize(result_num);
     d2_data.resize(result_num);
-    CHECK_THAT(a_data,
-               Catch::Matchers::Equals(std::vector<int>{4}));
-    CHECK_THAT(b_data,
-               Catch::Matchers::Equals(std::vector<uint32_t>{4}));
-    CHECK_THAT(d1_data,
-               Catch::Matchers::Equals(std::vector<int>{4}));
-    CHECK_THAT(d2_data,
-               Catch::Matchers::Equals(std::vector<int>{1}));
+    CHECK_THAT(a_data, Catch::Matchers::Equals(std::vector<int>{4}));
+    CHECK_THAT(b_data, Catch::Matchers::Equals(std::vector<uint32_t>{4}));
+    CHECK_THAT(d1_data, Catch::Matchers::Equals(std::vector<int>{4}));
+    CHECK_THAT(d2_data, Catch::Matchers::Equals(std::vector<int>{1}));
   }
 
   // Cleanup.

--- a/tiledb/api/c_api/buffer/buffer_api.cc
+++ b/tiledb/api/c_api/buffer/buffer_api.cc
@@ -50,13 +50,15 @@ void tiledb_buffer_free(tiledb_buffer_handle_t** buffer) {
   tiledb_buffer_handle_t::break_handle(*buffer);
 }
 
-capi_return_t tiledb_buffer_set_type(tiledb_buffer_handle_t* buffer, tiledb_datatype_t datatype) {
+capi_return_t tiledb_buffer_set_type(
+    tiledb_buffer_handle_t* buffer, tiledb_datatype_t datatype) {
   ensure_buffer_is_valid(buffer);
   buffer->set_datatype(static_cast<tiledb::sm::Datatype>(datatype));
   return TILEDB_OK;
 }
 
-capi_return_t tiledb_buffer_get_type(const tiledb_buffer_handle_t* buffer, tiledb_datatype_t* datatype) {
+capi_return_t tiledb_buffer_get_type(
+    const tiledb_buffer_handle_t* buffer, tiledb_datatype_t* datatype) {
   ensure_buffer_is_valid(buffer);
   ensure_output_pointer_is_valid(datatype);
   *datatype = static_cast<tiledb_datatype_t>(buffer->datatype());
@@ -64,10 +66,7 @@ capi_return_t tiledb_buffer_get_type(const tiledb_buffer_handle_t* buffer, tiled
 }
 
 capi_return_t tiledb_buffer_get_data(
-  const tiledb_buffer_t* buffer,
-  void** data,
-  uint64_t* num_bytes) {
-
+    const tiledb_buffer_t* buffer, void** data, uint64_t* num_bytes) {
   ensure_buffer_is_valid(buffer);
   ensure_output_pointer_is_valid(data);
   ensure_output_pointer_is_valid(num_bytes);
@@ -78,7 +77,8 @@ capi_return_t tiledb_buffer_get_data(
   return TILEDB_OK;
 }
 
-capi_return_t tiledb_buffer_set_data(tiledb_buffer_t* buffer, void* data, uint64_t size) {
+capi_return_t tiledb_buffer_set_data(
+    tiledb_buffer_t* buffer, void* data, uint64_t size) {
   ensure_buffer_is_valid(buffer);
 
   // Create a temporary Buffer object as a wrapper.
@@ -93,13 +93,13 @@ capi_return_t tiledb_buffer_set_data(tiledb_buffer_t* buffer, void* data, uint64
   return TILEDB_OK;
 }
 
-} // namespace tiledb::api
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
 capi_return_t tiledb_buffer_alloc(
-  tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) noexcept {
+    tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) noexcept {
   return api_entry_context<tiledb::api::tiledb_buffer_alloc>(ctx, buffer);
 }
 
@@ -108,30 +108,32 @@ void tiledb_buffer_free(tiledb_buffer_t** buffer) noexcept {
 }
 
 capi_return_t tiledb_buffer_set_type(
-  tiledb_ctx_t* ctx,
-  tiledb_buffer_t* buffer,
-  tiledb_datatype_t datatype) noexcept {
-  return api_entry_context<tiledb::api::tiledb_buffer_set_type>(ctx, buffer, datatype);
+    tiledb_ctx_t* ctx,
+    tiledb_buffer_t* buffer,
+    tiledb_datatype_t datatype) noexcept {
+  return api_entry_context<tiledb::api::tiledb_buffer_set_type>(
+      ctx, buffer, datatype);
 }
 
 capi_return_t tiledb_buffer_get_type(
-  tiledb_ctx_t* ctx,
-  const tiledb_buffer_t* buffer,
-  tiledb_datatype_t* datatype) noexcept {
-  return api_entry_context<tiledb::api::tiledb_buffer_get_type>(ctx, buffer, datatype);
+    tiledb_ctx_t* ctx,
+    const tiledb_buffer_t* buffer,
+    tiledb_datatype_t* datatype) noexcept {
+  return api_entry_context<tiledb::api::tiledb_buffer_get_type>(
+      ctx, buffer, datatype);
 }
 
 capi_return_t tiledb_buffer_get_data(
-  tiledb_ctx_t* ctx,
-  const tiledb_buffer_t* buffer,
-  void** data,
-  uint64_t* size) noexcept {
+    tiledb_ctx_t* ctx,
+    const tiledb_buffer_t* buffer,
+    void** data,
+    uint64_t* size) noexcept {
   return api_entry_context<tiledb::api::tiledb_buffer_get_data>(
-    ctx, buffer, data, size);
+      ctx, buffer, data, size);
 }
 
 capi_return_t tiledb_buffer_set_data(
-  tiledb_ctx_t* ctx, tiledb_buffer_t* buffer, void* data, uint64_t size) {
+    tiledb_ctx_t* ctx, tiledb_buffer_t* buffer, void* data, uint64_t size) {
   return api_entry_context<tiledb::api::tiledb_buffer_set_data>(
-    ctx, buffer, data, size);
+      ctx, buffer, data, size);
 }

--- a/tiledb/api/c_api/buffer/test/unit_capi_buffer.cc
+++ b/tiledb/api/c_api/buffer/test/unit_capi_buffer.cc
@@ -32,8 +32,8 @@
  */
 
 #include <test/support/tdb_catch.h>
-#include "tiledb/api/c_api/context/context_api_external.h"
 #include "../buffer_api_external.h"
+#include "tiledb/api/c_api/context/context_api_external.h"
 
 TEST_CASE("C API: Test buffer", "[capi][buffer]") {
   tiledb_ctx_handle_t* ctx{nullptr};
@@ -63,7 +63,7 @@ TEST_CASE("C API: Test buffer", "[capi][buffer]") {
     const unsigned alloc_size = 123;
     void* alloc = std::malloc(alloc_size);
     REQUIRE(
-      tiledb_buffer_set_data(ctx, buffer, alloc, alloc_size) == TILEDB_OK);
+        tiledb_buffer_set_data(ctx, buffer, alloc, alloc_size) == TILEDB_OK);
 
     // Check size/data
     void* data;
@@ -74,13 +74,13 @@ TEST_CASE("C API: Test buffer", "[capi][buffer]") {
 
     // Check it works to set again
     REQUIRE(
-      tiledb_buffer_set_data(ctx, buffer, alloc, alloc_size) == TILEDB_OK);
+        tiledb_buffer_set_data(ctx, buffer, alloc, alloc_size) == TILEDB_OK);
 
     // Buffers can alias
     tiledb_buffer_t* buffer2;
     REQUIRE(tiledb_buffer_alloc(ctx, &buffer2) == TILEDB_OK);
     REQUIRE(
-      tiledb_buffer_set_data(ctx, buffer2, alloc, alloc_size) == TILEDB_OK);
+        tiledb_buffer_set_data(ctx, buffer2, alloc, alloc_size) == TILEDB_OK);
     tiledb_buffer_free(&buffer2);
 
     // Check setting to nullptr works

--- a/tiledb/api/c_api/datatype/datatype_api.cc
+++ b/tiledb/api/c_api/datatype/datatype_api.cc
@@ -30,19 +30,21 @@
  * This file defines the datatype section of the C API for TileDB.
  */
 
+#include "datatype_api_external.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
 #include "tiledb/sm/enums/datatype.h"
-#include "datatype_api_external.h"
 
 namespace tiledb::api {
 
-capi_return_t tiledb_datatype_to_str(tiledb_datatype_t datatype, const char** str) {
+capi_return_t tiledb_datatype_to_str(
+    tiledb_datatype_t datatype, const char** str) {
   const auto& strval = tiledb::sm::datatype_str((tiledb::sm::Datatype)datatype);
   *str = strval.c_str();
   return strval.empty() ? TILEDB_ERR : TILEDB_OK;
 }
 
-capi_return_t tiledb_datatype_from_str(const char* str, tiledb_datatype_t* datatype) {
+capi_return_t tiledb_datatype_from_str(
+    const char* str, tiledb_datatype_t* datatype) {
   tiledb::sm::Datatype val = tiledb::sm::Datatype::UINT8;
   if (!tiledb::sm::datatype_enum(str, &val).ok()) {
     return TILEDB_ERR;
@@ -55,17 +57,17 @@ uint64_t tiledb_datatype_size(tiledb_datatype_t type) {
   return tiledb::sm::datatype_size(static_cast<tiledb::sm::Datatype>(type));
 }
 
-} // namespace tiledb::api
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_plain;
 
 capi_return_t tiledb_datatype_to_str(
-  tiledb_datatype_t datatype, const char** str) noexcept {
+    tiledb_datatype_t datatype, const char** str) noexcept {
   return api_entry_plain<tiledb::api::tiledb_datatype_to_str>(datatype, str);
 }
 
 capi_return_t tiledb_datatype_from_str(
-  const char* str, tiledb_datatype_t* datatype) noexcept {
+    const char* str, tiledb_datatype_t* datatype) noexcept {
   return api_entry_plain<tiledb::api::tiledb_datatype_from_str>(str, datatype);
 }
 

--- a/tiledb/api/c_api/datatype/test/unit_capi_datatype.cc
+++ b/tiledb/api/c_api/datatype/test/unit_capi_datatype.cc
@@ -40,7 +40,8 @@ struct TestCase {
   TestCase(tiledb_datatype_t dtype, const char* name, int defined_as)
       : dtype_(dtype)
       , name_(name)
-      , defined_as_(defined_as) {}
+      , defined_as_(defined_as) {
+  }
 
   tiledb_datatype_t dtype_;
   const char* name_;
@@ -60,7 +61,8 @@ struct TestCase {
   }
 };
 
-TEST_CASE("C API: Test datatype enum string conversion", "[capi][enums][datatype]") {
+TEST_CASE(
+    "C API: Test datatype enum string conversion", "[capi][enums][datatype]") {
   // clang-format off
   TestCase test = GENERATE(
     TestCase(TILEDB_INT32,          "INT32",          0),

--- a/tiledb/api/c_api/filesystem/filesystem_api.cc
+++ b/tiledb/api/c_api/filesystem/filesystem_api.cc
@@ -30,42 +30,42 @@
  * This file defines the filesystem section of the C API for TileDB.
  */
 
+#include "filesystem_api_external.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/enums/filesystem.h"
-#include "filesystem_api_external.h"
 
 namespace tiledb::api {
 
 capi_return_t tiledb_filesystem_to_str(
-  tiledb_filesystem_t filesystem, const char** str) {
+    tiledb_filesystem_t filesystem, const char** str) {
   const auto& strval =
-    tiledb::sm::filesystem_str((tiledb::sm::Filesystem)filesystem);
+      tiledb::sm::filesystem_str((tiledb::sm::Filesystem)filesystem);
   *str = strval.c_str();
   return strval.empty() ? TILEDB_ERR : TILEDB_OK;
 }
 
 capi_return_t tiledb_filesystem_from_str(
-  const char* str, tiledb_filesystem_t* filesystem) {
+    const char* str, tiledb_filesystem_t* filesystem) {
   tiledb::sm::Filesystem val = tiledb::sm::Filesystem::S3;
   if (!tiledb::sm::filesystem_enum(str, &val).ok())
-  return TILEDB_ERR;
+    return TILEDB_ERR;
   *filesystem = (tiledb_filesystem_t)val;
   return TILEDB_OK;
 }
 
-} // namespace tiledb::api
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_plain;
 
 capi_return_t tiledb_filesystem_to_str(
-  tiledb_filesystem_t filesystem, const char** str) noexcept {
+    tiledb_filesystem_t filesystem, const char** str) noexcept {
   return api_entry_plain<tiledb::api::tiledb_filesystem_to_str>(
-    filesystem, str);
+      filesystem, str);
 }
 
 capi_return_t tiledb_filesystem_from_str(
-  const char* str, tiledb_filesystem_t* filesystem) noexcept {
+    const char* str, tiledb_filesystem_t* filesystem) noexcept {
   return api_entry_plain<tiledb::api::tiledb_filesystem_from_str>(
-    str, filesystem);
+      str, filesystem);
 }

--- a/tiledb/api/c_api/filesystem/test/unit_capi_filesystem.cc
+++ b/tiledb/api/c_api/filesystem/test/unit_capi_filesystem.cc
@@ -39,7 +39,8 @@ struct TestCase {
   TestCase(tiledb_filesystem_t fs, const char* name, int defined_as)
       : fs_(fs)
       , name_(name)
-      , defined_as_(defined_as) {}
+      , defined_as_(defined_as) {
+  }
 
   tiledb_filesystem_t fs_;
   const char* name_;

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -66,7 +66,7 @@ inline void ensure_name_argument_is_valid(const char* name) {
 
 inline char* copy_string(const std::string& str) {
   auto ret = static_cast<char*>(std::malloc(str.size() + 1));
-  if(ret == nullptr) {
+  if (ret == nullptr) {
     return nullptr;
   }
 
@@ -76,7 +76,8 @@ inline char* copy_string(const std::string& str) {
   return ret;
 }
 
-capi_return_t tiledb_group_create(tiledb_ctx_handle_t* ctx, const char* group_uri) {
+capi_return_t tiledb_group_create(
+    tiledb_ctx_handle_t* ctx, const char* group_uri) {
   ensure_group_uri_argument_is_valid(group_uri);
 
   throw_if_not_ok(ctx->storage_manager()->group_create(group_uri));
@@ -85,13 +86,16 @@ capi_return_t tiledb_group_create(tiledb_ctx_handle_t* ctx, const char* group_ur
 }
 
 capi_return_t tiledb_group_alloc(
-    tiledb_ctx_handle_t* ctx, const char* group_uri, tiledb_group_handle_t** group) {
+    tiledb_ctx_handle_t* ctx,
+    const char* group_uri,
+    tiledb_group_handle_t** group) {
   ensure_output_pointer_is_valid(group);
   ensure_group_uri_argument_is_valid(group_uri);
 
   auto uri = tiledb::sm::URI(group_uri);
-  if(uri.is_invalid()) {
-    throw CAPIStatusException("Failed to create TileDB group object; Invalid URI");
+  if (uri.is_invalid()) {
+    throw CAPIStatusException(
+        "Failed to create TileDB group object; Invalid URI");
   }
 
   *group = tiledb_group_handle_t::make_handle(uri, ctx->storage_manager());
@@ -105,10 +109,12 @@ void tiledb_group_free(tiledb_group_handle_t** group) {
   tiledb_group_handle_t::break_handle(*group);
 }
 
-capi_return_t tiledb_group_open(tiledb_group_handle_t* group, tiledb_query_type_t query_type) {
+capi_return_t tiledb_group_open(
+    tiledb_group_handle_t* group, tiledb_query_type_t query_type) {
   ensure_group_is_valid(group);
 
-  throw_if_not_ok(group->group().open(static_cast<tiledb::sm::QueryType>(query_type)));
+  throw_if_not_ok(
+      group->group().open(static_cast<tiledb::sm::QueryType>(query_type)));
 
   return TILEDB_OK;
 }
@@ -132,7 +138,7 @@ capi_return_t tiledb_group_set_config(
 }
 
 capi_return_t tiledb_group_get_config(
-      tiledb_group_handle_t* group, tiledb_config_t** config) {
+    tiledb_group_handle_t* group, tiledb_config_t** config) {
   ensure_group_is_valid(group);
   ensure_output_pointer_is_valid(config);
 
@@ -151,19 +157,13 @@ capi_return_t tiledb_group_put_metadata(
   ensure_key_argument_is_valid(key);
 
   throw_if_not_ok(group->group().put_metadata(
-    key,
-    static_cast<tiledb::sm::Datatype>(value_type),
-    value_num,
-    value
-  ));
+      key, static_cast<tiledb::sm::Datatype>(value_type), value_num, value));
 
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_group_delete_group(
-    tiledb_group_t* group,
-    const char* uri,
-    const uint8_t recursive) {
+    tiledb_group_t* group, const char* uri, const uint8_t recursive) {
   ensure_group_is_valid(group);
   ensure_group_uri_argument_is_valid(uri);
 
@@ -227,7 +227,8 @@ capi_return_t tiledb_group_get_metadata_from_index(
   ensure_output_pointer_is_valid(value);
 
   tiledb::sm::Datatype type;
-  throw_if_not_ok(group->group().get_metadata(index, key, key_len, &type, value_num, value));
+  throw_if_not_ok(group->group().get_metadata(
+      index, key, key_len, &type, value_num, value));
 
   *value_type = static_cast<tiledb_datatype_t>(type);
 
@@ -271,7 +272,8 @@ capi_return_t tiledb_group_add_member(
     name_optional = name;
   }
 
-  throw_if_not_ok(group->group().mark_member_for_addition(uri, relative, name_optional));
+  throw_if_not_ok(
+      group->group().mark_member_for_addition(uri, relative, name_optional));
 
   return TILEDB_OK;
 }
@@ -368,9 +370,7 @@ capi_return_t tiledb_group_get_member_by_name(
 }
 
 capi_return_t tiledb_group_get_is_relative_uri_by_name(
-    tiledb_group_handle_t* group,
-    const char* name,
-    uint8_t* is_relative) {
+    tiledb_group_handle_t* group, const char* name, uint8_t* is_relative) {
   ensure_group_is_valid(group);
   ensure_name_argument_is_valid(name);
   ensure_output_pointer_is_valid(is_relative);
@@ -418,9 +418,7 @@ capi_return_t tiledb_group_get_query_type(
 }
 
 capi_return_t tiledb_group_dump_str(
-    tiledb_group_handle_t* group,
-    char** dump_ascii,
-    const uint8_t recursive) {
+    tiledb_group_handle_t* group, char** dump_ascii, const uint8_t recursive) {
   ensure_group_is_valid(group);
   ensure_output_pointer_is_valid(dump_ascii);
 
@@ -447,12 +445,11 @@ capi_return_t tiledb_serialize_group(
   // We're not using throw_if_not_ok here because we have to
   // clean up our allocated buffer if serialization fails.
   auto st = tiledb::sm::serialization::group_serialize(
-    &(group->group()),
-    static_cast<tiledb::sm::SerializationType>(serialize_type),
-    &(buf->buffer())
-  );
+      &(group->group()),
+      static_cast<tiledb::sm::SerializationType>(serialize_type),
+      &(buf->buffer()));
 
-  if(!st.ok()) {
+  if (!st.ok()) {
     tiledb_buffer_handle_t::break_handle(buf);
     throw StatusException(st);
   }
@@ -471,10 +468,9 @@ capi_return_t tiledb_deserialize_group(
   ensure_output_pointer_is_valid(group);
 
   throw_if_not_ok(tiledb::sm::serialization::group_deserialize(
-    &(group->group()),
-    static_cast<tiledb::sm::SerializationType>(serialize_type),
-    buffer->buffer()
-  ));
+      &(group->group()),
+      static_cast<tiledb::sm::SerializationType>(serialize_type),
+      buffer->buffer()));
 
   return TILEDB_OK;
 }
@@ -492,18 +488,17 @@ capi_return_t tiledb_serialize_group_metadata(
   // Get metadata to serialize, this will load it if it does not exist
   tiledb::sm::Metadata* metadata;
   auto st = group->group().metadata(&metadata);
-  if(!st.ok()) {
+  if (!st.ok()) {
     tiledb_buffer_handle_t::break_handle(buf);
     throw StatusException(st);
   }
 
   st = tiledb::sm::serialization::metadata_serialize(
-    metadata,
-    static_cast<tiledb::sm::SerializationType>(serialize_type),
-    &(buf->buffer())
-  );
+      metadata,
+      static_cast<tiledb::sm::SerializationType>(serialize_type),
+      &(buf->buffer()));
 
-  if(!st.ok()) {
+  if (!st.ok()) {
     tiledb_buffer_handle_t::break_handle(buf);
     throw StatusException(st);
   }
@@ -521,10 +516,9 @@ capi_return_t tiledb_deserialize_group_metadata(
   ensure_buffer_is_valid(buffer);
 
   throw_if_not_ok(tiledb::sm::serialization::metadata_deserialize(
-    group->group().unsafe_metadata(),
-    static_cast<tiledb::sm::SerializationType>(serialize_type),
-    buffer->buffer()
-  ));
+      group->group().unsafe_metadata(),
+      static_cast<tiledb::sm::SerializationType>(serialize_type),
+      buffer->buffer()));
 
   return TILEDB_OK;
 }
@@ -534,8 +528,10 @@ capi_return_t tiledb_group_consolidate_metadata(
   ensure_group_uri_argument_is_valid(group_uri);
   ensure_config_is_valid(config);
 
-  auto cfg = (config == nullptr) ? ctx->storage_manager()->config() : config->config();
-  throw_if_not_ok(ctx->storage_manager()->group_metadata_consolidate(group_uri, cfg));
+  auto cfg =
+      (config == nullptr) ? ctx->storage_manager()->config() : config->config();
+  throw_if_not_ok(
+      ctx->storage_manager()->group_metadata_consolidate(group_uri, cfg));
 
   return TILEDB_OK;
 }
@@ -545,14 +541,14 @@ capi_return_t tiledb_group_vacuum_metadata(
   ensure_group_uri_argument_is_valid(group_uri);
   ensure_config_is_valid(config);
 
-  auto cfg = (config == nullptr) ?
-      ctx->storage_manager()->config() : config->config();
+  auto cfg =
+      (config == nullptr) ? ctx->storage_manager()->config() : config->config();
   ctx->storage_manager()->group_metadata_vacuum(group_uri, cfg);
 
   return TILEDB_OK;
 }
 
-} // namespace tiledb::api
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
@@ -560,24 +556,28 @@ using tiledb::api::api_entry_with_context;
 
 capi_return_t tiledb_group_create(tiledb_ctx_t* ctx, const char* group_uri)
     TILEDB_NOEXCEPT {
-  return api_entry_with_context<tiledb::api::tiledb_group_create>(ctx, group_uri);
+  return api_entry_with_context<tiledb::api::tiledb_group_create>(
+      ctx, group_uri);
 }
 
 capi_return_t tiledb_group_alloc(
     tiledb_ctx_t* ctx,
     const char* group_uri,
     tiledb_group_t** group) TILEDB_NOEXCEPT {
-  return api_entry_with_context<tiledb::api::tiledb_group_alloc>(ctx, group_uri, group);
+  return api_entry_with_context<tiledb::api::tiledb_group_alloc>(
+      ctx, group_uri, group);
 }
 
 capi_return_t tiledb_group_open(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_query_type_t query_type) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_open>(ctx, group, query_type);
+  return api_entry_context<tiledb::api::tiledb_group_open>(
+      ctx, group, query_type);
 }
 
-capi_return_t tiledb_group_close(tiledb_ctx_t* ctx, tiledb_group_t* group) TILEDB_NOEXCEPT {
+capi_return_t tiledb_group_close(tiledb_ctx_t* ctx, tiledb_group_t* group)
+    TILEDB_NOEXCEPT {
   return api_entry_context<tiledb::api::tiledb_group_close>(ctx, group);
 }
 
@@ -589,14 +589,16 @@ capi_return_t tiledb_group_set_config(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_config_t* config) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_set_config>(ctx, group, config);
+  return api_entry_context<tiledb::api::tiledb_group_set_config>(
+      ctx, group, config);
 }
 
 capi_return_t tiledb_group_get_config(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_config_t** config) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_get_config>(ctx, group, config);
+  return api_entry_context<tiledb::api::tiledb_group_get_config>(
+      ctx, group, config);
 }
 
 capi_return_t tiledb_group_put_metadata(
@@ -621,7 +623,8 @@ capi_return_t tiledb_group_delete_group(
 
 capi_return_t tiledb_group_delete_metadata(
     tiledb_ctx_t* ctx, tiledb_group_t* group, const char* key) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_delete_metadata>(ctx, group, key);
+  return api_entry_context<tiledb::api::tiledb_group_delete_metadata>(
+      ctx, group, key);
 }
 
 capi_return_t tiledb_group_get_metadata(
@@ -637,7 +640,8 @@ capi_return_t tiledb_group_get_metadata(
 
 capi_return_t tiledb_group_get_metadata_num(
     tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* num) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_get_metadata_num>(ctx, group, num);
+  return api_entry_context<tiledb::api::tiledb_group_get_metadata_num>(
+      ctx, group, num);
 }
 
 capi_return_t tiledb_group_get_metadata_from_index(
@@ -675,12 +679,14 @@ capi_return_t tiledb_group_add_member(
 
 capi_return_t tiledb_group_remove_member(
     tiledb_ctx_t* ctx, tiledb_group_t* group, const char* uri) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_remove_member>(ctx, group, uri);
+  return api_entry_context<tiledb::api::tiledb_group_remove_member>(
+      ctx, group, uri);
 }
 
 capi_return_t tiledb_group_get_member_count(
     tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* count) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_get_member_count>(ctx, group, count);
+  return api_entry_context<tiledb::api::tiledb_group_get_member_count>(
+      ctx, group, count);
 }
 
 capi_return_t tiledb_group_get_member_by_index(
@@ -709,7 +715,8 @@ capi_return_t tiledb_group_get_is_relative_uri_by_name(
     tiledb_group_t* group,
     const char* name,
     uint8_t* relative) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_get_is_relative_uri_by_name>(
+  return api_entry_context<
+      tiledb::api::tiledb_group_get_is_relative_uri_by_name>(
       ctx, group, name, relative);
 }
 
@@ -717,21 +724,24 @@ capi_return_t tiledb_group_is_open(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     int32_t* is_open) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_is_open>(ctx, group, is_open);
+  return api_entry_context<tiledb::api::tiledb_group_is_open>(
+      ctx, group, is_open);
 }
 
 capi_return_t tiledb_group_get_uri(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char** group_uri) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_get_uri>(ctx, group, group_uri);
+  return api_entry_context<tiledb::api::tiledb_group_get_uri>(
+      ctx, group, group_uri);
 }
 
 capi_return_t tiledb_group_get_query_type(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_query_type_t* query_type) TILEDB_NOEXCEPT {
-  return api_entry_context<tiledb::api::tiledb_group_get_query_type>(ctx, group, query_type);
+  return api_entry_context<tiledb::api::tiledb_group_get_query_type>(
+      ctx, group, query_type);
 }
 
 capi_return_t tiledb_group_dump_str(

--- a/tiledb/api/c_api/object/object_api.cc
+++ b/tiledb/api/c_api/object/object_api.cc
@@ -30,11 +30,11 @@
  * This file defines the object section of the C API for TileDB.
  */
 
+#include "../context/context_api_internal.h"
+#include "object_api_external.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
 #include "tiledb/sm/enums/object_type.h"
 #include "tiledb/sm/enums/walk_order.h"
-#include "../context/context_api_internal.h"
-#include "object_api_external.h"
 
 namespace tiledb::api {
 
@@ -42,7 +42,7 @@ using ObjectCallback =
     std::function<int32_t(const char*, tiledb_object_t, void*)>;
 
 inline void ensure_callback_argument_is_valid(ObjectCallback cb) {
-  if(cb == nullptr) {
+  if (cb == nullptr) {
     throw CAPIStatusException("argument `callback` may not be nullptr");
   }
 }
@@ -83,35 +83,31 @@ capi_return_t tiledb_walk_order_from_str(
   return TILEDB_OK;
 }
 
-} // namespace tiledb::api
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_plain;
 using tiledb::api::api_entry_with_context;
 
 capi_return_t tiledb_object_type_to_str(
-    tiledb_object_t object_type,
-    const char** str) noexcept {
+    tiledb_object_t object_type, const char** str) noexcept {
   return api_entry_plain<tiledb::api::tiledb_object_type_to_str>(
-    object_type, str);
+      object_type, str);
 }
 
 capi_return_t tiledb_object_type_from_str(
-    const char* str,
-    tiledb_object_t* object_type) noexcept {
+    const char* str, tiledb_object_t* object_type) noexcept {
   return api_entry_plain<tiledb::api::tiledb_object_type_from_str>(
-    str, object_type);
+      str, object_type);
 }
 
 capi_return_t tiledb_walk_order_to_str(
-    tiledb_walk_order_t walk_order,
-    const char** str) noexcept {
+    tiledb_walk_order_t walk_order, const char** str) noexcept {
   return api_entry_plain<tiledb::api::tiledb_walk_order_to_str>(
       walk_order, str);
 }
 
 capi_return_t tiledb_walk_order_from_str(
-    const char* str,
-    tiledb_walk_order_t* walk_order) noexcept {
+    const char* str, tiledb_walk_order_t* walk_order) noexcept {
   return api_entry_plain<tiledb::api::tiledb_walk_order_from_str>(
       str, walk_order);
 }

--- a/tiledb/api/c_api/object/test/unit_capi_object_type.cc
+++ b/tiledb/api/c_api/object/test/unit_capi_object_type.cc
@@ -39,7 +39,8 @@ struct TestCase {
   TestCase(tiledb_object_t obj_type, const char* name, int defined_as)
       : obj_type_(obj_type)
       , name_(name)
-      , defined_as_(defined_as) {}
+      , defined_as_(defined_as) {
+  }
 
   tiledb_object_t obj_type_;
   const char* name_;

--- a/tiledb/api/c_api/object/test/unit_capi_object_walk_order.cc
+++ b/tiledb/api/c_api/object/test/unit_capi_object_walk_order.cc
@@ -39,7 +39,8 @@ struct TestCase {
   TestCase(tiledb_walk_order_t order, const char* name, int defined_as)
       : order_(order)
       , name_(name)
-      , defined_as_(defined_as) {}
+      , defined_as_(defined_as) {
+  }
 
   tiledb_walk_order_t order_;
   const char* name_;

--- a/tiledb/api/c_api/query/query_api.cc
+++ b/tiledb/api/c_api/query/query_api.cc
@@ -30,41 +30,41 @@
  * This file defines the query section of the C API for TileDB.
  */
 
+#include "query_api_external.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
 #include "tiledb/sm/enums/query_type.h"
-#include "query_api_external.h"
 
 namespace tiledb::api {
 
 int32_t tiledb_query_type_to_str(
-  tiledb_query_type_t query_type, const char** str) {
+    tiledb_query_type_t query_type, const char** str) {
   const auto& strval =
-    tiledb::sm::query_type_str((tiledb::sm::QueryType)query_type);
+      tiledb::sm::query_type_str((tiledb::sm::QueryType)query_type);
   *str = strval.c_str();
   return strval.empty() ? TILEDB_ERR : TILEDB_OK;
 }
 
 int32_t tiledb_query_type_from_str(
-  const char* str, tiledb_query_type_t* query_type) {
+    const char* str, tiledb_query_type_t* query_type) {
   tiledb::sm::QueryType val = tiledb::sm::QueryType::READ;
   if (!tiledb::sm::query_type_enum(str, &val).ok())
-  return TILEDB_ERR;
+    return TILEDB_ERR;
   *query_type = (tiledb_query_type_t)val;
   return TILEDB_OK;
 }
 
-} // namespace tiledb::api
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_plain;
 
 int32_t tiledb_query_type_to_str(
-  tiledb_query_type_t query_type, const char** str) noexcept {
+    tiledb_query_type_t query_type, const char** str) noexcept {
   return api_entry_plain<tiledb::api::tiledb_query_type_to_str>(
-    query_type, str);
+      query_type, str);
 }
 
 int32_t tiledb_query_type_from_str(
-  const char* str, tiledb_query_type_t* query_type) noexcept {
+    const char* str, tiledb_query_type_t* query_type) noexcept {
   return api_entry_plain<tiledb::api::tiledb_query_type_from_str>(
-    str, query_type);
+      str, query_type);
 }

--- a/tiledb/api/c_api/query/test/unit_capi_query_type.cc
+++ b/tiledb/api/c_api/query/test/unit_capi_query_type.cc
@@ -39,7 +39,8 @@ struct TestCase {
   TestCase(tiledb_query_type_t query_type, const char* name, int defined_as)
       : query_type_(query_type)
       , name_(name)
-      , defined_as_(defined_as) {}
+      , defined_as_(defined_as) {
+  }
 
   tiledb_query_type_t query_type_;
   const char* name_;

--- a/tiledb/platform/cert_file.cc
+++ b/tiledb/platform/cert_file.cc
@@ -39,4 +39,4 @@ std::once_flag CertFileTraits<LinuxOS>::cert_file_initialized_;
 std::string CertFileTraits<LinuxOS>::cert_file_;
 #endif
 
-} // namespce tiledb::platform
+}  // namespace tiledb::platform

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -261,7 +261,8 @@ TEST_CASE(
   // Try to register an array for read
   REQUIRE_THROWS_WITH(
       x.register_array(uri, *array.get(), QueryType::READ),
-      Catch::Matchers::ContainsSubstring("close array opened for exclusive modification"));
+      Catch::Matchers::ContainsSubstring(
+          "close array opened for exclusive modification"));
   REQUIRE(x.registry_size() == 1);
   REQUIRE(x.is_open(uri) == true);
 

--- a/tiledb/sm/curl/curl_init.cc
+++ b/tiledb/sm/curl/curl_init.cc
@@ -32,8 +32,8 @@
 
 #include <mutex>
 
-#include "tiledb/common/exception/exception.h"
 #include "curl_init.h"
+#include "tiledb/common/exception/exception.h"
 
 #ifdef TILEDB_SERIALIZATION
 #include <curl/curl.h>
@@ -56,12 +56,13 @@ namespace tiledb::sm::curl {
 static std::once_flag curl_lib_initialized;
 
 LibCurlInitializer::LibCurlInitializer() {
-  std::call_once(curl_lib_initialized, [](){
+  std::call_once(curl_lib_initialized, []() {
     auto rc = LIBCURL_INIT;
     if (rc != 0) {
-      throw common::StatusException("[TileDB::CurlInit]",
-          "Cannot initialize libcurl global state: got non-zero return code "
-            + std::to_string(rc));
+      throw common::StatusException(
+          "[TileDB::CurlInit]",
+          "Cannot initialize libcurl global state: got non-zero return code " +
+              std::to_string(rc));
     }
   });
 }

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -168,7 +168,7 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
         HERE(), account, thread_pool_->concurrency_level(), cert_file);
   } else {
     client_ = make_shared<azure::storage_lite::blob_client>(
-      HERE(), account, static_cast<int>(thread_pool_->concurrency_level()));
+        HERE(), account, static_cast<int>(thread_pool_->concurrency_level()));
   }
 
   // The Azure SDK does not provide a way to configure the retry

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1703,14 +1703,13 @@ VFS::multipart_upload_state(const URI& uri) {
     }
     return {Status::Ok(), state};
 #else
-    return {
-        LOG_STATUS(Status_VFSError("TileDB was built without S3 support")),
-        nullopt};
+    return {LOG_STATUS(Status_VFSError("TileDB was built without S3 support")),
+            nullopt};
 #endif
   } else if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return {
-        LOG_STATUS(Status_VFSError("Not yet supported for Azure")), nullopt};
+    return {LOG_STATUS(Status_VFSError("Not yet supported for Azure")),
+            nullopt};
 #else
     return {
         LOG_STATUS(Status_VFSError("TileDB was built without Azure support")),
@@ -1720,16 +1719,14 @@ VFS::multipart_upload_state(const URI& uri) {
 #ifdef HAVE_GCS
     return {LOG_STATUS(Status_VFSError("Not yet supported for GCS")), nullopt};
 #else
-    return {
-        LOG_STATUS(Status_VFSError("TileDB was built without GCS support")),
-        nullopt};
+    return {LOG_STATUS(Status_VFSError("TileDB was built without GCS support")),
+            nullopt};
 #endif
   }
 
-  return {
-      LOG_STATUS(
-          Status_VFSError("Unsupported URI schemes: " + uri.to_string())),
-      nullopt};
+  return {LOG_STATUS(
+              Status_VFSError("Unsupported URI schemes: " + uri.to_string())),
+          nullopt};
 }
 
 Status VFS::set_multipart_upload_state(

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -257,7 +257,10 @@ Status ChecksumMD5Filter::compare_checksum_part(
     char md5string_existing[33];
     for (uint64_t i = 0; i < Crypto::MD5_DIGEST_BYTES; ++i) {
       snprintf(
-          &md5string_existing[i * 2], 3, "%02x", (unsigned int)existing_digest[i]);
+          &md5string_existing[i * 2],
+          3,
+          "%02x",
+          (unsigned int)existing_digest[i]);
     }
 
     std::stringstream message;

--- a/tiledb/sm/filter/checksum_sha256_filter.cc
+++ b/tiledb/sm/filter/checksum_sha256_filter.cc
@@ -257,7 +257,10 @@ Status ChecksumSHA256Filter::compare_checksum_part(
     char shastring_existing[65];
     for (uint64_t i = 0; i < Crypto::SHA256_DIGEST_BYTES; ++i) {
       snprintf(
-          &shastring_existing[i * 2], 3, "%02x", (unsigned int)existing_digest[i]);
+          &shastring_existing[i * 2],
+          3,
+          "%02x",
+          (unsigned int)existing_digest[i]);
     }
 
     std::stringstream message;

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -419,7 +419,8 @@ void QueryCondition::apply_ast_node(
         starting_index += length;
         continue;
       } else if (!fragment_metadata[f]->array_schema()->is_field(field_name)) {
-        // Requested field does not exist in this result cell - added by evolution.
+        // Requested field does not exist in this result cell - added by
+        // evolution.
         for (size_t c = starting_index; c < starting_index + length; ++c) {
           result_cell_bitmap[c] = 0;
         }

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -225,12 +225,11 @@ RestClient::get_array_schema_from_rest(const URI& uri) {
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK_TUPLE(
       ensure_json_null_delimited_string(&returned_data), nullopt);
-  return {
-      Status::Ok(),
-      make_shared<ArraySchema>(
-          HERE(),
-          serialization::array_schema_deserialize(
-              serialization_type_, returned_data))};
+  return {Status::Ok(),
+          make_shared<ArraySchema>(
+              HERE(),
+              serialization::array_schema_deserialize(
+                  serialization_type_, returned_data))};
 }
 
 Status RestClient::post_array_schema_to_rest(
@@ -1317,10 +1316,9 @@ Status RestClient::set_header(const std::string&, const std::string&) {
 
 tuple<Status, optional<shared_ptr<ArraySchema>>>
 RestClient::get_array_schema_from_rest(const URI&) {
-  return {
-      LOG_STATUS(Status_RestError(
-          "Cannot use rest client; serialization not enabled.")),
-      nullopt};
+  return {LOG_STATUS(Status_RestError(
+              "Cannot use rest client; serialization not enabled.")),
+          nullopt};
 }
 
 Status RestClient::post_array_schema_to_rest(const URI&, const ArraySchema&) {
@@ -1397,18 +1395,16 @@ Status RestClient::post_array_schema_evolution_to_rest(
 
 tuple<Status, std::optional<bool>> RestClient::check_array_exists_from_rest(
     const URI&) {
-  return {
-      LOG_STATUS(Status_RestError(
-          "Cannot use rest client; serialization not enabled.")),
-      std::nullopt};
+  return {LOG_STATUS(Status_RestError(
+              "Cannot use rest client; serialization not enabled.")),
+          std::nullopt};
 }
 
 tuple<Status, std::optional<bool>> RestClient::check_group_exists_from_rest(
     const URI&) {
-  return {
-      LOG_STATUS(Status_RestError(
-          "Cannot use rest client; serialization not enabled.")),
-      std::nullopt};
+  return {LOG_STATUS(Status_RestError(
+              "Cannot use rest client; serialization not enabled.")),
+          std::nullopt};
 }
 
 Status RestClient::post_group_metadata_from_rest(const URI&, Group*) {


### PR DESCRIPTION
fix grouping of FIND_FILES arg to 'find' command, without parens seemed to be only processing the final .h -name pattern

---
TYPE: BUG
DESC: Fix grouping of FIND_FILES arg to 'find' command
