### PR TITLE
Build with GNU GCC on MacOS

### DIFF
--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -52,6 +52,7 @@ endif()
 find_package(Catch2 3.1
   HINTS
     ${CATCH_PATHS}
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 if(Catch2_FOUND)
   set(CATCH_INCLUDE_DIR ${Catch2_INCLUDE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -354,7 +354,7 @@ target_compile_definitions(tiledb_unit PRIVATE
 )
 
 # Linking dl is only needed on linux with gcc
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_target_properties(tiledb_unit PROPERTIES
       LINK_FLAGS "-Wl,--no-as-needed -ldl"
     )

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -93,7 +93,7 @@ target_compile_definitions(tiledb_explore_msys_handle_leakage PRIVATE
 )
 
 # Linking dl is only needed on linux with gcc
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_target_properties(tiledb_explore_msys_handle_leakage PROPERTIES
       LINK_FLAGS "-Wl,--no-as-needed -ldl"
     )

--- a/tiledb/common/dynamic_memory/traced_allocator.h
+++ b/tiledb/common/dynamic_memory/traced_allocator.h
@@ -216,8 +216,9 @@ class TracedAllocator : public Alloc<T> {
 
   void deallocate(pointer p, std::size_t n) noexcept {
     Alloc<T>& a{*this};
+    auto p_orig = std::launder(reinterpret_cast<char*>(p));
     inner_traits::deallocate(a, p, n);
-    Tracer::deallocate(p, sizeof(T), n, label_);
+    Tracer::deallocate(p_orig, sizeof(T), n, label_);
   }
 
   TracedAllocator select_on_container_copy_construction() const {


### PR DESCRIPTION
Minor fixes to allow building TileDB with GNU GCC on MacOS

---
TYPE: IMPROVEMENT
DESC: Allow building TileDB with GNU GCC on MacOS
