### PR TITLE
Query v2: Add array directory and fragment meta ser/deser behind flag

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -1222,13 +1222,14 @@ TEST_CASE(
     "Backwards compatibility: Upgrades an array of older version and "
     "write/read it",
     "[backwards-compat][upgrade-version][write-read-new-version]") {
-  bool serialized = false;
+  bool serialize = false, refactored_query_v2 = false;
   SECTION("no serialization") {
-    serialized = false;
+    serialize = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled") {
-    serialized = true;
+    serialize = true;
+    refactored_query_v2 = GENERATE(true, false);
   }
 #endif
 
@@ -1259,7 +1260,12 @@ TEST_CASE(
 
   ServerQueryBuffers server_buffers;
   submit_query_wrapper(
-      ctx, array_name, &query_read1, server_buffers, serialized);
+      ctx,
+      array_name,
+      &query_read1,
+      server_buffers,
+      serialize,
+      refactored_query_v2);
   array_read1.close();
 
   for (int i = 0; i < 4; i++) {
@@ -1281,14 +1287,19 @@ TEST_CASE(
   query_write.set_data_buffer("d2", d2_write);
 
   submit_query_wrapper(
-      ctx, array_name, &query_write, server_buffers, serialized);
+      ctx,
+      array_name,
+      &query_write,
+      server_buffers,
+      serialize,
+      refactored_query_v2);
 
   array_write.close();
 
   FragmentInfo fragment_info(ctx, array_name);
   fragment_info.load();
 
-  if (serialized) {
+  if (serialize) {
     FragmentInfo deserialized_fragment_info(ctx, array_name);
     tiledb_fragment_info_serialize(
         ctx.ptr().get(),
@@ -1324,7 +1335,12 @@ TEST_CASE(
       .set_data_buffer("d2", d2_read2);
 
   submit_query_wrapper(
-      ctx, array_name, &query_read2, server_buffers, serialized);
+      ctx,
+      array_name,
+      &query_read2,
+      server_buffers,
+      serialize,
+      refactored_query_v2);
   array_read2.close();
 
   for (int i = 0; i < 2; i++) {

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -87,7 +87,10 @@ struct ArrayFx {
   tiledb_encryption_type_t encryption_type_ = TILEDB_NO_ENCRYPTION;
   const char* encryption_key_ = nullptr;
 
-  // Buffers to allocate on query size for serialized queries
+  // Serialization parameters
+  bool serialize_ = false;
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
   tiledb::test::ServerQueryBuffers server_buffers_;
 
   // Functions
@@ -885,16 +888,16 @@ TEST_CASE_METHOD(
   std::string temp_dir = fs_vec_[0]->temp_dir();
 
   std::string array_name = temp_dir + "array-open-at-reads";
-  bool serialized = false;
   SECTION("- without encryption") {
     encryption_type_ = TILEDB_NO_ENCRYPTION;
     encryption_key_ = nullptr;
     SECTION("no serialization") {
-      serialized = false;
+      serialize_ = false;
     }
 #ifdef TILEDB_SERIALIZATION
     SECTION("serialization enabled") {
-      serialized = true;
+      serialize_ = true;
+      refactored_query_v2_ = GENERATE(true, false);
     }
 #endif
   }
@@ -902,14 +905,6 @@ TEST_CASE_METHOD(
   SECTION("- with encryption") {
     encryption_type_ = TILEDB_AES_256_GCM;
     encryption_key_ = "0123456789abcdeF0123456789abcdeF";
-    SECTION("no serialization") {
-      serialized = false;
-    }
-    SECTION("serialization enabled") {
-#ifdef TILEDB_SERIALIZATION
-      serialized = true;
-#endif
-    }
   }
 
   create_temp_dir(temp_dir);
@@ -960,7 +955,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1010,7 +1010,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_upd, &buffer_upd_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1069,7 +1074,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1128,7 +1138,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1180,7 +1195,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1238,7 +1258,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Clean up but don't close the array yet (we will reopen it).
@@ -1270,7 +1295,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Clean up but don't close the array yet (we will reopen it).
@@ -1305,7 +1335,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1370,7 +1405,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1435,7 +1475,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1474,16 +1519,16 @@ TEST_CASE_METHOD(
   std::string temp_dir = fs_vec_[0]->temp_dir();
 
   std::string array_name = temp_dir + "array-open-at-writes";
-  bool serialized = false;
   SECTION("- without encryption") {
     encryption_type_ = TILEDB_NO_ENCRYPTION;
     encryption_key_ = nullptr;
     SECTION("no serialization") {
-      serialized = false;
+      serialize_ = false;
     }
 #ifdef TILEDB_SERIALIZATION
     SECTION("serialization enabled") {
-      serialized = true;
+      serialize_ = true;
+      refactored_query_v2_ = GENERATE(true, false);
     }
 #endif
   }
@@ -1491,14 +1536,6 @@ TEST_CASE_METHOD(
   SECTION("- with encryption") {
     encryption_type_ = TILEDB_AES_256_GCM;
     encryption_key_ = "0123456789abcdeF0123456789abcdeF";
-    SECTION("no serialization") {
-      serialized = false;
-    }
-    SECTION("serialization enabled") {
-#ifdef TILEDB_SERIALIZATION
-      serialized = true;
-#endif
-    }
   }
 
   create_temp_dir(temp_dir);
@@ -1551,7 +1588,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_a1, &buffer_a1_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Get written timestamp
@@ -1617,7 +1659,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -1669,7 +1716,12 @@ TEST_CASE_METHOD(
       ctx_, query, "a", buffer_read, &buffer_read_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb::test::submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array and clean up
@@ -2575,24 +2627,33 @@ TEST_CASE_METHOD(
   // opened
   tiledb_query_t* deserialized_query;
   std::vector<uint8_t> serialized;
-  rc = tiledb_query_v2_serialize(
-      ctx_,
-      array_name.c_str(),
-      serialized,
-      true,
-      query_client,
-      &deserialized_query);
+  rc = serialize_query(ctx_, query_client, &serialized, 1);
   REQUIRE(rc == TILEDB_OK);
 
-  // 9. Server: Submit query WITHOUT re-opening the array, using under the hood
+  // 9. Server: Deserialize query request
+  // Allocate new context for server
+  tiledb_ctx_t* server_ctx;
+  tiledb_ctx_alloc(config, &server_ctx);
+  rc = deserialize_array_and_query(
+      server_ctx, serialized, &deserialized_query, array_name.c_str(), 0);
+
+  // 10. Server: Submit query WITHOUT re-opening the array, using under the hood
   // the array found in the deserialized query
-  rc = tiledb_query_submit(ctx_, deserialized_query);
+  rc = tiledb_query_submit(server_ctx, deserialized_query);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_finalize(ctx_, deserialized_query);
+  rc = tiledb_query_finalize(server_ctx, deserialized_query);
   CHECK(rc == TILEDB_OK);
 
-  // 10. Server: serialize the query with the results back to the client
-  // 11. Client: deserialize
+  // 11. Server: serialize the query with the results back to the client
+  rc = serialize_query(server_ctx, deserialized_query, &serialized, 0);
+  REQUIRE(rc == TILEDB_OK);
+
+  tiledb_ctx_free(&server_ctx);
+  CHECK(server_ctx == nullptr);
+
+  // 12. Client: Deserialize query
+  rc = deserialize_query(ctx_, serialized, query_client, 1);
+  REQUIRE(rc == TILEDB_OK);
 
   // Clean up
   tiledb_array_free(&array);

--- a/test/src/unit-capi-incomplete-2.cc
+++ b/test/src/unit-capi-incomplete-2.cc
@@ -52,8 +52,10 @@ struct IncompleteFx2 {
   // TileDB context
   tiledb_ctx_t* ctx_;
 
+  // Serialization parameters
   bool serialize_ = false;
-  // Buffers to allocate on query size for serialized queries
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
   ServerQueryBuffers server_buffers_;
 
   // Constructors/destructors
@@ -317,7 +319,12 @@ void IncompleteFx2::write_dense_full() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   // Close array
@@ -403,7 +410,12 @@ void IncompleteFx2::write_sparse_full() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   // Close array
@@ -468,7 +480,13 @@ void IncompleteFx2::check_dense_incomplete() {
   REQUIRE(rc == TILEDB_OK);
 
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -528,7 +546,13 @@ void IncompleteFx2::check_dense_until_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check buffer
@@ -544,7 +568,13 @@ void IncompleteFx2::check_dense_until_complete() {
 
   // Resubmit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -603,7 +633,13 @@ void IncompleteFx2::check_dense_shrink_buffer_size() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check buffer
@@ -625,7 +661,13 @@ void IncompleteFx2::check_dense_shrink_buffer_size() {
 
   // Resubmit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -687,7 +729,13 @@ void IncompleteFx2::check_dense_unsplittable_overflow() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Get status
@@ -749,7 +797,13 @@ void IncompleteFx2::check_dense_unsplittable_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check buffers
@@ -802,7 +856,13 @@ void IncompleteFx2::check_dense_reset_buffers() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check buffer
@@ -818,7 +878,13 @@ void IncompleteFx2::check_dense_reset_buffers() {
 
   // Resubmit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -880,7 +946,13 @@ void IncompleteFx2::check_sparse_incomplete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -939,7 +1011,13 @@ void IncompleteFx2::check_sparse_until_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -955,7 +1033,13 @@ void IncompleteFx2::check_sparse_until_complete() {
 
   // Resubmit the query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -970,7 +1054,13 @@ void IncompleteFx2::check_sparse_until_complete() {
 
   // Resubmit the query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check status
@@ -1030,7 +1120,13 @@ void IncompleteFx2::check_sparse_unsplittable_overflow() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
   tiledb_query_status_t status;
   rc = tiledb_query_get_status(ctx_, query, &status);
@@ -1091,7 +1187,13 @@ void IncompleteFx2::check_sparse_unsplittable_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Check buffers
@@ -1121,6 +1223,7 @@ TEST_CASE_METHOD(
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -1146,6 +1249,7 @@ TEST_CASE_METHOD(
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 

--- a/test/src/unit-capi-incomplete.cc
+++ b/test/src/unit-capi-incomplete.cc
@@ -54,8 +54,10 @@ struct IncompleteFx {
   // TileDB context
   tiledb_ctx_t* ctx_;
 
+  // Serialization parameters
   bool serialize_ = false;
-  // Buffers to allocate on query size for serialized queries
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
   ServerQueryBuffers server_buffers_;
 
   // Constructors/destructors
@@ -318,7 +320,12 @@ void IncompleteFx::write_dense_full() {
   CHECK(rc == TILEDB_OK);
 
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array
@@ -403,7 +410,12 @@ void IncompleteFx::write_sparse_full() {
   CHECK(rc == TILEDB_OK);
 
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   CHECK(rc == TILEDB_OK);
 
   // Close array
@@ -469,7 +481,13 @@ void IncompleteFx::check_dense_incomplete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -529,7 +547,13 @@ void IncompleteFx::check_dense_until_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check buffer
@@ -545,7 +569,13 @@ void IncompleteFx::check_dense_until_complete() {
 
   // Resubmit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -604,7 +634,13 @@ void IncompleteFx::check_dense_shrink_buffer_size() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check buffer
@@ -626,7 +662,13 @@ void IncompleteFx::check_dense_shrink_buffer_size() {
 
   // Resubmit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -688,7 +730,13 @@ void IncompleteFx::check_dense_unsplittable_overflow() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Get status
@@ -750,7 +798,13 @@ void IncompleteFx::check_dense_unsplittable_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check buffers
@@ -803,7 +857,13 @@ void IncompleteFx::check_dense_reset_buffers() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check buffer
@@ -819,7 +879,13 @@ void IncompleteFx::check_dense_reset_buffers() {
 
   // Resubmit query
   rc = submit_query_wrapper(
-      ctx_, DENSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      DENSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -878,7 +944,13 @@ void IncompleteFx::check_sparse_incomplete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -938,7 +1010,13 @@ void IncompleteFx::check_sparse_until_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -954,7 +1032,13 @@ void IncompleteFx::check_sparse_until_complete() {
 
   // Resubmit the query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check status
@@ -977,7 +1061,13 @@ void IncompleteFx::check_sparse_until_complete() {
   if (!use_refactored_sparse_global_order_reader()) {
     // Submit query
     rc = submit_query_wrapper(
-        ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+        ctx_,
+        SPARSE_ARRAY_NAME,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
     CHECK(rc == TILEDB_OK);
 
     // Check status
@@ -1036,7 +1126,13 @@ void IncompleteFx::check_sparse_unsplittable_overflow() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
   tiledb_query_status_t status;
   rc = tiledb_query_get_status(ctx_, query, &status);
@@ -1105,7 +1201,13 @@ void IncompleteFx::check_sparse_unsplittable_complete() {
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(rc == TILEDB_OK);
 
   // Check buffers
@@ -1135,6 +1237,7 @@ TEST_CASE_METHOD(
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -1160,6 +1263,7 @@ TEST_CASE_METHOD(
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -1182,9 +1286,12 @@ TEST_CASE_METHOD(
   SECTION("no serialization") {
     serialize_ = false;
   }
+#ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
+#endif
 
   remove_dense_array();
   create_dense_array();

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -107,7 +107,11 @@ struct SerializationFx {
   Context ctx;
   VFS vfs;
 
-  // Buffers to allocate on query size for serialized queries
+  // Serialization parameters
+  bool serialize_ = true;
+  bool refactored_query_v2_ = false;
+  bool finalize_ = false;
+  // Buffers to allocate on server side for serialized queries
   tiledb::test::ServerQueryBuffers server_buffers_;
 
   SerializationFx()
@@ -215,7 +219,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the write stats
@@ -259,7 +269,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the write stats
@@ -301,7 +317,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the write stats
@@ -320,7 +342,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the delete stats
@@ -365,7 +393,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the write stats
@@ -379,6 +413,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Query serialization, dense",
     "[query][dense][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_DENSE);
   auto expected_results = write_dense_array();
 
@@ -401,7 +436,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -445,7 +486,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -505,7 +552,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -555,7 +608,13 @@ TEST_CASE_METHOD(
     // Submit initial query.
     set_buffers(query);
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     // The deserialized query should also include the read stats
     check_read_stats(query);
@@ -571,7 +630,13 @@ TEST_CASE_METHOD(
     // Reset buffers, serialize and resubmit
     set_buffers(query);
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     // The deserialized query should also include the read stats
     check_read_stats(query);
@@ -589,7 +654,13 @@ TEST_CASE_METHOD(
     // Reset buffers, serialize and resubmit
     set_buffers(query);
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     // The deserialized query should also include the read stats
     check_read_stats(query);
@@ -610,6 +681,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Query serialization, sparse",
     "[query][sparse][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_SPARSE);
   write_sparse_array();
 
@@ -634,7 +706,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -655,6 +733,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Query serialization, sparse, old client",
     "[query][sparse][serialization][old-client]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_SPARSE);
   write_sparse_array();
 
@@ -685,7 +764,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -706,6 +791,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Query serialization, split coords, sparse",
     "[query][sparse][serialization][split-coords]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_SPARSE);
   write_sparse_array_split_coords();
 
@@ -730,7 +816,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -752,6 +844,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Query serialization, dense ranges",
     "[query][dense][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_DENSE);
   write_dense_array_ranges();
 
@@ -775,7 +868,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -811,7 +910,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -851,7 +956,13 @@ TEST_CASE_METHOD(
     set_buffers(query);
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     // The deserialized query should also include the read stats
     check_read_stats(query);
@@ -868,7 +979,13 @@ TEST_CASE_METHOD(
     set_buffers(query);
     // Submit query
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     // The deserialized query should also include the read stats
     check_read_stats(query);
@@ -885,7 +1002,13 @@ TEST_CASE_METHOD(
     set_buffers(query);
     // Submit query
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     // The deserialized query should also include the read stats
     check_read_stats(query);
@@ -906,6 +1029,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Query serialization, sparse delete",
     "[query][sparse][delete][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_SPARSE);
   write_sparse_array();
   write_sparse_delete();
@@ -931,7 +1055,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the read stats
@@ -952,13 +1082,13 @@ TEST_CASE_METHOD(
     SerializationFx,
     "Global order writes serialization",
     "[global-order-write][serialization][dense]") {
-  bool serialized = false;
   SECTION("no serialization") {
-    serialized = false;
+    serialize_ = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
-    serialized = true;
+    serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -1023,13 +1153,24 @@ TEST_CASE_METHOD(
     // Simulate REST submit()
     if (begin < end) {
       submit_query_wrapper(
-          ctx, array_uri, &query, server_buffers_, serialized, false);
+          ctx,
+          array_uri,
+          &query,
+          server_buffers_,
+          serialize_,
+          refactored_query_v2_,
+          false);
     }
   }
 
   // Submit query
-  auto rc =
-      submit_query_wrapper(ctx, array_uri, &query, server_buffers_, serialized);
+  auto rc = submit_query_wrapper(
+      ctx,
+      array_uri,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   REQUIRE(query.query_status() == Query::Status::COMPLETE);
@@ -1055,7 +1196,12 @@ TEST_CASE_METHOD(
         "a3", a3_result_offsets.data(), a3_result_offsets.size());
 
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, serialized);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 

--- a/test/src/unit-capi-serialized_queries_using_subarray.cc
+++ b/test/src/unit-capi-serialized_queries_using_subarray.cc
@@ -108,7 +108,11 @@ struct SerializationFx {
   Context ctx;
   VFS vfs;
 
-  // Buffers to allocate on query size for serialized queries
+  // Serialization parameters
+  bool serialize_ = true;
+  bool refactored_query_v2_ = false;
+  bool finalize_ = false;
+  // Buffers to allocate on server side for serialized queries
   tiledb::test::ServerQueryBuffers server_buffers_;
 
   SerializationFx()
@@ -207,7 +211,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     // The deserialized query should also include the write stats
@@ -253,7 +263,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
   }
 
@@ -292,7 +308,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
   }
 
@@ -334,7 +356,13 @@ struct SerializationFx {
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
   }
 };
@@ -345,6 +373,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "subarray - Query serialization, dense",
     "[query][dense][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_DENSE);
   auto expected_results = write_dense_array();
 
@@ -369,7 +398,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -407,7 +442,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -470,7 +511,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -506,7 +553,13 @@ TEST_CASE_METHOD(
     // Submit initial query.
     set_buffers(query);
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     REQUIRE(query.query_status() == Query::Status::INCOMPLETE);
@@ -520,7 +573,13 @@ TEST_CASE_METHOD(
     // Reset buffers, serialize and resubmit
     set_buffers(query);
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     REQUIRE(query.query_status() == Query::Status::INCOMPLETE);
@@ -534,7 +593,13 @@ TEST_CASE_METHOD(
     // Reset buffers, serialize and resubmit
     set_buffers(query);
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
@@ -551,6 +616,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "subarray - Query serialization, sparse",
     "[query][sparse][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_SPARSE);
   write_sparse_array();
 
@@ -578,7 +644,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -595,6 +667,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "subarray - Query serialization, split coords, sparse",
     "[query][sparse][serialization][split-coords]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_SPARSE);
   write_sparse_array_split_coords();
 
@@ -621,7 +694,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -639,6 +718,7 @@ TEST_CASE_METHOD(
     SerializationFx,
     "subarray - Query serialization, dense ranges",
     "[query][dense][serialization]") {
+  refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_DENSE);
   write_dense_array_ranges();
 
@@ -664,7 +744,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -698,7 +784,13 @@ TEST_CASE_METHOD(
 
     // Submit query
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
 
@@ -735,7 +827,13 @@ TEST_CASE_METHOD(
     // Submit initial query.
     set_buffers(query);
     auto rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::INCOMPLETE);
 
@@ -750,7 +848,13 @@ TEST_CASE_METHOD(
     set_buffers(query);
     // Submit query
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     REQUIRE(query.query_status() == Query::Status::INCOMPLETE);
@@ -765,7 +869,13 @@ TEST_CASE_METHOD(
     set_buffers(query);
     // Submit query
     rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        finalize_);
     REQUIRE(rc == TILEDB_OK);
 
     REQUIRE(query.query_status() == Query::Status::COMPLETE);

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -87,7 +87,10 @@ struct SparseArrayFx {
   // Vector of supported filsystems
   const std::vector<std::unique_ptr<SupportedFs>> fs_vec_;
 
-  // Buffers to allocate on query size for serialized queries
+  // Serialization parameters
+  bool serialize_ = false;
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
   ServerQueryBuffers server_buffers_;
 
   // Functions
@@ -5892,13 +5895,13 @@ TEST_CASE_METHOD(
     SparseArrayFx,
     "C API: Test sparse array, global order with 0-sized buffers",
     "[capi][sparse][global-check][zero-buffers]") {
-  bool serialized = false;
   SECTION("no serialization") {
-    serialized = false;
+    serialize_ = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
-    serialized = true;
+    serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -5950,7 +5953,13 @@ TEST_CASE_METHOD(
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
+      ctx,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Close array
@@ -6163,13 +6172,13 @@ TEST_CASE_METHOD(
     SparseArrayFx,
     "C API: Test sparse array, split coordinate buffers, global write",
     "[capi][sparse][split-coords][global]") {
-  bool serialized = false;
   SECTION("no serialization") {
-    serialized = false;
+    serialize_ = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
-    serialized = true;
+    serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -6245,7 +6254,12 @@ TEST_CASE_METHOD(
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   // Close array
@@ -6308,7 +6322,12 @@ TEST_CASE_METHOD(
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   tiledb_query_status_t status;
@@ -6941,13 +6960,13 @@ TEST_CASE_METHOD(
     SparseArrayFx,
     "Sparse array: 2D, multi write global order",
     "[capi][sparse][2D][multi-write]") {
-  bool serialized = false;
   SECTION("no serialization") {
-    serialized = false;
+    serialize_ = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled") {
-    serialized = true;
+    serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -7023,7 +7042,13 @@ TEST_CASE_METHOD(
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized, false);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   REQUIRE(rc == TILEDB_OK);
 
   // Create new buffers of smaller size to test being able to write multiple
@@ -7080,7 +7105,12 @@ TEST_CASE_METHOD(
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialized);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   // Close array

--- a/test/src/unit-capi-sparse_heter.cc
+++ b/test/src/unit-capi-sparse_heter.cc
@@ -59,10 +59,11 @@ struct SparseHeterFx {
   // Vector of supported filsystems
   const std::vector<std::unique_ptr<SupportedFs>> fs_vec_;
 
-  // Buffers to allocate on query size for serialized queries
-  ServerQueryBuffers server_buffers_;
-
+  // Serialization parameters
   bool serialize_ = false;
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
+  ServerQueryBuffers server_buffers_;
 
   // Functions
   SparseHeterFx();
@@ -537,7 +538,12 @@ void SparseHeterFx::write_sparse_array_float_int64(
 
   // Submit query
   rc = submit_query_wrapper(
-      ctx_, array_name, &query, server_buffers_, serialize_);
+      ctx_,
+      array_name,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
   REQUIRE(rc == TILEDB_OK);
 
   // Close array
@@ -732,6 +738,7 @@ TEST_CASE_METHOD(
   SECTION("- Serialization") {
 #ifdef TILEDB_SERIALIZATION
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
 #endif
   }
 
@@ -1086,6 +1093,7 @@ TEST_CASE_METHOD(
   }
   SECTION("- Serialization") {
     serialize_ = true;
+    refactored_query_v2_ = GENERATE(true, false);
   }
 
   SupportedFsLocal local_fs;

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -59,8 +59,10 @@ struct DeletesFx {
   VFS vfs_;
   sm::StorageManager* sm_;
 
+  // Serialization parameters
   bool serialize_ = false;
-  // Buffers to allocate on query size for serialized queries
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
   ServerQueryBuffers server_buffers_;
 
   std::string key_ = "0123456789abcdeF0123456789abcdeF";
@@ -243,7 +245,12 @@ void DeletesFx::write_sparse(
 
   // Submit/finalize the query.
   submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
 
   // Close array.
   array->close();
@@ -274,7 +281,12 @@ void DeletesFx::write_sparse_v11(uint64_t timestamp) {
 
   // Submit/finalize the query.
   submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_);
 
   // Close array.
   array.close();
@@ -324,7 +336,13 @@ void DeletesFx::read_sparse(
 
   // Submit the query.
   submit_query_wrapper(
-      ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+      ctx_,
+      SPARSE_ARRAY_NAME,
+      &query,
+      server_buffers_,
+      serialize_,
+      refactored_query_v2_,
+      false);
   CHECK(query.query_status() == Query::Status::COMPLETE);
 
   // Get the query stats.
@@ -395,7 +413,13 @@ void DeletesFx::write_delete_condition(
     query.submit();
   } else {
     submit_query_wrapper(
-        ctx_, SPARSE_ARRAY_NAME, &query, server_buffers_, serialize_, false);
+        ctx_,
+        SPARSE_ARRAY_NAME,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
   }
   CHECK(query.query_status() == Query::Status::COMPLETE);
 
@@ -460,18 +484,20 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Test writing delete condition",
     "[cppapi][deletes][write-check]") {
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
-
   remove_sparse_array();
 
   bool encrypt = GENERATE(true, false);
+
+#ifdef TILEDB_SERIALIZATION
+  // serialization not supported for encrypted arrays
+  if (!encrypt) {
+    serialize_ = GENERATE(false, true);
+    if (serialize_) {
+      refactored_query_v2_ = GENERATE(true, false);
+    }
+  }
+#endif
+
   create_sparse_array(false, encrypt);
 
   // Define query condition (a1 < 4).
@@ -538,6 +564,12 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Test deletes, reading with delete condition",
     "[cppapi][deletes][read]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
   remove_sparse_array();
 
   bool consolidate = GENERATE(true, false);
@@ -546,15 +578,6 @@ TEST_CASE_METHOD(
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   if (!consolidate && (vacuum || purge_deleted_cells)) {
     return;
@@ -650,6 +673,13 @@ TEST_CASE_METHOD(
     "CPP API: Test deletes, reading with delete condition, consolidated "
     "fragment",
     "[cppapi][deletes][read][consolidated]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   bool consolidate = GENERATE(true, false);
@@ -658,15 +688,6 @@ TEST_CASE_METHOD(
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   if (!consolidate && (vacuum || purge_deleted_cells)) {
     return;
@@ -840,6 +861,13 @@ TEST_CASE_METHOD(
     "CPP API: Test deletes, reading with delete condition, delete duplicates "
     "from later fragments",
     "[cppapi][deletes][duplicates]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   bool purge_deleted_cells = GENERATE(true, false);
@@ -848,15 +876,6 @@ TEST_CASE_METHOD(
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   if (!consolidate && (vacuum || purge_deleted_cells)) {
     return;
@@ -920,16 +939,15 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Test deletes, commits consolidation",
     "[cppapi][deletes][commits][consolidation]") {
-  bool vacuum = GENERATE(false, true);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
 #ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
+
+  bool vacuum = GENERATE(false, true);
+
   remove_sparse_array();
   create_sparse_array();
 
@@ -979,21 +997,19 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Test deletes, consolidation, delete same cell earlier",
     "[cppapi][deletes][consolidation][same-cell]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   bool allows_dups = GENERATE(true, false);
   bool legacy = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   create_sparse_array(allows_dups);
 
@@ -1108,6 +1124,13 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Test deletes, multiple consolidation with deletes",
     "[cppapi][deletes][consolidation][multiple]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   bool purge_deleted_cells = GENERATE(true, false);
@@ -1115,15 +1138,6 @@ TEST_CASE_METHOD(
   bool legacy = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   create_sparse_array(allows_dups);
 
@@ -1231,6 +1245,13 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Test deletes, multiple cells with same coords in same fragment",
     "[cppapi][deletes][consolidation][multiple-cells-same-coords]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   bool purge_deleted_cells = GENERATE(true, false);
@@ -1238,15 +1259,6 @@ TEST_CASE_METHOD(
   bool legacy = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   create_sparse_array(allows_dups);
 
@@ -1420,6 +1432,13 @@ TEST_CASE_METHOD(
     "across tiles",
     "[cppapi][deletes][consolidation][multiple-cells-same-coords][across-"
     "tiles]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   bool purge_deleted_cells = GENERATE(true, false);
@@ -1427,15 +1446,6 @@ TEST_CASE_METHOD(
   bool legacy = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
   tiledb_layout_t read_layout = GENERATE(TILEDB_UNORDERED, TILEDB_GLOBAL_ORDER);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
-#ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
-  }
-#endif
 
   create_sparse_array(allows_dups);
 
@@ -1608,14 +1618,13 @@ TEST_CASE_METHOD(
     "CPP API: Test consolidating fragment with delete timestamp, with purge "
     "option",
     "[cppapi][deletes][consolidation][with-delete-meta][purge]") {
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
 #ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
+
   remove_sparse_array();
 
   create_sparse_array(false);
@@ -1735,14 +1744,18 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Deletion of fragment writes by timestamp and uri",
     "[cppapi][deletes][fragments]") {
+#ifdef TILEDB_SERIALIZATION
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
+  }
+#endif
+
   remove_sparse_array();
 
   // Conditionally consolidate and vacuum
   bool consolidate = GENERATE(true, false);
   bool vacuum = GENERATE(true, false);
-#ifdef TILEDB_SERIALIZATION
-  serialize_ = GENERATE(true, false);
-#endif
 
   if (!consolidate && vacuum) {
     return;
@@ -1827,17 +1840,15 @@ TEST_CASE_METHOD(
     DeletesFx,
     "CPP API: Deletion of fragment writes consolidated with timestamps",
     "[cppapi][deletes][fragments][consolidation_with_timestamps]") {
-  remove_sparse_array();
-  bool vacuum = GENERATE(true, false);
-
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
 #ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
+
+  remove_sparse_array();
+  bool vacuum = GENERATE(true, false);
 
   // Write fragments at timestamps 1, 3, 5, 7
   create_sparse_array();
@@ -1899,12 +1910,10 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     DeletesFx, "CPP API: Deletion of array data", "[cppapi][deletes][array]") {
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
 #ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 
@@ -2008,12 +2017,10 @@ TEST_CASE_METHOD(
     return;
   }
 
-  SECTION("- No serialization") {
-    serialize_ = false;
-  }
 #ifdef TILEDB_SERIALIZATION
-  SECTION("- Serialization") {
-    serialize_ = true;
+  serialize_ = GENERATE(false, true);
+  if (serialize_) {
+    refactored_query_v2_ = GENERATE(true, false);
   }
 #endif
 

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -108,7 +108,8 @@ void write_2d_array(
     std::vector<T2>& buff_d2,
     std::vector<int32_t>& buff_a,
     tiledb_layout_t layout,
-    const bool serialized = false) {
+    const bool serialized = false,
+    const bool refactored_query_v2 = false) {
   Context ctx;
   Array array_w(ctx, array_name, TILEDB_WRITE);
   Query query_w(ctx, array_w, TILEDB_WRITE);
@@ -119,7 +120,12 @@ void write_2d_array(
   // Submit query
   test::ServerQueryBuffers server_buffers_;
   auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query_w, server_buffers_, serialized);
+      ctx,
+      array_name,
+      &query_w,
+      server_buffers_,
+      serialized,
+      refactored_query_v2);
   REQUIRE(rc == TILEDB_OK);
 
   array_w.close();
@@ -252,13 +258,14 @@ TEST_CASE("C++ API: Test Hilbert, errors", "[cppapi][hilbert][error]") {
 TEST_CASE(
     "C++ API: Test Hilbert, test 2D, int32, write unordered, read global",
     "[cppapi][hilbert][2d][int32]") {
-  bool serialized = false;
+  bool serialized = false, refactored_query_v2 = false;
   SECTION("no serialization") {
     serialized = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialized = true;
+    refactored_query_v2 = GENERATE(true, false);
   }
 #endif
   Context ctx;
@@ -279,7 +286,13 @@ TEST_CASE(
   std::vector<int32_t> buff_d1 = {1, 1, 4, 5};
   std::vector<int32_t> buff_d2 = {1, 3, 2, 4};
   write_2d_array<int32_t, int32_t>(
-      array_name, buff_d1, buff_d2, buff_a, TILEDB_UNORDERED, serialized);
+      array_name,
+      buff_d1,
+      buff_d2,
+      buff_a,
+      TILEDB_UNORDERED,
+      serialized,
+      refactored_query_v2);
 
   // Read
   SECTION("- Global order") {
@@ -294,7 +307,12 @@ TEST_CASE(
     query_r.set_layout(TILEDB_GLOBAL_ORDER);
     // Submit query
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query_r, server_buffers_, serialized);
+        ctx,
+        array_name,
+        &query_r,
+        server_buffers_,
+        serialized,
+        refactored_query_v2);
     REQUIRE(rc == TILEDB_OK);
     array_r.close();
 
@@ -319,7 +337,12 @@ TEST_CASE(
     query_r.set_layout(TILEDB_ROW_MAJOR);
     // Submit query
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query_r, server_buffers_, serialized);
+        ctx,
+        array_name,
+        &query_r,
+        server_buffers_,
+        serialized,
+        refactored_query_v2);
     REQUIRE(rc == TILEDB_OK);
     array_r.close();
 
@@ -344,7 +367,12 @@ TEST_CASE(
     query_r.set_layout(TILEDB_COL_MAJOR);
     // Submit query
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query_r, server_buffers_, serialized);
+        ctx,
+        array_name,
+        &query_r,
+        server_buffers_,
+        serialized,
+        refactored_query_v2);
     REQUIRE(rc == TILEDB_OK);
     array_r.close();
 
@@ -370,7 +398,12 @@ TEST_CASE(
     query_r.set_layout(TILEDB_UNORDERED);
     // Submit query
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query_r, server_buffers_, serialized);
+        ctx,
+        array_name,
+        &query_r,
+        server_buffers_,
+        serialized,
+        refactored_query_v2);
     REQUIRE(rc == TILEDB_OK);
     array_r.close();
 
@@ -405,7 +438,13 @@ TEST_CASE(
     query_r.set_layout(TILEDB_UNORDERED);
     // Submit query
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query_r, server_buffers_, serialized, false);
+        ctx,
+        array_name,
+        &query_r,
+        server_buffers_,
+        serialized,
+        refactored_query_v2,
+        false);
     REQUIRE(rc == TILEDB_OK);
     CHECK(query_r.query_status() == tiledb::Query::Status::COMPLETE);
     // check number of results
@@ -547,13 +586,14 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test Hilbert, test writing in global order",
     "[cppapi][hilbert][write][global-order]") {
-  bool serialized = false;
+  bool serialized = false, refactored_query_v2 = false;
   SECTION("no serialization") {
     serialized = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialized = true;
+    refactored_query_v2 = GENERATE(true, false);
   }
 #endif
 
@@ -587,7 +627,12 @@ TEST_CASE(
 
   test::ServerQueryBuffers server_buffers_;
   auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query_w, server_buffers_, serialized);
+      ctx,
+      array_name,
+      &query_w,
+      server_buffers_,
+      serialized,
+      refactored_query_v2);
   REQUIRE(rc == TILEDB_OK);
 
   // Remove array

--- a/test/src/unit-cppapi-updates.cc
+++ b/test/src/unit-cppapi-updates.cc
@@ -39,13 +39,14 @@ using namespace tiledb;
 TEST_CASE(
     "C++ API updates: test writing two identical fragments",
     "[updates][updates-identical-fragments]") {
-  bool serialized = false;
+  bool serialized = false, refactored_query_v2 = false;
   SECTION("no serialization") {
     serialized = false;
   }
 #ifdef TILEDB_SERIALIZATION
   SECTION("serialization enabled global order write") {
     serialized = true;
+    refactored_query_v2 = GENERATE(true, false);
   }
 #endif
   const std::string array_name = "updates_identical_fragments";
@@ -89,7 +90,12 @@ TEST_CASE(
       .set_offsets_buffer("a1", offsets_a1);
   test::ServerQueryBuffers server_buffers_;
   auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query_w1, server_buffers_, serialized);
+      ctx,
+      array_name,
+      &query_w1,
+      server_buffers_,
+      serialized,
+      refactored_query_v2);
   REQUIRE(rc == TILEDB_OK);
   array_w1.close();
 
@@ -101,7 +107,12 @@ TEST_CASE(
       .set_data_buffer("a1", data_a1)
       .set_offsets_buffer("a1", offsets_a1);
   rc = test::submit_query_wrapper(
-      ctx, array_name, &query_w2, server_buffers_, serialized);
+      ctx,
+      array_name,
+      &query_w2,
+      server_buffers_,
+      serialized,
+      refactored_query_v2);
   REQUIRE(rc == TILEDB_OK);
   array_w2.close();
 
@@ -120,7 +131,13 @@ TEST_CASE(
       .set_data_buffer("a1", r_data_a1)
       .set_offsets_buffer("a1", r_offsets_a1);
   rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
+      ctx,
+      array_name,
+      &query,
+      server_buffers_,
+      serialized,
+      refactored_query_v2,
+      false);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(query.query_status() == Query::Status::COMPLETE);
   array.close();
@@ -134,13 +151,11 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API updates: empty second write", "[updates][updates-empty-write]") {
-  bool serialized = false;
-  SECTION("no serialization") {
-    serialized = false;
-  }
+  bool serialized = false, refactored_query_v2 = false;
 #ifdef TILEDB_SERIALIZATION
-  SECTION("serialization enabled global order write") {
-    serialized = true;
+  serialized = GENERATE(false, true);
+  if (serialized) {
+    refactored_query_v2 = GENERATE(true, false);
   }
 #endif
 
@@ -172,7 +187,12 @@ TEST_CASE(
   // Submit query
   test::ServerQueryBuffers server_buffers_;
   auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query_w1, server_buffers_, serialized);
+      ctx,
+      array_name,
+      &query_w1,
+      server_buffers_,
+      serialized,
+      refactored_query_v2);
   REQUIRE(rc == TILEDB_OK);
 
   array_w1.close();
@@ -186,7 +206,12 @@ TEST_CASE(
 
   // Submit query
   rc = test::submit_query_wrapper(
-      ctx, array_name, &query_w2, server_buffers_, serialized);
+      ctx,
+      array_name,
+      &query_w2,
+      server_buffers_,
+      serialized,
+      refactored_query_v2);
   REQUIRE(rc == TILEDB_OK);
 
   array_w2.close();

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -86,7 +86,6 @@ struct VariableOffsetsFx {
     query.set_offsets_buffer("attr", data_offsets);
 
     // Submit query
-    test::ServerQueryBuffers server_buffers_;
     auto rc = test::submit_query_wrapper(
         ctx,
         array_name,

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -37,487 +37,523 @@
 
 using namespace tiledb;
 
-void create_sparse_array(const std::string& array_name) {
-  Context ctx;
-  VFS vfs(ctx);
-
-  // Create the array
-  if (vfs.is_dir(array_name))
-    vfs.remove_dir(array_name);
-
-  Domain dom(ctx);
-  dom.add_dimension(Dimension::create<int64_t>(ctx, "d1", {{1, 4}}, 2))
-      .add_dimension(Dimension::create<int64_t>(ctx, "d2", {{1, 4}}, 2));
-
-  ArraySchema schema(ctx, TILEDB_SPARSE);
-  Attribute attr(ctx, "attr", TILEDB_INT32);
-  attr.set_cell_val_num(TILEDB_VAR_NUM);
-  schema.add_attribute(attr);
-  schema.set_tile_order(TILEDB_ROW_MAJOR);
-  schema.set_cell_order(TILEDB_ROW_MAJOR);
-  schema.set_domain(dom);
-  schema.set_allows_dups(true);
-
-  Array::create(array_name, schema);
-}
-
-void write_sparse_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    std::vector<int32_t>& data,
-    std::vector<uint64_t>& data_offsets,
-    tiledb_layout_t layout) {
-  std::vector<int64_t> d1 = {1, 2, 3, 4};
-  std::vector<int64_t> d2 = {2, 1, 3, 4};
-
-  Array array(ctx, array_name, TILEDB_WRITE);
-  Query query(ctx, array, TILEDB_WRITE);
-  query.set_layout(layout);
-  query.set_data_buffer("d1", d1);
-  query.set_data_buffer("d2", d2);
-  query.set_data_buffer("attr", data);
-  query.set_offsets_buffer("attr", data_offsets);
-
-  // Submit query
+struct VariableOffsetsFx {
+  // Serialization parameters
+  bool serialize_ = false;
+  bool refactored_query_v2_ = false;
+  // Buffers to allocate on server side for serialized queries
   test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized);
-  REQUIRE(rc == TILEDB_OK);
 
-  array.close();
-}
+  void create_sparse_array(const std::string& array_name) {
+    Context ctx;
+    VFS vfs(ctx);
 
-void write_sparse_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool,  // serialized,
-    std::vector<int32_t>& data,
-    std::vector<uint32_t>& data_offsets,
-    tiledb_layout_t layout) {
-  std::vector<int64_t> d1 = {1, 2, 3, 4};
-  std::vector<int64_t> d2 = {2, 1, 3, 4};
+    // Create the array
+    if (vfs.is_dir(array_name))
+      vfs.remove_dir(array_name);
 
-  Array array(ctx, array_name, TILEDB_WRITE);
-  Query query(ctx, array, TILEDB_WRITE);
-  query.set_layout(layout);
-  query.set_data_buffer("d1", d1);
-  query.set_data_buffer("d2", d2);
-  query.set_data_buffer("attr", data.data(), data.size());
-  query.set_offsets_buffer(
-      "attr",
-      reinterpret_cast<uint64_t*>(data_offsets.data()),
-      data_offsets.size());
+    Domain dom(ctx);
+    dom.add_dimension(Dimension::create<int64_t>(ctx, "d1", {{1, 4}}, 2))
+        .add_dimension(Dimension::create<int64_t>(ctx, "d2", {{1, 4}}, 2));
 
-  /* TODO: enable this when sc21681 is fixed
+    ArraySchema schema(ctx, TILEDB_SPARSE);
+    Attribute attr(ctx, "attr", TILEDB_INT32);
+    attr.set_cell_val_num(TILEDB_VAR_NUM);
+    schema.add_attribute(attr);
+    schema.set_tile_order(TILEDB_ROW_MAJOR);
+    schema.set_cell_order(TILEDB_ROW_MAJOR);
+    schema.set_domain(dom);
+    schema.set_allows_dups(true);
+
+    Array::create(array_name, schema);
+  }
+
+  void write_sparse_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& data,
+      std::vector<uint64_t>& data_offsets,
+      tiledb_layout_t layout) {
+    std::vector<int64_t> d1 = {1, 2, 3, 4};
+    std::vector<int64_t> d2 = {2, 1, 3, 4};
+
+    Array array(ctx, array_name, TILEDB_WRITE);
+    Query query(ctx, array, TILEDB_WRITE);
+    query.set_layout(layout);
+    query.set_data_buffer("d1", d1);
+    query.set_data_buffer("d2", d2);
+    query.set_data_buffer("attr", data);
+    query.set_offsets_buffer("attr", data_offsets);
+
     // Submit query
     test::ServerQueryBuffers server_buffers_;
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query, server_buffers_, serialized);
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_);
     REQUIRE(rc == TILEDB_OK);
-  */
-  CHECK_NOTHROW(query.submit());
-  query.finalize();
 
-  array.close();
-}
+    array.close();
+  }
 
-void read_and_check_sparse_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    std::vector<int32_t>& expected_data,
-    std::vector<uint64_t>& expected_offsets,
-    tiledb_layout_t layout) {
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
+  void write_sparse_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& data,
+      std::vector<uint32_t>& data_offsets,
+      tiledb_layout_t layout) {
+    std::vector<int64_t> d1 = {1, 2, 3, 4};
+    std::vector<int64_t> d2 = {2, 1, 3, 4};
 
-  std::vector<int32_t> attr_val(expected_data.size());
-  std::vector<uint64_t> attr_off(expected_offsets.size());
+    Array array(ctx, array_name, TILEDB_WRITE);
+    Query query(ctx, array, TILEDB_WRITE);
+    query.set_layout(layout);
+    query.set_data_buffer("d1", d1);
+    query.set_data_buffer("d2", d2);
+    query.set_data_buffer("attr", data.data(), data.size());
+    query.set_offsets_buffer(
+        "attr",
+        reinterpret_cast<uint64_t*>(data_offsets.data()),
+        data_offsets.size());
 
-  query.set_layout(layout);
-  query.set_data_buffer("attr", attr_val);
-  query.set_offsets_buffer("attr", attr_off);
-
-  // Submit query
-  test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-
-  // Check the element offsets are properly returned
-  CHECK(attr_val == expected_data);
-  CHECK(attr_off == expected_offsets);
-
-  array.close();
-}
-
-void read_and_check_sparse_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool,  // serialized,
-    std::vector<int32_t>& expected_data,
-    std::vector<uint32_t>& expected_offsets,
-    tiledb_layout_t layout) {
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
-
-  std::vector<int32_t> attr_val(expected_data.size());
-  std::vector<uint32_t> attr_off(expected_offsets.size());
-  query.set_layout(layout);
-  // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-  // accepts it
-  query.set_data_buffer("attr", attr_val.data(), attr_val.size());
-  query.set_offsets_buffer(
-      "attr", reinterpret_cast<uint64_t*>(attr_off.data()), attr_off.size());
-
-  /* TODO: enable this when sc21681 is fixed
+    /* TODO: enable this when sc21681 is fixed
       // Submit query
-    test::ServerQueryBuffers server_buffers_;
-    auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query, server_buffers_, serialized, false);
-    REQUIRE(rc == TILEDB_OK);
-  */
-  CHECK_NOTHROW(query.submit());
+      auto rc = test::submit_query_wrapper(
+          ctx, array_name, &query, server_buffers_, serialize_,
+      refactored_query_v2_); REQUIRE(rc == TILEDB_OK);
+    */
+    CHECK_NOTHROW(query.submit());
+    query.finalize();
 
-  // Check the element offsets are properly returned
-  CHECK(attr_val == expected_data);
-  CHECK(attr_off == expected_offsets);
-
-  array.close();
-}
-
-void reset_read_buffers(
-    std::vector<int32_t>& data, std::vector<uint64_t>& offsets) {
-  data.assign(data.size(), 0);
-  offsets.assign(offsets.size(), 0);
-}
-
-void partial_read_and_check_sparse_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    std::vector<int32_t>& exp_data_part1,
-    std::vector<uint64_t>& exp_off_part1,
-    std::vector<int32_t>& exp_data_part2,
-    std::vector<uint64_t>& exp_off_part2,
-    tiledb_layout_t layout) {
-  // The size of read buffers is smaller than the size
-  // of all the data, so we'll do partial reads
-  std::vector<int32_t> attr_val(exp_data_part1.size());
-  std::vector<uint64_t> attr_off(exp_off_part1.size());
-
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
-  query.set_layout(layout);
-  query.set_data_buffer("attr", attr_val);
-  query.set_offsets_buffer("attr", attr_off);
-
-  // Check that first partial read returns expected results
-  test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-  Query::Status status = query.query_status();
-  CHECK(status == Query::Status::INCOMPLETE);
-  CHECK(attr_val == exp_data_part1);
-  CHECK(attr_off == exp_off_part1);
-
-  // Check that second partial read returns expected results
-  rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-  status = query.query_status();
-  CHECK(status == Query::Status::COMPLETE);
-  CHECK(attr_val == exp_data_part2);
-  CHECK(attr_off == exp_off_part2);
-
-  array.close();
-}
-
-void read_and_check_empty_coords_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    tiledb_layout_t layout) {
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
-
-  std::vector<int32_t> attr_val(4);
-  std::vector<uint64_t> attr_off(4);
-
-  query.set_layout(layout);
-  query.set_data_buffer("attr", attr_val);
-  query.set_offsets_buffer("attr", attr_off);
-
-  // Query outside unwritten coordinates of the array
-  int64_t d1_start = 1, d1_end = 2;
-  int64_t d2_start = 3, d2_end = 4;
-  query.add_range("d1", d1_start, d1_end);
-  query.add_range("d2", d2_start, d2_end);
-
-  // Submit query
-  test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-
-  // Check the element offsets are properly returned
-  uint64_t offset_elem_num = 0, data_vals_num = 0, validity_elem_num = 0;
-  std::tie(offset_elem_num, data_vals_num, validity_elem_num) =
-      query.result_buffer_elements_nullable()["attr"];
-
-  CHECK(offset_elem_num == 0);
-  CHECK(data_vals_num == 0);
-
-  array.close();
-}
-
-void create_dense_array(const std::string& array_name) {
-  Context ctx;
-  VFS vfs(ctx);
-
-  // Create the array
-  if (vfs.is_dir(array_name))
-    vfs.remove_dir(array_name);
-
-  Domain dom(ctx);
-  dom.add_dimension(Dimension::create<int64_t>(ctx, "d1", {{1, 4}}, 2))
-      .add_dimension(Dimension::create<int64_t>(ctx, "d2", {{1, 4}}, 2));
-
-  ArraySchema schema(ctx, TILEDB_DENSE);
-  Attribute attr(ctx, "attr", TILEDB_INT32);
-  attr.set_cell_val_num(TILEDB_VAR_NUM);
-  schema.add_attribute(attr);
-  schema.set_tile_order(TILEDB_ROW_MAJOR);
-  schema.set_cell_order(TILEDB_ROW_MAJOR);
-  schema.set_domain(dom);
-
-  Array::create(array_name, schema);
-}
-
-void write_dense_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    std::vector<int32_t>& data,
-    std::vector<uint64_t>& data_offsets,
-    tiledb_layout_t layout,
-    shared_ptr<Config> config = nullptr) {
-  std::vector<int64_t> d1 = {1, 1, 2, 2};
-  std::vector<int64_t> d2 = {1, 2, 1, 2};
-
-  Array array(ctx, array_name, TILEDB_WRITE);
-  Query query(ctx, array, TILEDB_WRITE);
-
-  if (config != nullptr) {
-    query.set_config(*config);
-
-    // Validate we can retrieve set config
-    Config config2 = query.config();
-    bool same = *config == config2;
-    CHECK(same == true);
+    array.close();
   }
 
-  query.set_data_buffer("attr", data);
-  query.set_offsets_buffer("attr", data_offsets);
-  query.set_layout(layout);
-  if (layout == TILEDB_UNORDERED) {
-    // sparse write to dense array
-    query.set_data_buffer("d1", d1);
-    query.set_data_buffer("d2", d2);
-  } else {
-    query.set_subarray<int64_t>({1, 2, 1, 2});
-  }
+  void read_and_check_sparse_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& expected_data,
+      std::vector<uint64_t>& expected_offsets,
+      tiledb_layout_t layout) {
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
 
-  // Submit query
-  test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized);
-  REQUIRE(rc == TILEDB_OK);
+    std::vector<int32_t> attr_val(expected_data.size());
+    std::vector<uint64_t> attr_off(expected_offsets.size());
 
-  array.close();
-}
+    query.set_layout(layout);
+    query.set_data_buffer("attr", attr_val);
+    query.set_offsets_buffer("attr", attr_off);
 
-void write_dense_array(
-    Context ctx,
-    const std::string& array_name,
-    bool,  // serialized,
-    std::vector<int32_t>& data,
-    std::vector<uint32_t>& data_offsets,
-    tiledb_layout_t layout,
-    shared_ptr<Config> config = nullptr) {
-  std::vector<int64_t> d1 = {1, 1, 2, 2};
-  std::vector<int64_t> d2 = {1, 2, 1, 2};
-
-  Array array(ctx, array_name, TILEDB_WRITE);
-  Query query(ctx, array, TILEDB_WRITE);
-
-  if (config != nullptr) {
-    query.set_config(*config);
-
-    // Validate we can retrieve set config
-    Config config2 = query.config();
-    bool same = *config == config2;
-    CHECK(same == true);
-  }
-
-  // Write using a 32-bit vector, but cast it to 64-bit pointer so that the API
-  // accepts it
-  query.set_data_buffer("attr", data.data(), data.size());
-  query.set_offsets_buffer(
-      "attr",
-      reinterpret_cast<uint64_t*>(data_offsets.data()),
-      data_offsets.size());
-  query.set_layout(layout);
-  if (layout == TILEDB_UNORDERED) {
-    // sparse write to dense array
-    query.set_data_buffer("d1", d1);
-    query.set_data_buffer("d2", d2);
-  } else {
-    query.set_subarray<int64_t>({1, 2, 1, 2});
-  }
-
-  /* TODO: enable this when sc21681 is fixed
-    test::ServerQueryBuffers server_buffers_;
-    auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query, server_buffers_, serialized);
-    REQUIRE(rc == TILEDB_OK);
-  */
-  CHECK_NOTHROW(query.submit());
-  query.finalize();
-
-  array.close();
-}
-
-void read_and_check_dense_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    std::vector<int32_t>& expected_data,
-    std::vector<uint64_t>& expected_offsets,
-    shared_ptr<Config> config = nullptr) {
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
-
-  if (config != nullptr) {
-    query.set_config(*config);
-
-    // Validate we can retrieve set config
-    Config config2 = query.config();
-    bool same = *config == config2;
-    CHECK(same == true);
-  }
-
-  std::vector<int32_t> attr_val(expected_data.size());
-  std::vector<uint64_t> attr_off(expected_offsets.size());
-  query.set_subarray<int64_t>({1, 2, 1, 2});
-  query.set_data_buffer("attr", attr_val);
-  query.set_offsets_buffer("attr", attr_off);
-
-  // Submit query
-  test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-
-  // Check the element offsets are properly returned
-  CHECK(attr_val == expected_data);
-  CHECK(attr_off == expected_offsets);
-
-  array.close();
-}
-
-void read_and_check_dense_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool,  // serialized,
-    std::vector<int32_t>& expected_data,
-    std::vector<uint32_t>& expected_offsets,
-    shared_ptr<Config> config = nullptr) {
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
-
-  if (config != nullptr) {
-    query.set_config(*config);
-
-    // Validate we can retrieve set config
-    Config config2 = query.config();
-    bool same = *config == config2;
-    CHECK(same == true);
-  }
-
-  std::vector<int32_t> attr_val(expected_data.size());
-  std::vector<uint32_t> attr_off(expected_offsets.size());
-  query.set_subarray<int64_t>({1, 2, 1, 2});
-  // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
-  // accepts it
-  query.set_data_buffer("attr", attr_val.data(), attr_val.size());
-  query.set_offsets_buffer(
-      "attr", reinterpret_cast<uint64_t*>(attr_off.data()), attr_off.size());
-
-  /* TODO: enable this when sc21681 is fixed
     // Submit query
-    test::ServerQueryBuffers server_buffers_;
     auto rc = test::submit_query_wrapper(
-        ctx, array_name, &query, server_buffers_, serialized, false);
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
     REQUIRE(rc == TILEDB_OK);
-  */
-  CHECK_NOTHROW(query.submit());
-  query.finalize();
 
-  // Check the element offsets are properly returned
-  CHECK(attr_val == expected_data);
-  CHECK(attr_off == expected_offsets);
+    // Check the element offsets are properly returned
+    CHECK(attr_val == expected_data);
+    CHECK(attr_off == expected_offsets);
 
-  array.close();
-}
+    array.close();
+  }
 
-void partial_read_and_check_dense_array(
-    Context ctx,
-    const std::string& array_name,
-    const bool serialized,
-    std::vector<int32_t>& exp_data_part1,
-    std::vector<uint64_t>& exp_off_part1,
-    std::vector<int32_t>& exp_data_part2,
-    std::vector<uint64_t>& exp_off_part2) {
-  // The size of read buffers is smaller than the size
-  // of all the data, so we'll do partial reads
-  std::vector<int32_t> attr_val(exp_data_part1.size());
-  std::vector<uint64_t> attr_off(exp_off_part1.size());
+  void read_and_check_sparse_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& expected_data,
+      std::vector<uint32_t>& expected_offsets,
+      tiledb_layout_t layout) {
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
 
-  Array array(ctx, array_name, TILEDB_READ);
-  Query query(ctx, array, TILEDB_READ);
-  query.set_subarray<int64_t>({1, 2, 1, 2});
-  query.set_data_buffer("attr", attr_val);
-  query.set_offsets_buffer("attr", attr_off);
+    std::vector<int32_t> attr_val(expected_data.size());
+    std::vector<uint32_t> attr_off(expected_offsets.size());
+    query.set_layout(layout);
+    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
+    // accepts it
+    query.set_data_buffer("attr", attr_val.data(), attr_val.size());
+    query.set_offsets_buffer(
+        "attr", reinterpret_cast<uint64_t*>(attr_off.data()), attr_off.size());
 
-  // Check that first partial read returns expected results
-  test::ServerQueryBuffers server_buffers_;
-  auto rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-  CHECK(attr_val == exp_data_part1);
-  CHECK(attr_off == exp_off_part1);
+    /* TODO: enable this when sc21681 is fixed
+        // Submit query
+      auto rc = test::submit_query_wrapper(
+          ctx, array_name, &query, server_buffers_, serialize_,
+      refactored_query_v2_, false); REQUIRE(rc == TILEDB_OK);
+    */
+    CHECK_NOTHROW(query.submit());
 
-  // Check that second partial read returns expected results
-  rc = test::submit_query_wrapper(
-      ctx, array_name, &query, server_buffers_, serialized, false);
-  REQUIRE(rc == TILEDB_OK);
-  CHECK(attr_val == exp_data_part2);
-  CHECK(attr_off == exp_off_part2);
+    // Check the element offsets are properly returned
+    CHECK(attr_val == expected_data);
+    CHECK(attr_off == expected_offsets);
 
-  array.close();
-}
+    array.close();
+  }
 
-TEST_CASE(
+  void reset_read_buffers(
+      std::vector<int32_t>& data, std::vector<uint64_t>& offsets) {
+    data.assign(data.size(), 0);
+    offsets.assign(offsets.size(), 0);
+  }
+
+  void partial_read_and_check_sparse_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& exp_data_part1,
+      std::vector<uint64_t>& exp_off_part1,
+      std::vector<int32_t>& exp_data_part2,
+      std::vector<uint64_t>& exp_off_part2,
+      tiledb_layout_t layout) {
+    // The size of read buffers is smaller than the size
+    // of all the data, so we'll do partial reads
+    std::vector<int32_t> attr_val(exp_data_part1.size());
+    std::vector<uint64_t> attr_off(exp_off_part1.size());
+
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
+    query.set_layout(layout);
+    query.set_data_buffer("attr", attr_val);
+    query.set_offsets_buffer("attr", attr_off);
+
+    // Check that first partial read returns expected results
+    auto rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
+    REQUIRE(rc == TILEDB_OK);
+    Query::Status status = query.query_status();
+    CHECK(status == Query::Status::INCOMPLETE);
+    CHECK(attr_val == exp_data_part1);
+    CHECK(attr_off == exp_off_part1);
+
+    // Check that second partial read returns expected results
+    rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
+    REQUIRE(rc == TILEDB_OK);
+    status = query.query_status();
+    CHECK(status == Query::Status::COMPLETE);
+    CHECK(attr_val == exp_data_part2);
+    CHECK(attr_off == exp_off_part2);
+
+    array.close();
+  }
+
+  void read_and_check_empty_coords_array(
+      Context ctx, const std::string& array_name, tiledb_layout_t layout) {
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
+
+    std::vector<int32_t> attr_val(4);
+    std::vector<uint64_t> attr_off(4);
+
+    query.set_layout(layout);
+    query.set_data_buffer("attr", attr_val);
+    query.set_offsets_buffer("attr", attr_off);
+
+    // Query outside unwritten coordinates of the array
+    int64_t d1_start = 1, d1_end = 2;
+    int64_t d2_start = 3, d2_end = 4;
+    query.add_range("d1", d1_start, d1_end);
+    query.add_range("d2", d2_start, d2_end);
+
+    // Submit query
+    auto rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
+    REQUIRE(rc == TILEDB_OK);
+
+    // Check the element offsets are properly returned
+    uint64_t offset_elem_num = 0, data_vals_num = 0, validity_elem_num = 0;
+    std::tie(offset_elem_num, data_vals_num, validity_elem_num) =
+        query.result_buffer_elements_nullable()["attr"];
+
+    CHECK(offset_elem_num == 0);
+    CHECK(data_vals_num == 0);
+
+    array.close();
+  }
+
+  void create_dense_array(const std::string& array_name) {
+    Context ctx;
+    VFS vfs(ctx);
+
+    // Create the array
+    if (vfs.is_dir(array_name))
+      vfs.remove_dir(array_name);
+
+    Domain dom(ctx);
+    dom.add_dimension(Dimension::create<int64_t>(ctx, "d1", {{1, 4}}, 2))
+        .add_dimension(Dimension::create<int64_t>(ctx, "d2", {{1, 4}}, 2));
+
+    ArraySchema schema(ctx, TILEDB_DENSE);
+    Attribute attr(ctx, "attr", TILEDB_INT32);
+    attr.set_cell_val_num(TILEDB_VAR_NUM);
+    schema.add_attribute(attr);
+    schema.set_tile_order(TILEDB_ROW_MAJOR);
+    schema.set_cell_order(TILEDB_ROW_MAJOR);
+    schema.set_domain(dom);
+
+    Array::create(array_name, schema);
+  }
+
+  void write_dense_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& data,
+      std::vector<uint64_t>& data_offsets,
+      tiledb_layout_t layout,
+      shared_ptr<Config> config = nullptr) {
+    std::vector<int64_t> d1 = {1, 1, 2, 2};
+    std::vector<int64_t> d2 = {1, 2, 1, 2};
+
+    Array array(ctx, array_name, TILEDB_WRITE);
+    Query query(ctx, array, TILEDB_WRITE);
+
+    if (config != nullptr) {
+      query.set_config(*config);
+
+      // Validate we can retrieve set config
+      Config config2 = query.config();
+      bool same = *config == config2;
+      CHECK(same == true);
+    }
+
+    query.set_data_buffer("attr", data);
+    query.set_offsets_buffer("attr", data_offsets);
+    query.set_layout(layout);
+    if (layout == TILEDB_UNORDERED) {
+      // sparse write to dense array
+      query.set_data_buffer("d1", d1);
+      query.set_data_buffer("d2", d2);
+    } else {
+      query.set_subarray<int64_t>({1, 2, 1, 2});
+    }
+
+    // Submit query
+    auto rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_);
+    REQUIRE(rc == TILEDB_OK);
+
+    array.close();
+  }
+
+  void write_dense_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& data,
+      std::vector<uint32_t>& data_offsets,
+      tiledb_layout_t layout,
+      shared_ptr<Config> config = nullptr) {
+    std::vector<int64_t> d1 = {1, 1, 2, 2};
+    std::vector<int64_t> d2 = {1, 2, 1, 2};
+
+    Array array(ctx, array_name, TILEDB_WRITE);
+    Query query(ctx, array, TILEDB_WRITE);
+
+    if (config != nullptr) {
+      query.set_config(*config);
+
+      // Validate we can retrieve set config
+      Config config2 = query.config();
+      bool same = *config == config2;
+      CHECK(same == true);
+    }
+
+    // Write using a 32-bit vector, but cast it to 64-bit pointer so that the
+    // API accepts it
+    query.set_data_buffer("attr", data.data(), data.size());
+    query.set_offsets_buffer(
+        "attr",
+        reinterpret_cast<uint64_t*>(data_offsets.data()),
+        data_offsets.size());
+    query.set_layout(layout);
+    if (layout == TILEDB_UNORDERED) {
+      // sparse write to dense array
+      query.set_data_buffer("d1", d1);
+      query.set_data_buffer("d2", d2);
+    } else {
+      query.set_subarray<int64_t>({1, 2, 1, 2});
+    }
+
+    /* TODO: enable this when sc21681 is fixed
+      auto rc = test::submit_query_wrapper(
+          ctx, array_name, &query, server_buffers_, serialize_,
+      refactored_query_v2_); REQUIRE(rc == TILEDB_OK);
+    */
+    CHECK_NOTHROW(query.submit());
+    query.finalize();
+
+    array.close();
+  }
+
+  void read_and_check_dense_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& expected_data,
+      std::vector<uint64_t>& expected_offsets,
+      shared_ptr<Config> config = nullptr) {
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
+
+    if (config != nullptr) {
+      query.set_config(*config);
+
+      // Validate we can retrieve set config
+      Config config2 = query.config();
+      bool same = *config == config2;
+      CHECK(same == true);
+    }
+
+    std::vector<int32_t> attr_val(expected_data.size());
+    std::vector<uint64_t> attr_off(expected_offsets.size());
+    query.set_subarray<int64_t>({1, 2, 1, 2});
+    query.set_data_buffer("attr", attr_val);
+    query.set_offsets_buffer("attr", attr_off);
+
+    // Submit query
+    auto rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
+    REQUIRE(rc == TILEDB_OK);
+
+    // Check the element offsets are properly returned
+    CHECK(attr_val == expected_data);
+    CHECK(attr_off == expected_offsets);
+
+    array.close();
+  }
+
+  void read_and_check_dense_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& expected_data,
+      std::vector<uint32_t>& expected_offsets,
+      shared_ptr<Config> config = nullptr) {
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
+
+    if (config != nullptr) {
+      query.set_config(*config);
+
+      // Validate we can retrieve set config
+      Config config2 = query.config();
+      bool same = *config == config2;
+      CHECK(same == true);
+    }
+
+    std::vector<int32_t> attr_val(expected_data.size());
+    std::vector<uint32_t> attr_off(expected_offsets.size());
+    query.set_subarray<int64_t>({1, 2, 1, 2});
+    // Read using a 32-bit vector, but cast it to 64-bit pointer so that the API
+    // accepts it
+    query.set_data_buffer("attr", attr_val.data(), attr_val.size());
+    query.set_offsets_buffer(
+        "attr", reinterpret_cast<uint64_t*>(attr_off.data()), attr_off.size());
+
+    /* TODO: enable this when sc21681 is fixed
+      // Submit query
+      auto rc = test::submit_query_wrapper(
+          ctx, array_name, &query, server_buffers_, serialize_,
+      refactored_query_v2_, false); REQUIRE(rc == TILEDB_OK);
+    */
+    CHECK_NOTHROW(query.submit());
+    query.finalize();
+
+    // Check the element offsets are properly returned
+    CHECK(attr_val == expected_data);
+    CHECK(attr_off == expected_offsets);
+
+    array.close();
+  }
+
+  void partial_read_and_check_dense_array(
+      Context ctx,
+      const std::string& array_name,
+      std::vector<int32_t>& exp_data_part1,
+      std::vector<uint64_t>& exp_off_part1,
+      std::vector<int32_t>& exp_data_part2,
+      std::vector<uint64_t>& exp_off_part2) {
+    // The size of read buffers is smaller than the size
+    // of all the data, so we'll do partial reads
+    std::vector<int32_t> attr_val(exp_data_part1.size());
+    std::vector<uint64_t> attr_off(exp_off_part1.size());
+
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array, TILEDB_READ);
+    query.set_subarray<int64_t>({1, 2, 1, 2});
+    query.set_data_buffer("attr", attr_val);
+    query.set_offsets_buffer("attr", attr_off);
+
+    // Check that first partial read returns expected results
+    auto rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
+    REQUIRE(rc == TILEDB_OK);
+    CHECK(attr_val == exp_data_part1);
+    CHECK(attr_off == exp_off_part1);
+
+    // Check that second partial read returns expected results
+    rc = test::submit_query_wrapper(
+        ctx,
+        array_name,
+        &query,
+        server_buffers_,
+        serialize_,
+        refactored_query_v2_,
+        false);
+    REQUIRE(rc == TILEDB_OK);
+    CHECK(attr_val == exp_data_part2);
+    CHECK(attr_off == exp_off_part2);
+
+    array.close();
+  }
+};
+
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test element offsets : sparse array",
     "[var-offsets][element-offset][sparse]") {
 #ifdef TILEDB_SERIALIZATION
-  // bool serialized = GENERATE(true, false);
-  bool serialized = false;
-#else
-  bool serialized = false;
+  serialize_ = true;
+  refactored_query_v2_ = GENERATE(true, false);
 #endif
   std::string array_name = "test_element_offset";
   create_sparse_array(array_name);
@@ -532,45 +568,34 @@ TEST_CASE(
     std::vector<uint64_t> byte_offsets = {0, 4, 12, 20};
 
     SECTION("Unordered write") {
-      write_sparse_array(
-          ctx, array_name, serialized, data, byte_offsets, TILEDB_UNORDERED);
+      write_sparse_array(ctx, array_name, data, byte_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx, array_name, serialized, data, byte_offsets, TILEDB_ROW_MAJOR);
+            ctx, array_name, data, byte_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            byte_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, byte_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx, array_name, serialized, data, byte_offsets, TILEDB_UNORDERED);
+            ctx, array_name, data, byte_offsets, TILEDB_UNORDERED);
       }
     }
     SECTION("Global order write") {
       write_sparse_array(
-          ctx, array_name, serialized, data, byte_offsets, TILEDB_GLOBAL_ORDER);
+          ctx, array_name, data, byte_offsets, TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx, array_name, serialized, data, byte_offsets, TILEDB_ROW_MAJOR);
+            ctx, array_name, data, byte_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            byte_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, byte_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx, array_name, serialized, data, byte_offsets, TILEDB_UNORDERED);
+            ctx, array_name, data, byte_offsets, TILEDB_UNORDERED);
       }
     }
   }
@@ -585,69 +610,34 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx, array_name, serialized, data, element_offsets, TILEDB_UNORDERED);
+          ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            element_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            element_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            element_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
       }
     }
     SECTION("Global order write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          element_offsets,
-          TILEDB_GLOBAL_ORDER);
+          ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            element_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            element_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            element_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
       }
     }
   }
@@ -658,13 +648,13 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test element offsets : dense array",
     "[var-offsets][element-offset][dense]") {
 #ifdef TILEDB_SERIALIZATION
-  bool serialized = GENERATE(true, false);
-#else
-  bool serialized = false;
+  serialize_ = true;
+  refactored_query_v2_ = GENERATE(true, false);
 #endif
   std::string array_name = "test_element_offset";
   create_dense_array(array_name);
@@ -679,16 +669,13 @@ TEST_CASE(
     std::vector<uint64_t> byte_offsets = {0, 4, 12, 20};
 
     SECTION("Ordered write") {
-      write_dense_array(
-          ctx, array_name, serialized, data, byte_offsets, TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, byte_offsets);
+      write_dense_array(ctx, array_name, data, byte_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, byte_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx, array_name, serialized, data, byte_offsets, TILEDB_GLOBAL_ORDER);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, byte_offsets);
+          ctx, array_name, data, byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, byte_offsets);
     }
   }
 
@@ -702,20 +689,13 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx, array_name, serialized, data, element_offsets, TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, element_offsets);
+          ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, element_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          element_offsets,
-          TILEDB_GLOBAL_ORDER);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, element_offsets);
+          ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, element_offsets);
     }
   }
 
@@ -725,13 +705,13 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test offsets extra element: sparse array",
     "[var-offsets][extra-offset][sparse]") {
 #ifdef TILEDB_SERIALIZATION
-  bool serialized = GENERATE(true, false);
-#else
-  bool serialized = false;
+  serialize_ = true;
+  refactored_query_v2_ = GENERATE(true, false);
 #endif
   std::string array_name = "test_extra_offset";
   create_sparse_array(array_name);
@@ -748,24 +728,18 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_sparse_array(
-          ctx, array_name, serialized, data, data_offsets, TILEDB_UNORDERED);
+      write_sparse_array(ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx, array_name, serialized, data, data_offsets, TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx, array_name, serialized, data, data_offsets, TILEDB_UNORDERED);
+            ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
       }
     }
 
@@ -781,74 +755,34 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_UNORDERED);
+              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                data_offsets,
-                TILEDB_ROW_MAJOR);
+                ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
           }
           SECTION("Global order read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                data_offsets,
-                TILEDB_GLOBAL_ORDER);
+                ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
           }
           SECTION("UNORDERED read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                data_offsets,
-                TILEDB_UNORDERED);
+                ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
           }
         }
         SECTION("Global order write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                data_offsets,
-                TILEDB_ROW_MAJOR);
+                ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
           }
           SECTION("Global order read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                data_offsets,
-                TILEDB_GLOBAL_ORDER);
+                ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
           }
           SECTION("Unordered read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                data_offsets,
-                TILEDB_UNORDERED);
+                ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
           }
         }
       }
@@ -862,74 +796,34 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_UNORDERED);
+              ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                element_offsets,
-                TILEDB_ROW_MAJOR);
+                ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
           }
           SECTION("Global order read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                element_offsets,
-                TILEDB_GLOBAL_ORDER);
+                ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
           }
           SECTION("Unordered read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                element_offsets,
-                TILEDB_UNORDERED);
+                ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
           }
         }
         SECTION("Global order write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                element_offsets,
-                TILEDB_ROW_MAJOR);
+                ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
           }
           SECTION("Global order read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                element_offsets,
-                TILEDB_GLOBAL_ORDER);
+                ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
           }
           SECTION("Unordered read") {
             read_and_check_sparse_array(
-                ctx,
-                array_name,
-                serialized,
-                data,
-                element_offsets,
-                TILEDB_UNORDERED);
+                ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
           }
         }
       }
@@ -943,44 +837,34 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_UNORDERED);
+              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             read_and_check_empty_coords_array(
-                ctx, array_name, serialized, TILEDB_ROW_MAJOR);
+                ctx, array_name, TILEDB_ROW_MAJOR);
           }
           SECTION("Global order read") {
             read_and_check_empty_coords_array(
-                ctx, array_name, serialized, TILEDB_GLOBAL_ORDER);
+                ctx, array_name, TILEDB_GLOBAL_ORDER);
           }
           SECTION("Unordered read") {
             read_and_check_empty_coords_array(
-                ctx, array_name, serialized, TILEDB_UNORDERED);
+                ctx, array_name, TILEDB_UNORDERED);
           }
         }
         SECTION("Global order write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             read_and_check_empty_coords_array(
-                ctx, array_name, serialized, TILEDB_ROW_MAJOR);
+                ctx, array_name, TILEDB_ROW_MAJOR);
           }
           SECTION("Global order read") {
             read_and_check_empty_coords_array(
-                ctx, array_name, serialized, TILEDB_GLOBAL_ORDER);
+                ctx, array_name, TILEDB_GLOBAL_ORDER);
           }
           SECTION("Unordered read") {
             read_and_check_empty_coords_array(
-                ctx, array_name, serialized, TILEDB_UNORDERED);
+                ctx, array_name, TILEDB_UNORDERED);
           }
         }
       }
