### PR TITLE
Build all tests in Full CI, prevent SC-24653

### DIFF
--- a/experimental/tiledb/common/dag/data_block/test/unit_pool_allocator.cc
+++ b/experimental/tiledb/common/dag/data_block/test/unit_pool_allocator.cc
@@ -39,11 +39,11 @@
 using namespace tiledb::common;
 
 class big_class {
-  [[maybe_unused]] std::array<char, 2 * 1024 * 1024> storage_;
+  std::array<char, 2 * 1024 * 1024> storage_;
 };
 
 class small_class {
-  [[maybe_unused]] std::array<char, 4 * 1024> storage_;
+  std::array<char, 4 * 1024> storage_;
 };
 
 /**

--- a/experimental/tiledb/common/dag/nodes/detail/simple/mimo.h
+++ b/experimental/tiledb/common/dag/nodes/detail/simple/mimo.h
@@ -495,7 +495,7 @@ class GeneralFunctionNode<
       case NodeState::init:
 
         instruction_counter_ = NodeState::input;
-	[[fallthrough]];
+        [[fallthrough]];
 
       case NodeState::input:
         /*
@@ -532,7 +532,7 @@ class GeneralFunctionNode<
         drain_all();
 
         instruction_counter_ = NodeState::compute;
-	[[fallthrough]];
+        [[fallthrough]];
 
       case NodeState::compute:
 
@@ -554,7 +554,7 @@ class GeneralFunctionNode<
         }
 
         instruction_counter_ = NodeState::output;
-	[[fallthrough]];
+        [[fallthrough]];
 
       case NodeState::output:
         if constexpr (!is_consumer_) {

--- a/experimental/tiledb/common/dag/nodes/detail/simple/mimo.h
+++ b/experimental/tiledb/common/dag/nodes/detail/simple/mimo.h
@@ -495,6 +495,8 @@ class GeneralFunctionNode<
       case NodeState::init:
 
         instruction_counter_ = NodeState::input;
+	[[fallthrough]];
+
       case NodeState::input:
         /*
          * Here begins pull-check-extract-drain (aka `input`)
@@ -530,6 +532,8 @@ class GeneralFunctionNode<
         drain_all();
 
         instruction_counter_ = NodeState::compute;
+	[[fallthrough]];
+
       case NodeState::compute:
 
         /*
@@ -550,6 +554,8 @@ class GeneralFunctionNode<
         }
 
         instruction_counter_ = NodeState::output;
+	[[fallthrough]];
+
       case NodeState::output:
         if constexpr (!is_consumer_) {
           /*

--- a/experimental/tiledb/common/dag/nodes/test/unit_general_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_general_nodes.cc
@@ -794,8 +794,8 @@ TEST_CASE(
     CHECK(std::equal(input2.begin(), input2.end(), output2.begin()) == false);
   }
 
-  ProducerNode<AsyncMover3, size_t> source_node1(generators{19});
-  ProducerNode<AsyncMover3, double> source_node2(generators{337});
+  ProducerNode<AsyncMover3, size_t> source_node1{generators{19}};
+  ProducerNode<AsyncMover3, double> source_node2{generators{337}};
 
   GeneralFunctionNode<
       AsyncMover3,

--- a/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
@@ -1136,7 +1136,7 @@ TEMPLATE_TEST_CASE(
   }
 
   Producer source_node([&i]() { return (*i++); });
-  Consumer sink_node(terminal{j});
+  Consumer sink_node{terminal{j}};
 
   auto a = Edge(source_node, sink_node);
   auto source = [&]() { source_node.run_for(rounds); };
@@ -1242,7 +1242,7 @@ TEMPLATE_TEST_CASE(
   auto w = std::back_inserter(output);
   terminal c{w};
 
-  Producer source_node(generators{19});
+  Producer source_node{generators{19}};
   Function mid_node([](size_t k) { return k; });
   Consumer sink_node{c};
 

--- a/experimental/tiledb/common/dag/state_machine/test/unit_sched.cc
+++ b/experimental/tiledb/common/dag/state_machine/test/unit_sched.cc
@@ -599,9 +599,6 @@ void test_stingy(Mover1& a, Mover2& b, bool debug = false) {
 
   auto mid_node_fn = [&](alt_triple_maker_state<size_t>& alt_state) {
     switch (alt_state.counter) {
-      if (debug) {
-        std::cout << "mid node iteration " << alt_state.n << std::endl;
-      }
 
       case state::init: {
         alt_state.n = rounds;

--- a/experimental/tiledb/common/dag/state_machine/test/unit_sched.cc
+++ b/experimental/tiledb/common/dag/state_machine/test/unit_sched.cc
@@ -599,7 +599,6 @@ void test_stingy(Mover1& a, Mover2& b, bool debug = false) {
 
   auto mid_node_fn = [&](alt_triple_maker_state<size_t>& alt_state) {
     switch (alt_state.counter) {
-
       case state::init: {
         alt_state.n = rounds;
       }

--- a/experimental/tiledb/common/dag/utility/test/unit_spinlock.cc
+++ b/experimental/tiledb/common/dag/utility/test/unit_spinlock.cc
@@ -34,6 +34,8 @@
 #include <future>
 #include <mutex>
 #include <vector>
+#include <chrono>
+#include <thread>
 #include "../spinlock.h"
 
 using namespace tiledb::common;

--- a/experimental/tiledb/common/dag/utility/test/unit_spinlock.cc
+++ b/experimental/tiledb/common/dag/utility/test/unit_spinlock.cc
@@ -31,11 +31,11 @@
  */
 
 #include <test/support/tdb_catch.h>
+#include <chrono>
 #include <future>
 #include <mutex>
-#include <vector>
-#include <chrono>
 #include <thread>
+#include <vector>
 #include "../spinlock.h"
 
 using namespace tiledb::common;

--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -55,6 +55,6 @@ make -C tiledb install
 cd $GITHUB_WORKSPACE/build
 ls -la
 
-make -j4 -C tiledb tiledb_unit
+make -j4 -C tiledb tests
 make -j4 -C tiledb tiledb_regression
 make -j4 -C tiledb all_link_complete


### PR DESCRIPTION
Build all tests in Full CI, in order to prevent SC-24653 (failed unit test build w/ experimental enabled).

---
TYPE: NO_HISTORY