### PR TITLE
Check that loggers aren't nullptr

### DIFF
--- a/tiledb/sm/array/test/unit_array_directory.cc
+++ b/tiledb/sm/array/test/unit_array_directory.cc
@@ -30,6 +30,7 @@
  * Tests the `ArrayDirectory` class.
  */
 
+#include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array_directory.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 
@@ -63,7 +64,8 @@ TEST_CASE(
     "[array-directory][timestamp-overlap]") {
   WhiteboxArrayDirectory wb_array_dir;
   Config cfg;
-  ContextResources resources{cfg, nullptr, 1, 1, ""};
+  auto logger = make_shared<Logger>(HERE(), "foo");
+  ContextResources resources{cfg, logger, 1, 1, ""};
   ArrayDirectory array_dir(resources, URI());
   wb_array_dir.set_open_timestamps(array_dir, 2, 4);
 

--- a/tiledb/sm/storage_manager/context_resources.cc
+++ b/tiledb/sm/storage_manager/context_resources.cc
@@ -64,6 +64,10 @@ ContextResources::ContextResources(
    */
   stats::all_stats.register_stats(stats_);
 
+  if (!logger_) {
+    throw std::logic_error("Logger must not be nullptr");
+  }
+
   if constexpr (TILEDB_SERIALIZATION_ENABLED) {
     auto server_address = config_.get<std::string>("rest.server_address");
     if (server_address) {


### PR DESCRIPTION
Fix unit_array segfault that was missed when fixing unit_consistency

---
TYPE: BUG
DESC: Avoid segfault in unit_array
