### PR TITLE
Add UTF-8 attribute binary comparison support for QueryConditions

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -96,6 +96,7 @@ void create_array(
     Context& ctx,
     tiledb_array_type_t array_type,
     bool set_dups,
+    bool add_utf8_attr,
     std::vector<int>& a_data_read,
     std::vector<float>& b_data_read) {
   Domain domain(ctx);
@@ -116,6 +117,15 @@ void create_array(
   }
   schema.add_attribute(attr_a);
   schema.add_attribute(attr_b);
+  if (add_utf8_attr) {
+    Attribute attr_c = Attribute::create(ctx, "c", TILEDB_STRING_UTF8);
+    attr_c.set_cell_val_num(TILEDB_VAR_NUM);
+    if (array_type == TILEDB_DENSE) {
+      std::string ohai("ohai");
+      attr_c.set_fill_value(ohai.data(), ohai.size());
+    }
+    schema.add_attribute(attr_c);
+  }
   Array::create(array_name, schema);
 
   // Write some initial data and close the array.
@@ -123,31 +133,47 @@ void create_array(
   std::vector<int> col_dims;
   std::vector<int> a_data;
   std::vector<float> b_data;
+  std::vector<uint8_t> c_data;
+  std::vector<uint64_t> c_offsets;
+
+  std::vector<std::string> c_choices = {std::string("bird"),
+                                        std::string("bunny"),
+                                        std::string("cat"),
+                                        std::string("dog")};
 
   for (int i = 0; i < num_rows * num_rows; ++i) {
     int row = (i / num_rows) + 1;
     int col = (i % num_rows) + 1;
     int a = i % 2 == 1 ? 0 : 1;
     float b;
+    std::string c_str;
     if (i % 8 == 0) {
       // b = 3.4
       b = 3.4f;
+      c_str = c_choices[0];
     } else if (i % 4 == 0) {
       // 3.45 <= b <= 3.7
       b = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / 0.25));
       b += 3.45f;
+      c_str = c_choices[1];
     } else if (i % 2 == 0) {
       // b <= 3.2
       b = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / 3.2));
+      c_str = c_choices[2];
     } else {
       // b = 4.2
       b = 4.2f;
+      c_str = c_choices[3];
     }
 
     row_dims.push_back(row);
     col_dims.push_back(col);
     a_data.push_back(a);
     b_data.push_back(b);
