### PR TITLE
Error out no-op set_config calls: Array

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -664,6 +664,8 @@ TEST_CASE_METHOD(
     tiledb_array_schema_t* read_schema;
     rc = tiledb_array_get_schema(ctx_, array, &read_schema);
     REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_array_close(ctx_, array);
+    REQUIRE(rc == TILEDB_OK);
     rc = tiledb_config_set(cfg, "sm.encryption_key", bad_key, &err);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(err == nullptr);
@@ -682,10 +684,6 @@ TEST_CASE_METHOD(
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_array_open(ctx_, array2, TILEDB_READ);
     REQUIRE(rc == TILEDB_ERR);
-
-    // Check reopening works
-    rc = tiledb_array_reopen(ctx_, array);
-    REQUIRE(rc == TILEDB_OK);
 
     // Close arrays
     rc = tiledb_array_close(ctx_, array2);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -145,9 +145,11 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic]") {
     CHECK((std::string)array.config()["b"] == "10");
 
     // Create a config for the array
+    array.close();
     tiledb::Config cfg2;
     cfg2["b"] = "5";
     array.set_config(cfg2);
+    array.open(TILEDB_READ);
 
     // Check that the config values are correct
     CHECK((std::string)array.config()["a"] == "1");

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1736,7 +1736,13 @@ int submit_query_wrapper(
         &error);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(error == nullptr);
+
+    REQUIRE(tiledb_array_close(client_ctx, array) == TILEDB_OK);
     REQUIRE(tiledb_array_set_config(client_ctx, array, config) == TILEDB_OK);
+    tiledb_query_type_t query_type;
+    REQUIRE_SAFE(
+        tiledb_query_get_type(client_ctx, *query, &query_type) == TILEDB_OK);
+    REQUIRE(tiledb_array_open(client_ctx, array, query_type) == TILEDB_OK);
   }
 
   // Get the query type

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -855,9 +855,9 @@ uint64_t Array::timestamp_end_opened_at() const {
 }
 
 void Array::set_config(Config config) {
-  if (is_opening_or_closing_) {
+  if (is_open()) {
     throw ArrayStatusException(
-        "[set_config] Cannot set a config on an opening or closing array");
+        "[set_config] Cannot set a config on an open array");
   }
   config_.inherit(config);
 }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -540,7 +540,7 @@ void Array::delete_array(const URI& uri) {
     auto rest_client = resources_.rest_client();
     if (rest_client == nullptr) {
       throw ArrayStatusException(
-          "[Array::delete_array] Remote array with no REST client.");
+          "[delete_array] Remote array with no REST client.");
     }
     rest_client->delete_array_from_rest(uri);
   } else {
@@ -560,7 +560,7 @@ void Array::delete_fragments(
   // #TODO Add rest support for delete_fragments
   if (remote_) {
     throw ArrayStatusException(
-        "[Array::delete_fragments] Remote arrays currently unsupported.");
+        "[delete_fragments] Remote arrays currently unsupported.");
   } else {
     storage_manager_->delete_fragments(
         uri.c_str(), timestamp_start, timestamp_end);
@@ -576,7 +576,7 @@ void Array::delete_fragments_list(
   // #TODO Add rest support for delete_fragments_list
   if (remote_) {
     throw ArrayStatusException(
-        "[Array::delete_fragments_list] Remote arrays currently unsupported.");
+        "[delete_fragments_list] Remote arrays currently unsupported.");
   } else {
     auto array_dir = ArrayDirectory(
         resources_, uri, 0, std::numeric_limits<uint64_t>::max());
@@ -854,9 +854,12 @@ uint64_t Array::timestamp_end_opened_at() const {
   return timestamp_end_opened_at_;
 }
 
-Status Array::set_config(Config config) {
+void Array::set_config(Config config) {
+  if (is_opening_or_closing_) {
+    throw ArrayStatusException(
+        "[set_config] Cannot set a config on an opening or closing array");
+  }
   config_.inherit(config);
-  return Status::Ok();
 }
 
 Config Array::config() const {

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -334,7 +334,7 @@ class Array {
   Status set_timestamp_end_opened_at(const uint64_t timestamp_end_opened_at);
 
   /** Directly set the array config. */
-  Status set_config(Config config);
+  void set_config(Config config);
 
   /** Retrieves a reference to the array config. */
   Config config() const;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -333,8 +333,24 @@ class Array {
   /** Directly set the timestamp end opened at value. */
   Status set_timestamp_end_opened_at(const uint64_t timestamp_end_opened_at);
 
-  /** Directly set the array config. */
+  /** Directly set the array config.
+   *
+   * @pre The array must be closed.
+   */
   void set_config(Config config);
+
+  /**
+   * Directly set the array config.
+   *
+   * @param config
+   *
+   * @note This is a potentially unsafe operation. Arrays should be closed when
+   * setting a config. This is necessary to maintain current serialization
+   * behavior.
+   */
+  inline void unsafe_set_config(Config config) {
+    config_.inherit(config);
+  }
 
   /** Retrieves a reference to the array config. */
   Config config() const;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3069,7 +3069,7 @@ int32_t tiledb_array_set_config(
   if (sanity_check(ctx, array) == TILEDB_ERR)
     return TILEDB_ERR;
   api::ensure_config_is_valid(config);
-  throw_if_not_ok(array->array_->set_config(config->config()));
+  array->array_->set_config(config->config());
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -511,7 +511,11 @@ class Array {
     return timestamp_end;
   }
 
-  /** Sets the array config. */
+  /**
+   * Sets the array config.
+   *
+   * @pre The array must be closed.
+   */
   void set_config(const Config& config) const {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_array_set_config(

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -345,7 +345,7 @@ Status array_open_from_capnp(
     tdb_unique_ptr<Config> decoded_config = nullptr;
     RETURN_NOT_OK(
         config_from_capnp(array_open_reader.getConfig(), &decoded_config));
-    array->set_config(*decoded_config);
+    array->unsafe_set_config(*decoded_config);
   }
 
   if (array_open_reader.hasQueryType()) {

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -345,7 +345,7 @@ Status array_open_from_capnp(
     tdb_unique_ptr<Config> decoded_config = nullptr;
     RETURN_NOT_OK(
         config_from_capnp(array_open_reader.getConfig(), &decoded_config));
-    RETURN_NOT_OK(array->set_config(*decoded_config));
+    array->set_config(*decoded_config);
   }
 
   if (array_open_reader.hasQueryType()) {


### PR DESCRIPTION
Setting a config on an open `Array` is considered a no-op, so throw accordingly. Add `Array::unsafe_set_config` to maintain current serialization behavior.

---
TYPE: IMPROVEMENT
DESC: Error out no-op set_config calls, Array
