### PR TITLE
Fragment consolidation: using correct buffer weights.

### DIFF
--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -597,7 +597,7 @@ FragmentConsolidator::create_buffers(
       std::accumulate(buffer_weights.begin(), buffer_weights.end(), 0);
 
   // Allocate space for each buffer.
-  auto adjusted_budget = total_budget / total_weights * total_weights;
+  uint64_t adjusted_budget = total_budget / total_weights * total_weights;
   for (unsigned i = 0; i < buffer_num; ++i) {
     buffer_sizes[i] = std::max<uint64_t>(
         1, adjusted_budget * buffer_weights[i] / total_weights);

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -544,16 +544,16 @@ FragmentConsolidator::create_buffers(
     const auto attr = array_schema.attributes()[i];
     const auto var_size = attr->var_size();
 
-    // First buffer is either the var size data or the fixed size data.
+    // First buffer is either the var size offsets or the fixed size data.
     buffer_weights.emplace_back(
-        var_size ? avg_cell_sizes[attr->name()] : attr->cell_size());
+        var_size ? constants::cell_var_offset_size : attr->cell_size());
 
-    // For var size attributes, add the offsets buffer weight.
+    // For var size attributes, add the data buffer weight.
     if (var_size) {
-      buffer_weights.emplace_back(constants::cell_var_offset_size);
+      buffer_weights.emplace_back(avg_cell_sizes[attr->name()]);
     }
 
-    // For nullable attributes, add the offsets buffer weight.
+    // For nullable attributes, add the validity buffer weight.
     if (attr->nullable()) {
       buffer_weights.emplace_back(constants::cell_validity_size);
     }
@@ -564,13 +564,13 @@ FragmentConsolidator::create_buffers(
       const auto dim = domain.dimension_ptr(i);
       const auto var_size = dim->var_size();
 
-      // First buffer is either the var size data or the fixed size data.
+      // First buffer is either the var size offsets or the fixed size data.
       buffer_weights.emplace_back(
-          var_size ? avg_cell_sizes[dim->name()] : dim->coord_size());
+          var_size ? constants::cell_var_offset_size : dim->coord_size());
 
-      // For var size attributes, add the offsets buffer weight.
+      // For var size attributes, add the data buffer weight.
       if (var_size) {
-        buffer_weights.emplace_back(constants::cell_var_offset_size);
+        buffer_weights.emplace_back(avg_cell_sizes[dim->name()]);
       }
     }
   }
@@ -597,9 +597,10 @@ FragmentConsolidator::create_buffers(
       std::accumulate(buffer_weights.begin(), buffer_weights.end(), 0);
 
   // Allocate space for each buffer.
+  auto adjusted_budget = total_budget / total_weights * total_weights;
   for (unsigned i = 0; i < buffer_num; ++i) {
-    buffer_sizes[i] =
-        std::max<uint64_t>(1, total_budget * buffer_weights[i] / total_weights);
+    buffer_sizes[i] = std::max<uint64_t>(
+        1, adjusted_budget * buffer_weights[i] / total_weights);
     buffers[i].resize(buffer_sizes[i]);
   }
 

--- a/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
@@ -199,14 +199,14 @@ TEST_CASE(
   SECTION("int32 dim, var attr") {
     schema =
         make_schema(true, {Datatype::INT32}, {Datatype::STRING_ASCII}, {false});
-    expected_sizes = {750, 1500, 750};
+    expected_sizes = {1496, 748, 748};
     avg_cell_sizes["a1"] = 4;
   }
 
   SECTION("int32 dim, nullable var attr") {
     schema =
         make_schema(true, {Datatype::INT32}, {Datatype::STRING_ASCII}, {true});
-    expected_sizes = {941, 1882, 235, 941};
+    expected_sizes = {1880, 940, 235, 940};
     avg_cell_sizes["a1"] = 4;
   }
 
@@ -216,7 +216,7 @@ TEST_CASE(
         {Datatype::INT32, Datatype::INT64},
         {Datatype::STRING_ASCII},
         {false});
-    expected_sizes = {666, 1333, 666, 1333};
+    expected_sizes = {1328, 664, 664, 1328};
     avg_cell_sizes["a1"] = 4;
   }
 
@@ -226,7 +226,7 @@ TEST_CASE(
         {Datatype::INT32, Datatype::STRING_ASCII},
         {Datatype::UINT8},
         {true});
-    expected_sizes = {166, 166, 666, 2666, 1333};
+    expected_sizes = {166, 166, 664, 1328, 2656};
     avg_cell_sizes["d2"] = 16;
   }
 


### PR DESCRIPTION
This change corrects buffer weights in the fragment consolidator for var sized attributes. Before this change, the fixed/var buffer weights were mixed. The issue manifested itself as a segfault for nullable attributes as the number of validity cells in the buffers was incorrect.

---
TYPE: IMPROVEMENT
DESC: Fragment consolidation: using correct buffer weights.
