### PR TITLE
Fix initialization of include_coords for multipart, sparse, unordered remote queries (#3795)

### DIFF
--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -86,9 +86,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           buffers,
           subarray,
           layout,
-          condition)
-    , tile_offsets_min_frag_idx_(std::numeric_limits<unsigned>::max())
-    , tile_offsets_max_frag_idx_(0) {
+          condition) {
   include_coords_ = false;
   SparseIndexReaderBase::init(skip_checks_serialization);
 

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -86,8 +86,10 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
           buffers,
           subarray,
           layout,
-          condition) {
-  include_coords_ = subarray_.is_set() || bitsort_attribute_.has_value();
+          condition)
+    , tile_offsets_min_frag_idx_(std::numeric_limits<unsigned>::max())
+    , tile_offsets_max_frag_idx_(0) {
+  include_coords_ = false;
   SparseIndexReaderBase::init(skip_checks_serialization);
 
   // Initialize memory budget variables.
@@ -158,6 +160,9 @@ Status SparseUnorderedWithDupsReader<BitmapType>::initialize_memory_budget() {
 
 template <class BitmapType>
 Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
+  // Subarray is not known to be explicitly set until buffers are deserialized
+  include_coords_ = subarray_.is_set() || bitsort_attribute_.has_value();
+
   auto timer_se = stats_->start_timer("dowork");
 
   // Make sure user didn't request delete timestamps.
@@ -215,7 +220,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     for (auto& result_tile : result_tiles_) {
       if (!result_tile.coords_loaded()) {
         result_tile.set_coords_loaded();
-        ;
         result_tiles_created.emplace_back(&result_tile);
       } else {
         result_tiles_loaded.emplace_back(&result_tile);


### PR DESCRIPTION
Fix SC-24602, bug related to the state of the Subarray object during query deserialization. Since the first remote query submit is always initialized to REST with a call to `Query::create_strategy`, the value of `include_coords_` is corrected after initial query deserialization. On a second submission, we don't need to call `Query::create_strategy` since the query is already in progress, and `include_coords_` doesn't reflect the final state of the fully initialized Subarray.

---
TYPE: BUG
DESC: Fix initialization of include_coords for multipart, sparse, unordered remote queries