### PR TITLE
Check exactly 2 dimensions are used with WebP filter.

### DIFF
--- a/test/src/unit-cppapi-webp-filter.cc
+++ b/test/src/unit-cppapi-webp-filter.cc
@@ -223,108 +223,6 @@ template <>
   return domain;
 }
 
-// TODO: When this test passes it can be combined with `C++ API: WEBP Filter`.
-// We can explicitly run the test with `tiledb_unit [.xfail]` for debugging.
-using DimensionTypesSmall = std::tuple<int8_t, int16_t, uint8_t, uint16_t>;
-TEMPLATE_LIST_TEST_CASE(
-    "C++ API: WEBP Filter small dims",
-    "[cppapi][filter][webp]",
-    DimensionTypesSmall) {
-  if constexpr (webp_filter_exists) {
-    Context ctx;
-    VFS vfs(ctx);
-    if (vfs.is_dir(webp_array_name)) {
-      vfs.remove_dir(webp_array_name);
-    }
-
-    uint8_t format_expected = GENERATE(
-        TILEDB_WEBP_RGB, TILEDB_WEBP_RGBA, TILEDB_WEBP_BGR, TILEDB_WEBP_BGRA);
-    uint8_t lossless_expected = GENERATE(1, 0);
-
-    Filter filter(ctx, TILEDB_FILTER_WEBP);
-    REQUIRE(filter.filter_type() == TILEDB_FILTER_WEBP);
-    REQUIRE(
-        filter.to_str(filter.filter_type()) == sm::constants::filter_webp_str);
-
-    float quality_found;
-    REQUIRE_NOTHROW(filter.set_option(TILEDB_WEBP_QUALITY, 100.0f));
-    REQUIRE_NOTHROW(
-        filter.get_option<float>(TILEDB_WEBP_QUALITY, &quality_found));
-    REQUIRE(100.0f == quality_found);
-
-    uint8_t format_found;
-    REQUIRE_NOTHROW(
-        filter.set_option(TILEDB_WEBP_INPUT_FORMAT, &format_expected));
-    REQUIRE_NOTHROW(filter.get_option(TILEDB_WEBP_INPUT_FORMAT, &format_found));
-    REQUIRE(format_expected == format_found);
-
-    // Check WEBP_LOSSLESS option.
-    uint8_t lossless_found;
-    REQUIRE_NOTHROW(
-        filter.set_option(TILEDB_WEBP_LOSSLESS, &lossless_expected));
-    REQUIRE_NOTHROW(filter.get_option(TILEDB_WEBP_LOSSLESS, &lossless_found));
-    REQUIRE(lossless_expected == lossless_found);
-
-    // Test against images of different sizes.
-    Domain domain = create_domain<TestType>(ctx, format_expected);
-    uint8_t pixel_depth = format_expected < TILEDB_WEBP_RGBA ? 3 : 4;
-    TestType height = domain.dimension(0).template domain<TestType>().second;
-    TestType width =
-        domain.dimension(1).template domain<TestType>().second / pixel_depth;
-
-    FilterList filterList(ctx);
-    filterList.add_filter(filter);
-
-    // This attribute is used for all colorspace formats: RGB, RGBA, BGR, BGRA.
-    auto a = Attribute::create<uint8_t>(ctx, "rgb");
-    a.set_filter_list(filterList);
-
-    ArraySchema schema(ctx, TILEDB_DENSE);
-    schema.set_domain(domain);
-    schema.add_attribute(a);
-    Array::create(webp_array_name, schema);
-
-    auto rgb = create_image(width, height, pixel_depth);
-
-    // Write pixel data to the array.
-    Array array(ctx, webp_array_name, TILEDB_WRITE);
-    Query write(ctx, array);
-    write.set_layout(TILEDB_ROW_MAJOR).set_data_buffer("rgb", rgb);
-    write.submit();
-    array.close();
-    REQUIRE(Query::Status::COMPLETE == write.query_status());
-
-    array.open(TILEDB_READ);
-    std::vector<uint8_t> read_rgb((width * pixel_depth) * height);
-    std::vector<TestType> subarray = {
-        1, height, 1, (TestType)(width * pixel_depth)};
-    Query read(ctx, array);
-    read.set_layout(TILEDB_ROW_MAJOR)
-        .set_subarray(subarray)
-        .set_data_buffer("rgb", read_rgb);
-    read.submit();
-    array.close();
-    REQUIRE(Query::Status::COMPLETE == read.query_status());
-
-    if (lossless_expected == 1) {
-      // Lossless compression should be exact.
-      REQUIRE_THAT(read_rgb, Catch::Matchers::Equals(rgb));
-    } else {
-      // Lossy compression at 100.0f quality should be approx.
-      REQUIRE_THAT(read_rgb, Catch::Matchers::Approx(rgb).margin(200));
-    }
-
-    if constexpr (png_found) {
-      write_image(
-          read_rgb, width, height, pixel_depth, format_expected, nullptr);
-    }
-
-    if (vfs.is_dir(webp_array_name)) {
-      vfs.remove_dir(webp_array_name);
-    }
-  }
-}
-
 using TestTypes = std::tuple<uint16_t, int16_t, int32_t, int64_t, uint32_t>;
 TEMPLATE_LIST_TEST_CASE(
     "C++ API: WEBP filter schema validation",
@@ -423,7 +321,15 @@ TEMPLATE_LIST_TEST_CASE(
   }
 }
 