@@ -1074,13 +958,11 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_sparse_array(
-          ctx, array_name, serialized, data, data_offsets, TILEDB_UNORDERED);
+      write_sparse_array(ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         partial_read_and_check_sparse_array(
             ctx,
             array_name,
-            serialized,
             data_part1,
             data_off_part1,
             data_part2,
@@ -1091,7 +973,6 @@ TEST_CASE(
         partial_read_and_check_sparse_array(
             ctx,
             array_name,
-            serialized,
             data_part1,
             data_off_part1,
             data_part2,
@@ -1102,7 +983,6 @@ TEST_CASE(
         partial_read_and_check_sparse_array(
             ctx,
             array_name,
-            serialized,
             data_part1,
             data_off_part1,
             data_part2,
@@ -1127,17 +1007,11 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_UNORDERED);
+              ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_off_part1,
                 data_part2,
@@ -1148,7 +1022,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_off_part1,
                 data_part2,
@@ -1159,7 +1032,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_off_part1,
                 data_part2,
@@ -1169,17 +1041,11 @@ TEST_CASE(
         }
         SECTION("Global order write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_off_part1,
                 data_part2,
@@ -1190,7 +1056,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_off_part1,
                 data_part2,
@@ -1201,7 +1066,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_off_part1,
                 data_part2,
@@ -1224,17 +1088,11 @@ TEST_CASE(
 
         SECTION("Unordered write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_UNORDERED);
+              ctx, array_name, data, element_offsets, TILEDB_UNORDERED);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_elem_off_part1,
                 data_part2,
@@ -1245,7 +1103,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_elem_off_part1,
                 data_part2,
@@ -1256,7 +1113,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_elem_off_part1,
                 data_part2,
@@ -1266,17 +1122,11 @@ TEST_CASE(
         }
         SECTION("Global order write") {
           write_sparse_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
           SECTION("Row major read") {
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_elem_off_part1,
                 data_part2,
@@ -1287,7 +1137,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_elem_off_part1,
                 data_part2,
@@ -1298,7 +1147,6 @@ TEST_CASE(
             partial_read_and_check_sparse_array(
                 ctx,
                 array_name,
-                serialized,
                 data_part1,
                 data_elem_off_part1,
                 data_part2,
@@ -1312,7 +1160,7 @@ TEST_CASE(
         // Write data with extra element
         data_offsets.push_back(sizeof(data[0]) * data.size());
         write_sparse_array(
-            ctx, array_name, serialized, data, data_offsets, TILEDB_UNORDERED);
+            ctx, array_name, data, data_offsets, TILEDB_UNORDERED);
 
         // Submit read query
         Context ctx(config);
@@ -1395,13 +1243,13 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test offsets extra element: dense array",
     "[var-offsets][extra-offset][dense]") {
 #ifdef TILEDB_SERIALIZATION
-  bool serialized = GENERATE(true, false);
-#else
-  bool serialized = false;
+  serialize_ = true;
+  refactored_query_v2_ = GENERATE(true, false);
 #endif
   std::string array_name = "test_extra_offset";
   create_dense_array(array_name);
@@ -1418,10 +1266,8 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_dense_array(
-          ctx, array_name, serialized, data, data_offsets, TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_offsets);
+      write_dense_array(ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_offsets);
     }
 
     SECTION("Extra element") {
@@ -1436,25 +1282,13 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_ROW_MAJOR);
-          read_and_check_dense_array(
-              ctx, array_name, serialized, data, data_offsets);
+              ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
+          read_and_check_dense_array(ctx, array_name, data, data_offsets);
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_GLOBAL_ORDER);
-          read_and_check_dense_array(
-              ctx, array_name, serialized, data, data_offsets);
+              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
+          read_and_check_dense_array(ctx, array_name, data, data_offsets);
         }
       }
 
@@ -1468,25 +1302,13 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_ROW_MAJOR);
-          read_and_check_dense_array(
-              ctx, array_name, serialized, data, element_offsets);
+              ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
+          read_and_check_dense_array(ctx, array_name, data, element_offsets);
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_GLOBAL_ORDER);
-          read_and_check_dense_array(
-              ctx, array_name, serialized, data, element_offsets);
+              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
+          read_and_check_dense_array(ctx, array_name, data, element_offsets);
         }
       }
 
@@ -1573,12 +1395,10 @@ TEST_CASE(
       config = ctx.config();
       CHECK((std::string)config["sm.var_offsets.extra_element"] == "false");
 
-      write_dense_array(
-          ctx, array_name, serialized, data, data_offsets, TILEDB_ROW_MAJOR);
+      write_dense_array(ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
       partial_read_and_check_dense_array(
           ctx,
           array_name,
-          serialized,
           data_part1,
           data_off_part1,
           data_part2,
@@ -1601,16 +1421,10 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_ROW_MAJOR);
+              ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
-              serialized,
               data_part1,
               data_off_part1,
               data_part2,
@@ -1618,16 +1432,10 @@ TEST_CASE(
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              data_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, data_offsets, TILEDB_GLOBAL_ORDER);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
-              serialized,
               data_part1,
               data_off_part1,
               data_part2,
@@ -1648,16 +1456,10 @@ TEST_CASE(
 
         SECTION("Ordered write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_ROW_MAJOR);
+              ctx, array_name, data, element_offsets, TILEDB_ROW_MAJOR);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
-              serialized,
               data_part1,
               data_elem_off_part1,
               data_part2,
@@ -1665,16 +1467,10 @@ TEST_CASE(
         }
         SECTION("Global order write") {
           write_dense_array(
-              ctx,
-              array_name,
-              serialized,
-              data,
-              element_offsets,
-              TILEDB_GLOBAL_ORDER);
+              ctx, array_name, data, element_offsets, TILEDB_GLOBAL_ORDER);
           partial_read_and_check_dense_array(
               ctx,
               array_name,
-              serialized,
               data_part1,
               data_elem_off_part1,
               data_part2,
@@ -1687,7 +1483,7 @@ TEST_CASE(
         // Write data with extra element
         data_offsets.push_back(sizeof(data[0]) * data.size());
         write_dense_array(
-            ctx, array_name, serialized, data, data_offsets, TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_offsets, TILEDB_ROW_MAJOR);
 
         // Submit read query
         Array array(ctx, array_name, TILEDB_READ);
@@ -1770,14 +1566,14 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test 32-bit offsets: sparse array",
     "[var-offsets][32bit-offset][sparse]") {
 #ifdef TILEDB_SERIALIZATION
   /* TODO: set this to true this when sc21681 is fixed */
-  bool serialized = false;
-#else
-  bool serialized = false;
+  serialize_ = false;
+  // refactored_query_v2_ = GENERATE(true, false);
 #endif
   std::string array_name = "test_32bit_offset";
   create_sparse_array(array_name);
@@ -1796,74 +1592,34 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_UNORDERED);
+          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
       }
     }
     SECTION("Global order write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_GLOBAL_ORDER);
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
       }
     }
   }
@@ -1878,74 +1634,34 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_element_offsets,
-          TILEDB_UNORDERED);
+          ctx, array_name, data, data_element_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_element_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_element_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unoredered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_element_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, data_element_offsets, TILEDB_UNORDERED);
       }
     }
     SECTION("Global order write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_element_offsets,
-          TILEDB_GLOBAL_ORDER);
+          ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_element_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_element_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_element_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, data_element_offsets, TILEDB_UNORDERED);
       }
     }
   }
