### PR TITLE
C API string handles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ list(APPEND TILEDB_C_API_RELATIVE_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/object/object_api_external.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/query/query_api_enum.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/query/query_api_external.h"
+    "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/string/string_api_external.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/vfs/vfs_api_enum.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/vfs/vfs_api_external.h"
 )

--- a/tiledb/api/c_api/CMakeLists.txt
+++ b/tiledb/api/c_api/CMakeLists.txt
@@ -85,5 +85,8 @@ add_subdirectory(object)
 # `query`: no dependencies yet but will have some
 add_subdirectory(query)
 
+# `string`: no dependencies
+add_subdirectory(string)
+
 # `vfs`: depends on `context`
 add_subdirectory(vfs)

--- a/tiledb/api/c_api/api_external_common.h
+++ b/tiledb/api/c_api/api_external_common.h
@@ -37,6 +37,7 @@
  * Use C headers since we need to compile externally-visible headers as C
  */
 #ifndef TILEDB_CAPI_WRAPPING
+#include <stddef.h>
 #include <stdint.h>
 #endif
 

--- a/tiledb/api/c_api/string/CMakeLists.txt
+++ b/tiledb/api/c_api/string/CMakeLists.txt
@@ -1,0 +1,49 @@
+#
+# tiledb/api/c_api/string/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+
+list(APPEND SOURCES
+    string_api.cc
+)
+gather_sources(${SOURCES})
+
+#
+# object library `capi_string`
+#
+add_library(capi_string OBJECT ${SOURCES})
+target_link_libraries(capi_string PUBLIC export)
+target_link_libraries(capi_string PUBLIC baseline $<TARGET_OBJECTS:baseline>)
+
+#
+# Test-compile of object library ensures link-completeness
+#
+add_executable(compile_capi_string EXCLUDE_FROM_ALL)
+target_link_libraries(compile_capi_string PRIVATE capi_string)
+target_sources(compile_capi_string PRIVATE test/compile_capi_string_main.cc)
+add_dependencies(all_link_complete compile_capi_string)
+
+add_test_subdirectory()

