### PR TITLE
Implement delete_fragments_list API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,6 +563,7 @@ if (TILEDB_TESTS)
   add_dependencies(tests unit_capi_handle unit_capi_exception_wrapper)
   # C API basics
   add_dependencies(tests unit_capi_error unit_capi_config unit_capi_context)
+  add_dependencies(tests unit_capi_array)
   add_dependencies(tests unit_capi_buffer)
   add_dependencies(tests unit_capi_data_order)
   add_dependencies(tests unit_capi_datatype)

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1714,14 +1714,26 @@ TEST_CASE_METHOD(
       Catch::Matchers::ContainsSubstring(
           "Query type must be MODIFY_EXCLUSIVE"));
   CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 2);
-
   array->close();
+
+  // Try to delete a fragment uri that doesn't exist
+  std::string extraneous_fragment =
+      std::string(SPARSE_ARRAY_NAME) + "/" +
+      tiledb::sm::constants::array_fragments_dir_name + "/extraneous";
+  const char* extraneous_fragments[1] = {extraneous_fragment.c_str()};
+  REQUIRE_THROWS_WITH(
+      Array::delete_fragments_list(
+          ctx_, SPARSE_ARRAY_NAME, extraneous_fragments, 1),
+      Catch::Matchers::ContainsSubstring(
+          "is not a fragment of the ArrayDirectory"));
+  CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 2);
+
   remove_sparse_array();
 }
 
 TEST_CASE_METHOD(
     DeletesFx,
-    "CPP API: Deletion of fragment writes",
+    "CPP API: Deletion of fragment writes by timestamp and uri",
     "[cppapi][deletes][fragments]") {
   remove_sparse_array();
 
@@ -1748,6 +1760,7 @@ TEST_CASE_METHOD(
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 3);
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 5);
   write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 7);
+  CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 4);
 
   if (consolidate) {
     consolidate_commits_sparse(vacuum);
@@ -1764,11 +1777,22 @@ TEST_CASE_METHOD(
   }
 
   // Delete fragments
-  std::unique_ptr<Array> array =
-      std::make_unique<Array>(ctx_, SPARSE_ARRAY_NAME, TILEDB_MODIFY_EXCLUSIVE);
-  array->delete_fragments(SPARSE_ARRAY_NAME, 2, 6);
-  CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 2);
-  array->close();
+  SECTION("delete fragments by timestamps") {
+    std::unique_ptr<Array> array = std::make_unique<Array>(
+        ctx_, SPARSE_ARRAY_NAME, TILEDB_MODIFY_EXCLUSIVE);
+    array->delete_fragments(SPARSE_ARRAY_NAME, 2, 6);
+    array->close();
+  }
+
+  SECTION("delete fragments by uris") {
+    FragmentInfo fragment_info(ctx_, std::string(SPARSE_ARRAY_NAME));
+    fragment_info.load();
+    auto fragment_name1 = fragment_info.fragment_uri(1);
+    auto fragment_name2 = fragment_info.fragment_uri(2);
+    const char* fragment_uris[2] = {fragment_name1.c_str(),
+                                    fragment_name2.c_str()};
+    Array::delete_fragments_list(ctx_, SPARSE_ARRAY_NAME, fragment_uris, 2);
+  }
 
   // Check commits directory after deletion
   if (consolidate) {
@@ -1786,6 +1810,7 @@ TEST_CASE_METHOD(
       CHECK(commits_dir.dir_size() == 4);
     }
   }