@@ -1960,74 +1676,34 @@ TEST_CASE(
 
     SECTION("Unordered write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_UNORDERED);
+          ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
       }
     }
     SECTION("Global order write") {
       write_sparse_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_GLOBAL_ORDER);
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       SECTION("Row major read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_ROW_MAJOR);
+            ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
       }
       SECTION("Global order read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_GLOBAL_ORDER);
+            ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
       }
       SECTION("Unordered read") {
         read_and_check_sparse_array(
-            ctx,
-            array_name,
-            serialized,
-            data,
-            data_byte_offsets,
-            TILEDB_UNORDERED);
+            ctx, array_name, data, data_byte_offsets, TILEDB_UNORDERED);
       }
     }
   }
@@ -2042,14 +1718,14 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test 32-bit offsets: dense array",
     "[var-offsets][32bit-offset][dense]") {
 #ifdef TILEDB_SERIALIZATION
   /* TODO: set this to true this when sc21681 is fixed */
-  bool serialized = false;
-#else
-  bool serialized = false;
+  serialize_ = false;
+  refactored_query_v2_ = GENERATE(true, false);
 #endif
   std::string array_name = "test_32bit_offset";
   create_dense_array(array_name);
@@ -2068,25 +1744,13 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_byte_offsets);
+          ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_GLOBAL_ORDER);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_byte_offsets);
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
   }
 
