### PR TITLE
Filter pipeline: make chunk range path default and remove other.

### DIFF
--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -114,6 +114,28 @@ Tile create_tile_for_unfiltering(uint64_t nelts, WriterTile& tile) {
   return ret;
 }
 
+void run_reverse(
+    const tiledb::sm::Config& config,
+    ThreadPool& tp,
+    Tile& unfiltered_tile,
+    FilterPipeline& pipeline,
+    bool success = true) {
+  ChunkData chunk_data;
+  unfiltered_tile.load_chunk_data(chunk_data);
+  CHECK(
+      success == pipeline
+                     .run_reverse(
+                         &test::g_helper_stats,
+                         &unfiltered_tile,
+                         nullptr,
+                         chunk_data,
+                         0,
+                         chunk_data.filtered_chunks_.size(),
+                         tp.concurrency_level(),
+                         config)
+                     .ok());
+}
+
 /**
  * Simple filter that modifies the input stream by adding 1 to every input
  * element.
@@ -625,11 +647,7 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -718,11 +736,7 @@ TEST_CASE(
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -779,11 +793,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -830,11 +840,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -927,11 +933,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -983,11 +985,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1047,11 +1045,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1098,11 +1092,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1195,11 +1185,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1251,11 +1237,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1314,11 +1296,7 @@ TEST_CASE(
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1411,11 +1389,7 @@ TEST_CASE(
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1462,11 +1436,7 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
@@ -1488,11 +1458,7 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
@@ -1516,11 +1482,7 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     CHECK(tile.filtered_buffer().size() < nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
@@ -1602,11 +1564,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         9);  // Number of chunks
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
@@ -1631,11 +1589,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         9);  // Number of chunks
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
@@ -1662,11 +1616,7 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         9);  // Number of chunks
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
 
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
@@ -1734,11 +1684,7 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1803,11 +1749,7 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1909,11 +1851,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -1979,11 +1917,7 @@ TEST_CASE(
     }
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2047,11 +1981,8 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter][modify]") {
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
+
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2151,11 +2082,8 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
+
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2232,11 +2160,8 @@ TEST_CASE("Filter: Test pipeline copy", "[filter][copy]") {
   }
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, pipeline);
+
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2319,11 +2244,8 @@ TEST_CASE("Filter: Test random pipeline", "[filter][random]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
+
     for (uint64_t n = 0; n < nelts; n++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
@@ -2353,11 +2275,8 @@ TEST_CASE(
   CHECK(tile.filtered_buffer().size() != 0);
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(md5_pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile, md5_pipeline);
+
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
@@ -2378,11 +2297,7 @@ TEST_CASE(
   CHECK(tile2.filtered_buffer().size() != 0);
 
   auto unfiltered_tile2 = create_tile_for_unfiltering(nelts, tile2);
-  CHECK(sha_256_pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
-            .ok());
-  CHECK(unfiltered_tile2.filtered_size() == 0);
+  run_reverse(config, tp, unfiltered_tile2, sha_256_pipeline);
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
     CHECK(unfiltered_tile2.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
@@ -2436,11 +2351,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2464,12 +2375,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
       CHECK(tile.filtered_buffer().size() != 0);
 
       auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-      CHECK(
-          pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-      CHECK(unfiltered_tile.filtered_size() == 0);
+      run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
         CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2504,11 +2410,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2544,11 +2446,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t))
@@ -2576,11 +2474,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2692,11 +2586,7 @@ TEST_CASE(
     CHECK(compressed_size < nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2722,12 +2612,7 @@ TEST_CASE(
       CHECK(tile.filtered_buffer().size() != 0);
 
       auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-      CHECK(
-          pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-      CHECK(unfiltered_tile.filtered_size() == 0);
+      run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
         CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2764,11 +2649,7 @@ TEST_CASE(
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2827,11 +2708,7 @@ TEST_CASE(
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t))
@@ -2862,11 +2739,7 @@ TEST_CASE(
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2922,11 +2795,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
                             nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -2949,12 +2818,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       CHECK(tile.filtered_buffer().size() != 0);
 
       auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-      CHECK(
-          pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-      CHECK(unfiltered_tile.filtered_size() == 0);
+      run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
         CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3076,11 +2940,7 @@ TEST_CASE(
         pipeline_metadata_size + total_md_size + nelts * sizeof(uint64_t));
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3107,12 +2967,7 @@ TEST_CASE(
       CHECK(tile.filtered_buffer().size() != 0);
 
       auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-      CHECK(
-          pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-      CHECK(unfiltered_tile.filtered_size() == 0);
+      run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
         CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3158,11 +3013,7 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3192,12 +3043,7 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     CHECK(tile2.filtered_buffer().size() != 0);
 
     auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
-    CHECK(
-        pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
-            .ok());
-    CHECK(unfiltered_tile2.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
       CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
@@ -3256,11 +3102,7 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3292,12 +3134,7 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     CHECK(tile2.filtered_buffer().size() != 0);
 
     auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
-    CHECK(
-        pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
-            .ok());
-    CHECK(unfiltered_tile2.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
       CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
@@ -3327,11 +3164,7 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3361,12 +3194,7 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     CHECK(tile2.filtered_buffer().size() != 0);
 
     auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
-    CHECK(
-        pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
-            .ok());
-    CHECK(unfiltered_tile2.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
       CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
@@ -3425,11 +3253,7 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3461,12 +3285,7 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     CHECK(tile2.filtered_buffer().size() != 0);
 
     auto unfiltered_tile2 = create_tile_for_unfiltering(nelts2, tile2);
-    CHECK(
-        pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile2, nullptr, &tp, config)
-            .ok());
-    CHECK(unfiltered_tile2.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
       CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
@@ -3508,11 +3327,7 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     CHECK(tile.filtered_buffer().size() != 0);
 
     auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3528,21 +3343,14 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     filter->set_key(key);
 
     unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-    CHECK(
-        !pipeline
-             .run_reverse(
-                 &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-             .ok());
+    run_reverse(config, tp, unfiltered_tile, pipeline, false);
 
     // Fix key and check success.
     unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
     key[0]--;
     filter->set_key(key);
-    CHECK(pipeline
-              .run_reverse(
-                  &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-              .ok());
-    CHECK(unfiltered_tile.filtered_size() == 0);
+    run_reverse(config, tp, unfiltered_tile, pipeline);
+
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
       CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
@@ -3622,10 +3430,7 @@ void testing_float_scaling_filter() {
   CHECK(tile.filtered_buffer().size() != 0);
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
+  run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     FloatingType elt = 0.0f;
     CHECK(unfiltered_tile
@@ -3688,10 +3493,7 @@ void testing_xor_filter(Datatype t) {
   CHECK(tile.filtered_buffer().size() != 0);
 
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
-  CHECK(pipeline
-            .run_reverse(
-                &test::g_helper_stats, &unfiltered_tile, nullptr, &tp, config)
-            .ok());
+  run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     T elt = 0;
     CHECK(unfiltered_tile.read(&elt, i * sizeof(T), sizeof(T)).ok());

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -369,6 +369,31 @@ Status FilterPipeline::run_forward(
   return Status::Ok();
 }
 
+void FilterPipeline::run_reverse(
+    stats::Stats* stats,
+    Tile& tile,
+    ThreadPool& compute_tp,
+    const Config& config) const {
+  ChunkData chunk_data;
+  tile.load_chunk_data(chunk_data);
+  throw_if_not_ok(parallel_for(
+      &compute_tp,
+      0,
+      chunk_data.filtered_chunks_.size(),
+      [&](const unsigned c) {
+        return run_reverse(
+            stats,
+            &tile,
+            nullptr,
+            chunk_data,
+            c,
+            c + 1,
+            compute_tp.concurrency_level(),
+            config);
+      }));
+  tile.clear_filtered_buffer();
+}
+
 Status FilterPipeline::run_reverse(
     stats::Stats* const reader_stats,
     Tile* const tile,

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -207,70 +207,24 @@ class FilterPipeline {
       bool chunking = true) const;
 
   /**
-   * Runs the pipeline in reverse on the given filtered tile. This is used
-   * during reads, and processes filtered Tile data (e.g. compressed) into
-   * unfiltered Tile data.
-   *
-   * This expects as input a Tile in the following byte format:
-   *
-   *   number_of_chunks (uint64_t)
-   *   chunk0_orig_len (uint32_t)
-   *   chunk0_data_len (uint32_t)
-   *   chunk0_metadata_len (uint32_t)
-   *   chunk0_metadata (uint8_t[])
-   *   chunk0_data (uint8_t[])
-   *   chunk1_orig_len (uint32_t)
-   *   chunk1_data_len (uint32_t)
-   *   chunk1_metadata_len (uint32_t)
-   *   chunk1_metadata (uint8_t[])
-   *   chunk1_data (uint8_t[])
-   *   ...
-   *   chunkN_orig_len (uint32_t)
-   *   chunkN_data_len (uint32_t)
-   *   chunkN_metadata_len (uint32_t)
-   *   chunkN_metadata (uint8_t[])
-   *   chunkN_data (uint8_t[])
-   *
-   * And modifies the Tile's buffer to contain the unfiltered byte array:
-   *
-   *   tile_data (uint8_t[])
-   *
-   * The length of tile_data will be the sum of all chunkI_orig_len for I in 0
-   * to N.
-   *
-   * @param reader_stats Reader stats
-   * @param tile Tile to unfilter
-   * @param offsets_tile Offsets tile to unfilter, null if it will be unfilered
-   * separately
-   * @param compute_tp The thread pool for compute-bound tasks.
-   * @param config The global config.
-   * @return Status
-   */
-  Status run_reverse(
-      stats::Stats* reader_stats,
-      Tile* const tile,
-      Tile* const offsets_tile,
-      ThreadPool* compute_tp,
-      const Config& config) const;
-
-  /**
    * Run the given chunk range in reverse through the pipeline.
    *
-   * @param reader_stats Stats to record in the function
-   * @param tile Current tile on which the filter pipeline is being run
+   * @param reader_stats Stats to record in the function.
+   * @param tile Current tile on which the filter pipeline is being run.
    * @param offsets_tile Offsets tile to unfilter, null if it will be unfilered
-   * separately
-   * @param chunk_data The tile chunk info, buffers and offsets
-   * @param min_chunk_index The chunk range index to start from
-   * @param max_chunk_index The chunk range index to end at
-   * @param concurrency_level The maximum level of concurrency
+   * separately.
+   * @param chunk_data The tile chunk info, buffers and offsets.
+   * @param min_chunk_index The chunk range index to start from.
+   * @param max_chunk_index The chunk range index to end at.
+   * @param concurrency_level The maximum level of concurrency.
    * @param config The global config.
-   * @return Status
+   * @return Status.
    */
 
