### PR TITLE
Tile metadata generator: fix buffer overflow on string comparison.

### DIFF
--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -415,10 +415,12 @@ void TileMetadataGenerator::min_max<char>(
   // Process all cells, starting at the second value.
   auto value = data + start * cell_size_;
   for (uint64_t c = start; c < end; c++) {
-    min_ =
-        strncmp((const char*)min_, (const char*)value, size) > 0 ? value : min_;
-    max_ =
-        strncmp((const char*)max_, (const char*)value, size) < 0 ? value : max_;
+    min_ = strncmp((const char*)min_, (const char*)value, cell_size_) > 0 ?
+               value :
+               min_;
+    max_ = strncmp((const char*)max_, (const char*)value, cell_size_) < 0 ?
+               value :
+               max_;
     value += cell_size_;
   }
 }


### PR DESCRIPTION
This change uses the proper variable for string comparisons when generating metadata on writes.

---
TYPE: IMPROVEMENT
DESC: Tile metadata generator: fix buffer overflow on string comparison.
