### PR TITLE
Avoid derefencing a nullptr in unit_consistency

### DIFF
--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -169,7 +169,8 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ContextResources resources(config, nullptr, 1, 1, "");
+  auto logger = make_shared<Logger>(HERE(), "foo");
+  ContextResources resources(config, logger, 1, 1, "");
   StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Register array
@@ -194,7 +195,8 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ContextResources resources(config, nullptr, 1, 1, "");
+  auto logger = make_shared<Logger>(HERE(), "foo");
+  ContextResources resources(config, logger, 1, 1, "");
   StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   std::vector<tdb_unique_ptr<Array>> arrays;
@@ -236,7 +238,8 @@ TEST_CASE(
 
   // Create a StorageManager
   Config config;
-  ContextResources resources(config, nullptr, 1, 1, "");
+  auto logger = make_shared<Logger>(HERE(), "foo");
+  ContextResources resources(config, logger, 1, 1, "");
   StorageManager sm(resources, make_shared<Logger>(HERE(), ""), config);
 
   // Create an array


### PR DESCRIPTION
Fix unit_consistency segfault by passing a logger instead of nullptr

---
TYPE: BUG
DESC: Fix segfault in unit_consistency
