### PR TITLE
Avoid use-after-free bug

### DIFF
--- a/tiledb/sm/filter/bitsort_filter.cc
+++ b/tiledb/sm/filter/bitsort_filter.cc
@@ -375,7 +375,7 @@ void BitSortFilter::run_reverse_dim_tile(
   }
 
   // Clear out the filtered buffer.
-  filtered_buffer.clear();
+  // filtered_buffer.clear();
 }
 
 BitSortFilter* BitSortFilter::clone_impl() const {


### PR DESCRIPTION
This isn't the complete fix. It just shows the cause is that the bitsort_filter is resetting a buffer in the middle of a parallel computation while other threads may still be accessing the underlying FilteredBuffer data.

---
TYPE: BUG
DESC: Avoid use-after-free in bitsort filters
