### PR TITLE
Error out no-op set_config calls: Group

### DIFF
--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -132,7 +132,7 @@ capi_return_t tiledb_group_set_config(
   ensure_group_is_valid(group);
   ensure_config_is_valid(config);
 
-  throw_if_not_ok(group->group().set_config(config->config()));
+  group->group().set_config(config->config());
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -142,10 +142,10 @@ tiledb_group_close(tiledb_ctx_t* ctx, tiledb_group_t* group) TILEDB_NOEXCEPT;
  * @code{.c}
  * tiledb_group_t* group;
  * tiledb_group_alloc(ctx, "s3://tiledb_bucket/my_group", &group);
- * tiledb_group_open(ctx, group, TILEDB_READ);
  * // Set the config for the given group.
  * tiledb_config_t* config;
  * tiledb_group_set_config(ctx, group, config);
+ * tiledb_group_open(ctx, group, TILEDB_READ);
  * @endcode
  *
  * @param ctx The TileDB context.
@@ -153,9 +153,7 @@ tiledb_group_close(tiledb_ctx_t* ctx, tiledb_group_t* group) TILEDB_NOEXCEPT;
  * @param config The config to be set.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  *
- * @note The group does not need to be opened via `tiledb_group_open_at` to use
- *      this function.
- * @note The config should be set before opening an group.
+ * @pre The config must be set on a closed group.
  */
 TILEDB_EXPORT capi_return_t tiledb_group_set_config(
     tiledb_ctx_t* ctx,

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -7,7 +7,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -112,7 +112,11 @@ class Group {
     ctx.handle_error(tiledb_group_open(c_ctx, group_.get(), query_type));
   }
 
-  /** Sets the group config. */
+  /**
+   * Sets the group config.
+   *
+   * @pre The group must be closed.
+   */
   void set_config(const Config& config) const {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_group_set_config(

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,10 +51,10 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
-class DeleteGroupStatusException : public StatusException {
+class GroupStatusException : public StatusException {
  public:
-  explicit DeleteGroupStatusException(const std::string& message)
-      : StatusException("DeleteGroup", message) {
+  explicit GroupStatusException(const std::string& message)
+      : StatusException("Group", message) {
   }
 };
 
@@ -301,12 +301,13 @@ Status Group::get_query_type(QueryType* query_type) const {
 void Group::delete_group(const URI& uri, bool recursive) {
   // Check that group is open
   if (!is_open_) {
-    throw DeleteGroupStatusException("Group is not open");
+    throw GroupStatusException("[delete_group] Group is not open");
   }
 
   // Check that query type is MODIFY_EXCLUSIVE
   if (query_type_ != QueryType::MODIFY_EXCLUSIVE) {
-    throw DeleteGroupStatusException("Query type must be MODIFY_EXCLUSIVE");
+    throw GroupStatusException(
+        "[delete_group] Query type must be MODIFY_EXCLUSIVE");
   }
 
   // Delete group members within the group when deleting recursively
@@ -332,7 +333,8 @@ void Group::delete_group(const URI& uri, bool recursive) {
   if (remote_) {
     auto rest_client = storage_manager_->rest_client();
     if (rest_client == nullptr)
-      throw DeleteGroupStatusException("Remote group with no REST client.");
+      throw GroupStatusException(
+          "[delete_group] Remote group with no REST client.");
     rest_client->delete_group_from_rest(uri);
   } else {
     storage_manager_->delete_group(uri.c_str());
@@ -527,9 +529,11 @@ const Config& Group::config() const {
   return config_;
 }
 
-Status Group::set_config(Config config) {
-  config_ = config;
-  return Status::Ok();
+void Group::set_config(Config config) {
+  if (is_open()) {
+    throw GroupStatusException("[set_config] Cannot set config; Group is open");
+  }
+  config_.inherit(config);
 }
 
 Status Group::clear() {

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -220,9 +220,23 @@ class Group {
    * Set the config on the group
    *
    * @param config
-   * @return status
+   *
+   * @pre The Group must be closed
    */
-  Status set_config(Config config);
+  void set_config(Config config);
+
+  /**
+   * Set the config on the group
+   *
+   * @param config
+   *
+   * @note This is a potentially unsafe operation. Groups should be closed when
+   * setting a config. Until C.41 compliance, this is necessary for
+   * serialization.
+   */
+  inline void unsafe_set_config(Config config) {
+    config_.inherit(config);
+  }
 
   /**
    * Add a member to a group, this will be flushed to disk on close

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -210,7 +210,7 @@ Status group_from_capnp(
   if (group_reader.hasConfig()) {
     tdb_unique_ptr<Config> decoded_config = nullptr;
     RETURN_NOT_OK(config_from_capnp(group_reader.getConfig(), &decoded_config));
-    RETURN_NOT_OK(group->set_config(*decoded_config));
+    group->unsafe_set_config(*decoded_config);
   }
 
   if (group_reader.hasGroup()) {
@@ -312,7 +312,7 @@ Status group_update_from_capnp(
   if (group_reader.hasConfig()) {
     tdb_unique_ptr<Config> decoded_config = nullptr;
     RETURN_NOT_OK(config_from_capnp(group_reader.getConfig(), &decoded_config));
-    RETURN_NOT_OK(group->set_config(*decoded_config));
+    group->unsafe_set_config(*decoded_config);
   }
 
   if (group_reader.hasGroupUpdate()) {


### PR DESCRIPTION
Setting a config on an open `Group` is considered a no-op, so throw accordingly. Add `unsafe_set_config` to maintain serialization behavior until `Group` is C.41 compliant. 

---
TYPE: IMPROVEMENT
DESC: Error out no-op set_config calls, Group
