### PR TITLE
Fix stack buffer overflow in unit_rtree

### DIFF
--- a/tiledb/sm/rtree/test/unit_rtree.cc
+++ b/tiledb/sm/rtree/test/unit_rtree.cc
@@ -98,7 +98,7 @@ Domain create_domain(
     }
     ByteVecValue tile_extent;
     if (dim_tile_extents[d] != nullptr) {
-      auto tile_extent_size = 2 * datatype_size(dim_types[d]);
+      auto tile_extent_size = datatype_size(dim_types[d]);
       tile_extent.resize(tile_extent_size);
       std::memcpy(tile_extent.data(), dim_tile_extents[d], tile_extent_size);
     }


### PR DESCRIPTION
A minor typo in unit_rtree lead a helper function to attempt copying too many bytes when creating tile extents.

---
TYPE: BUG
DESC: Fix shallow test-only bug in unit_rtree.cc
