### PR TITLE
Bug fix: allow reopening a remote array with Consistency Controller

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -785,6 +785,14 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   }
 
   if (remote_) {
+    try {
+      set_array_closed();
+    } catch (std::exception& e) {
+      is_opening_or_closing_ = false;
+      throw Status_ArrayError(e.what());
+    }
+    is_opening_or_closing_ = false;
+
     return open(
         query_type_,
         encryption_key_->encryption_type(),


### PR DESCRIPTION
Deregister a remote array from the Consistency multimap before reopening.

---
TYPE: BUG
DESC: Deregister a remote array from the Consistency multimap before reopening. 
