### PR TITLE
Ordered dimension label reader: handle empty array.

### DIFF
--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -339,6 +339,33 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CPPOrderedDimLabelReaderFixedDoubleFx,
+    "Ordered dimension label reader: Invalid no data",
+    "[ordered-dim-label-reader][invalid][no-data]") {
+  Array array(ctx_, array_name, TILEDB_READ);
+  Query query(ctx_, array, TILEDB_READ);
+
+  // Set attribute ranges.
+  std::vector<double> ranges{0.4, 0.8};
+  std::vector<Range> input_ranges;
+  input_ranges.emplace_back(&ranges[0], &ranges[1], sizeof(double));
+
+  Subarray subarray(ctx_, array);
+  subarray.ptr()->subarray_->set_attribute_ranges("labels", input_ranges);
+
+  query.ptr()->query_->set_dimension_label_ordered_read(increasing_labels_);
+  std::vector<int> index(ranges.size());
+  query.set_data_buffer("index", index);
+  query.set_subarray(subarray);
+  REQUIRE_THROWS_WITH(
+      query.submit(),
+      ContainsSubstring("OrderedDimLabelReader: Cannot read dim label; "
+                        "Dimension label is empty"));
+
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CPPOrderedDimLabelReaderFixedDoubleFx,
     "Ordered dimension label reader: fixed double labels, single fragment, "
     "increasing",
     "[ordered-dim-label-reader][fixed][double][single-fragment][increasing]") {

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -248,6 +248,12 @@ void OrderedDimLabelReader::label_read() {
   // Sanity checks.
   assert(std::is_integral<IndexType>::value);
 
+  // Handle empty array.
+  if (fragment_metadata_.empty()) {
+    throw OrderedDimLabelReaderStatusException(
+        "Cannot read dim label; Dimension label is empty");
+  }
+
   // Precompute data.
   auto&& [non_empty_domain, non_empty_domains, frag_first_array_tile_idx] =
       cache_dimension_label_data<IndexType>();


### PR DESCRIPTION
Thanks @jp-dark for the unit test.

---
TYPE: IMPROVEMENT
DESC: Ordered dimension label reader: handle empty array.
