### PR TITLE
Use different config variable for enabling array v2 and query v3

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -238,6 +238,7 @@ void check_save_to_file() {
   ss << "rest.server_address https://api.tiledb.com\n";
   ss << "rest.server_serialization_format CAPNP\n";
   ss << "rest.use_refactored_array_open false\n";
+  ss << "rest.use_refactored_array_open_and_query_submit false\n";
   ss << "sm.allow_separate_attribute_writes false\n";
   ss << "sm.allow_updates_experimental false\n";
   ss << "sm.check_coord_dups true\n";
@@ -565,6 +566,13 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_set(
+      config,
+      "rest.use_refactored_array_open_and_query_submit",
+      "true",
+      &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_set(
       config, "sm.fragment_info.preload_mbrs", "true", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
@@ -587,6 +595,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.load_metadata_on_array_open"] = "false";
   all_param_values["rest.load_non_empty_domain_on_array_open"] = "false";
   all_param_values["rest.use_refactored_array_open"] = "true";
+  all_param_values["rest.use_refactored_array_open_and_query_submit"] = "true";
   all_param_values["sm.allow_separate_attribute_writes"] = "false";
   all_param_values["sm.allow_updates_experimental"] = "false";
   all_param_values["sm.encryption_key"] = "";

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -1802,9 +1802,6 @@ TEST_CASE_METHOD(
   tiledb_error_t* error;
   tiledb_config_t* config;
   tiledb_config_alloc(&config, &error);
-  REQUIRE(
-      tiledb_config_set(config, "rest.resubmit_incomplete", "false", &error) ==
-      TILEDB_OK);
 
   // Keep other REST server parameters the same
   REQUIRE(

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1570,9 +1570,18 @@ int array_open_wrapper(
   REQUIRE(rc == TILEDB_OK);
 
   // this helper only applies to refactored array open, so set it in the config
+  // Note: we actually set use_refactored_array_open_and_query_submit instead of
+  // simple use_refactored_array_open here, because we want array_open_wrapper
+  // to be usable in query_v3 tests that require that flag to be set right
+  // from the beginning for full Array objects to be retrieved on array open.
+  // There are dedicated tests in unit-capi-array.cc that are testing array v2
+  // feature with just setting use_refactored_array_open config variable.
   tiledb_error_t* error = nullptr;
   rc = tiledb_config_set(
-      config, "rest.use_refactored_array_open", "true", &error);
+      config,
+      "rest.use_refactored_array_open_and_query_submit",
+      "true",
+      &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
   REQUIRE(

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1721,7 +1721,10 @@ int submit_query_wrapper(
   if (refactored_query_v2) {
     tiledb_error_t* error = nullptr;
     rc = tiledb_config_set(
-        config, "rest.use_refactored_array_open", "true", &error);
+        config,
+        "rest.use_refactored_array_open_and_query_submit",
+        "true",
+        &error);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(error == nullptr);
     REQUIRE(tiledb_array_set_config(client_ctx, array, config) == TILEDB_OK);

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -938,8 +938,8 @@ int array_open_wrapper(
  * e.g. once in the test Fixture definition or just before the call to
  * submit_query_wrapper.
  * @param serialize_query True if this is a remote array open, false if not.
- * @param refactored_query_v2 If "rest.use_refactored_array_open" should be
- * true.
+ * @param refactored_query_v2 If
+ * "rest.use_refactored_array_open_and_query_submit" should be true.
  * @param finalize Finalize or not the query after submitting it.
  */
 int submit_query_wrapper(

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -534,10 +534,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Authentication token for REST server (used instead of
  *    username/password). <br>
  *    **Default**: ""
- * - `rest.resubmit_incomplete` <br>
- *    If true, incomplete queries received from server are automatically
- *    resubmitted before returning to user control. <br>
- *    **Default**: "true"
  * - `rest.ignore_ssl_validation` <br>
  *    Have curl ignore ssl peer and host validation for REST server. <br>
  *    **Default**: false
@@ -574,6 +570,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `rest.use_refactored_array_open` <br>
  *    If true, the new, experimental REST routes and APIs for opening an array
  *    will be used <br>
+ *    **Default**: false
+ * - `rest.use_refactored_array_open_and_query_submit` <br>
+ *    If true, the new, experimental REST routes and APIs for opening an array
+ *    and submitting a query will be used <br>
  *    **Default**: false
  * - `rest.curl.buffer_size` <br>
  *    Set curl buffer size for REST requests <br>

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1125,11 +1125,27 @@ bool Array::use_refactored_array_open() const {
       "rest.use_refactored_array_open", &refactored_array_open, &found);
   if (!status.ok() || !found) {
     throw std::runtime_error(
-        "Cannot get use_refactored_array_open configuration option from "
+        "Cannot get rest.use_refactored_array_open configuration option from "
         "config");
   }
 
-  return refactored_array_open;
+  return refactored_array_open || use_refactored_query_submit();
+}
+
+bool Array::use_refactored_query_submit() const {
+  auto found = false;
+  auto refactored_query_submit = false;
+  auto status = config_.get<bool>(
+      "rest.use_refactored_array_open_and_query_submit",
+      &refactored_query_submit,
+      &found);
+  if (!status.ok() || !found) {
+    throw std::runtime_error(
+        "Cannot get rest.use_refactored_array_open_and_query_submit "
+        "configuration option from config");
+  }
+
+  return refactored_query_submit;
 }
 
 std::unordered_map<std::string, uint64_t> Array::get_average_var_cell_sizes()

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -486,6 +486,9 @@ class Array {
   /** Checks the config to see if refactored array open should be used. */
   bool use_refactored_array_open() const;
 
+  /** Checks the config to see if refactored query submit should be used. */
+  bool use_refactored_query_submit() const;
+
   /**
    * Sets the array state as open.
    *

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -93,6 +93,7 @@ const std::string Config::REST_CURL_VERBOSE = "false";
 const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_USE_REFACTORED_ARRAY_OPEN = "false";
+const std::string Config::REST_USE_REFACTORED_QUERY_SUBMIT = "false";
 const std::string Config::SM_ALLOW_SEPARATE_ATTRIBUTE_WRITES = "false";
 const std::string Config::SM_ALLOW_UPDATES_EXPERIMENTAL = "false";
 const std::string Config::SM_ENCRYPTION_KEY = "";
@@ -242,6 +243,9 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "rest.use_refactored_array_open",
         Config::REST_USE_REFACTORED_ARRAY_OPEN),
+    std::make_pair(
+        "rest.use_refactored_array_open_and_query_submit",
+        Config::REST_USE_REFACTORED_QUERY_SUBMIT),
     std::make_pair(
         "config.env_var_prefix", Config::CONFIG_ENVIRONMENT_VARIABLE_PREFIX),
     std::make_pair("config.logging_level", Config::CONFIG_LOGGING_LEVEL),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -108,6 +108,9 @@ class Config {
   /** Refactored array open is disabled by default */
   static const std::string REST_USE_REFACTORED_ARRAY_OPEN;
 
+  /** Refactored query submit is disabled by default */
+  static const std::string REST_USE_REFACTORED_QUERY_SUBMIT;
+
   /** The prefix to use for checking for parameter environmental variables. */
   static const std::string CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -711,10 +711,6 @@ class Config {
    *    Authentication token for REST server (used instead of
    *    username/password). <br>
    *    **Default**: ""
-   * - `rest.resubmit_incomplete` <br>
-   *    If true, incomplete queries received from server are automatically
-   *    resubmitted before returning to user control. <br>
-   *    **Default**: "true"
    * - `rest.ignore_ssl_validation` <br>
    *    Have curl ignore ssl peer and host validation for REST server. <br>
    *    **Default**: false
@@ -752,6 +748,10 @@ class Config {
    * - `rest.use_refactored_array_open` <br>
    *    If true, the new, experimental REST routes and APIs for opening an array
    *    will be used <br>
+   *    **Default**: false
+   * - `rest.use_refactored_array_open_and_query_submit` <br>
+   *    If true, the new, experimental REST routes and APIs for opening an array
+   *    and submitting a query will be used <br>
    *    **Default**: false
    * - `rest.curl.buffer_size` <br>
    *    Set curl buffer size for REST requests <br>

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -111,18 +111,14 @@ Status RestClient::init(
     RETURN_NOT_OK(serialization_type_enum(c_str, &serialization_type_));
 
   bool found = false;
-  RETURN_NOT_OK(config_->get<bool>(
-      "rest.resubmit_incomplete", &resubmit_incomplete_, &found));
-
-  found = false;
   auto status = config_->get<bool>(
-      "rest.use_refactored_array_open",
+      "rest.use_refactored_array_open_and_query_submit",
       &use_refactored_array_and_query_,
       &found);
   if (!status.ok() || !found) {
     throw std::runtime_error(
-        "Cannot get use_refactored_array_open configuration option from "
-        "config");
+        "Cannot get rest.use_refactored_array_open_and_query_submit "
+        "configuration option from config");
   }
 
   return Status::Ok();

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -151,7 +151,7 @@ Status array_to_capnp(
         *(schema.second.get()), &schema_builder, client_side));
   }
 
-  if (array->use_refactored_array_open()) {
+  if (array->use_refactored_query_submit()) {
     // Serialize array directory (load if not loaded already)
     const auto array_directory = array->load_array_directory();
     auto array_directory_builder = array_builder->initArrayDirectory();
@@ -171,7 +171,9 @@ Status array_to_capnp(
         }
       }
     }
+  }
 
+  if (array->use_refactored_array_open()) {
     if (array->serialize_non_empty_domain()) {
       auto nonempty_domain_builder = array_builder->initNonEmptyDomain();
       RETURN_NOT_OK(


### PR DESCRIPTION
Introducing a new configuration variable `"rest.use_refactored_array_open_and_query_submit"`for enabling/disabling query v3 instead of piggybacking on `"rest.use_refactored_array_open"` for both array v2 and query v3.
The reason is that we need to be able to enable and use array v2 and query v3 independently as some people are already setting array v2 by default and query v3 is not yet fully supported on the Cloud side so we don't want to be blocking array v2 users.
Shortcut: sc25257

---
TYPE: IMPROVEMENT
DESC: Use different config variable for enabling open v2 and query v3
