### PR TITLE
Make "Incompatible format version" easier to debug

### DIFF
--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1922,12 +1922,12 @@ TEST_CASE(
   // Try writing to a newer-versioned (UINT32_MAX) array
   REQUIRE_THROWS_WITH(
       Array(ctx, new_array_name, TILEDB_WRITE),
-      Catch::Matchers::ContainsSubstring("Incompatible format version."));
+      Catch::Matchers::ContainsSubstring("incompatible format version"));
 
   // Try reading from a newer-versioned (UINT32_MAX) array
   REQUIRE_THROWS_WITH(
       Array(ctx, new_array_name, TILEDB_READ),
-      Catch::Matchers::ContainsSubstring("Incompatible format version."));
+      Catch::Matchers::ContainsSubstring("incompatible format version"));
 
   // Clean up
   VFS vfs(ctx);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -963,8 +963,10 @@ ArraySchema ArraySchema::deserialize(
   // #TODO Add security validation
   auto version = deserializer.read<uint32_t>();
   if (!(version <= constants::format_version)) {
-    throw ArraySchemaStatusException(
-        "Failed to deserialize array schema; Incompatible format version.");
+    std::stringstream ss;
+    ss << "Failed to deserialize array schema; Incompatible format version: ";
+    ss << "got " << version << "; expected <= " << constants::format_version;
+    throw ArraySchemaStatusException(ss.str().c_str());
   }
 
   // Load allows_dups

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -963,10 +963,11 @@ ArraySchema ArraySchema::deserialize(
   // #TODO Add security validation
   auto version = deserializer.read<uint32_t>();
   if (!(version <= constants::format_version)) {
-    std::stringstream ss;
-    ss << "Failed to deserialize array schema; Incompatible format version: ";
-    ss << "got " << version << "; expected <= " << constants::format_version;
-    throw ArraySchemaStatusException(ss.str().c_str());
+    throw ArraySchemaStatusException(
+        "Failed to deserialize array schema: incompatible format version: "
+        "got " +
+        std::to_string(version) +
+        "; expected <= " + std::to_string(constants::format_version));
   }
 
   // Load allows_dups


### PR DESCRIPTION
Found while debugging TileDB-SOMA-Py unit tests with @bekadavis9 . While local directories can easily be inspected with `tiledb.open("foo").schema.version`, unit-test files are ephemeral and harder to get at. This PR helps.

---
TYPE: IMPROVEMENT
DESC: Show expected and actual version numbers in the error message