### PR TITLE
Add tiledb_query_condition_create_expression API

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-capi-partial-attribute-write.cc
   src/unit-capi-query.cc
   src/unit-capi-query_2.cc
+  src/unit-capi-query-condition-create.cc
   src/unit-capi-smoke-test.cc
   src/unit-capi-sparse_array.cc
   src/unit-capi-sparse_heter.cc

--- a/test/src/unit-capi-query-condition-create.cc
+++ b/test/src/unit-capi-query-condition-create.cc
@@ -1,0 +1,171 @@
+/**
+ * @file unit-capi-query-condiiton-create.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the C API for query condition creation functions
+ */
+
+#include <test/support/tdb_catch.h>
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_experimental.h"
+
+TEST_CASE(
+    "C API: Test QueryCondition value creation",
+    "[capi][query-condition][create]") {
+  tiledb_ctx_t* ctx;
+  auto rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  const char* name = "attr";
+  int32_t value = 42;
+
+  tiledb_query_condition_t* cond;
+
+  SECTION("ctx is nullptr") {
+    rc = tiledb_query_condition_create_value(
+        nullptr, name, &value, sizeof(value), TILEDB_EQ, &cond);
+    REQUIRE(rc == TILEDB_INVALID_CONTEXT);
+  }
+
+  SECTION("name is nullptr") {
+    rc = tiledb_query_condition_create_value(
+        ctx, nullptr, &value, sizeof(value), TILEDB_EQ, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("value is nullptr when size > 0") {
+    rc = tiledb_query_condition_create_value(
+        ctx, name, nullptr, sizeof(value), TILEDB_EQ, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("cond is nullptr") {
+    rc = tiledb_query_condition_create_value(
+        ctx, name, &value, sizeof(value), TILEDB_EQ, nullptr);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("success") {
+    rc = tiledb_query_condition_create_value(
+        ctx, name, &value, sizeof(value), TILEDB_EQ, &cond);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_query_condition_free(&cond);
+  }
+
+  SECTION("success with nullptr for value and 0 for size") {
+    rc = tiledb_query_condition_create_value(
+        ctx, name, nullptr, 0, TILEDB_EQ, &cond);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_query_condition_free(&cond);
+  }
+}
+
+TEST_CASE(
+    "C API: Test QueryCondition expression creation",
+    "[capi][query-condition][create]") {
+  tiledb_ctx_t* ctx;
+  auto rc = tiledb_ctx_alloc(nullptr, &ctx);
+  REQUIRE(rc == TILEDB_OK);
+
+  int32_t v1 = 2;
+  int32_t v2 = 3;
+  int32_t v3 = 5;
+
+  tiledb_query_condition_t* qc1;
+  tiledb_query_condition_t* qc2;
+  tiledb_query_condition_t* qc3;
+
+  rc = tiledb_query_condition_create_value(
+      ctx, "a1", &v1, sizeof(v1), TILEDB_EQ, &qc1);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_query_condition_create_value(
+      ctx, "a2", &v2, sizeof(v2), TILEDB_EQ, &qc2);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_query_condition_create_value(
+      ctx, "a3", &v3, sizeof(v3), TILEDB_EQ, &qc3);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_query_condition_t* cond_list[3] = {qc1, qc2, qc3};
+
+  tiledb_query_condition_t* cond;
+
+  SECTION("ctx is nullptr") {
+    rc = tiledb_query_condition_create_expression(
+        nullptr, cond_list, 3, TILEDB_AND, &cond);
+    REQUIRE(rc == TILEDB_INVALID_CONTEXT);
+  }
+
+  SECTION("cond_list is nullptr") {
+    rc = tiledb_query_condition_create_expression(
+        ctx, nullptr, 3, TILEDB_AND, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("cond_list has nullptr element") {
+    tiledb_query_condition_t* cond_list2[3] = {qc1, nullptr, qc2};
+    rc = tiledb_query_condition_create_expression(
+        ctx, cond_list2, 3, TILEDB_AND, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("cond_list has more than 1 element for TILEDB_NOT") {
+    tiledb_query_condition_t* cond_list2[2] = {qc1, qc2};
+    rc = tiledb_query_condition_create_expression(
+        ctx, cond_list2, 2, TILEDB_NOT, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("cond_list has fewer than 2 elements for TILEDB_AND") {
+    tiledb_query_condition_t* cond_list2[1] = {qc1};
+    rc = tiledb_query_condition_create_expression(
+        ctx, cond_list2, 1, TILEDB_AND, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("cond_list has fewer than 2 elements for TILEDB_OR") {
+    tiledb_query_condition_t* cond_list2[1] = {qc1};
+    rc = tiledb_query_condition_create_expression(
+        ctx, cond_list2, 1, TILEDB_OR, &cond);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("cond is nullptr") {
+    rc = tiledb_query_condition_create_expression(
+        ctx, cond_list, 3, TILEDB_AND, nullptr);
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("sucesss") {
+    rc = tiledb_query_condition_create_expression(
+        ctx, cond_list, 3, TILEDB_AND, &cond);
+    REQUIRE(rc == TILEDB_OK);
+    tiledb_query_condition_free(&cond);
+  }
+}

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2820,7 +2820,7 @@ TILEDB_EXPORT void tiledb_query_condition_free(tiledb_query_condition_t** cond)
  *
  * @param ctx The TileDB context.
  * @param cond The allocated query condition object.
- * @param attribute_name The attribute name.
+ * @param field_name The attribute or dimension name.
  * @param condition_value The value to compare against an attribute value.
  * @param condition_value_size The byte size of `condition_value`.
  * @param op The comparison operator.
@@ -2829,7 +2829,7 @@ TILEDB_EXPORT void tiledb_query_condition_free(tiledb_query_condition_t** cond)
 TILEDB_EXPORT int32_t tiledb_query_condition_init(
     tiledb_ctx_t* ctx,
     tiledb_query_condition_t* cond,
-    const char* attribute_name,
+    const char* field_name,
     const void* condition_value,
     uint64_t condition_value_size,
     tiledb_query_condition_op_t op) TILEDB_NOEXCEPT;

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -401,6 +401,115 @@ TILEDB_EXPORT int32_t tiledb_query_get_status_details(
     tiledb_query_t* query,
     tiledb_query_status_details_t* status_details) TILEDB_NOEXCEPT;
 
+/* ****************************** */
+/*          QUERY CONDITION       */
+/* ****************************** */
+
+/**
+ * Allocates a TileDB query condition value object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t value = 5;
+ * tiledb_query_condition_t* query_condition;
+ * tiledb_query_condition_create_value(
+ *    ctx,
+ *    "longitude",
+ *    &value,
+ *    sizeof(value),
+ *    TILEDB_LT,
+ *    &query_condition);
+ *
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param attribute_name The attribute name.
+ * @param condition_value The value to compare against an attribute value.
+ * @param condition_value_size The byte size of `condition_value`.
+ * @param op The comparison operator.
+ * @param query_condition The query condition to create
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_condition_create_value(
+    tiledb_ctx_t* ctx,
+    const char* attribute_name,
+    const void* condition_value,
+    uint64_t condition_value_size,
+    tiledb_query_condition_op_t op,
+    tiledb_query_condition_t** cond) TILEDB_NOEXCEPT;
+
+/**
+ * Allocates a TileDB query condition expression object.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t value_1 = 5;
+ * tiledb_query_condition_t* query_condition_1;
+ * tiledb_query_condition_create_comparison(
+ *   ctx,
+ *   "longitude",
+ *   &value_1,
+ *   sizeof(value_1),
+ *   TILEDB_LT,
+ *   &query_condition_1);
+ *
+ * uint32_t value_2 = 20;
+ * tiledb_query_condition_t* query_condition_2;
+ * tiledb_query_condition_create_comparison(
+ *   ctx,
+ *   "latitude",
+ *   &value_2,
+ *   sizeof(value_2),
+ *   TILEDB_GE,
+ *   &query_condition_2);
+ *
+ * uint32_t value_3 = 100;
+ * tiledb_query_condition_t* query_condition_3;
+ * tiledb_query_condition_create_comparison(
+ *   ctx,
+ *   "latitude",
+ *   &value_3,
+ *   sizeof(value_3),
+ *   TILEDB_LE,
+ *   &query_condition_3);
+ *
+ * tiledb_query_condition_t* conditions[3];
+ * conditions[0] = &query_condition_1;
+ * conditions[1] = &query_condition_2;
+ * conditions[2] = &query_condition_3;
+ * tiledb_query_condition_t* query_condition_4;
+ * tiledb_query_condition_create_expression(
+ *   ctx,
+ *   conditions,
+ *   3,
+ *   TILEDB_AND,
+ *   &query_condition_4);
+ *
+ * tiledb_query_condition_free(&query_condition_1);
+ * tiledb_query_condition_free(&query_condition_2);
+ * tiledb_query_condition_free(&query_condition_3);
+ *
+ * tiledb_query_set_condition(ctx, query, query_condition_4);
+ * tiledb_query_submit(ctx, query);
+ * tiledb_query_condition_free(&query_condition_4);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param cond_list The list of conditions to combine
+ * @param cond_list_len The number of conditions in cond_list
+ * @param op The combination operator to use
+ * @param combined_cond The query condition to create
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_query_condition_create_expression(
+    tiledb_ctx_t* ctx,
+    tiledb_query_condition_t** cond_list,
+    size_t cond_list_len,
+    tiledb_query_condition_combination_op_t op,
+    tiledb_query_condition_t** cond) TILEDB_NOEXCEPT;
+
 /* ********************************* */
 /*              CONTEXT              */
 /* ********************************* */

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -62,6 +62,36 @@ class QueryCondition {
   /** Default constructor. */
   QueryCondition();
 
+  /** Construct a field/value QueryCondition */
+  QueryCondition(
+      std::string field_name,
+      const void* condition_value,
+      uint64_t condition_value_size,
+      const QueryConditionOp& op);
+
+  /** Construct a field/value QueryCondition */
+  template <
+      typename T,
+      typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+  QueryCondition(
+      std::string field_name, T condition_value, const QueryConditionOp& op)
+      : QueryCondition(field_name, &condition_value, sizeof(T), op) {
+  }
+
+  /** Construct a field/value QueryCondition */
+  QueryCondition(
+      std::string field_name,
+      std::string condition_value,
+      const QueryConditionOp& op)
+      : QueryCondition(
+            field_name, condition_value.c_str(), condition_value.size(), op) {
+  }
+
+  /** Construct an expression QueryCondition */
+  QueryCondition(
+      std::vector<QueryCondition*> conditions,
+      const QueryConditionCombinationOp& combination_op);
+
   /** Constructor from a marker. */
   QueryCondition(const std::string& condition_marker);
 


### PR DESCRIPTION
This allows building QueryConditions that are boolean combinations of multiple sub-QueryConditions.

---
TYPE: C_API
DESC: Add tiledb_query_condition_alloc_value and tiledb_query_condition_alloc_combined