+  CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 2);
 
   // Read array
   uint64_t buffer_size = 4;

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1789,8 +1789,8 @@ TEST_CASE_METHOD(
     fragment_info.load();
     auto fragment_name1 = fragment_info.fragment_uri(1);
     auto fragment_name2 = fragment_info.fragment_uri(2);
-    const char* fragment_uris[2] = {fragment_name1.c_str(),
-                                    fragment_name2.c_str()};
+    const char* fragment_uris[2] = {
+        fragment_name1.c_str(), fragment_name2.c_str()};
     Array::delete_fragments_list(ctx_, SPARSE_ARRAY_NAME, fragment_uris, 2);
   }
 

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1740,14 +1740,8 @@ TEST_CASE_METHOD(
   // Conditionally consolidate and vacuum
   bool consolidate = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
 #ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
+  serialize_ = GENERATE(true, false);
 #endif
 
   if (!consolidate && vacuum) {

--- a/tiledb/api/c_api/CMakeLists.txt
+++ b/tiledb/api/c_api/CMakeLists.txt
@@ -49,6 +49,9 @@ target_include_directories(export INTERFACE ${TILEDB_SOURCE_ROOT}/tiledb/sm/c_ap
 # depends on `context`, as context handles are often the first argument.
 #
 
+# `array`: no dependencies
+add_subdirectory(array)
+
 # `buffer`: no dependencies
 add_subdirectory(buffer)
 

--- a/tiledb/api/c_api/array/CMakeLists.txt
+++ b/tiledb/api/c_api/array/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/api/c_api/vfs/test/CMakeLists.txt
+# tiledb/api/c_api/array/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2022 TileDB, Inc.
+# Copyright (c) 2023 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,18 +26,4 @@
 
 include(common NO_POLICY_SCOPE)
 
-add_executable(unit_capi_vfs EXCLUDE_FROM_ALL)
-find_package(Catch_EP REQUIRED)
-target_link_libraries(unit_capi_vfs PUBLIC Catch2::Catch2WithMain)
-target_link_libraries(unit_capi_vfs PUBLIC capi_vfs)
-
-# Sources for tests
-target_sources(unit_capi_vfs PUBLIC
-    unit_capi_vfs.cc
-)
-
-add_test(
-    NAME "unit_capi_vfs"
-    COMMAND $<TARGET_FILE:unit_capi_vfs>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+add_test_subdirectory()

--- a/tiledb/api/c_api/array/test/CMakeLists.txt
+++ b/tiledb/api/c_api/array/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/api/c_api/vfs/test/CMakeLists.txt
+# tiledb/api/c_api/array/test/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2022 TileDB, Inc.
+# Copyright (c) 2023 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,19 +25,28 @@
 #
 
 include(common NO_POLICY_SCOPE)
-
-add_executable(unit_capi_vfs EXCLUDE_FROM_ALL)
 find_package(Catch_EP REQUIRED)
-target_link_libraries(unit_capi_vfs PUBLIC Catch2::Catch2WithMain)
-target_link_libraries(unit_capi_vfs PUBLIC capi_vfs)
+
+# #TODO: link only against a new CAPI array handle, not all core objects
+add_executable(
+    unit_capi_array EXCLUDE_FROM_ALL
+    $<TARGET_OBJECTS:TILEDB_CORE_OBJECTS>
+)
+
+target_link_libraries(unit_capi_array
+  PUBLIC
+    Catch2::Catch2WithMain
+    export
+    TILEDB_CORE_OBJECTS_ILIB
+)
 
 # Sources for tests
-target_sources(unit_capi_vfs PUBLIC
-    unit_capi_vfs.cc
+target_sources(unit_capi_array PUBLIC  
+    unit_capi_array.cc
 )
 
 add_test(
-    NAME "unit_capi_vfs"
-    COMMAND $<TARGET_FILE:unit_capi_vfs>
+    NAME "unit_capi_array"
+    COMMAND $<TARGET_FILE:unit_capi_array>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/tiledb/api/c_api/array/test/unit_capi_array.cc
+++ b/tiledb/api/c_api/array/test/unit_capi_array.cc
@@ -1,0 +1,80 @@
+/**
+ * @file tiledb/api/c_api/array/test/unit_capi_array.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * Validates the arguments for the Array C API.
+ */
+
+#define CATCH_CONFIG_MAIN
+#include <test/support/tdb_catch.h>
+#include "tiledb/api/c_api_test_support/testsupport_capi_context.h"
+#include "tiledb/sm/c_api/tiledb.h"
+
+using tiledb::api::test_support::ordinary_context;
+const char* TEST_URI = "unit_capi_array";
+
+TEST_CASE(
+    "C API: tiledb_array_delete_fragments_list argument validation",
+    "[capi][array]") {
+  ordinary_context x;
+  const char* fragment_uris[1] = {"unit_capi_array/__fragments/fragment_uri"};
+  /*
+   * No "success" section here; too much overhead to set up.
+   */
+  SECTION("null context") {
+    auto rc{tiledb_array_delete_fragments_list(
+        nullptr, TEST_URI, fragment_uris, 1)};
+    CHECK(tiledb_status(rc) == TILEDB_INVALID_CONTEXT);
+  }
+  SECTION("null uri") {
+    auto rc{tiledb_array_delete_fragments_list(
+        x.context, nullptr, fragment_uris, 1)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("empty uri") {
+    const char* empty_uri = "";
+    auto rc{tiledb_array_delete_fragments_list(
+        x.context, empty_uri, fragment_uris, 1)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("null fragment_uris") {
+    const char* null_fragment_uris[1] = {nullptr};
+    auto rc{tiledb_array_delete_fragments_list(
+        x.context, TEST_URI, null_fragment_uris, 1)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("empty uri") {
+    const char* empty_fragment_uris[1] = {""};
+    auto rc{tiledb_array_delete_fragments_list(
+        x.context, TEST_URI, empty_fragment_uris, 1)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("invalid num_fragments") {
+    auto rc{tiledb_array_delete_fragments_list(
+        x.context, TEST_URI, fragment_uris, 0)};
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
+  }
+}

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -25,7 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  *
- * @section DESCRIPTION
+ * Validates the arguments for the VFS C API.
  */
 
 #define CATCH_CONFIG_MAIN

--- a/tiledb/doxygen/source/c-api.rst
+++ b/tiledb/doxygen/source/c-api.rst
@@ -223,6 +223,8 @@ Array
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_delete_fragments
     :project: TileDB-C
+.. doxygenfunction:: tiledb_array_delete_fragments_list
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_array_open
     :project: TileDB-C
 .. doxygenfunction:: tiledb_array_open_at_with_key

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -560,32 +560,55 @@ void Array::delete_array(const URI& uri) {
   throw_if_not_ok(this->close());
 }
 
-Status Array::delete_fragments(
+void Array::delete_fragments(
     const URI& uri, uint64_t timestamp_start, uint64_t timestamp_end) {
   // Check that query type is MODIFY_EXCLUSIVE
   if (query_type_ != QueryType::MODIFY_EXCLUSIVE) {
-    return LOG_STATUS(Status_ArrayError(
+    throw StatusException(Status_ArrayError(
         "[Array::delete_fragments] Query type must be MODIFY_EXCLUSIVE"));
   }
 
   // Check that array is open
   if (!is_open() && !controller().is_open(uri)) {
-    return LOG_STATUS(
+    throw StatusException(
         Status_ArrayError("[Array::delete_fragments] Array is closed"));
   }
 
   // Check that array is not in the process of opening or closing
   if (is_opening_or_closing_) {
-    return LOG_STATUS(Status_ArrayError(
+    throw StatusException(Status_ArrayError(
         "[Array::delete_fragments] "
         "May not perform simultaneous open or close operations."));
   }
 
   // Delete fragments
-  RETURN_NOT_OK(storage_manager_->delete_fragments(
-      uri.c_str(), timestamp_start, timestamp_end));
+  storage_manager_->delete_fragments(
+      uri.c_str(), timestamp_start, timestamp_end);
+}
 
-  return Status::Ok();
+void Array::delete_fragments_list(
+    const URI& uri, const std::vector<std::string> fragment_uris) {
+  // Check that query type is MODIFY_EXCLUSIVE
+  if (query_type_ != QueryType::MODIFY_EXCLUSIVE) {
+    throw StatusException(Status_ArrayError(
+        "[Array::delete_fragments_list] Query type must be MODIFY_EXCLUSIVE"));
+  }
+
+  // Check that array is open
+  if (!is_open() && !controller().is_open(uri)) {
+    throw StatusException(
+        Status_ArrayError("[Array::delete_fragments_list] Array is closed"));
+  }
+
+  // Check that array is not in the process of opening or closing
+  if (is_opening_or_closing_) {
+    throw StatusException(Status_ArrayError(
+        "[Array::delete_fragments_list] "
+        "May not perform simultaneous open or close operations."));
+  }
+
+  // Delete fragments
+  storage_manager_->delete_fragments_list(uri.c_str(), fragment_uris);
 }
 
 bool Array::is_empty() const {

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -539,7 +539,7 @@ void Array::delete_array(const URI& uri) {
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr) {
-      throw Status_ArrayError(
+      throw ArrayStatusException(
           "[Array::delete_array] Remote array with no REST client.");
     }
     rest_client->delete_array_from_rest(uri);
@@ -557,8 +557,14 @@ void Array::delete_fragments(
   ensure_array_is_valid_for_delete(uri);
 
   // Delete fragments
-  storage_manager_->delete_fragments(
-      uri.c_str(), timestamp_start, timestamp_end);
+  // #TODO Add rest support for delete_fragments
+  if (remote_) {
+    throw ArrayStatusException(
+        "[Array::delete_fragments] Remote arrays currently unsupported.");
+  } else {
+    storage_manager_->delete_fragments(
+        uri.c_str(), timestamp_start, timestamp_end);
+  }
 }
 
 void Array::delete_fragments_list(
@@ -567,9 +573,15 @@ void Array::delete_fragments_list(
   ensure_array_is_valid_for_delete(uri);
 
   // Delete fragments
-  auto array_dir =
-      ArrayDirectory(resources_, uri, 0, std::numeric_limits<uint64_t>::max());
-  array_dir.delete_fragments_list(fragment_uris);
+  // #TODO Add rest support for delete_fragments_list
+  if (remote_) {
+    throw ArrayStatusException(
+        "[Array::delete_fragments_list] Remote arrays currently unsupported.");
+  } else {
+    auto array_dir = ArrayDirectory(
+        resources_, uri, 0, std::numeric_limits<uint64_t>::max());
+    array_dir.delete_fragments_list(fragment_uris);
+  }
 }
 
 bool Array::is_empty() const {

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -567,12 +567,8 @@ void Array::delete_fragments_list(
   ensure_array_is_valid_for_delete(uri);
 
   // Delete fragments
-  auto array_dir = ArrayDirectory(
-      &resources_.vfs(),
-      &resources_.compute_tp(),
-      uri,
-      0,
-      std::numeric_limits<uint64_t>::max());
+  auto array_dir =
+      ArrayDirectory(resources_, uri, 0, std::numeric_limits<uint64_t>::max());
   array_dir.delete_fragments_list(fragment_uris);
 }
 

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -224,12 +224,22 @@ class Array {
    * @param uri The uri of the Array whose fragments are to be deleted.
    * @param timestamp_start The start timestamp at which to delete fragments.
    * @param timestamp_end The end timestamp at which to delete fragments.
-   * @return Status
    *
    * @pre The Array must be open for exclusive writes
    */
-  Status delete_fragments(
+  void delete_fragments(
       const URI& uri, uint64_t timestamp_start, uint64_t timstamp_end);
+
+  /**
+   * Deletes the fragments with the given URIs from the Array with given URI.
+   *
+   * @param uri The uri of the Array whose fragments are to be deleted.
+   * @param fragment_uris The uris of the fragments to be deleted.
+   *
+   * @pre The Array must be open for exclusive writes
+   */
+  void delete_fragments_list(
+      const URI& uri, const std::vector<std::string> fragment_uris);
 
   /** Returns a constant pointer to the encryption key. */
   const EncryptionKey* encryption_key() const;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -239,7 +239,7 @@ class Array {
    * @pre The Array must be open for exclusive writes
    */
   void delete_fragments_list(
-      const URI& uri, const std::vector<std::string> fragment_uris);
+      const URI& uri, const std::vector<URI>& fragment_uris);
 
   /** Returns a constant pointer to the encryption key. */
   const EncryptionKey* encryption_key() const;
@@ -502,6 +502,11 @@ class Array {
   inline void set_query_type(QueryType query_type) {
     query_type_ = query_type;
   }
+
+  /**
+   * Checks the array is open, in MODIFY_EXCLUSIVE mode, before deleting data.
+   */
+  void ensure_array_is_valid_for_delete(const URI& uri);
 
   /**
    * Returns a map of the computed average cell size for var size

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -131,6 +131,62 @@ const uint64_t& ArrayDirectory::timestamp_end() const {
   return timestamp_end_;
 }
 
+void ArrayDirectory::write_commit_ignore_file(
+    const std::vector<URI>& commit_uris_to_ignore) {
+  auto name = compute_new_fragment_name(
+      commit_uris_to_ignore.front(),
+      commit_uris_to_ignore.back(),
+      constants::format_version);
+
+  // Write URIs, relative to the array URI.
+  std::stringstream ss;
+  auto base_uri_size = uri().to_string().size();
+  for (const auto& uri : commit_uris_to_ignore) {
+    ss << uri.to_string().substr(base_uri_size) << "\n";
+  }
+
+  // Write an ignore file to ensure consolidated WRT files still work
+  auto data = ss.str();
+  URI ignore_file_uri = get_commits_dir(constants::format_version)
+                            .join_path(name + constants::ignore_file_suffix);
+  throw_if_not_ok(vfs_->write(ignore_file_uri, data.c_str(), data.size()));
+  throw_if_not_ok(vfs_->close_file(ignore_file_uri));
+}
+
+void ArrayDirectory::delete_fragments_list(
+    const std::vector<URI>& fragment_uris) {
+  // Get fragment URIs from the array that match the input fragment_uris
+  auto filtered_uris = filtered_fragment_uris(true);
+  auto uris = filtered_uris.fragment_uris(fragment_uris);
+
+  // Retrieve commit uris to delete and ignore
+  std::vector<URI> commit_uris_to_delete;
+  std::vector<URI> commit_uris_to_ignore;
+  for (auto& timestamped_uri : uris) {
+    auto commit_uri = get_commit_uri(timestamped_uri.uri_);
+    commit_uris_to_delete.emplace_back(commit_uri);
+    if (consolidated_commit_uris_set().count(commit_uri.c_str()) != 0) {
+      commit_uris_to_ignore.emplace_back(commit_uri);
+    }
+  }
+
+  // Write ignore file
+  if (commit_uris_to_ignore.size() != 0) {
+    write_commit_ignore_file(commit_uris_to_ignore);
+  }
+
+  // Delete fragments and commits
+  throw_if_not_ok(parallel_for(tp_, 0, uris.size(), [&](size_t i) {
+    RETURN_NOT_OK(vfs_->remove_dir(uris[i].uri_));
+    bool is_file = false;
+    RETURN_NOT_OK(vfs_->is_file(commit_uris_to_delete[i], &is_file));
+    if (is_file) {
+      RETURN_NOT_OK(vfs_->remove_file(commit_uris_to_delete[i]));
+    }
+    return Status::Ok();
+  }));
+}
+
 Status ArrayDirectory::load() {
   assert(!loaded_);
 
@@ -380,27 +436,25 @@ URI ArrayDirectory::get_vacuum_uri(const URI& fragment_uri) const {
   return URI(temp_uri.to_string() + constants::vacuum_file_suffix);
 }
 
-tuple<Status, optional<std::string>> ArrayDirectory::compute_new_fragment_name(
+std::string ArrayDirectory::compute_new_fragment_name(
     const URI& first, const URI& last, format_version_t format_version) const {
   // Get uuid
   std::string uuid;
-  RETURN_NOT_OK_TUPLE(uuid::generate_uuid(&uuid, false), nullopt);
+  throw_if_not_ok(uuid::generate_uuid(&uuid, false));
 
   // For creating the new fragment URI
 
   // Get timestamp ranges
   std::pair<uint64_t, uint64_t> t_first, t_last;
-  RETURN_NOT_OK_TUPLE(
-      utils::parse::get_timestamp_range(first, &t_first), nullopt);
-  RETURN_NOT_OK_TUPLE(
-      utils::parse::get_timestamp_range(last, &t_last), nullopt);
+  throw_if_not_ok(utils::parse::get_timestamp_range(first, &t_first));
+  throw_if_not_ok(utils::parse::get_timestamp_range(last, &t_last));
 
   // Create new URI
   std::stringstream ss;
   ss << "/__" << t_first.first << "_" << t_last.second << "_" << uuid << "_"
      << format_version;
 
-  return {Status::Ok(), ss.str()};
+  return ss.str();
 }
 
 bool ArrayDirectory::loaded() const {

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -163,7 +163,7 @@ void ArrayDirectory::delete_fragments_list(
   std::vector<URI> commit_uris_to_delete;
   std::vector<URI> commit_uris_to_ignore;
   for (auto& timestamped_uri : uris) {
-    auto commit_uri = get_commit_uri(timestamped_uri.uri_);
+    auto commit_uri = get_commit_uri(timestamped_uri);
     commit_uris_to_delete.emplace_back(commit_uri);
     if (consolidated_commit_uris_set().count(commit_uri.c_str()) != 0) {
       commit_uris_to_ignore.emplace_back(commit_uri);
@@ -177,7 +177,7 @@ void ArrayDirectory::delete_fragments_list(
 
   // Delete fragments and commits
   throw_if_not_ok(parallel_for(tp_, 0, uris.size(), [&](size_t i) {
-    RETURN_NOT_OK(vfs_->remove_dir(uris[i].uri_));
+    RETURN_NOT_OK(vfs_->remove_dir(uris[i]));
     bool is_file = false;
     RETURN_NOT_OK(vfs_->is_file(commit_uris_to_delete[i], &is_file));
     if (is_file) {

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -143,34 +143,15 @@ class ArrayDirectory {
     std::vector<URI> fragment_uris(
         const std::vector<URI>& fragments_list) const {
       std::vector<URI> uris;
-
-      // Use a FragmentSet for parsing large fragment lists
-      if (fragments_list.size() > 100) {
-        FragmentSet fragment_set = fragment_uris_to_set();
-        for (auto fragment : fragments_list) {
-          auto iter = fragment_set.find(fragment);
-          if (iter == fragment_set.end()) {
-            throw std::runtime_error(
-                "[ArrayDirectory::fragment_uris] " + fragment.to_string() +
-                " is not a fragment of the ArrayDirectory.");
-          } else {
-            uris.emplace_back(*iter);
-          }
-        }
-      } else {
-        for (auto fragment : fragments_list) {
-          for (auto uri : fragment_uris_) {
-            if (fragment == uri.uri_) {
-              uris.emplace_back(uri.uri_);
-              break;
-            } else {
-              if (uri == fragment_uris_.back()) {
-                throw std::runtime_error(
-                    "[ArrayDirectory::fragment_uris] " + fragment.to_string() +
-                    " is not a fragment of the ArrayDirectory.");
-              }
-            }
-          }
+      FragmentSet fragment_set = fragment_uris_to_set();
+      for (auto fragment : fragments_list) {
+        auto iter = fragment_set.find(fragment);
+        if (iter == fragment_set.end()) {
+          throw std::runtime_error(
+              "[ArrayDirectory::fragment_uris] " + fragment.to_string() +
+              " is not a fragment of the ArrayDirectory.");
+        } else {
+          uris.emplace_back(*iter);
         }
       }
       return uris;
@@ -205,8 +186,7 @@ class ArrayDirectory {
     /* ********************************* */
 
     /**
-     * Convert the filtered fragment URIs into a FragmentSet for parsing large
-     * amounts of fragments.
+     * Convert the filtered fragment URIs into a FragmentSet to ease parsing.
      *
      * Note: this function is private and may only be called internally.
      */

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -131,17 +131,17 @@ class ArrayDirectory {
 
     /** Returns the filtered fragment URIs matching the given fragments_list. */
     std::vector<TimestampedURI> fragment_uris(
-        std::vector<std::string> fragments_list) const {
+        const std::vector<URI>& fragments_list) const {
       std::vector<TimestampedURI> uris;
       for (auto fragment : fragments_list) {
         for (auto uri : fragment_uris_) {
-          if (URI(fragment) == uri.uri_) {
+          if (fragment == uri.uri_) {
             uris.emplace_back(uri);
             break;
           } else {
             if (uri == fragment_uris_.back()) {
               throw std::runtime_error(
-                  "[ArrayDirectory::fragment_uris] " + fragment +
+                  "[ArrayDirectory::fragment_uris] " + fragment.to_string() +
                   " is not a fragment of the ArrayDirectory.");
             }
           }
@@ -359,7 +359,7 @@ class ArrayDirectory {
    * The new fragment name is computed
    * as `__<first_URI_timestamp>_<last_URI_timestamp>_<uuid>`.
    */
-  tuple<Status, optional<std::string>> compute_new_fragment_name(
+  std::string compute_new_fragment_name(
       const URI& first, const URI& last, format_version_t format_version) const;
 
   /** Returns `true` if `load` has been run. */
@@ -374,6 +374,12 @@ class ArrayDirectory {
 
   /** Returns the end timestamp of the files to be considered */
   const uint64_t& timestamp_end() const;
+
+  /** Writes a commit ignore file. */
+  void write_commit_ignore_file(const std::vector<URI>& commit_uris_to_ignore);
+
+  /** Deletes the array fragments at the given fragment URIs. */
+  void delete_fragments_list(const std::vector<URI>& fragment_uris);
 
   /* ACCESSORS */
 

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -129,6 +129,27 @@ class ArrayDirectory {
       return fragment_uris_;
     };
 
+    /** Returns the filtered fragment URIs matching the given fragments_list. */
+    std::vector<TimestampedURI> fragment_uris(
+        std::vector<std::string> fragments_list) const {
+      std::vector<TimestampedURI> uris;
+      for (auto fragment : fragments_list) {
+        for (auto uri : fragment_uris_) {
+          if (URI(fragment) == uri.uri_) {
+            uris.emplace_back(uri);
+            break;
+          } else {
+            if (uri == fragment_uris_.back()) {
+              throw std::runtime_error(
+                  "[ArrayDirectory::fragment_uris] " + fragment +
+                  " is not a fragment of the ArrayDirectory.");
+            }
+          }
+        }
+      }
+      return uris;
+    };
+
    private:
     /* ********************************* */
     /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2960,14 +2960,11 @@ int32_t tiledb_array_delete_fragments(
   return TILEDB_OK;
 }
 
-int32_t tiledb_array_delete_fragments_list(
+capi_return_t tiledb_array_delete_fragments_list(
     tiledb_ctx_t* ctx,
     const char* uri,
     const char** fragment_uris,
-    const uint64_t num_fragments) {
-  if (sanity_check(ctx) == TILEDB_ERR)
-    return TILEDB_ERR;
-
+    const size_t num_fragments) {
   // Allocate an array object
   tiledb_array_t* array = new (std::nothrow) tiledb_array_t;
   try {
@@ -2991,10 +2988,10 @@ int32_t tiledb_array_delete_fragments_list(
       0));
 
   // Convert the list of fragment uris to a vector
-  std::vector<std::string> uris;
+  std::vector<tiledb::sm::URI> uris;
   uris.reserve(num_fragments);
-  for (uint64_t i = 0; i < num_fragments; i++) {
-    uris.emplace_back(fragment_uris[i]);
+  for (size_t i = 0; i < num_fragments; i++) {
+    uris.emplace_back(tiledb::sm::URI(fragment_uris[i]));
   }
 
   try {
@@ -7074,11 +7071,11 @@ int32_t tiledb_array_delete_fragments(
       ctx, array, uri, timestamp_start, timestamp_end);
 }
 
-int32_t tiledb_array_delete_fragments_list(
+capi_return_t tiledb_array_delete_fragments_list(
     tiledb_ctx_t* ctx,
     const char* uri,
     const char** fragment_uris,
-    const uint64_t num_fragments) noexcept {
+    const size_t num_fragments) noexcept {
   return api_entry<tiledb::api::tiledb_array_delete_fragments_list>(
       ctx, uri, fragment_uris, num_fragments);
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2966,28 +2966,19 @@ capi_return_t tiledb_array_delete_fragments_list(
     const char* fragment_uris[],
     const size_t num_fragments) {
   if (tiledb::sm::URI(uri).is_invalid()) {
-    auto st =
-        Status_Error("Failed to delete_fragments_list; Invalid input uri");
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
+    throw api::CAPIStatusException(
+        "Failed to delete_fragments_list; Invalid input uri");
   }
 
   if (num_fragments < 1) {
-    auto st = Status_Error(
+    throw api::CAPIStatusException(
         "Failed to delete_fragments_list; Invalid input number of fragments");
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
   }
 
   for (size_t i = 0; i < num_fragments; i++) {
     if (tiledb::sm::URI(fragment_uris[i]).is_invalid()) {
-      auto st = Status_Error(
+      throw api::CAPIStatusException(
           "Failed to delete_fragments_list; Invalid input fragment uri");
-      LOG_STATUS_NO_RETURN_VALUE(st);
-      save_error(ctx, st);
-      return TILEDB_ERR;
     }
   }
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -2963,8 +2963,34 @@ int32_t tiledb_array_delete_fragments(
 capi_return_t tiledb_array_delete_fragments_list(
     tiledb_ctx_t* ctx,
     const char* uri,
-    const char** fragment_uris,
+    const char* fragment_uris[],
     const size_t num_fragments) {
+  if (tiledb::sm::URI(uri).is_invalid()) {
+    auto st =
+        Status_Error("Failed to delete_fragments_list; Invalid input uri");
+    LOG_STATUS_NO_RETURN_VALUE(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  if (num_fragments < 1) {
+    auto st = Status_Error(
+        "Failed to delete_fragments_list; Invalid input number of fragments");
+    LOG_STATUS_NO_RETURN_VALUE(st);
+    save_error(ctx, st);
+    return TILEDB_ERR;
+  }
+
+  for (size_t i = 0; i < num_fragments; i++) {
+    if (tiledb::sm::URI(fragment_uris[i]).is_invalid()) {
+      auto st = Status_Error(
+          "Failed to delete_fragments_list; Invalid input fragment uri");
+      LOG_STATUS_NO_RETURN_VALUE(st);
+      save_error(ctx, st);
+      return TILEDB_ERR;
+    }
+  }
+
   // Allocate an array object
   tiledb_array_t* array = new (std::nothrow) tiledb_array_t;
   try {
@@ -7074,7 +7100,7 @@ int32_t tiledb_array_delete_fragments(
 capi_return_t tiledb_array_delete_fragments_list(
     tiledb_ctx_t* ctx,
     const char* uri,
-    const char** fragment_uris,
+    const char* fragment_uris[],
     const size_t num_fragments) noexcept {
   return api_entry<tiledb::api::tiledb_array_delete_fragments_list>(
       ctx, uri, fragment_uris, num_fragments);

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3917,6 +3917,31 @@ TILEDB_EXPORT int32_t tiledb_array_delete_fragments(
     uint64_t timestamp_end) TILEDB_NOEXCEPT;
 
 /**
+ * Deletes array fragments with the input uris.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * auto fragment_uris{
+ *   "hdfs:///temp/my_array/__fragments/1",
+ *   "hdfs:///temp/my_array/__fragments/2"};
+ * tiledb_array_delete_fragments_list(
+ *   ctx, "hdfs:///temp/my_array", fragment_uris, 2);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param uri The URI of the fragments' parent Array.
+ * @param fragment_uris The URIs of the fragments to be deleted.
+ * @param num_fragments The number of fragments to be deleted.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_array_delete_fragments_list(
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
+    const char** fragment_uris,
+    const uint64_t num_fragments) TILEDB_NOEXCEPT;
+
+/**
  * Opens a TileDB array. The array is opened using a query type as input.
  * This is to indicate that queries created for this `tiledb_array_t`
  * object will inherit the query type. In other words, `tiledb_array_t`

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -3922,7 +3922,7 @@ TILEDB_EXPORT int32_t tiledb_array_delete_fragments(
  * **Example:**
  *
  * @code{.c}
- * auto fragment_uris{
+ * const char* fragment_uris[2] = {
  *   "hdfs:///temp/my_array/__fragments/1",
  *   "hdfs:///temp/my_array/__fragments/2"};
  * tiledb_array_delete_fragments_list(
@@ -3938,7 +3938,7 @@ TILEDB_EXPORT int32_t tiledb_array_delete_fragments(
 TILEDB_EXPORT int32_t tiledb_array_delete_fragments_list(
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    const char** fragment_uris,
+    const char* fragment_uris[],
     const size_t num_fragments) TILEDB_NOEXCEPT;
 
 /**

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -3939,7 +3939,7 @@ TILEDB_EXPORT int32_t tiledb_array_delete_fragments_list(
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const char** fragment_uris,
-    const uint64_t num_fragments) TILEDB_NOEXCEPT;
+    const size_t num_fragments) TILEDB_NOEXCEPT;
 
 /**
  * Opens a TileDB array. The array is opened using a query type as input.

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -311,8 +311,7 @@ void FragmentConsolidator::vacuum(const char* array_name) {
       filtered_fragment_uris.commit_uris_to_ignore();
 
   if (commit_uris_to_ignore.size() > 0) {
-    throw_if_not_ok(storage_manager_->write_commit_ignore_file(
-        array_dir, commit_uris_to_ignore));
+    array_dir.write_commit_ignore_file(commit_uris_to_ignore);
   }
 
   // Delete the commit and vacuum files
@@ -645,10 +644,9 @@ Status FragmentConsolidator::create_queries(
   auto last = (*query_r)->last_fragment_uri();
 
   auto write_version = array_for_reads->array_schema_latest().write_version();
-  auto&& [st, fragment_name] =
+  auto fragment_name =
       array_for_reads->array_directory().compute_new_fragment_name(
           first, last, write_version);
-  RETURN_NOT_OK(st);
 
   // Create write query
   *query_w = tdb_new(Query, storage_manager_, array_for_writes, fragment_name);
@@ -672,7 +670,7 @@ Status FragmentConsolidator::create_queries(
   // Set the URI for the new fragment.
   auto frag_uri =
       array_for_reads->array_directory().get_fragments_dir(write_version);
-  *new_fragment_uri = frag_uri.join_path(fragment_name.value());
+  *new_fragment_uri = frag_uri.join_path(fragment_name);
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -92,14 +92,11 @@ Status FragmentMetaConsolidator::consolidate(
   auto first = meta.front()->fragment_uri();
   auto last = meta.back()->fragment_uri();
   auto write_version = array.array_schema_latest().write_version();
-  auto&& [st, name] =
-      array_dir.compute_new_fragment_name(first, last, write_version);
-  RETURN_NOT_OK(st);
+  auto name = array_dir.compute_new_fragment_name(first, last, write_version);
 
   auto frag_md_uri = array_dir.get_fragment_metadata_dir(write_version);
   RETURN_NOT_OK(storage_manager_->vfs()->create_dir(frag_md_uri));
-  uri =
-      URI(frag_md_uri.to_string() + name.value() + constants::meta_file_suffix);
+  uri = URI(frag_md_uri.to_string() + name + constants::meta_file_suffix);
 
   // Get the consolidated fragment metadata version
   auto meta_name = uri.remove_trailing_slash().last_path_part();

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -7,7 +7,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -390,7 +390,7 @@ class Array {
   static void delete_fragments_list(
       const Context& ctx,
       const std::string& uri,
-      const char** fragment_uris,
+      const char* fragment_uris[],
       const size_t num_fragments) {
     ctx.handle_error(tiledb_array_delete_fragments_list(
         ctx.ptr().get(), uri.c_str(), fragment_uris, num_fragments));

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -391,7 +391,7 @@ class Array {
       const Context& ctx,
       const std::string& uri,
       const char** fragment_uris,
-      const uint64_t num_fragments) {
+      const size_t num_fragments) {
     ctx.handle_error(tiledb_array_delete_fragments_list(
         ctx.ptr().get(), uri.c_str(), fragment_uris, num_fragments));
   }

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -385,6 +385,18 @@ class Array {
   }
 
   /**
+   * Deletes the fragments with the input uris on an array with the input uri.
+   */
+  static void delete_fragments_list(
+      const Context& ctx,
+      const std::string& uri,
+      const char** fragment_uris,
+      const uint64_t num_fragments) {
+    ctx.handle_error(tiledb_array_delete_fragments_list(
+        ctx.ptr().get(), uri.c_str(), fragment_uris, num_fragments));
+  }
+
+  /**
    * @brief Opens the array. The array is opened using a query type as input.
    *
    * This is to indicate that queries created for this `Array`

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -375,10 +375,18 @@ class StorageManagerCanonical {
    * @param array_name The name of the array whose fragments are to be deleted.
    * @param timestamp_start The start timestamp at which to delete.
    * @param timestamp_end The end timestamp at which to delete.
-   * @return Status
    */
-  Status delete_fragments(
+  void delete_fragments(
       const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
+
+  /**
+   * Cleans up the array fragments.
+   *
+   * @param array_name The name of the array whose fragments are to be deleted.
+   * @param fragment_uris The list of fragment uris to be deleted.
+   */
+  void delete_fragments_list(
+      const char* array_name, const std::vector<std::string> fragment_uris);
 
   /**
    * Cleans up the group data.

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -342,15 +342,6 @@ class StorageManagerCanonical {
       const Config& config);
 
   /**
-   * Writes a commit ignore file.
-   *
-   * @param array_dir The ArrayDirectory where the data is stored.
-   * @param commit_uris_to_ignore The commit files that are to be ignored.
-   */
-  Status write_commit_ignore_file(
-      ArrayDirectory array_dir, const std::vector<URI>& commit_uris_to_ignore);
-
-  /**
    * Writes a consolidated commits file.
    *
    * @param write_version Write version.
@@ -378,15 +369,6 @@ class StorageManagerCanonical {
    */
   void delete_fragments(
       const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
-
-  /**
-   * Cleans up the array fragments.
-   *
-   * @param array_name The name of the array whose fragments are to be deleted.
-   * @param fragment_uris The list of fragment uris to be deleted.
-   */
-  void delete_fragments_list(
-      const char* array_name, const std::vector<std::string> fragment_uris);
 
   /**
    * Cleans up the group data.


### PR DESCRIPTION
Implement `delete_fragments_list` API. Similar to `delete_fragments`, this API deletes fragments with the given URIs. Note that this API _may_ be called _after_ `delete_fragments`, which deletes on timestamps.

---
TYPE: FEATURE
DESC: Implement delete_fragments_list API
