### PR TITLE
Add two C-API functions for checking label data on subarrays

### DIFF
--- a/test/src/test-capi-subarray-labels.cc
+++ b/test/src/test-capi-subarray-labels.cc
@@ -127,6 +127,10 @@ TEST_CASE_METHOD(
   require_tiledb_ok(tiledb_subarray_alloc(ctx, array, &subarray));
 
   // Check label range num is zero for all labels.
+  int32_t has_label_ranges{0};
+  require_tiledb_ok(
+      tiledb_subarray_has_label_ranges(ctx, subarray, 0, &has_label_ranges));
+  CHECK(has_label_ranges == 0);
   uint64_t range_num{0};
   require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "label", &range_num));
@@ -139,6 +143,10 @@ TEST_CASE_METHOD(
   double r1[2]{-1.0, 1.0};
   require_tiledb_ok(tiledb_subarray_add_label_range(
       ctx, subarray, "label", &r1[0], &r1[1], nullptr));
+  // Check has label ranges.
+  require_tiledb_ok(
+      tiledb_subarray_has_label_ranges(ctx, subarray, 0, &has_label_ranges));
+  CHECK(has_label_ranges != 0);
   // Check no regular ranges set.
   require_tiledb_ok(
       tiledb_subarray_get_range_num(ctx, subarray, 0, &range_num));
@@ -151,6 +159,12 @@ TEST_CASE_METHOD(
   require_tiledb_ok(
       tiledb_subarray_get_label_range_num(ctx, subarray, "id", &range_num));
   CHECK(range_num == 0);
+  // Get the name of the set label.
+  const char* label_name;
+  require_tiledb_ok(
+      tiledb_subarray_get_label_name(ctx, subarray, 0, &label_name));
+  std::string expected_label_name{"label"};
+  CHECK(label_name == expected_label_name);
 
   // Check getting the range back
   const void* r1_start{};

--- a/tiledb/sm/c_api/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/tiledb_dimension_label.cc
@@ -129,6 +129,13 @@ capi_return_t tiledb_subarray_add_label_range_var(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_subarray_get_label_name(
+    tiledb_subarray_t* subarray, uint32_t dim_idx, const char** label_name) {
+  const auto& name = subarray->subarray_->get_label_name(dim_idx);
+  *label_name = name.c_str();
+  return TILEDB_OK;
+}
+
 capi_return_t tiledb_subarray_get_label_range(
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -166,6 +173,15 @@ capi_return_t tiledb_subarray_get_label_range_var_size(
     uint64_t* end_size) {
   subarray->subarray_->get_label_range_var_size(
       dim_name, range_idx, start_size, end_size);
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_subarray_has_label_ranges(
+    const tiledb_subarray_t* subarray,
+    const uint32_t dim_idx,
+    int32_t* has_label_ranges) {
+  bool has_ranges = subarray->subarray_->has_label_ranges(dim_idx);
+  *has_label_ranges = has_ranges ? 1 : 0;
   return TILEDB_OK;
 }
 
@@ -249,6 +265,15 @@ capi_return_t tiledb_subarray_add_label_range_var(
       ctx, subarray, label_name, start, start_size, end, end_size);
 }
 
+capi_return_t tiledb_subarray_get_label_name(
+    tiledb_ctx_t* ctx,
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const char** label_name) noexcept {
+  return api_entry_context<detail::tiledb_subarray_get_label_name>(
+      ctx, subarray, dim_idx, label_name);
+}
+
 capi_return_t tiledb_subarray_get_label_range(
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
@@ -290,4 +315,13 @@ capi_return_t tiledb_subarray_get_label_range_var_size(
     uint64_t* end_size) noexcept {
   return api_entry_context<detail::tiledb_subarray_get_label_range_var_size>(
       ctx, subarray, dim_name, range_idx, start_size, end_size);
+}
+
+capi_return_t tiledb_subarray_has_label_ranges(
+    tiledb_ctx_t* ctx,
+    const tiledb_subarray_t* subarray,
+    const uint32_t dim_idx,
+    int32_t* has_label_ranges) noexcept {
+  return api_entry_context<detail::tiledb_subarray_has_label_ranges>(
+      ctx, subarray, dim_idx, has_label_ranges);
 }

--- a/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
+++ b/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
@@ -250,6 +250,13 @@ TILEDB_EXPORT capi_return_t tiledb_subarray_add_label_range_var(
     const void* end,
     uint64_t end_size) TILEDB_NOEXCEPT;
 
+/** TODO: DOCS */
+TILEDB_EXPORT capi_return_t tiledb_subarray_get_label_name(
+    tiledb_ctx_t* ctx,
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const char** label_name) TILEDB_NOEXCEPT;
+
 /**
  * Retrieves a specific label range of the subarray from the ranges set for the
  * given dimension label name.
@@ -365,6 +372,13 @@ TILEDB_EXPORT capi_return_t tiledb_subarray_get_label_range_var_size(
     uint64_t range_idx,
     uint64_t* start_size,
     uint64_t* end_size) TILEDB_NOEXCEPT;
+
+/** TODO: DOCS */
+TILEDB_EXPORT capi_return_t tiledb_subarray_has_label_ranges(
+    tiledb_ctx_t* ctx,
+    const tiledb_subarray_t* subarray,
+    const uint32_t dim_idx,
+    int32_t* has_label_range) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
+++ b/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
@@ -250,7 +250,24 @@ TILEDB_EXPORT capi_return_t tiledb_subarray_add_label_range_var(
     const void* end,
     uint64_t end_size) TILEDB_NOEXCEPT;
 
-/** TODO: DOCS */
+/**
+ * Gets the name of the dimension label for label ranges set on this dimension
+ * of the subarray.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * char* label_name;
+ * tiledb_subarray_get_label_name(
+ *     ctx, subarray, 0, &label_name);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @pram subarray The subarray.
+ * @param dim_idx The dimension index the label ranges are set on.
+ * @param label_name The output name of the dimension label.
+ * @return `TILEDB_OK` for success or `TILEDB_ERR` for error.
+ */
 TILEDB_EXPORT capi_return_t tiledb_subarray_get_label_name(
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
@@ -373,7 +390,24 @@ TILEDB_EXPORT capi_return_t tiledb_subarray_get_label_range_var_size(
     uint64_t* start_size,
     uint64_t* end_size) TILEDB_NOEXCEPT;
 
-/** TODO: DOCS */
+/**
+ * Checks whether the subarray has label ranges set on the requested dimension.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int32_t has_label_range;
+ * tiledb_array_schema_has_label_ranges(
+ *     ctx, array_schema, "label_0", &has_label_range);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param subarray The subarray.
+ * @param dim_idx The index of the dimension to check for label ranges.
+ * @param has_label_range Set to `1` if the subarray has label ranges set
+ *      on the given dimension, else `0`.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
 TILEDB_EXPORT capi_return_t tiledb_subarray_has_label_ranges(
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -114,7 +114,7 @@ Subarray::Subarray(
     StorageManager* storage_manager)
     : stats_(
           parent_stats ? parent_stats->create_child("Subarray") :
-                         storage_manager ?
+          storage_manager ?
                          storage_manager->stats()->create_child("subSubarray") :
                          nullptr)
     , logger_(logger->clone("Subarray", ++logger_id_))


### PR DESCRIPTION
Add useful functions for checking label ranges on a subarray.

---
TYPE: C_API
DESC: Add `tiledb_subarray_has_label_ranges` and `tiledb_subarray_get_label_name`