### PR TITLE
Set santizer settings for all of TileDB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,25 @@ if (COMPILER_SUPPORTS_AVX2)
   add_compile_options(${COMPILER_AVX2_FLAG})
 endif()
 
-
+# HACK: Set the sanitizer configuration globally after the
+# superbuild has finished. We want to enable sanitization for
+# TileDB, but not our dependencies.
+#
+# The reasoning for setting this globally is due to false positives
+# in the `AddressSanitizerContainerOverflow` checks [1].
+#
+# [1] https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow#false-positives
+if (SANITIZER)
+  string(TOLOWER ${SANITIZER} SANITIZER)
+  if (NOT SANITIZER MATCHES "^(address|memory|leak|thread|undefined)$")
+    message(FATAL_ERROR "Unknown clang sanitizer: ${SANITIZER})")
+  else()
+    message(STATUS "The TileDB library is compiled with sanitizer ${SANITIZER} enabled")
+  endif()
+  add_compile_options(-DTILEDB_SANITIZER=${SANITIZER})
+  add_compile_options(-g -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=${SANITIZER})
+  add_link_options(-fsanitize=${SANITIZER})
+endif()
 
 #######################################################
 # Header Files

--- a/test/src/unit-cppapi-bitsort-filter.cc
+++ b/test/src/unit-cppapi-bitsort-filter.cc
@@ -30,6 +30,8 @@
  * Tests the C++ API for bitsort filter related functions.
  */
 
+#ifndef TILEDB_SANITIZER
+
 #include <map>
 #include <optional>
 #include <random>
@@ -930,3 +932,5 @@ TEMPLATE_TEST_CASE(
         hilbert_order);
   }
 }
+
+#endif  // ifndef TILEDB_SANITIZER

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -443,22 +443,6 @@ endif()
 # Compile options/definitions
 ############################################################
 
-if (SANITIZER)
-  if (NOT CMAKE_BUILD_TYPE MATCHES "Debug")
-    message(FATAL_ERROR "Sanitizers only enabled for Debug build")
-  endif()
-  string(TOLOWER ${SANITIZER} SANITIZER)
-  if (NOT SANITIZER MATCHES "^(address|memory|leak|thread|undefined)$")
-    message(FATAL_ERROR "Unknown clang sanitizer: ${SANITIZER})")
-  else()
-    message(STATUS "The TileDB library is compiled with sanitizer ${SANITIZER} enabled")
-  endif()
-  target_compile_options(TILEDB_CORE_OBJECTS
-    PRIVATE
-      -g -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=${SANITIZER}
-  )
-endif()
-
 if (TILEDB_VERBOSE)
   add_definitions(-DTILEDB_VERBOSE)
   message(STATUS "The TileDB library is compiled with verbosity.")


### PR DESCRIPTION
This changes ensures that all TileDB source code is compiled and linked with the required sanitizer options when requested. For the time being we're living with this hack for running nightly ASAN tests until we update the build to avoid the need.

This also disables the unit-cppapi-bitsort-filter.cc test when run under ASAN as it currently fails due to a user-after-free issue. We're currently unsure on whether we'll be keeping this particular filter so for now we just avoid the issue when running ASAN. We're keeping the test around to run in other builds just to prevent unnoticed bitrot.

<long description>

---
TYPE: IMPROVEMENT
DESC: Set ASAN options for TileDB
