### PR TITLE
Refactor filestore API so that it uses internal TileDB library calls. 

### DIFF
--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -31,60 +31,66 @@
  * This file defines the C API of TileDB for filestore.
  **/
 
-// Avoid deprecation warnings for the cpp api
-#define TILEDB_DEPRECATED
-
 #include "tiledb/api/c_api/attribute/attribute_api_internal.h"
 #include "tiledb/api/c_api/config/config_api_internal.h"
 #include "tiledb/api/c_api/dimension/dimension_api_internal.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
-#include "tiledb/common/common-std.h"
+#include "tiledb/common/common.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
+#include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/c_api/api_argument_validator.h"
-#include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
-#include "tiledb/sm/cpp_api/array.h"
-#include "tiledb/sm/cpp_api/array_schema.h"
-#include "tiledb/sm/cpp_api/attribute.h"
-#include "tiledb/sm/cpp_api/context.h"
-#include "tiledb/sm/cpp_api/dimension.h"
-#include "tiledb/sm/cpp_api/filter_list.h"
-#include "tiledb/sm/cpp_api/query.h"
-#include "tiledb/sm/cpp_api/subarray.h"
-#include "tiledb/sm/cpp_api/vfs.h"
+#include "tiledb/sm/compressors/zstd_compressor.h"
+#include "tiledb/sm/enums/array_type.h"
+#include "tiledb/sm/enums/compressor.h"
+#include "tiledb/sm/enums/encryption_type.h"
+#include "tiledb/sm/enums/filter_type.h"
+#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/enums/mime_type.h"
+#include "tiledb/sm/enums/query_type.h"
+#include "tiledb/sm/enums/vfs_mode.h"
+#include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/filter/compression_filter.h"
+#include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/mgc_dict.h"
+#include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/query/query.h"
+#include "tiledb/sm/storage_manager/context.h"
+#include "tiledb/sm/subarray/subarray.h"
+#include "tiledb/type/range/range.h"
 
 namespace tiledb::common::detail {
 
 // Forward declarations
 uint64_t compute_tile_extent_based_on_file_size(uint64_t file_size);
-std::pair<Status, optional<std::string>> libmagic_get_mime(
-    void* data, uint64_t size);
-std::pair<Status, optional<std::string>> libmagic_get_mime_encoding(
-    void* data, uint64_t size);
+std::string libmagic_get_mime(void* data, uint64_t size);
+std::string libmagic_get_mime_encoding(void* data, uint64_t size);
 bool libmagic_file_is_compressed(void* data, uint64_t size);
-Status read_file_header(
-    const VFS& vfs, const char* uri, std::vector<char>& header);
+void read_file_header(
+    tiledb::sm::VFS& vfs, const char* uri, std::vector<char>& header);
 std::pair<std::string, std::string> strip_file_extension(const char* file_uri);
-std::pair<Status, optional<uint64_t>> get_buffer_size_from_config(
-    const Context& context, uint64_t tile_extent);
+uint64_t get_buffer_size_from_config(
+    const tiledb::sm::Config& config, uint64_t tile_extent);
 
 int32_t tiledb_filestore_schema_create(
     tiledb_ctx_t* ctx, const char* uri, tiledb_array_schema_t** array_schema) {
-  if (sanity_check(ctx) == TILEDB_ERR) {
-    *array_schema = nullptr;
-    return TILEDB_ERR;
-  }
-
-  Context context(ctx, false);
+  tiledb::sm::Context& context = ctx->context();
   uint64_t tile_extent = tiledb::sm::constants::filestore_default_tile_extent;
 
   bool is_compressed_libmagic = true;
   if (uri) {
     // The user provided a uri, let's examine the file and get some insights
     // Get the file size, calculate a reasonable tile extent
-    VFS vfs(context);
-    uint64_t file_size = vfs.file_size(std::string(uri));
+    tiledb::sm::VFS vfs(
+        &context.resources().stats(),
+        context.compute_tp(),
+        context.io_tp(),
+        context.storage_manager()->config());
+    uint64_t file_size;
+    throw_if_not_ok(vfs.file_size(tiledb::sm::URI(uri), &file_size));
     if (file_size) {
       tile_extent = compute_tile_extent_based_on_file_size(file_size);
     }
@@ -92,64 +98,78 @@ int32_t tiledb_filestore_schema_create(
     // Detect if the file is compressed or not
     uint64_t size = std::min(file_size, static_cast<uint64_t>(1024));
     std::vector<char> header(size);
-    auto st = read_file_header(vfs, uri, header);
+
     // Don't fail if compression cannot be detected, log a message
     // and default to uncompressed array
-    if (st.ok()) {
+    try {
+      read_file_header(vfs, uri, header);
       is_compressed_libmagic = libmagic_file_is_compressed(header.data(), size);
-    } else {
-      LOG_STATUS_NO_RETURN_VALUE(
-          Status_Error("Compression couldn't be detected - " + st.message()));
+    } catch (const std::exception& e) {
+      LOG_STATUS_NO_RETURN_VALUE(Status_Error(
+          std::string("Compression couldn't be detected - ") + e.what()));
     }
   }
 
   *array_schema = new (std::nothrow) tiledb_array_schema_t;
   if (*array_schema == nullptr) {
-    auto st = Status_Error(
+    throw std::runtime_error(
         "Failed to create TileDB Array Schema object; Memory allocation error");
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_OOM;
   }
 
   try {
-    ArraySchema schema(context, TILEDB_DENSE);
-
     // Share ownership of the internal ArraySchema ptr
     // All other calls for adding domains, attributes, etc
     // create copies of the underlying core objects from within
     // the cpp objects constructed here
-    (*array_schema)->array_schema_ = schema.ptr()->array_schema_;
+    (*array_schema)->array_schema_ = make_shared<tiledb::sm::ArraySchema>(
+        HERE(), tiledb::sm::ArrayType::DENSE);
+    auto& schema = (*array_schema)->array_schema_;
 
-    auto dim = Dimension::create<uint64_t>(
-        context,
+    // Define the range of the dimension.
+    uint64_t range_lo = 0;
+    uint64_t range_hi = std::numeric_limits<uint64_t>::max() - tile_extent - 1;
+    tiledb::type::Range range_obj(&range_lo, &range_hi, sizeof(uint64_t));
+
+    // Define the tile extent as a tiledb::sm::ByteVecValue.
+    std::vector<uint8_t> tile_extent_vec(sizeof(uint64_t), 0);
+    memcpy(tile_extent_vec.data(), &tile_extent, sizeof(uint64_t));
+
+    auto dim = make_shared<tiledb::sm::Dimension>(
+        HERE(),
         tiledb::sm::constants::filestore_dimension_name,
-        {0, std::numeric_limits<uint64_t>::max() - tile_extent - 1},
-        tile_extent);
+        tiledb::sm::Datatype::UINT64,
+        1,
+        range_obj,
+        tiledb::sm::FilterPipeline{},
+        tiledb::sm::ByteVecValue(std::move(tile_extent_vec)));
 
-    Domain domain(context);
-    domain.add_dimension(dim);
+    auto domain = make_shared<tiledb::sm::Domain>(HERE());
+    throw_if_not_ok(domain.get()->add_dimension(dim));
 
-    auto attr = Attribute::create(
-        context, tiledb::sm::constants::filestore_attribute_name, TILEDB_BLOB);
+    auto attr = make_shared<tiledb::sm::Attribute>(
+        HERE(),
+        tiledb::sm::constants::filestore_attribute_name,
+        tiledb::sm::Datatype::BLOB);
 
     // If the input file is not compressed, add our own compression
     if (!is_compressed_libmagic) {
-      FilterList filter(context);
-      filter.add_filter({context, TILEDB_FILTER_ZSTD});
-      attr.set_filter_list(filter);
+      tiledb::sm::FilterPipeline filter;
+      filter.add_filter(tiledb::sm::CompressionFilter(
+          tiledb::sm::Compressor::ZSTD,
+          tiledb::sm::ZStd::default_level(),
+          tiledb::sm::Datatype::ANY));
+      attr.get()->set_filter_pipeline(filter);
     }
 
-    schema.set_domain(domain);
-    schema.set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
-    schema.add_attribute(attr);
+    throw_if_not_ok(schema->set_domain(domain));
+    throw_if_not_ok(schema->set_tile_order(tiledb::sm::Layout::ROW_MAJOR));
+    throw_if_not_ok(schema->set_cell_order(tiledb::sm::Layout::ROW_MAJOR));
+    throw_if_not_ok(schema->add_attribute(attr));
   } catch (const std::exception& e) {
-    auto st = Status_Error(
-        std::string("Internal TileDB uncaught exception; ") + e.what());
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
+    (*array_schema)->array_schema_ = nullptr;
     delete *array_schema;
-    return TILEDB_ERR;
+    throw std::logic_error(
+        std::string("Internal TileDB uncaught exception; ") + e.what());
   }
 
   return TILEDB_OK;
@@ -164,78 +184,72 @@ int32_t tiledb_filestore_uri_import(
     return TILEDB_ERR;
   }
 
-  Context context(ctx, false);
+  tiledb::sm::Context& context = ctx->context();
 
   // Get the file size
-  VFS vfs(context);
-  uint64_t file_size = vfs.file_size(std::string(file_uri));
+  tiledb::sm::VFS vfs(
+      &context.resources().stats(),
+      context.compute_tp(),
+      context.io_tp(),
+      context.storage_manager()->config());
+  uint64_t file_size;
+  throw_if_not_ok(vfs.file_size(tiledb::sm::URI(file_uri), &file_size));
   if (!file_size) {
     return TILEDB_OK;  // NOOP
   }
 
   // Sync up the fragment timestamp and metadata timestamp
-  Array array(
-      context,
-      std::string(filestore_array_uri),
-      TILEDB_WRITE,
-      TemporalPolicy(TimeTravel, tiledb_timestamp_now_ms()));
+  uint64_t time_now = tiledb_timestamp_now_ms();
+  auto array = make_shared<tiledb::sm::Array>(
+      HERE(), tiledb::sm::URI(filestore_array_uri), context.storage_manager());
+  throw_if_not_ok(array->open(
+      tiledb::sm::QueryType::WRITE,
+      0,
+      time_now,
+      tiledb::sm::EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0));
 
   // Detect mimetype and encoding with libmagic
   uint64_t size = std::min(file_size, static_cast<uint64_t>(1024));
   std::vector<char> header(size);
-  auto st = read_file_header(vfs, file_uri, header);
-  if (!st.ok()) {
-    save_error(ctx, st);
-    LOG_STATUS_NO_RETURN_VALUE(Status_Error(
-        "MIME type and encoding couldn't be detected - " + st.message()));
-    return TILEDB_ERR;
-  }
-  auto&& [st1, mime] = libmagic_get_mime(header.data(), header.size());
-  if (!st1.ok()) {
-    save_error(ctx, st1);
-    LOG_STATUS_NO_RETURN_VALUE(st1);
-    return TILEDB_ERR;
-  }
-  auto&& [st2, mime_encoding] =
-      libmagic_get_mime_encoding(header.data(), header.size());
-  if (!st2.ok()) {
-    save_error(ctx, st2);
-    LOG_STATUS_NO_RETURN_VALUE(st2);
-    return TILEDB_ERR;
-  }
+  read_file_header(vfs, file_uri, header);
+  auto mime = libmagic_get_mime(header.data(), header.size());
+  auto mime_encoding = libmagic_get_mime_encoding(header.data(), header.size());
 
   // We need to dump all the relevant metadata at this point so that
   // clients have all the necessary info when consuming the array
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_size_key,
-      TILEDB_UINT64,
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_size_key.c_str(),
+      tiledb::sm::Datatype::UINT64,
       1,
       &file_size);
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_mime_encoding_key,
-      TILEDB_STRING_UTF8,
-      static_cast<uint32_t>(mime_encoding.value().size()),
-      mime_encoding.value().c_str());
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_mime_type_key,
-      TILEDB_STRING_UTF8,
-      static_cast<uint32_t>(mime.value().size()),
-      mime.value().c_str());
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_mime_encoding_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
+      static_cast<uint32_t>(mime_encoding.size()),
+      mime_encoding.c_str());
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_mime_type_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
+      static_cast<uint32_t>(mime.size()),
+      mime.c_str());
   auto&& [fname, fext] = strip_file_extension(file_uri);
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_original_filename_key,
-      TILEDB_STRING_UTF8,
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_original_filename_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
       static_cast<uint32_t>(fname.size()),
       fname.c_str());
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_file_extension_key,
-      TILEDB_STRING_UTF8,
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_file_extension_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
       static_cast<uint32_t>(fext.size()),
       fext.c_str());
 
   // Write the data in batches using the global order writer
