### PR TITLE
Deprecate tiledb_query_submit_async

### DIFF
--- a/doc/policy/api_changes.md
+++ b/doc/policy/api_changes.md
@@ -70,6 +70,10 @@ Function removal shall be announced one release cycle before removal, following 
 - `tiledb_array_consolidate_metadata`
 - `tiledb_array_consolidate_metadata_with_key`
 
+### 2.13.0..2.14.0
+
+- `tiledb_query_submit_async`
+
 ## Deprecation History Generation
 
 <details>

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2500,7 +2500,7 @@ tiledb_query_submit(tiledb_ctx_t* ctx, tiledb_query_t* query) TILEDB_NOEXCEPT;
  *    thread pool, long-running callbacks should be dispatched to another
  *    thread.
  */
-TILEDB_EXPORT int32_t tiledb_query_submit_async(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_query_submit_async(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     void (*callback)(void*),


### PR DESCRIPTION
---
TYPE: DEPRECATION
DESC: Deprecate tiledb_query_submit_async

TYPE: C_API
DESC: Deprecate tiledb_query_submit_async