### PR TITLE
Enable RLE and Dictionary encoding on UTF-8 attrs

### DIFF
--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -583,18 +583,18 @@ TEST_CASE(
         a1_data,
         a1_offsets,
         TILEDB_GLOBAL_ORDER);
-    SECTION("Row major read") {
-      read_and_check_sparse_array_string_attr(
-          ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
-    }
+    //SECTION("Row major read") {
+    //  read_and_check_sparse_array_string_attr(
+    //      ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
+    //}
     SECTION("Global order read") {
       read_and_check_sparse_array_string_attr(
           ctx, array_name, a1_data, a1_offsets, TILEDB_GLOBAL_ORDER);
     }
-    SECTION("Unordered read") {
-      read_and_check_sparse_array_string_attr(
-          ctx, array_name, a1_data, a1_offsets, TILEDB_UNORDERED);
-    }
+    //SECTION("Unordered read") {
+    //  read_and_check_sparse_array_string_attr(
+    //      ctx, array_name, a1_data, a1_offsets, TILEDB_UNORDERED);
+    //}
   }
 
   // Clean up

--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -583,18 +583,18 @@ TEST_CASE(
         a1_data,
         a1_offsets,
         TILEDB_GLOBAL_ORDER);
-    //SECTION("Row major read") {
-    //  read_and_check_sparse_array_string_attr(
-    //      ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
-    //}
+    SECTION("Row major read") {
+      read_and_check_sparse_array_string_attr(
+          ctx, array_name, a1_data, a1_offsets, TILEDB_ROW_MAJOR);
+    }
     SECTION("Global order read") {
       read_and_check_sparse_array_string_attr(
           ctx, array_name, a1_data, a1_offsets, TILEDB_GLOBAL_ORDER);
     }
-    //SECTION("Unordered read") {
-    //  read_and_check_sparse_array_string_attr(
-    //      ctx, array_name, a1_data, a1_offsets, TILEDB_UNORDERED);
-    //}
+    SECTION("Unordered read") {
+      read_and_check_sparse_array_string_attr(
+          ctx, array_name, a1_data, a1_offsets, TILEDB_UNORDERED);
+    }
   }
 
   // Clean up

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -345,7 +345,8 @@ Status Attribute::set_filter_pipeline(const FilterPipeline& pipeline) {
                                 "attribute with a real datatype"));
   }
 
