### PR TITLE
Override config default if AWS_{DEFAULT_}REGION environment variable …

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -275,7 +275,7 @@ Status S3::init(
       "vfs.s3.multipart_part_size", &multipart_part_size_, &found));
   assert(found);
   file_buffer_size_ = multipart_part_size_ * max_parallel_ops_;
-  region_ = config.get("vfs.s3.region", &found);
+  region_ = config.get<std::string>("vfs.s3.region").value_or("");
   assert(found);
   RETURN_NOT_OK(config.get<bool>(
       "vfs.s3.use_virtual_addressing", &use_virtual_addressing_, &found));


### PR DESCRIPTION
If AWS_REGION or AWS_DEFAULT_REGION variable is set in the
environment, we want to defer to the SDK to interpret them
rather than defaulting to us-east-1.

Fixes [SC-23827](https://app.shortcut.com/tiledb-inc/story/23827)

Test in https://github.com/TileDB-Inc/TileDB-Py/pull/1560

---
TYPE: IMPROVEMENT
DESC: Override config default if AWS_{DEFAULT_}REGION environment variable is set
