### PR TITLE
For Comment Only: Use lambda template to simplify "copy pasta" in switch/case

### DIFF
--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -529,6 +529,20 @@ void QueryCondition::apply_ast_node(
   }
 }
 
+template <int I>
+struct foo {
+  using type = std::integral_constant<int, I>;
+};
+template <int I>
+using foo_t = typename foo<I>::type;
+
+template <QueryConditionOp I>
+struct qc_op {
+  using type = std::integral_constant<QueryConditionOp, I>;
+};
+template <QueryConditionOp I>
+using qc_op_t = typename qc_op<I>::type;
+
 template <typename T, typename CombinationOp>
 void QueryCondition::apply_ast_node(
     const tdb_unique_ptr<ASTNode>& node,
@@ -540,8 +554,8 @@ void QueryCondition::apply_ast_node(
     const std::vector<ResultCellSlab>& result_cell_slabs,
     CombinationOp combination_op,
     std::vector<uint8_t>& result_cell_bitmap) const {
-  auto g = [&, *this]<QueryConditionOp Condition>() {
-    return apply_ast_node<T, Condition>(
+  auto g = [&, *this](auto Condition) {
+    return apply_ast_node<T, decltype(Condition)::value>(
         node,
         fragment_metadata,
         stride,
@@ -555,22 +569,22 @@ void QueryCondition::apply_ast_node(
 
   switch (node->get_op()) {
     case QueryConditionOp::LT:
-      g.template operator()<QueryConditionOp::LT>();
+      g(qc_op_t<QueryConditionOp::LT>{});
       break;
     case QueryConditionOp::LE:
-      g.template operator()<QueryConditionOp::LE>();
+      g(qc_op_t<QueryConditionOp::LE>{});
       break;
     case QueryConditionOp::GT:
-      g.template operator()<QueryConditionOp::GT>();
+      g(qc_op_t<QueryConditionOp::GT>{});
       break;
     case QueryConditionOp::GE:
-      g.template operator()<QueryConditionOp::GE>();
+      g(qc_op_t<QueryConditionOp::GE>{});
       break;
     case QueryConditionOp::EQ:
-      g.template operator()<QueryConditionOp::EQ>();
+      g(qc_op_t<QueryConditionOp::EQ>{});
       break;
     case QueryConditionOp::NE:
-      g.template operator()<QueryConditionOp::NE>();
+      g(qc_op_t<QueryConditionOp::NE>{});
       break;
     default:
       throw std::runtime_error(
@@ -608,8 +622,8 @@ void QueryCondition::apply_ast_node(
     }
   }
 
-  auto g = [&, *this ]<class T>() {
-    return apply_ast_node<T, CombinationOp>(
+  auto g = [&, *this](auto T) {
+    return apply_ast_node<decltype(T), CombinationOp>(
         node,
         fragment_metadata,
         stride,
@@ -623,43 +637,43 @@ void QueryCondition::apply_ast_node(
 
   switch (type) {
     case Datatype::INT8:
-      g.template operator()<int8_t>();
+      g(int8_t{});
       break;
     case Datatype::UINT8:
-      g.template operator()<uint8_t>();
+      g(uint8_t{});
       break;
     case Datatype::INT16:
-      g.template operator()<int16_t>();
+      g(int16_t{});
       break;
     case Datatype::UINT16:
-      g.template operator()<uint16_t>();
+      g(uint16_t{});
       break;
     case Datatype::INT32:
-      g.template operator()<int32_t>();
+      g(int32_t{});
       break;
     case Datatype::UINT32:
-      g.template operator()<uint32_t>();
+      g(uint32_t{});
       break;
     case Datatype::INT64:
-      g.template operator()<int64_t>();
+      g(int64_t{});
       break;
     case Datatype::UINT64:
-      g.template operator()<uint64_t>();
+      g(uint64_t{});
       break;
     case Datatype::FLOAT32:
-      g.template operator()<float>();
+      g(float{});
       break;
     case Datatype::FLOAT64:
-      g.template operator()<double>();
+      g(double{});
       break;
     case Datatype::STRING_ASCII:
-      g.template operator()<char*>();
+      g((char*){});
       break;
     case Datatype::CHAR: {
       if (var_size) {
-        g.template operator()<char*>();
+        g((char*){});
       } else {
-        g.template operator()<char>();
+        g(char{});
       }
     } break;
     case Datatype::DATETIME_YEAR:
@@ -675,7 +689,7 @@ void QueryCondition::apply_ast_node(
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
     case Datatype::DATETIME_AS:
-      g.template operator()<int64_t>();
+      g(int64_t{});
       break;
     case Datatype::ANY:
     case Datatype::BLOB:
@@ -954,8 +968,8 @@ void QueryCondition::apply_ast_node_dense(
     const bool nullable,
     CombinationOp combination_op,
     span<uint8_t> result_buffer) const {
-  auto g = [&, *this]<QueryConditionOp Condition>() {
-    return apply_ast_node_dense<T, Condition>(
+  auto g = [&, *this](auto Condition) {
+    return apply_ast_node_dense<T, decltype(Condition)::value>(
         node,
         result_tile,
         start,
@@ -969,22 +983,22 @@ void QueryCondition::apply_ast_node_dense(
 
   switch (node->get_op()) {
     case QueryConditionOp::LT:
-      g.template operator()<QueryConditionOp::LT>();
+      g(qc_op_t<QueryConditionOp::LT>{});
       break;
     case QueryConditionOp::LE:
-      g.template operator()<QueryConditionOp::LE>();
+      g(qc_op_t<QueryConditionOp::LE>{});
       break;
     case QueryConditionOp::GT:
-      g.template operator()<QueryConditionOp::GT>();
+      g(qc_op_t<QueryConditionOp::GT>{});
       break;
     case QueryConditionOp::GE:
-      g.template operator()<QueryConditionOp::GE>();
+      g(qc_op_t<QueryConditionOp::GE>{});
       break;
     case QueryConditionOp::EQ:
-      g.template operator()<QueryConditionOp::EQ>();
+      g(qc_op_t<QueryConditionOp::EQ>{});
       break;
     case QueryConditionOp::NE:
-      g.template operator()<QueryConditionOp::NE>();
+      g(qc_op_t<QueryConditionOp::NE>{});
       break;
     default:
       throw std::runtime_error(
@@ -1032,8 +1046,8 @@ void QueryCondition::apply_ast_node_dense(
     return;
   }
 
-  auto g = [&, *this ]<class T>() {
-    return apply_ast_node_dense<T, CombinationOp>(
+  auto g = [&, *this](auto T) {
+    return apply_ast_node_dense<decltype(T), CombinationOp>(
         node,
         result_tile,
         start,
@@ -1046,45 +1060,46 @@ void QueryCondition::apply_ast_node_dense(
   };
 
   switch (attribute->type()) {
-    case Datatype::INT8: {
-      g.template operator()<int8_t>();
-    } break;
+    case Datatype::INT8:
+      g(int8_t{});
+      break;
     case Datatype::BOOL:
     case Datatype::UINT8:
-      g.template operator()<uint8_t>();
+      g(uint8_t{});
       break;
     case Datatype::INT16:
-      g.template operator()<int16_t>();
+      g(int16_t{});
       break;
     case Datatype::UINT16:
-      g.template operator()<uint16_t>();
+      g(uint16_t{});
       break;
     case Datatype::INT32:
-      g.template operator()<int32_t>();
+      g(int32_t{});
       break;
     case Datatype::UINT32:
-      g.template operator()<int16_t>();
+      g(uint32_t{});
       break;
     case Datatype::INT64:
-      g.template operator()<int64_t>();
+      g(int64_t{});
       break;
     case Datatype::UINT64:
-      g.template operator()<uint64_t>();
+      g(uint64_t{});
       break;
     case Datatype::FLOAT32:
-      g.template operator()<float>();
+      g(float{});
       break;
     case Datatype::FLOAT64:
-      g.template operator()<double>();
+      g(double{});
       break;
     case Datatype::STRING_ASCII:
-      g.template operator()<char*>();
+      g((char*){});
+      g((char*){});
       break;
     case Datatype::CHAR: {
       if (var_size) {
-        g.template operator()<char*>();
+        g((char*){});
       } else {
-        g.template operator()<char>();
+        g(char{});
       }
     } break;
     case Datatype::DATETIME_YEAR:
@@ -1100,7 +1115,7 @@ void QueryCondition::apply_ast_node_dense(
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
     case Datatype::DATETIME_AS:
-      g.template operator()<int64_t>();
+      g(int64_t{});
       break;
     case Datatype::ANY:
     case Datatype::BLOB:
@@ -1514,15 +1529,10 @@ void QueryCondition::apply_ast_node_sparse(
     const bool var_size,
     CombinationOp combination_op,
     std::vector<BitmapType>& result_bitmap) const {
-  auto g = [*this,
-            &node,
-            &result_tile,
-            &var_size,
-            &combination_op,
-            &result_bitmap]<QueryConditionOp Condition>() {
+  auto g = [&, *this](auto Condition) {
     return apply_ast_node_sparse<
         T,
-        Condition,
+        decltype(Condition)::value,
         BitmapType,
         CombinationOp,
         nullable>(node, result_tile, var_size, combination_op, result_bitmap);
@@ -1530,22 +1540,22 @@ void QueryCondition::apply_ast_node_sparse(
 
   switch (node->get_op()) {
     case QueryConditionOp::LT:
-      g.template operator()<QueryConditionOp::LT>();
+      g(qc_op_t<QueryConditionOp::LT>{});
       break;
     case QueryConditionOp::LE:
-      g.template operator()<QueryConditionOp::LE>();
+      g(qc_op_t<QueryConditionOp::LE>{});
       break;
     case QueryConditionOp::GT:
-      g.template operator()<QueryConditionOp::GT>();
+      g(qc_op_t<QueryConditionOp::GT>{});
       break;
     case QueryConditionOp::GE:
-      g.template operator()<QueryConditionOp::GE>();
+      g(qc_op_t<QueryConditionOp::GE>{});
       break;
     case QueryConditionOp::EQ:
-      g.template operator()<QueryConditionOp::EQ>();
+      g(qc_op_t<QueryConditionOp::EQ>{});
       break;
     case QueryConditionOp::NE:
-      g.template operator()<QueryConditionOp::NE>();
+      g(qc_op_t<QueryConditionOp::NE>{});
       break;
     default:
       throw std::runtime_error(
@@ -1618,51 +1628,51 @@ void QueryCondition::apply_ast_node_sparse(
     }
   }
 
-  auto g = [&, *this ]<class T>() {
-    return apply_ast_node_sparse<T, BitmapType, CombinationOp>(
+  auto g = [&, *this](auto T) {
+    return apply_ast_node_sparse<decltype(T), BitmapType, CombinationOp>(
         node, result_tile, var_size, nullable, combination_op, result_bitmap);
   };
 
   switch (type) {
     case Datatype::INT8:
-      g.template operator()<int8_t>();
+      g(int8_t{});
       break;
     case Datatype::BOOL:
     case Datatype::UINT8:
-      g.template operator()<uint8_t>();
+      g(uint8_t{});
       break;
     case Datatype::INT16:
-      g.template operator()<int16_t>();
+      g(int16_t{});
       break;
     case Datatype::UINT16:
-      g.template operator()<int16_t>();
+      g(uint16_t{});
       break;
     case Datatype::INT32:
-      g.template operator()<int32_t>();
+      g(int32_t{});
       break;
     case Datatype::UINT32:
-      g.template operator()<uint32_t>();
+      g(uint32_t{});
       break;
     case Datatype::INT64:
-      g.template operator()<int64_t>();
+      g(int64_t{});
       break;
     case Datatype::UINT64:
-      g.template operator()<uint64_t>();
+      g(uint64_t{});
       break;
     case Datatype::FLOAT32:
-      g.template operator()<float>();
+      g(float{});
       break;
     case Datatype::FLOAT64:
-      g.template operator()<double>();
+      g(double{});
       break;
     case Datatype::STRING_ASCII:
-      g.template operator()<char*>();
+      g((char*){});
       break;
     case Datatype::CHAR: {
       if (var_size) {
-        g.template operator()<char*>();
+        g((char*){});
       } else {
-        g.template operator()<char>();
+        g((char){});
       }
     } break;
     case Datatype::DATETIME_YEAR:
@@ -1678,7 +1688,7 @@ void QueryCondition::apply_ast_node_sparse(
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
     case Datatype::DATETIME_AS:
-      g.template operator()<int64_t>();
+      g(int64_t{});
       break;
     case Datatype::ANY:
     case Datatype::BLOB:

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -540,78 +540,37 @@ void QueryCondition::apply_ast_node(
     const std::vector<ResultCellSlab>& result_cell_slabs,
     CombinationOp combination_op,
     std::vector<uint8_t>& result_cell_bitmap) const {
+  auto g = [&, *this]<QueryConditionOp Condition>() {
+    return apply_ast_node<T, Condition>(
+        node,
+        fragment_metadata,
+        stride,
+        var_size,
+        nullable,
+        fill_value,
+        result_cell_slabs,
+        combination_op,
+        result_cell_bitmap);
+  };
+
   switch (node->get_op()) {
     case QueryConditionOp::LT:
-      apply_ast_node<T, QueryConditionOp::LT, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
+      g.template operator()<QueryConditionOp::LT>();
       break;
     case QueryConditionOp::LE:
-      apply_ast_node<T, QueryConditionOp::LE, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
+      g.template operator()<QueryConditionOp::LE>();
       break;
     case QueryConditionOp::GT:
-      apply_ast_node<T, QueryConditionOp::GT, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
+      g.template operator()<QueryConditionOp::GT>();
       break;
     case QueryConditionOp::GE:
-      apply_ast_node<T, QueryConditionOp::GE, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
+      g.template operator()<QueryConditionOp::GE>();
       break;
     case QueryConditionOp::EQ:
-      apply_ast_node<T, QueryConditionOp::EQ, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
+      g.template operator()<QueryConditionOp::EQ>();
       break;
     case QueryConditionOp::NE:
-      apply_ast_node<T, QueryConditionOp::NE, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
+      g.template operator()<QueryConditionOp::NE>();
       break;
     default:
       throw std::runtime_error(
@@ -649,162 +608,58 @@ void QueryCondition::apply_ast_node(
     }
   }
 
+  auto g = [&, *this ]<class T>() {
+    return apply_ast_node<T, CombinationOp>(
+        node,
+        fragment_metadata,
+        stride,
+        var_size,
+        nullable,
+        fill_value,
+        result_cell_slabs,
+        combination_op,
+        result_cell_bitmap);
+  };
+
   switch (type) {
-    case Datatype::INT8: {
-      apply_ast_node<int8_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::UINT8: {
-      apply_ast_node<uint8_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::INT16: {
-      apply_ast_node<int16_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::UINT16: {
-      apply_ast_node<uint16_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::INT32: {
-      apply_ast_node<int32_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::UINT32: {
-      apply_ast_node<uint32_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::INT64: {
-      apply_ast_node<int64_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::UINT64: {
-      apply_ast_node<uint64_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::FLOAT32: {
-      apply_ast_node<float, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::FLOAT64: {
-      apply_ast_node<double, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
-    case Datatype::STRING_ASCII: {
-      apply_ast_node<char*, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
+    case Datatype::INT8:
+      g.template operator()<int8_t>();
+      break;
+    case Datatype::UINT8:
+      g.template operator()<uint8_t>();
+      break;
+    case Datatype::INT16:
+      g.template operator()<int16_t>();
+      break;
+    case Datatype::UINT16:
+      g.template operator()<uint16_t>();
+      break;
+    case Datatype::INT32:
+      g.template operator()<int32_t>();
+      break;
+    case Datatype::UINT32:
+      g.template operator()<uint32_t>();
+      break;
+    case Datatype::INT64:
+      g.template operator()<int64_t>();
+      break;
+    case Datatype::UINT64:
+      g.template operator()<uint64_t>();
+      break;
+    case Datatype::FLOAT32:
+      g.template operator()<float>();
+      break;
+    case Datatype::FLOAT64:
+      g.template operator()<double>();
+      break;
+    case Datatype::STRING_ASCII:
+      g.template operator()<char*>();
+      break;
     case Datatype::CHAR: {
       if (var_size) {
-        apply_ast_node<char*, CombinationOp>(
-            node,
-            fragment_metadata,
-            stride,
-            var_size,
-            nullable,
-            fill_value,
-            result_cell_slabs,
-            combination_op,
-            result_cell_bitmap);
+        g.template operator()<char*>();
       } else {
-        apply_ast_node<char, CombinationOp>(
-            node,
-            fragment_metadata,
-            stride,
-            var_size,
-            nullable,
-            fill_value,
-            result_cell_slabs,
-            combination_op,
-            result_cell_bitmap);
+        g.template operator()<char>();
       }
     } break;
     case Datatype::DATETIME_YEAR:
@@ -819,18 +674,9 @@ void QueryCondition::apply_ast_node(
     case Datatype::DATETIME_NS:
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
-    case Datatype::DATETIME_AS: {
-      apply_ast_node<int64_t, CombinationOp>(
-          node,
-          fragment_metadata,
-          stride,
-          var_size,
-          nullable,
-          fill_value,
-          result_cell_slabs,
-          combination_op,
-          result_cell_bitmap);
-    } break;
+    case Datatype::DATETIME_AS:
+      g.template operator()<int64_t>();
+      break;
     case Datatype::ANY:
     case Datatype::BLOB:
     case Datatype::STRING_UTF8:
@@ -1108,78 +954,37 @@ void QueryCondition::apply_ast_node_dense(
     const bool nullable,
     CombinationOp combination_op,
     span<uint8_t> result_buffer) const {
+  auto g = [&, *this]<QueryConditionOp Condition>() {
+    return apply_ast_node_dense<T, Condition>(
+        node,
+        result_tile,
+        start,
+        src_cell,
+        stride,
+        var_size,
+        nullable,
+        combination_op,
+        result_buffer);
+  };
+
   switch (node->get_op()) {
     case QueryConditionOp::LT:
-      apply_ast_node_dense<T, QueryConditionOp::LT, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<QueryConditionOp::LT>();
       break;
     case QueryConditionOp::LE:
-      apply_ast_node_dense<T, QueryConditionOp::LE, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<QueryConditionOp::LE>();
       break;
     case QueryConditionOp::GT:
-      apply_ast_node_dense<T, QueryConditionOp::GT, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<QueryConditionOp::GT>();
       break;
     case QueryConditionOp::GE:
-      apply_ast_node_dense<T, QueryConditionOp::GE, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<QueryConditionOp::GE>();
       break;
     case QueryConditionOp::EQ:
-      apply_ast_node_dense<T, QueryConditionOp::EQ, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<QueryConditionOp::EQ>();
       break;
     case QueryConditionOp::NE:
-      apply_ast_node_dense<T, QueryConditionOp::NE, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<QueryConditionOp::NE>();
       break;
     default:
       throw std::runtime_error(
@@ -1227,163 +1032,59 @@ void QueryCondition::apply_ast_node_dense(
     return;
   }
 
+  auto g = [&, *this ]<class T>() {
+    return apply_ast_node_dense<T, CombinationOp>(
+        node,
+        result_tile,
+        start,
+        src_cell,
+        stride,
+        var_size,
+        nullable,
+        combination_op,
+        result_buffer);
+  };
+
   switch (attribute->type()) {
     case Datatype::INT8: {
-      apply_ast_node_dense<int8_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
+      g.template operator()<int8_t>();
     } break;
     case Datatype::BOOL:
-    case Datatype::UINT8: {
-      apply_ast_node_dense<uint8_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::INT16: {
-      apply_ast_node_dense<int16_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::UINT16: {
-      apply_ast_node_dense<uint16_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::INT32: {
-      apply_ast_node_dense<int32_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::UINT32: {
-      apply_ast_node_dense<uint32_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::INT64: {
-      apply_ast_node_dense<int64_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::UINT64: {
-      apply_ast_node_dense<uint64_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::FLOAT32: {
-      apply_ast_node_dense<float, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::FLOAT64: {
-      apply_ast_node_dense<double, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
-    case Datatype::STRING_ASCII: {
-      apply_ast_node_dense<char*, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
+    case Datatype::UINT8:
+      g.template operator()<uint8_t>();
+      break;
+    case Datatype::INT16:
+      g.template operator()<int16_t>();
+      break;
+    case Datatype::UINT16:
+      g.template operator()<uint16_t>();
+      break;
+    case Datatype::INT32:
+      g.template operator()<int32_t>();
+      break;
+    case Datatype::UINT32:
+      g.template operator()<int16_t>();
+      break;
+    case Datatype::INT64:
+      g.template operator()<int64_t>();
+      break;
+    case Datatype::UINT64:
+      g.template operator()<uint64_t>();
+      break;
+    case Datatype::FLOAT32:
+      g.template operator()<float>();
+      break;
+    case Datatype::FLOAT64:
+      g.template operator()<double>();
+      break;
+    case Datatype::STRING_ASCII:
+      g.template operator()<char*>();
+      break;
     case Datatype::CHAR: {
       if (var_size) {
-        apply_ast_node_dense<char*, CombinationOp>(
-            node,
-            result_tile,
-            start,
-            src_cell,
-            stride,
-            var_size,
-            nullable,
-            combination_op,
-            result_buffer);
+        g.template operator()<char*>();
       } else {
-        apply_ast_node_dense<char, CombinationOp>(
-            node,
-            result_tile,
-            start,
-            src_cell,
-            stride,
-            var_size,
-            nullable,
-            combination_op,
-            result_buffer);
+        g.template operator()<char>();
       }
     } break;
     case Datatype::DATETIME_YEAR:
@@ -1398,18 +1099,9 @@ void QueryCondition::apply_ast_node_dense(
     case Datatype::DATETIME_NS:
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
-    case Datatype::DATETIME_AS: {
-      apply_ast_node_dense<int64_t, CombinationOp>(
-          node,
-          result_tile,
-          start,
-          src_cell,
-          stride,
-          var_size,
-          nullable,
-          combination_op,
-          result_buffer);
-    } break;
+    case Datatype::DATETIME_AS:
+      g.template operator()<int64_t>();
+      break;
     case Datatype::ANY:
     case Datatype::BLOB:
     case Datatype::STRING_UTF8:
@@ -1822,54 +1514,38 @@ void QueryCondition::apply_ast_node_sparse(
     const bool var_size,
     CombinationOp combination_op,
     std::vector<BitmapType>& result_bitmap) const {
+  auto g = [*this,
+            &node,
+            &result_tile,
+            &var_size,
+            &combination_op,
+            &result_bitmap]<QueryConditionOp Condition>() {
+    return apply_ast_node_sparse<
+        T,
+        Condition,
+        BitmapType,
+        CombinationOp,
+        nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+  };
+
   switch (node->get_op()) {
     case QueryConditionOp::LT:
-      apply_ast_node_sparse<
-          T,
-          QueryConditionOp::LT,
-          BitmapType,
-          CombinationOp,
-          nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+      g.template operator()<QueryConditionOp::LT>();
       break;
     case QueryConditionOp::LE:
-      apply_ast_node_sparse<
-          T,
-          QueryConditionOp::LE,
-          BitmapType,
-          CombinationOp,
-          nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+      g.template operator()<QueryConditionOp::LE>();
       break;
     case QueryConditionOp::GT:
-      apply_ast_node_sparse<
-          T,
-          QueryConditionOp::GT,
-          BitmapType,
-          CombinationOp,
-          nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+      g.template operator()<QueryConditionOp::GT>();
       break;
     case QueryConditionOp::GE:
-      apply_ast_node_sparse<
-          T,
-          QueryConditionOp::GE,
-          BitmapType,
-          CombinationOp,
-          nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+      g.template operator()<QueryConditionOp::GE>();
       break;
     case QueryConditionOp::EQ:
-      apply_ast_node_sparse<
-          T,
-          QueryConditionOp::EQ,
-          BitmapType,
-          CombinationOp,
-          nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+      g.template operator()<QueryConditionOp::EQ>();
       break;
     case QueryConditionOp::NE:
-      apply_ast_node_sparse<
-          T,
-          QueryConditionOp::NE,
-          BitmapType,
-          CombinationOp,
-          nullable>(node, result_tile, var_size, combination_op, result_bitmap);
+      g.template operator()<QueryConditionOp::NE>();
       break;
     default:
       throw std::runtime_error(
@@ -1944,53 +1620,53 @@ void QueryCondition::apply_ast_node_sparse(
 
   switch (type) {
     case Datatype::INT8: {
-      apply_ast_node_sparse<int8_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<int8_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::BOOL:
     case Datatype::UINT8: {
-      apply_ast_node_sparse<uint8_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<uint8_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::INT16: {
-      apply_ast_node_sparse<int16_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<int16_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::UINT16: {
-      apply_ast_node_sparse<uint16_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<uint16_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::INT32: {
-      apply_ast_node_sparse<int32_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<int32_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::UINT32: {
-      apply_ast_node_sparse<uint32_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<uint32_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::INT64: {
-      apply_ast_node_sparse<int64_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<int64_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::UINT64: {
-      apply_ast_node_sparse<uint64_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<uint64_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::FLOAT32: {
-      apply_ast_node_sparse<float, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<float>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::FLOAT64: {
-      apply_ast_node_sparse<double, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<double>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::STRING_ASCII: {
-      apply_ast_node_sparse<char*, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<char*>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::CHAR: {
       if (var_size) {
-        apply_ast_node_sparse<char*, BitmapType, CombinationOp>(
+        apply_ast_node_sparse<char*>(
             node,
             result_tile,
             var_size,
@@ -1998,7 +1674,7 @@ void QueryCondition::apply_ast_node_sparse(
             combination_op,
             result_bitmap);
       } else {
-        apply_ast_node_sparse<char, BitmapType, CombinationOp>(
+        apply_ast_node_sparse<char>(
             node,
             result_tile,
             var_size,
@@ -2020,7 +1696,7 @@ void QueryCondition::apply_ast_node_sparse(
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
     case Datatype::DATETIME_AS: {
-      apply_ast_node_sparse<int64_t, BitmapType, CombinationOp>(
+      apply_ast_node_sparse<int64_t>(
           node, result_tile, var_size, nullable, combination_op, result_bitmap);
     } break;
     case Datatype::ANY:

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -1618,69 +1618,51 @@ void QueryCondition::apply_ast_node_sparse(
     }
   }
 
+  auto g = [&, *this ]<class T>() {
+    return apply_ast_node_sparse<T, BitmapType, CombinationOp>(
+        node, result_tile, var_size, nullable, combination_op, result_bitmap);
+  };
+
   switch (type) {
-    case Datatype::INT8: {
-      apply_ast_node_sparse<int8_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
+    case Datatype::INT8:
+      g.template operator()<int8_t>();
+      break;
     case Datatype::BOOL:
-    case Datatype::UINT8: {
-      apply_ast_node_sparse<uint8_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::INT16: {
-      apply_ast_node_sparse<int16_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::UINT16: {
-      apply_ast_node_sparse<uint16_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::INT32: {
-      apply_ast_node_sparse<int32_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::UINT32: {
-      apply_ast_node_sparse<uint32_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::INT64: {
-      apply_ast_node_sparse<int64_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::UINT64: {
-      apply_ast_node_sparse<uint64_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::FLOAT32: {
-      apply_ast_node_sparse<float>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::FLOAT64: {
-      apply_ast_node_sparse<double>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
-    case Datatype::STRING_ASCII: {
-      apply_ast_node_sparse<char*>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
+    case Datatype::UINT8:
+      g.template operator()<uint8_t>();
+      break;
+    case Datatype::INT16:
+      g.template operator()<int16_t>();
+      break;
+    case Datatype::UINT16:
+      g.template operator()<int16_t>();
+      break;
+    case Datatype::INT32:
+      g.template operator()<int32_t>();
+      break;
+    case Datatype::UINT32:
+      g.template operator()<uint32_t>();
+      break;
+    case Datatype::INT64:
+      g.template operator()<int64_t>();
+      break;
+    case Datatype::UINT64:
+      g.template operator()<uint64_t>();
+      break;
+    case Datatype::FLOAT32:
+      g.template operator()<float>();
+      break;
+    case Datatype::FLOAT64:
+      g.template operator()<double>();
+      break;
+    case Datatype::STRING_ASCII:
+      g.template operator()<char*>();
+      break;
     case Datatype::CHAR: {
       if (var_size) {
-        apply_ast_node_sparse<char*>(
-            node,
-            result_tile,
-            var_size,
-            nullable,
-            combination_op,
-            result_bitmap);
+        g.template operator()<char*>();
       } else {
-        apply_ast_node_sparse<char>(
-            node,
-            result_tile,
-            var_size,
-            nullable,
-            combination_op,
-            result_bitmap);
+        g.template operator()<char>();
       }
     } break;
     case Datatype::DATETIME_YEAR:
@@ -1695,10 +1677,9 @@ void QueryCondition::apply_ast_node_sparse(
     case Datatype::DATETIME_NS:
     case Datatype::DATETIME_PS:
     case Datatype::DATETIME_FS:
-    case Datatype::DATETIME_AS: {
-      apply_ast_node_sparse<int64_t>(
-          node, result_tile, var_size, nullable, combination_op, result_bitmap);
-    } break;
+    case Datatype::DATETIME_AS:
+      g.template operator()<int64_t>();
+      break;
     case Datatype::ANY:
     case Datatype::BLOB:
     case Datatype::STRING_UTF8:


### PR DESCRIPTION
(This is a second PR for the switch/case fix, branched from dev.)

There is way too much "copy pasta" in the switch/case statements in query_condition.cc. This PR illustrates how to use C++20 lambda templates to greatly simplify the switch/case statements. There is probably a slightly simpler syntax for invoking the lambda than the one that is there, but the approach used centralizes the function call and parameter passing that is otherwise spread throughout the switch/case. It is probably possible to use something like a variant to get rid of the switch/case altogether, but I am not sure what that would do performance relative to the slight simplification of the code.

Template argument deduction rather than a lambda template could be used to accomplish the same simplification, so it is another approach to consider if we don't want to rely on (or wait for) C++20.

There are a few other switch/case that could probably also be cleaned up, but they are also inside some template meta programming so I didn't attempt to shorten those.

This simplifies some things enough that it might be more obvious how to unify legacy/sparse/dense, by picking the appropriate lambda based on legacy/dense/sparse -- but I haven't dived into that. (I leave it as an exercise to the reader.)

Several of the sets of "Cmp" functions can also be condensed. That will be slightly more involved, but would not require C++20.

Follow Up: I measured the object file size before and after to make sure the use of lambda templates didn't increase the object file size. There was no appreciable change.

dev:

query_condition.cc.o: 1253096
unit_query_condition.cc.o: 1019552
lums/tmp/query_condition:

query_condition.cc.o: 1255328
unit_query_condition.cc.o: 1019552

---
TYPE: IMPROVEMENT
DESC: Simplify switch/case with C++20 lambda templates.

