### PR TITLE
Fix stack-use-after-free in unit_thread_pool

### DIFF
--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -146,13 +146,20 @@ TEST_CASE("ThreadPool: Test wait status", "[threadpool]") {
   REQUIRE(result == 100);
 }
 
+struct AtomicHolder {
+  AtomicHolder(int val)
+      : val_(val) {
+  }
+  std::atomic<int> val_;
+};
+
 TEST_CASE("ThreadPool: Test no wait", "[threadpool]") {
   {
     ThreadPool pool{4};
-    std::atomic<int> result(0);
+    auto ptr = tdb::make_shared<AtomicHolder>(HERE(), 0);
     for (int i = 0; i < 5; i++) {
-      ThreadPool::Task task = pool.execute([&result]() {
-        result++;
+      ThreadPool::Task task = pool.execute([result = ptr]() {
+        result->val_++;
         std::this_thread::sleep_for(std::chrono::milliseconds(random_ms(1000)));
         return Status::Ok();
       });


### PR DESCRIPTION
The point of this test is to make sure thread pools clean up after
themselves when going out of scope. The test as written contained a
stack-use-after-free due to the std::atomic variable being deallocated
while there were still threads running with references to it. This just
moves the std::atomic into a shared_ptr which is then referenced by each
thread pool task.

---
TYPE: BUG
DESC: Fix stack use after free bug in unit_thread_pool