### PR TITLE
Add gcc-12 CI target and bump HDFS and serialization targets to ubunt…

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -20,6 +20,14 @@ on:
         default: ''
         required: true
         type: string
+      matrix_compiler_cc:
+        default: 'gcc'
+        required: false
+        type: string
+      matrix_compiler_cxx:
+        default: 'g++'
+        required: false
+        type: string
       timeout:
         default: 90
         description: 'Job timeout (minutes)'
@@ -30,7 +38,8 @@ env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_CI_BACKEND: ${{ inputs.ci_backend }}
   TILEDB_CI_OS: runner.os
-  CXX: g++
+  CXX: ${{ inputs.matrix_compiler_cxx }}
+  CC: ${{ inputs.matrix_compiler_cc }}
   bootstrap_args: ${{ inputs.bootstrap_args }}
 
 jobs:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -45,15 +45,18 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_option: SERIALIZATION
-      matrix_image: ubuntu-20.04
+      matrix_image: ubuntu-22.04
       bootstrap_args: '--enable-serialization --enable-release-symbols'
 
   ci4:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: HDFS
-      matrix_image: ubuntu-20.04
+      matrix_image: ubuntu-22.04
+      matrix_compiler_cc: 'gcc-12'
+      matrix_compiler_cxx: 'g++-12'
       bootstrap_args: '--enable-hdfs --enable-static-tiledb'
+
   ci5:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:


### PR DESCRIPTION
Add gcc-12 CI target and bump HDFS and serialization targets to ubuntu 22.04

---
TYPE: NO_HISTORY
DESC: Add gcc-12 CI target and bump HDFS and serialization targets to ubuntu 22.04