--- a/tiledb/api/c_api/string/CMakeLists.txt
+++ b/tiledb/api/c_api/string/CMakeLists.txt
@@ -25,6 +25,7 @@
 #
 
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 list(APPEND SOURCES
     string_api.cc
@@ -34,16 +35,10 @@ gather_sources(${SOURCES})
 #
 # object library `capi_string`
 #
-add_library(capi_string OBJECT ${SOURCES})
-target_link_libraries(capi_string PUBLIC export)
-target_link_libraries(capi_string PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_capi_string EXCLUDE_FROM_ALL)
-target_link_libraries(compile_capi_string PRIVATE capi_string)
-target_sources(compile_capi_string PRIVATE test/compile_capi_string_main.cc)
-add_dependencies(all_link_complete compile_capi_string)
+commence(object_library capi_string)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api/string/string_api.cc
+++ b/tiledb/api/c_api/string/string_api.cc
@@ -1,0 +1,67 @@
+/**
+ * @file tiledb/api/c_api/string/string_api.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the string section of the C API for TileDB.
+ */
+
+#include "string_api_external.h"
+#include "string_api_internal.h"
+#include "tiledb/api/c_api_support/c_api_support.h"
+
+namespace tiledb::api {
+
+capi_return_t tiledb_string_view(
+    tiledb_string_t* s, const char** data, size_t* length) {
+  ensure_string_is_valid(s);
+  ensure_output_pointer_is_valid(data);
+  ensure_output_pointer_is_valid(length);
+  auto sv{s->view()};
+  *data = sv.data();
+  *length = sv.length();
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_string_free(tiledb_string_handle_t** s) {
+  ensure_output_pointer_is_valid(s);
+  ensure_string_is_valid(*s);
+  tiledb_string_handle_t::break_handle(*s);
+  return TILEDB_OK;
+}
+
+}  // namespace tiledb::api
+
+capi_return_t tiledb_string_view(
+    tiledb_string_t* s, const char** data, size_t* length) noexcept {
+  return tiledb::api::api_entry_plain<tiledb::api::tiledb_string_view>(
+      s, data, length);
+}
+
+capi_return_t tiledb_string_free(tiledb_string_handle_t** s) noexcept {
+  return tiledb::api::api_entry_plain<tiledb::api::tiledb_string_free>(s);
+}

--- a/tiledb/api/c_api/string/string_api_external.h
+++ b/tiledb/api/c_api/string/string_api_external.h
@@ -1,0 +1,94 @@
+/**
+ * @file tiledb/api/c_api/string/string_api_external.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the string section of the C API for TileDB.
+ */
+
+#ifndef TILEDB_CAPI_STRING_EXTERNAL_H
+#define TILEDB_CAPI_STRING_EXTERNAL_H
+
+#include "../api_external_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * C API carrier for a TileDB string
+ *
+ * TileDB strings are designed as output-only strings. They hold string values
+ * that API function return through pointer-typed output arguments. The
+ * interface is, by design, insufficient for use as input arguments; for these,
+ * ordinary `char *` strings suffice.
+ */
+typedef struct tiledb_string_handle_t tiledb_string_t;
+
+/**
+ * Returns a view (i.e. data and length) of a TileDB string object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_string_t* s = NULL;
+ * // tiledb_something_outputs_a_string(..., &s);
+ * const char* data;
+ * size_t length;
+ * tiledb_string_view(s, &data, &length);
+ * printf("\"%s\" has length %d\n", data, length);
+ * tiledb_string_free(&s);
+ * @endcode
+ *
+ * @param s A TileDB string object
+ * @param[out] data The contents of the string
+ * @param[out] length The length of the string
+ */
+TILEDB_EXPORT capi_return_t tiledb_string_view(
+    tiledb_string_t* s, const char** data, size_t* length) TILEDB_NOEXCEPT;
+
+/**
+ * Frees the resources associated with a TileDB string object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_string_t* s = NULL;
+ * // tiledb_something_outputs_a_string(..., &s);
+ * tiledb_string_free(&s);
+ * @endcode
+ *
+ * @param s A TileDB string object
+ */
+TILEDB_EXPORT capi_return_t tiledb_string_free(tiledb_string_t** s)
+    TILEDB_NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TILEDB_CAPI_STRING_EXTERNAL_H

--- a/tiledb/api/c_api/string/string_api_internal.h
+++ b/tiledb/api/c_api/string/string_api_internal.h
@@ -1,0 +1,89 @@
+/**
+ * @file tiledb/api/c_api/string/string_api_internal.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains internal implementation details of the string section of
+ * the C API for TileDB.
+ */
+
+#ifndef TILEDB_CAPI_STRING_INTERNAL_H
+#define TILEDB_CAPI_STRING_INTERNAL_H
+
+#include "tiledb/api/c_api_support/handle/handle.h"
+
+/**
+ * Handle `struct` for API string objects.
+ */
+struct tiledb_string_handle_t
+    : public tiledb::api::CAPIHandle<tiledb_string_handle_t> {
+  /**
+   * Type name
+   */
+  static constexpr std::string_view object_type_name{"string"};
+
+ private:
+  /**
+   * The content of an string object is a std::string. Not quite duh, but close.
+   */
+  std::string value_;
+
+ public:
+  /**
+   * Default constructor constructs an empty string
+   */
+  tiledb_string_handle_t()
+      : value_{} {
+  }
+
+  /**
+   * Ordinary constructor.
+   * @param s A string
+   */
+  explicit tiledb_string_handle_t(const std::string& s)
+      : value_{s} {
+  }
+
+  [[nodiscard]] inline const std::string_view view() const {
+    return std::string_view{value_};
+  }
+};
+
+namespace tiledb::api {
+
+/**
+ * Returns after successfully validating a string handle. Throws otherwise.
+ *
+ * @param string Possibly-valid pointer to a string handle
+ */
+inline void ensure_string_is_valid(const tiledb_string_handle_t* string) {
+  ensure_handle_is_valid(string);
+}
+
+}  // namespace tiledb::api
+
+#endif  // TILEDB_CAPI_STRING_INTERNAL_H

--- a/tiledb/api/c_api/string/test/CMakeLists.txt
+++ b/tiledb/api/c_api/string/test/CMakeLists.txt
@@ -24,20 +24,9 @@
 # THE SOFTWARE.
 #
 
-add_executable(unit_capi_string EXCLUDE_FROM_ALL)
-find_package(Catch_EP REQUIRED)
-target_link_libraries(unit_capi_string PUBLIC Catch2::Catch2WithMain)
+include(unit_test)
 
-# Sources for code under test
-target_link_libraries(unit_capi_string PUBLIC capi_string)
-
-# Sources for tests
-target_sources(unit_capi_string PUBLIC
-    unit_capi_string.cc
-    )
-
-add_test(
-    NAME "unit_capi_string"
-    COMMAND $<TARGET_FILE:unit_capi_string>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+commence(unit_test capi_string)
+  this_target_sources(unit_capi_string.cc)
+  this_target_object_libraries(capi_string)
+conclude(unit_test)

--- a/tiledb/api/c_api/string/test/CMakeLists.txt
+++ b/tiledb/api/c_api/string/test/CMakeLists.txt
@@ -1,0 +1,43 @@
+#
+# tiledb/api/c_api/string/test/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+add_executable(unit_capi_string EXCLUDE_FROM_ALL)
+find_package(Catch_EP REQUIRED)
+target_link_libraries(unit_capi_string PUBLIC Catch2::Catch2WithMain)
+
+# Sources for code under test
+target_link_libraries(unit_capi_string PUBLIC capi_string)
+
+# Sources for tests
+target_sources(unit_capi_string PUBLIC
+    unit_capi_string.cc
+    )
+
+add_test(
+    NAME "unit_capi_string"
+    COMMAND $<TARGET_FILE:unit_capi_string>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/tiledb/api/c_api/string/test/compile_capi_string_main.cc
+++ b/tiledb/api/c_api/string/test/compile_capi_string_main.cc
@@ -1,0 +1,35 @@
+/**
+ * @file tiledb/api/c_api/string/test/compile_capi_string_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../string_api_internal.h"
+
+int main() {
+  auto x{tiledb_string_handle_t::make_handle("foo")};
+  tiledb_string_handle_t::break_handle(x);
+  return 0;
+}

--- a/tiledb/api/c_api/string/test/unit_capi_string.cc
+++ b/tiledb/api/c_api/string/test/unit_capi_string.cc
@@ -1,0 +1,78 @@
+/**
+ * @file tiledb/api/c_api/string/test/unit_capi_string.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <test/support/tdb_catch.h>
+#include "../string_api_external.h"
+#include "../string_api_internal.h"
+
+TEST_CASE("C API: tiledb_string_view argument validation", "[capi][string]") {
+  auto s{tiledb_string_handle_t::make_handle("foo")};
+  const char* data{};
+  size_t length{};
+  SECTION("null string handle") {
+    auto rc{tiledb_string_view(nullptr, &data, &length)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("null data") {
+    auto rc{tiledb_string_view(s, nullptr, &length)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("null length") {
+    auto rc{tiledb_string_view(s, &data, nullptr)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  tiledb_string_handle_t::break_handle(s);
+}
+
+TEST_CASE("C API: tiledb_string_view basic behavior", "[capi][string]") {
+  auto s{tiledb_string_handle_t::make_handle("foo")};
+  const char* data{};
+  size_t length{};
+  auto rc{tiledb_string_view(s, &data, &length)};
+  REQUIRE(tiledb_status(rc) == TILEDB_OK);
+  REQUIRE(length == 3);
+  CHECK(std::string(data, length) == "foo");
+  tiledb_string_handle_t::break_handle(s);
+}
+
+TEST_CASE("C API: tiledb_string_free argument validation", "[capi][string]") {
+  /*
+   * `void` returns mean we have no return status to check
+   */
+  SECTION("null argument") {
+    capi_return_t rc{tiledb_string_free(nullptr)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("non-null argument, null string handle") {
+    tiledb_string_handle_t* string{nullptr};
+    capi_return_t rc{tiledb_string_free(&string)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+}


### PR DESCRIPTION
Add a string handle so that C API functions can output strings with independent lifespans. These handles are not yet used in any function. This PR sets the stage for allowing new API functions that use them.

---
TYPE: C_API
DESC: Add a string handle so that C API functions can output strings with independent lifespans.