+    c_offsets.push_back(c_data.size());
+    for (size_t c_idx = 0; c_idx < c_str.size(); c_idx++) {
+      c_data.push_back(c_str.at(c_idx));
+    }
   }
 
   if (array_type == TILEDB_SPARSE) {
@@ -159,6 +185,10 @@ void create_array(
         .set_data_buffer("a", a_data)
         .set_data_buffer("b", b_data);
 
+    if (add_utf8_attr) {
+      query_w.set_data_buffer("c", c_data).set_offsets_buffer("c", c_offsets);
+    }
+
     query_w.submit();
     query_w.finalize();
     array_w.close();
@@ -168,6 +198,10 @@ void create_array(
     query_w.set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", a_data)
         .set_data_buffer("b", b_data);
+
+    if (add_utf8_attr) {
+      query_w.set_data_buffer("c", c_data).set_offsets_buffer("c", c_offsets);
+    }
 
     query_w.submit();
     query_w.finalize();
@@ -234,22 +268,42 @@ static void perform_query(
   query.submit();
 }
 
+static void perform_query(
+    std::vector<int>& a_data,
+    std::vector<float>& b_data,
+    std::string& c_data,
+    std::vector<uint64_t>& c_offsets,
+    const QueryCondition& qc,
+    tiledb_layout_t layout_type,
+    Query& query) {
+  query.set_layout(layout_type)
+      .set_data_buffer("a", a_data)
+      .set_data_buffer("b", b_data)
+      .set_data_buffer("c", c_data)
+      .set_offsets_buffer("c", c_offsets)
+      .set_condition(qc);
+  query.submit();
+}
+
 struct TestParams {
   TestParams(
       tiledb_array_type_t array_type,
       tiledb_layout_t layout,
       bool set_dups,
-      bool legacy)
+      bool legacy,
+      bool add_utf8_attr = false)
       : array_type_(array_type)
       , layout_(layout)
       , set_dups_(set_dups)
-      , legacy_(legacy) {
+      , legacy_(legacy)
+      , add_utf8_attr_(add_utf8_attr) {
   }
 
   tiledb_array_type_t array_type_;
   tiledb_layout_t layout_;
   bool set_dups_;
   bool legacy_;
+  bool add_utf8_attr_;
 };
 
 TEST_CASE(
@@ -286,7 +340,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -411,7 +470,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -535,7 +599,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -669,7 +738,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -789,7 +863,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -946,7 +1025,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -1013,6 +1097,184 @@ TEST_CASE(
     // elements.
     auto table = query.result_buffer_elements();
     REQUIRE(table.size() == 2);
+    REQUIRE(table["a"].first == 0);
+    REQUIRE(table["a"].second == 64);
+    REQUIRE(table["b"].first == 0);
+    REQUIRE(table["b"].second == 64);
+
+    for (int r = 7; r <= 14; ++r) {
+      for (int c = 7; c <= 14; ++c) {
+        int original_arr_i = index_from_row_col(r, c);
+        int i = ((r - 7) * 8) + (c - 7);
+        // The buffer should have kept elements that were originally constructed
+        // to have values that satisfy the range [3.3, 3.7] but are not equal
+        // to 3.4. This means that any element whose original index is 4 mod 8
+        // should have been kept.
+        if (original_arr_i % 8 == 4) {
+          // Checking for original value.
+          REQUIRE(a_data_read_2[i] == 1);
+          REQUIRE(a_data_read_2[i] == a_data_read[original_arr_i]);
+          REQUIRE(
+              fabs(b_data_read_2[i] - b_data_read[original_arr_i]) <
+              std::numeric_limits<float>::epsilon());
+        } else {
+          // Checking for fill value.
+          REQUIRE(a_data_read_2[i] == a_fill_value);
+          REQUIRE(
+              fabs(b_data_read_2[i] - b_fill_value) <
+              std::numeric_limits<float>::epsilon());
+        }
+      }
+    }
+  }
+
+  query.finalize();
+  array.close();
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+TEST_CASE(
+    "Testing read query with complex QC, with ranges across tiles on both "
+    "dimensions and a UTF-8 attribute",
+    "[query][query-condition][utf8]") {
+  // Initial setup.
+  std::srand(static_cast<uint32_t>(time(0)));
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Define query condition (b < 4.0f AND b <= 3.7f AND b >= 3.3f AND b
+  // != 3.4f);
+  QueryCondition qc1(ctx);
+  float val1 = 4.0f;
+  qc1.init("b", &val1, sizeof(float), TILEDB_LT);
+
+  QueryCondition qc2(ctx);
+  float val2 = 3.7f;
+  qc2.init("b", &val2, sizeof(float), TILEDB_LE);
+
+  QueryCondition qc3(ctx);
+  float val3 = 3.3f;
+  qc3.init("b", &val3, sizeof(float), TILEDB_GE);
+
+  QueryCondition qc4(ctx);
+  float val4 = 3.4f;
+  qc4.init("b", &val4, sizeof(float), TILEDB_NE);
+
+  QueryCondition qc5(ctx);
+  std::string val5("dog");
+  qc5.init("c", val5.data(), val5.size(), TILEDB_LE);
+
+  QueryCondition qc6 = qc1.combine(qc2, TILEDB_AND);
+  QueryCondition qc7 = qc6.combine(qc3, TILEDB_AND);
+  QueryCondition qc8 = qc7.combine(qc4, TILEDB_AND);
+  QueryCondition qc = qc8.combine(qc5, TILEDB_AND);
+
+  // Create buffers with size of the results of the two queries.
+  std::vector<int> a_data_read(num_rows * num_rows);
+  std::vector<float> b_data_read(num_rows * num_rows);
+
+  // These buffers store the results of the second query made with the query
+  // condition specified above.
+  std::vector<int> a_data_read_2(64);
+  std::vector<float> b_data_read_2(64);
+  std::string c_data_read_2;
+  c_data_read_2.resize(64 * 5);
+  std::vector<uint64_t> c_data_offsets_2(64);
+
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false, true),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false, true));
+
+  // Setup by creating buffers to store all elements of the original array.
+  create_array(
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
+
+  // Create the query, which reads over the entire array with query condition
+  // (b < 4.0).
+  Config config;
+  if (params.legacy_) {
+    config.set("sm.query.sparse_global_order.reader", "legacy");
+    config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
+  }
+  Context ctx2 = Context(config);
+  Array array(ctx2, array_name, TILEDB_READ);
+  Query query(ctx2, array);
+
+  // Define range.
+  int range[] = {7, 14};
+  query.add_range("rows", range[0], range[1])
+      .add_range("cols", range[0], range[1]);
+
+  // Perform query and validate.
+  perform_query(
+      a_data_read_2,
+      b_data_read_2,
+      c_data_read_2,
+      c_data_offsets_2,
+      qc,
+      params.layout_,
+      query);
+  if (params.array_type_ == TILEDB_SPARSE) {
+    // Check the query for accuracy. The query results should contain 8
+    // elements.
+    auto table = query.result_buffer_elements();
+    REQUIRE(table.size() == 3);
+    REQUIRE(table["a"].first == 0);
+    REQUIRE(table["a"].second == 8);
+    REQUIRE(table["b"].first == 0);
+    REQUIRE(table["b"].second == 8);
+
+    int i = 0;
+    std::vector<std::pair<int, int>> ranges_vec;
+    ranges_vec.push_back(std::make_pair(7, 8));
+    ranges_vec.push_back(std::make_pair(9, 12));
+    ranges_vec.push_back(std::make_pair(13, 14));
+
+    for (size_t a = 0; a < 3; ++a) {    // Iterating over rows.
+      for (size_t b = 0; b < 3; ++b) {  // Iterating over cols.
+        int row_lo = ranges_vec[a].first;
+        int row_hi = ranges_vec[a].second;
+        int col_lo = ranges_vec[b].first;
+        int col_hi = ranges_vec[b].second;
+
+        for (int r = row_lo; r <= row_hi; ++r) {
+          for (int c = col_lo; c <= col_hi; ++c) {
+            int original_arr_i = index_from_row_col(r, c);
+            // The buffer should have kept elements that were originally
+            // constructed to have values that satisfy the range [3.3, 3.7] but
+            // are not equal to 3.4. This means that any element whose original
+            // index is 4 mod 8 should be in the result buffer.
+            if (original_arr_i % 8 == 4) {
+              REQUIRE(a_data_read_2[i] == 1);
+              REQUIRE(a_data_read_2[i] == a_data_read[original_arr_i]);
+              REQUIRE(
+                  fabs(b_data_read_2[i] - b_data_read[original_arr_i]) <
+                  std::numeric_limits<float>::epsilon());
+              i += 1;
+            }
+          }
+        }
+      }
+    }
+  } else {
+    // Check the query for accuracy. The query results should contain 64
+    // elements.
+    auto table = query.result_buffer_elements();
+    REQUIRE(table.size() == 3);
     REQUIRE(table["a"].first == 0);
     REQUIRE(table["a"].second == 64);
     REQUIRE(table["b"].first == 0);
@@ -1175,7 +1437,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -1276,7 +1543,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -1391,7 +1663,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -1490,7 +1767,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -1619,6 +1901,7 @@ TEST_CASE(
   std::vector<float> b_data_read_2(num_rows * num_rows);
 
   // Generate test parameters.
+  // PJD: Why not dense here?
   TestParams params = GENERATE(
       TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
       TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, false),
@@ -1626,7 +1909,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).
@@ -1805,7 +2093,12 @@ TEST_CASE(
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(
-      ctx, params.array_type_, params.set_dups_, a_data_read, b_data_read);
+      ctx,
+      params.array_type_,
+      params.set_dups_,
+      params.add_utf8_attr_,
+      a_data_read,
+      b_data_read);
 
   // Create the query, which reads over the entire array with query condition
   // (b < 4.0).

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1188,7 +1188,7 @@ void QueryCondition::apply_ast_node_dense(
     const uint64_t* buffer_offsets =
         static_cast<uint64_t*>(tile_offsets.data()) + src_cell;
     const uint64_t buffer_offsets_el =
-        tile_offsets.size() / constants::cell_var_offset_size;
+        (tile_offsets.size() / constants::cell_var_offset_size) - src_cell;
 
     // Iterate through each cell in this slab.
     for (uint64_t c = 0; c < result_buffer.size(); ++c) {

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1186,20 +1186,20 @@ void QueryCondition::apply_ast_node_dense(
 
     const auto& tile_offsets = tile_tuple->fixed_tile();
     const uint64_t* buffer_offsets =
-        static_cast<uint64_t*>(tile_offsets.data()) + src_cell;
+        static_cast<uint64_t*>(tile_offsets.data());
     const uint64_t buffer_offsets_el =
-        (tile_offsets.size() / constants::cell_var_offset_size) - src_cell;
+        tile_offsets.size() / constants::cell_var_offset_size;
 
     // Iterate through each cell in this slab.
     for (uint64_t c = 0; c < result_buffer.size(); ++c) {
-      // Check the previous cell here, which breaks vectorization but as this
+      // Check the next cell here, which breaks vectorization but as this
       // is string data requiring a strcmp which cannot be vectorized, this is
       // ok.
-      const uint64_t buffer_offset = buffer_offsets[start + c * stride];
-      const uint64_t next_cell_offset =
-          (start + c * stride + 1 < buffer_offsets_el) ?
-              buffer_offsets[start + c * stride + 1] :
-              buffer_size;
+      const uint64_t offset_idx = start + src_cell + c * stride;
+      const uint64_t buffer_offset = buffer_offsets[offset_idx];
+      const uint64_t next_cell_offset = (offset_idx + 1 < buffer_offsets_el) ?
+                                            buffer_offsets[offset_idx + 1] :
+                                            buffer_size;
       const uint64_t cell_size = next_cell_offset - buffer_offset;
 
       // Get the cell value.

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -302,6 +302,142 @@ struct QueryCondition::BinaryCmpNullChecks<char*, QueryConditionOp::NE> {
   }
 };
 
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::LT`. */
+template <>
+struct QueryCondition::BinaryCmpNullChecks<uint8_t*, QueryConditionOp::LT> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs == nullptr) {
+      return false;
+    }
+
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp < 0;
+    }
+
+    return lhs_size < rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::LE. */
+template <>
+struct QueryCondition::BinaryCmpNullChecks<uint8_t*, QueryConditionOp::LE> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs == nullptr) {
+      return false;
+    }
+
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp < 0;
+    }
+
+    return lhs_size <= rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::GT`. */
+template <>
+struct QueryCondition::BinaryCmpNullChecks<uint8_t*, QueryConditionOp::GT> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs == nullptr) {
+      return false;
+    }
+
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp > 0;
+    }
+
+    return lhs_size > rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::GE`. */
+template <>
+struct QueryCondition::BinaryCmpNullChecks<uint8_t*, QueryConditionOp::GE> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs == nullptr) {
+      return false;
+    }
+
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp > 0;
+    }
+
+    return lhs_size >= rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::EQ`. */
+template <>
+struct QueryCondition::BinaryCmpNullChecks<uint8_t*, QueryConditionOp::EQ> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs == rhs) {
+      return true;
+    }
+
+    if (lhs == nullptr || rhs == nullptr) {
+      return false;
+    }
+
+    if (lhs_size != rhs_size) {
+      return false;
+    }
+
+    return memcmp(
+               static_cast<const uint8_t*>(lhs),
+               static_cast<const uint8_t*>(rhs),
+               lhs_size) == 0;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::NE`. */
+template <>
+struct QueryCondition::BinaryCmpNullChecks<uint8_t*, QueryConditionOp::NE> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (rhs == nullptr && lhs != nullptr) {
+      return true;
+    }
+
+    if (lhs == nullptr || rhs == nullptr) {
+      return false;
+    }
+
+    if (lhs_size != rhs_size) {
+      return true;
+    }
+
+    return memcmp(
+               static_cast<const uint8_t*>(lhs),
+               static_cast<const uint8_t*>(rhs),
+               lhs_size) != 0;
+  }
+};
+
 /** Partial template specialization for `QueryConditionOp::LT`. */
 template <typename T>
 struct QueryCondition::BinaryCmpNullChecks<T, QueryConditionOp::LT> {
@@ -831,9 +967,20 @@ void QueryCondition::apply_ast_node(
           combination_op,
           result_cell_bitmap);
     } break;
+    case Datatype::STRING_UTF8: {
+      apply_ast_node<uint8_t*, CombinationOp>(
+          node,
+          fragment_metadata,
+          stride,
+          var_size,
+          nullable,
+          fill_value,
+          result_cell_slabs,
+          combination_op,
+          result_cell_bitmap);
+    } break;
     case Datatype::ANY:
     case Datatype::BLOB:
-    case Datatype::STRING_UTF8:
     case Datatype::STRING_UTF16:
     case Datatype::STRING_UTF32:
     case Datatype::STRING_UCS2:
@@ -1410,9 +1557,20 @@ void QueryCondition::apply_ast_node_dense(
           combination_op,
           result_buffer);
     } break;
+    case Datatype::STRING_UTF8: {
+      apply_ast_node_dense<uint8_t*, CombinationOp>(
+          node,
+          result_tile,
+          start,
+          src_cell,
+          stride,
+          var_size,
+          nullable,
+          combination_op,
+          result_buffer);
+    } break;
     case Datatype::ANY:
     case Datatype::BLOB:
-    case Datatype::STRING_UTF8:
     case Datatype::STRING_UTF16:
     case Datatype::STRING_UTF32:
     case Datatype::STRING_UCS2:
@@ -1582,7 +1740,7 @@ struct QueryCondition::BinaryCmp<char*, QueryConditionOp::LT> {
   }
 };
 
-/** Partial template specialization for `char*` and `QueryConditionOp::LE. */
+/** Full template specialization for `char*` and `QueryConditionOp::LE. */
 template <>
 struct QueryCondition::BinaryCmp<char*, QueryConditionOp::LE> {
   static inline bool cmp(
@@ -1598,7 +1756,7 @@ struct QueryCondition::BinaryCmp<char*, QueryConditionOp::LE> {
   }
 };
 
-/** Partial template specialization for `char*` and `QueryConditionOp::GT`. */
+/** Full template specialization for `char*` and `QueryConditionOp::GT`. */
 template <>
 struct QueryCondition::BinaryCmp<char*, QueryConditionOp::GT> {
   static inline bool cmp(
@@ -1614,7 +1772,7 @@ struct QueryCondition::BinaryCmp<char*, QueryConditionOp::GT> {
   }
 };
 
-/** Partial template specialization for `char*` and `QueryConditionOp::GE`. */
+/** Full template specialization for `char*` and `QueryConditionOp::GE`. */
 template <>
 struct QueryCondition::BinaryCmp<char*, QueryConditionOp::GE> {
   static inline bool cmp(
@@ -1630,7 +1788,7 @@ struct QueryCondition::BinaryCmp<char*, QueryConditionOp::GE> {
   }
 };
 
-/** Partial template specialization for `char*` and `QueryConditionOp::EQ`. */
+/** Full template specialization for `char*` and `QueryConditionOp::EQ`. */
 template <>
 struct QueryCondition::BinaryCmp<char*, QueryConditionOp::EQ> {
   static inline bool cmp(
@@ -1646,7 +1804,7 @@ struct QueryCondition::BinaryCmp<char*, QueryConditionOp::EQ> {
   }
 };
 
-/** Partial template specialization for `char*` and `QueryConditionOp::NE`. */
+/** Full template specialization for `char*` and `QueryConditionOp::NE`. */
 template <>
 struct QueryCondition::BinaryCmp<char*, QueryConditionOp::NE> {
   static inline bool cmp(
@@ -1658,6 +1816,110 @@ struct QueryCondition::BinaryCmp<char*, QueryConditionOp::NE> {
     return strncmp(
                static_cast<const char*>(lhs),
                static_cast<const char*>(rhs),
+               lhs_size) != 0;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::LT`. */
+template <>
+struct QueryCondition::BinaryCmp<uint8_t*, QueryConditionOp::LT> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const char*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp < 0;
+    }
+
+    return lhs_size < rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::LE. */
+template <>
+struct QueryCondition::BinaryCmp<uint8_t*, QueryConditionOp::LE> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp < 0;
+    }
+
+    return lhs_size <= rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::GT`. */
+template <>
+struct QueryCondition::BinaryCmp<uint8_t*, QueryConditionOp::GT> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp > 0;
+    }
+
+    return lhs_size > rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::GE`. */
+template <>
+struct QueryCondition::BinaryCmp<uint8_t*, QueryConditionOp::GE> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    const size_t min_size = std::min<size_t>(lhs_size, rhs_size);
+    const int cmp = memcmp(
+        static_cast<const uint8_t*>(lhs),
+        static_cast<const uint8_t*>(rhs),
+        min_size);
+    if (cmp != 0) {
+      return cmp > 0;
+    }
+
+    return lhs_size >= rhs_size;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::EQ`. */
+template <>
+struct QueryCondition::BinaryCmp<uint8_t*, QueryConditionOp::EQ> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs_size != rhs_size) {
+      return false;
+    }
+
+    return memcmp(
+               static_cast<const uint8_t*>(lhs),
+               static_cast<const uint8_t*>(rhs),
+               lhs_size) == 0;
+  }
+};
+
+/** Full template specialization for `uint8_t*` and `QueryConditionOp::NE`. */
+template <>
+struct QueryCondition::BinaryCmp<uint8_t*, QueryConditionOp::NE> {
+  static inline bool cmp(
+      const void* lhs, uint64_t lhs_size, const void* rhs, uint64_t rhs_size) {
+    if (lhs_size != rhs_size) {
+      return true;
+    }
+
+    return memcmp(
+               static_cast<const uint8_t*>(lhs),
+               static_cast<const uint8_t*>(rhs),
                lhs_size) != 0;
   }
 };
@@ -2023,9 +2285,12 @@ void QueryCondition::apply_ast_node_sparse(
       apply_ast_node_sparse<int64_t, BitmapType, CombinationOp>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
+    case Datatype::STRING_UTF8: {
+      apply_ast_node_sparse<uint8_t*, BitmapType, CombinationOp>(
+          node, result_tile, var_size, nullable, combination_op, result_bitmap);
+    } break;
     case Datatype::ANY:
     case Datatype::BLOB:
-    case Datatype::STRING_UTF8:
     case Datatype::STRING_UTF16:
     case Datatype::STRING_UTF32:
     case Datatype::STRING_UCS2:

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -4032,6 +4032,431 @@ TEST_CASE(
 /**
  * @brief Function that takes a selection of QueryConditions, with their
  * expected results, and combines them together. This function is
+ * exclusively for UTF-8 string query conditions.
+ *
+ * @param field_name The field name of the query condition.
+ * @param result_tile The result tile of the array we're running the query on.
+ * @param tp_vec The vector that stores the test parameter structs.
+ */
+void populate_utf8_string_test_params_vector(
+    const std::string& field_name,
+    ResultTile* result_tile,
+    std::vector<TestParams>& tp_vec) {
+  // UTF-8 String data sorted according to raw byte comparisons.
+  std::string upper_a = "\x41";
+  std::string upper_aa = "\x41\x41";
+  std::string lower_a = "\x61";
+  std::string lower_a0 = "\x61\x30";
+  std::string lower_aa = "\x61\x61";
+  std::string n_plus_tilda = "\x6e\xcc\x83";
+  std::string n_with_tilda = "\xc3\xb1";
+  std::string u_with_umlaut = "\xc3\xbc";
+  std::string infinity = "\xe2\x88\x9e";
+  std::string snowman = "\xe2\x98\x83\xef\xb8\x8f";
+  std::string mahjong = "\xf0\x9f\x80\x84";
+  std::string yarn = "\xf0\x9f\xa7\xb6";
+  std::string flag_gr = "\xf0\x9f\x87\xac\xf0\x9f\x87\xb7";
+  std::string icecream = "\xf0\x9f\x8d\xa8";
+  std::string doughnut = "\xf0\x9f\x8d\xa9";
+
+  // N.B. This is a cop-pasta of populate_string_test_params_vector
+  // updated to use different string data. The equivalency table is:
+  //
+  // alice -> upper_a
+  // ask -> uper_aa
+  // bob -> lower_a
+  // bye -> lower_a0
+  // craig -> lower_aa
+  // dave -> n_plus_tilda
+  // erin -> n_with_tilda
+  // eve -> u_with_umlaut
+  // frank -> infinity
+  // grace -> snowman
+  // heidi -> mahjong
+  // hi -> yarn
+  // ivan -> flag_gr
+  // judy -> icecream
+  // just -> doughnut
+
+  // $val < u_with_umlaut
+  {
+    QueryCondition qc;
+    REQUIRE(qc.init(
+                  std::string(field_name),
+                  u_with_umlaut.data(),
+                  u_with_umlaut.size(),
+                  QueryConditionOp::LT)
+                .ok());
+    std::vector<uint8_t> expected_bitmap = {1, 1, 1, 1, 1, 0, 0, 0, 0, 0};
+    std::vector<ResultCellSlab> expected_slabs = {{result_tile, 0, 5}};
+    TestParams tp(
+        std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+    tp_vec.push_back(tp);
+  }
+
+  // $val >= lower_a && $val <= u_with_umlaut
+  {
+    QueryCondition qc1;
+    REQUIRE(qc1.init(
+                   std::string(field_name),
+                   u_with_umlaut.data(),
+                   u_with_umlaut.size(),
+                   QueryConditionOp::LE)
+                .ok());
+
+    QueryCondition qc2;
+    REQUIRE(qc2.init(
+                   std::string(field_name),
+                   lower_a.data(),
+                   lower_a.size(),
+                   QueryConditionOp::GE)
+                .ok());
+
+    QueryCondition qc;
+    REQUIRE(qc1.combine(qc2, QueryConditionCombinationOp::AND, &qc).ok());
+    std::vector<uint8_t> expected_bitmap = {0, 1, 1, 1, 1, 0, 0, 0, 0, 0};
+    std::vector<ResultCellSlab> expected_slabs = {{result_tile, 1, 4}};
+    TestParams tp(
+        std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+    tp_vec.push_back(tp);
+  }
+
+  // $val >= u_with_umlaut || $val <= lower_a
+  {
+    QueryCondition qc1;
+    REQUIRE(qc1.init(
+                   std::string(field_name),
+                   u_with_umlaut.data(),
+                   u_with_umlaut.size(),
+                   QueryConditionOp::GE)
+                .ok());
+
+    QueryCondition qc2;
+    REQUIRE(qc2.init(
+                   std::string(field_name),
+                   lower_a.data(),
+                   lower_a.size(),
+                   QueryConditionOp::LE)
+                .ok());
+
+    QueryCondition qc;
+    REQUIRE(qc1.combine(qc2, QueryConditionCombinationOp::OR, &qc).ok());
+
+    std::vector<uint8_t> expected_bitmap = {1, 1, 0, 0, 0, 1, 1, 1, 1, 1};
+    std::vector<ResultCellSlab> expected_slabs = {{result_tile, 0, 2},
+                                                  {result_tile, 5, 5}};
+    TestParams tp(
+        std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+    tp_vec.push_back(tp);
+  }
+
+  // ($val > upper_aa && $val <= yarn) || ($val > lower_a0 && $val < doughnut)
+  // I.e., OR of 2 AND ASTs
+  {
+    QueryCondition qc1;
+    REQUIRE(qc1.init(
+                   std::string(field_name),
+                   upper_aa.data(),
+                   upper_aa.size(),
+                   QueryConditionOp::GT)
+                .ok());
+
+    QueryCondition qc2;
+    REQUIRE(qc2.init(
+                   std::string(field_name),
+                   yarn.data(),
+                   yarn.size(),
+                   QueryConditionOp::LE)
+                .ok());
+
+    QueryCondition qc3;
+    REQUIRE(qc3.init(
+                   std::string(field_name),
+                   lower_a0.data(),
+                   lower_a0.size(),
+                   QueryConditionOp::GT)
+                .ok());
+
+    QueryCondition qc4;
+    REQUIRE(qc4.init(
+                   std::string(field_name),
+                   doughnut.data(),
+                   doughnut.size(),
+                   QueryConditionOp::LT)
+                .ok());
+
+    QueryCondition qc5, qc6, qc;
+    REQUIRE(qc1.combine(qc2, QueryConditionCombinationOp::AND, &qc5).ok());
+    REQUIRE(qc3.combine(qc4, QueryConditionCombinationOp::AND, &qc6).ok());
+    REQUIRE(qc5.combine(qc6, QueryConditionCombinationOp::OR, &qc).ok());
+
+    std::vector<uint8_t> expected_bitmap = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    std::vector<ResultCellSlab> expected_slabs = {{result_tile, 1, 9}};
+    TestParams tp(
+        std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+    tp_vec.push_back(tp);
+  }
+
+  // ($val == lower_aa || $val == mahjong) &&
+  //    ($val > u_with_umlaut || $val < lower_a0)
+  // I.e., AND of 2 OR ASTs
+  {
+    QueryCondition qc1;
+    REQUIRE(qc1.init(
+                   std::string(field_name),
+                   lower_aa.data(),
+                   lower_aa.size(),
+                   QueryConditionOp::EQ)
+                .ok());
+
+    QueryCondition qc2;
+    REQUIRE(qc2.init(
+                   std::string(field_name),
+                   mahjong.data(),
+                   mahjong.size(),
+                   QueryConditionOp::EQ)
+                .ok());
+
+    QueryCondition qc3;
+    REQUIRE(qc3.init(
+                   std::string(field_name),
+                   u_with_umlaut.data(),
+                   u_with_umlaut.size(),
+                   QueryConditionOp::GT)
+                .ok());
+
+    QueryCondition qc4;
+    REQUIRE(qc4.init(
+                   std::string(field_name),
+                   lower_a0.data(),
+                   lower_a0.size(),
+                   QueryConditionOp::LT)
+                .ok());
+
+    QueryCondition qc5, qc6, qc;
+    REQUIRE(qc1.combine(qc2, QueryConditionCombinationOp::OR, &qc5).ok());
+    REQUIRE(qc3.combine(qc4, QueryConditionCombinationOp::OR, &qc6).ok());
+    REQUIRE(qc5.combine(qc6, QueryConditionCombinationOp::AND, &qc).ok());
+
+    std::vector<uint8_t> expected_bitmap = {0, 0, 0, 0, 0, 0, 0, 1, 0, 0};
+    std::vector<ResultCellSlab> expected_slabs = {{result_tile, 7, 1}};
+    TestParams tp(
+        std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+    tp_vec.push_back(tp);
+  }
+
+  {
+    std::vector<std::string> vec = {
+        upper_a, lower_aa, n_with_tilda, snowman, flag_gr};
+    // $val != upper_a && $val != lower_a && $val != n_with_tilda &&
+    //    $val != snowman && $val != flag_gr
+    // I.e., combine multiple simple AND clauses
+    {
+      std::vector<QueryCondition> val_nodes;
+      for (uint64_t i = 0; i < 5; ++i) {
+        QueryCondition temp;
+        REQUIRE(temp.init(
+                        std::string(field_name),
+                        vec[i].c_str(),
+                        vec[i].size(),
+                        QueryConditionOp::NE)
+                    .ok());
+        val_nodes.push_back(temp);
+      }
+
+      QueryCondition qc1, qc2, qc3, qc;
+      REQUIRE(val_nodes[0]
+                  .combine(val_nodes[1], QueryConditionCombinationOp::AND, &qc1)
+                  .ok());
+      REQUIRE(qc1.combine(val_nodes[2], QueryConditionCombinationOp::AND, &qc2)
+                  .ok());
+      REQUIRE(qc2.combine(val_nodes[3], QueryConditionCombinationOp::AND, &qc3)
+                  .ok());
+      REQUIRE(qc3.combine(val_nodes[4], QueryConditionCombinationOp::AND, &qc)
+                  .ok());
+
+      std::vector<uint8_t> expected_bitmap = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+      std::vector<ResultCellSlab> expected_slabs = {{result_tile, 1, 1},
+                                                    {result_tile, 3, 1},
+                                                    {result_tile, 5, 1},
+                                                    {result_tile, 7, 1},
+                                                    {result_tile, 9, 1}};
+      TestParams tp(
+          std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+      tp_vec.push_back(tp);
+    }
+
+    // $val == $upper_a || $val == lower_a || $val == n_with_tilda ||
+    //    $ val == snowman || $val == flag_gr
+    // I.e., combine multiple simple OR clauses
+    {
+      std::vector<QueryCondition> val_nodes;
+      for (uint64_t i = 0; i < 5; ++i) {
+        QueryCondition temp;
+        REQUIRE(temp.init(
+                        std::string(field_name),
+                        vec[i].c_str(),
+                        vec[i].size(),
+                        QueryConditionOp::EQ)
+                    .ok());
+        val_nodes.push_back(temp);
+      }
+
+      QueryCondition qc1, qc2, qc3, qc;
+      REQUIRE(val_nodes[0]
+                  .combine(val_nodes[1], QueryConditionCombinationOp::OR, &qc1)
+                  .ok());
+      REQUIRE(qc1.combine(val_nodes[2], QueryConditionCombinationOp::OR, &qc2)
+                  .ok());
+      REQUIRE(qc2.combine(val_nodes[3], QueryConditionCombinationOp::OR, &qc3)
+                  .ok());
+      REQUIRE(
+          qc3.combine(val_nodes[4], QueryConditionCombinationOp::OR, &qc).ok());
+
+      std::vector<uint8_t> expected_bitmap = {1, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+      std::vector<ResultCellSlab> expected_slabs = {{result_tile, 0, 1},
+                                                    {result_tile, 2, 1},
+                                                    {result_tile, 4, 1},
+                                                    {result_tile, 6, 1},
+                                                    {result_tile, 8, 1}};
+      TestParams tp(
+          std::move(qc), std::move(expected_bitmap), std::move(expected_slabs));
+      tp_vec.push_back(tp);
+    }
+  }
+}
+
+TEST_CASE(
+    "QueryCondition: Test combinations, string with UTF-8 data",
+    "[QueryCondition][combinations][string][utf-8]") {
+  // Setup.
+  const std::string field_name = "foo";
+  const uint64_t cells = 10;
+  const Datatype type = Datatype::STRING_UTF8;
+
+  // Initialize the array schema.
+  shared_ptr<ArraySchema> array_schema = make_shared<ArraySchema>(HERE());
+  Attribute attr(field_name, type);
+  REQUIRE(attr.set_nullable(false).ok());
+  REQUIRE(attr.set_cell_val_num(constants::var_num).ok());
+  REQUIRE(attr.set_fill_value("ac", 2 * sizeof(char)).ok());
+
+  REQUIRE(
+      array_schema->add_attribute(make_shared<Attribute>(HERE(), &attr)).ok());
+  Domain domain;
+  Dimension dim("dim1", Datatype::UINT32);
+  uint32_t bounds[2] = {1, cells};
+  Range range(bounds, 2 * sizeof(uint32_t));
+  REQUIRE(dim.set_domain(range).ok());
+  REQUIRE(domain.add_dimension(make_shared<Dimension>(HERE(), &dim)).ok());
+  REQUIRE(array_schema->set_domain(make_shared<Domain>(HERE(), &domain)).ok());
+
+  // For pasting into a Python shell:
+  //
+  // To install pyicu on MacOS:
+  // $ brew install icu4c
+  // $ python3 -m venv venv
+  // $ source venv/bin/activate
+  // $ PATH="$(brew --prefix icu4c)/bin:$PATH" pip install pyicu
+  //
+  // If you run the snippet below you'll see that the sort order
+  // changes drastically using the ICU collator. Specifically, you
+  // should see the following orders for without and with ICU collation:
+  //
+  //   A a aa n-yay n-yay :infinity: :snowman: :mahjong: :flag-gr: :icecream:
+  //   :infinity: :snowman: :flag-gr: :mahjong: :icecream: a A aa n-yay n-yay
+  //
+  // data = [
+  //   b"\x41".decode("utf-8"),
+  //   b"\x61".decode("utf-8"),
+  //   b"\x61\x61".decode("utf-8"),
+  //   b"\x6e\xcc\x83".decode("utf-8"),
+  //   b"\xc3\xb1".decode("utf-8"),
+  //   b"\xe2\x88\x9e".decode("utf-8"),
+  //   b"\xe2\x98\x83\xef\xb8\x8f".decode("utf-8"),
+  //   b"\xf0\x9f\x80\x84".decode("utf-8"),
+  //   b"\xf0\x9f\x87\xac\xf0\x9f\x87\xb7".decode("utf-8"),
+  //   b"\xf0\x9f\x8d\xa8".decode("utf-8")
+  // ]
+  // sorted(data)
+  // import icu
+  // coll = icu.Collator.createInstance()
+  // sorted(data, key=coll.getSortKey)
+
+  // UTF-8 String Data
+  //
+  // These strings are sorted according to raw byte comparisons
+  // without the use of ICU collation. The Python snippet above shows
+  // the difference between the two sort methods.
+  std::vector<std::string> utf8_data = {
+      "\x41",                              // "A"
+      "\x61",                              // "a"
+      "\x61\x61",                          // "aa"
+      "\x6e\xcc\x83",                      // n-plus-tilda
+      "\xc3\xb1",                          // n-with-tilda
+      "\xe2\x88\x9e",                      // :infinity:
+      "\xe2\x98\x83\xef\xb8\x8f",          // :snowman:
+      "\xf0\x9f\x80\x84",                  // :mahjong:
+      "\xf0\x9f\x87\xac\xf0\x9f\x87\xb7",  // :flag-gr:
+      "\xf0\x9f\x8d\xa8"                   // :icecream:
+  };
+
+  std::string data;
+  std::vector<uint64_t> offsets;
+  uint64_t curr_offset = 0;
+  for (auto& elem : utf8_data) {
+    data += elem;
+    offsets.push_back(curr_offset);
+    curr_offset += elem.size();
+  }
+
+  // Initialize the result tile.
+  ResultTile::TileSizes tile_sizes(
+      cells * constants::cell_var_offset_size,
+      0,
+      data.size(),
+      0,
+      std::nullopt,
+      std::nullopt);
+  ResultTile result_tile(0, 0, *array_schema);
+  result_tile.init_attr_tile(
+      constants::format_version, *array_schema, field_name, tile_sizes);
+
+  ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
+  Tile* const tile = &tile_tuple->var_tile();
+
+  REQUIRE(tile->write(data.c_str(), 0, data.size()).ok());
+
+  // Write the tile offsets.
+  Tile* const tile_offsets = &tile_tuple->fixed_tile();
+  REQUIRE(
+      tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+
+  std::vector<TestParams> tp_vec;
+  populate_utf8_string_test_params_vector(field_name, &result_tile, tp_vec);
+
+  SECTION("Validate apply.") {
+    for (auto& elem : tp_vec) {
+      validate_qc_apply(elem, cells, array_schema, result_tile);
+    }
+  }
+
+  SECTION("Validate apply_sparse.") {
+    for (auto& elem : tp_vec) {
+      validate_qc_apply_sparse(elem, cells, array_schema, result_tile);
+    }
+  }
+
+  SECTION("Validate apply_dense.") {
+    for (auto& elem : tp_vec) {
+      validate_qc_apply_dense(elem, cells, array_schema, result_tile);
+    }
+  }
+}
+
+/**
+ * @brief Function that takes a selection of QueryConditions, with their
+ * expected results, and combines them together. This function is
  * exclusively for nullable query conditions.
  *
  * @param field_name The field name of the query condition.

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1582,7 +1582,7 @@ void test_apply(
  */
 template <>
 void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
-  REQUIRE(type == Datatype::STRING_ASCII);
+  REQUIRE((type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8));
 
   const std::string field_name = "foo";
   const uint64_t cells = 10;
@@ -1694,6 +1694,9 @@ TEST_CASE("QueryCondition: Test apply", "[QueryCondition][apply]") {
   test_apply<char*>(Datatype::STRING_ASCII);
   test_apply<char*>(Datatype::STRING_ASCII, true);
   test_apply<char*>(Datatype::STRING_ASCII, false, true);
+  test_apply<char*>(Datatype::STRING_UTF8);
+  test_apply<char*>(Datatype::STRING_UTF8, true);
+  test_apply<char*>(Datatype::STRING_UTF8, false, true);
 }
 
 TEST_CASE(
@@ -1702,7 +1705,7 @@ TEST_CASE(
   const std::string field_name = "foo";
   const uint64_t cells = 10;
   const char* fill_value = "ac";
-  const Datatype type = Datatype::STRING_ASCII;
+  const Datatype type = GENERATE(Datatype::STRING_ASCII, Datatype::STRING_UTF8);
   bool var_size = true;
   bool nullable = GENERATE(true, false);
   bool null_cmp = GENERATE(true, false);
@@ -2232,7 +2235,7 @@ void test_apply_dense(
 template <>
 void test_apply_dense<char*>(
     const Datatype type, bool var_size, bool nullable) {
-  REQUIRE(type == Datatype::STRING_ASCII);
+  REQUIRE((type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8));
 
   const std::string field_name = "foo";
   const uint64_t cells = 10;
@@ -2355,6 +2358,9 @@ TEST_CASE(
   test_apply_dense<char*>(Datatype::STRING_ASCII);
   test_apply_dense<char*>(Datatype::STRING_ASCII, true);
   test_apply_dense<char*>(Datatype::STRING_ASCII, false, true);
+  test_apply_dense<char*>(Datatype::STRING_UTF8);
+  test_apply_dense<char*>(Datatype::STRING_UTF8, true);
+  test_apply_dense<char*>(Datatype::STRING_UTF8, false, true);
 }
 
 TEST_CASE(
@@ -2363,7 +2369,7 @@ TEST_CASE(
   const std::string field_name = "foo";
   const uint64_t cells = 10;
   const char* fill_value = "ac";
-  const Datatype type = Datatype::STRING_ASCII;
+  const Datatype type = GENERATE(Datatype::STRING_ASCII, Datatype::STRING_UTF8);
   bool var_size = true;
   bool nullable = GENERATE(true, false);
   bool null_cmp = GENERATE(true, false);
@@ -2874,7 +2880,7 @@ void test_apply_sparse(
 template <>
 void test_apply_sparse<char*>(
     const Datatype type, bool var_size, bool nullable) {
-  REQUIRE(type == Datatype::STRING_ASCII);
+  REQUIRE((type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8));
 
   const std::string field_name = "foo";
   const uint64_t cells = 10;
@@ -2997,6 +3003,9 @@ TEST_CASE(
   test_apply_sparse<char*>(Datatype::STRING_ASCII);
   test_apply_sparse<char*>(Datatype::STRING_ASCII, true);
   test_apply_sparse<char*>(Datatype::STRING_ASCII, false, true);
+  test_apply_sparse<char*>(Datatype::STRING_UTF8);
+  test_apply_sparse<char*>(Datatype::STRING_UTF8, true);
+  test_apply_sparse<char*>(Datatype::STRING_UTF8, false, true);
 }
 
 /**
@@ -3955,7 +3964,7 @@ TEST_CASE(
   // Setup.
   const std::string field_name = "foo";
   const uint64_t cells = 10;
-  const Datatype type = Datatype::STRING_ASCII;
+  const Datatype type = GENERATE(Datatype::STRING_ASCII, Datatype::STRING_UTF8);
 
   // Initialize the array schema.
   shared_ptr<ArraySchema> array_schema = make_shared<ArraySchema>(HERE());
@@ -4304,7 +4313,7 @@ TEST_CASE(
   const std::string field_name = "foo";
   const uint64_t cells = 10;
   const char* fill_value = "ac";
-  const Datatype type = Datatype::STRING_ASCII;
+  const Datatype type = GENERATE(Datatype::STRING_ASCII, Datatype::STRING_UTF8);
   bool var_size = true;
   bool nullable = GENERATE(true, false);
   bool null_cmp = GENERATE(true, false);


### PR DESCRIPTION
Add basic UTF-8 support for QueryConditions on attributes.

This adds a basic binary comparison of UTF-8 data. This means that QueryConditions can work with UTF-8 attribute data while it does not allow for Unicode aware comparisons. A specific description of the algorithm would be:

> UTF-8 string data is comparisons are performed on the underlying Unicode code points without regard for any Unicode aware semantics.

An alternative way of stating that is that we're comparing UTF-8 data with `memcmp` and completely disregard the Unicode properties of the data. Future work will be required to support proper Unicode aware comparisons.

---
TYPE: FEATURE
DESC: Add UTF-8 attribute binary comparison support for QueryConditions