-  VFS::filebuf fb(vfs);
-  if (!fb.open(std::string(file_uri), std::ios::in)) {
+  auto fb_open_status =
+      vfs.open_file(tiledb::sm::URI(file_uri), tiledb::sm::VFSMode::VFS_READ);
+  if (!fb_open_status.ok()) {
     auto st = Status_Error(
         "Failed to open the file; Invalid file URI or incorrect file "
         "permissions");
@@ -243,26 +257,26 @@ int32_t tiledb_filestore_uri_import(
     save_error(ctx, st);
     return TILEDB_ERR;
   }
-  std::istream input(&fb);
 
   // tiledb:// uri hack
   // We need to special case on tiledb uris until we implement
   // serialization for global order writes. Until then, we write
   // timestamped fragments in row-major order.
-  bool is_tiledb_uri = array.ptr()->array_->is_remote();
+  bool is_tiledb_uri = array->is_remote();
   uint64_t tile_extent = compute_tile_extent_based_on_file_size(file_size);
-  auto&& [st3, buffer_size] = get_buffer_size_from_config(context, tile_extent);
-  if (!st3.ok()) {
-    LOG_STATUS_NO_RETURN_VALUE(st3);
-    save_error(ctx, st3);
-    return TILEDB_ERR;
-  }
+  auto buffer_size = get_buffer_size_from_config(
+      context.storage_manager()->config(), tile_extent);
 
-  Query query(context, array);
-  query.set_layout(TILEDB_GLOBAL_ORDER);
-  std::vector<std::byte> buffer(*buffer_size);
+  tiledb::sm::Query query(context.storage_manager(), array);
+  throw_if_not_ok(query.set_layout(tiledb::sm::Layout::GLOBAL_ORDER));
+  std::vector<std::byte> buffer(buffer_size);
 
-  Subarray subarray(context, array);
+  tiledb::sm::Subarray subarray(
+      array.get(),
+      nullptr,
+      context.storage_manager()->logger(),
+      true,
+      context.storage_manager());
   // We need to get the right end boundary of the last space tile.
   // The last chunk either falls exactly on the end of the file
   // or it goes beyond the end of the file so that it's equal in size
@@ -272,85 +286,109 @@ int32_t tiledb_filestore_uri_import(
        static_cast<uint64_t>(file_size % tile_extent != 0)) *
           tile_extent -
       1;
-  subarray.add_range(0, static_cast<uint64_t>(0), last_space_tile_boundary);
+  uint64_t range_arr[] = {static_cast<uint64_t>(0), last_space_tile_boundary};
+  tiledb::type::Range subarray_range(
+      static_cast<void*>(range_arr), sizeof(uint64_t) * 2);
+  throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
   query.set_subarray(subarray);
 
-  auto tiledb_cloud_fix = [&](uint64_t start, uint64_t end, uint64_t nbytes) {
-    Query query(context, array);
-    query.set_layout(TILEDB_ROW_MAJOR);
-    Subarray subarray(context, array);
-    subarray.add_range(0, start, end);
-    query.set_subarray(subarray);
-    query.set_data_buffer(
-        tiledb::sm::constants::filestore_attribute_name, buffer.data(), nbytes);
-    query.submit();
+  auto tiledb_cloud_fix = [&](uint64_t start, uint64_t end) {
+    tiledb::sm::Query query(context.storage_manager(), array);
+    throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
+    tiledb::sm::Subarray subarray_cloud_fix(
+        array.get(),
+        nullptr,
+        context.storage_manager()->logger(),
+        true,
+        context.storage_manager());
+
+    uint64_t cloud_fix_range_arr[] = {start, end};
+    tiledb::type::Range subarray_range_cloud_fix(
+        static_cast<void*>(cloud_fix_range_arr), sizeof(uint64_t) * 2);
+    throw_if_not_ok(
+        subarray_cloud_fix.add_range(0, std::move(subarray_range_cloud_fix)));
+    query.set_subarray(subarray_cloud_fix);
+    uint64_t data_buff_len = end - start + 1;
+    throw_if_not_ok(query.set_data_buffer(
+        tiledb::sm::constants::filestore_attribute_name,
+        buffer.data(),
+        &data_buff_len));
+    throw_if_not_ok(query.submit());
+  };
+
+  auto read_wrapper =
+      [&file_size, &vfs, &file_uri, &buffer](uint64_t start) -> uint64_t {
+    if (start >= file_size)
+      return 0;
+
+    uint64_t readlen = buffer.size();
+    if (start + buffer.size() > file_size) {
+      readlen = file_size - start;
+    }
+    throw_if_not_ok(
+        vfs.read(tiledb::sm::URI(file_uri), start, buffer.data(), readlen));
+    return readlen;
   };
 
   uint64_t start_range = 0;
-  uint64_t end_range = *buffer_size - 1;
-  while (input.read(reinterpret_cast<char*>(buffer.data()), *buffer_size)) {
+  uint64_t end_range = buffer_size - 1;
+  uint64_t readlen = 0;
+  while ((readlen = read_wrapper(start_range)) > 0) {
+    uint64_t end_cloud_fix = end_range;
+    uint64_t query_buffer_len = buffer_size;
+    if (readlen < buffer_size) {
+      end_cloud_fix = start_range + readlen;
+      query_buffer_len = last_space_tile_boundary -
+                         file_size / (buffer_size) * (buffer_size) + 1;
+      std::memset(buffer.data() + readlen, 0, buffer_size - readlen);
+    }
+
     if (is_tiledb_uri) {
-      tiledb_cloud_fix(start_range, end_range, buffer.size());
-      start_range += *buffer_size;
-      end_range += *buffer_size;
+      tiledb_cloud_fix(start_range, end_cloud_fix);
     } else {
-      query.set_data_buffer(
+      throw_if_not_ok(query.set_data_buffer(
           tiledb::sm::constants::filestore_attribute_name,
           buffer.data(),
-          *buffer_size);
-      query.submit();
+          &query_buffer_len));
+      throw_if_not_ok(query.submit());
     }
+
+    start_range += readlen;
+    end_range += readlen;
   }
 
-  // If the end of the file was reached, but less than buffer_size bytes
-  // were read, write the read bytes into the array.
-  // Check input.gcount() to guard against the case when file_size is
-  // a multiple of buffer_size, thus eof gets set but there are no more
-  // bytes to read
-  if (input.eof() && input.gcount() > 0) {
-    size_t read_bytes = input.gcount();
-    // Initialize the remaining empty cells to 0
-    std::memset(buffer.data() + read_bytes, 0, *buffer_size - read_bytes);
-    uint64_t last_tile_size = last_space_tile_boundary -
-                              file_size / (*buffer_size) * (*buffer_size) + 1;
-    if (is_tiledb_uri) {
-      tiledb_cloud_fix(start_range, start_range + read_bytes - 1, read_bytes);
-    } else {
-      query.set_data_buffer(
-          tiledb::sm::constants::filestore_attribute_name,
-          buffer.data(),
-          last_tile_size);
-      query.submit();
-    }
-  } else if (!input.eof()) {
+  if (start_range < file_size) {
     // Something must have gone wrong whilst reading the file
-    auto st = Status_Error("Error whilst reading the file");
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    fb.close();
-    return TILEDB_ERR;
+    throw_if_not_ok(vfs.close_file(tiledb::sm::URI(file_uri)));
+    throw std::runtime_error("Error whilst reading the file");
   }
 
   if (!is_tiledb_uri) {
     // Dump the fragment on disk
-    query.finalize();
+    throw_if_not_ok(query.finalize());
   }
-  fb.close();
+  throw_if_not_ok(vfs.close_file(tiledb::sm::URI(file_uri)));
+
+  throw_if_not_ok(array->close());
 
   return TILEDB_OK;
 }
 
 int32_t tiledb_filestore_uri_export(
     tiledb_ctx_t* ctx, const char* file_uri, const char* filestore_array_uri) {
-  if (sanity_check(ctx) == TILEDB_ERR || !filestore_array_uri || !file_uri) {
+  if (!filestore_array_uri || !file_uri) {
     return TILEDB_ERR;
   }
 
-  Context context(ctx, false);
-
-  VFS vfs(context);
-  VFS::filebuf fb(vfs);
-  if (!fb.open(std::string(file_uri), std::ios::out)) {
+  tiledb::sm::Context& context = ctx->context();
+  tiledb::sm::VFS vfs(
+      &context.resources().stats(),
+      context.compute_tp(),
+      context.io_tp(),
+      context.storage_manager()->config());
+  auto fb_open_status =
+      vfs.open_file(tiledb::sm::URI(file_uri), tiledb::sm::VFSMode::VFS_WRITE);
+  if (!fb_open_status.ok()) {
     auto st = Status_Error(
         "Failed to open the file; Invalid file URI or incorrect file "
         "permissions");
@@ -359,15 +397,23 @@ int32_t tiledb_filestore_uri_export(
     return TILEDB_ERR;
   }
 
-  std::ostream output(&fb);
+  auto array = make_shared<tiledb::sm::Array>(
+      HERE(), tiledb::sm::URI(filestore_array_uri), context.storage_manager());
+  throw_if_not_ok(array->open(
+      tiledb::sm::QueryType::READ,
+      tiledb::sm::EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0));
 
-  Array array(context, std::string(filestore_array_uri), TILEDB_READ);
-  tiledb_datatype_t dtype;
+  tiledb::sm::Datatype dtype;
   uint32_t num;
-  const void* size;
-  array.get_metadata(
-      tiledb::sm::constants::filestore_metadata_size_key, &dtype, &num, &size);
-  if (!size) {
+  const void* file_size_ptr = nullptr;
+  array->get_metadata(
+      tiledb::sm::constants::filestore_metadata_size_key.c_str(),
+      &dtype,
+      &num,
+      &file_size_ptr);
+  if (!file_size_ptr) {
     auto st = Status_Error(
         "The array metadata doesn't contain the " +
         tiledb::sm::constants::filestore_metadata_size_key + "key");
@@ -376,54 +422,66 @@ int32_t tiledb_filestore_uri_export(
     return TILEDB_ERR;
   }
 
-  uint64_t file_size = *static_cast<const uint64_t*>(size);
+  uint64_t file_size = *static_cast<const uint64_t*>(file_size_ptr);
   uint64_t tile_extent = compute_tile_extent_based_on_file_size(file_size);
-  auto&& [st3, buffer_size] = get_buffer_size_from_config(context, tile_extent);
-  if (!st3.ok()) {
-    LOG_STATUS_NO_RETURN_VALUE(st3);
-    save_error(ctx, st3);
-    return TILEDB_ERR;
-  }
+  auto buffer_size = get_buffer_size_from_config(
+      context.storage_manager()->config(), tile_extent);
 
-  std::vector<std::byte> data(*buffer_size);
+  std::vector<std::byte> data(buffer_size);
   uint64_t start_range = 0;
-  uint64_t end_range = std::min(file_size, *buffer_size) - 1;
+  uint64_t end_range = std::min(file_size, buffer_size) - 1;
   do {
     uint64_t write_size = end_range - start_range + 1;
-    Subarray subarray(context, array);
-    subarray.add_range(0, start_range, end_range);
-    Query query(context, array);
-    query.set_layout(TILEDB_ROW_MAJOR);
+    tiledb::sm::Subarray subarray(
+        array.get(),
+        nullptr,
+        context.storage_manager()->logger(),
+        true,
+        context.storage_manager());
+    uint64_t subarray_range_arr[] = {start_range, end_range};
+    tiledb::type::Range subarray_range(
+        static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
+    throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+
+    tiledb::sm::Query query(context.storage_manager(), array);
+    throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
     query.set_subarray(subarray);
 
     // Cloud compatibility hack. Currently stored tiledb file arrays have a
     // TILEDB_UINT8 attribute. We should pass the right datatype here to
     // support reads from existing tiledb file arrays.
+    auto&& [st, schema] = array->get_array_schema();
+    throw_if_not_ok(st);
     auto attr_type =
-        array.schema()
-            .attribute(tiledb::sm::constants::filestore_attribute_name)
-            .type();
-    if (attr_type == TILEDB_UINT8) {
-      query.set_data_buffer(
+        schema.value()
+            ->attribute(tiledb::sm::constants::filestore_attribute_name)
+            ->type();
+    if (attr_type == tiledb::sm::Datatype::UINT8) {
+      throw_if_not_ok(query.set_data_buffer(
           tiledb::sm::constants::filestore_attribute_name,
           reinterpret_cast<uint8_t*>(data.data()),
-          write_size);
+          &write_size));
     } else {
-      query.set_data_buffer(
+      throw_if_not_ok(query.set_data_buffer(
           tiledb::sm::constants::filestore_attribute_name,
           data.data(),
-          write_size);
+          &write_size));
     }
-    query.submit();
+    throw_if_not_ok(query.submit());
 
-    output.write(reinterpret_cast<char*>(data.data()), write_size);
+    throw_if_not_ok(vfs.write(
+        tiledb::sm::URI(file_uri),
+        reinterpret_cast<char*>(data.data()),
+        write_size));
 
     start_range = end_range + 1;
-    end_range = std::min(file_size - 1, end_range + *buffer_size);
+    end_range = std::min(file_size - 1, end_range + buffer_size);
   } while (start_range <= end_range);
 
-  output.flush();
-  fb.close();
+  throw_if_not_ok(vfs.sync(tiledb::sm::URI(file_uri)));
+  throw_if_not_ok(vfs.close_file(tiledb::sm::URI(file_uri)));
+
+  throw_if_not_ok(array->close());
 
   return TILEDB_OK;
 }
@@ -442,68 +500,75 @@ int32_t tiledb_filestore_buffer_import(
     return TILEDB_OK;  // NOOP
   }
 
-  Context context(ctx, false);
+  tiledb::sm::Context& context = ctx->context();
 
   // Sync up the fragment timestamp and metadata timestamp
-  Array array(
-      context,
-      std::string(filestore_array_uri),
-      TILEDB_WRITE,
-      TemporalPolicy(TimeTravel, tiledb_timestamp_now_ms()));
+  uint64_t time_now = tiledb_timestamp_now_ms();
+  auto array = make_shared<tiledb::sm::Array>(
+      HERE(), tiledb::sm::URI(filestore_array_uri), context.storage_manager());
+  throw_if_not_ok(array->open(
+      tiledb::sm::QueryType::WRITE,
+      0,
+      time_now,
+      tiledb::sm::EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0));
 
   // Detect mimetype and encoding with libmagic
   uint64_t s = std::min(size, static_cast<size_t>(1024));
-  auto&& [st1, mime]{libmagic_get_mime(buf, s)};
-  if (!st1.ok()) {
-    save_error(ctx, st1);
-    LOG_STATUS_NO_RETURN_VALUE(st1);
-    return TILEDB_ERR;
-  }
-  auto&& [st2, mime_encoding]{libmagic_get_mime_encoding(buf, s)};
-  if (!st2.ok()) {
-    save_error(ctx, st2);
-    LOG_STATUS_NO_RETURN_VALUE(st2);
-    return TILEDB_ERR;
-  }
+  auto mime = libmagic_get_mime(buf, s);
+  auto mime_encoding = libmagic_get_mime_encoding(buf, s);
 
   // We need to dump all the relevant metadata at this point so that
   // clients have all the necessary info when consuming the array
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_size_key,
-      TILEDB_UINT64,
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_size_key.c_str(),
+      tiledb::sm::Datatype::UINT64,
       1,
       &size);
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_mime_encoding_key,
-      TILEDB_STRING_UTF8,
-      static_cast<uint32_t>(mime_encoding.value().size()),
-      mime_encoding.value().c_str());
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_mime_type_key,
-      TILEDB_STRING_UTF8,
-      static_cast<uint32_t>(mime.value().size()),
-      mime.value().c_str());
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_original_filename_key,
-      TILEDB_STRING_UTF8,
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_mime_encoding_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
+      static_cast<uint32_t>(mime_encoding.size()),
+      mime_encoding.c_str());
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_mime_type_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
+      static_cast<uint32_t>(mime.size()),
+      mime.c_str());
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_original_filename_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
       static_cast<uint32_t>(0),
       "");
-  array.put_metadata(
-      tiledb::sm::constants::filestore_metadata_file_extension_key,
-      TILEDB_STRING_UTF8,
+  array->put_metadata(
+      tiledb::sm::constants::filestore_metadata_file_extension_key.c_str(),
+      tiledb::sm::Datatype::STRING_UTF8,
       static_cast<uint32_t>(0),
       "");
 
-  Query query(context, array);
-  query.set_layout(TILEDB_ROW_MAJOR);
+  tiledb::sm::Query query(context.storage_manager(), array);
+  throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
 
-  Subarray subarray(context, array);
-  subarray.add_range(
-      0, static_cast<uint64_t>(0), static_cast<uint64_t>(size - 1));
+  tiledb::sm::Subarray subarray(
+      array.get(),
+      nullptr,
+      context.storage_manager()->logger(),
+      true,
+      context.storage_manager());
+  uint64_t subarray_range_arr[] = {
+      static_cast<uint64_t>(0), static_cast<uint64_t>(size - 1)};
+  tiledb::type::Range subarray_range(
+      static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
+  throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+
   query.set_subarray(subarray);
-  query.set_data_buffer(
-      tiledb::sm::constants::filestore_attribute_name, buf, size);
-  query.submit();
+  uint64_t size_tmp = size;
+  throw_if_not_ok(query.set_data_buffer(
+      tiledb::sm::constants::filestore_attribute_name, buf, &size_tmp));
+  throw_if_not_ok(query.submit());
+
+  throw_if_not_ok(array->close());
 
   return TILEDB_OK;
 }
@@ -514,60 +579,84 @@ int32_t tiledb_filestore_buffer_export(
     size_t offset,
     void* buf,
     size_t size) {
-  if (sanity_check(ctx) == TILEDB_ERR || !filestore_array_uri || !buf) {
+  if (!filestore_array_uri || !buf) {
     return TILEDB_ERR;
   }
 
-  Context context(ctx, false);
-
-  Array array(context, std::string(filestore_array_uri), TILEDB_READ);
+  tiledb::sm::Context& context = ctx->context();
+  auto array = make_shared<tiledb::sm::Array>(
+      HERE(), tiledb::sm::URI(filestore_array_uri), context.storage_manager());
+  throw_if_not_ok(array->open(
+      tiledb::sm::QueryType::READ,
+      tiledb::sm::EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0));
 
   // Check whether the user requested more data than the array contains.
   // Return an error if that's the case.
   // This is valid only when the array metadata contains the file_size key
-  tiledb_datatype_t dtype;
+  tiledb::sm::Datatype dtype;
   uint32_t num;
-  const void* file_size;
-  array.get_metadata(
-      tiledb::sm::constants::filestore_metadata_size_key,
+  const void* file_size = nullptr;
+  array->get_metadata(
+      tiledb::sm::constants::filestore_metadata_size_key.c_str(),
       &dtype,
       &num,
       &file_size);
-  if (file_size && *static_cast<const uint64_t*>(file_size) < offset + size) {
-    auto st =
-        Status_Error("The number of bytes requested is bigger than the array");
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
+  if (!file_size) {
+    throw(Status_Error(
+        "The array metadata doesn't contain the " +
+        tiledb::sm::constants::filestore_metadata_size_key + "key"));
+  } else if (*static_cast<const uint64_t*>(file_size) < offset + size) {
+    throw(
+        Status_Error("The number of bytes requested is bigger than the array"));
   }
 
-  Subarray subarray(context, array);
-  subarray.add_range(
-      0,
-      static_cast<uint64_t>(offset),
-      static_cast<uint64_t>(offset + size - 1));
-  Query query(context, array);
-  query.set_layout(TILEDB_ROW_MAJOR);
+  tiledb::sm::Subarray subarray(
+      array.get(),
+      nullptr,
+      context.storage_manager()->logger(),
+      true,
+      context.storage_manager());
+  uint64_t subarray_range_arr[] = {
+      static_cast<uint64_t>(offset), static_cast<uint64_t>(offset + size - 1)};
+  tiledb::type::Range subarray_range(
+      static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
+  throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+
+  tiledb::sm::Query query(context.storage_manager(), array);
+  throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
   query.set_subarray(subarray);
-  query.set_data_buffer(
-      tiledb::sm::constants::filestore_attribute_name, buf, size);
-  query.submit();
+  uint64_t size_tmp = size;
+  throw_if_not_ok(query.set_data_buffer(
+      tiledb::sm::constants::filestore_attribute_name, buf, &size_tmp));
+  throw_if_not_ok(query.submit());
+
+  throw_if_not_ok(array->close());
 
   return TILEDB_OK;
 }
 
 int32_t tiledb_filestore_size(
     tiledb_ctx_t* ctx, const char* filestore_array_uri, size_t* size) {
-  if (sanity_check(ctx) == TILEDB_ERR || !filestore_array_uri || !size) {
+  if (!filestore_array_uri || !size) {
     return TILEDB_ERR;
   }
 
-  Context context(ctx, false);
-  Array array(context, std::string(filestore_array_uri), TILEDB_READ);
+  tiledb::sm::Context& context = ctx->context();
+  tiledb::sm::Array array(
+      tiledb::sm::URI(filestore_array_uri), context.storage_manager());
 
-  tiledb_datatype_t dtype;
-  if (!array.has_metadata(
-          tiledb::sm::constants::filestore_metadata_size_key, &dtype)) {
+  throw_if_not_ok(array.open(
+      tiledb::sm::QueryType::READ,
+      tiledb::sm::EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0));
+
+  std::optional<tiledb::sm::Datatype> type = array.metadata_type(
+      tiledb::sm::constants::filestore_metadata_size_key.c_str());
+  bool has_key = type.has_value();
+  if (!has_key) {
     LOG_STATUS_NO_RETURN_VALUE(Status_Error(
         std::string("Filestore size key not found in array metadata; this "
                     "filestore may not have been imported: ") +
@@ -575,13 +664,21 @@ int32_t tiledb_filestore_size(
     return TILEDB_ERR;
   }
   uint32_t num;
-  const void* file_size;
+  const void* file_size = nullptr;
   array.get_metadata(
-      tiledb::sm::constants::filestore_metadata_size_key,
-      &dtype,
+      tiledb::sm::constants::filestore_metadata_size_key.c_str(),
+      &type.value(),
       &num,
       &file_size);
+
+  if (!file_size) {
+    throw(std::logic_error(
+        "The array metadata should contain the " +
+        tiledb::sm::constants::filestore_metadata_size_key + "key"));
+  }
   *size = *static_cast<const uint64_t*>(file_size);
+
+  throw_if_not_ok(array.close());
 
   return TILEDB_OK;
 }
@@ -615,50 +712,44 @@ uint64_t compute_tile_extent_based_on_file_size(uint64_t file_size) {
   }
 }
 
-std::pair<Status, optional<std::string>> libmagic_get_mime(
-    void* data, uint64_t size) {
+std::string libmagic_get_mime(void* data, uint64_t size) {
   magic_t magic = magic_open(MAGIC_MIME_TYPE);
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
     std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {
-        Status_Error(std::string("Cannot load magic database - ") + errmsg),
-        nullopt};
+    throw std::runtime_error(
+        std::string("Cannot load magic database - ") + errmsg);
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
     std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {
-        Status_Error(std::string("Cannot get the mime type - ") + errmsg),
-        nullopt};
+    throw std::runtime_error(
+        std::string("Cannot get the mime type - ") + errmsg);
   }
   std::string mime(rv);
   magic_close(magic);
-  return {Status::Ok(), mime};
+  return mime;
 }
 
-std::pair<Status, optional<std::string>> libmagic_get_mime_encoding(
-    void* data, uint64_t size) {
+std::string libmagic_get_mime_encoding(void* data, uint64_t size) {
   magic_t magic = magic_open(MAGIC_MIME_ENCODING);
   if (tiledb::sm::magic_dict::magic_mgc_embedded_load(magic)) {
     std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {
-        Status_Error(std::string("Cannot load magic database - ") + errmsg),
-        nullopt};
+    throw std::runtime_error(
+        std::string("Cannot load magic database - ") + errmsg);
   }
   auto rv = magic_buffer(magic, data, size);
   if (!rv) {
     std::string errmsg(magic_error(magic));
     magic_close(magic);
-    return {
-        Status_Error(std::string("Cannot get the mime encoding - ") + errmsg),
-        nullopt};
+    throw std::runtime_error(
+        std::string("Cannot get the mime encoding - ") + errmsg);
   }
   std::string mime(rv);
   magic_close(magic);
-  return {Status::Ok(), mime};
+  return mime;
 }
 
 bool libmagic_file_is_compressed(void* data, uint64_t size) {
@@ -687,18 +778,12 @@ bool libmagic_file_is_compressed(void* data, uint64_t size) {
   return compressed_mime_types.find(mime) != compressed_mime_types.end();
 }
 
-Status read_file_header(
-    const VFS& vfs, const char* uri, std::vector<char>& header) {
-  VFS::filebuf fb(vfs);
-  if (!fb.open(uri, std::ios::in)) {
-    return Status_Error("the file couldn't be opened");
-  }
-  std::istream input(&fb);
-  if (!input.read(header.data(), header.size())) {
-    return Status_Error("the file couldn't be read");
-  }
-  fb.close();
-  return Status::Ok();
+void read_file_header(
+    tiledb::sm::VFS& vfs, const char* uri, std::vector<char>& header) {
+  const tiledb::sm::URI uri_obj = tiledb::sm::URI(uri);
+  throw_if_not_ok(vfs.open_file(uri_obj, tiledb::sm::VFSMode::VFS_READ));
+  throw_if_not_ok(vfs.read(uri_obj, 0, header.data(), header.size()));
+  throw_if_not_ok(vfs.close_file(uri_obj));
 }
 
 std::pair<std::string, std::string> strip_file_extension(const char* file_uri) {
@@ -710,27 +795,24 @@ std::pair<std::string, std::string> strip_file_extension(const char* file_uri) {
   return {uri.substr(fname_pos, ext_pos - fname_pos), ext};
 }
 
-std::pair<Status, optional<uint64_t>> get_buffer_size_from_config(
-    const Context& context, uint64_t tile_extent) {
+uint64_t get_buffer_size_from_config(
+    const tiledb::sm::Config& config, uint64_t tile_extent) {
   bool found = false;
   uint64_t buffer_size;
-  auto st = context.config().ptr()->config().get<uint64_t>(
-      "filestore.buffer_size", &buffer_size, &found);
+  auto st = config.get<uint64_t>("filestore.buffer_size", &buffer_size, &found);
 
-  RETURN_NOT_OK_TUPLE(st, nullopt);
+  throw_if_not_ok(st);
   assert(found);
 
   if (buffer_size < tile_extent) {
-    auto st = Status_Error(
+    throw std::runtime_error(
         "The buffer size configured via filestore.buffer_size"
         "is smaller than current " +
         std::to_string(tile_extent) + " tile extent");
-    return {st, nullopt};
   }
   // Round the buffer size down to the nearest tile
   buffer_size = buffer_size / tile_extent * tile_extent;
-
-  return {Status::Ok(), buffer_size};
+  return buffer_size;
 }
 
 }  // namespace tiledb::common::detail
@@ -739,7 +821,7 @@ using tiledb::api::api_entry_plain;
 template <auto f>
 constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
 
-TILEDB_EXPORT int32_t tiledb_filestore_schema_create(
+int32_t tiledb_filestore_schema_create(
     tiledb_ctx_t* ctx,
     const char* uri,
     tiledb_array_schema_t** array_schema) noexcept {
@@ -747,7 +829,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_schema_create(
       ctx, uri, array_schema);
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_uri_import(
+int32_t tiledb_filestore_uri_import(
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     const char* file_uri,
@@ -756,7 +838,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_uri_import(
       ctx, filestore_array_uri, file_uri, mime_type);
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_uri_export(
+int32_t tiledb_filestore_uri_export(
     tiledb_ctx_t* ctx,
     const char* file_uri,
     const char* filestore_array_uri) noexcept {
@@ -764,7 +846,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_uri_export(
       ctx, file_uri, filestore_array_uri);
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_buffer_import(
+int32_t tiledb_filestore_buffer_import(
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     void* buf,
@@ -774,7 +856,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_buffer_import(
       ctx, filestore_array_uri, buf, size, mime_type);
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_buffer_export(
+int32_t tiledb_filestore_buffer_export(
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     size_t offset,
@@ -784,18 +866,18 @@ TILEDB_EXPORT int32_t tiledb_filestore_buffer_export(
       ctx, filestore_array_uri, offset, buf, size);
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_size(
+int32_t tiledb_filestore_size(
     tiledb_ctx_t* ctx, const char* filestore_array_uri, size_t* size) noexcept {
   return api_entry<detail::tiledb_filestore_size>(
       ctx, filestore_array_uri, size);
 }
 
-TILEDB_EXPORT int32_t tiledb_mime_type_to_str(
+int32_t tiledb_mime_type_to_str(
     tiledb_mime_type_t mime_type, const char** str) noexcept {
   return api_entry_plain<detail::tiledb_mime_type_to_str>(mime_type, str);
 }
 
-TILEDB_EXPORT int32_t tiledb_mime_type_from_str(
+int32_t tiledb_mime_type_from_str(
     const char* str, tiledb_mime_type_t* mime_type) noexcept {
   return api_entry_plain<detail::tiledb_mime_type_from_str>(str, mime_type);
 }

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -110,12 +110,7 @@ int32_t tiledb_filestore_schema_create(
     }
   }
 
-  *array_schema = new (std::nothrow) tiledb_array_schema_t;
-  if (*array_schema == nullptr) {
-    throw api::CAPIStatusException(
-        "Failed to create TileDB Array Schema object; Memory allocation error");
-  }
-
+  *array_schema = new tiledb_array_schema_t;
   try {
     // Share ownership of the internal ArraySchema ptr
     // All other calls for adding domains, attributes, etc
@@ -144,7 +139,7 @@ int32_t tiledb_filestore_schema_create(
         tiledb::sm::ByteVecValue(std::move(tile_extent_vec)));
 
     auto domain = make_shared<tiledb::sm::Domain>(HERE());
-    throw_if_not_ok(domain.get()->add_dimension(dim));
+    throw_if_not_ok(domain->add_dimension(dim));
 
     auto attr = make_shared<tiledb::sm::Attribute>(
         HERE(),
@@ -158,7 +153,7 @@ int32_t tiledb_filestore_schema_create(
           tiledb::sm::Compressor::ZSTD,
           tiledb::sm::ZStd::default_level(),
           tiledb::sm::Datatype::ANY));
-      attr.get()->set_filter_pipeline(filter);
+      attr->set_filter_pipeline(filter);
     }
 
     throw_if_not_ok(schema->set_domain(domain));
@@ -478,7 +473,6 @@ int32_t tiledb_filestore_uri_export(
     end_range = std::min(file_size - 1, end_range + buffer_size);
   } while (start_range <= end_range);
 
-  throw_if_not_ok(vfs.sync(tiledb::sm::URI(file_uri)));
   throw_if_not_ok(vfs.close_file(tiledb::sm::URI(file_uri)));
 
   throw_if_not_ok(array->close());


### PR DESCRIPTION

I am currently refactoring `tiledb/c_api/tiledb_filestore.cc` so that it uses only internal API calls, as opposed to the C++ external API calls.

---
TYPE: IMPROVEMENT
DESC: Refactor filestore API so that it uses internal TileDB library calls. 
