### PR TITLE
Move StorageManager::array_open functions to Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,10 @@ core/src/temp
 coverage.info
 test/benchmarking/build/*
 test/bin/*
+test/cpp_unit_webp.png
 test/inputs/arrays/read_compatibility_test*
 test/obj/*
+test/regression/foo1
 test/tiledb_test/*
 Doxyfile.log
 doxyfile.inc

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -542,6 +542,9 @@ class Array {
   /** TileDB storage manager. */
   StorageManager* storage_manager_;
 
+  /** TileDB Context Resources. */
+  ContextResources& resources_;
+
   /** The array config. */
   Config config_;
 
@@ -588,6 +591,44 @@ class Array {
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
+
+  /**
+   * Opens an array for reads at a timestamp. All the metadata of the
+   * fragments created before or at the input timestamp are retrieved.
+   *
+   * If a timestamp_start is provided, this API will open the array between
+   * `timestamp_start` and `timestamp_end`.
+   *
+   * @param array The array to be opened.
+   * @return tuple of Status, latest ArraySchema, map of all array schemas and
+   * vector of FragmentMetadata
+   *        Status Ok on success, else error
+   *        ArraySchema The array schema to be retrieved after the
+   *           array is opened.
+   *        ArraySchemaMap Map of all array schemas found keyed by name
+   *        fragment_metadata The fragment metadata to be retrieved
+   *           after the array is opened.
+   */
+  tuple<
+      optional<shared_ptr<ArraySchema>>,
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
+      optional<std::vector<shared_ptr<FragmentMetadata>>>>
+  open_for_reads();
+
+  /**
+   * Opens an array for reads without fragments.
+   *
+   * @param array The array to be opened.
+   * @return tuple of Status, latest ArraySchema and map of all array schemas
+   *        Status Ok on success, else error
+   *        ArraySchema The array schema to be retrieved after the
+   *          array is opened.
+   *        ArraySchemaMap Map of all array schemas found keyed by name
+   */
+  tuple<
+      optional<shared_ptr<ArraySchema>>,
+      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
+  open_for_reads_without_fragments();
 
   /** Clears the cached max buffer sizes and subarray. */
   void clear_last_max_buffer_sizes();

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -248,46 +248,6 @@ class StorageManagerCanonical {
       MemoryTracker* memory_tracker,
       const EncryptionKey& enc_key);
 
-  /**
-   * Opens an array for reads at a timestamp. All the metadata of the
-   * fragments created before or at the input timestamp are retrieved.
-   *
-   * If a timestamp_start is provided, this API will open the array between
-   * `timestamp_start` and `timestamp_end`.
-   *
-   * @param array The array to be opened.
-   * @return tuple of Status, latest ArraySchema, map of all array schemas and
-   * vector of FragmentMetadata
-   *        Status Ok on success, else error
-   *        ArraySchema The array schema to be retrieved after the
-   *           array is opened.
-   *        ArraySchemaMap Map of all array schemas found keyed by name
-   *        fragment_metadata The fragment metadata to be retrieved
-   *           after the array is opened.
-   */
-  tuple<
-      Status,
-      optional<shared_ptr<ArraySchema>>,
-      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
-      optional<std::vector<shared_ptr<FragmentMetadata>>>>
-  array_open_for_reads(Array* array);
-
-  /**
-   * Opens an array for reads without fragments.
-   *
-   * @param array The array to be opened.
-   * @return tuple of Status, latest ArraySchema and map of all array schemas
-   *        Status Ok on success, else error
-   *        ArraySchema The array schema to be retrieved after the
-   *          array is opened.
-   *        ArraySchemaMap Map of all array schemas found keyed by name
-   */
-  tuple<
-      Status,
-      optional<shared_ptr<ArraySchema>>,
-      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
-  array_open_for_reads_without_fragments(Array* array);
-
   /** Opens an array for writes.
    *
    * @param array The array to open.
@@ -338,26 +298,6 @@ class StorageManagerCanonical {
   tuple<Status, optional<std::vector<shared_ptr<FragmentMetadata>>>>
   array_load_fragments(
       Array* array, const std::vector<TimestampedURI>& fragment_info);
-
-  /**
-   * Reopen an array for reads.
-   *
-   * @param array The array to reopen.
-   * @return tuple of Status, latest ArraySchema, map of all array schemas and
-   * vector of FragmentMetadata
-   *        Status Ok on success, else error
-   *        ArraySchema The array schema to be retrieved after the
-   *          array is opened.
-   *        ArraySchemaMap Map of all array schemas found keyed by name
-   *        FragmentMetadata The fragment metadata to be retrieved
-   *          after the array is opened.
-   */
-  tuple<
-      Status,
-      optional<shared_ptr<ArraySchema>>,
-      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>,
-      optional<std::vector<shared_ptr<FragmentMetadata>>>>
-  array_reopen(Array* array);
 
   /**
    * Consolidates the fragments of an array into a single one.


### PR DESCRIPTION
This is a straightforward movement of code from StorageManager to Array to work on removing StorageManager references from the Array class.

This PR is on the smaller side because the next phase of moving functions involves quite a bit more movement of functions between StorageManager, Array, and ArrayDirectory.

---
TYPE: IMPROVEMENT
DESC: Move array open methods from StorageManager to Array