-  if (type_ == Datatype::STRING_ASCII && var_size() && pipeline.size() > 1) {
+  if ((type_ == Datatype::STRING_ASCII || type_ == Datatype::STRING_UTF8) &&
+      var_size() && pipeline.size() > 1) {
     if (pipeline.has_filter(FilterType::FILTER_RLE) &&
         pipeline.get_filter(0)->type() != FilterType::FILTER_RLE) {
       return LOG_STATUS(Status_ArraySchemaError(

--- a/tiledb/sm/compressors/test/unit_dict_compressor.cc
+++ b/tiledb/sm/compressors/test/unit_dict_compressor.cc
@@ -369,3 +369,64 @@ TEST_CASE(
     CHECK(expected_offsets[i] == decompressed_offsets[i]);
   }
 }
+
+TEST_CASE(
+    "Compression-Dictionary: Test compression of UTF-8 strings",
+    "[compression][dict][utf-8]") {
+  std::vector<std::string> uncompressed_v = {
+      "föö", "föö", "fööbär", "bär", "bär", "bär", "bär"};
+  std::vector<std::string_view> uncompressed;
+  // the reference here is crucial, otherwise a temp string is created and
+  // therefore string_view will outlive it
+  for (const std::string& str : uncompressed_v) {
+    uncompressed.emplace_back(str);
+  }
+
+  // The dictionary is created sequentially in order of appearance
+  std::vector<std::string_view> dict_expected{
+      uncompressed_v[0], uncompressed_v[2], uncompressed_v[3]};
+
+  // Allocate the compressed array - we know the size will be 7
+  std::vector<std::byte> compressed(7);
+  auto dict =
+      tiledb::sm::DictEncoding::compress<uint8_t>(uncompressed, compressed);
+  CHECK(dict == dict_expected);
+
+  std::vector<uint8_t> exp_compressed{0, 0, 1, 2, 2, 2, 2};
+  CHECK(
+      memcmp(
+          exp_compressed.data(),
+          reinterpret_cast<uint8_t*>(compressed.data()),
+          exp_compressed.size()) == 0);
+
+  // Decompress the previously compressed array
+  const char* exp_decompressed =
+      "föö"
+      "föö"
+      "fööbär"
+      "bär"
+      "bär"
+      "bär"
+      "bär";
+
+  std::vector<std::string> dict_orig = {"föö", "fööbär", "bär"};
+
+  const auto exp_decomp_size = strlen(exp_decompressed);
+  std::vector<std::byte> decompressed(exp_decomp_size);
+  const auto num_strings = 7;
+  std::vector<uint64_t> decompressed_offsets(num_strings);
+  tiledb::sm::DictEncoding::decompress<uint8_t>(
+      compressed, dict_orig, decompressed, decompressed_offsets);
+
+  // In decompressed array there are only chars, so compare using memcpy
+  CHECK(
+      memcmp(
+          exp_decompressed,
+          reinterpret_cast<const char*>(decompressed.data()),
+          decompressed.size()) == 0);
+
+  std::vector<uint64_t> expected_offsets{0, 5, 10, 19, 23, 27, 31};
+  for (uint32_t i = 0; i < expected_offsets.size(); i++) {
+    CHECK(expected_offsets[i] == decompressed_offsets[i]);
+  }
+}

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -227,7 +227,9 @@ Status CompressionFilter::run_forward(
     return LOG_STATUS(
         Status_FilterError("Input is too large to be compressed."));
 
-  if (tile.type() == Datatype::STRING_ASCII && offsets_tile) {
+  if ((tile.type() == Datatype::STRING_ASCII ||
+       tile.type() == Datatype::STRING_UTF8) &&
+      offsets_tile) {
     if (compressor_ == Compressor::RLE ||
         compressor_ == Compressor::DICTIONARY_ENCODING)
       return compress_var_string_coords(
@@ -299,7 +301,9 @@ Status CompressionFilter::run_reverse(
   Buffer* metadata_buffer = output_metadata->buffer_ptr(0);
   assert(metadata_buffer != nullptr);
 
-  if (tile.type() == Datatype::STRING_ASCII && version_ >= 12 && offsets_tile) {
+  if ((tile.type() == Datatype::STRING_ASCII ||
+       tile.type() == Datatype::STRING_UTF8) &&
+      version_ >= 12 && offsets_tile) {
     if (compressor_ == Compressor::RLE ||
         compressor_ == Compressor::DICTIONARY_ENCODING)
       return decompress_var_string_coords(

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -726,11 +726,13 @@ Status FilterPipeline::append_encryption_filter(
 
 bool FilterPipeline::skip_offsets_filtering(
     const Datatype type, const uint32_t version) const {
-  if (version >= 12 && type == Datatype::STRING_ASCII &&
+  if (version >= 12 &&
+      (type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8) &&
       has_filter(FilterType::FILTER_RLE)) {
     return true;
   } else if (
-      version >= 13 && type == Datatype::STRING_ASCII &&
+      version >= 13 &&
+      (type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8) &&
       has_filter(FilterType::FILTER_DICTIONARY)) {
     return true;
   }
@@ -740,7 +742,8 @@ bool FilterPipeline::skip_offsets_filtering(
 
 bool FilterPipeline::use_tile_chunking(
     const bool is_var, const uint32_t version, const Datatype type) const {
-  if (is_var && type == Datatype::STRING_ASCII) {
+  if (is_var &&
+      (type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8)) {
     if (version >= 12 && has_filter(FilterType::FILTER_RLE)) {
       return false;
     } else if (version >= 13 && has_filter(FilterType::FILTER_DICTIONARY)) {


### PR DESCRIPTION
This enables the RLE and dictionary encoding filters for UTF-8 attributes.


---
TYPE: IMPROVEMENT
DESC: Enable RLE and Dictionary encoding on UTF-8 attributes.
