### PR TITLE
Fix buffer size error in deserializing query

### DIFF
--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -1229,6 +1229,7 @@ TEST_CASE_METHOD(
   // Only makes sense in serialization
   return;
 #endif
+  refactored_query_v2_ = GENERATE(true, false);
 
   create_array(TILEDB_SPARSE);
   write_sparse_array();
@@ -1251,7 +1252,13 @@ TEST_CASE_METHOD(
   Query::Status status;
   do {
     int rc = submit_query_wrapper(
-        ctx, array_uri, &query, server_buffers_, true, false);
+        ctx,
+        array_uri,
+        &query,
+        server_buffers_,
+        true,
+        refactored_query_v2_,
+        false);
     REQUIRE(rc == TILEDB_OK);
 
     status = query.query_status();

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -1219,3 +1219,43 @@ TEST_CASE_METHOD(
     }
   }
 }
+
+TEST_CASE_METHOD(
+    SerializationFx,
+    "Derialization of a var size read query correctly resets original buffer "
+    "sizes",
+    "[capi][query][serialization][reset-buffers]") {
+#ifndef TILEDB_SERIALIZATION
+  // Only makes sense in serialization
+  return;
+#endif
+
+  create_array(TILEDB_SPARSE);
+  write_sparse_array();
+
+  Array array(ctx, array_uri, TILEDB_READ);
+  Query query(ctx, array);
+  query.set_layout(TILEDB_UNORDERED);
+
+  uint64_t up_limit = 16;
+  std::vector<char> a3_data(up_limit);
+  uint64_t offsets_size = up_limit / 8;
+  std::vector<uint64_t> a3_offsets(offsets_size);
+
+  auto set_buffers = [&]() {
+    query.set_data_buffer("a3", a3_data.data(), a3_data.size());
+    query.set_offsets_buffer("a3", a3_offsets.data(), a3_offsets.size());
+  };
+
+  set_buffers();
+  Query::Status status;
+  do {
+    int rc = submit_query_wrapper(
+        ctx, array_uri, &query, server_buffers_, true, false);
+    REQUIRE(rc == TILEDB_OK);
+
+    status = query.query_status();
+  } while (status == Query::Status::INCOMPLETE);
+
+  REQUIRE(status == Query::Status::COMPLETE);
+}

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -538,6 +538,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
         }
 
         // Add all tiles for this fragment.
+        all_tiles_loaded_[f] = start == tile_num;
         for (uint64_t t = start; t < tile_num; t++) {
           budget_exceeded = add_result_tile(
               dim_num,

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1488,11 +1488,6 @@ Status query_from_capnp(
     uint8_t* existing_validity_buffer = nullptr;
     uint64_t existing_validity_buffer_size = 0;
 
-    // For writes and read (client side) we need ptrs to set the sizes properly
-    uint64_t* existing_buffer_size_ptr = nullptr;
-    uint64_t* existing_offset_buffer_size_ptr = nullptr;
-    uint64_t* existing_validity_buffer_size_ptr = nullptr;
-
     auto var_size = schema.var_size(name);
     auto nullable = schema.is_nullable(name);
     const QueryBuffer& query_buffer = query->buffer(name);
@@ -1529,7 +1524,11 @@ Status query_from_capnp(
         }
       }
     } else if (query_type == QueryType::WRITE) {
-      // For writes we need to use get_buffer and clientside
+      // For writes we need ptrs to set the sizes properly
+      uint64_t* existing_buffer_size_ptr = nullptr;
+      uint64_t* existing_offset_buffer_size_ptr = nullptr;
+      uint64_t* existing_validity_buffer_size_ptr = nullptr;
+
       if (var_size) {
         if (!nullable) {
           RETURN_NOT_OK(query->get_data_buffer(
@@ -1683,7 +1682,8 @@ Status query_from_capnp(
           // attr_copy_state==nulptr models the case of deserialization code
           // being called via the C API tiledb_query_deserialize (e.g. unit
           // test serialization wrappers).
-          // When a rest_client exists, there is always a copy_state
+          // When a rest_client exists, there is always a non null copy_state
+          // incoming argument from which attr_copy_state is initialized
           if (attr_copy_state == nullptr) {
             // Set the size directly on the query (so user can introspect on
             // result size).
@@ -1729,7 +1729,8 @@ Status query_from_capnp(
           // attr_copy_state==nulptr models the case of deserialization code
           // being called via the C API tiledb_query_deserialize (e.g. unit
           // test serialization wrappers).
-          // When a rest_client exists, there is always a copy_state
+          // When a rest_client exists, there is always a non null copy_state
+          // incoming argument from which attr_copy_state is initialized
           if (attr_copy_state == nullptr) {
             // Set the size directly on the query (so user can introspect on
             // result size).

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1495,7 +1495,7 @@ Status query_from_capnp(
 
     auto var_size = schema.var_size(name);
     auto nullable = schema.is_nullable(name);
-    if (type == QueryType::READ && context == SerializationContext::SERVER) {
+    if (type == QueryType::READ) {
       const QueryBuffer& query_buffer = query->buffer(name);
       // We use the query_buffer directly in order to get the original buffer
       // sizes. This avoid a problem where an incomplete query will change the
@@ -1528,7 +1528,7 @@ Status query_from_capnp(
               query_buffer.original_validity_vector_size_;
         }
       }
-    } else if (query_type == QueryType::WRITE || type == QueryType::READ) {
+    } else if (query_type == QueryType::WRITE) {
       // For writes we need to use get_buffer and clientside
       if (var_size) {
         if (!nullable) {


### PR DESCRIPTION
This bug was originally found in MariaDB, but could be easily reproduced using C/C++ APIs: In the case of incomplete queries the client could potentially error out thinking that the data he received from the REST server for a dimension/attribute could not fit in the user buffers.

We have tracked down the root cause to be that, in the case of Incomplete queries, the client had a wrong idea of the actual size of the users buffers, which could perfectly fit the data received from the server. The reason is that after a query returns from the REST server, and only in the client side, we update the user buffer sizes to the actual data sizes received from server, so that the user can check the result size on reads. So if the next data received from the server are more than the data received in the previous `query.submit()` the client thinks that they don't fit the user buffers.

The reason this bug was not found earlier in that Python API that is mostly used by customers reallocate user buffers on incomplete queries, so the sizes are always reset to the right size. However, MariaDB uses C/C++ APIs and it was very easy to hit this problem with any var-sized data.

So, in order to work around this bug, we use the `original_buffer_size`s that are stored along with the actual `buffer_sizes` to determine if the data received from the REST server fit, instead of the actual `buffer_sizes`. This was already being done on the Server side so it was straightforward to extend to the client.

After this fix, a reader bug has also been uncovered, where when no Subarray is set for a sparse unordered with duplicates query, the reader was failing to detect when he was done processing all tiles of a fragment, and it would either hit an assert in debug or get in an infinite loop in release. This PR addresses this issue as well.

This is joint work with @robertbindar and @KiterLuc 

---
TYPE: BUG
DESC: Fix buffer size error in deserializing query