-using DimensionTypes = std::tuple<int32_t, int64_t, uint32_t, uint64_t>;
+using DimensionTypes = std::tuple<
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t>;
 TEMPLATE_LIST_TEST_CASE(
     "C++ API: WEBP Filter", "[cppapi][filter][webp]", DimensionTypes) {
   if constexpr (webp_filter_exists) {

--- a/test/src/unit-cppapi-webp-filter.cc
+++ b/test/src/unit-cppapi-webp-filter.cc
@@ -266,16 +266,20 @@ TEMPLATE_LIST_TEST_CASE(
       ArraySchema invalid_schema(ctx, TILEDB_DENSE);
       invalid_schema.set_domain(invalid_domain);
       invalid_schema.add_attribute(valid_attr);
-      REQUIRE_THROWS_AS(
-          Array::create(webp_array_name, invalid_schema), tiledb::TileDBError);
+      REQUIRE_THROWS_WITH(
+          Array::create(webp_array_name, invalid_schema),
+          Catch::Matchers::ContainsSubstring(
+              "WebP filter requires exactly 2 dimensions Y, X"));
 
       // Test with > 2 dimensions.
       invalid_domain.add_dimensions(
           Dimension::create<uint64_t>(ctx, "x", {{1, 100}}, 90),
           Dimension::create<uint64_t>(ctx, "z", {{1, 100}}, 90));
       invalid_schema.set_domain(invalid_domain);
-      REQUIRE_THROWS_AS(
-          Array::create(webp_array_name, invalid_schema), tiledb::TileDBError);
+      REQUIRE_THROWS_WITH(
+          Array::create(webp_array_name, invalid_schema),
+          Catch::Matchers::ContainsSubstring(
+              "WebP filter requires exactly 2 dimensions Y, X"));
     }
 
     // In dense arrays, all dimensions must have matching datatype.
@@ -289,8 +293,10 @@ TEMPLATE_LIST_TEST_CASE(
       ArraySchema invalid_schema(ctx, TILEDB_DENSE);
 
       // This is also enforced by ArraySchema::check_webp_filter.
-      REQUIRE_THROWS_AS(
-          invalid_schema.set_domain(invalid_domain), tiledb::TileDBError);
+      REQUIRE_THROWS_WITH(
+          invalid_schema.set_domain(invalid_domain),
+          Catch::Matchers::ContainsSubstring(
+              "In dense arrays, all dimensions must have the same datatype"));
     }
 
     // WebP filter supports only uint8 attributes.
@@ -299,8 +305,10 @@ TEMPLATE_LIST_TEST_CASE(
       invalid_schema.set_domain(valid_domain);
 
       invalid_schema.add_attribute(invalid_attr);
-      REQUIRE_THROWS_AS(
-          Array::create(webp_array_name, invalid_schema), tiledb::TileDBError);
+      REQUIRE_THROWS_WITH(
+          Array::create(webp_array_name, invalid_schema),
+          Catch::Matchers::ContainsSubstring(
+              "WebP filter supports only uint8 attributes"));
     }
 
     // WebP filter can only be applied to dense arrays.
@@ -309,8 +317,10 @@ TEMPLATE_LIST_TEST_CASE(
       invalid_schema.set_domain(valid_domain);
       invalid_schema.add_attribute(valid_attr);
 
-      REQUIRE_THROWS_AS(
-          Array::create(webp_array_name, invalid_schema), tiledb::TileDBError);
+      REQUIRE_THROWS_WITH(
+          Array::create(webp_array_name, invalid_schema),
+          Catch::Matchers::ContainsSubstring(
+              "WebP filter can only be applied to dense arrays"));
     }
 
     REQUIRE_NOTHROW(Array::create(webp_array_name, valid_schema));

--- a/test/src/unit-cppapi-webp-filter.cc
+++ b/test/src/unit-cppapi-webp-filter.cc
@@ -179,8 +179,8 @@ std::vector<uint8_t> create_image(
 // These templates will not be used if built with TILEDB_WEBP=OFF
 template <typename T>
 [[maybe_unused]] Domain create_domain(const Context& ctx, uint8_t format) {
-  T height = GENERATE(131, 217, 1003);
-  T width = GENERATE(103, 277, 1001);
+  T height = GENERATE(131, 217);
+  T width = GENERATE(103, 277);
   uint8_t pixel_depth = format < TILEDB_WEBP_RGBA ? 3 : 4;
   auto y = Dimension::create<T>(ctx, "y", {{1, height}}, height / 2);
   auto x = Dimension::create<T>(

--- a/test/src/unit-cppapi-webp-filter.cc
+++ b/test/src/unit-cppapi-webp-filter.cc
@@ -256,7 +256,7 @@ TEMPLATE_LIST_TEST_CASE(
     auto invalid_attr = Attribute::create<TestType>(ctx, "rgb");
     invalid_attr.set_filter_list(filterList);
 
-    // WebP filter requires exactly 2 dimensions for X, Y.
+    // WebP filter requires exactly 2 dimensions for Y, X.
     {
       Domain invalid_domain(ctx);
       invalid_domain.add_dimension(
@@ -270,7 +270,7 @@ TEMPLATE_LIST_TEST_CASE(
           Array::create(webp_array_name, invalid_schema), tiledb::TileDBError);
 
       // Test with > 2 dimensions.
-      invalid_domain.template add_dimensions(
+      invalid_domain.add_dimensions(
           Dimension::create<uint64_t>(ctx, "x", {{1, 100}}, 90),
           Dimension::create<uint64_t>(ctx, "z", {{1, 100}}, 90));
       invalid_schema.set_domain(invalid_domain);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -374,10 +374,9 @@ void ArraySchema::check_webp_filter() const {
           "WebP filter can only be applied to dense arrays");
     }
 
-    // WebP filter requires at least 2 dimensions for Y, X.
-    if (dim_map_.size() < 2) {
+    if (dim_map_.size() != 2) {
       throw ArraySchemaStatusException(
-          "WebP filter requires at least 2 dimensions");
+          "WebP filter requires exactly 2 dimensions Y, X.");
     }
     auto y_dim = dimension_ptr(0);
     auto x_dim = dimension_ptr(1);

--- a/tiledb/sm/array_schema/dimension.h
+++ b/tiledb/sm/array_schema/dimension.h
@@ -318,7 +318,7 @@ class Dimension {
   template <
       class T,
       typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-  static T tile_extent_mult(const T& v, const T& tile_extent) {
+  static uint64_t tile_extent_mult(const T& v, const T& tile_extent) {
     typedef typename std::make_unsigned<T>::type unsigned_t;
     return (unsigned_t)v * (unsigned_t)tile_extent;
   }


### PR DESCRIPTION
Fixes SC-24766. Validations for the WebP schema would only throw if we used less than 2 dimensions, when we should instead check that we were using exactly 2 dimensions. I modified the schema validation for WebP and added a test to check the exception is thrown for both cases.

Fixes segmentation fault in SC-24759 and removes `.xfail` tag from WebP small dims test. The segfault was due to an overflow from casting back to a signed return type `T` after use of `std::make_unsigned<T>::type` in [tile_extent_mult](https://github.com/TileDB-Inc/TileDB/blob/dev/tiledb/sm/array_schema/dimension.h#L318-L324)

---
TYPE: BUG
DESC: Fixes SC-24766, SC-24759