### PR TITLE
is_compiler_gnu should be true under mingw32 compiler.

### DIFF
--- a/tiledb/platform/platform.h
+++ b/tiledb/platform/platform.h
@@ -49,28 +49,5 @@ constexpr bool is_os_macosx = false;
 constexpr bool is_os_linux = true;
 #endif  // _WIN32
 
-/** Compiler */
-#if defined(__clang__)
-constexpr bool is_compiler_clang = true;
-constexpr bool is_compiler_gnu = false;
-constexpr bool is_compiler_msvc = false;
-constexpr bool is_compiler_mingw = false;
-#elif defined(__GNUC__) || defined(__GNUG__)
-constexpr bool is_compiler_clang = false;
-constexpr bool is_compiler_gnu = true;
-constexpr bool is_compiler_msvc = false;
-constexpr bool is_compiler_mingw = false;
-#elif defined(_MSC_VER)
-constexpr bool is_compiler_clang = false;
-constexpr bool is_compiler_gnu = false;
-constexpr bool is_compiler_msvc = true;
-constexpr bool is_compiler_mingw = false;
-#elif defined(__MINGW32__)
-constexpr bool is_compiler_clang = false;
-constexpr bool is_compiler_gnu = true;
-constexpr bool is_compiler_msvc = false;
-constexpr bool is_compiler_mingw = true;
-#endif
-
 }  // namespace tiledb::platform
 #endif  // TILEDB_PLATFORM_H

--- a/tiledb/platform/platform.h
+++ b/tiledb/platform/platform.h
@@ -67,7 +67,7 @@ constexpr bool is_compiler_msvc = true;
 constexpr bool is_compiler_mingw = false;
 #elif defined(__MINGW32__)
 constexpr bool is_compiler_clang = false;
-constexpr bool is_compiler_gnu = false;
+constexpr bool is_compiler_gnu = true;
 constexpr bool is_compiler_msvc = false;
 constexpr bool is_compiler_mingw = true;
 #endif


### PR DESCRIPTION
Per request by @ihnorton I have deleted the compiler section.

---
TYPE: IMPROVEMENT
DESC: is_compiler_gnu should be true under mingw32 compiler.