@@ -2100,25 +1764,13 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_element_offsets,
-          TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_element_offsets);
+          ctx, array_name, data, data_element_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_element_offsets,
-          TILEDB_GLOBAL_ORDER);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_element_offsets);
+          ctx, array_name, data, data_element_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, data_element_offsets);
     }
   }
 
@@ -2132,25 +1784,13 @@ TEST_CASE(
 
     SECTION("Ordered write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_ROW_MAJOR);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_byte_offsets);
+          ctx, array_name, data, data_byte_offsets, TILEDB_ROW_MAJOR);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
     SECTION("Global order write") {
       write_dense_array(
-          ctx,
-          array_name,
-          serialized,
-          data,
-          data_byte_offsets,
-          TILEDB_GLOBAL_ORDER);
-      read_and_check_dense_array(
-          ctx, array_name, serialized, data, data_byte_offsets);
+          ctx, array_name, data, data_byte_offsets, TILEDB_GLOBAL_ORDER);
+      read_and_check_dense_array(ctx, array_name, data, data_byte_offsets);
     }
   }
 
@@ -2164,7 +1804,8 @@ TEST_CASE(
     vfs.remove_dir(array_name);
 }
 
-TEST_CASE(
+TEST_CASE_METHOD(
+    VariableOffsetsFx,
     "C++ API: Test 32-bit offsets: sparse array with string dimension",
     "[var-offsets-dim][32bit-offset][sparse]") {
   std::string array_name = "test_32bit_offset_string_dim";

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1743,7 +1743,7 @@ int submit_query_wrapper(
   // Allocate new context for server
   tiledb_ctx_t* server_ctx;
   tiledb_ctx_alloc(config, &server_ctx);
-  tiledb_array_t* array_server;
+  tiledb_array_t* array_server = nullptr;
   if (refactored_query_v2) {
     rc = deserialize_array_and_query(
         server_ctx, serialized, &server_deser_query, array_uri.c_str(), 0);

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -908,18 +908,20 @@ int deserialize_array_and_query(
 
 /**
  * Helper method that wraps tiledb_array_open() and inserts a serialization
- * step, if serialization is enabled. The added serialization steps are
- * designed to closely mimic the behavior of the REST server.
+ * step, if serialization is enabled. This wrapper models exclusively the
+ * refactored array open (array open v2) serialization path. The added
+ * serialization steps are designed to closely mimic the behavior of the REST
+ * server.
  *
  * @param ctx Context.
  * @param query_type Type of query to open the array for.
- * @param serialize_query True if this is a remote array open, false if not.
+ * @param serialize True if this is a remote array open, false if not.
  * @param open_array Output open array.
  */
 int array_open_wrapper(
     tiledb_ctx_t* ctx,
     tiledb_query_type_t query_type,
-    bool serialize_query,
+    bool serialize,
     tiledb_array_t** open_array);
 
 /**
@@ -936,6 +938,8 @@ int array_open_wrapper(
  * e.g. once in the test Fixture definition or just before the call to
  * submit_query_wrapper.
  * @param serialize_query True if this is a remote array open, false if not.
+ * @param refactored_query_v2 If "rest.use_refactored_array_open" should be
+ * true.
  * @param finalize Finalize or not the query after submitting it.
  */
 int submit_query_wrapper(
@@ -944,6 +948,7 @@ int submit_query_wrapper(
     tiledb_query_t** query,
     ServerQueryBuffers& buffers,
     bool serialize_query,
+    bool refactored_query_v2 = false,
     bool finalize = true);
 
 /** C++ wrapper of submit_query_wrapper */
@@ -953,6 +958,7 @@ int submit_query_wrapper(
     Query* query,
     ServerQueryBuffers& buffers,
     bool serialize_query,
+    bool refactored_query_v2 = false,
     bool finalize = true);
 
 /**

--- a/test/support/src/serialization_wrappers.cc
+++ b/test/support/src/serialization_wrappers.cc
@@ -180,29 +180,3 @@ int tiledb_fragment_info_serialize(
   tiledb_buffer_free(&buffer);
   return rc;
 }
-
-int tiledb_query_v2_serialize(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    std::vector<uint8_t>& serialized,
-    bool client_to_server,
-    tiledb_query_t* query_to_serialize,
-    tiledb_query_t** query_deserialized) {
-  // Serialize and Deserialize
-  int rc = tiledb::test::serialize_query(
-      ctx, query_to_serialize, &serialized, client_to_server);
-  REQUIRE(rc == TILEDB_OK);
-
-  if (client_to_server) {
-    // server side deserialization
-    rc = tiledb::test::deserialize_array_and_query(
-        ctx, serialized, query_deserialized, array_uri, 0);
-  } else {
-    // client side deserialization
-    rc = tiledb::test::deserialize_query(
-        ctx, serialized, *query_deserialized, 1);
-  }
-
-  REQUIRE(rc == TILEDB_OK);
-  return rc;
-}

--- a/test/support/src/serialization_wrappers.h
+++ b/test/support/src/serialization_wrappers.h
@@ -128,24 +128,4 @@ int tiledb_fragment_info_serialize(
     tiledb_fragment_info_t* fragment_info_before_serialization,
     tiledb_fragment_info_t* fragment_info_deserialized,
     tiledb_serialization_type_t serialize_type);
-
-/**
- * Wrap a query serialize/deserialize call
- *
- * @param ctx Tiledb context
- * @param array_uri Array to execute the query on
- * @param serialized Vector allocated externally to store serialized data
- * @param client_to_server If it's server or client serializing this query
- * @param query_to_serialize Query to serialize
- * @param query_deserialized Query to deserialize into
- * @return status
- */
-int tiledb_query_v2_serialize(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    std::vector<uint8_t>& serialized,
-    bool client_to_server,
-    tiledb_query_t* query_to_serialize,
-    tiledb_query_t** query_deserialized);
-
 #endif  // TILEDB_TEST_SERIALIZATION_WRAPPERS_H

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1408,6 +1408,10 @@ Status Array::load_remote_non_empty_domain() {
 }
 
 ArrayDirectory& Array::load_array_directory() {
+  if (array_dir_.loaded()) {
+    return array_dir_;
+  }
+
   if (remote_) {
     throw std::logic_error(
         "Loading array directory for remote arrays is not supported");
@@ -1417,15 +1421,9 @@ ArrayDirectory& Array::load_array_directory() {
                query_type_ == QueryType::MODIFY_EXCLUSIVE) ?
                   ArrayDirectoryMode::SCHEMA_ONLY :
                   ArrayDirectoryMode::READ;
-  if (!array_dir_.loaded()) {
-    array_dir_ = ArrayDirectory(
-        resources_,
-        array_uri_,
-        timestamp_start_,
-        timestamp_end_opened_at_,
-        mode);
-    array_dir_.loaded() = true;
-  }
+
+  array_dir_ = ArrayDirectory(
+      resources_, array_uri_, timestamp_start_, timestamp_end_opened_at_, mode);
 
   return array_dir_;
 }


### PR DESCRIPTION
Running some examples I found out that there is a problem in array directory serialization after the latest merge of Query v2 work. However, array directory serialization should not be happening unless `rest.use_refactored_array_open` config is `true`, which means that I omitted to check for this condition in that case.

This PR:
1) Restores `dev` by conditionally serializing array directory and fragment metadata only if the config variable is set to `true`.
2) Uses different client and server contexts in all serialization tests.
3) Refactors/expands ALL serialization tests to test for both the "old" way of client-rest server serialization and the "new" one (query v2). This assures that today things work correctly with both values of `rest.use_refactored_array_open` and that backwards compatibility will be maintained when we will default to `true`.

TODO for another ticket and PR to follow: Fix the actual problem for the cases where `rest.use_refactored_array_open` is `true`

---
TYPE: IMPROVEMENT
DESC: Query v2: Add array directory and fragment meta ser/deser behind config flag
