### PR TITLE
FragmentInfo::get_fragment_name - fix bug but deprecate API

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5910,7 +5910,7 @@ TILEDB_EXPORT int32_t tiledb_fragment_info_load(
  * @param name The fragment name to be retrieved.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT int32_t tiledb_fragment_info_get_fragment_name(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_fragment_info_get_fragment_name(
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,

--- a/tiledb/sm/cpp_api/fragment_info.h
+++ b/tiledb/sm/cpp_api/fragment_info.h
@@ -92,6 +92,7 @@ class FragmentInfo {
   }
 
   /** Returns the name of the fragment with the given index. */
+  TILEDB_DEPRECATED
   std::string fragment_name(uint32_t fid) const {
     auto& ctx = ctx_.get();
     const char* name_c;

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -740,10 +740,9 @@ Status FragmentInfo::get_version(uint32_t fid, uint32_t* version) const {
 tuple<Status, optional<shared_ptr<ArraySchema>>> FragmentInfo::get_array_schema(
     uint32_t fid) {
   if (fid >= fragment_num())
-    return {
-        LOG_STATUS(Status_FragmentInfoError(
-            "Cannot get array schema; Invalid fragment index")),
-        nullopt};
+    return {LOG_STATUS(Status_FragmentInfoError(
+                "Cannot get array schema; Invalid fragment index")),
+            nullopt};
   URI schema_uri;
   uint32_t version = single_fragment_info_vec_[fid].format_version();
   if (version >= 10) {

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -206,10 +206,7 @@ Status FragmentInfo::get_fragment_name(uint32_t fid, const char** name) const {
     return LOG_STATUS(Status_FragmentInfoError(
         "Cannot get fragment URI; Invalid fragment index"));
 
-  auto meta = single_fragment_info_vec_[fid].meta();
-  auto meta_name =
-      meta->fragment_uri().remove_trailing_slash().last_path_part();
-  *name = meta_name.c_str();
+  *name = single_fragment_info_vec_[fid].name().c_str();
 
   return Status::Ok();
 }
@@ -743,9 +740,10 @@ Status FragmentInfo::get_version(uint32_t fid, uint32_t* version) const {
 tuple<Status, optional<shared_ptr<ArraySchema>>> FragmentInfo::get_array_schema(
     uint32_t fid) {
   if (fid >= fragment_num())
-    return {LOG_STATUS(Status_FragmentInfoError(
-                "Cannot get array schema; Invalid fragment index")),
-            nullopt};
+    return {
+        LOG_STATUS(Status_FragmentInfoError(
+            "Cannot get array schema; Invalid fragment index")),
+        nullopt};
   URI schema_uri;
   uint32_t version = single_fragment_info_vec_[fid].format_version();
   if (version >= 10) {

--- a/tiledb/sm/fragment/single_fragment_info.h
+++ b/tiledb/sm/fragment/single_fragment_info.h
@@ -55,6 +55,7 @@ class SingleFragmentInfo {
   /** Constructor. */
   SingleFragmentInfo() {
     uri_ = URI("");
+    name_ = "";
     version_ = 0;
     cell_num_ = 0;
     sparse_ = false;
@@ -73,6 +74,7 @@ class SingleFragmentInfo {
       const NDRange& expanded_non_empty_domain,
       shared_ptr<FragmentMetadata> meta)
       : uri_(uri)
+      , name_(meta->fragment_uri().remove_trailing_slash().last_path_part())
       , version_(meta->format_version())
       , sparse_(sparse)
       , timestamp_range_(timestamp_range)
@@ -147,6 +149,11 @@ class SingleFragmentInfo {
     return uri_;
   }
 
+  /** Returns the fragment name. */
+  const std::string& name() const {
+    return name_;
+  }
+
   /** Returns the timestamp range. */
   const std::pair<uint64_t, uint64_t>& timestamp_range() const {
     return timestamp_range_;
@@ -219,6 +226,13 @@ class SingleFragmentInfo {
   /** The fragment URI. */
   URI uri_;
 
+  /**
+   * The fragment name.
+   *
+   * #TODO: Remove upon removal of tiledb_fragment_info_get_fragment_name.
+   */
+  std::string name_;
+
   /** The format version of the fragment. */
   format_version_t version_;
 
@@ -261,6 +275,7 @@ class SingleFragmentInfo {
   SingleFragmentInfo clone() const {
     SingleFragmentInfo clone;
     clone.uri_ = uri_;
+    clone.name_ = name_;
     clone.version_ = version_;
     clone.cell_num_ = cell_num_;
     clone.sparse_ = sparse_;
@@ -277,6 +292,7 @@ class SingleFragmentInfo {
   /** Swaps the contents (all field values) of this info with the given info. */
   void swap(SingleFragmentInfo& info) {
     std::swap(uri_, info.uri_);
+    std::swap(name_, info.name_);
     std::swap(version_, info.version_);
     std::swap(cell_num_, info.cell_num_);
     std::swap(sparse_, info.sparse_);


### PR DESCRIPTION
Fix the bug in `FragmentInfo::get_fragment_name` by _temporarily_ adding a `name_` member variable to `SingleFragmentInfo`. This PR also _deprecates_ `tiledb_fragment_info_get_fragment_name`. Upon the removal of the deprecated API, `SingleFragmentInfo::name_` shall also be removed. 

---
TYPE: IMPROVEMENT
DESC: FragmentInfo::get_fragment_name - fix internal bug and deprecate external API
