### PR TITLE
Move more resources into ContextResources

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -95,7 +95,7 @@ Array::Array(
     , timestamp_end_opened_at_(UINT64_MAX)
     , storage_manager_(storage_manager)
     , resources_(storage_manager_->resources())
-    , config_(storage_manager_->config())
+    , config_(resources_.config())
     , remote_(array_uri.is_tiledb())
     , metadata_()
     , metadata_loaded_(false)
@@ -181,7 +181,7 @@ Status Array::open_without_fragments(
     }
 
     if (remote_) {
-      auto rest_client = storage_manager_->rest_client();
+      auto rest_client = resources_.rest_client();
       if (rest_client == nullptr) {
         throw Status_ArrayError(
             "Cannot open array; remote array with no REST client.");
@@ -356,7 +356,7 @@ Status Array::open(
     }
 
     if (remote_) {
-      auto rest_client = storage_manager_->rest_client();
+      auto rest_client = resources_.rest_client();
       if (rest_client == nullptr) {
         throw Status_ArrayError(
             "Cannot open array; remote array with no REST client.");
@@ -490,7 +490,7 @@ Status Array::close() {
         // Set metadata loaded to be true so when serialization fetchs the
         // metadata it won't trigger a deadlock
         metadata_loaded_ = true;
-        auto rest_client = storage_manager_->rest_client();
+        auto rest_client = resources_.rest_client();
         if (rest_client == nullptr)
           throw Status_ArrayError(
               "Error closing array; remote array with no REST client.");
@@ -537,7 +537,7 @@ void Array::delete_array(const URI& uri) {
 
   // Delete array data
   if (remote_) {
-    auto rest_client = storage_manager_->rest_client();
+    auto rest_client = resources_.rest_client();
     if (rest_client == nullptr) {
       throw ArrayStatusException(
           "[Array::delete_array] Remote array with no REST client.");
@@ -1295,7 +1295,7 @@ Status Array::compute_max_buffer_sizes(
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*
         buffer_sizes) const {
   if (remote_) {
-    auto rest_client = storage_manager_->rest_client();
+    auto rest_client = resources_.rest_client();
     if (rest_client == nullptr) {
       return LOG_STATUS(Status_ArrayError(
           "Cannot get max buffer sizes; remote array with no REST client."));
@@ -1377,7 +1377,7 @@ Status Array::compute_max_buffer_sizes(
 
 Status Array::load_metadata() {
   if (remote_) {
-    auto rest_client = storage_manager_->rest_client();
+    auto rest_client = resources_.rest_client();
     if (rest_client == nullptr) {
       return LOG_STATUS(Status_ArrayError(
           "Cannot load metadata; remote array with no REST client."));
@@ -1395,7 +1395,7 @@ Status Array::load_metadata() {
 
 Status Array::load_remote_non_empty_domain() {
   if (remote_) {
-    auto rest_client = storage_manager_->rest_client();
+    auto rest_client = resources_.rest_client();
     if (rest_client == nullptr) {
       return LOG_STATUS(Status_ArrayError(
           "Cannot load metadata; remote array with no REST client."));

--- a/tiledb/sm/array/test/unit_array_directory.cc
+++ b/tiledb/sm/array/test/unit_array_directory.cc
@@ -63,7 +63,7 @@ TEST_CASE(
     "[array-directory][timestamp-overlap]") {
   WhiteboxArrayDirectory wb_array_dir;
   Config cfg;
-  ContextResources resources{cfg, 1, 1, ""};
+  ContextResources resources{cfg, nullptr, 1, 1, ""};
   ArrayDirectory array_dir(resources, URI());
   wb_array_dir.set_open_timestamps(array_dir, 2, 4);
 

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -169,7 +169,7 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ContextResources resources(config, 1, 1, "");
+  ContextResources resources(config, nullptr, 1, 1, "");
   StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Register array
@@ -194,7 +194,7 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ContextResources resources(config, 1, 1, "");
+  ContextResources resources(config, nullptr, 1, 1, "");
   StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   std::vector<tdb_unique_ptr<Array>> arrays;
@@ -236,7 +236,7 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ContextResources resources(config, 1, 1, "");
+  ContextResources resources(config, nullptr, 1, 1, "");
   StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Create an array

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -49,7 +49,9 @@ namespace tiledb {
 namespace sm {
 
 class ArraySchema;
+class ArraySchemaEvolution;
 class Config;
+class FragmentInfo;
 class Query;
 
 enum class SerializationType : uint8_t;

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -52,6 +52,7 @@ Context::Context(const Config& config)
           HERE(), logger_prefix_ + std::to_string(++logger_id_)))
     , resources_(
           config,
+          logger_,
           get_compute_thread_count(config),
           get_io_thread_count(config),
           // TODO: Remove `.StorageManager` from statistic names

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -34,6 +34,7 @@
 #define TILEDB_CONTEXT_RESOURCES_H
 
 #include "tiledb/common/exception/exception.h"
+#include "tiledb/common/logger_public.h"
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/vfs.h"
@@ -42,6 +43,8 @@
 using namespace tiledb::common;
 
 namespace tiledb::sm {
+
+class RestClient;
 
 /**
  * This class manages the context for the C API, wrapping a
@@ -61,6 +64,7 @@ class ContextResources {
   /** Constructor. */
   explicit ContextResources(
       const Config& config,
+      shared_ptr<Logger> logger,
       size_t compute_thread_count,
       size_t io_thread_count,
       std::string stats_name);
@@ -71,6 +75,16 @@ class ContextResources {
   /* ********************************* */
   /*                API                */
   /* ********************************* */
+
+  /** Returns the config object. */
+  [[nodiscard]] inline Config& config() const {
+    return config_;
+  }
+
+  /** Returns the internal logger object. */
+  [[nodiscard]] inline shared_ptr<Logger> logger() const {
+    return logger_;
+  }
 
   /** Returns the thread pool for compute-bound tasks. */
   [[nodiscard]] inline ThreadPool& compute_tp() const {
@@ -91,10 +105,20 @@ class ContextResources {
     return vfs_;
   }
 
+  [[nodiscard]] inline shared_ptr<RestClient> rest_client() const {
+    return rest_client_;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /** The configuration for this ContextResources */
+  mutable Config config_;
+
+  /** The class logger. */
+  shared_ptr<Logger> logger_;
 
   /** The thread pool for compute-bound tasks. */
   mutable ThreadPool compute_tp_;
@@ -110,6 +134,9 @@ class ContextResources {
    * filesystem backend. Note that this is stateful.
    */
   mutable VFS vfs_;
+
+  /** The rest client (may be null if none was configured). */
+  shared_ptr<RestClient> rest_client_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -624,7 +624,9 @@ class StorageManagerCanonical {
    * If the storage manager was configured with a REST server, return the
    * client instance. Else, return nullptr.
    */
-  RestClient* rest_client() const;
+  inline RestClient* rest_client() const {
+    return resources_.rest_client().get();
+  }
 
   /**
    * Checks if the input URI represents an array.
@@ -995,9 +997,6 @@ class StorageManagerCanonical {
   /** Tags for the context object. */
   std::unordered_map<std::string, std::string> tags_;
 
-  /** The rest client (may be null if none was configured). */
-  tdb_unique_ptr<RestClient> rest_client_;
-
   /* ********************************* */
   /*         PRIVATE METHODS           */
   /* ********************************* */
@@ -1064,9 +1063,6 @@ class StorageManagerCanonical {
 
   /** Block until there are zero in-progress queries. */
   void wait_for_zero_in_progress();
-
-  /** Initializes a REST client, if one was configured. */
-  Status init_rest_client();
 
   /** Sets default tag values on this StorageManagerCanonical. */
   Status set_default_tags();

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -117,8 +117,9 @@ void InfoCommand::run() {
 
 void InfoCommand::print_tile_sizes() const {
   Config config;
-  ContextResources resources(config, 1, 1, "");
-  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
+  auto logger = make_shared<Logger>(HERE(), "");
+  ContextResources resources(config, logger, 1, 1, "");
+  StorageManager sm(resources, logger, config);
 
   // Open the array
   URI uri(array_uri_);
@@ -187,8 +188,9 @@ void InfoCommand::print_tile_sizes() const {
 
 void InfoCommand::print_schema_info() const {
   Config config;
-  ContextResources resources(config, 1, 1, "");
-  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
+  auto logger = make_shared<Logger>(HERE(), "");
+  ContextResources resources(config, logger, 1, 1, "");
+  StorageManager sm(resources, logger, config);
 
   // Open the array
   URI uri(array_uri_);
@@ -204,8 +206,9 @@ void InfoCommand::print_schema_info() const {
 
 void InfoCommand::write_svg_mbrs() const {
   Config config;
-  ContextResources resources(config, 1, 1, "");
-  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
+  auto logger = make_shared<Logger>(HERE(), "");
+  ContextResources resources(config, logger, 1, 1, "");
+  StorageManager sm(resources, logger, config);
 
   // Open the array
   URI uri(array_uri_);
@@ -279,8 +282,9 @@ void InfoCommand::write_svg_mbrs() const {
 
 void InfoCommand::write_text_mbrs() const {
   Config config;
-  ContextResources resources(config, 1, 1, "");
-  StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
+  auto logger = make_shared<Logger>(HERE(), "");
+  ContextResources resources(config, logger, 1, 1, "");
+  StorageManager sm(resources, logger, config);
 
   // Open the array
   URI uri(array_uri_);


### PR DESCRIPTION
Move more resources into ContextResources

This moves the logger and rest_client instances into ContextResources and also adds a reference to the Config.

---
TYPE: IMPROVEMENT
DESC: Move more resources into ContextResources