### PR TITLE
Simplify the Win32 VFS code.

### DIFF
--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -75,7 +75,9 @@ struct WinFx {
   }
 
   ~WinFx() {
-    REQUIRE(win_.remove_dir(TEMP_DIR).ok());
+    if (path_exists(TEMP_DIR)) {
+      REQUIRE(win_.remove_dir(TEMP_DIR).ok());
+    }
   }
 
   bool path_exists(std::string path) {
@@ -246,6 +248,8 @@ TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows][filesystem]") {
 TEST_CASE_METHOD(
     WinFx, "Test writing large files", "[.nightly_only][windows][large-file]") {
   const uint64_t five_gigabytes = static_cast<uint64_t>(5) << 30;
+
+  REQUIRE(win_.create_dir(TEMP_DIR).ok());
 
   std::string file = TEMP_DIR + "\\large-file";
 

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -83,7 +83,7 @@ struct WinFx {
   }
 };
 
-TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
+TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows][filesystem]") {
   using tiledb::sm::path_win::is_win_path;
   const std::string test_dir_path = TEMP_DIR + "/win_tests";
   const std::string test_file_path = TEMP_DIR + "/win_tests/tiledb_test_file";

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -242,4 +242,17 @@ TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
   CHECK(win_.is_file(URI(test_file_path + "2").to_path()));
 }
 
+TEST_CASE_METHOD(
+    WinFx, "Test writing large files", "[.nightly_only][windows][large-file]") {
+  const uint64_t five_gigabytes = static_cast<uint64_t>(5) << 30;
+
+  std::string file = TEMP_DIR + "\\large-file";
+
+  std::vector<uint8_t> buffer(five_gigabytes);
+
+  REQUIRE(win_.write(file, buffer.data(), buffer.size()).ok());
+
+  REQUIRE(win_.read(file, 0, buffer.data(), buffer.size()).ok());
+}
+
 #endif  // _WIN32

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -595,7 +595,8 @@ Status Win::write_at(
   const char* byte_buffer = reinterpret_cast<const char*>(buffer);
   while (buffer_size > 0) {
     DWORD bytes_to_write = buffer_size > std::numeric_limits<DWORD>::max() ?
-        std::numeric_limits<DWORD>::max() : (DWORD)buffer_size;
+                               std::numeric_limits<DWORD>::max() :
+                               (DWORD)buffer_size;
     DWORD bytes_written = 0;
     LARGE_INTEGER offset;
     offset.QuadPart = file_offset;

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -436,6 +436,7 @@ Status Win::read(
         get_last_error_msg("CreateFile") + ")"));
   }
 
+  char* byte_buffer = reinterpret_cast<char*>(buffer);
   do {
     LARGE_INTEGER offset_lg_int;
     offset_lg_int.QuadPart = offset;
@@ -446,7 +447,8 @@ Status Win::read(
                                   std::numeric_limits<DWORD>::max() :
                                   (DWORD)nbytes;
     DWORD num_bytes_read = 0;
-    if (ReadFile(file_h, buffer, num_bytes_to_read, &num_bytes_read, &ov) ==
+    if (ReadFile(
+            file_h, byte_buffer, num_bytes_to_read, &num_bytes_read, &ov) ==
         0) {
       auto gle = GetLastError();
       CloseHandle(file_h);
@@ -456,6 +458,7 @@ Status Win::read(
                       "num_bytes_read " + std::to_string(num_bytes_read) +
                           " != nbyes " + std::to_string(nbytes))));
     }
+    byte_buffer += num_bytes_read;
     offset += num_bytes_read;
     nbytes -= num_bytes_read;
   } while (nbytes > 0);

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -438,16 +438,11 @@ Status Win::read(
 
   LARGE_INTEGER offset_lg_int;
   offset_lg_int.QuadPart = offset;
-  if (SetFilePointerEx(file_h, offset_lg_int, NULL, FILE_BEGIN) == 0) {
-    auto gle = GetLastError();
-    CloseHandle(file_h);
-    return LOG_STATUS(Status_IOError(
-        "Cannot read from file '" + path + "'; File seek error " +
-        get_last_error_msg(gle, "SetFilePointerEx")));
-  }
-
+  OVERLAPPED ov = {0, 0, {{0, 0}}, 0};
+  ov.Offset = offset_lg_int.LowPart;
+  ov.OffsetHigh = offset_lg_int.HighPart;
   unsigned long num_bytes_read = 0;
-  if (ReadFile(file_h, buffer, nbytes, &num_bytes_read, NULL) == 0 ||
+  if (ReadFile(file_h, buffer, nbytes, &num_bytes_read, &ov) == 0 ||
       num_bytes_read != nbytes) {
     auto gle = GetLastError();
     CloseHandle(file_h);


### PR DESCRIPTION
This PR simplifies the Win32 VFS code that reads and writes from files. For file writing we call the `WriteFile` function in only one place, and if it writes less bytes than we told it, we don't fail but continue with the rest. And for reading we use an `OVERLAPPED` to specify the offset and avoid using `SetFilePointerEx` (which [has been described by Microsoft as an anachronism](https://learn.microsoft.com/en-US/archive/blogs/winserverperformance/designing-applications-for-high-performance-part-iii-2#:~:text=The%20old%20DOS%20SetFilePointer%20API%20is%20an%20anachronism.%20One%20should%20specify%20the%20file%20offset%20in%20the%20overlapped%20structure%20even%20for%20synchronous%20I/O.%20It%20should%20never%20be%20necessary%20to%20resort%20to%20the%20hack%20of%20having%20private%20file%20handles%20for%20each%20thread.)).

Let's see what CI thinks.

---
TYPE: IMPROVEMENT
DESC: Refactor and simplify Win32 VFS code.