### PR TITLE
Core build error on test/regression/targets/sc-18250.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,13 @@ list(APPEND TILEDB_C_API_FILENAME_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_version.h"
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_experimental.h"
 )
+
+if (TILEDB_SERIALIZATION)
+    list(APPEND TILEDB_C_API_FILENAME_HEADERS
+        "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_serialization.h"
+    )
+endif()
+
 list(APPEND TILEDB_C_API_RELATIVE_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/api_external_common.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/buffer/buffer_api_external.h"


### PR DESCRIPTION
Fixed by adding tiledb_serialization.h to the C API headers in the in-build distribution of TileDB.

---
TYPE: BUG
DESC: Core build error on test/regression/targets/sc-18250.cc