-  Status run_reverse_chunk_range(
+  Status run_reverse(
       stats::Stats* const reader_stats,
       Tile* const tile,
+      Tile* const offsets_tile,
       const ChunkData& chunk_data,
       const uint64_t min_chunk_index,
       const uint64_t max_chunk_index,
@@ -381,42 +335,6 @@ class FilterPipeline {
       std::vector<uint64_t>& chunk_offsets,
       FilteredBuffer& output,
       ThreadPool* const compute_tp) const;
-
-  /**
-   * Run the given list of chunks in reverse through the pipeline.
-   *
-   * @param tile Current tile on which the filter pipeline is being run
-   * @param offsets_tile Current offsets tile for var sized
-   * attributes/dimensions.
-   * @param input Filtered chunk buffers to reverse.
-   * @param output Chunked buffer where output of the last stage
-   *    will be written.
-   * @param compute_tp The thread pool for compute-bound tasks.
-   * @param config The global config.
-   * @return Status
-   */
-  Status filter_chunks_reverse(
-      Tile& tile,
-      Tile* const offsets_tile,
-      const std::vector<tuple<void*, uint32_t, uint32_t, uint32_t>>& input,
-      ThreadPool* const compute_tp,
-      const Config& config) const;
-
-  /**
-   * The internal work routine for `run_reverse`.
-   *
-   * @param tile Tile to filter
-   * @param offsets_tile Offsets tile for var sized tile to filter.
-   * @param compute_tp The thread pool for compute-bound tasks.
-   * @param config The global config.
-   * @return Status
-   */
-  Status run_reverse_internal(
-      stats::Stats* reader_stats,
-      Tile* const tile,
-      Tile* const offsets_tile,
-      ThreadPool* compute_tp,
-      const Config& config) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -207,6 +207,20 @@ class FilterPipeline {
       bool chunking = true) const;
 
   /**
+   * Runs the pipeline in reverse on the given tile.
+   *
+   * @param reader_stats Stats to record in the function.
+   * @param tile Current tile on which the filter pipeline is being run.
+   * @param compute_tp Compute theread pool.
+   * @param config Global config.
+   */
+  void run_reverse(
+      stats::Stats* stats,
+      Tile& tile,
+      ThreadPool& compute_tp,
+      const Config& config) const;
+
+  /**
    * Run the given chunk range in reverse through the pipeline.
    *
    * @param reader_stats Stats to record in the function.
@@ -220,7 +234,6 @@ class FilterPipeline {
    * @param config The global config.
    * @return Status.
    */
-
   Status run_reverse(
       stats::Stats* const reader_stats,
       Tile* const tile,

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -706,8 +706,7 @@ ReaderBase::load_tile_chunk_data(
 
   const FilterPipeline& filters = array_schema_.filters(name);
   if (!var_size ||
-      !filters.skip_offsets_filtering(
-          nullable ? t->type() : t_var->type(), array_schema_.version())) {
+      !filters.skip_offsets_filtering(t_var->type(), array_schema_.version())) {
     unfiltered_tile_size = t->load_chunk_data(tile_chunk_data);
   }
 
@@ -1134,7 +1133,7 @@ Status ReaderBase::unfilter_tile_nullable(
   auto concurrency_level = storage_manager_->compute_tp()->concurrency_level();
 
   const bool skip_offsets_filtering =
-      filters.skip_offsets_filtering(tile->type(), array_schema_.version());
+      filters.skip_offsets_filtering(tile_var->type(), array_schema_.version());
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -706,7 +706,8 @@ ReaderBase::load_tile_chunk_data(
 
   const FilterPipeline& filters = array_schema_.filters(name);
   if (!var_size ||
-      !filters.skip_offsets_filtering(t_var->type(), array_schema_.version())) {
+      !filters.skip_offsets_filtering(
+          nullable ? t->type() : t_var->type(), array_schema_.version())) {
     unfiltered_tile_size = t->load_chunk_data(tile_chunk_data);
   }
 
@@ -1133,7 +1134,7 @@ Status ReaderBase::unfilter_tile_nullable(
   auto concurrency_level = storage_manager_->compute_tp()->concurrency_level();
 
   const bool skip_offsets_filtering =
-      filters.skip_offsets_filtering(tile_var->type(), array_schema_.version());
+      filters.skip_offsets_filtering(tile->type(), array_schema_.version());
 
   // Append an encryption unfilter when necessary.
   RETURN_NOT_OK(FilterPipeline::append_encryption_filter(

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -468,7 +468,7 @@ class ReaderBase : public StrategyBase {
    * @param result_tiles Vector containing the tiles to be unfiltered.
    * @return Status
    */
-  Status unfilter_tiles_chunk_range(
+  Status unfilter_tiles(
       const std::string& name,
       const std::vector<ResultTile*>& result_tiles) const;
 
@@ -485,7 +485,7 @@ class ReaderBase : public StrategyBase {
    * @param tile_chunk_data Tile chunk info, buffers and offsets
    * @return Status
    */
-  Status unfilter_tile_chunk_range(
+  Status unfilter_tile(
       uint64_t num_range_threads,
       uint64_t thread_idx,
       const std::string& name,
@@ -506,7 +506,7 @@ class ReaderBase : public StrategyBase {
    * @param tile_var_chunk_data Value tile chunk info, buffers and offsets
    * @return Status
    */
-  Status unfilter_tile_chunk_range(
+  Status unfilter_tile(
       uint64_t num_range_threads,
       uint64_t thread_idx,
       const std::string& name,
@@ -531,7 +531,7 @@ class ReaderBase : public StrategyBase {
    * offsets
    * @return Status
    */
-  Status unfilter_tile_chunk_range_nullable(
+  Status unfilter_tile_nullable(
       uint64_t num_range_threads,
       uint64_t thread_idx,
       const std::string& name,
@@ -557,7 +557,7 @@ class ReaderBase : public StrategyBase {
    * offsets
    * @return Status
    */
-  Status unfilter_tile_chunk_range_nullable(
+  Status unfilter_tile_nullable(
       uint64_t num_range_threads,
       uint64_t thread_idx,
       const std::string& name,
@@ -567,72 +567,6 @@ class ReaderBase : public StrategyBase {
       const ChunkData& tile_var_chunk_data,
       Tile* tile_validity,
       const ChunkData& tile_validity_chunk_data) const;
-
-  /**
-   * Filters the tiles on a particular attribute/dimension from all input
-   * fragments based on the tile info in `result_tiles`.
-   *
-   * @param name Attribute/dimension whose tiles will be unfiltered.
-   * @param result_tiles Vector containing the tiles to be unfiltered.
-   * @return Status
-   */
-  Status unfilter_tiles(
-      const std::string& name,
-      const std::vector<ResultTile*>& result_tiles) const;
-
-  /**
-   * Runs the input fixed-sized tile for the input attribute or dimension
-   * through the filter pipeline. The tile buffer is modified to contain the
-   * output of the pipeline.
-   *
-   * @param name The attribute/dimension the tile belong to.
-   * @param tile The tile to be unfiltered.
-   * @return Status
-   */
-  Status unfilter_tile(const std::string& name, Tile* tile) const;
-
-  /**
-   * Runs the input var-sized tile for the input attribute or dimension through
-   * the filter pipeline. The tile buffer is modified to contain the output of
-   * the pipeline.
-   *
-   * @param name The attribute/dimension the tile belong to.
-   * @param tile The offsets tile to be unfiltered.
-   * @param tile_var The value tile to be unfiltered.
-   * @return Status
-   */
-  Status unfilter_tile(
-      const std::string& name, Tile* tile, Tile* tile_var) const;
-
-  /**
-   * Runs the input fixed-sized tile for the input nullable attribute
-   * through the filter pipeline. The tile buffer is modified to contain the
-   * output of the pipeline.
-   *
-   * @param name The attribute/dimension the tile belong to.
-   * @param tile The tile to be unfiltered.
-   * @param tile_validity The validity tile to be unfiltered.
-   * @return Status
-   */
-  Status unfilter_tile_nullable(
-      const std::string& name, Tile* tile, Tile* tile_validity) const;
-
-  /**
-   * Runs the input var-sized tile for the input nullable attribute through
-   * the filter pipeline. The tile buffer is modified to contain the output of
-   * the pipeline.
-   *
-   * @param name The attribute/dimension the tile belong to.
-   * @param tile The offsets tile to be unfiltered.
-   * @param tile_var The value tile to be unfiltered.
-   * @param tile_validity The validity tile to be unfiltered.
-   * @return Status
-   */
-  Status unfilter_tile_nullable(
-      const std::string& name,
-      Tile* tile,
-      Tile* tile_var,
-      Tile* tile_validity) const;
 
   /**
    * Returns the configured bytesize for var-sized attribute offsets
@@ -717,19 +651,9 @@ class ReaderBase : public StrategyBase {
       ResultTile* const tile,
       const bool var_size,
       const bool nullable,
-      ChunkData* const tile_chunk_data,
-      ChunkData* const tile_chunk_var_data,
-      ChunkData* const tile_chunk_validity_data) const;
-
-  /**
-   * Reads the chunk data of a tile buffer and populates a chunk data structure
-   *
-   * @param tile Offsets tile to be unfiltered.
-   * @param tile_chunk_data Tile chunk info, buffers and offsets
-   * @return Status
-   */
-  tuple<Status, optional<uint64_t>> load_chunk_data(
-      Tile* const tile, ChunkData* chunk_data) const;
+      ChunkData& tile_chunk_data,
+      ChunkData& tile_chunk_var_data,
+      ChunkData& tile_chunk_validity_data) const;
 
   /**
    * Unfilter a specific range of chunks in tile
@@ -748,7 +672,7 @@ class ReaderBase : public StrategyBase {
    * offsets
    * @return Status
    */
-  Status unfilter_tile_chunk_range(
+  Status unfilter_tile(
       const std::string& name,
       ResultTile* const tile,
       const bool var_size,

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -461,8 +461,7 @@ class ReaderBase : public StrategyBase {
 
   /**
    * Filters the tiles on a particular attribute/dimension from all input
-   * fragments based on the tile info in `result_tiles`. Used only by new
-   * readers that parallelize on chunk ranges.
+   * fragments based on the tile info in `result_tiles`.
    *
    * @param name Attribute/dimension whose tiles will be unfiltered.
    * @param result_tiles Vector containing the tiles to be unfiltered.
@@ -475,8 +474,7 @@ class ReaderBase : public StrategyBase {
   /**
    * Runs the input fixed-sized tile for the input attribute or dimension
    * through the filter pipeline. The tile buffer is modified to contain the
-   * output of the pipeline. Used only by new readers that parallelize on chunk
-   * ranges.
+   * output of the pipeline.
    *
    * @param num_range_threads Total number of range threads.
    * @param range_thread_idx Current range thread index.
@@ -495,7 +493,7 @@ class ReaderBase : public StrategyBase {
   /**
    * Runs the input var-sized tile for the input attribute or dimension through
    * the filter pipeline. The tile buffer is modified to contain the output of
-   * the pipeline. Used only by new readers that parallelize on chunk ranges.
+   * the pipeline.
    *
    * @param num_range_threads Total number of range threads.
    * @param range_thread_idx Current range thread index.
@@ -518,8 +516,7 @@ class ReaderBase : public StrategyBase {
   /**
    * Runs the input fixed-sized tile for the input nullable attribute
    * through the filter pipeline. The tile buffer is modified to contain the
-   * output of the pipeline. Used only by new readers that parallelize on chunk
-   * ranges.
+   * output of the pipeline.
    *
    * @param num_range_threads Total number of range threads.
    * @param range_thread_idx Current range thread index.
@@ -543,7 +540,7 @@ class ReaderBase : public StrategyBase {
   /**
    * Runs the input var-sized tile for the input nullable attribute through
    * the filter pipeline. The tile buffer is modified to contain the output of
-   * the pipeline. Used only by new readers that parallelize on chunk ranges.
+   * the pipeline.
    *
    * @param num_range_threads Total number of range threads.
    * @param range_thread_idx Current range thread index.

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -102,27 +102,8 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
 
   // Unfilter
   assert(tile.filtered());
-
-  ChunkData chunk_data;
-  tile.load_chunk_data(chunk_data);
-
-  throw_if_not_ok(parallel_for(
-      &resources_.compute_tp(),
-      0,
-      chunk_data.filtered_chunks_.size(),
-      [&](const unsigned c) {
-        return header.filters.run_reverse(
-            &resources_.stats(),
-            &tile,
-            nullptr,
-            chunk_data,
-            c,
-            c + 1,
-            resources_.compute_tp().concurrency_level(),
-            config);
-      }));
-
-  tile.clear_filtered_buffer();
+  header.filters.run_reverse(
+      &resources_.stats(), tile, resources_.compute_tp(), config);
   assert(!tile.filtered());
 
   return {Status::Ok(), std::move(tile)};

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -261,6 +261,34 @@ class Tile : public TileBase {
    */
   Status zip_coordinates();
 
+  /**
+   * Reads the chunk data of a tile buffer and populates a chunk data structure.
+   *
+   * This expects as input a Tile in the following byte format:
+   *
+   *   number_of_chunks (uint64_t)
+   *   chunk0_orig_len (uint32_t)
+   *   chunk0_data_len (uint32_t)
+   *   chunk0_metadata_len (uint32_t)
+   *   chunk0_metadata (uint8_t[])
+   *   chunk0_data (uint8_t[])
+   *   chunk1_orig_len (uint32_t)
+   *   chunk1_data_len (uint32_t)
+   *   chunk1_metadata_len (uint32_t)
+   *   chunk1_metadata (uint8_t[])
+   *   chunk1_data (uint8_t[])
+   *   ...
+   *   chunkN_orig_len (uint32_t)
+   *   chunkN_data_len (uint32_t)
+   *   chunkN_metadata_len (uint32_t)
+   *   chunkN_metadata (uint8_t[])
+   *   chunkN_data (uint8_t[])
+   *
+   * @param chunk_data Tile chunk info, buffers and offsets.
+   * @return Original size.
+   */
+  uint64_t load_chunk_data(ChunkData& chunk_data);
+
   /** Swaps the contents (all field values) of this tile with the given tile. */
   void swap(Tile& tile);
 
@@ -305,13 +333,10 @@ class WriterTile : public TileBase {
    *
    * @param tile_size The total size of the tile.
    * @param tile_cell_size The cell size.
-   * @param chunk_size Mutates to the calculated chunk size.
-   * @return Status
+   * @return Chunk size.
    */
-  static Status compute_chunk_size(
-      const uint64_t tile_size,
-      const uint64_t tile_cell_size,
-      uint32_t* const chunk_size);
+  static uint32_t compute_chunk_size(
+      const uint64_t tile_size, const uint64_t tile_cell_size);
 
   /**
    * Override max_tile_chunk_size_ used to process tile chunks in parallel.

--- a/tiledb/storage_format/serialization/test/unit_serializers.cc
+++ b/tiledb/storage_format/serialization/test/unit_serializers.cc
@@ -1,5 +1,5 @@
 /**
- * @file unit_validity_vector.cc
+ * @file unit_serializers.cc
  *
  * @section LICENSE
  *


### PR DESCRIPTION
When the filter pipeline was changed to filter ranges of chunks, the other path was left around to simplify the work and avoid potential performance impact on the legacy reader. Now that the legacy reader is mostly decommissioned, we can remove the old path safely.

---
TYPE: IMPROVEMENT
DESC: Filter pipeline: make chunk range path default and remove other.
