### PR TITLE
Add QueryExperimental `set_data_buffer` API that supports labels

### DIFF
--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -2348,6 +2348,8 @@ class Query {
   }
 
  private:
+  friend class QueryExperimental;
+
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */


### PR DESCRIPTION
* Add experimental `set_data_buffer` API that handles dimension labels
---
TYPE: CPP_API 
DESC: Add experimental `set_data_buffer` API that handles dimension labels
