### PR TITLE
Split Tile class into different classes for read and write.

### DIFF
--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -83,7 +83,7 @@ struct DenseTilerFx {
       uint64_t range_size,
       tiledb::sm::Subarray* subarray);
   template <class T>
-  bool check_tile(Tile& tile, const std::vector<T>& data);
+  bool check_tile(WriterTile& tile, const std::vector<T>& data);
 };
 
 DenseTilerFx::DenseTilerFx() {
@@ -171,7 +171,7 @@ void DenseTilerFx::close_array() {
 }
 
 template <class T>
-bool DenseTilerFx::check_tile(Tile& tile, const std::vector<T>& data) {
+bool DenseTilerFx::check_tile(WriterTile& tile, const std::vector<T>& data) {
   std::vector<T> tile_data(data.size());
   CHECK(tile.size() == data.size() * sizeof(T));
   CHECK(tile.read(&tile_data[0], 0, data.size() * sizeof(T)).ok());
@@ -390,7 +390,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -404,7 +404,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -431,7 +431,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2(
+  WriterTileTuple tile2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -457,7 +457,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile3(
+  WriterTileTuple tile3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -508,7 +508,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -522,7 +522,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -574,7 +574,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -588,7 +588,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1413,7 +1413,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1433,7 +1433,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1455,7 +1455,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1473,7 +1473,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_2.fixed_tile(), c_data1_2));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1507,7 +1507,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1551,7 +1551,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile3_0(
+  WriterTileTuple tile3_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1571,7 +1571,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile3_0.fixed_tile(), c_data3_0));
 
   // Test get tile 1
-  WriterTile tile3_1(
+  WriterTileTuple tile3_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1593,7 +1593,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile3_1.fixed_tile(), c_data3_1));
 
   // Test get tile 2
-  WriterTile tile3_2(
+  WriterTileTuple tile3_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1611,7 +1611,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile3_2.fixed_tile(), c_data3_2));
 
   // Test get tile 3
-  WriterTile tile3_3(
+  WriterTileTuple tile3_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1645,7 +1645,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile4_0(
+  WriterTileTuple tile4_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1715,7 +1715,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1739,7 +1739,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1762,7 +1762,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_1.fixed_tile(), c_data1_1));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1784,7 +1784,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_2.fixed_tile(), c_data1_2));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1820,7 +1820,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1882,7 +1882,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile3_0(
+  WriterTileTuple tile3_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1906,7 +1906,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile3_0.fixed_tile(), c_data3_0));
 
   // Test get tile 1
-  WriterTile tile3_1(
+  WriterTileTuple tile3_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1929,7 +1929,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile3_1.fixed_tile(), c_data3_1));
 
   // Test get tile 2
-  WriterTile tile3_2(
+  WriterTileTuple tile3_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1951,7 +1951,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile3_2.fixed_tile(), c_data3_2));
 
   // Test get tile 3
