### PR TITLE
[Backport release-2.13] Query condition: fix when attribute condition is not in user buffers.

### DIFF
--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -416,7 +416,12 @@ Status DenseReader::dense_read() {
 
   // Process attributes.
   std::vector<std::string> to_read(1);
-  for (auto& name : names) {
+  for (auto& buff : buffers_) {
+    auto& name = buff.first;
+    if (name == constants::coords || array_schema_.is_dim(name)) {
+      continue;
+    }
+
     if (condition_.field_names().count(name) == 0) {
       // Read and unfilter tiles.
       to_read[0] = name;


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/5ac7e1d5dc38b2b5295620db9575116b3365a0cc from https://github.com/TileDB-Inc/TileDB/pull/3713

---
TYPE: IMPROVEMENT
DESC: Query condition: fix when attribute condition is not in user buffers.