### PR TITLE
Dense reader: process smaller units of work.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -171,6 +171,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-compression-rle.cc
   src/unit-crypto.cc
   src/unit-ctx.cc
+  src/unit-dense-reader.cc
   src/unit-DenseTiler.cc
   src/unit-dimension.cc
   src/unit-duplicates.cc

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -276,6 +276,7 @@ void check_save_to_file() {
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition "
         "0.25\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges 0.1\n";
+  ss << "sm.mem.tile_memory_budget 2147483648\n";
   ss << "sm.mem.total_budget 10737418240\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
@@ -605,6 +606,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.query.sparse_global_order.reader"] = "refactored";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
   all_param_values["sm.mem.malloc_trim"] = "true";
+  all_param_values["sm.mem.tile_memory_budget"] = "2147483648";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_query_condition"] =

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1,0 +1,447 @@
+/**
+ * @file unit-dense-reader.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the dense reader.
+ */
+
+#include "test/support/src/helpers.h"
+#include "tiledb/common/common.h"
+#include "tiledb/sm/c_api/tiledb.h"
+#include "tiledb/sm/c_api/tiledb_struct_def.h"
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/readers/dense_reader.h"
+
+#ifdef _WIN32
+#include "tiledb/sm/filesystem/win.h"
+#else
+#include "tiledb/sm/filesystem/posix.h"
+#endif
+
+#include <test/support/tdb_catch.h>
+
+using namespace tiledb::sm;
+using namespace tiledb::test;
+
+/* ********************************* */
+/*         STRUCT DEFINITION         */
+/* ********************************* */
+
+struct CDenseFx {
+  tiledb_ctx_t* ctx_ = nullptr;
+  tiledb_vfs_t* vfs_ = nullptr;
+  std::string temp_dir_;
+  std::string array_name_;
+  const char* ARRAY_NAME = "test_dense_reader";
+  std::string total_budget_;
+  std::string tile_memory_budget_;
+
+  void create_default_array_1d();
+  void create_default_array_1d_string();
+  void write_1d_fragment(int* subarray, int* data, uint64_t* data_size);
+  void write_1d_fragment_strings(
+      int* subarray,
+      char* data,
+      uint64_t* data_size,
+      uint64_t* offsets,
+      uint64_t* offsets_size);
+  void read(int* subarray, int* data, uint64_t* data_size);
+  void read_strings(
+      int* subarray,
+      char* data,
+      uint64_t* data_size,
+      uint64_t* offsets,
+      uint64_t* offsets_size);
+  void reset_config();
+  void update_config();
+
+  CDenseFx();
+  ~CDenseFx();
+};
+
+CDenseFx::CDenseFx() {
+  reset_config();
+
+  // Create temporary directory based on the supported filesystem.
+#ifdef _WIN32
+  temp_dir_ = tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
+#else
+  temp_dir_ = "file://" + tiledb::sm::Posix::current_dir() + "/tiledb_test/";
+#endif
+  create_dir(temp_dir_, ctx_, vfs_);
+  array_name_ = temp_dir_ + ARRAY_NAME;
+}
+
+CDenseFx::~CDenseFx() {
+  remove_dir(temp_dir_, ctx_, vfs_);
+  tiledb_ctx_free(&ctx_);
+  tiledb_vfs_free(&vfs_);
+}
+
+void CDenseFx::reset_config() {
+  total_budget_ = "1048576";
+  tile_memory_budget_ = "1024";
+  update_config();
+}
+
+void CDenseFx::update_config() {
+  if (ctx_ != nullptr) {
+    tiledb_ctx_free(&ctx_);
+  }
+
+  if (vfs_ != nullptr) {
+    tiledb_vfs_free(&vfs_);
+  }
+
+  tiledb_config_t* config;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  REQUIRE(
+      tiledb_config_set(
+          config, "sm.mem.total_budget", total_budget_.c_str(), &error) ==
+      TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  REQUIRE(
+      tiledb_config_set(
+          config,
+          "sm.mem.tile_memory_budget",
+          tile_memory_budget_.c_str(),
+          &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  tiledb_config_free(&config);
+}
+
+void CDenseFx::create_default_array_1d() {
+  int domain[] = {1, 200};
+  int tile_extent = 10;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_INT32},
+      {domain},
+      {&tile_extent},
+      {"a"},
+      {TILEDB_INT32},
+      {1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      10);  // allows dups.
+}
+
+void CDenseFx::create_default_array_1d_string() {
+  int domain[] = {1, 200};
+  int tile_extent = 10;
+  create_array(
+      ctx_,
+      array_name_,
+      TILEDB_DENSE,
+      {"d"},
+      {TILEDB_INT32},
+      {domain},
+      {&tile_extent},
+      {"a"},
+      {TILEDB_STRING_ASCII},
+      {TILEDB_VAR_NUM},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      TILEDB_ROW_MAJOR,
+      TILEDB_ROW_MAJOR,
+      10);  // allows dups.
+}
+
+void CDenseFx::write_1d_fragment(
+    int* subarray, int* data, uint64_t* data_size) {
+  // Open array for writing.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create the query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set subarray.
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query.
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Close array.
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up.
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void CDenseFx::write_1d_fragment_strings(
+    int* subarray,
+    char* data,
+    uint64_t* data_size,
+    uint64_t* offsets,
+    uint64_t* offsets_size) {
+  // Open array for writing.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Create the query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_offsets_buffer(ctx_, query, "a", offsets, offsets_size);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Set subarray.
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query.
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Close array.
+  rc = tiledb_array_close(ctx_, array);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up.
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void CDenseFx::read(int* subarray, int* data, uint64_t* data_size) {
+  // Open array for reading.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+
+  // Set subarray.
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query.
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Check the internal loop count against expected value.
+  auto stats = ((DenseReader*)query->query_->strategy())->stats();
+  REQUIRE(stats != nullptr);
+  auto counters = stats->counters();
+  REQUIRE(counters != nullptr);
+  auto loop_num =
+      counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+  CHECK(2 == loop_num->second);
+
+  // Clean up.
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+void CDenseFx::read_strings(
+    int* subarray,
+    char* data,
+    uint64_t* data_size,
+    uint64_t* offsets,
+    uint64_t* offsets_size) {
+  // Open array for reading.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query.
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+
+  // Set subarray.
+  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_offsets_buffer(ctx_, query, "a", offsets, offsets_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query.
+  rc = tiledb_query_submit(ctx_, query);
+  CHECK(rc == TILEDB_OK);
+
+  // Clean up.
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+}
+
+/* ********************************* */
+/*                TESTS              */
+/* ********************************* */
+
+TEST_CASE_METHOD(
+    CDenseFx,
+    "Dense reader: tile budget exceeded, fixed attribute",
+    "[dense-reader][tile-budget-exceeded][fixed]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d();
+
+  // Write a fragment.
+  int subarray[] = {1, 20};
+  int data[] = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+  uint64_t data_size = sizeof(data);
+  write_1d_fragment(subarray, data, &data_size);
+
+  // Each tile is 40 bytes, this will only allow to load one.
+  tile_memory_budget_ = "50";
+  update_config();
+
+  // Try to read.
+  int data_r[20] = {0};
+  uint64_t data_r_size = sizeof(data_r);
+  read(subarray, data_r, &data_r_size);
+
+  CHECK(data_r_size == data_size);
+  CHECK(!std::memcmp(data, data_r, data_size));
+}
+
+TEST_CASE_METHOD(
+    CDenseFx,
+    "Dense reader: tile budget exceeded, var attribute",
+    "[dense-reader][tile-budget-exceeded][var]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d_string();
+
+  // Write a fragment.
+  int subarray[] = {1, 20};
+  char data[] = "1234567891011121314151617181920";
+  uint64_t data_size = sizeof(data) - 1;
+  uint64_t offsets[] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                        11, 13, 15, 17, 19, 21, 23, 25, 27, 29};
+  uint64_t offsets_size = sizeof(offsets);
+  write_1d_fragment_strings(subarray, data, &data_size, offsets, &offsets_size);
+
+  // Each tile is 40 bytes, this will only allow to load one.
+  tile_memory_budget_ = "50";
+  update_config();
+
+  // Try to read.
+  char data_r[100] = {0};
+  uint64_t data_r_size = sizeof(data_r);
+  uint64_t offsets_r[20] = {0};
+  uint64_t offsets_r_size = sizeof(offsets_r);
+  read_strings(subarray, data_r, &data_r_size, offsets_r, &offsets_r_size);
+
+  CHECK(data_r_size == data_size);
+  CHECK(!std::memcmp(data, data_r, data_size));
+  CHECK(offsets_r_size == offsets_size);
+  CHECK(!std::memcmp(offsets, offsets_r, offsets_size));
+}
+
+TEST_CASE_METHOD(
+    CDenseFx,
+    "Dense reader: tile budget exceeded, var attribute, unaligned read",
+    "[dense-reader][tile-budget-exceeded][var-unaligned]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d_string();
+
+  // Write a fragment.
+  int subarray[] = {1, 20};
+  char data[] = "1234567891011121314151617181920";
+  uint64_t data_size = sizeof(data) - 1;
+  uint64_t offsets[] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                        11, 13, 15, 17, 19, 21, 23, 25, 27, 29};
+  uint64_t offsets_size = sizeof(offsets);
+  write_1d_fragment_strings(subarray, data, &data_size, offsets, &offsets_size);
+
+  // Each tile is 40 bytes, this will only allow to load one.
+  tile_memory_budget_ = "50";
+  update_config();
+
+  // Try to read.
+  int subarray_r[] = {6, 15};
+  char data_r[100] = {0};
+  uint64_t data_r_size = sizeof(data_r);
+  uint64_t offsets_r[10] = {0};
+  uint64_t offsets_r_size = sizeof(offsets_r);
+  read_strings(subarray_r, data_r, &data_r_size, offsets_r, &offsets_r_size);
+
+  char c_data[] = "6789101112131415";
+  uint64_t c_data_size = sizeof(c_data) - 1;
+  uint64_t c_offsets[] = {0, 1, 2, 3, 4, 6, 8, 10, 12, 14};
+  uint64_t c_offsets_size = sizeof(c_offsets);
+  CHECK(data_r_size == c_data_size);
+  CHECK(!std::memcmp(c_data, data_r, c_data_size));
+  CHECK(offsets_r_size == c_offsets_size);
+  CHECK(!std::memcmp(c_offsets, offsets_r, c_offsets_size));
+}

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -231,8 +231,11 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: refactored
  * - `sm.mem.malloc_trim` <br>
  *    Should malloc_trim be called on context and query destruction? This might
- * reduce residual memory usage. <br>
+ *    reduce residual memory usage. <br>
  *    **Default**: true
+ * - `sm.mem.tile_memory_budget` <br>
+ *    Tile memory budget, only respected in the dense reader for now. <br>
+ *    **Default**: 2GB
  * - `sm.mem.total_budget` <br>
  *    Memory budget for readers and writers. <br>
  *    **Default**: 10GB

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -105,14 +105,15 @@ const std::string Config::SM_CHECK_GLOBAL_ORDER = "true";
 const std::string Config::SM_SKIP_EST_SIZE_PARTITIONING = "false";
 const std::string Config::SM_SKIP_UNARY_PARTITIONING_BUDGET_CHECK = "false";
 const std::string Config::SM_MEMORY_BUDGET = "5368709120";       // 5GB
-const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB;
+const std::string Config::SM_MEMORY_BUDGET_VAR = "10737418240";  // 10GB
 const std::string Config::SM_QUERY_DENSE_QC_COORDS_MODE = "false";
 const std::string Config::SM_QUERY_DENSE_READER = "refactored";
 const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "refactored";
 const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
     "refactored";
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";
-const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";  // 10GB;
+const std::string Config::SM_TILE_MEMORY_BUDGET = "2147483648";  // 2GB
+const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";   // 10GB
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION =
     "0.25";
@@ -276,6 +277,7 @@ const std::map<std::string, std::string> default_config_values = {
         "sm.query.sparse_unordered_with_dups.reader",
         Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER),
     std::make_pair("sm.mem.malloc_trim", Config::SM_MEM_MALLOC_TRIM),
+    std::make_pair("sm.mem.tile_memory_budget", Config::SM_TILE_MEMORY_BUDGET),
     std::make_pair("sm.mem.total_budget", Config::SM_MEM_TOTAL_BUDGET),
     std::make_pair(
         "sm.mem.reader.sparse_global_order.ratio_coords",

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -198,6 +198,9 @@ class Config {
   /** Should malloc_trim be called on query/ctx destructors. */
   static const std::string SM_MEM_MALLOC_TRIM;
 
+  /** Maximum tile memory budget for readers. */
+  static const std::string SM_TILE_MEMORY_BUDGET;
+
   /** Maximum memory budget for readers and writers. */
   static const std::string SM_MEM_TOTAL_BUDGET;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -414,6 +414,9 @@ class Config {
    *    Should malloc_trim be called on context and query destruction? This
    *    might reduce residual memory usage. <br>
    *    **Default**: true
+   * - `sm.mem.tile_memory_budget` <br>
+   *    Tile memory budget, only respected in the dense reader for now. <br>
+   *    **Default**: 2GB
    * - `sm.mem.total_budget` <br>
    *    Memory budget for readers and writers. <br>
    *    **Default**: 10GB

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -116,8 +116,7 @@ Status DeletesAndUpdates::finalize() {
   return Status::Ok();
 }
 
-Status DeletesAndUpdates::initialize_memory_budget() {
-  return Status::Ok();
+void DeletesAndUpdates::initialize_memory_budget() {
 }
 
 Status DeletesAndUpdates::dowork() {

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
@@ -88,7 +88,7 @@ class DeletesAndUpdates : public StrategyBase, public IQueryStrategy {
   }
 
   /** Initialize the memory budget variables. */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /** Performs a delete query using its set members. */
   Status dowork();

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -48,7 +48,7 @@ class IQueryStrategy {
   virtual ~IQueryStrategy() = default;
 
   /** Initialize the memory budget variables. */
-  virtual Status initialize_memory_budget() = 0;
+  virtual void initialize_memory_budget() = 0;
 
   /** Performs a query using its set members. */
   virtual Status dowork() = 0;

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -169,8 +169,7 @@ QueryStatusDetailsReason Reader::status_incomplete_reason() const {
                         QueryStatusDetailsReason::REASON_NONE;
 }
 
-Status Reader::initialize_memory_budget() {
-  return Status::Ok();
+void Reader::initialize_memory_budget() {
 }
 
 const Reader::ReadState* Reader::read_state() const {

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -100,7 +100,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
   QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initialize the memory budget variables. */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /** Returns the current read state. */
   const ReadState* read_state() const;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -895,7 +895,7 @@ Status Query::process() {
   }
 
   return Status::Ok();
-}  // namespace sm
+}
 
 IQueryStrategy* Query::strategy(bool skip_checks_serialization) {
   if (strategy_ == nullptr) {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1249,8 +1249,9 @@ Status Query::set_config(const Config& config) {
   config_ = config;
 
   // Refresh memory budget configuration.
-  if (strategy_ != nullptr)
-    RETURN_NOT_OK(strategy_->initialize_memory_budget());
+  if (strategy_ != nullptr) {
+    strategy_->initialize_memory_budget();
+  }
 
   // Set subarray's config for backwards compatibility
   // Users expect the query config to effect the subarray based on existing

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -87,7 +87,8 @@ DenseReader::DenseReader(
           buffers,
           subarray,
           layout,
-          condition) {
+          condition)
+    , array_memory_tracker_(array->memory_tracker()) {
   elements_mode_ = false;
 
   // Sanity checks.
@@ -271,14 +272,6 @@ Status DenseReader::dense_read() {
   compute_result_space_tiles<DimType>(
       subarray, read_state_.partitioner_.subarray(), result_space_tiles);
 
-  std::vector<ResultTile*> result_tiles;
-  for (const auto& result_space_tile : result_space_tiles) {
-    for (const auto& result_tile : result_space_tile.second.result_tiles()) {
-      result_tiles.push_back(const_cast<ResultTile*>(&result_tile.second));
-    }
-  }
-  std::sort(result_tiles.begin(), result_tiles.end(), result_tile_cmp);
-
   // Compute subarrays for each tile.
   const auto& tile_coords = subarray.tile_coords();
   stats_->add_counter("num_tiles", tile_coords.size());
@@ -347,14 +340,6 @@ Status DenseReader::dense_read() {
     }
   }
 
-  // Compute parallelization parameters.
-  uint64_t num_range_threads = 1;
-  const auto num_threads = storage_manager_->compute_tp()->concurrency_level();
-  if (tile_coords.size() < num_threads) {
-    // Ceil the division between thread_num and tile_num.
-    num_range_threads = 1 + ((num_threads - 1) / tile_coords.size());
-  }
-
   // Compute attribute names to load and copy.
   std::vector<std::string> names;
   std::vector<std::string> fixed_names;
@@ -389,56 +374,100 @@ Status DenseReader::dense_read() {
   RETURN_CANCEL_OR_ERROR(load_tile_offsets(
       read_state_.partitioner_.subarray().relevant_fragments(), names));
 
-  auto&& [st, qc_result] = apply_query_condition<DimType, OffType>(
-      subarray,
-      tile_extents,
-      result_tiles,
-      tile_subarrays,
-      tile_offsets,
-      range_info,
-      result_space_tiles,
-      num_range_threads);
-  RETURN_CANCEL_OR_ERROR(st);
+  uint64_t tc_start = 0;
+  uint64_t tc_end = 0;
+  std::vector<uint8_t> qc_result(
+      condition_.empty() ? 0 : subarray.cell_num(), 1);
+  while (tc_end < tile_coords.size()) {
+    // Get result tiles to process on this iteration.
+    auto&& [ret_tc_end, result_tiles] = compute_result_tiles<DimType>(
+        names, condition_names, subarray, tc_start, result_space_tiles);
+    tc_end = ret_tc_end;
+
+    // Compute parallelization parameters.
+    uint64_t num_range_threads = 1;
+    const auto num_threads =
+        storage_manager_->compute_tp()->concurrency_level();
+    if ((tc_end - tc_start) < num_threads) {
+      // Ceil the division between thread_num and tile_num.
+      num_range_threads = 1 + ((num_threads - 1) / (tc_end - tc_start));
+    }
+
+    // Apply the query condition.
+    auto st = apply_query_condition<DimType, OffType>(
+        subarray,
+        tc_start,
+        tc_end,
+        condition_names,
+        tile_extents,
+        result_tiles,
+        tile_subarrays,
+        tile_offsets,
+        range_info,
+        result_space_tiles,
+        num_range_threads,
+        qc_result);
+    RETURN_CANCEL_OR_ERROR(st);
+
+    // For `qc_coords_mode` just fill in the coordinates and skip attribute
+    // processing.
+    if (qc_coords_mode_) {
+      for (auto& name : names) {
+        clear_tiles(name, result_tiles);
+      }
+
+      tc_start = tc_end;
+      continue;
+    }
+
+    // Process all attributes, names starts with the query condition names to
+    // clear the memory. Also, a name in names might not be in the user buffers
+    // so we might skip the copy but still clear the memory.
+    std::vector<std::string> to_read(1);
+    for (auto& name : names) {
+      if (name == constants::coords || array_schema_.is_dim(name)) {
+        continue;
+      }
+
+      if (condition_names.count(name) == 0) {
+        // Read and unfilter tiles.
+        to_read[0] = name;
+        RETURN_CANCEL_OR_ERROR(
+            read_and_unfilter_attribute_tiles(to_read, result_tiles));
+      }
+
+      // Only copy names that are present in the user buffers.
+      if (buffers_.count(name) != 0) {
+        // Copy attribute data to users buffers.
+        status = copy_attribute<DimType, OffType>(
+            name,
+            tile_extents,
+            subarray,
+            tc_start,
+            tc_end,
+            tile_subarrays,
+            tile_offsets,
+            range_info,
+            result_space_tiles,
+            qc_result,
+            num_range_threads);
+        RETURN_CANCEL_OR_ERROR(status);
+      }
+
+      clear_tiles(name, result_tiles);
+    }
+
+    if (read_state_.overflowed_) {
+      return Status::Ok();
+    }
+
+    tc_start = tc_end;
+  }
 
   // For `qc_coords_mode` just fill in the coordinates and skip attribute
   // processing.
   if (qc_coords_mode_) {
     fill_dense_coords<DimType>(subarray, qc_result);
-    return Status::Ok();
-  }
-
-  // Process attributes.
-  std::vector<std::string> to_read(1);
-  for (auto& buff : buffers_) {
-    auto& name = buff.first;
-    if (name == constants::coords || array_schema_.is_dim(name)) {
-      continue;
-    }
-
-    if (condition_.field_names().count(name) == 0) {
-      // Read and unfilter tiles.
-      to_read[0] = name;
-      RETURN_CANCEL_OR_ERROR(
-          read_and_unfilter_attribute_tiles(to_read, result_tiles));
-    }
-
-    // Copy attribute data to users buffers.
-    status = copy_attribute<DimType, OffType>(
-        name,
-        tile_extents,
-        subarray,
-        tile_subarrays,
-        tile_offsets,
-        range_info,
-        result_space_tiles,
-        *qc_result,
-        num_range_threads);
-    RETURN_CANCEL_OR_ERROR(status);
-
-    clear_tiles(name, result_tiles);
-  }
-
-  if (read_state_.overflowed_) {
     return Status::Ok();
   }
 
@@ -463,18 +492,23 @@ void DenseReader::init_read_state() {
 
   // Get config values.
   bool found = false;
-  uint64_t memory_budget = 0;
-  if (!config_.get<uint64_t>("sm.memory_budget", &memory_budget, &found).ok()) {
-    throw DenseReaderStatusException("Cannot get setting");
-  }
-  assert(found);
-
-  uint64_t memory_budget_var = 0;
-  if (!config_.get<uint64_t>("sm.memory_budget_var", &memory_budget_var, &found)
+  if (!config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found)
            .ok()) {
     throw DenseReaderStatusException("Cannot get setting");
   }
   assert(found);
+  if (!config_
+           .get<uint64_t>(
+               "sm.mem.tile_memory_budget", &tile_memory_budget_, &found)
+           .ok()) {
+    throw DenseReaderStatusException("Cannot get setting");
+  }
+  assert(found);
+
+  // Validate memory budget values.
+  if (tile_memory_budget_ > memory_budget_) {
+    throw DenseReaderStatusException("sm.tile_memory_budget > sm.total_budget");
+  }
 
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
@@ -517,18 +551,13 @@ void DenseReader::init_read_state() {
         "sm.query.dense.qc_coords_mode requires a query condition");
   }
 
-  // Consider the validity memory budget to be identical to `sm.memory_budget`
-  // because the validity vector is currently a bytemap. When converted to a
-  // bitmap, this can be budgeted as `sm.memory_budget` / 8.
-  uint64_t memory_budget_validity = memory_budget;
-
   // Create read state.
   read_state_.partitioner_ = SubarrayPartitioner(
       &config_,
       subarray_,
-      memory_budget,
-      memory_budget_var,
-      memory_budget_validity,
+      std::numeric_limits<uint64_t>::max(),
+      std::numeric_limits<uint64_t>::max(),
+      std::numeric_limits<uint64_t>::max(),
       storage_manager_->compute_tp(),
       stats_,
       logger_);
@@ -583,24 +612,127 @@ void DenseReader::init_read_state() {
   read_state_.initialized_ = true;
 }
 
+/**
+ * Compute the maximum tile coords that we can process on this itereation to
+ * respect the memory budget.
+ */
+template <class DimType>
+tuple<uint64_t, std::vector<ResultTile*>> DenseReader::compute_result_tiles(
+    const std::vector<std::string>& names,
+    const std::unordered_set<std::string>& condition_names,
+    Subarray& subarray,
+    uint64_t tc_start,
+    std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles) {
+  // For easy reference.
+  const auto& tile_coords = subarray.tile_coords();
+
+  // Keep track of the required memory to load the result space tiles. The first
+  // element of this vector is an aggregate of all query condition fields,
+  // followed by the rest of the buffers in names.
+  std::vector<uint64_t> required_memory(
+      names.size() - condition_names.size() + 1);
+
+  // Create the vector of result tiles to operate on. We stop once we reach the
+  // end or the memory budget. The memory budget is combined for all query
+  // condition attributes.
+  std::vector<ResultTile*> result_tiles;
+  uint64_t tc_end{tc_start};
+  bool done = false;
+  while (!done && tc_end < tile_coords.size()) {
+    const DimType* tc = (DimType*)&tile_coords[tc_end][0];
+    auto it = result_space_tiles.find(tc);
+    assert(it != result_space_tiles.end());
+
+    // Compute the required memory to load the query condition tiles for the
+    // current result space tile.
+    uint64_t condition_memory = 0;
+    for (const auto& result_tile : it->second.result_tiles()) {
+      auto& rt = result_tile.second;
+      for (uint64_t n = 0; n < condition_names.size(); n++) {
+        condition_memory +=
+            get_attribute_tile_size(names[n], rt.frag_idx(), rt.tile_idx());
+      }
+    }
+
+    // If we reached the memory budget, stop. Always include the first tile.
+    if (tc_end != tc_start &&
+        required_memory[0] + condition_memory > tile_memory_budget_) {
+      done = true;
+      break;
+    } else {
+      required_memory[0] += condition_memory;
+    }
+
+    // Compute the required memory to load the tiles for each names for the
+    // current space tile.
+    for (uint64_t n = condition_names.size(); n < names.size(); n++) {
+      uint64_t r_idx = n + 1 - condition_names.size();
+      uint64_t tile_memory = 0;
+      for (const auto& result_tile : it->second.result_tiles()) {
+        auto& rt = result_tile.second;
+        tile_memory +=
+            get_attribute_tile_size(names[n], rt.frag_idx(), rt.tile_idx());
+      }
+
+      // If we reached the memory budget, stop. Always include the first tile.
+      if (tc_end != tc_start &&
+          required_memory[r_idx] + tile_memory > tile_memory_budget_) {
+        done = true;
+        break;
+      } else {
+        required_memory[r_idx] += tile_memory;
+      }
+    }
+
+    if (done) {
+      break;
+    }
+
+    // Add the result tiles for this space tile to the returned list to
+    // process.
+    for (const auto& result_tile : it->second.result_tiles()) {
+      result_tiles.push_back(const_cast<ResultTile*>(&result_tile.second));
+    }
+
+    tc_end++;
+  }
+  std::sort(result_tiles.begin(), result_tiles.end(), result_tile_cmp);
+
+  // If we only include one tile, make sure we don't exceed the memory budget.
+  if (tc_end == tc_start + 1) {
+    const auto available_memory =
+        memory_budget_ - array_memory_tracker_->get_memory_usage();
+    for (auto mem : required_memory) {
+      if (mem > available_memory) {
+        throw DenseReaderStatusException(
+            "Cannot process a single tile, increase memory budget");
+      }
+    }
+  }
+
+  return {tc_end, result_tiles};
+}
+
 /** Apply the query condition. */
 template <class DimType, class OffType>
-tuple<Status, optional<std::vector<uint8_t>>>
-DenseReader::apply_query_condition(
+Status DenseReader::apply_query_condition(
     Subarray& subarray,
+    const uint64_t tc_start,
+    const uint64_t tc_end,
+    const std::unordered_set<std::string>& condition_names,
     const std::vector<DimType>& tile_extents,
     std::vector<ResultTile*>& result_tiles,
     DynamicArray<Subarray>& tile_subarrays,
     std::vector<uint64_t>& tile_offsets,
     const std::vector<RangeInfo<DimType>>& range_info,
     std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
-    const uint64_t num_range_threads) {
+    const uint64_t num_range_threads,
+    std::vector<uint8_t>& qc_result) {
   auto timer_se = stats_->start_timer("apply_query_condition");
-  std::vector<uint8_t> qc_result;
+
   if (!condition_.empty()) {
     // For easy reference.
     const auto& tile_coords = subarray.tile_coords();
-    const auto cell_num = subarray.cell_num();
     const auto dim_num = array_schema_.dim_num();
     auto stride = array_schema_.domain().stride<DimType>(layout_);
     const auto cell_order = array_schema_.cell_order();
@@ -608,29 +740,24 @@ DenseReader::apply_query_condition(
 
     // Compute the result of the query condition.
     std::vector<std::string> qc_names;
-    qc_names.reserve(condition_.field_names().size());
-    for (auto& name : condition_.field_names()) {
+    qc_names.reserve(condition_names.size());
+    for (auto& name : condition_names) {
       qc_names.emplace_back(name);
     }
 
     // Read and unfilter query condition attributes.
-    {
-      RETURN_CANCEL_OR_ERROR_TUPLE(
-          read_and_unfilter_attribute_tiles(qc_names, result_tiles));
-    }
+    RETURN_CANCEL_OR_ERROR(
+        read_and_unfilter_attribute_tiles(qc_names, result_tiles));
 
     if (stride == UINT64_MAX) {
       stride = 1;
     }
 
-    // Initialize the result buffer.
-    qc_result.resize(cell_num, 1);
-
     // Process all tiles in parallel.
     auto status = parallel_for_2d(
         storage_manager_->compute_tp(),
-        0,
-        tile_coords.size(),
+        tc_start,
+        tc_end,
         0,
         num_range_threads,
         [&](uint64_t t, uint64_t range_thread_idx) {
@@ -674,7 +801,8 @@ DenseReader::apply_query_condition(
                   iter.cell_slab_coords(),
                   iter.cell_slab_length());
               if (overlaps) {
-                // Re-initialize the bitmap to 1 in case of overlapping domains.
+                // Re-initialize the bitmap to 1 in case of overlapping
+                // domains.
                 if (i != static_cast<int32_t>(frag_domains.size()) - 1) {
                   for (uint64_t c = start; c <= end; c++) {
                     dest_ptr[c] = 1;
@@ -704,10 +832,10 @@ DenseReader::apply_query_condition(
 
           return Status::Ok();
         });
-    RETURN_NOT_OK_TUPLE(status, nullopt);
+    RETURN_NOT_OK(status);
   }
 
-  return {Status::Ok(), qc_result};
+  return Status::Ok();
 }
 
 template <class OffType>
@@ -753,6 +881,8 @@ Status DenseReader::copy_attribute(
     const std::string& name,
     const std::vector<DimType>& tile_extents,
     const Subarray& subarray,
+    const uint64_t tc_start,
+    const uint64_t tc_end,
     const DynamicArray<Subarray>& tile_subarrays,
     const std::vector<uint64_t>& tile_offsets,
     const std::vector<RangeInfo<DimType>>& range_info,
@@ -783,8 +913,8 @@ Status DenseReader::copy_attribute(
       auto timer_se = stats_->start_timer("copy_offset_tiles");
       auto status = parallel_for_2d(
           storage_manager_->compute_tp(),
-          0,
-          tile_coords.size(),
+          tc_start,
+          tc_end,
           0,
           num_range_threads,
           [&](uint64_t t, uint64_t range_thread_idx) {
@@ -839,8 +969,8 @@ Status DenseReader::copy_attribute(
       // Process var data in parallel.
       auto status = parallel_for_2d(
           storage_manager_->compute_tp(),
-          0,
-          tile_coords.size(),
+          tc_start,
+          tc_end,
           0,
           num_range_threads,
           [&](uint64_t t, uint64_t range_thread_idx) {
@@ -880,8 +1010,8 @@ Status DenseReader::copy_attribute(
       // Process values in parallel.
       auto status = parallel_for_2d(
           storage_manager_->compute_tp(),
-          0,
-          tile_coords.size(),
+          tc_start,
+          tc_end,
           0,
           num_range_threads,
           [&](uint64_t t, uint64_t range_thread_idx) {
@@ -1062,8 +1192,8 @@ Status DenseReader::copy_fixed_tiles(
         end = end + 1;
       }
 
-      // Fill the non written cells for the first fragment domain with the fill
-      // value.
+      // Fill the non written cells for the first fragment domain with the
+      // fill value.
 
       // Calculate the destination pointers.
       auto dest_ptr = dst_buf + cell_offset * cell_size;

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -150,7 +150,7 @@ void DenseReader::initialize_memory_budget() {
   }
 
   // Set the memory budget for the array
-  array_memory_tracker_->set_budget(memory_budget_ - tile_memory_budget_);
+  array_memory_tracker_->set_budget(memory_budget_);
 }
 
 const DenseReader::ReadState* DenseReader::read_state() const {
@@ -647,6 +647,9 @@ tuple<uint64_t, std::vector<ResultTile*>> DenseReader::compute_result_tiles(
     uint64_t t_start,
     std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles) {
   // For easy reference.
+  const uint64_t left_over_budget = std::min(
+      tile_memory_budget_,
+      memory_budget_ - array_memory_tracker_->get_memory_usage());
   const auto& tile_coords = subarray.tile_coords();
 
   // Keep track of the required memory to load the result space tiles. The first
@@ -679,7 +682,7 @@ tuple<uint64_t, std::vector<ResultTile*>> DenseReader::compute_result_tiles(
 
     // If we reached the memory budget, stop. Always include the first tile.
     if (t_end != t_start &&
-        required_memory[0] + condition_memory > tile_memory_budget_) {
+        required_memory[0] + condition_memory > left_over_budget) {
       done = true;
       break;
     } else {
@@ -699,7 +702,7 @@ tuple<uint64_t, std::vector<ResultTile*>> DenseReader::compute_result_tiles(
 
       // If we reached the memory budget, stop. Always include the first tile.
       if (t_end != t_start &&
-          required_memory[r_idx] + tile_memory > tile_memory_budget_) {
+          required_memory[r_idx] + tile_memory > left_over_budget) {
         done = true;
         break;
       } else {

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -150,7 +150,10 @@ void DenseReader::initialize_memory_budget() {
   }
 
   // Set the memory budget for the array
-  array_memory_tracker_->set_budget(memory_budget_);
+  if (!array_memory_tracker_->set_budget(memory_budget_)) {
+    throw DenseReaderStatusException(
+        "Memory budget is too small to open array");
+  }
 }
 
 const DenseReader::ReadState* DenseReader::read_state() const {
@@ -733,6 +736,12 @@ tuple<uint64_t, std::vector<ResultTile*>> DenseReader::compute_result_tiles(
         throw DenseReaderStatusException(
             "Cannot process a single tile, increase memory budget");
       }
+    }
+
+    if (required_memory_query_condition > available_memory) {
+      throw DenseReaderStatusException(
+          "Cannot process a single tile because of query condition, increase "
+          "memory budget");
     }
   }
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -510,6 +510,9 @@ void DenseReader::init_read_state() {
     throw DenseReaderStatusException("sm.tile_memory_budget > sm.total_budget");
   }
 
+  // Set the memory budget for the array data.
+  array_memory_tracker_->set_budget(memory_budget_ - tile_memory_budget_);
+
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -125,7 +125,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initialize the memory budget variables. */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /** Returns the current read state. */
   const ReadState* read_state() const;

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -192,15 +192,15 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::vector<std::string>& names,
       const std::unordered_set<std::string>& condition_names,
       Subarray& subarray,
-      uint64_t tc_start,
+      uint64_t t_start,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles);
 
   /** Apply the query condition. */
   template <class DimType, class OffType>
   Status apply_query_condition(
       Subarray& subarray,
-      const uint64_t tc_start,
-      const uint64_t tc_end,
+      const uint64_t t_start,
+      const uint64_t t_end,
       const std::unordered_set<std::string>& condition_names,
       const std::vector<DimType>& tile_extents,
       std::vector<ResultTile*>& result_tiles,
@@ -213,10 +213,12 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
 
   /** Fix offsets buffer after reading all offsets. */
   template <class OffType>
-  uint64_t fix_offsets_buffer(
+  void fix_offsets_buffer(
       const std::string& name,
       const bool nullable,
-      const uint64_t cell_num,
+      const uint64_t subarray_start_cell,
+      const uint64_t subarray_end_cell,
+      uint64_t& var_buffer_size,
       std::vector<void*>& var_data);
 
   /** Copy attribute into the users buffers. */
@@ -225,10 +227,13 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<DimType>& tile_extents,
       const Subarray& subarray,
-      const uint64_t tc_start,
-      const uint64_t tc_end,
+      const uint64_t t_start,
+      const uint64_t t_end,
+      const uint64_t subarray_start_cell,
+      const uint64_t subarray_end_cell,
       const DynamicArray<Subarray>& tile_subarrays,
       const std::vector<uint64_t>& tile_offsets,
+      uint64_t& var_buffer_size,
       const std::vector<RangeInfo<DimType>>& range_info,
       std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
       const std::vector<uint8_t>& qc_result,
@@ -267,6 +272,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       ResultSpaceTile<DimType>& result_space_tile,
       const Subarray& subarray,
       const Subarray& tile_subarray,
+      const uint64_t subarray_start_cell,
       const uint64_t global_cell_offset,
       std::vector<void*>& var_data,
       const std::vector<RangeInfo<DimType>>& range_info,
@@ -282,6 +288,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       ResultSpaceTile<DimType>& result_space_tile,
       const Subarray& subarray,
       const Subarray& tile_subarray,
+      const uint64_t subarray_start_cell,
       const uint64_t global_cell_offset,
       std::vector<void*>& var_data,
       const std::vector<RangeInfo<DimType>>& range_info,

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -161,8 +161,7 @@ QueryStatusDetailsReason OrderedDimLabelReader::status_incomplete_reason()
   return QueryStatusDetailsReason::REASON_NONE;
 }
 
-Status OrderedDimLabelReader::initialize_memory_budget() {
-  return Status::Ok();
+void OrderedDimLabelReader::initialize_memory_budget() {
 }
 
 Status OrderedDimLabelReader::dowork() {

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -288,7 +288,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   QueryStatusDetailsReason status_incomplete_reason() const;
 
   /** Initialize the memory budget variables. */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /** Performs a read query using its set members. */
   Status dowork();

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -100,10 +100,7 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
   SparseIndexReaderBase::init(skip_checks_serialization);
 
   // Initialize memory budget variables.
-  if (!initialize_memory_budget().ok()) {
-    throw SparseGlobalOrderReaderStatusException(
-        "Cannot initialize memory budget");
-  }
+  initialize_memory_budget();
 }
 
 /* ****************************** */
@@ -128,33 +125,31 @@ SparseGlobalOrderReader<BitmapType>::status_incomplete_reason() const {
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::initialize_memory_budget() {
+void SparseGlobalOrderReader<BitmapType>::initialize_memory_budget() {
   bool found = false;
-  RETURN_NOT_OK(
+  throw_if_not_ok(
       config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found));
   assert(found);
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_array_data",
       &memory_budget_ratio_array_data_,
       &found));
   assert(found);
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_coords",
       &memory_budget_ratio_coords_,
       &found));
   assert(found);
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_query_condition",
       &memory_budget_ratio_query_condition_,
       &found));
   assert(found);
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_tile_ranges",
       &memory_budget_ratio_tile_ranges_,
       &found));
   assert(found);
-
-  return Status::Ok();
 }
 
 template <class BitmapType>

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -117,7 +117,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @return Status.
    */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /**
    * Performs a read query using its set members.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -93,10 +93,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
   SparseIndexReaderBase::init(skip_checks_serialization);
 
   // Initialize memory budget variables.
-  if (!initialize_memory_budget().ok()) {
-    throw SparseUnorderedWithDupsReaderStatusException(
-        "Cannot initialize memory budget");
-  }
+  initialize_memory_budget();
 
   // Get the setting that allows to partially load tile offsets. This is done
   // for this reader only for now.
@@ -138,37 +135,35 @@ SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
 }
 
 template <class BitmapType>
-Status SparseUnorderedWithDupsReader<BitmapType>::initialize_memory_budget() {
+void SparseUnorderedWithDupsReader<BitmapType>::initialize_memory_budget() {
   bool found = false;
-  RETURN_NOT_OK(
+  throw_if_not_ok(
       config_.get<uint64_t>("sm.mem.total_budget", &memory_budget_, &found));
   assert(found);
 
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data",
       &memory_budget_ratio_array_data_,
       &found));
   assert(found);
 
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
       &memory_budget_ratio_coords_,
       &found));
   assert(found);
 
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition",
       &memory_budget_ratio_query_condition_,
       &found));
   assert(found);
 
-  RETURN_NOT_OK(config_.get<double>(
+  throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges",
       &memory_budget_ratio_tile_ranges_,
       &found));
   assert(found);
-
-  return Status::Ok();
 }
 
 template <class BitmapType>

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -141,7 +141,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    *
    * @return Status.
    */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /**
    * Performs a read query using its set members.

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -316,8 +316,7 @@ void WriterBase::check_var_attr_offsets() const {
   }
 }
 
-Status WriterBase::initialize_memory_budget() {
-  return Status::Ok();
+void WriterBase::initialize_memory_budget() {
 }
 
 /* ****************************** */

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -116,7 +116,7 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   bool get_dedup_coords() const;
 
   /** Initialize the memory budget variables. */
-  Status initialize_memory_budget();
+  void initialize_memory_budget();
 
   /** Sets current setting of check_coord_dups_ */
   void set_check_coord_dups(bool b);


### PR DESCRIPTION
This makes the dense reader process smaller units of work so that it uses less memory overall. That way, we limit expensive operations when data is moved across large ranges of memory.

The limit of data to process at once is specified in a new configuration setting `sm.mem.tile_memory_budget` that will eventually be shared across multiple readers.

SC-10286

---
TYPE: IMPROVEMENT
DESC: Dense reader: process smaller units of work.