-  WriterTile tile3_3(
+  WriterTileTuple tile3_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -1987,7 +1987,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile4_0(
+  WriterTileTuple tile4_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2078,7 +2078,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2094,7 +2094,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2155,7 +2155,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2171,7 +2171,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2226,7 +2226,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2239,7 +2239,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.fixed_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2274,7 +2274,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2(
+  WriterTileTuple tile2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2301,7 +2301,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile3(
+  WriterTileTuple tile3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2356,7 +2356,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0_a1(
+  WriterTileTuple tile1_0_a1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2366,7 +2366,7 @@ TEST_CASE_METHOD(
   CHECK(tiler1.get_tile(0, "a1", tile1_0_a1).ok());
   std::vector<int32_t> c_data1_0_a1 = {fill_value, fill_value, 1, 2, 3};
   CHECK(check_tile<int32_t>(tile1_0_a1.fixed_tile(), c_data1_0_a1));
-  WriterTile tile1_0_a2(
+  WriterTileTuple tile1_0_a2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2379,7 +2379,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<double>(tile1_0_a2.fixed_tile(), c_data1_0_a2));
 
   // Test get tile 1
-  WriterTile tile1_1_a1(
+  WriterTileTuple tile1_1_a1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2390,7 +2390,7 @@ TEST_CASE_METHOD(
   std::vector<int32_t> c_data1_1_a1 = {
       4, fill_value, fill_value, fill_value, fill_value};
   CHECK(check_tile<int32_t>(tile1_1_a1.fixed_tile(), c_data1_1_a1));
-  WriterTile tile1_1_a2(
+  WriterTileTuple tile1_1_a2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2420,7 +2420,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2_a1(
+  WriterTileTuple tile2_a1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2430,7 +2430,7 @@ TEST_CASE_METHOD(
   CHECK(tiler2.get_tile(0, "a1", tile2_a1).ok());
   std::vector<int32_t> c_data2_a1 = {fill_value, 1, 2, 3, 4};
   CHECK(check_tile<int32_t>(tile2_a1.fixed_tile(), c_data2_a1));
-  WriterTile tile2_a2(
+  WriterTileTuple tile2_a2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2456,7 +2456,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile3_a1(
+  WriterTileTuple tile3_a1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2466,7 +2466,7 @@ TEST_CASE_METHOD(
   CHECK(tiler3.get_tile(0, "a1", tile3_a1).ok());
   std::vector<int32_t> c_data3_a1 = {fill_value, 1, 2, 3, 4};
   CHECK(check_tile<int32_t>(tile3_a1.fixed_tile(), c_data3_a1));
-  WriterTile tile3_a2(
+  WriterTileTuple tile3_a2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2529,7 +2529,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2551,7 +2551,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile1_0.validity_tile(), c_data1_0));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2573,7 +2573,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile1_1.validity_tile(), c_data1_1));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2592,7 +2592,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile1_2.validity_tile(), c_data1_2));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2633,7 +2633,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2696,7 +2696,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler3(&buffers, &subarray3, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile3_0(
+  WriterTileTuple tile3_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2718,7 +2718,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile3_0.validity_tile(), c_data3_0));
 
   // Test get tile 1
-  WriterTile tile3_1(
+  WriterTileTuple tile3_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2740,7 +2740,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile3_1.validity_tile(), c_data3_1));
 
   // Test get tile 2
-  WriterTile tile3_2(
+  WriterTileTuple tile3_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2759,7 +2759,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile3_2.validity_tile(), c_data3_2));
 
   // Test get tile 3
-  WriterTile tile3_3(
+  WriterTileTuple tile3_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2800,7 +2800,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler4(&buffers, &subarray4, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile4_0(
+  WriterTileTuple tile4_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       false,
@@ -2888,7 +2888,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -2928,7 +2928,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -2976,7 +2976,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3007,7 +3007,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<uint8_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3060,7 +3060,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3222,7 +3222,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler1(&buffers, &subarray1, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3262,7 +3262,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3310,7 +3310,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3341,7 +3341,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3413,7 +3413,7 @@ TEST_CASE_METHOD(
   DenseTiler<int32_t> tiler2(&buffers, &subarray2, &test::g_helper_stats);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3577,7 +3577,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3617,7 +3617,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3665,7 +3665,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3696,7 +3696,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3770,7 +3770,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "bytes", 64, true);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3920,7 +3920,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -3960,7 +3960,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4008,7 +4008,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4039,7 +4039,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4096,7 +4096,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "elements", 64, false);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4246,7 +4246,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray1, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
-  WriterTile tile1_0(
+  WriterTileTuple tile1_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4286,7 +4286,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_0.var_tile(), c_data1_0_val));
 
   // Test get tile 1
-  WriterTile tile1_1(
+  WriterTileTuple tile1_1(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4334,7 +4334,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_1.var_tile(), c_data1_1_val));
 
   // Test get tile 2
-  WriterTile tile1_2(
+  WriterTileTuple tile1_2(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4365,7 +4365,7 @@ TEST_CASE_METHOD(
   CHECK(check_tile<int32_t>(tile1_2.var_tile(), c_data1_2_val));
 
   // Test get tile 3
-  WriterTile tile1_3(
+  WriterTileTuple tile1_3(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,
@@ -4422,7 +4422,7 @@ TEST_CASE_METHOD(
       &buffers, &subarray2, &test::g_helper_stats, "elements", 32, false);
 
   // Test get tile 0
-  WriterTile tile2_0(
+  WriterTileTuple tile2_0(
       array_->array_->array_schema_latest(),
       array_->array_->array_schema_latest().domain().cell_num_per_tile(),
       true,

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -66,14 +66,49 @@ using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm;
 
-Tile recreate_tile_for_unfiltering(
-    const uint32_t dim_num, const uint64_t tile_size, Tile&& tile) {
+WriterTile make_increasing_tile(const uint64_t nelts) {
+  const uint64_t tile_size = nelts * sizeof(uint64_t);
+  const uint64_t cell_size = sizeof(uint64_t);
+
+  WriterTile tile(
+      constants::format_version, Datatype::UINT64, cell_size, tile_size);
+  for (uint64_t i = 0; i < nelts; i++) {
+    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+  }
+
+  return tile;
+}
+
+WriterTile make_offsets_tile(std::vector<uint64_t>& offsets) {
+  const uint64_t offsets_tile_size =
+      offsets.size() * constants::cell_var_offset_size;
+
+  WriterTile offsets_tile(
+      constants::format_version,
+      Datatype::UINT64,
+      constants::cell_var_offset_size,
+      offsets_tile_size);
+
+  // Set up test data
+  for (uint64_t i = 0; i < offsets.size(); i++) {
+    CHECK(offsets_tile
+              .write(
+                  &offsets[i],
+                  i * constants::cell_var_offset_size,
+                  constants::cell_var_offset_size)
+              .ok());
+  }
+
+  return offsets_tile;
+}
+
+Tile create_tile_for_unfiltering(uint64_t nelts, WriterTile& tile) {
   Tile ret(
       tile.format_version(),
       tile.type(),
       tile.cell_size(),
-      dim_num,
-      tile_size,
+      0,
+      tile.cell_size() * nelts,
       tile.filtered_buffer().size());
   memcpy(
       ret.filtered_buffer().data(),
@@ -98,7 +133,7 @@ class Add1InPlace : public tiledb::sm::Filter {
   }
 
   Status run_forward(
-      const Tile&,
+      const WriterTile&,
       void* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -169,7 +204,7 @@ class Add1OutOfPlace : public tiledb::sm::Filter {
   }
 
   Status run_forward(
-      const Tile&,
+      const WriterTile&,
       void* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -262,7 +297,7 @@ class AddNInPlace : public tiledb::sm::Filter {
   }
 
   Status run_forward(
-      const Tile&,
+      const WriterTile&,
       void* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -345,7 +380,7 @@ class PseudoChecksumFilter : public tiledb::sm::Filter {
   }
 
   Status run_forward(
-      const Tile&,
+      const WriterTile&,
       void* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -436,7 +471,7 @@ class Add1IncludingMetadataFilter : public tiledb::sm::Filter {
   }
 
   Status run_forward(
-      const Tile&,
+      const WriterTile&,
       void* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -555,22 +590,7 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
 
   // Set up test data
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -607,13 +627,16 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
     offset += sizeof(uint64_t);
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 }
@@ -624,22 +647,7 @@ TEST_CASE(
 
   // Set up test data
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -670,30 +678,11 @@ TEST_CASE(
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
-  Tile::set_max_tile_chunk_size(80);
+  WriterTile::set_max_tile_chunk_size(80);
   CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
             .ok());
 
@@ -731,17 +720,20 @@ TEST_CASE(
     }
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE(
@@ -749,22 +741,7 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -804,14 +781,16 @@ TEST_CASE(
       offset += sizeof(uint64_t);
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -853,14 +832,16 @@ TEST_CASE(
       offset += sizeof(uint64_t);
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -872,22 +853,7 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -918,33 +884,14 @@ TEST_CASE(
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(Add1InPlace());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
 
@@ -982,21 +929,23 @@ TEST_CASE(
       }
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Multi-stage") {
     // Add a few more +1 filters and re-run.
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     pipeline.add_filter(Add1InPlace());
     pipeline.add_filter(Add1InPlace());
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
@@ -1036,19 +985,21 @@ TEST_CASE(
       }
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE(
@@ -1058,22 +1009,7 @@ TEST_CASE(
 
   // Set up test data
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -1113,14 +1049,16 @@ TEST_CASE(
       offset += sizeof(uint64_t);
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -1162,14 +1100,16 @@ TEST_CASE(
       offset += sizeof(uint64_t);
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -1181,22 +1121,7 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -1227,33 +1152,14 @@ TEST_CASE(
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(Add1OutOfPlace());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
 
@@ -1291,21 +1197,23 @@ TEST_CASE(
       }
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Multi-stage") {
     // Add a few more +1 filters and re-run.
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     pipeline.add_filter(Add1OutOfPlace());
     pipeline.add_filter(Add1OutOfPlace());
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
@@ -1345,19 +1253,21 @@ TEST_CASE(
       }
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE(
@@ -1367,22 +1277,7 @@ TEST_CASE(
 
   // Set up test data
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -1421,13 +1316,16 @@ TEST_CASE(
     offset += sizeof(uint64_t);
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 }
@@ -1438,22 +1336,7 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -1484,30 +1367,11 @@ TEST_CASE(
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
-  Tile::set_max_tile_chunk_size(80);
+  WriterTile::set_max_tile_chunk_size(80);
   pipeline.add_filter(Add1InPlace());
   pipeline.add_filter(Add1OutOfPlace());
   pipeline.add_filter(Add1InPlace());
@@ -1549,39 +1413,27 @@ TEST_CASE(
     }
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test compression", "[filter][compression]") {
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up dummy array schema (needed by compressor filter for cell size, etc).
   uint32_t dim_dom[] = {1, 10};
@@ -1612,16 +1464,18 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -1636,16 +1490,18 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -1662,16 +1518,18 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -1681,22 +1539,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -1727,26 +1570,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   // Set up dummy array schema (needed by compressor filter for cell size, etc).
   uint32_t dim_dom[] = {1, 10};
@@ -1767,7 +1591,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
   ThreadPool tp(4);
 
   SECTION("- Simple") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     pipeline.add_filter(Add1InPlace());
     pipeline.add_filter(Add1OutOfPlace());
     pipeline.add_filter(CompressionFilter(tiledb::sm::Compressor::LZ4, 5));
@@ -1780,22 +1604,24 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         tile.filtered_buffer().value_at_as<uint64_t>(0) ==
         9);  // Number of chunks
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- With checksum stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     pipeline.add_filter(PseudoChecksumFilter());
     pipeline.add_filter(CompressionFilter(tiledb::sm::Compressor::LZ4, 5));
 
@@ -1807,22 +1633,24 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         tile.filtered_buffer().value_at_as<uint64_t>(0) ==
         9);  // Number of chunks
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- With multiple stages") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     pipeline.add_filter(Add1InPlace());
     pipeline.add_filter(PseudoChecksumFilter());
     pipeline.add_filter(Add1OutOfPlace());
@@ -1836,21 +1664,23 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         tile.filtered_buffer().value_at_as<uint64_t>(0) ==
         9);  // Number of chunks
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
@@ -1859,22 +1689,7 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
   // Set up test data
   const uint64_t nelts = 100;
   const uint64_t expected_checksum = 4950;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -1921,14 +1736,16 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
       offset += sizeof(uint64_t);
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -1988,14 +1805,16 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
       offset += sizeof(uint64_t);
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -2006,22 +1825,7 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -2052,26 +1856,7 @@ TEST_CASE(
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   std::vector<uint64_t> expected_checksums{
       91, 99, 275, 238, 425, 525, 1350, 825, 1122};
@@ -2081,7 +1866,7 @@ TEST_CASE(
   pipeline.add_filter(PseudoChecksumFilter());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
 
@@ -2126,20 +1911,22 @@ TEST_CASE(
       }
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Multi-stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     pipeline.add_filter(Add1OutOfPlace());
     pipeline.add_filter(Add1InPlace());
     pipeline.add_filter(PseudoChecksumFilter());
@@ -2194,19 +1981,21 @@ TEST_CASE(
       }
     }
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test pipeline modify filter", "[filter][modify]") {
@@ -2214,22 +2003,7 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter][modify]") {
 
   // Set up test data
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -2275,13 +2049,16 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter][modify]") {
     offset += sizeof(uint64_t);
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 }
@@ -2290,22 +2067,7 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -2336,26 +2098,7 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -2372,7 +2115,7 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
   CHECK(add_n != nullptr);
   add_n->set_increment(2);
 
-  Tile::set_max_tile_chunk_size(80);
+  WriterTile::set_max_tile_chunk_size(80);
   CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
             .ok());
 
@@ -2410,17 +2153,20 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
     }
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test pipeline copy", "[filter][copy]") {
@@ -2429,22 +2175,7 @@ TEST_CASE("Filter: Test pipeline copy", "[filter][copy]") {
   const uint64_t expected_checksum = 5350;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -2503,13 +2234,16 @@ TEST_CASE("Filter: Test pipeline copy", "[filter][copy]") {
     offset += sizeof(uint64_t);
   }
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == i);
   }
 }
@@ -2518,22 +2252,6 @@ TEST_CASE("Filter: Test random pipeline", "[filter][random]") {
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
 
   EncryptionKey encryption_key;
   REQUIRE(encryption_key
@@ -2568,6 +2286,8 @@ TEST_CASE("Filter: Test random pipeline", "[filter][random]") {
 
   ThreadPool tp(4);
   for (int i = 0; i < 100; i++) {
+    auto tile = make_increasing_tile(nelts);
+
     // Construct a random pipeline
     FilterPipeline pipeline;
     const unsigned max_num_filters = 6;
@@ -2601,14 +2321,16 @@ TEST_CASE("Filter: Test random pipeline", "[filter][random]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t n = 0; n < nelts; n++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == n);
     }
   }
@@ -2621,22 +2343,7 @@ TEST_CASE(
   REQUIRE(config.set("sm.skip_checksum_validation", "true").ok());
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // MD5
   FilterPipeline md5_pipeline;
@@ -2648,34 +2355,41 @@ TEST_CASE(
   CHECK(tile.size() == 0);
   CHECK(tile.filtered_buffer().size() != 0);
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
   CHECK(md5_pipeline
-            .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile.filtered_buffer().size() == 0);
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == n);
   }
 
   // SHA256
+  auto tile2 = make_increasing_tile(nelts);
+
   FilterPipeline sha_256_pipeline;
   ChecksumMD5Filter sha_256_filter;
   sha_256_pipeline.add_filter(sha_256_filter);
-  CHECK(sha_256_pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp)
-            .ok());
-  CHECK(tile.size() == 0);
-  CHECK(tile.filtered_buffer().size() != 0);
+  CHECK(
+      sha_256_pipeline.run_forward(&test::g_helper_stats, &tile2, nullptr, &tp)
+          .ok());
+  CHECK(tile2.size() == 0);
+  CHECK(tile2.filtered_buffer().size() != 0);
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
+  auto unfiltered_tile2 = create_tile_for_unfiltering(nelts, tile2);
   CHECK(sha_256_pipeline
-            .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
             .ok());
-  CHECK(tile.filtered_buffer().size() == 0);
+  CHECK(unfiltered_tile2.filtered_buffer().size() == 0);
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
-    CHECK(tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK(unfiltered_tile2.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
+              .ok());
     CHECK(elt == n);
   }
 }
@@ -2685,28 +2399,14 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
 
   // Set up test data
   const uint64_t nelts = 1000;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(BitWidthReductionFilter());
 
   SECTION("- Single stage") {
+    auto tile = make_increasing_tile(nelts);
+
     CHECK(
         pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
 
@@ -2738,14 +2438,16 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     auto compressed_size = tile.filtered_buffer().size();
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -2754,6 +2456,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     std::vector<uint32_t> window_sizes = {
         32, 64, 128, 256, 437, 512, 1024, 2000};
     for (auto window_size : window_sizes) {
+      auto tile = make_increasing_tile(nelts);
+
       pipeline.get_filter<BitWidthReductionFilter>()->set_max_window_size(
           window_size);
 
@@ -2762,14 +2466,17 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
 
-      tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-      CHECK(pipeline
-                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-                .ok());
-      CHECK(tile.filtered_buffer().size() == 0);
+      auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+      CHECK(
+          pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+      CHECK(unfiltered_tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                  .ok());
         CHECK(elt == i);
       }
     }
@@ -2782,13 +2489,11 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     std::uniform_int_distribution<> rng(0, std::numeric_limits<int32_t>::max());
     INFO("Random element seed: " << seed);
 
-    Tile tile(
+    WriterTile tile(
         constants::format_version,
         Datatype::UINT64,
-        cell_size,
-        dim_num,
-        tile_size,
-        0);
+        sizeof(uint64_t),
+        nelts * sizeof(uint64_t));
 
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
@@ -2801,14 +2506,16 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK((int64_t)elt == rng(gen_copy));
     }
   }
@@ -2822,19 +2529,15 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
         std::numeric_limits<int32_t>::max());
     INFO("Random element seed: " << seed);
 
-    const uint64_t tile_size2 = nelts * sizeof(uint32_t);
-
-    Tile tile(
+    WriterTile tile(
         constants::format_version,
-        Datatype::UINT64,
-        cell_size,
-        dim_num,
-        tile_size2,
-        0);
+        Datatype::UINT32,
+        sizeof(uint32_t),
+        nelts * sizeof(uint32_t));
 
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
-      uint64_t val = (uint32_t)rng(gen);
+      uint32_t val = (uint32_t)rng(gen);
       CHECK(tile.write(&val, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
     }
 
@@ -2843,26 +2546,26 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size2, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t))
+                .ok());
       CHECK(elt == rng(gen_copy));
     }
   }
 
   SECTION("- Byte overflow") {
-    Tile tile(
+    WriterTile tile(
         constants::format_version,
         Datatype::UINT64,
-        cell_size,
-        dim_num,
-        tile_size,
-        0);
+        sizeof(uint64_t),
+        nelts * sizeof(uint64_t));
 
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
@@ -2875,14 +2578,16 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i % 257);
     }
   }
@@ -2894,22 +2599,6 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -2943,30 +2632,15 @@ TEST_CASE(
   const uint64_t offsets_tile_size =
       offsets.size() * constants::cell_var_offset_size;
 
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
-
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(BitWidthReductionFilter());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    auto tile = make_increasing_tile(nelts);
+    auto offsets_tile = make_offsets_tile(offsets);
+
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
 
@@ -3020,23 +2694,27 @@ TEST_CASE(
     auto compressed_size = tile.filtered_buffer().size();
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Window sizes") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     std::vector<uint32_t> window_sizes = {
         32, 64, 128, 256, 437, 512, 1024, 2000};
     for (auto window_size : window_sizes) {
+      auto tile = make_increasing_tile(nelts);
+      auto offsets_tile = make_offsets_tile(offsets);
       pipeline.get_filter<BitWidthReductionFilter>()->set_max_window_size(
           window_size);
 
@@ -3046,34 +2724,36 @@ TEST_CASE(
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
 
-      tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-      CHECK(pipeline
-                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-                .ok());
-      CHECK(tile.filtered_buffer().size() == 0);
+      auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+      CHECK(
+          pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+      CHECK(unfiltered_tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                  .ok());
         CHECK(elt == i);
       }
     }
   }
 
   SECTION("- Random values") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     std::random_device rd;
     auto seed = rd();
     std::mt19937 gen(seed), gen_copy(seed);
     std::uniform_int_distribution<> rng(0, std::numeric_limits<int32_t>::max());
     INFO("Random element seed: " << seed);
 
-    Tile tile(
+    WriterTile tile(
         constants::format_version,
         Datatype::UINT64,
-        cell_size,
-        dim_num,
-        tile_size,
-        0);
+        sizeof(uint64_t),
+        nelts * sizeof(uint64_t));
+    auto offsets_tile = make_offsets_tile(offsets);
 
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
@@ -3086,20 +2766,22 @@ TEST_CASE(
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK((int64_t)elt == rng(gen_copy));
     }
   }
 
   SECTION(" - Random signed values") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     std::random_device rd;
     auto seed = rd();
     std::mt19937 gen(seed), gen_copy(seed);
@@ -3108,19 +2790,15 @@ TEST_CASE(
         std::numeric_limits<int32_t>::max());
     INFO("Random element seed: " << seed);
 
-    const uint64_t tile_size2 = nelts * sizeof(uint32_t);
-
-    Tile tile(
+    WriterTile tile(
         constants::format_version,
-        Datatype::UINT64,
-        cell_size,
-        dim_num,
-        tile_size2,
-        0);
+        Datatype::UINT32,
+        sizeof(uint32_t),
+        nelts * sizeof(uint32_t));
 
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
-      uint64_t val = (uint32_t)rng(gen);
+      uint32_t val = (uint32_t)rng(gen);
       CHECK(tile.write(&val, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
     }
 
@@ -3129,13 +2807,11 @@ TEST_CASE(
       offsets32[i] /= 2;
     }
 
-    Tile offsets_tile32(
+    WriterTile offsets_tile32(
         constants::format_version,
         Datatype::UINT64,
         constants::cell_var_offset_size,
-        dim_num,
-        offsets_tile_size,
-        0);
+        offsets_tile_size);
 
     // Set up test data
     for (uint64_t i = 0; i < offsets.size(); i++) {
@@ -3153,27 +2829,27 @@ TEST_CASE(
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size2, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t))
+                .ok());
       CHECK(elt == rng(gen_copy));
     }
   }
 
   SECTION("- Byte overflow") {
-    Tile::set_max_tile_chunk_size(80);
-    Tile tile(
+    WriterTile::set_max_tile_chunk_size(80);
+    WriterTile tile(
         constants::format_version,
         Datatype::UINT64,
-        cell_size,
-        dim_num,
-        tile_size,
-        0);
+        sizeof(uint64_t),
+        nelts * sizeof(uint64_t));
 
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
@@ -3181,24 +2857,28 @@ TEST_CASE(
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
     }
 
+    auto offsets_tile = make_offsets_tile(offsets);
+
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i % 257);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
@@ -3206,28 +2886,13 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
 
   // Set up test data
   const uint64_t nelts = 1000;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(PositiveDeltaFilter());
 
   SECTION("- Single stage") {
+    auto tile = make_increasing_tile(nelts);
     CHECK(
         pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
 
@@ -3259,14 +2924,16 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
         encoded_size == pipeline_metadata_size + filter_metadata_size +
                             nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -3275,6 +2942,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
     std::vector<uint32_t> window_sizes = {
         32, 64, 128, 256, 437, 512, 1024, 2000};
     for (auto window_size : window_sizes) {
+      auto tile = make_increasing_tile(nelts);
       pipeline.get_filter<PositiveDeltaFilter>()->set_max_window_size(
           window_size);
 
@@ -3283,20 +2951,24 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
 
-      tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-      CHECK(pipeline
-                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-                .ok());
-      CHECK(tile.filtered_buffer().size() == 0);
+      auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+      CHECK(
+          pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+      CHECK(unfiltered_tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                  .ok());
         CHECK(elt == i);
       }
     }
   }
 
   SECTION("- Error on non-positive delta data") {
+    auto tile = make_increasing_tile(nelts);
     for (uint64_t i = 0; i < nelts; i++) {
       auto val = nelts - i;
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
@@ -3313,22 +2985,6 @@ TEST_CASE(
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -3359,33 +3015,15 @@ TEST_CASE(
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
-
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(PositiveDeltaFilter());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    auto tile = make_increasing_tile(nelts);
+    auto offsets_tile = make_offsets_tile(offsets);
+
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
 
@@ -3440,23 +3078,28 @@ TEST_CASE(
         encoded_size ==
         pipeline_metadata_size + total_md_size + nelts * sizeof(uint64_t));
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Window sizes") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     std::vector<uint32_t> window_sizes = {
         32, 64, 128, 256, 437, 512, 1024, 2000};
     for (auto window_size : window_sizes) {
+      auto tile = make_increasing_tile(nelts);
+      auto offsets_tile = make_offsets_tile(offsets);
+
       pipeline.get_filter<PositiveDeltaFilter>()->set_max_window_size(
           window_size);
 
@@ -3466,21 +3109,27 @@ TEST_CASE(
       CHECK(tile.size() == 0);
       CHECK(tile.filtered_buffer().size() != 0);
 
-      tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-      CHECK(pipeline
-                .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-                .ok());
-      CHECK(tile.filtered_buffer().size() == 0);
+      auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+      CHECK(
+          pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+      CHECK(unfiltered_tile.filtered_buffer().size() == 0);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                  .ok());
         CHECK(elt == i);
       }
     }
   }
 
   SECTION("- Error on non-positive delta data") {
-    Tile::set_max_tile_chunk_size(80);
+    auto tile = make_increasing_tile(nelts);
+    auto offsets_tile = make_offsets_tile(offsets);
+
+    WriterTile::set_max_tile_chunk_size(80);
     for (uint64_t i = 0; i < nelts; i++) {
       auto val = nelts - i;
       CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
@@ -3491,7 +3140,7 @@ TEST_CASE(
              .ok());
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
@@ -3499,22 +3148,7 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
 
   // Set up test data
   const uint64_t nelts = 1000;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -3526,14 +3160,16 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -3542,13 +3178,11 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     const uint32_t nelts2 = 1001;
     const uint64_t tile_size2 = nelts2 * sizeof(uint32_t);
 
-    Tile tile2(
+    WriterTile tile2(
         constants::format_version,
         Datatype::UINT32,
         sizeof(uint32_t),
-        dim_num,
-        tile_size2,
-        0);
+        tile_size2);
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
@@ -3560,15 +3194,17 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
 
-    tile2 =
-        recreate_tile_for_unfiltering(dim_num, tile_size2, std::move(tile2));
-    CHECK(pipeline
-              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
-              .ok());
-    CHECK(tile2.filtered_buffer().size() == 0);
+    auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
+    CHECK(
+        pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
+            .ok());
+    CHECK(unfiltered_tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -3578,22 +3214,7 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -3624,62 +3245,43 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(BitshuffleFilter());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Indivisible by 8") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     const uint32_t nelts2 = 1001;
     const uint64_t tile_size2 = nelts2 * sizeof(uint32_t);
 
-    Tile tile2(
+    WriterTile tile2(
         constants::format_version,
         Datatype::UINT32,
         sizeof(uint32_t),
-        dim_num,
-        tile_size2,
-        0);
+        tile_size2);
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
@@ -3692,20 +3294,22 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
 
-    tile2 =
-        recreate_tile_for_unfiltering(dim_num, tile_size2, std::move(tile2));
-    CHECK(pipeline
-              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
-              .ok());
-    CHECK(tile2.filtered_buffer().size() == 0);
+    auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
+    CHECK(
+        pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
+            .ok());
+    CHECK(unfiltered_tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
@@ -3713,22 +3317,7 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
 
   // Set up test data
   const uint64_t nelts = 1000;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
@@ -3740,14 +3329,16 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -3756,13 +3347,11 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     const uint32_t nelts2 = 1001;
     const uint64_t tile_size2 = nelts2 * sizeof(uint32_t);
 
-    Tile tile2(
+    WriterTile tile2(
         constants::format_version,
         Datatype::UINT32,
         sizeof(uint32_t),
-        dim_num,
-        tile_size2,
-        0);
+        tile_size2);
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
@@ -3774,15 +3363,17 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
 
-    tile2 =
-        recreate_tile_for_unfiltering(dim_num, tile_size2, std::move(tile2));
-    CHECK(pipeline
-              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
-              .ok());
-    CHECK(tile2.filtered_buffer().size() == 0);
+    auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
+    CHECK(
+        pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
+            .ok());
+    CHECK(unfiltered_tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -3792,22 +3383,7 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
   tiledb::sm::Config config;
 
   const uint64_t nelts = 100;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   // Set up test data
   std::vector<uint64_t> sizes{
@@ -3838,62 +3414,43 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
   }
   offsets[offsets.size() - 1] = offset;
 
-  const uint64_t offsets_tile_size =
-      offsets.size() * constants::cell_var_offset_size;
-
-  Tile offsets_tile(
-      constants::format_version,
-      Datatype::UINT64,
-      constants::cell_var_offset_size,
-      dim_num,
-      offsets_tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
-  }
+  auto offsets_tile = make_offsets_tile(offsets);
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
   pipeline.add_filter(ByteshuffleFilter());
 
   SECTION("- Single stage") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
               .ok());
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
   SECTION("- Uneven number of elements") {
-    Tile::set_max_tile_chunk_size(80);
+    WriterTile::set_max_tile_chunk_size(80);
     const uint32_t nelts2 = 1001;
     const uint64_t tile_size2 = nelts2 * sizeof(uint32_t);
 
-    Tile tile2(
+    WriterTile tile2(
         constants::format_version,
         Datatype::UINT32,
         sizeof(uint32_t),
-        dim_num,
-        tile_size2,
-        0);
+        tile_size2);
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
@@ -3906,20 +3463,22 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     CHECK(tile2.size() == 0);
     CHECK(tile2.filtered_buffer().size() != 0);
 
-    tile2 =
-        recreate_tile_for_unfiltering(dim_num, tile_size2, std::move(tile2));
-    CHECK(pipeline
-              .run_reverse(&test::g_helper_stats, &tile2, nullptr, &tp, config)
-              .ok());
-    CHECK(tile2.filtered_buffer().size() == 0);
+    auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
+    CHECK(
+        pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
+            .ok());
+    CHECK(unfiltered_tile2.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
+                .ok());
       CHECK(elt == i);
     }
   }
 
-  Tile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
+  WriterTile::set_max_tile_chunk_size(constants::max_tile_chunk_size);
 }
 
 TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
@@ -3927,22 +3486,7 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
 
   // Set up test data
   const uint64_t nelts = 1000;
-  const uint64_t tile_size = nelts * sizeof(uint64_t);
-  const uint64_t cell_size = sizeof(uint64_t);
-  const uint32_t dim_num = 0;
-
-  Tile tile(
-      constants::format_version,
-      Datatype::UINT64,
-      cell_size,
-      dim_num,
-      tile_size,
-      0);
-
-  // Set up test data
-  for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
-  }
+  auto tile = make_increasing_tile(nelts);
 
   SECTION("- AES-256-GCM") {
     FilterPipeline pipeline;
@@ -3966,41 +3510,46 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     CHECK(tile.size() == 0);
     CHECK(tile.filtered_buffer().size() != 0);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
 
     // Check error decrypting with wrong key.
+    tile = make_increasing_tile(nelts);
     CHECK(
         pipeline.run_forward(&test::g_helper_stats, &tile, nullptr, &tp).ok());
     key[0]++;
     filter->set_key(key);
 
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-    CHECK(!pipeline
-               .run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-               .ok());
+    unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+    CHECK(
+        !pipeline
+             .run_reverse(
+                 &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+             .ok());
 
-    // Fix key and check success. Note: this test depends on the implementation
-    // leaving the tile data unmodified when the decryption fails, which is not
-    // true in general use of the filter pipeline.
-    tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
+    // Fix key and check success.
+    unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
     key[0]--;
     filter->set_key(key);
-    CHECK(
-        pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
-            .ok());
-    CHECK(tile.filtered_buffer().size() == 0);
+    CHECK(pipeline
+              .run_reverse(
+                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
+              .ok());
+    CHECK(unfiltered_tile.filtered_buffer().size() == 0);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
+                .ok());
       CHECK(elt == i);
     }
   }
@@ -4014,7 +3563,7 @@ void testing_float_scaling_filter() {
   const uint64_t nelts = 100;
   const uint64_t tile_size = nelts * sizeof(FloatingType);
   const uint64_t cell_size = sizeof(FloatingType);
-  const uint32_t dim_num = 0;
+  ;
 
   Datatype t = Datatype::FLOAT32;
   switch (sizeof(FloatingType)) {
@@ -4032,7 +3581,7 @@ void testing_float_scaling_filter() {
     }
   }
 
-  Tile tile(constants::format_version, t, cell_size, dim_num, tile_size, 0);
+  WriterTile tile(constants::format_version, t, cell_size, tile_size);
 
   std::vector<FloatingType> float_result_vec;
   double scale = 2.53;
@@ -4075,12 +3624,16 @@ void testing_float_scaling_filter() {
   CHECK(tile.size() == 0);
   CHECK(tile.filtered_buffer().size() != 0);
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
   for (uint64_t i = 0; i < nelts; i++) {
     FloatingType elt = 0.0f;
-    CHECK(tile.read(&elt, i * sizeof(FloatingType), sizeof(FloatingType)).ok());
+    CHECK(unfiltered_tile
+              .read(&elt, i * sizeof(FloatingType), sizeof(FloatingType))
+              .ok());
     CHECK(elt == float_result_vec[i]);
   }
 }
@@ -4110,9 +3663,9 @@ void testing_xor_filter(Datatype t) {
   const uint64_t nelts = 100;
   const uint64_t tile_size = nelts * sizeof(T);
   const uint64_t cell_size = sizeof(T);
-  const uint32_t dim_num = 0;
+  ;
 
-  Tile tile(constants::format_version, t, cell_size, dim_num, tile_size, 0);
+  WriterTile tile(constants::format_version, t, cell_size, tile_size);
 
   // Setting up the random number generator for the XOR filter testing.
   std::mt19937_64 gen(0x57A672DE);
@@ -4137,12 +3690,14 @@ void testing_xor_filter(Datatype t) {
   CHECK(tile.size() == 0);
   CHECK(tile.filtered_buffer().size() != 0);
 
-  tile = recreate_tile_for_unfiltering(dim_num, tile_size, std::move(tile));
-  CHECK(pipeline.run_reverse(&test::g_helper_stats, &tile, nullptr, &tp, config)
+  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  CHECK(pipeline
+            .run_reverse(
+                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
             .ok());
   for (uint64_t i = 0; i < nelts; i++) {
     T elt = 0;
-    CHECK(tile.read(&elt, i * sizeof(T), sizeof(T)).ok());
+    CHECK(unfiltered_tile.read(&elt, i * sizeof(T), sizeof(T)).ok());
     CHECK(elt == results[i]);
   }
 }

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -35,7 +35,7 @@
 #include "tiledb/common/common.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::sm;
 
@@ -95,7 +95,7 @@ TEMPLATE_LIST_TEST_CASE(
   }
 
   // Initialize a new tile.
-  WriterTile writer_tile(
+  WriterTileTuple writer_tile(
       schema,
       num_cells,
       false,
@@ -263,7 +263,7 @@ TEMPLATE_LIST_TEST_CASE(
 
   // Initialize a new tile.
   auto tiledb_type = static_cast<Datatype>(type.tiledb_type);
-  WriterTile writer_tile(schema, 4, false, false, sizeof(T), tiledb_type);
+  WriterTileTuple writer_tile(schema, 4, false, false, sizeof(T), tiledb_type);
   auto tile_buff = (T*)writer_tile.fixed_tile().data();
 
   // Once an overflow happens, the computation should abort, try to add a few
@@ -288,7 +288,8 @@ TEMPLATE_LIST_TEST_CASE(
   // Test negative overflow.
   if constexpr (std::is_signed_v<T>) {
     // Initialize a new tile.
-    WriterTile writer_tile(schema, 4, false, false, sizeof(T), tiledb_type);
+    WriterTileTuple writer_tile(
+        schema, 4, false, false, sizeof(T), tiledb_type);
     auto tile_buff = (T*)writer_tile.fixed_tile().data();
 
     // Once an overflow happens, the computation should abort, try to add a few
@@ -354,7 +355,8 @@ TEST_CASE(
   }
 
   // Initialize tile.
-  WriterTile writer_tile(schema, num_cells, true, nullable, 1, Datatype::CHAR);
+  WriterTileTuple writer_tile(
+      schema, num_cells, true, nullable, 1, Datatype::CHAR);
   auto offsets_tile_buff = (uint64_t*)writer_tile.offset_tile().data();
 
   // Initialize a new nullable tile.
@@ -437,7 +439,7 @@ TEST_CASE(
 
   // Store '123' and '12'
   // Initialize offsets tile.
-  WriterTile writer_tile(schema, 2, true, false, 1, Datatype::CHAR);
+  WriterTileTuple writer_tile(schema, 2, true, false, 1, Datatype::CHAR);
   auto offsets_tile_buff = (uint64_t*)writer_tile.offset_tile().data();
   offsets_tile_buff[0] = 0;
   offsets_tile_buff[1] = 3;

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -279,7 +279,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/generic_tile_io.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/tile_metadata_generator.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/writer_tile.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/tile/writer_tile_tuple.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/storage_format/uri/generate_uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/storage_format/uri/parse_uri.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/type/range/range.cc

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -321,7 +321,7 @@ bool Dimension::coincides_with_tiles(const Range& r) const {
 }
 
 template <class T>
-Range Dimension::compute_mbr(const Tile& tile) {
+Range Dimension::compute_mbr(const WriterTile& tile) {
   auto cell_num = tile.cell_num();
   assert(cell_num > 0);
 
@@ -340,14 +340,14 @@ Range Dimension::compute_mbr(const Tile& tile) {
   return mbr;
 }
 
-Range Dimension::compute_mbr(const Tile& tile) const {
+Range Dimension::compute_mbr(const WriterTile& tile) const {
   assert(compute_mbr_func_ != nullptr);
   return compute_mbr_func_(tile);
 }
 
 template <>
 Range Dimension::compute_mbr_var<char>(
-    const Tile& tile_off, const Tile& tile_val) {
+    const WriterTile& tile_off, const WriterTile& tile_val) {
   auto d_val_size = tile_val.size();
   auto cell_num = tile_off.cell_num();
   assert(cell_num > 0);
@@ -376,7 +376,7 @@ Range Dimension::compute_mbr_var<char>(
 }
 
 Range Dimension::compute_mbr_var(
-    const Tile& tile_off, const Tile& tile_val) const {
+    const WriterTile& tile_off, const WriterTile& tile_val) const {
   assert(compute_mbr_var_func_ != nullptr);
   return compute_mbr_var_func_(tile_off, tile_val);
 }

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -454,27 +454,29 @@ class Dimension {
    * Computes the minimum bounding range of the values stored in
    * `tile`. Applicable only to fixed-size dimensions.
    */
-  Range compute_mbr(const Tile& tile) const;
+  Range compute_mbr(const WriterTile& tile) const;
 
   /**
    * Computed the minimum bounding range of the values stored in
    * `tile`.
    */
   template <class T>
-  static Range compute_mbr(const Tile& tile);
+  static Range compute_mbr(const WriterTile& tile);
 
   /**
    * Computes the minimum bounding range of the values stored in
    * `tile_val`. Applicable only to var-sized dimensions.
    */
-  Range compute_mbr_var(const Tile& tile_off, const Tile& tile_val) const;
+  Range compute_mbr_var(
+      const WriterTile& tile_off, const WriterTile& tile_val) const;
 
   /**
    * Computes the minimum bounding range of the values stored in
    * `tile_val`. Applicable only to var-sized dimensions.
    */
   template <class T>
-  static Range compute_mbr_var(const Tile& tile_off, const Tile& tile_val);
+  static Range compute_mbr_var(
+      const WriterTile& tile_off, const WriterTile& tile_val);
 
   /**
    * Crops the input 1D range such that it does not exceed the
@@ -797,13 +799,14 @@ class Dimension {
    * Stores the appropriate templated compute_mbr() function based on the
    * dimension datatype.
    */
-  std::function<Range(const Tile&)> compute_mbr_func_;
+  std::function<Range(const WriterTile&)> compute_mbr_func_;
 
   /**
    * Stores the appropriate templated compute_mbr_var() function based on the
    * dimension datatype.
    */
-  std::function<Range(const Tile&, const Tile&)> compute_mbr_var_func_;
+  std::function<Range(const WriterTile&, const WriterTile&)>
+      compute_mbr_var_func_;
 
   /**
    * Stores the appropriate templated crop_range() function based on the

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -121,13 +121,14 @@ Status FragmentMetaConsolidator::consolidate(
   }
 
   // Serialize all fragment metadata footers in parallel
-  std::vector<tiledb_unique_ptr<Tile>> tiles(meta.size());
+  std::vector<tiledb_unique_ptr<WriterTile>> tiles(meta.size());
   auto status = parallel_for(
       storage_manager_->compute_tp(), 0, tiles.size(), [&](size_t i) {
         SizeComputationSerializer size_computation_serializer;
         throw_if_not_ok(meta[i]->write_footer(size_computation_serializer));
         tiles[i].reset(tdb_new(
-            Tile, Tile::from_generic(size_computation_serializer.size())));
+            WriterTile,
+            WriterTile::from_generic(size_computation_serializer.size())));
         Serializer serializer(tiles[i]->data(), tiles[i]->size());
         throw_if_not_ok(meta[i]->write_footer(serializer));
 
@@ -163,7 +164,7 @@ Status FragmentMetaConsolidator::consolidate(
   SizeComputationSerializer size_computation_serializer;
   serialize_data(size_computation_serializer, offset);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   serialize_data(serializer, offset);

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -98,13 +98,13 @@ void BitWidthReductionFilter::dump(FILE* out) const {
 }
 
 Status BitWidthReductionFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const support_data,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  Tile* const offsets_tile = static_cast<Tile*>(support_data);
+  WriterTile* const offsets_tile = static_cast<WriterTile*>(support_data);
   auto tile_type = tile.type();
   auto tile_type_size = static_cast<uint8_t>(datatype_size(tile_type));
 
@@ -177,8 +177,8 @@ Status BitWidthReductionFilter::run_forward(
 
 template <typename T>
 Status BitWidthReductionFilter::run_forward(
-    const Tile&,
-    Tile* const,
+    const WriterTile&,
+    WriterTile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/bit_width_reduction_filter.h
+++ b/tiledb/sm/filter/bit_width_reduction_filter.h
@@ -101,7 +101,7 @@ class BitWidthReductionFilter : public Filter {
    * Reduce the bit size of the given input into the given output.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -180,8 +180,8 @@ class BitWidthReductionFilter : public Filter {
   /** Run_forward method templated on the tile cell datatype. */
   template <typename T>
   Status run_forward(
-      const Tile& tile,
-      Tile* const tile_offsets,
+      const WriterTile& tile,
+      WriterTile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/bitshuffle_filter.cc
+++ b/tiledb/sm/filter/bitshuffle_filter.cc
@@ -59,7 +59,7 @@ void BitshuffleFilter::dump(FILE* out) const {
 }
 
 Status BitshuffleFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
@@ -126,7 +126,7 @@ Status BitshuffleFilter::compute_parts(
 }
 
 Status BitshuffleFilter::shuffle_part(
-    const Tile& tile, const ConstBuffer* part, Buffer* output) const {
+    const WriterTile& tile, const ConstBuffer* part, Buffer* output) const {
   auto tile_type = tile.type();
   auto tile_type_size = static_cast<uint8_t>(datatype_size(tile_type));
   auto part_nelts = part->size() / tile_type_size;

--- a/tiledb/sm/filter/bitshuffle_filter.h
+++ b/tiledb/sm/filter/bitshuffle_filter.h
@@ -86,7 +86,7 @@ class BitshuffleFilter : public Filter {
    * Shuffle the bits of the input data into the output data buffer.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -128,7 +128,7 @@ class BitshuffleFilter : public Filter {
    * @return Status
    */
   Status shuffle_part(
-      const Tile& tile, const ConstBuffer* part, Buffer* output) const;
+      const WriterTile& tile, const ConstBuffer* part, Buffer* output) const;
 
   /**
    * Perform bit unshuffling on the given input buffer.

--- a/tiledb/sm/filter/bitsort_filter.cc
+++ b/tiledb/sm/filter/bitsort_filter.cc
@@ -57,14 +57,14 @@ void BitSortFilter::dump(FILE* out) const {
 }
 
 Status BitSortFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const support_data,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  const std::vector<Tile*> dim_tiles =
-      *static_cast<std::vector<Tile*>*>(support_data);
+  const std::vector<WriterTile*> dim_tiles =
+      *static_cast<std::vector<WriterTile*>*>(support_data);
 
   // Since run_forward interprets the filter's data as integers, we case on
   // the size of the type and pass in the corresponding integer type into
@@ -97,7 +97,7 @@ Status BitSortFilter::run_forward(
 
 template <typename AttrType>
 Status BitSortFilter::run_forward(
-    const std::vector<Tile*>& dim_tiles,
+    const std::vector<WriterTile*>& dim_tiles,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
@@ -187,7 +187,7 @@ Status BitSortFilter::run_forward(
 
 template <typename DimType>
 void BitSortFilter::run_forward_dim_tile(
-    const std::vector<size_t>& cell_pos, Tile* dim_tile) const {
+    const std::vector<size_t>& cell_pos, WriterTile* dim_tile) const {
   // Obtain the pointer to the data the code modifies.
   uint64_t cell_num = cell_pos.size();
   DimType* tile_data = dim_tile->data_as<DimType>();

--- a/tiledb/sm/filter/bitsort_filter.h
+++ b/tiledb/sm/filter/bitsort_filter.h
@@ -82,7 +82,7 @@ class BitSortFilter : public Filter {
    * @return Status
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -128,7 +128,7 @@ class BitSortFilter : public Filter {
    */
   template <typename AttrType>
   Status run_forward(
-      const std::vector<Tile*>& dim_tiles,
+      const std::vector<WriterTile*>& dim_tiles,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,
@@ -163,7 +163,7 @@ class BitSortFilter : public Filter {
    */
   template <typename DimType>
   void run_forward_dim_tile(
-      const std::vector<size_t>& positions, Tile* dim_tile) const;
+      const std::vector<size_t>& positions, WriterTile* dim_tile) const;
 
   /**
    * @brief Unsorts the input buffer and restores the array by sorting the

--- a/tiledb/sm/filter/byteshuffle_filter.cc
+++ b/tiledb/sm/filter/byteshuffle_filter.cc
@@ -59,7 +59,7 @@ void ByteshuffleFilter::dump(FILE* out) const {
 }
 
 Status ByteshuffleFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
@@ -94,7 +94,7 @@ Status ByteshuffleFilter::run_forward(
 }
 
 Status ByteshuffleFilter::shuffle_part(
-    const Tile& tile, const ConstBuffer* part, Buffer* output) const {
+    const WriterTile& tile, const ConstBuffer* part, Buffer* output) const {
   auto tile_type = tile.type();
   auto tile_type_size = static_cast<uint8_t>(datatype_size(tile_type));
 

--- a/tiledb/sm/filter/byteshuffle_filter.h
+++ b/tiledb/sm/filter/byteshuffle_filter.h
@@ -78,7 +78,7 @@ class ByteshuffleFilter : public Filter {
    * Shuffle the bytes of the input data into the output data buffer.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -110,7 +110,7 @@ class ByteshuffleFilter : public Filter {
    * @return Status
    */
   Status shuffle_part(
-      const Tile& tile, const ConstBuffer* part, Buffer* output) const;
+      const WriterTile& tile, const ConstBuffer* part, Buffer* output) const;
 
   /**
    * Perform byte unshuffling on the given input buffer.

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -61,7 +61,7 @@ void ChecksumMD5Filter::dump(FILE* out) const {
 }
 
 Status ChecksumMD5Filter::run_forward(
-    const Tile&,
+    const WriterTile&,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,

--- a/tiledb/sm/filter/checksum_md5_filter.h
+++ b/tiledb/sm/filter/checksum_md5_filter.h
@@ -84,7 +84,7 @@ class ChecksumMD5Filter : public Filter {
    * Encrypt the bytes of the input data into the output data buffer.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/checksum_sha256_filter.cc
+++ b/tiledb/sm/filter/checksum_sha256_filter.cc
@@ -61,7 +61,7 @@ void ChecksumSHA256Filter::dump(FILE* out) const {
 }
 
 Status ChecksumSHA256Filter::run_forward(
-    const Tile&,
+    const WriterTile&,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,

--- a/tiledb/sm/filter/checksum_sha256_filter.h
+++ b/tiledb/sm/filter/checksum_sha256_filter.h
@@ -84,7 +84,7 @@ class ChecksumSHA256Filter : public Filter {
    * Encrypt the bytes of the input data into the output data buffer.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -209,13 +209,13 @@ Status CompressionFilter::get_option_impl(
 }
 
 Status CompressionFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const support_data,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  Tile* const offsets_tile = static_cast<Tile*>(support_data);
+  WriterTile* const offsets_tile = static_cast<WriterTile*>(support_data);
   // Easy case: no compression
   if (compressor_ == Compressor::NO_COMPRESSION) {
     RETURN_NOT_OK(output->append_view(input));
@@ -316,7 +316,7 @@ Status CompressionFilter::run_reverse(
 }
 
 Status CompressionFilter::compress_part(
-    const Tile& tile,
+    const WriterTile& tile,
     ConstBuffer* part,
     Buffer* output,
     FilterBuffer* output_metadata) const {
@@ -437,7 +437,7 @@ Status CompressionFilter::decompress_part(
 
 tuple<std::vector<std::string_view>, uint64_t>
 CompressionFilter::create_input_view(
-    const FilterBuffer& input, Tile* const offsets_tile) {
+    const FilterBuffer& input, WriterTile* const offsets_tile) {
   auto input_buf = static_cast<const char*>(input.buffers()[0].data());
   auto offsets_data = static_cast<uint64_t*>(offsets_tile->data());
   auto offsets_size = offsets_tile->size() / constants::cell_var_offset_size;
@@ -473,7 +473,7 @@ uint8_t CompressionFilter::compute_bytesize(uint64_t param_length) {
 
 Status CompressionFilter::compress_var_string_coords(
     const FilterBuffer& input,
-    Tile* const offsets_tile,
+    WriterTile* const offsets_tile,
     FilterBuffer& output,
     FilterBuffer& output_metadata) const {
   if (input.num_buffers() != 1) {
@@ -619,7 +619,8 @@ Status CompressionFilter::decompress_var_string_coords(
   return Status::Ok();
 }
 
-uint64_t CompressionFilter::overhead(const Tile& tile, uint64_t nbytes) const {
+uint64_t CompressionFilter::overhead(
+    const WriterTile& tile, uint64_t nbytes) const {
   auto cell_size = tile.cell_size();
 
   switch (compressor_) {

--- a/tiledb/sm/filter/compression_filter.h
+++ b/tiledb/sm/filter/compression_filter.h
@@ -115,7 +115,7 @@ class CompressionFilter : public Filter {
    * Compress the given input into the given output.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -173,7 +173,7 @@ class CompressionFilter : public Filter {
 
   /** Helper function to compress a single contiguous buffer (part). */
   Status compress_part(
-      const Tile& tile,
+      const WriterTile& tile,
       ConstBuffer* part,
       Buffer* output,
       FilterBuffer* output_metadata) const;
@@ -203,7 +203,7 @@ class CompressionFilter : public Filter {
    */
   Status compress_var_string_coords(
       const FilterBuffer& input,
-      Tile* const offsets_tile,
+      WriterTile* const offsets_tile,
       FilterBuffer& output,
       FilterBuffer& output_metadata) const;
 
@@ -224,7 +224,7 @@ class CompressionFilter : public Filter {
   static Compressor filter_to_compressor(FilterType type);
 
   /** Computes the compression overhead on nbytes of the input data. */
-  uint64_t overhead(const Tile& tile, uint64_t nbytes) const;
+  uint64_t overhead(const WriterTile& tile, uint64_t nbytes) const;
 
   /** Sets an option on this filter. */
   Status set_option_impl(FilterOption option, const void* value) override;
@@ -241,7 +241,7 @@ class CompressionFilter : public Filter {
   /** Creates a vector of views of the input strings and returns the max string
    * size */
   static tuple<std::vector<std::string_view>, uint64_t> create_input_view(
-      const FilterBuffer& input, Tile* const offsets_tile);
+      const FilterBuffer& input, WriterTile* const offsets_tile);
 
   /**
    * Return the number of bytes required to store an integer

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.cc
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.cc
@@ -71,7 +71,7 @@ void EncryptionAES256GCMFilter::dump(FILE* out) const {
 }
 
 Status EncryptionAES256GCMFilter::run_forward(
-    const Tile&,
+    const WriterTile&,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,

--- a/tiledb/sm/filter/encryption_aes256gcm_filter.h
+++ b/tiledb/sm/filter/encryption_aes256gcm_filter.h
@@ -97,7 +97,7 @@ class EncryptionAES256GCMFilter : public Filter {
    * Encrypt the bytes of the input data into the output data buffer.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/filter.h
+++ b/tiledb/sm/filter/filter.h
@@ -47,6 +47,7 @@ class Buffer;
 class ConstBuffer;
 class FilterBuffer;
 class Tile;
+class WriterTile;
 
 enum class FilterOption : uint8_t;
 enum class FilterType : uint8_t;
@@ -102,7 +103,7 @@ class Filter {
    * @return
    */
   virtual Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -96,7 +96,9 @@ void FilterPipeline::clear() {
 
 tuple<Status, optional<std::vector<uint64_t>>>
 FilterPipeline::get_var_chunk_sizes(
-    uint32_t chunk_size, Tile* const tile, Tile* const offsets_tile) const {
+    uint32_t chunk_size,
+    WriterTile* const tile,
+    WriterTile* const offsets_tile) const {
   std::vector<uint64_t> chunk_offsets;
   if (offsets_tile != nullptr) {
     uint64_t num_offsets =
@@ -151,7 +153,7 @@ FilterPipeline::get_var_chunk_sizes(
 }
 
 Status FilterPipeline::filter_chunks_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* support_data,
     uint32_t chunk_size,
     std::vector<uint64_t>& chunk_offsets,
@@ -428,8 +430,8 @@ uint32_t FilterPipeline::max_chunk_size() const {
 
 Status FilterPipeline::run_forward(
     stats::Stats* const writer_stats,
-    Tile* const tile,
-    Tile* const offsets_tile,
+    WriterTile* const tile,
+    WriterTile* const offsets_tile,
     ThreadPool* const compute_tp,
     void* support_data,
     bool use_chunking) const {
@@ -440,11 +442,8 @@ Status FilterPipeline::run_forward(
 
   uint32_t chunk_size = 0;
   if (use_chunking) {
-    RETURN_NOT_OK(Tile::compute_chunk_size(
-        tile->size(),
-        tile->zipped_coords_dim_num(),
-        tile->cell_size(),
-        &chunk_size));
+    RETURN_NOT_OK(WriterTile::compute_chunk_size(
+        tile->size(), tile->cell_size(), &chunk_size));
   } else {
     chunk_size = tile->size();
   }
@@ -603,16 +602,8 @@ Status FilterPipeline::run_reverse_internal(
 
   reader_stats->add_counter("read_unfiltered_byte_num", total_orig_size);
 
-  const Status st = filter_chunks_reverse(
-      *tile, support_data, filtered_chunks, compute_tp, config);
-  if (!st.ok()) {
-    tile->clear_data();
-
-    if (offsets_tile) {
-      offsets_tile->clear_data();
-    }
-    return st;
-  }
+  RETURN_NOT_OK(filter_chunks_reverse(
+      *tile, support_data, filtered_chunks, compute_tp, config));
 
   // Clear the filtered buffer now that we have reverse-filtered it into
   // 'tile->buffer()'.

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -202,8 +202,8 @@ class FilterPipeline {
    */
   Status run_forward(
       stats::Stats* writer_stats,
-      Tile* tile,
-      Tile* offsets_tile,
+      WriterTile* tile,
+      WriterTile* offsets_tile,
       ThreadPool* compute_tp,
       void* support_data = nullptr,
       bool chunking = true) const;
@@ -361,7 +361,9 @@ class FilterPipeline {
    * @return Status, chunk offsets vector.
    */
   tuple<Status, optional<std::vector<uint64_t>>> get_var_chunk_sizes(
-      uint32_t chunk_size, Tile* const tile, Tile* const offsets_tile) const;
+      uint32_t chunk_size,
+      WriterTile* const tile,
+      WriterTile* const offsets_tile) const;
 
   /**
    * Run the given buffer forward through the pipeline.
@@ -377,7 +379,7 @@ class FilterPipeline {
    * @return Status
    */
   Status filter_chunks_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* support_data,
       uint32_t chunk_size,
       std::vector<uint64_t>& chunk_offsets,

--- a/tiledb/sm/filter/float_scaling_filter.cc
+++ b/tiledb/sm/filter/float_scaling_filter.cc
@@ -132,7 +132,7 @@ Status FloatScalingFilter::run_forward(
 }
 
 Status FloatScalingFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,

--- a/tiledb/sm/filter/float_scaling_filter.h
+++ b/tiledb/sm/filter/float_scaling_filter.h
@@ -100,7 +100,7 @@ class FloatScalingFilter : public Filter {
    * with the pre-specified byte width.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/noop_filter.cc
+++ b/tiledb/sm/filter/noop_filter.cc
@@ -56,7 +56,7 @@ void NoopFilter::dump(FILE* out) const {
 }
 
 Status NoopFilter::run_forward(
-    const Tile&,
+    const WriterTile&,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,

--- a/tiledb/sm/filter/noop_filter.h
+++ b/tiledb/sm/filter/noop_filter.h
@@ -58,7 +58,7 @@ class NoopFilter : public Filter {
    * Run forward.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -61,13 +61,13 @@ void PositiveDeltaFilter::dump(FILE* out) const {
 }
 
 Status PositiveDeltaFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const support_data,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  Tile* const offsets_tile = static_cast<Tile*>(support_data);
+  WriterTile* const offsets_tile = static_cast<WriterTile*>(support_data);
   auto tile_type = tile.type();
 
   // If encoding can't work, just return the input unmodified.
@@ -139,8 +139,8 @@ Status PositiveDeltaFilter::run_forward(
 
 template <typename T>
 Status PositiveDeltaFilter::run_forward(
-    const Tile&,
-    Tile* const,
+    const WriterTile&,
+    WriterTile* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
     FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/positive_delta_filter.h
+++ b/tiledb/sm/filter/positive_delta_filter.h
@@ -92,7 +92,7 @@ class PositiveDeltaFilter : public Filter {
    * Perform positive-delta encoding of the given input into the given output.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
@@ -142,8 +142,8 @@ class PositiveDeltaFilter : public Filter {
   /** Run_forward method templated on the tile cell datatype. */
   template <typename T>
   Status run_forward(
-      const Tile& tile,
-      Tile* const tile_offsets,
+      const WriterTile& tile,
+      WriterTile* const tile_offsets,
       FilterBuffer* input_metadata,
       FilterBuffer* input,
       FilterBuffer* output_metadata,

--- a/tiledb/sm/filter/webp_filter.cc
+++ b/tiledb/sm/filter/webp_filter.cc
@@ -51,7 +51,7 @@ namespace tiledb::sm {
  */
 
 Status WebpFilter::run_forward(
-    const Tile&,
+    const WriterTile&,
     void* const,
     FilterBuffer*,
     FilterBuffer*,
@@ -98,7 +98,7 @@ using namespace tiledb::common;
 namespace tiledb::sm {
 
 Status WebpFilter::run_forward(
-    const Tile&,
+    const WriterTile&,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,
@@ -376,7 +376,7 @@ void WebpFilter::set_extents(const std::vector<ByteVecValue>& extents) {
     throw StatusException(Status_FilterError(
         "Tile extents too large; Max size WebP image is 16383x16383 pixels"));
   }
-  Tile::set_max_tile_chunk_size(extents_.first * extents_.second);
+  WriterTile::set_max_tile_chunk_size(extents_.first * extents_.second);
 }
 
 template void WebpFilter::set_extents<uint8_t>(

--- a/tiledb/sm/filter/webp_filter.h
+++ b/tiledb/sm/filter/webp_filter.h
@@ -157,7 +157,7 @@ class WebpFilter : public Filter {
    * @return Status::Ok() on success. Throws on failure.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/filter/xor_filter.cc
+++ b/tiledb/sm/filter/xor_filter.cc
@@ -49,7 +49,7 @@ void XORFilter::dump(FILE* out) const {
 }
 
 Status XORFilter::run_forward(
-    const Tile& tile,
+    const WriterTile& tile,
     void* const,
     FilterBuffer* input_metadata,
     FilterBuffer* input,

--- a/tiledb/sm/filter/xor_filter.h
+++ b/tiledb/sm/filter/xor_filter.h
@@ -73,7 +73,7 @@ class XORFilter : public Filter {
    * of elements.
    */
   Status run_forward(
-      const Tile& tile,
+      const WriterTile& tile,
       void* const support_data,
       FilterBuffer* input_metadata,
       FilterBuffer* input,

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3925,12 +3925,12 @@ Status FragmentMetadata::store_rtree(
   return Status::Ok();
 }
 
-Tile FragmentMetadata::write_rtree() {
+WriterTile FragmentMetadata::write_rtree() {
   rtree_.build_tree();
   SizeComputationSerializer size_computation_serializer;
   rtree_.serialize(size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   rtree_.serialize(serializer);
@@ -4027,7 +4027,9 @@ Status FragmentMetadata::read_file_footer(
 }
 
 Status FragmentMetadata::write_generic_tile_to_file(
-    const EncryptionKey& encryption_key, Tile& tile, uint64_t* nbytes) const {
+    const EncryptionKey& encryption_key,
+    WriterTile& tile,
+    uint64_t* nbytes) const {
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
 
@@ -4037,7 +4039,7 @@ Status FragmentMetadata::write_generic_tile_to_file(
   return Status::Ok();
 }
 
-Status FragmentMetadata::write_footer_to_file(Tile& tile) const {
+Status FragmentMetadata::write_footer_to_file(WriterTile& tile) const {
   URI fragment_metadata_uri = fragment_uri_.join_path(
       std::string(constants::fragment_metadata_filename));
 
@@ -4057,7 +4059,7 @@ void FragmentMetadata::store_tile_offsets(
   SizeComputationSerializer size_computation_serializer;
   write_tile_offsets(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_offsets(idx, serializer);
@@ -4085,7 +4087,7 @@ void FragmentMetadata::store_tile_var_offsets(
   SizeComputationSerializer size_computation_serializer;
   write_tile_var_offsets(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_var_offsets(idx, serializer);
@@ -4115,7 +4117,7 @@ void FragmentMetadata::store_tile_var_sizes(
   SizeComputationSerializer size_computation_serializer;
   write_tile_var_sizes(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_var_sizes(idx, serializer);
@@ -4143,7 +4145,7 @@ void FragmentMetadata::store_tile_validity_offsets(
   SizeComputationSerializer size_computation_serializer;
   write_tile_validity_offsets(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_validity_offsets(idx, serializer);
@@ -4173,7 +4175,7 @@ void FragmentMetadata::store_tile_mins(
   SizeComputationSerializer size_computation_serializer;
   write_tile_mins(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_mins(idx, serializer);
@@ -4210,7 +4212,7 @@ void FragmentMetadata::store_tile_maxs(
   SizeComputationSerializer size_computation_serializer;
   write_tile_maxs(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_maxs(idx, serializer);
@@ -4247,7 +4249,7 @@ void FragmentMetadata::store_tile_sums(
   SizeComputationSerializer size_computation_serializer;
   write_tile_sums(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_sums(idx, serializer);
@@ -4273,7 +4275,7 @@ void FragmentMetadata::store_tile_null_counts(
   SizeComputationSerializer size_computation_serializer;
   write_tile_null_counts(idx, size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   write_tile_null_counts(idx, serializer);
@@ -4327,7 +4329,7 @@ void FragmentMetadata::store_fragment_min_max_sum_null_count(
   SizeComputationSerializer size_computation_serializer;
   serialize_data(size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   serialize_data(serializer);
@@ -4354,7 +4356,7 @@ void FragmentMetadata::store_processed_conditions(
   SizeComputationSerializer size_computation_serializer;
   serialize_processed_conditions(size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   serialize_processed_conditions(serializer);
@@ -4686,7 +4688,7 @@ Status FragmentMetadata::store_footer(const EncryptionKey& encryption_key) {
   (void)encryption_key;  // Not used for now, maybe in the future
   SizeComputationSerializer size_computation_serializer;
   RETURN_NOT_OK(write_footer(size_computation_serializer));
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   RETURN_NOT_OK(write_footer(serializer));

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1774,7 +1774,7 @@ class FragmentMetadata {
   Status store_footer(const EncryptionKey& encryption_key);
 
   /** Writes the R-tree to a tile. */
-  Tile write_rtree();
+  WriterTile write_rtree();
 
   /** Writes the non-empty domain to the input buffer. */
   void write_non_empty_domain(Serializer& serializer) const;
@@ -1988,7 +1988,9 @@ class FragmentMetadata {
    * @return Status
    */
   Status write_generic_tile_to_file(
-      const EncryptionKey& encryption_key, Tile& tile, uint64_t* nbytes) const;
+      const EncryptionKey& encryption_key,
+      WriterTile& tile,
+      uint64_t* nbytes) const;
 
   /**
    * Writes the contents of the input buffer at the end of the fragment
@@ -1996,7 +1998,7 @@ class FragmentMetadata {
    * retrieval upon reading (as its size is predictable based on the
    * number of attributes).
    */
-  Status write_footer_to_file(Tile&) const;
+  Status write_footer_to_file(WriterTile&) const;
 
   /**
    * Simple clean up function called in the case of error. It removes the

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -76,7 +76,8 @@ TEST_CASE(
 
   SizeComputationSerializer size_computation_serializer1;
   metadata_to_serialize1.serialize(size_computation_serializer1);
-  Tile tile1{Tile::from_generic(size_computation_serializer1.size())};
+  WriterTile tile1{
+      WriterTile::from_generic(size_computation_serializer1.size())};
 
   Serializer serializer1(tile1.data(), tile1.size());
   metadata_to_serialize1.serialize(serializer1);
@@ -87,7 +88,8 @@ TEST_CASE(
 
   SizeComputationSerializer size_computation_serializer2;
   metadata_to_serialize2.serialize(size_computation_serializer2);
-  Tile tile2{Tile::from_generic(size_computation_serializer2.size())};
+  WriterTile tile2{
+      WriterTile::from_generic(size_computation_serializer2.size())};
 
   Serializer serializer2(tile2.data(), tile2.size());
   metadata_to_serialize2.serialize(serializer2);
@@ -102,15 +104,42 @@ TEST_CASE(
 
   SizeComputationSerializer size_computation_serializer3;
   metadata_to_serialize3.serialize(size_computation_serializer3);
-  Tile tile3{Tile::from_generic(size_computation_serializer3.size())};
+  WriterTile tile3{
+      WriterTile::from_generic(size_computation_serializer3.size())};
 
   Serializer serializer3(tile3.data(), tile3.size());
   metadata_to_serialize3.serialize(serializer3);
 
   metadata_tiles.resize(3);
-  metadata_tiles[0] = tdb::make_shared<Tile>(HERE(), std::move(tile1));
-  metadata_tiles[1] = tdb::make_shared<Tile>(HERE(), std::move(tile2));
-  metadata_tiles[2] = tdb::make_shared<Tile>(HERE(), std::move(tile3));
+  metadata_tiles[0] = tdb::make_shared<Tile>(
+      HERE(),
+      tile1.format_version(),
+      tile1.type(),
+      tile1.cell_size(),
+      0,
+      tile1.size(),
+      tile1.filtered_buffer().size());
+  memcpy(metadata_tiles[0]->data(), tile1.data(), tile1.size());
+
+  metadata_tiles[1] = tdb::make_shared<Tile>(
+      HERE(),
+      tile2.format_version(),
+      tile2.type(),
+      tile2.cell_size(),
+      0,
+      tile2.size(),
+      tile2.filtered_buffer().size());
+  memcpy(metadata_tiles[1]->data(), tile2.data(), tile2.size());
+
+  metadata_tiles[2] = tdb::make_shared<Tile>(
+      HERE(),
+      tile3.format_version(),
+      tile3.type(),
+      tile3.cell_size(),
+      0,
+      tile3.size(),
+      tile3.filtered_buffer().size());
+  memcpy(metadata_tiles[2]->data(), tile3.data(), tile3.size());
 
   auto meta{Metadata::deserialize(metadata_tiles)};
 

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -164,7 +164,7 @@ Status DeletesAndUpdates::dowork() {
 
   // Serialize the negated condition (aud update values if they are not empty)
   // and write to disk.
-  Tile serialized_condition =
+  WriterTile serialized_condition =
       update_values_.empty() ?
           tiledb::sm::deletes_and_updates::serialization::serialize_condition(
               condition_.negated_condition()) :

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -93,9 +93,9 @@ storage_size_t get_serialized_condition_size(
   return size_computation_serializer.size();
 }
 
-Tile serialize_condition(const QueryCondition& query_condition) {
-  Tile tile{
-      Tile::from_generic(get_serialized_condition_size(query_condition.ast()))};
+WriterTile serialize_condition(const QueryCondition& query_condition) {
+  WriterTile tile{WriterTile::from_generic(
+      get_serialized_condition_size(query_condition.ast()))};
 
   Serializer serializer(tile.data(), tile.size());
   serialize_condition_impl(query_condition.ast(), serializer);
@@ -178,11 +178,12 @@ storage_size_t get_serialized_update_condition_and_values_size(
   return size_computation_serializer.size();
 }
 
-Tile serialize_update_condition_and_values(
+WriterTile serialize_update_condition_and_values(
     const QueryCondition& query_condition,
     const std::vector<UpdateValue>& update_values) {
-  Tile tile{Tile::from_generic(get_serialized_update_condition_and_values_size(
-      query_condition.ast(), update_values))};
+  WriterTile tile{
+      WriterTile::from_generic(get_serialized_update_condition_and_values_size(
+          query_condition.ast(), update_values))};
 
   Serializer serializer(tile.data(), tile.size());
   serialize_condition_impl(query_condition.ast(), serializer);

--- a/tiledb/sm/query/deletes_and_updates/serialization.h
+++ b/tiledb/sm/query/deletes_and_updates/serialization.h
@@ -48,7 +48,7 @@ enum class NodeType : uint8_t { EXPRESSION = 0, VALUE };
  * @param query_condition Query condition to serialize.
  * @return Serialized query condition tile.
  */
-Tile serialize_condition(const QueryCondition& query_condition);
+WriterTile serialize_condition(const QueryCondition& query_condition);
 
 /**
  * Deserializes the condition.
@@ -73,7 +73,7 @@ QueryCondition deserialize_condition(
  * @param update_values Update values to serialize.
  * @return Serialized condition and update values tile.
  */
-Tile serialize_update_condition_and_values(
+WriterTile serialize_update_condition_and_values(
     const QueryCondition& query_condition,
     const std::vector<UpdateValue>& update_values);
 

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -54,7 +54,7 @@
 #include "tiledb/sm/query/writers/unordered_writer.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 #include <cassert>
 #include <iostream>

--- a/tiledb/sm/query/writers/dense_tiler.cc
+++ b/tiledb/sm/query/writers/dense_tiler.cc
@@ -39,7 +39,7 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
@@ -190,7 +190,7 @@ const typename DenseTiler<T>::CopyPlan DenseTiler<T>::copy_plan(
 
 template <class T>
 Status DenseTiler<T>::get_tile(
-    uint64_t id, const std::string& name, WriterTile& tile) {
+    uint64_t id, const std::string& name, WriterTileTuple& tile) {
   auto timer_se = stats_->start_timer("get_tile");
 
   // Checks
@@ -218,13 +218,11 @@ Status DenseTiler<T>::get_tile(
     std::vector<uint8_t> fill_var(sizeof(uint64_t), 0);
 
     // Initialize position tile
-    Tile tile_pos(
+    WriterTile tile_pos(
         constants::format_version,
         constants::cell_var_offset_type,
         constants::cell_var_offset_size,
-        0,
-        tile_off_size,
-        0);
+        tile_off_size);
 
     // Fill entire tile with MAX_UINT64
     std::vector<uint64_t> to_write(
@@ -503,7 +501,7 @@ std::vector<std::array<T, 2>> DenseTiler<T>::tile_subarray(uint64_t id) const {
 
 template <class T>
 Status DenseTiler<T>::copy_tile(
-    uint64_t id, uint64_t cell_size, uint8_t* buff, Tile& tile) const {
+    uint64_t id, uint64_t cell_size, uint8_t* buff, WriterTile& tile) const {
   // Calculate copy plan
   const CopyPlan copy_plan = this->copy_plan(id);
 
@@ -577,7 +575,7 @@ Status DenseTiler<T>::copy_tile(
 
 template <class T>
 void DenseTiler<T>::compute_tile_metadata(
-    const std::string& name, uint64_t id, WriterTile& tile) const {
+    const std::string& name, uint64_t id, WriterTileTuple& tile) const {
   // Calculate copy plan
   const CopyPlan copy_plan = this->copy_plan(id);
 

--- a/tiledb/sm/query/writers/dense_tiler.h
+++ b/tiledb/sm/query/writers/dense_tiler.h
@@ -44,7 +44,7 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/subarray/subarray.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::common;
 
@@ -173,7 +173,7 @@ class DenseTiler {
    *     be preallocated and initialized before passed to the function.
    * @return Status
    */
-  Status get_tile(uint64_t id, const std::string& name, WriterTile& tile);
+  Status get_tile(uint64_t id, const std::string& name, WriterTileTuple& tile);
 
   /**
    * Returns the number of tiles to be created. This is equal
@@ -318,7 +318,7 @@ class DenseTiler {
    * @return Status
    */
   Status copy_tile(
-      uint64_t id, uint64_t cell_size, uint8_t* buff, Tile& tile) const;
+      uint64_t id, uint64_t cell_size, uint8_t* buff, WriterTile& tile) const;
 
   /**
    * Computes the tile metadata according to the copy plan.
@@ -330,7 +330,7 @@ class DenseTiler {
    *    filled in.
    */
   void compute_tile_metadata(
-      const std::string& name, uint64_t id, WriterTile& tile) const;
+      const std::string& name, uint64_t id, WriterTileTuple& tile) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -51,7 +51,7 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 #include "tiledb/storage_format/uri/generate_uri.h"
 
 using namespace tiledb;
@@ -208,10 +208,10 @@ Status GlobalOrderWriter::init_global_write_state() {
     const auto capacity = array_schema_.capacity();
     const auto cell_num_per_tile =
         coords_info_.has_coords_ ? capacity : domain.cell_num_per_tile();
-    auto last_tile_vector =
-        std::pair<std::string, WriterTileVector>(name, WriterTileVector());
+    auto last_tile_vector = std::pair<std::string, WriterTileTupleVector>(
+        name, WriterTileTupleVector());
     try {
-      last_tile_vector.second.emplace_back(WriterTile(
+      last_tile_vector.second.emplace_back(WriterTileTuple(
           array_schema_,
           cell_num_per_tile,
           var_size,
@@ -760,7 +760,7 @@ Status GlobalOrderWriter::global_write() {
     RETURN_CANCEL_OR_ERROR(compute_coord_dups(&coord_dups));
   }
 
-  std::unordered_map<std::string, WriterTileVector> tiles;
+  std::unordered_map<std::string, WriterTileTupleVector> tiles;
   RETURN_CANCEL_OR_ERROR(prepare_full_tiles(coord_dups, &tiles));
 
   // Find number of tiles and gather stats
@@ -862,12 +862,12 @@ void GlobalOrderWriter::nuke_global_write_state() {
 
 Status GlobalOrderWriter::prepare_full_tiles(
     const std::set<uint64_t>& coord_dups,
-    std::unordered_map<std::string, WriterTileVector>* tiles) const {
+    std::unordered_map<std::string, WriterTileTupleVector>* tiles) const {
   auto timer_se = stats_->start_timer("prepare_tiles");
 
   // Initialize attribute and coordinate tiles
   for (const auto& it : buffers_) {
-    (*tiles)[it.first] = WriterTileVector();
+    (*tiles)[it.first] = WriterTileTupleVector();
   }
 
   auto num = buffers_.size();
@@ -889,7 +889,7 @@ Status GlobalOrderWriter::prepare_full_tiles(
 Status GlobalOrderWriter::prepare_full_tiles(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
-    WriterTileVector* tiles) const {
+    WriterTileTupleVector* tiles) const {
   return array_schema_.var_size(name) ?
              prepare_full_tiles_var(name, coord_dups, tiles) :
              prepare_full_tiles_fixed(name, coord_dups, tiles);
@@ -898,7 +898,7 @@ Status GlobalOrderWriter::prepare_full_tiles(
 Status GlobalOrderWriter::prepare_full_tiles_fixed(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
-    WriterTileVector* tiles) const {
+    WriterTileTupleVector* tiles) const {
   // For easy reference
   auto nullable = array_schema_.is_nullable(name);
   auto type = array_schema_.type(name);
@@ -969,7 +969,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
   if (full_tile_num > 0) {
     tiles->reserve(full_tile_num);
     for (uint64_t i = 0; i < full_tile_num; i++) {
-      tiles->emplace_back(WriterTile(
+      tiles->emplace_back(WriterTileTuple(
           array_schema_, cell_num_per_tile, false, nullable, cell_size, type));
     }
 
@@ -1067,7 +1067,7 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
 Status GlobalOrderWriter::prepare_full_tiles_var(
     const std::string& name,
     const std::set<uint64_t>& coord_dups,
-    WriterTileVector* tiles) const {
+    WriterTileTupleVector* tiles) const {
   // For easy reference
   auto it = buffers_.find(name);
   auto nullable = array_schema_.is_nullable(name);
@@ -1176,7 +1176,7 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
   if (full_tile_num > 0) {
     tiles->reserve(full_tile_num);
     for (uint64_t i = 0; i < full_tile_num; i++) {
-      tiles->emplace_back(WriterTile(
+      tiles->emplace_back(WriterTileTuple(
           array_schema_, cell_num_per_tile, true, nullable, cell_size, type));
     }
 
@@ -1356,12 +1356,12 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
 uint64_t GlobalOrderWriter::num_tiles_to_write(
     uint64_t start,
     uint64_t tile_num,
-    std::unordered_map<std::string, WriterTileVector>& tiles) {
+    std::unordered_map<std::string, WriterTileTupleVector>& tiles) {
   // Cache variables to prevent map lookups.
   const auto buf_names = buffer_names();
   std::vector<bool> var_size;
   std::vector<bool> nullable;
-  std::vector<WriterTileVector*> writer_tile_vectors;
+  std::vector<WriterTileTupleVector*> writer_tile_vectors;
   var_size.reserve(buf_names.size());
   nullable.reserve(buf_names.size());
   writer_tile_vectors.reserve(buf_names.size());

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -66,7 +66,7 @@ class GlobalOrderWriter : public WriterBase {
      * second tile is the values tile. In both cases, the third tile stores a
      * validity tile for nullable attributes.
      */
-    std::unordered_map<std::string, WriterTileVector> last_tiles_;
+    std::unordered_map<std::string, WriterTileTupleVector> last_tiles_;
 
     /**
      * Stores the last offset into the var size tile buffer for var size
@@ -304,7 +304,7 @@ class GlobalOrderWriter : public WriterBase {
    */
   Status prepare_full_tiles(
       const std::set<uint64_t>& coord_dups,
-      std::unordered_map<std::string, WriterTileVector>* tiles) const;
+      std::unordered_map<std::string, WriterTileTupleVector>* tiles) const;
 
   /**
    * Applicable only to write in global order. It prepares only full
@@ -323,7 +323,7 @@ class GlobalOrderWriter : public WriterBase {
   Status prepare_full_tiles(
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * Applicable only to write in global order. It prepares only full
@@ -342,7 +342,7 @@ class GlobalOrderWriter : public WriterBase {
   Status prepare_full_tiles_fixed(
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * Applicable only to write in global order. It prepares only full
@@ -361,7 +361,7 @@ class GlobalOrderWriter : public WriterBase {
   Status prepare_full_tiles_var(
       const std::string& name,
       const std::set<uint64_t>& coord_dups,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * Return the number of tiles to write depending on the desired fragment
@@ -376,7 +376,7 @@ class GlobalOrderWriter : public WriterBase {
   uint64_t num_tiles_to_write(
       uint64_t start,
       uint64_t tile_num,
-      std::unordered_map<std::string, WriterTileVector>& tiles);
+      std::unordered_map<std::string, WriterTileTupleVector>& tiles);
 
   /**
    * Close the current fragment and start a new one. The closed fragment will

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -52,7 +52,7 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb;
 using namespace tiledb::common;
@@ -243,9 +243,9 @@ Status OrderedWriter::ordered_write() {
   auto attr_num = buffers_.size();
   auto compute_tp = storage_manager_->compute_tp();
   auto thread_num = compute_tp->concurrency_level();
-  std::unordered_map<std::string, std::vector<WriterTileVector>> tiles;
+  std::unordered_map<std::string, std::vector<WriterTileTupleVector>> tiles;
   for (const auto& buff : buffers_) {
-    tiles.emplace(buff.first, std::vector<WriterTileVector>());
+    tiles.emplace(buff.first, std::vector<WriterTileTupleVector>());
   }
 
   if (attr_num > tile_num) {  // Parallelize over attributes
@@ -329,7 +329,7 @@ Status OrderedWriter::ordered_write() {
 template <class T>
 Status OrderedWriter::prepare_filter_and_write_tiles(
     const std::string& name,
-    std::vector<WriterTileVector>& tile_batches,
+    std::vector<WriterTileTupleVector>& tile_batches,
     shared_ptr<FragmentMetadata> frag_meta,
     DenseTiler<T>* dense_tiler,
     uint64_t thread_num) {
@@ -362,7 +362,7 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
     assert(batch_size > 0);
     tile_batches[b].reserve(batch_size);
     for (uint64_t i = 0; i < batch_size; i++) {
-      tile_batches[b].emplace_back(WriterTile(
+      tile_batches[b].emplace_back(WriterTileTuple(
           array_schema_, cell_num_per_tile, var, nullable, cell_size, type));
     }
     auto st = parallel_for(

--- a/tiledb/sm/query/writers/ordered_writer.h
+++ b/tiledb/sm/query/writers/ordered_writer.h
@@ -130,7 +130,7 @@ class OrderedWriter : public WriterBase {
   template <class T>
   Status prepare_filter_and_write_tiles(
       const std::string& name,
-      std::vector<WriterTileVector>& tile_batches,
+      std::vector<WriterTileTupleVector>& tile_batches,
       shared_ptr<FragmentMetadata> frag_meta,
       DenseTiler<T>* dense_tiler,
       uint64_t thread_num);

--- a/tiledb/sm/query/writers/unordered_writer.h
+++ b/tiledb/sm/query/writers/unordered_writer.h
@@ -143,7 +143,7 @@ class UnorderedWriter : public WriterBase {
   Status prepare_tiles(
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      std::unordered_map<std::string, WriterTileVector>* tiles) const;
+      std::unordered_map<std::string, WriterTileTupleVector>* tiles) const;
 
   /**
    * It prepares the tiles for the input attribute or dimension, re-organizing
@@ -161,7 +161,7 @@ class UnorderedWriter : public WriterBase {
       const std::string& name,
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * It prepares the tiles for the input attribute or dimension, re-organizing
@@ -180,7 +180,7 @@ class UnorderedWriter : public WriterBase {
       const std::string& name,
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * It prepares the tiles for the input attribute or dimension, re-organizing
@@ -199,7 +199,7 @@ class UnorderedWriter : public WriterBase {
       const std::string& name,
       const std::vector<uint64_t>& cell_pos,
       const std::set<uint64_t>& coord_dups,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * Sorts the coordinates of the user buffers, creating a vector with

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -45,7 +45,7 @@
 #include "tiledb/sm/query/writers/dense_tiler.h"
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::common;
 
@@ -57,7 +57,7 @@ class DomainBuffersView;
 class FragmentMetadata;
 class TileMetadataGenerator;
 
-using WriterTileVector = std::vector<WriterTile>;
+using WriterTileTupleVector = std::vector<WriterTileTuple>;
 
 /** Processes write queries. */
 class WriterBase : public StrategyBase, public IQueryStrategy {
@@ -251,7 +251,8 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    * @return MBRs.
    */
   std::vector<NDRange> compute_mbrs(
-      const std::unordered_map<std::string, WriterTileVector>& tiles) const;
+      const std::unordered_map<std::string, WriterTileTupleVector>& tiles)
+      const;
 
   /**
    * Set the coordinates metadata (e.g., MBRs).
@@ -266,7 +267,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   void set_coords_metadata(
       const uint64_t start_tile_idx,
       const uint64_t end_tile_idx,
-      const std::unordered_map<std::string, WriterTileVector>& tiles,
+      const std::unordered_map<std::string, WriterTileTupleVector>& tiles,
       const std::vector<NDRange>& mbrs,
       shared_ptr<FragmentMetadata> meta) const;
 
@@ -280,7 +281,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    */
   Status compute_tiles_metadata(
       uint64_t tile_num,
-      std::unordered_map<std::string, WriterTileVector>& tiles) const;
+      std::unordered_map<std::string, WriterTileTupleVector>& tiles) const;
 
   /**
    * Returns the i-th coordinates in the coordinate buffers in string
@@ -305,7 +306,8 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    * filter pipelines. The tile buffers are modified to contain the output
    * of the pipeline.
    */
-  Status filter_tiles(std::unordered_map<std::string, WriterTileVector>* tiles);
+  Status filter_tiles(
+      std::unordered_map<std::string, WriterTileTupleVector>* tiles);
 
   /**
    * Runs the input tiles for the input attribute through the filter pipeline.
@@ -315,7 +317,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    * @param tile The tiles to be filtered.
    * @return Status
    */
-  Status filter_tiles(const std::string& name, WriterTileVector* tiles);
+  Status filter_tiles(const std::string& name, WriterTileTupleVector* tiles);
 
   /**
    * Runs the input tiles for the input attribute through the filter pipeline
@@ -328,7 +330,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    */
   Status filter_tiles_bitsort(
       const std::string& name,
-      std::unordered_map<std::string, WriterTileVector>* tiles);
+      std::unordered_map<std::string, WriterTileTupleVector>* tiles);
 
   /**
    * Runs the input tile for the input attribute/dimension through the filter
@@ -346,8 +348,8 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
    */
   Status filter_tile(
       const std::string& name,
-      Tile* tile,
-      Tile* offsets_tile,
+      WriterTile* tile,
+      WriterTile* offsets_tile,
       bool offsets,
       bool nullable,
       void* support_data);
@@ -382,7 +384,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   Status init_tiles(
       const std::string& name,
       uint64_t tile_num,
-      WriterTileVector* tiles) const;
+      WriterTileTupleVector* tiles) const;
 
   /**
    * Optimize the layout for 1D arrays. Specifically, if the array
@@ -456,7 +458,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
       const uint64_t start_tile_idx,
       const uint64_t end_tile_idx,
       shared_ptr<FragmentMetadata> frag_meta,
-      std::unordered_map<std::string, WriterTileVector>* tiles);
+      std::unordered_map<std::string, WriterTileTupleVector>* tiles);
 
   /**
    * Writes the input tiles for the input attribute/dimension to storage.
@@ -478,7 +480,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
       const std::string& name,
       shared_ptr<FragmentMetadata> frag_meta,
       uint64_t start_tile_id,
-      WriterTileVector* tiles,
+      WriterTileTupleVector* tiles,
       bool close_files = true);
 
   /**
@@ -505,7 +507,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   template <class T>
   Status prepare_filter_and_write_tiles(
       const std::string& name,
-      std::vector<WriterTileVector>& tile_batches,
+      std::vector<WriterTileTupleVector>& tile_batches,
       tdb_shared_ptr<FragmentMetadata> frag_meta,
       DenseTiler<T>* dense_tiler,
       uint64_t thread_num);

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1963,7 +1963,7 @@ Status StorageManagerCanonical::store_group_detail(
   SizeComputationSerializer size_computation_serializer;
   group->serialize(size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
 
   Serializer serializer(tile.data(), tile.size());
   group->serialize(serializer);
@@ -1992,7 +1992,7 @@ Status StorageManagerCanonical::store_array_schema(
   SizeComputationSerializer size_computation_serializer;
   array_schema->serialize(size_computation_serializer);
 
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
   Serializer serializer(tile.data(), tile.size());
   array_schema->serialize(serializer);
 
@@ -2035,7 +2035,7 @@ Status StorageManagerCanonical::store_metadata(
   if (0 == size_computation_serializer.size()) {
     return Status::Ok();
   }
-  Tile tile{Tile::from_generic(size_computation_serializer.size())};
+  WriterTile tile{WriterTile::from_generic(size_computation_serializer.size())};
   Serializer serializer(tile.data(), tile.size());
   metadata->serialize(serializer);
 
@@ -2051,7 +2051,7 @@ Status StorageManagerCanonical::store_metadata(
 }
 
 Status StorageManagerCanonical::store_data_to_generic_tile(
-    Tile& tile, const URI& uri, const EncryptionKey& encryption_key) {
+    WriterTile& tile, const URI& uri, const EncryptionKey& encryption_key) {
   GenericTileIO tile_io(resources_, uri);
   uint64_t nbytes = 0;
   Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -1011,7 +1011,7 @@ class StorageManagerCanonical {
    * @return Status
    */
   Status store_data_to_generic_tile(
-      Tile& tile, const URI& uri, const EncryptionKey& encryption_key);
+      WriterTile& tile, const URI& uri, const EncryptionKey& encryption_key);
 
   /** Closes a file, flushing its contents to persistent storage. */
   Status close_file(const URI& uri);

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -150,7 +150,7 @@ GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
 }
 
 Status GenericTileIO::write_generic(
-    Tile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes) {
+    WriterTile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   // Create a header
   GenericTileHeader header;
   RETURN_NOT_OK(init_generic_tile_header(tile, &header, encryption_key));
@@ -227,7 +227,7 @@ Status GenericTileIO::configure_encryption_filter(
 }
 
 Status GenericTileIO::init_generic_tile_header(
-    Tile* tile,
+    WriterTile* tile,
     GenericTileHeader* header,
     const EncryptionKey& encryption_key) const {
   header->tile_size = tile->size();

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -158,7 +158,7 @@ class GenericTileIO {
    * @return Status
    */
   Status write_generic(
-      Tile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      WriterTile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes);
 
   /**
    * Serialize a generic tile header.
@@ -209,7 +209,7 @@ class GenericTileIO {
    * @return Status
    */
   Status init_generic_tile_header(
-      Tile* tile,
+      WriterTile* tile,
       GenericTileHeader* header,
       const EncryptionKey& encryption_key) const;
 };

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -42,30 +42,37 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
-class TileStatusException : public StatusException {
- public:
-  explicit TileStatusException(const std::string& message)
-      : StatusException("Tile", message) {
-  }
-};
-
 /* ****************************** */
 /*           STATIC INIT          */
 /* ****************************** */
-uint64_t Tile::max_tile_chunk_size_ = constants::max_tile_chunk_size;
+uint64_t WriterTile::max_tile_chunk_size_ = constants::max_tile_chunk_size;
 
 /* ****************************** */
 /*           STATIC API           */
 /* ****************************** */
 
-Status Tile::compute_chunk_size(
+Tile Tile::from_generic(storage_size_t tile_size) {
+  return {0,
+          constants::generic_tile_datatype,
+          constants::generic_tile_cell_size,
+          0,
+          tile_size,
+          0};
+}
+
+WriterTile WriterTile::from_generic(storage_size_t tile_size) {
+  return {0,
+          constants::generic_tile_datatype,
+          constants::generic_tile_cell_size,
+          tile_size};
+}
+
+Status WriterTile::compute_chunk_size(
     const uint64_t tile_size,
-    const uint32_t tile_dim_num,
     const uint64_t tile_cell_size,
     uint32_t* const chunk_size) {
-  const uint32_t dim_num = tile_dim_num > 0 ? tile_dim_num : 1;
-  const uint64_t dim_tile_size = tile_size / dim_num;
-  const uint64_t dim_cell_size = tile_cell_size / dim_num;
+  const uint64_t dim_tile_size = tile_size;
+  const uint64_t dim_cell_size = tile_cell_size;
 
   uint64_t chunk_size64 = std::min(max_tile_chunk_size_, dim_tile_size);
   chunk_size64 = chunk_size64 / dim_cell_size * dim_cell_size;
@@ -78,22 +85,40 @@ Status Tile::compute_chunk_size(
   return Status::Ok();
 }
 
-void Tile::set_max_tile_chunk_size(uint64_t max_tile_chunk_size) {
+void WriterTile::set_max_tile_chunk_size(uint64_t max_tile_chunk_size) {
   max_tile_chunk_size_ = max_tile_chunk_size;
-}
-
-Tile Tile::from_generic(storage_size_t tile_size) {
-  return {0,
-          constants::generic_tile_datatype,
-          constants::generic_tile_cell_size,
-          0,
-          tile_size,
-          0};
 }
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
+
+TileBase::TileBase(
+    const format_version_t format_version,
+    const Datatype type,
+    const uint64_t cell_size,
+    const uint64_t size)
+    : data_(static_cast<char*>(tdb_malloc(size)), tiledb_free)
+    , size_(size)
+    , cell_size_(cell_size)
+    , format_version_(format_version)
+    , type_(type) {
+}
+
+TileBase::TileBase(TileBase&& tile)
+    : data_(std::move(tile.data_))
+    , size_(std::move(tile.size_))
+    , cell_size_(std::move(tile.cell_size_))
+    , format_version_(std::move(tile.format_version_))
+    , type_(std::move(tile.type_)) {
+}
+
+TileBase& TileBase::operator=(TileBase&& tile) {
+  // Swap with the argument
+  swap(tile);
+
+  return *this;
+}
 
 Tile::Tile(
     const format_version_t format_version,
@@ -102,22 +127,14 @@ Tile::Tile(
     const unsigned int zipped_coords_dim_num,
     const uint64_t size,
     const uint64_t filtered_size)
-    : data_(static_cast<char*>(tdb_malloc(size)), tiledb_free)
-    , size_(size)
-    , cell_size_(cell_size)
+    : TileBase(format_version, type, cell_size, size)
     , zipped_coords_dim_num_(zipped_coords_dim_num)
-    , format_version_(format_version)
-    , type_(type)
     , filtered_buffer_(filtered_size) {
 }
 
 Tile::Tile(Tile&& tile)
-    : data_(std::move(tile.data_))
-    , size_(std::move(tile.size_))
-    , cell_size_(std::move(tile.cell_size_))
+    : TileBase(std::move(tile))
     , zipped_coords_dim_num_(std::move(tile.zipped_coords_dim_num_))
-    , format_version_(std::move(tile.format_version_))
-    , type_(std::move(tile.type_))
     , filtered_buffer_(std::move(tile.filtered_buffer_)) {
 }
 
@@ -128,22 +145,41 @@ Tile& Tile::operator=(Tile&& tile) {
   return *this;
 }
 
+WriterTile::WriterTile(
+    const format_version_t format_version,
+    const Datatype type,
+    const uint64_t cell_size,
+    const uint64_t size)
+    : TileBase(format_version, type, cell_size, size)
+    , filtered_buffer_(0) {
+}
+
+WriterTile::WriterTile(WriterTile&& tile)
+    : TileBase(std::move(tile))
+    , filtered_buffer_(std::move(tile.filtered_buffer_)) {
+}
+
+WriterTile& WriterTile::operator=(WriterTile&& tile) {
+  // Swap with the argument
+  swap(tile);
+
+  return *this;
+}
+
 /* ****************************** */
 /*               API              */
 /* ****************************** */
 
-uint64_t Tile::cell_num() const {
-  return size() / cell_size_;
+void TileBase::swap(TileBase& tile) {
+  std::swap(size_, tile.size_);
+  std::swap(data_, tile.data_);
+  std::swap(cell_size_, tile.cell_size_);
+  std::swap(format_version_, tile.format_version_);
+  std::swap(type_, tile.type_);
 }
 
-void Tile::clear_data() {
-  data_ = nullptr;
-  size_ = 0;
-}
-
-Status Tile::read(
+Status TileBase::read(
     void* const buffer, const uint64_t offset, const uint64_t nbytes) const {
-  assert(!filtered());
   if (nbytes > size_ - offset) {
     return LOG_STATUS(Status_TileError(
         "Read tile overflow; may not read beyond buffer size"));
@@ -152,8 +188,7 @@ Status Tile::read(
   return Status::Ok();
 }
 
-Status Tile::write(const void* data, uint64_t offset, uint64_t nbytes) {
-  assert(!filtered());
+Status TileBase::write(const void* data, uint64_t offset, uint64_t nbytes) {
   if (nbytes > size_ - offset) {
     return LOG_STATUS(
         Status_TileError("Write tile overflow; would write out of bounds"));
@@ -163,25 +198,6 @@ Status Tile::write(const void* data, uint64_t offset, uint64_t nbytes) {
   size_ = std::max(offset + nbytes, size_);
 
   return Status::Ok();
-}
-
-Status Tile::write_var(const void* data, uint64_t offset, uint64_t nbytes) {
-  if (size_ - offset < nbytes) {
-    auto new_alloc_size = size_ == 0 ? offset + nbytes : size_;
-    while (new_alloc_size < offset + nbytes)
-      new_alloc_size *= 2;
-
-    auto new_data =
-        static_cast<char*>(tdb_realloc(data_.release(), new_alloc_size));
-    if (new_data == nullptr) {
-      return LOG_STATUS(Status_TileError(
-          "Cannot reallocate buffer; Memory allocation failed"));
-    }
-    data_.reset(new_data);
-    size_ = new_alloc_size;
-  }
-
-  return write(data, offset, nbytes);
 }
 
 Status Tile::zip_coordinates() {
@@ -215,14 +231,39 @@ Status Tile::zip_coordinates() {
 }
 
 void Tile::swap(Tile& tile) {
-  // Note swapping buffer pointers here.
+  TileBase::swap(tile);
   std::swap(filtered_buffer_, tile.filtered_buffer_);
-  std::swap(size_, tile.size_);
-  std::swap(data_, tile.data_);
-  std::swap(cell_size_, tile.cell_size_);
   std::swap(zipped_coords_dim_num_, tile.zipped_coords_dim_num_);
-  std::swap(format_version_, tile.format_version_);
-  std::swap(type_, tile.type_);
+}
+
+void WriterTile::clear_data() {
+  data_ = nullptr;
+  size_ = 0;
+}
+
+Status WriterTile::write_var(
+    const void* data, uint64_t offset, uint64_t nbytes) {
+  if (size_ - offset < nbytes) {
+    auto new_alloc_size = size_ == 0 ? offset + nbytes : size_;
+    while (new_alloc_size < offset + nbytes)
+      new_alloc_size *= 2;
+
+    auto new_data =
+        static_cast<char*>(tdb_realloc(data_.release(), new_alloc_size));
+    if (new_data == nullptr) {
+      return LOG_STATUS(Status_TileError(
+          "Cannot reallocate buffer; Memory allocation failed"));
+    }
+    data_.reset(new_data);
+    size_ = new_alloc_size;
+  }
+
+  return write(data, offset, nbytes);
+}
+
+void WriterTile::swap(WriterTile& tile) {
+  TileBase::swap(tile);
+  std::swap(filtered_buffer_, tile.filtered_buffer_);
 }
 
 }  // namespace sm

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2022 WriterTileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@
  */
 
 #include "tiledb/sm/tile/tile_metadata_generator.h"
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::common;
 
@@ -44,7 +44,7 @@ namespace sm {
 
 template <typename T>
 void Sum<T, int64_t>::sum(
-    const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
+    const WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
   auto sum_data = reinterpret_cast<int64_t*>(sum.data());
@@ -70,7 +70,7 @@ void Sum<T, int64_t>::sum(
 
 template <typename T>
 void Sum<T, uint64_t>::sum(
-    const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
+    const WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
   auto sum_data = reinterpret_cast<uint64_t*>(sum.data());
@@ -89,7 +89,7 @@ void Sum<T, uint64_t>::sum(
 
 template <typename T>
 void Sum<T, double>::sum(
-    const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
+    const WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum) {
   // Get pointers to the data and cell num.
   auto values = tile.data_as<T>();
   auto sum_data = reinterpret_cast<double*>(sum.data());
@@ -111,8 +111,8 @@ void Sum<T, double>::sum(
 
 template <typename T>
 void Sum<T, int64_t>::sum_nullable(
-    const Tile& tile,
-    const Tile& validity_tile,
+    const WriterTile& tile,
+    const WriterTile& validity_tile,
     uint64_t start,
     uint64_t end,
     ByteVec& sum) {
@@ -144,8 +144,8 @@ void Sum<T, int64_t>::sum_nullable(
 
 template <typename T>
 void Sum<T, uint64_t>::sum_nullable(
-    const Tile& tile,
-    const Tile& validity_tile,
+    const WriterTile& tile,
+    const WriterTile& validity_tile,
     uint64_t start,
     uint64_t end,
     ByteVec& sum) {
@@ -170,8 +170,8 @@ void Sum<T, uint64_t>::sum_nullable(
 
 template <typename T>
 void Sum<T, double>::sum_nullable(
-    const Tile& tile,
-    const Tile& validity_tile,
+    const WriterTile& tile,
+    const WriterTile& validity_tile,
     uint64_t start,
     uint64_t end,
     ByteVec& sum) {
@@ -288,13 +288,13 @@ TileMetadataGenerator::TileMetadataGenerator(
 /*               API              */
 /* ****************************** */
 
-void TileMetadataGenerator::process_full_tile(const WriterTile& tile) {
+void TileMetadataGenerator::process_full_tile(const WriterTileTuple& tile) {
   uint64_t cell_num = tile.cell_num();
   process_cell_slab(tile, 0, cell_num);
 }
 
 void TileMetadataGenerator::process_cell_slab(
-    const WriterTile& tile, uint64_t start, uint64_t end) {
+    const WriterTileTuple& tile, uint64_t start, uint64_t end) {
   if (!var_size_) {
     // Switch depending on datatype.
     switch (type_) {
@@ -368,7 +368,7 @@ void TileMetadataGenerator::process_cell_slab(
   }
 }
 
-void TileMetadataGenerator::set_tile_metadata(WriterTile& tile) {
+void TileMetadataGenerator::set_tile_metadata(WriterTileTuple& tile) {
   tile.set_metadata(min_, min_size_, max_, max_size_, sum_, null_count_);
 }
 
@@ -378,7 +378,7 @@ void TileMetadataGenerator::set_tile_metadata(WriterTile& tile) {
 
 template <class T>
 void TileMetadataGenerator::min_max(
-    const Tile& tile, uint64_t start, uint64_t end) {
+    const WriterTile& tile, uint64_t start, uint64_t end) {
   // Get pointer to the data and cell num.
   auto values = tile.data_as<T>();
 
@@ -397,7 +397,7 @@ void TileMetadataGenerator::min_max(
 
 template <>
 void TileMetadataGenerator::min_max<char>(
-    const Tile& tile, uint64_t start, uint64_t end) {
+    const WriterTile& tile, uint64_t start, uint64_t end) {
   // For strings, return null for empty tiles.
   auto size = tile.size();
   if (size == 0) {
@@ -425,7 +425,10 @@ void TileMetadataGenerator::min_max<char>(
 
 template <class T>
 void TileMetadataGenerator::min_max_nullable(
-    const Tile& tile, const Tile& validity_tile, uint64_t start, uint64_t end) {
+    const WriterTile& tile,
+    const WriterTile& validity_tile,
+    uint64_t start,
+    uint64_t end) {
   auto values = tile.data_as<T>();
   auto validity_values = validity_tile.data_as<uint8_t>();
 
@@ -448,7 +451,10 @@ void TileMetadataGenerator::min_max_nullable(
 
 template <>
 void TileMetadataGenerator::min_max_nullable<char>(
-    const Tile& tile, const Tile& validity_tile, uint64_t start, uint64_t end) {
+    const WriterTile& tile,
+    const WriterTile& validity_tile,
+    uint64_t start,
+    uint64_t end) {
   // Get pointers to the data and cell num.
   auto value = tile.data_as<char>();
   auto validity_values = validity_tile.data_as<uint8_t>();
@@ -475,7 +481,7 @@ void TileMetadataGenerator::min_max_nullable<char>(
 
 template <class T>
 void TileMetadataGenerator::process_cell_range(
-    const WriterTile& tile, uint64_t start, uint64_t end) {
+    const WriterTileTuple& tile, uint64_t start, uint64_t end) {
   min_size_ = max_size_ = cell_size_;
   const auto& fixed_tile = tile.fixed_tile();
 
@@ -511,7 +517,7 @@ void TileMetadataGenerator::process_cell_range(
 }
 
 void TileMetadataGenerator::process_cell_range_var(
-    const WriterTile& tile, uint64_t start, uint64_t end) {
+    const WriterTileTuple& tile, uint64_t start, uint64_t end) {
   assert(tile.var_size());
 
   const auto& offset_tile = tile.offset_tile();

--- a/tiledb/sm/tile/tile_metadata_generator.h
+++ b/tiledb/sm/tile/tile_metadata_generator.h
@@ -44,7 +44,7 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
-class WriterTile;
+class WriterTileTuple;
 
 /**
  * Sum structure used to bind a type and sum type to a sum and sum_nullable
@@ -60,7 +60,7 @@ struct Sum {
    * @param end End cell index.
    * @param sum The current sum.
    */
-  static void sum(Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum(WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum);
 
   /**
    * Add the sum cells of from [start, end] to the current sum for a nullable
@@ -73,8 +73,8 @@ struct Sum {
    * @param sum The current sum.
    */
   static void sum_nullable(
-      const Tile& tile,
-      const Tile& tile_validity,
+      const WriterTile& tile,
+      const WriterTile& tile_validity,
       uint64_t start,
       uint64_t end,
       ByteVec& sum);
@@ -85,10 +85,11 @@ struct Sum {
  */
 template <typename T>
 struct Sum<T, int64_t> {
-  static void sum(const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum(
+      const WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum);
   static void sum_nullable(
-      const Tile& tile,
-      const Tile& tile_validity,
+      const WriterTile& tile,
+      const WriterTile& tile_validity,
       uint64_t start,
       uint64_t end,
       ByteVec& sum);
@@ -99,10 +100,11 @@ struct Sum<T, int64_t> {
  */
 template <typename T>
 struct Sum<T, uint64_t> {
-  static void sum(const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum(
+      const WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum);
   static void sum_nullable(
-      const Tile& tile,
-      const Tile& tile_validity,
+      const WriterTile& tile,
+      const WriterTile& tile_validity,
       uint64_t start,
       uint64_t end,
       ByteVec& sum);
@@ -113,10 +115,11 @@ struct Sum<T, uint64_t> {
  */
 template <typename T>
 struct Sum<T, double> {
-  static void sum(const Tile& tile, uint64_t start, uint64_t end, ByteVec& sum);
+  static void sum(
+      const WriterTile& tile, uint64_t start, uint64_t end, ByteVec& sum);
   static void sum_nullable(
-      const Tile& tile,
-      const Tile& tile_validity,
+      const WriterTile& tile,
+      const WriterTile& tile_validity,
       uint64_t start,
       uint64_t end,
       ByteVec& sum);
@@ -212,7 +215,7 @@ class TileMetadataGenerator {
    *
    * @param tile Writer tile that contains the data.
    */
-  void process_full_tile(const WriterTile& tile);
+  void process_full_tile(const WriterTileTuple& tile);
 
   /**
    * Compute metatada for a slab.
@@ -221,14 +224,15 @@ class TileMetadataGenerator {
    * @param start Start cell index.
    * @param end End cell index.
    */
-  void process_cell_slab(const WriterTile& tile, uint64_t start, uint64_t end);
+  void process_cell_slab(
+      const WriterTileTuple& tile, uint64_t start, uint64_t end);
 
   /**
    * Copies the metadata to the tile once done processing slabs.
    *
    * @param tile Writer tile to copy the metadata to.
    */
-  void set_tile_metadata(WriterTile& tile);
+  void set_tile_metadata(WriterTileTuple& tile);
 
  private:
   /* ********************************* */
@@ -280,7 +284,7 @@ class TileMetadataGenerator {
    * @param end End cell index.
    */
   template <class T>
-  void min_max(const Tile& tile, uint64_t start, uint64_t end);
+  void min_max(const WriterTile& tile, uint64_t start, uint64_t end);
 
   /**
    * Updates the min and max of a fixed data tile with nullable values.
@@ -292,8 +296,8 @@ class TileMetadataGenerator {
    */
   template <class T>
   void min_max_nullable(
-      const Tile& tile,
-      const Tile& tile_validity,
+      const WriterTile& tile,
+      const WriterTile& tile_validity,
       uint64_t start,
       uint64_t end);
 
@@ -305,7 +309,7 @@ class TileMetadataGenerator {
    * @param end End index.
    */
   void process_cell_range_var(
-      const WriterTile& tile, uint64_t start, uint64_t end);
+      const WriterTileTuple& tile, uint64_t start, uint64_t end);
 
   /**
    * Process cell range for fixed size attribute.
@@ -315,7 +319,8 @@ class TileMetadataGenerator {
    * @param end End index.
    */
   template <class T>
-  void process_cell_range(const WriterTile& tile, uint64_t start, uint64_t end);
+  void process_cell_range(
+      const WriterTileTuple& tile, uint64_t start, uint64_t end);
 
   /**
    * Min max function for var sized attributes.

--- a/tiledb/sm/tile/writer_tile_tuple.cc
+++ b/tiledb/sm/tile/writer_tile_tuple.cc
@@ -1,5 +1,5 @@
 /**
- * @file   writer_tile.cc
+ * @file   writer_tile_tuple.cc
  *
  * @section LICENSE
  *
@@ -27,10 +27,10 @@
  *
  * @section DESCRIPTION
  *
- * This file implements class WriterTile.
+ * This file implements class WriterTileTuple.
  */
 
-#include "tiledb/sm/tile/writer_tile.h"
+#include "tiledb/sm/tile/writer_tile_tuple.h"
 #include "tiledb/sm/array_schema/domain.h"
 
 using namespace tiledb::common;
@@ -42,7 +42,7 @@ namespace sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-WriterTile::WriterTile(
+WriterTileTuple::WriterTileTuple(
     const ArraySchema& array_schema,
     const uint64_t cell_num_per_tile,
     const bool var_size,
@@ -50,37 +50,29 @@ WriterTile::WriterTile(
     const uint64_t cell_size,
     const Datatype type)
     : fixed_tile_(
-          var_size ? Tile(
+          var_size ? WriterTile(
                          array_schema.write_version(),
                          constants::cell_var_offset_type,
                          constants::cell_var_offset_size,
-                         0,
-                         cell_num_per_tile * constants::cell_var_offset_size,
-                         0) :
-                     Tile(
+                         cell_num_per_tile * constants::cell_var_offset_size) :
+                     WriterTile(
                          array_schema.write_version(),
                          type,
                          cell_size,
-                         0,
-                         cell_num_per_tile * cell_size,
-                         0))
+                         cell_num_per_tile * cell_size))
     , var_tile_(
-          var_size ? std::optional<Tile>(Tile(
+          var_size ? std::optional<WriterTile>(WriterTile(
                          array_schema.write_version(),
                          type,
                          datatype_size(type),
-                         0,
-                         cell_num_per_tile * constants::cell_var_offset_size,
-                         0)) :
+                         cell_num_per_tile * constants::cell_var_offset_size)) :
                      std::nullopt)
     , validity_tile_(
-          nullable ? std::optional<Tile>(Tile(
+          nullable ? std::optional<WriterTile>(WriterTile(
                          array_schema.write_version(),
                          constants::cell_validity_type,
                          constants::cell_validity_size,
-                         0,
-                         cell_num_per_tile * constants::cell_validity_size,
-                         0)) :
+                         cell_num_per_tile * constants::cell_validity_size)) :
                      std::nullopt)
     , cell_size_(cell_size)
     , var_pre_filtered_size_(0)
@@ -90,7 +82,7 @@ WriterTile::WriterTile(
     , cell_num_(cell_num_per_tile) {
 }
 
-WriterTile::WriterTile(WriterTile&& tile)
+WriterTileTuple::WriterTileTuple(WriterTileTuple&& tile)
     : fixed_tile_(std::move(tile.fixed_tile_))
     , var_tile_(std::move(tile.var_tile_))
     , validity_tile_(std::move(tile.validity_tile_))
@@ -105,7 +97,7 @@ WriterTile::WriterTile(WriterTile&& tile)
     , cell_num_(std::move(tile.cell_num_)) {
 }
 
-WriterTile& WriterTile::operator=(WriterTile&& tile) {
+WriterTileTuple& WriterTileTuple::operator=(WriterTileTuple&& tile) {
   // Swap with the argument
   swap(tile);
 
@@ -116,7 +108,7 @@ WriterTile& WriterTile::operator=(WriterTile&& tile) {
 /*               API              */
 /* ****************************** */
 
-void WriterTile::set_metadata(
+void WriterTileTuple::set_metadata(
     const void* min,
     const uint64_t min_size,
     const void* max,
@@ -143,7 +135,7 @@ void WriterTile::set_metadata(
   }
 }
 
-void WriterTile::swap(WriterTile& tile) {
+void WriterTileTuple::swap(WriterTileTuple& tile) {
   std::swap(fixed_tile_, tile.fixed_tile_);
   std::swap(var_tile_, tile.var_tile_);
   std::swap(validity_tile_, tile.validity_tile_);

--- a/tiledb/sm/tile/writer_tile_tuple.h
+++ b/tiledb/sm/tile/writer_tile_tuple.h
@@ -1,5 +1,5 @@
 /**
- * @file   writer_tile.h
+ * @file   writer_tile_tuple.h
  *
  * @section LICENSE
  *
@@ -27,11 +27,11 @@
  *
  * @section DESCRIPTION
  *
- * This file defines class WriterTile.
+ * This file defines class WriterTileTuple.
  */
 
-#ifndef TILEDB_WRITER_TILE_H
-#define TILEDB_WRITER_TILE_H
+#ifndef TILEDB_WRITER_TILE_TUPLE_H
+#define TILEDB_WRITER_TILE_TUPLE_H
 
 #include "tiledb/sm/tile/tile.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
@@ -44,13 +44,13 @@ namespace sm {
 /**
  * Handles tile information, with added data used by writer.
  */
-class WriterTile {
+class WriterTileTuple {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  WriterTile(
+  WriterTileTuple(
       const ArraySchema& array_schema,
       const uint64_t cell_num_per_tile,
       const bool var_size,
@@ -59,37 +59,37 @@ class WriterTile {
       const Datatype type);
 
   /** Move constructor. */
-  WriterTile(WriterTile&& tile);
+  WriterTileTuple(WriterTileTuple&& tile);
 
   /** Move-assign operator. */
-  WriterTile& operator=(WriterTile&& tile);
+  WriterTileTuple& operator=(WriterTileTuple&& tile);
 
-  DISABLE_COPY_AND_COPY_ASSIGN(WriterTile);
+  DISABLE_COPY_AND_COPY_ASSIGN(WriterTileTuple);
 
   /* ********************************* */
   /*                API                */
   /* ********************************* */
 
   /** Returns the fixed tile. */
-  inline Tile& fixed_tile() {
+  inline WriterTile& fixed_tile() {
     assert(!var_tile_.has_value());
     return fixed_tile_;
   }
 
   /** Returns the fixed tile. */
-  inline const Tile& fixed_tile() const {
+  inline const WriterTile& fixed_tile() const {
     assert(!var_tile_.has_value());
     return fixed_tile_;
   }
 
   /** Returns the offset tile. */
-  inline Tile& offset_tile() {
+  inline WriterTile& offset_tile() {
     assert(var_tile_.has_value());
     return fixed_tile_;
   }
 
   /** Returns the offset tile. */
-  inline const Tile& offset_tile() const {
+  inline const WriterTile& offset_tile() const {
     assert(var_tile_.has_value());
     return fixed_tile_;
   }
@@ -100,12 +100,12 @@ class WriterTile {
   }
 
   /** Returns the var tile. */
-  inline Tile& var_tile() {
+  inline WriterTile& var_tile() {
     return *var_tile_;
   }
 
   /** Returns the var tile. */
-  inline const Tile& var_tile() const {
+  inline const WriterTile& var_tile() const {
     return *var_tile_;
   }
 
@@ -115,12 +115,12 @@ class WriterTile {
   }
 
   /** Returns the validity tile. */
-  inline Tile& validity_tile() {
+  inline WriterTile& validity_tile() {
     return *validity_tile_;
   }
 
   /** Returns the validity tile. */
-  inline const Tile& validity_tile() const {
+  inline const WriterTile& validity_tile() const {
     return *validity_tile_;
   }
 
@@ -216,7 +216,7 @@ class WriterTile {
   }
 
   /** Swaps the contents (all field values) of this tile with the given tile. */
-  void swap(WriterTile& tile);
+  void swap(WriterTileTuple& tile);
 
  private:
   /* ********************************* */
@@ -227,13 +227,13 @@ class WriterTile {
    * Fixed data tile. Contains offsets for var size attribute/dimension and
    * the data itself in case of fixed sized attribute/dimension.
    */
-  Tile fixed_tile_;
+  WriterTile fixed_tile_;
 
   /** Var data tile. */
-  std::optional<Tile> var_tile_;
+  std::optional<WriterTile> var_tile_;
 
   /** Validity data tile. */
-  std::optional<Tile> validity_tile_;
+  std::optional<WriterTile> validity_tile_;
 
   /** Cell size for this attribute. */
   uint64_t cell_size_;
@@ -266,4 +266,4 @@ class WriterTile {
 }  // namespace sm
 }  // namespace tiledb
 
-#endif  // TILEDB_WRITER_TILE_H
+#endif  // TILEDB_WRITER_TILE_TUPLE_H


### PR DESCRIPTION
This is preparation work for the work to remove the extra allocation in VFS. To do this, we'll need tiles on the read path to point inside of a larger memory allocation for the filtered buffers. For writes, it is harder to compute the sizes for the filtered buffers for filters that compress the data so we want to keep it as is for now. Splitting the read tiles and write tiles into separate classes will facilitate the work.

This also changes the old WriterTile class to WriterTileTuple, which matches better the code on the read side which uses TileTuple.

---
TYPE: IMPROVEMENT
DESC: Split Tile class into different classes for read and write.
