### PR TITLE
Include coordinates for multipart remote queries

### DIFF
--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -89,7 +89,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           condition)
     , tile_offsets_min_frag_idx_(std::numeric_limits<unsigned>::max())
     , tile_offsets_max_frag_idx_(0) {
-  include_coords_ = subarray_.is_set() || bitsort_attribute_.has_value();
+  include_coords_ = false;
   SparseIndexReaderBase::init(skip_checks_serialization);
 
   // Initialize memory budget variables.
@@ -173,11 +173,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::initialize_memory_budget() {
 
 template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
-  // Ensure we include coordinates for multipart remote queries.
-  if (array_->is_remote()) {
-    // Subarray is not known to be explicitly set until buffers are deserialized
-    include_coords_ = subarray_.is_set() || bitsort_attribute_.has_value();
-  }
+  // Subarray is not known to be explicitly set until buffers are deserialized
+  include_coords_ = subarray_.is_set() || bitsort_attribute_.has_value();
 
   auto timer_se = stats_->start_timer("dowork");
 

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -173,6 +173,12 @@ Status SparseUnorderedWithDupsReader<BitmapType>::initialize_memory_budget() {
 
 template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
+  // Ensure we include coordinates for multipart remote queries.
+  if (array_->is_remote()) {
+    // Subarray is not known to be explicitly set until buffers are deserialized
+    include_coords_ = subarray_.is_set() || bitsort_attribute_.has_value();
+  }
+
   auto timer_se = stats_->start_timer("dowork");
 
   // Make sure user didn't request delete timestamps.
@@ -233,7 +239,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     for (auto& result_tile : result_tiles_) {
       if (!result_tile.coords_loaded()) {
         result_tile.set_coords_loaded();
-        ;
         result_tiles_created.emplace_back(&result_tile);
       } else {
         result_tiles_loaded.emplace_back(&result_tile);


### PR DESCRIPTION
I found the bug to be related to the state of the Subarray object during query deserialization. Since the first remote query submit is always initialized to REST with a call to `Query::create_strategy`, the value of `include_coords_` is corrected after initial query deserialization. On a second submission, we don't need to call `Query::create_strategy` since the query is already in progress, and `include_coords_` doesn't reflect the final state of the fully initialized Subarray.

---
TYPE: BUG
DESC: Ensures coordinate tiles are initialized for multipart remote queries
