### PR TITLE
RLE and dictionary filter only enabled for UTF8 since format version 17.

### DIFF
--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -713,13 +713,13 @@ Status FilterPipeline::append_encryption_filter(
 
 bool FilterPipeline::skip_offsets_filtering(
     const Datatype type, const uint32_t version) const {
-  if (version >= 12 &&
-      (type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8) &&
+  if (((version >= 12 && type == Datatype::STRING_ASCII) ||
+       (version >= 17 && type == Datatype::STRING_UTF8)) &&
       has_filter(FilterType::FILTER_RLE)) {
     return true;
   } else if (
-      version >= 13 &&
-      (type == Datatype::STRING_ASCII || type == Datatype::STRING_UTF8) &&
+      ((version >= 13 && type == Datatype::STRING_ASCII) ||
+       (version >= 17 && type == Datatype::STRING_UTF8)) &&
       has_filter(FilterType::FILTER_DICTIONARY)) {
     return true;
   }

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -1409,7 +1409,8 @@ Status ReaderBase::unfilter_tile_nullable(
   // Reverse the tile filters.
   // If offsets don't need to be unfiltered separately, it means they
   // will be created on the fly from filtered var-length data
-  if (filters.skip_offsets_filtering(tile->type(), array_schema_.version())) {
+  if (filters.skip_offsets_filtering(
+          tile_var->type(), array_schema_.version())) {
     RETURN_NOT_OK(filters.run_reverse(
         stats_,
         tile_var,


### PR DESCRIPTION
This fixes an issue in the filter pipeline where we should only skip offsets unfiltering for RLE/dictionary filters for UTF8 strings starting at version 17.

---
TYPE: IMPROVEMENT
DESC: RLE and dictionary filter only enabled for UTF8 since format version 17.
