### PR TITLE
Move Dimension Labels outside experimental build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ list(APPEND TILEDB_C_API_FILENAME_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_enum.h"
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_version.h"
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_experimental.h"
+    "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_dimension_label_experimental.h"
 )
 
 if (TILEDB_SERIALIZATION)

--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -4,7 +4,7 @@ title: Format Specification
 
 **Notes:**
 
-* The current TileDB format version number is **17** (`uint32_t`).
+* The current TileDB format version number is **18** (`uint32_t`).
 * Data written by TileDB and referenced in this document is **little-endian**
   with the following exceptions:
 

--- a/format_spec/array_file_hierarchy.md
+++ b/format_spec/array_file_hierarchy.md
@@ -26,6 +26,7 @@ my_array                                # array folder
           |_ <timestamped_name>.meta    # consol. fragment meta file
           |_ ...                  
     |_ __meta                           # array metadata folder
+    |_ __labels                         # dimension label folder
 
 ```
 
@@ -46,3 +47,4 @@ Inside the array folder, you can find the following:
 * Inside the same commit folder, any number of [ignore files](./ignore_file.md) of the form `<timestamped_name>.ign`.
 * Inside of a fragment metadata folder, any number of [consolidated fragment metadata files](./consolidated_fragment_metadata_file.md) of the form `<timestamped_name>.meta`.
 * [Array metadata](./metadata.md) folder `__meta`.
+* Inside of a labels folder, additional TileDB arrays storing dimension label data.

--- a/format_spec/array_schema.md
+++ b/format_spec/array_schema.md
@@ -54,6 +54,10 @@ The array schema file consists of a single [generic tile](./generic_tile.md), wi
 | Attribute 1 | [Attribute](#attribute) | First attribute |
 | … | … | … |
 | Attribute N | [Attribute](#attribute) | Nth attribute |
+| Num labels | `uint32_t` | Number of dimension labels in the array |
+| Label 1 | [Dimension Label](#dimension_label) | First dimension label |
+| … | … | … |
+| Label N | [Dimension Label](#dimension_label) | Nth dimension label |
 
 ## Domain
 
@@ -98,3 +102,25 @@ The attribute has internal format:
 | Nullable | `bool` | Whether or not the attribute can be null |
 | Fill value validity | `uint8_t` | The validity fill value |
 | Order | `uint8_t` | Order of the data stored in the attribute. This may be unordered, increasing or decreasing |
+
+## Dimension Label
+
+The dimension label has internal format:
+
+| **Field**                  | **Type**   | **Description** |
+| :------------------------- | :--------- | :-------------- |
+| Dimension index            | `uint32_t` | Index of the dimension the label is for |
+| Label order                | `uint8_t`  | Order of the label data |
+| Dimension label name length| `uint64_t` | Number of characters in the dimension label name |
+| Dimension label name       | `char []`  | The name of the dimension label |
+| Relative URI               | `bool`     | If the URI of the array the label data is stored in is relative to this array |
+| URI length                 | `uint64_t` | The number of characters in the URI |
+| URI                        | `char []`  | The URI the label data is stored in |
+| Label attribute name length| `uint32_t` | The length of the attribute name of the label data |
+| Label attribute name       | `char []`  | The name of the attribute the label data is stored in |
+| Label datatype             | `uint8_t`  | The datatype of the label data |
+| Label cell_val_num         | `uint32_t` | The number of values per cell of the label data. For variable-length labels, this is `std::numeric_limits<uint32_t>::max()` |
+| Label domain size          | `uint64_t` | The size of the label domain |
+| Label domain start size    | `uint64_t` | The size of the first value of the domain for variable-lenght datatypes. For fixed-lenght labels, this is 0|
+| Label domain data          | `uint8_t[]`| Byte array of length equal to domain size above, storing the min, max values of the dimension |
+| Is external                | `bool`     | If the URI is not stored as part of this array |

--- a/format_spec/array_schema.md
+++ b/format_spec/array_schema.md
@@ -112,15 +112,15 @@ The dimension label has internal format:
 | Dimension index            | `uint32_t` | Index of the dimension the label is for |
 | Label order                | `uint8_t`  | Order of the label data |
 | Dimension label name length| `uint64_t` | Number of characters in the dimension label name |
-| Dimension label name       | `char []`  | The name of the dimension label |
-| Relative URI               | `bool`     | If the URI of the array the label data is stored in is relative to this array |
+| Dimension label name       | `uint8_t []`  | The name of the dimension label |
+| Relative URI               | `uint8_t`     | If the URI of the array the label data is stored in is relative to this array |
 | URI length                 | `uint64_t` | The number of characters in the URI |
-| URI                        | `char []`  | The URI the label data is stored in |
+| URI                        | `uint8_t []`  | The URI the label data is stored in |
 | Label attribute name length| `uint32_t` | The length of the attribute name of the label data |
-| Label attribute name       | `char []`  | The name of the attribute the label data is stored in |
+| Label attribute name       | `uint8_t []`  | The name of the attribute the label data is stored in |
 | Label datatype             | `uint8_t`  | The datatype of the label data |
 | Label cell_val_num         | `uint32_t` | The number of values per cell of the label data. For variable-length labels, this is `std::numeric_limits<uint32_t>::max()` |
 | Label domain size          | `uint64_t` | The size of the label domain |
 | Label domain start size    | `uint64_t` | The size of the first value of the domain for variable-lenght datatypes. For fixed-lenght labels, this is 0|
 | Label domain data          | `uint8_t[]`| Byte array of length equal to domain size above, storing the min, max values of the dimension |
-| Is external                | `bool`     | If the URI is not stored as part of this array |
+| Is external                | `uint8_t`     | If the URI is not stored as part of this array |

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -113,7 +113,14 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/test-capi-array-write-ordered-attr-fixed.cc
   src/test-capi-array-write-ordered-attr-var.cc
   src/test-capi-consolidation-plan.cc
+  src/test-capi-array-many-dimension-labels.cc
+  src/test-capi-dimension-label.cc
+  src/test-capi-dimension-label-encrypted.cc
+  src/test-capi-dense-array-dimension-label.cc
+  src/test-capi-dense-array-dimension-label-var.cc
   src/test-capi-query-error-handling.cc
+  src/test-capi-sparse-array-dimension-label.cc
+  src/test-capi-subarray-labels.cc
   src/test-cppapi-consolidation-plan.cc
   src/unit-average-cell-size.cc
   src/unit-azure.cc
@@ -252,18 +259,6 @@ if (TILEDB_ARROW_TESTS)
   list(APPEND TILEDB_UNIT_TEST_SOURCES
     src/unit-arrow.cc
     ${CMAKE_SOURCE_DIR}/tiledb/sm/cpp_api/arrow_io_impl.h
-  )
-endif()
-
-if (TILEDB_EXPERIMENTAL_FEATURES)
-  list(APPEND TILEDB_UNIT_TEST_SOURCES
-    src/test-capi-array-many-dimension-labels.cc
-    src/test-capi-dimension-label.cc
-    src/test-capi-dimension-label-encrypted.cc
-    src/test-capi-dense-array-dimension-label.cc
-    src/test-capi-dense-array-dimension-label-var.cc
-    src/test-capi-sparse-array-dimension-label.cc
-    src/test-capi-subarray-labels.cc
   )
 endif()
 

--- a/test/src/test-capi-array-many-dimension-labels.cc
+++ b/test/src/test-capi-array-many-dimension-labels.cc
@@ -36,7 +36,6 @@
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/array_schema/dimension_label_reference.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -362,24 +362,6 @@ TEST_CASE_METHOD(
     }
   }
 
-  if constexpr (is_experimental_build) {
-    SECTION("Write unordered labels", "[UnorderedLabels]") {
-      // Set the label order.
-      label_order = TILEDB_UNORDERED_DATA;
-
-      // Set the data values.
-      input_label_data_raw = {15, 30, 20, 10};
-
-      // Set the attribute values.
-      SECTION("With array data") {
-        input_attr_data = {0.5, 1.0, 1.5, 2.0};
-      }
-      SECTION("Without array data") {
-        input_attr_data = {};
-      }
-    }
-  }
-
   // Create label data from raw data.
   std::string input_label_data{};
   std::vector<uint64_t> input_label_offsets(4);
@@ -413,7 +395,7 @@ TEST_CASE_METHOD(
   }
 
   // Check range reader.
-  if (label_order != TILEDB_UNORDERED_DATA) {
+  {
     INFO("Reading data by label range.");
 
     // Check full range

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -324,7 +324,7 @@ TEST_CASE_METHOD(
     "[capi][query][DimensionLabel][var]") {
   // Array parameters.
   std::vector<uint64_t> index_domain{0, 3};
-  tiledb_data_order_t label_order;
+  tiledb_data_order_t label_order{};
 
   // Vectors for input data.
   std::vector<uint64_t> input_label_data_raw{};

--- a/test/src/test-capi-dense-array-dimension-label-var.cc
+++ b/test/src/test-capi-dense-array-dimension-label-var.cc
@@ -40,7 +40,6 @@
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/array_schema/dimension_label_reference.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -363,19 +362,21 @@ TEST_CASE_METHOD(
     }
   }
 
-  SECTION("Write unordered labels", "[UnorderedLabels]") {
-    // Set the label order.
-    label_order = TILEDB_UNORDERED_DATA;
+  if constexpr (is_experimental_build) {
+    SECTION("Write unordered labels", "[UnorderedLabels]") {
+      // Set the label order.
+      label_order = TILEDB_UNORDERED_DATA;
 
-    // Set the data values.
-    input_label_data_raw = {15, 30, 20, 10};
+      // Set the data values.
+      input_label_data_raw = {15, 30, 20, 10};
 
-    // Set the attribute values.
-    SECTION("With array data") {
-      input_attr_data = {0.5, 1.0, 1.5, 2.0};
-    }
-    SECTION("Without array data") {
-      input_attr_data = {};
+      // Set the attribute values.
+      SECTION("With array data") {
+        input_attr_data = {0.5, 1.0, 1.5, 2.0};
+      }
+      SECTION("Without array data") {
+        input_attr_data = {};
+      }
     }
   }
 

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -408,24 +408,6 @@ TEST_CASE_METHOD(
     }
   }
 
-  if constexpr (is_experimental_build) {
-    SECTION("Write unordered labels and array", "[UnorderedLabels]") {
-      // Set the label order.
-      label_order = TILEDB_UNORDERED_DATA;
-
-      // Set the data values.
-      input_label_data = {-0.5, 1.0, 0.0, -1.0};
-
-      // Set the attribute values.
-      SECTION("With array data") {
-        input_attr_data = {0.5, 1.0, 1.5, 2.0};
-      }
-      SECTION("Without array data") {
-        input_attr_data = {};
-      }
-    }
-  }
-
   INFO(
       "Testing array with label order " +
       data_order_str(static_cast<DataOrder>(label_order)) + ".");
@@ -441,7 +423,7 @@ TEST_CASE_METHOD(
   }
 
   // Check range reader.
-  if (label_order != TILEDB_UNORDERED_DATA) {
+  {
     INFO("Reading data by label range.");
 
     // Check query on full range.

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -374,7 +374,7 @@ TEST_CASE_METHOD(
   std::vector<double> input_attr_data{};
 
   // Dimension label parameters.
-  tiledb_data_order_t label_order;
+  tiledb_data_order_t label_order{};
 
   SECTION("Write increasing labels", "[IncreasingLabels]") {
     // Set the label order.
@@ -478,7 +478,7 @@ TEST_CASE_METHOD(
   std::vector<double> input_attr_data{};
 
   // Dimension label parameters.
-  tiledb_data_order_t label_order;
+  tiledb_data_order_t label_order{};
 
   SECTION("Increasing labels with bad order", "[IncreasingLabels]") {
     label_order = TILEDB_INCREASING_DATA;

--- a/test/src/test-capi-dense-array-dimension-label.cc
+++ b/test/src/test-capi-dense-array-dimension-label.cc
@@ -35,7 +35,6 @@
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -409,19 +408,21 @@ TEST_CASE_METHOD(
     }
   }
 
-  SECTION("Write unordered labels and array", "[UnorderedLabels]") {
-    // Set the label order.
-    label_order = TILEDB_UNORDERED_DATA;
+  if constexpr (is_experimental_build) {
+    SECTION("Write unordered labels and array", "[UnorderedLabels]") {
+      // Set the label order.
+      label_order = TILEDB_UNORDERED_DATA;
 
-    // Set the data values.
-    input_label_data = {-0.5, 1.0, 0.0, -1.0};
+      // Set the data values.
+      input_label_data = {-0.5, 1.0, 0.0, -1.0};
 
-    // Set the attribute values.
-    SECTION("With array data") {
-      input_attr_data = {0.5, 1.0, 1.5, 2.0};
-    }
-    SECTION("Without array data") {
-      input_attr_data = {};
+      // Set the attribute values.
+      SECTION("With array data") {
+        input_attr_data = {0.5, 1.0, 1.5, 2.0};
+      }
+      SECTION("Without array data") {
+        input_attr_data = {};
+      }
     }
   }
 

--- a/test/src/test-capi-dimension-label-encrypted.cc
+++ b/test/src/test-capi-dimension-label-encrypted.cc
@@ -34,7 +34,6 @@
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"

--- a/test/src/test-capi-dimension-label.cc
+++ b/test/src/test-capi-dimension-label.cc
@@ -34,7 +34,6 @@
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -60,6 +59,7 @@ TEST_CASE_METHOD(
   // Create and add dimension label schema (both fixed and variable length
   // examples).
   auto label_type = GENERATE(TILEDB_FLOAT64, TILEDB_STRING_ASCII);
+  auto label_order = GENERATE(TILEDB_INCREASING_DATA, TILEDB_DECREASING_DATA);
 
   // Create an array schema.
   uint64_t x_domain[2]{0, 63};
@@ -83,7 +83,7 @@ TEST_CASE_METHOD(
       false);
 
   require_tiledb_ok(tiledb_array_schema_add_dimension_label(
-      ctx, array_schema, 0, "label", TILEDB_INCREASING_DATA, label_type));
+      ctx, array_schema, 0, "label", label_order, label_type));
 
   // Check array schema and number of dimension labels.
   require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
@@ -135,6 +135,100 @@ TEST_CASE_METHOD(
 
   // Free remaining resources
   tiledb_array_schema_free(&loaded_array_schema);
+}
+
+TEST_CASE_METHOD(
+    TemporaryDirectoryFixture,
+    "Write and read back TileDB array schema with dimension label for "
+    "unordered labels",
+    "[capi][ArraySchema][DimensionLabel]") {
+  // Create and add dimension label schema (both fixed and variable length
+  // examples).
+  auto label_type = GENERATE(TILEDB_FLOAT64, TILEDB_STRING_ASCII);
+
+  // Create an array schema.
+  uint64_t x_domain[2]{0, 63};
+  uint64_t x_tile_extent{64};
+  uint64_t y_domain[2]{0, 63};
+  uint64_t y_tile_extent{64};
+  auto array_schema = create_array_schema(
+      ctx,
+      TILEDB_DENSE,
+      {"x", "y"},
+      {TILEDB_UINT64, TILEDB_UINT64},
+      {&x_domain[0], &y_domain[0]},
+      {&x_tile_extent, &y_tile_extent},
+      {"a"},
+      {TILEDB_FLOAT64},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      4096,
+      false);
+
+  if constexpr (is_experimental_build) {
+    require_tiledb_ok(tiledb_array_schema_add_dimension_label(
+        ctx, array_schema, 0, "label", TILEDB_UNORDERED_DATA, label_type));
+
+    // Check array schema and number of dimension labels.
+    require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
+    auto dim_label_num = array_schema->array_schema_->dim_label_num();
+    REQUIRE(dim_label_num == 1);
+
+    // Check the dimension label properies.
+    tiledb_dimension_label_t* dim_label;
+    require_tiledb_ok(tiledb_array_schema_get_dimension_label_from_name(
+        ctx, array_schema, "label", &dim_label));
+    uint32_t label_cell_val_num;
+    check_tiledb_ok(tiledb_dimension_label_get_label_cell_val_num(
+        ctx, dim_label, &label_cell_val_num));
+    tiledb_datatype_t label_type_;
+    check_tiledb_ok(
+        tiledb_dimension_label_get_label_type(ctx, dim_label, &label_type_));
+    if (label_type == TILEDB_FLOAT64) {
+      CHECK(label_cell_val_num == 1);
+      CHECK(label_type_ == TILEDB_FLOAT64);
+    } else {
+      CHECK(label_cell_val_num == tiledb::sm::constants::var_num);
+      CHECK(label_type_ == TILEDB_STRING_ASCII);
+    }
+    const char* dim_label_uri;
+    check_tiledb_ok(
+        tiledb_dimension_label_get_uri(ctx, dim_label, &dim_label_uri));
+    std::string expected_dim_label_uri{"__labels/l0"};
+    CHECK(dim_label_uri == expected_dim_label_uri);
+    tiledb_dimension_label_free(&dim_label);
+
+    // Create array.
+    auto array_name =
+        create_temporary_array("simple_array_with_label", array_schema);
+    tiledb_array_schema_free(&array_schema);
+
+    // Load array schema and check number of labels.
+    tiledb_array_schema_t* loaded_array_schema{nullptr};
+    require_tiledb_ok(tiledb_array_schema_load(
+        ctx, array_name.c_str(), &loaded_array_schema));
+
+    // Check the array schema has the expected dimension label.
+    auto loaded_dim_label_num =
+        loaded_array_schema->array_schema_->dim_label_num();
+    CHECK(loaded_dim_label_num == 1);
+    int32_t has_label;
+    check_tiledb_ok(tiledb_array_schema_has_dimension_label(
+        ctx, loaded_array_schema, "label", &has_label));
+    CHECK(has_label == 1);
+
+    // Free remaining resources
+    tiledb_array_schema_free(&loaded_array_schema);
+  } else {
+    check_tiledb_error_with(
+        tiledb_array_schema_add_dimension_label(
+            ctx, array_schema, 0, "label", TILEDB_UNORDERED_DATA, label_type),
+        "ArraySchema: Cannot add dimension label; Unordered dimension labels "
+        "are not yet supported.");
+    tiledb_array_schema_free(&array_schema);
+  }
 }
 
 TEST_CASE_METHOD(

--- a/test/src/test-capi-dimension-label.cc
+++ b/test/src/test-capi-dimension-label.cc
@@ -167,68 +167,12 @@ TEST_CASE_METHOD(
       4096,
       false);
 
-  if constexpr (is_experimental_build) {
-    require_tiledb_ok(tiledb_array_schema_add_dimension_label(
-        ctx, array_schema, 0, "label", TILEDB_UNORDERED_DATA, label_type));
-
-    // Check array schema and number of dimension labels.
-    require_tiledb_ok(tiledb_array_schema_check(ctx, array_schema));
-    auto dim_label_num = array_schema->array_schema_->dim_label_num();
-    REQUIRE(dim_label_num == 1);
-
-    // Check the dimension label properies.
-    tiledb_dimension_label_t* dim_label;
-    require_tiledb_ok(tiledb_array_schema_get_dimension_label_from_name(
-        ctx, array_schema, "label", &dim_label));
-    uint32_t label_cell_val_num;
-    check_tiledb_ok(tiledb_dimension_label_get_label_cell_val_num(
-        ctx, dim_label, &label_cell_val_num));
-    tiledb_datatype_t label_type_;
-    check_tiledb_ok(
-        tiledb_dimension_label_get_label_type(ctx, dim_label, &label_type_));
-    if (label_type == TILEDB_FLOAT64) {
-      CHECK(label_cell_val_num == 1);
-      CHECK(label_type_ == TILEDB_FLOAT64);
-    } else {
-      CHECK(label_cell_val_num == tiledb::sm::constants::var_num);
-      CHECK(label_type_ == TILEDB_STRING_ASCII);
-    }
-    const char* dim_label_uri;
-    check_tiledb_ok(
-        tiledb_dimension_label_get_uri(ctx, dim_label, &dim_label_uri));
-    std::string expected_dim_label_uri{"__labels/l0"};
-    CHECK(dim_label_uri == expected_dim_label_uri);
-    tiledb_dimension_label_free(&dim_label);
-
-    // Create array.
-    auto array_name =
-        create_temporary_array("simple_array_with_label", array_schema);
-    tiledb_array_schema_free(&array_schema);
-
-    // Load array schema and check number of labels.
-    tiledb_array_schema_t* loaded_array_schema{nullptr};
-    require_tiledb_ok(tiledb_array_schema_load(
-        ctx, array_name.c_str(), &loaded_array_schema));
-
-    // Check the array schema has the expected dimension label.
-    auto loaded_dim_label_num =
-        loaded_array_schema->array_schema_->dim_label_num();
-    CHECK(loaded_dim_label_num == 1);
-    int32_t has_label;
-    check_tiledb_ok(tiledb_array_schema_has_dimension_label(
-        ctx, loaded_array_schema, "label", &has_label));
-    CHECK(has_label == 1);
-
-    // Free remaining resources
-    tiledb_array_schema_free(&loaded_array_schema);
-  } else {
-    check_tiledb_error_with(
-        tiledb_array_schema_add_dimension_label(
-            ctx, array_schema, 0, "label", TILEDB_UNORDERED_DATA, label_type),
-        "ArraySchema: Cannot add dimension label; Unordered dimension labels "
-        "are not yet supported.");
-    tiledb_array_schema_free(&array_schema);
-  }
+  check_tiledb_error_with(
+      tiledb_array_schema_add_dimension_label(
+          ctx, array_schema, 0, "label", TILEDB_UNORDERED_DATA, label_type),
+      "ArraySchema: Cannot add dimension label; Unordered dimension labels "
+      "are not yet supported.");
+  tiledb_array_schema_free(&array_schema);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -358,31 +358,6 @@ TEST_CASE_METHOD(
     index_data_sorted_by_label = {3, 2, 1, 0};
   }
 
-  if constexpr (is_experimental_build) {
-    SECTION("Write unordered labels and array", "[UnorderedLabels]") {
-      // Set the label order.
-      label_order = TILEDB_UNORDERED_DATA;
-
-      // Set the data values.
-      input_index_data = {0, 3, 2, 1};
-      input_label_data = {1.0, 0.0, -0.5, -1.0};
-
-      SECTION("With attribute values") {
-        input_attr_data = {0.5, 1.0, 1.5, 2.0};
-        attr_data_sorted_by_index = {0.5, 2.0, 1.5, 1.0};
-      }
-      SECTION("Without attribute values") {
-        input_attr_data = {};
-        attr_data_sorted_by_index = {};
-      }
-
-      // Define expected output data.
-      label_data_sorted_by_index = {1.0, -1.0, -0.5, 0.0};
-      label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
-      index_data_sorted_by_label = {1, 2, 3, 0};
-    }
-  }
-
   INFO(
       "Testing array with label order " +
       data_order_str(static_cast<DataOrder>(label_order)) + ".");
@@ -399,7 +374,7 @@ TEST_CASE_METHOD(
   }
 
   // Check values when reading by label ranges.
-  if (label_order != TILEDB_UNORDERED_DATA) {
+  {
     INFO("Reading data by label range.");
 
     // Check query on full range.

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -312,7 +312,7 @@ TEST_CASE_METHOD(
   std::vector<uint64_t> index_data_sorted_by_label{};
 
   // Dimension label parameters.
-  tiledb_data_order_t label_order;
+  tiledb_data_order_t label_order{};
 
   SECTION("Write increasing labels", "[IncreasingLabels]") {
     // Set the label order.
@@ -437,7 +437,7 @@ TEST_CASE_METHOD(
   std::vector<double> input_attr_data{};
 
   // Dimension label parameters.
-  tiledb_data_order_t label_order;
+  tiledb_data_order_t label_order{};
 
   SECTION("Increasing labels with bad order", "[IncreasingLabels]") {
     label_order = TILEDB_INCREASING_DATA;

--- a/test/src/test-capi-sparse-array-dimension-label.cc
+++ b/test/src/test-capi-sparse-array-dimension-label.cc
@@ -36,7 +36,6 @@
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/array_schema/dimension_label_reference.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -359,27 +358,29 @@ TEST_CASE_METHOD(
     index_data_sorted_by_label = {3, 2, 1, 0};
   }
 
-  SECTION("Write unordered labels and array", "[UnorderedLabels]") {
-    // Set the label order.
-    label_order = TILEDB_UNORDERED_DATA;
+  if constexpr (is_experimental_build) {
+    SECTION("Write unordered labels and array", "[UnorderedLabels]") {
+      // Set the label order.
+      label_order = TILEDB_UNORDERED_DATA;
 
-    // Set the data values.
-    input_index_data = {0, 3, 2, 1};
-    input_label_data = {1.0, 0.0, -0.5, -1.0};
+      // Set the data values.
+      input_index_data = {0, 3, 2, 1};
+      input_label_data = {1.0, 0.0, -0.5, -1.0};
 
-    SECTION("With attribute values") {
-      input_attr_data = {0.5, 1.0, 1.5, 2.0};
-      attr_data_sorted_by_index = {0.5, 2.0, 1.5, 1.0};
+      SECTION("With attribute values") {
+        input_attr_data = {0.5, 1.0, 1.5, 2.0};
+        attr_data_sorted_by_index = {0.5, 2.0, 1.5, 1.0};
+      }
+      SECTION("Without attribute values") {
+        input_attr_data = {};
+        attr_data_sorted_by_index = {};
+      }
+
+      // Define expected output data.
+      label_data_sorted_by_index = {1.0, -1.0, -0.5, 0.0};
+      label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
+      index_data_sorted_by_label = {1, 2, 3, 0};
     }
-    SECTION("Without attribute values") {
-      input_attr_data = {};
-      attr_data_sorted_by_index = {};
-    }
-
-    // Define expected output data.
-    label_data_sorted_by_index = {1.0, -1.0, -0.5, 0.0};
-    label_data_sorted_by_label = {-1.0, -0.5, 0.0, 1.0};
-    index_data_sorted_by_label = {1, 2, 3, 0};
   }
 
   INFO(

--- a/test/src/test-capi-subarray-labels.cc
+++ b/test/src/test-capi-subarray-labels.cc
@@ -34,7 +34,6 @@
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/sm/c_api/tiledb_experimental.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -76,12 +76,6 @@ if (TILEDB_SERIALIZATION)
   )
 endif()
 
-if (TILEDB_EXPERIMENTAL_FEATURES)
-  list(APPEND TILEDB_PUBLIC_HEADERS
-    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_dimension_label.h
-  )
-endif()
-
 if (TILEDB_CPP_API)
   list(APPEND TILEDB_PUBLIC_HEADERS
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/tiledb
@@ -151,6 +145,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/buffer/buffer_list.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/api_argument_validator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_dimension_label.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_filestore.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cache/buffer_lru_cache.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/compressors/bzip_compressor.cc
@@ -287,10 +282,6 @@ set(TILEDB_CORE_SOURCES
 list(APPEND TILEDB_CORE_SOURCES ${TILEDB_COMMON_SOURCES})
 list(APPEND TILEDB_CORE_SOURCES ${TILEDB_API_SOURCES})
 
-if (TILEDB_EXPERIMENTAL_FEATURES)
-  list(APPEND TILEDB_CORE_SOURCES
-    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_dimension_label.cc)
-endif()
 
 
 #openssl3 md5 deprecation mitigation

--- a/tiledb/api/c_api/dimension_label/dimension_label_api_internal.h
+++ b/tiledb/api/c_api/dimension_label/dimension_label_api_internal.h
@@ -80,7 +80,7 @@ struct tiledb_dimension_label_handle_t
 
 namespace tiledb::api {
 /**
- * Returns if the argumetn is a valid dimension label: non-nall, valid as a
+ * Returns if the argument is a valid dimension label: non-null, valid as a
  * handle
  *
  * @param dim_label A dimension label of unknown validity

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -948,10 +948,9 @@ void ArraySchema::add_dimension_label(
   // Add dimension label
   try {
     // Create relative URI in dimension label directory
-    URI uri{
-        constants::array_dimension_labels_dir_name + "/l" +
-            std::to_string(nlabel_internal_),
-        false};
+    URI uri{constants::array_dimension_labels_dir_name + "/l" +
+                std::to_string(nlabel_internal_),
+            false};
 
     // Create the dimension label reference.
     auto dim_label_ref = make_shared<DimensionLabelReference>(
@@ -1318,8 +1317,8 @@ void ArraySchema::check_attribute_dimension_label_names() const {
   std::set<std::string> names;
   // Check attribute and dimension names are unique.
   auto dim_num = this->dim_num();
-  uint64_t expected_unique_names{
-      dim_num + attributes_.size() + dimension_label_references_.size()};
+  uint64_t expected_unique_names{dim_num + attributes_.size() +
+                                 dimension_label_references_.size()};
   for (const auto& attr : attributes_) {
     names.insert(attr->name());
   }

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -794,16 +794,14 @@ void ArraySchema::serialize(Serializer& serializer) const {
   }
 
   // Write dimension labels
-  if constexpr (is_experimental_build) {
-    auto label_num = static_cast<uint32_t>(dimension_label_references_.size());
-    if (label_num != dimension_label_references_.size()) {
-      throw ArraySchemaStatusException(
-          "Overflow when attempting to serialize label number.");
-    }
-    serializer.write<uint32_t>(label_num);
-    for (auto& label : dimension_label_references_) {
-      label->serialize(serializer, version);
-    }
+  auto label_num = static_cast<uint32_t>(dimension_label_references_.size());
+  if (label_num != dimension_label_references_.size()) {
+    throw ArraySchemaStatusException(
+        "Overflow when attempting to serialize label number.");
+  }
+  serializer.write<uint32_t>(label_num);
+  for (auto& label : dimension_label_references_) {
+    label->serialize(serializer, version);
   }
 }
 
@@ -856,11 +854,9 @@ bool ArraySchema::var_size(const std::string& name) const {
   }
 
   // Dimension label
-  if constexpr (is_experimental_build) {
-    auto dim_label_ref_it = dimension_label_reference_map_.find(name);
-    if (dim_label_ref_it != dimension_label_reference_map_.end()) {
-      return dim_label_ref_it->second->is_var();
-    }
+  auto dim_label_ref_it = dimension_label_reference_map_.find(name);
+  if (dim_label_ref_it != dimension_label_reference_map_.end()) {
+    return dim_label_ref_it->second->is_var();
   }
 
   // Name is not an attribute or dimension
@@ -943,9 +939,10 @@ void ArraySchema::add_dimension_label(
   // Add dimension label
   try {
     // Create relative URI in dimension label directory
-    URI uri{constants::array_dimension_labels_dir_name + "/l" +
-                std::to_string(nlabel_internal_),
-            false};
+    URI uri{
+        constants::array_dimension_labels_dir_name + "/l" +
+            std::to_string(nlabel_internal_),
+        false};
 
     // Create the dimension label reference.
     auto dim_label_ref = make_shared<DimensionLabelReference>(
@@ -1059,13 +1056,11 @@ ArraySchema ArraySchema::deserialize(
 
   // Load dimension labels
   std::vector<shared_ptr<const DimensionLabelReference>> dimension_labels;
-  if constexpr (is_experimental_build) {
-    if (version == constants::format_version) {
-      uint32_t label_num = deserializer.read<uint32_t>();
-      for (uint32_t i{0}; i < label_num; ++i) {
-        dimension_labels.emplace_back(
-            DimensionLabelReference::deserialize(deserializer, version));
-      }
+  if (version >= 18) {
+    uint32_t label_num = deserializer.read<uint32_t>();
+    for (uint32_t i{0}; i < label_num; ++i) {
+      dimension_labels.emplace_back(
+          DimensionLabelReference::deserialize(deserializer, version));
     }
   }
 
@@ -1314,8 +1309,8 @@ void ArraySchema::check_attribute_dimension_label_names() const {
   std::set<std::string> names;
   // Check attribute and dimension names are unique.
   auto dim_num = this->dim_num();
-  uint64_t expected_unique_names{dim_num + attributes_.size() +
-                                 dimension_label_references_.size()};
+  uint64_t expected_unique_names{
+      dim_num + attributes_.size() + dimension_label_references_.size()};
   for (const auto& attr : attributes_) {
     names.insert(attr->name());
   }

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -893,12 +893,10 @@ void ArraySchema::add_dimension_label(
     Datatype label_type,
     bool check_name) {
   // Check the label order is valid.
-  if constexpr (!is_experimental_build) {
-    if (label_order == DataOrder::UNORDERED_DATA) {
-      throw ArraySchemaStatusException(
-          "Cannot add dimension label; Unordered dimension labels are not yet "
-          "supported.");
-    }
+  if (label_order == DataOrder::UNORDERED_DATA) {
+    throw ArraySchemaStatusException(
+        "Cannot add dimension label; Unordered dimension labels are not yet "
+        "supported.");
   }
 
   // Check domain is set and `dim_id` is a valid dimension index.

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -892,6 +892,15 @@ void ArraySchema::add_dimension_label(
     DataOrder label_order,
     Datatype label_type,
     bool check_name) {
+  // Check the label order is valid.
+  if constexpr (!is_experimental_build) {
+    if (label_order == DataOrder::UNORDERED_DATA) {
+      throw ArraySchemaStatusException(
+          "Cannot add dimension label; Unordered dimension labels are not yet "
+          "supported.");
+    }
+  }
+
   // Check domain is set and `dim_id` is a valid dimension index.
   if (!domain_) {
     throw ArraySchemaStatusException(

--- a/tiledb/sm/array_schema/dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/dimension_label_reference.cc
@@ -107,6 +107,15 @@ DimensionLabelReference::DimensionLabelReference(
     }
   }
 
+  // Check the label order is valid.
+  if constexpr (!is_experimental_build) {
+    if (label_order == DataOrder::UNORDERED_DATA) {
+      std::invalid_argument(
+          "Unordered dimension labels are only supported in experimental "
+          "builds.");
+    }
+  }
+
   // Check URI is relative if it is internal to the array.
   if (!is_external_ && !relative_uri_) {
     throw std::invalid_argument(
@@ -152,6 +161,15 @@ DimensionLabelReference::DimensionLabelReference(
     std::throw_with_nested(std::invalid_argument(
         "Datatype Datatype::" + datatype_str(label_type) +
         " is not a valid dimension datatype."));
+  }
+
+  // Check the label order is valid.
+  if constexpr (!is_experimental_build) {
+    if (label_order == DataOrder::UNORDERED_DATA) {
+      std::invalid_argument(
+          "Unordered dimension labels are only supported in experimental "
+          "builds.");
+    }
   }
 
   // Create and set dimension label domain.

--- a/tiledb/sm/array_schema/dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/dimension_label_reference.cc
@@ -110,9 +110,9 @@ DimensionLabelReference::DimensionLabelReference(
   // Check the label order is valid.
   if constexpr (!is_experimental_build) {
     if (label_order == DataOrder::UNORDERED_DATA) {
-      std::invalid_argument(
-          "Unordered dimension labels are only supported in experimental "
-          "builds.");
+      throw std::invalid_argument(
+          "Cannot create dimension label reference; Unordered dimension labels "
+          "are not yet supported.");
     }
   }
 
@@ -166,9 +166,8 @@ DimensionLabelReference::DimensionLabelReference(
   // Check the label order is valid.
   if constexpr (!is_experimental_build) {
     if (label_order == DataOrder::UNORDERED_DATA) {
-      std::invalid_argument(
-          "Unordered dimension labels are only supported in experimental "
-          "builds.");
+      throw std::invalid_argument(
+          "Unordered dimension labels are not yet supported.");
     }
   }
 

--- a/tiledb/sm/array_schema/dimension_label_reference.cc
+++ b/tiledb/sm/array_schema/dimension_label_reference.cc
@@ -108,12 +108,10 @@ DimensionLabelReference::DimensionLabelReference(
   }
 
   // Check the label order is valid.
-  if constexpr (!is_experimental_build) {
-    if (label_order == DataOrder::UNORDERED_DATA) {
-      throw std::invalid_argument(
-          "Cannot create dimension label reference; Unordered dimension labels "
-          "are not yet supported.");
-    }
+  if (label_order == DataOrder::UNORDERED_DATA) {
+    throw std::invalid_argument(
+        "Cannot create dimension label reference; Unordered dimension labels "
+        "are not yet supported.");
   }
 
   // Check URI is relative if it is internal to the array.
@@ -164,11 +162,9 @@ DimensionLabelReference::DimensionLabelReference(
   }
 
   // Check the label order is valid.
-  if constexpr (!is_experimental_build) {
-    if (label_order == DataOrder::UNORDERED_DATA) {
-      throw std::invalid_argument(
-          "Unordered dimension labels are not yet supported.");
-    }
+  if (label_order == DataOrder::UNORDERED_DATA) {
+    throw std::invalid_argument(
+        "Unordered dimension labels are not yet supported.");
   }
 
   // Create and set dimension label domain.

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3129,12 +3129,10 @@ int32_t tiledb_array_create(
     }
 
     // Check no dimension labels (not yet implemented in REST)
-    if constexpr (is_experimental_build) {
-      if (array_schema->array_schema_->dim_label_num() > 0) {
-        throw StatusException(
-            Status_Error("Failed to create array; remote arrays with dimension "
-                         "labels are not currently supported."));
-      }
+    if (array_schema->array_schema_->dim_label_num() > 0) {
+      throw StatusException(
+          Status_Error("Failed to create array; remote arrays with dimension "
+                       "labels are not currently supported."));
     }
 
     throw_if_not_ok(rest_client->post_array_schema_to_rest(
@@ -3149,25 +3147,23 @@ int32_t tiledb_array_create(
         uri, array_schema->array_schema_, key));
 
     // Create any dimension labels in the array.
-    if constexpr (is_experimental_build) {
-      for (tiledb::sm::ArraySchema::dimension_label_size_type ilabel{0};
-           ilabel < array_schema->array_schema_->dim_label_num();
-           ++ilabel) {
-        // Get dimension label information and define URI and name.
-        const auto& dim_label_ref =
-            array_schema->array_schema_->dimension_label_reference(ilabel);
-        if (dim_label_ref.is_external())
-          continue;
-        if (!dim_label_ref.has_schema()) {
-          throw StatusException(
-              Status_Error("Failed to create array. Dimension labels that are "
-                           "not external must have a schema."));
-        }
-
-        // Create the dimension label array with the same key.
-        throw_if_not_ok(ctx->storage_manager()->array_create(
-            dim_label_ref.uri(uri), dim_label_ref.schema(), key));
+    for (tiledb::sm::ArraySchema::dimension_label_size_type ilabel{0};
+         ilabel < array_schema->array_schema_->dim_label_num();
+         ++ilabel) {
+      // Get dimension label information and define URI and name.
+      const auto& dim_label_ref =
+          array_schema->array_schema_->dimension_label_reference(ilabel);
+      if (dim_label_ref.is_external())
+        continue;
+      if (!dim_label_ref.has_schema()) {
+        throw StatusException(
+            Status_Error("Failed to create array. Dimension labels that are "
+                         "not external must have a schema."));
       }
+
+      // Create the dimension label array with the same key.
+      throw_if_not_ok(ctx->storage_manager()->array_create(
+          dim_label_ref.uri(uri), dim_label_ref.schema(), key));
     }
   }
   return TILEDB_OK;
@@ -3216,12 +3212,10 @@ int32_t tiledb_array_create_with_key(
     }
 
     // Check no dimension labels (not yet implemented in REST)
-    if constexpr (is_experimental_build) {
-      if (array_schema->array_schema_->dim_label_num() > 0) {
-        throw StatusException(
-            Status_Error("Failed to create array; remote arrays with dimension "
-                         "labels are not currently supported."));
-      }
+    if (array_schema->array_schema_->dim_label_num() > 0) {
+      throw StatusException(
+          Status_Error("Failed to create array; remote arrays with dimension "
+                       "labels are not currently supported."));
     }
 
     throw_if_not_ok(rest_client->post_array_schema_to_rest(
@@ -3239,25 +3233,23 @@ int32_t tiledb_array_create_with_key(
         uri, array_schema->array_schema_, key));
 
     // Create any dimension labels in the array.
-    if constexpr (is_experimental_build) {
-      for (tiledb::sm::ArraySchema::dimension_label_size_type ilabel{0};
-           ilabel < array_schema->array_schema_->dim_label_num();
-           ++ilabel) {
-        // Get dimension label information and define URI and name.
-        const auto& dim_label_ref =
-            array_schema->array_schema_->dimension_label_reference(ilabel);
-        if (dim_label_ref.is_external())
-          continue;
-        if (!dim_label_ref.has_schema()) {
-          throw StatusException(
-              Status_Error("Failed to create array. Dimension labels that are "
-                           "not external must have a schema."));
-        }
-
-        // Create the dimension label array with the same key.
-        throw_if_not_ok(ctx->storage_manager()->array_create(
-            dim_label_ref.uri(uri), dim_label_ref.schema(), key));
+    for (tiledb::sm::ArraySchema::dimension_label_size_type ilabel{0};
+         ilabel < array_schema->array_schema_->dim_label_num();
+         ++ilabel) {
+      // Get dimension label information and define URI and name.
+      const auto& dim_label_ref =
+          array_schema->array_schema_->dimension_label_reference(ilabel);
+      if (dim_label_ref.is_external())
+        continue;
+      if (!dim_label_ref.has_schema()) {
+        throw StatusException(
+            Status_Error("Failed to create array. Dimension labels that are "
+                         "not external must have a schema."));
       }
+
+      // Create the dimension label array with the same key.
+      throw_if_not_ok(ctx->storage_manager()->array_create(
+          dim_label_ref.uri(uri), dim_label_ref.schema(), key));
     }
   }
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/tiledb_dimension_label.cc
@@ -26,12 +26,12 @@
  * THE SOFTWARE.
  */
 
-#include "tiledb/sm/c_api/tiledb_dimension_label.h"
 #include "tiledb/api/c_api/dimension_label/dimension_label_api_internal.h"
 #include "tiledb/api/c_api/filter_list/filter_list_api_internal.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
 #include "tiledb/sm/c_api/api_argument_validator.h"
 #include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_dimension_label_experimental.h"
 
 using namespace tiledb::common;
 

--- a/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
+++ b/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
@@ -1,5 +1,5 @@
 /**
- * @file tiledb/sm/c_api/tiledb_dimension_label.h
+ * @file tiledb/sm/c_api/tiledb_dimension_label_experimental.h
  *
  * @section LICENSE
  *

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -42,6 +42,7 @@
  * API sections
  */
 #include "tiledb/api/c_api/group/group_api_external_experimental.h"
+#include "tiledb_dimension_label_experimental.h"
 
 /* ********************************* */
 /*               MACROS              */

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -637,7 +637,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization base format version number. */
-const format_version_t base_format_version = 17;
+const format_version_t base_format_version = 18;
 
 /**
  * The TileDB serialization format version number.

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -245,11 +245,10 @@ tuple<
 StorageManagerCanonical::array_open_for_writes(Array* array) {
   // Checks
   if (!vfs()->supports_uri_scheme(array->array_uri()))
-    return {
-        logger_->status(Status_StorageManagerError(
-            "Cannot open array; URI scheme unsupported.")),
-        nullopt,
-        nullopt};
+    return {logger_->status(Status_StorageManagerError(
+                "Cannot open array; URI scheme unsupported.")),
+            nullopt,
+            nullopt};
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
@@ -268,10 +267,9 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
       err << version;
       err << ") is not the library format version (";
       err << constants::format_version << ")";
-      return {
-          logger_->status(Status_StorageManagerError(err.str())),
-          nullopt,
-          nullopt};
+      return {logger_->status(Status_StorageManagerError(err.str())),
+              nullopt,
+              nullopt};
     }
   } else {
     if (version > constants::format_version) {
@@ -280,10 +278,9 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
       err << version;
       err << ") is newer than library format version (";
       err << constants::format_version << ")";
-      return {
-          logger_->status(Status_StorageManagerError(err.str())),
-          nullopt,
-          nullopt};
+      return {logger_->status(Status_StorageManagerError(err.str())),
+              nullopt,
+              nullopt};
     }
   }
 
@@ -1456,10 +1453,9 @@ StorageManagerCanonical::load_array_schema_from_uri(
   Deserializer deserializer(tile.data(), tile.size());
 
   try {
-    return {
-        Status::Ok(),
-        make_shared<ArraySchema>(
-            HERE(), ArraySchema::deserialize(deserializer, schema_uri))};
+    return {Status::Ok(),
+            make_shared<ArraySchema>(
+                HERE(), ArraySchema::deserialize(deserializer, schema_uri))};
   } catch (const StatusException& e) {
     return {Status_StorageManagerError(e.what()), nullopt};
   }
@@ -1472,10 +1468,9 @@ StorageManagerCanonical::load_array_schema_latest(
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
-    return {
-        logger_->status(Status_StorageManagerError(
-            "Cannot load array schema; Invalid array URI")),
-        nullopt};
+    return {logger_->status(Status_StorageManagerError(
+                "Cannot load array schema; Invalid array URI")),
+            nullopt};
 
   // Load schema from URI
   const URI& schema_uri = array_dir.latest_array_schema_uri();
@@ -1517,17 +1512,15 @@ StorageManagerCanonical::load_all_array_schemas(
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
-    return {
-        logger_->status(Status_StorageManagerError(
-            "Cannot load all array schemas; Invalid array URI")),
-        nullopt};
+    return {logger_->status(Status_StorageManagerError(
+                "Cannot load all array schemas; Invalid array URI")),
+            nullopt};
 
   const std::vector<URI>& schema_uris = array_dir.array_schema_uris();
   if (schema_uris.empty()) {
-    return {
-        logger_->status(Status_StorageManagerError(
-            "Cannot get the array schema vector; No array schemas found.")),
-        nullopt};
+    return {logger_->status(Status_StorageManagerError(
+                "Cannot get the array schema vector; No array schemas found.")),
+            nullopt};
   }
 
   std::vector<shared_ptr<ArraySchema>> schema_vector;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -245,10 +245,11 @@ tuple<
 StorageManagerCanonical::array_open_for_writes(Array* array) {
   // Checks
   if (!vfs()->supports_uri_scheme(array->array_uri()))
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot open array; URI scheme unsupported.")),
-            nullopt,
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot open array; URI scheme unsupported.")),
+        nullopt,
+        nullopt};
 
   // Load array schemas
   auto&& [st_schemas, array_schema_latest, array_schemas_all] =
@@ -267,9 +268,10 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
       err << version;
       err << ") is not the library format version (";
       err << constants::format_version << ")";
-      return {logger_->status(Status_StorageManagerError(err.str())),
-              nullopt,
-              nullopt};
+      return {
+          logger_->status(Status_StorageManagerError(err.str())),
+          nullopt,
+          nullopt};
     }
   } else {
     if (version > constants::format_version) {
@@ -278,9 +280,10 @@ StorageManagerCanonical::array_open_for_writes(Array* array) {
       err << version;
       err << ") is newer than library format version (";
       err << constants::format_version << ")";
-      return {logger_->status(Status_StorageManagerError(err.str())),
-              nullopt,
-              nullopt};
+      return {
+          logger_->status(Status_StorageManagerError(err.str())),
+          nullopt,
+          nullopt};
     }
   }
 
@@ -721,11 +724,10 @@ Status StorageManagerCanonical::array_create(
       array_uri.join_path(constants::array_fragment_meta_dir_name);
   RETURN_NOT_OK(vfs()->create_dir(array_fragment_metadata_uri));
 
-  if constexpr (is_experimental_build) {
-    URI array_dimension_labels_uri =
-        array_uri.join_path(constants::array_dimension_labels_dir_name);
-    RETURN_NOT_OK(vfs()->create_dir(array_dimension_labels_uri));
-  }
+  // Create dimension label directory
+  URI array_dimension_labels_uri =
+      array_uri.join_path(constants::array_dimension_labels_dir_name);
+  RETURN_NOT_OK(vfs()->create_dir(array_dimension_labels_uri));
 
   // Get encryption key from config
   Status st;
@@ -1454,9 +1456,10 @@ StorageManagerCanonical::load_array_schema_from_uri(
   Deserializer deserializer(tile.data(), tile.size());
 
   try {
-    return {Status::Ok(),
-            make_shared<ArraySchema>(
-                HERE(), ArraySchema::deserialize(deserializer, schema_uri))};
+    return {
+        Status::Ok(),
+        make_shared<ArraySchema>(
+            HERE(), ArraySchema::deserialize(deserializer, schema_uri))};
   } catch (const StatusException& e) {
     return {Status_StorageManagerError(e.what()), nullopt};
   }
@@ -1469,9 +1472,10 @@ StorageManagerCanonical::load_array_schema_latest(
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot load array schema; Invalid array URI")),
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot load array schema; Invalid array URI")),
+        nullopt};
 
   // Load schema from URI
   const URI& schema_uri = array_dir.latest_array_schema_uri();
@@ -1513,15 +1517,17 @@ StorageManagerCanonical::load_all_array_schemas(
 
   const URI& array_uri = array_dir.uri();
   if (array_uri.is_invalid())
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot load all array schemas; Invalid array URI")),
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot load all array schemas; Invalid array URI")),
+        nullopt};
 
   const std::vector<URI>& schema_uris = array_dir.array_schema_uris();
   if (schema_uris.empty()) {
-    return {logger_->status(Status_StorageManagerError(
-                "Cannot get the array schema vector; No array schemas found.")),
-            nullopt};
+    return {
+        logger_->status(Status_StorageManagerError(
+            "Cannot get the array schema vector; No array schemas found.")),
+        nullopt};
   }
 
   std::vector<shared_ptr<ArraySchema>> schema_vector;


### PR DESCRIPTION
Move dimension labels outside of the experimental build for increasing/decreasing labels and add to `tiledb_experimental.h` header. Add test to make sure unordered labels are still experimental only.

---
TYPE: FEATURE
DESC: Enables dimension labels for the C-API
