### PR TITLE
CI not exiting on failure, add 'set -e'+ and break up &&'d commands to achieve exit on intermediate command failure

### DIFF
--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -39,6 +39,8 @@ popd
 # ...
 # given the above, explicitly check and bail.
 poss_ret_exit_code=$?
+# show a quick 'summary' of anything that was successfully built
+ls -l $GITHUB_WORKSPACE/test/benchmarking/build 
 if [ $poss_ret_exit_code -ne 0 ] ;  then
   return $poss_ret_exit_code 2>/dev/null
   exit $poss_ret_exit_code

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -27,9 +27,23 @@ set -xeuo pipefail
 
 # Builds CI benchmarks and checks test status
 pushd $GITHUB_WORKSPACE/test/benchmarking && \
-mkdir build && cd build && \
+mkdir -p build && cd build && \
 cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist ../src && make && \
 popd
+# man bash
+# ...
+# -e The shell does not exit if the command that fails is part of the command
+# list immediately following a while or until keyword, part of the test 
+# following the if or elif reserved words, part of any command executed in a && 
+# or || list except the command following the final && or  || ...
+# ...
+# given the above, explicitly check and bail.
+poss_ret_exit_code=$?
+if [ $poss_ret_exit_code ] ; then
+  return $poss_ret_exit_code 2>/dev/null
+  exit $poss_ret_exit_code
+fi
+
 
 testfile=$(mktemp)
 mv $testfile $testfile.cc

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -39,7 +39,7 @@ popd
 # ...
 # given the above, explicitly check and bail.
 poss_ret_exit_code=$?
-if [ $poss_ret_exit_code ] ; then
+if [ $poss_ret_exit_code -ne 0 ] ;  then
   return $poss_ret_exit_code 2>/dev/null
   exit $poss_ret_exit_code
 fi

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -32,26 +32,6 @@ cd build
 cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist ../src
 make
 popd
-#~ pushd $GITHUB_WORKSPACE/test/benchmarking && \
-#~ mkdir -p build && cd build && \
-#~ cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist ../src && make && \
-#~ popd
-#~ # man bash
-#~ # ...
-#~ # -e The shell does not exit if the command that fails is part of the command
-#~ # list immediately following a while or until keyword, part of the test 
-#~ # following the if or elif reserved words, part of any command executed in a && 
-#~ # or || list except the command following the final && or  || ...
-#~ # ...
-#~ # given the above, explicitly check and bail.
-#~ poss_ret_exit_code=$?
-#~ # show a quick 'summary' of anything that was successfully built
-#~ ls -l $GITHUB_WORKSPACE/test/benchmarking/build 
-#~ if [ $poss_ret_exit_code -ne 0 ] ;  then
-  #~ return $poss_ret_exit_code 2>/dev/null
-  #~ exit $poss_ret_exit_code
-#~ fi
-
 
 testfile=$(mktemp)
 mv $testfile $testfile.cc

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -26,25 +26,31 @@
 set -xeuo pipefail
 
 # Builds CI benchmarks and checks test status
-pushd $GITHUB_WORKSPACE/test/benchmarking && \
-mkdir -p build && cd build && \
-cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist ../src && make && \
+pushd $GITHUB_WORKSPACE/test/benchmarking
+mkdir -p build
+cd build
+cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist ../src
+make
 popd
-# man bash
-# ...
-# -e The shell does not exit if the command that fails is part of the command
-# list immediately following a while or until keyword, part of the test 
-# following the if or elif reserved words, part of any command executed in a && 
-# or || list except the command following the final && or  || ...
-# ...
-# given the above, explicitly check and bail.
-poss_ret_exit_code=$?
-# show a quick 'summary' of anything that was successfully built
-ls -l $GITHUB_WORKSPACE/test/benchmarking/build 
-if [ $poss_ret_exit_code -ne 0 ] ;  then
-  return $poss_ret_exit_code 2>/dev/null
-  exit $poss_ret_exit_code
-fi
+#~ pushd $GITHUB_WORKSPACE/test/benchmarking && \
+#~ mkdir -p build && cd build && \
+#~ cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/dist ../src && make && \
+#~ popd
+#~ # man bash
+#~ # ...
+#~ # -e The shell does not exit if the command that fails is part of the command
+#~ # list immediately following a while or until keyword, part of the test 
+#~ # following the if or elif reserved words, part of any command executed in a && 
+#~ # or || list except the command following the final && or  || ...
+#~ # ...
+#~ # given the above, explicitly check and bail.
+#~ poss_ret_exit_code=$?
+#~ # show a quick 'summary' of anything that was successfully built
+#~ ls -l $GITHUB_WORKSPACE/test/benchmarking/build 
+#~ if [ $poss_ret_exit_code -ne 0 ] ;  then
+  #~ return $poss_ret_exit_code 2>/dev/null
+  #~ exit $poss_ret_exit_code
+#~ fi
 
 
 testfile=$(mktemp)

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -23,6 +23,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
+set -xeuo pipefail
 
 # Builds CI benchmarks and checks test status
 pushd $GITHUB_WORKSPACE/test/benchmarking && \

--- a/test/benchmarking/src/bench_large_io.cc
+++ b/test/benchmarking/src/bench_large_io.cc
@@ -160,11 +160,9 @@ class Benchmark : public BenchmarkBase {
           non_empty[1].second.first,
           non_empty[1].second.second};
 
-      auto max_elements = array.max_buffer_elements(subarray);
-      data_a_.resize(max_elements["a"].second);
-      sparse_coords_.resize(max_elements[TILEDB_COORDS].second);
-
       Query query(ctx_, array);
+      data_a_.resize(query.est_result_size("a"));
+      sparse_coords_.resize(query.est_result_size("TILEDB_COORDS"));
       query.set_subarray(subarray)
           .set_layout(TILEDB_ROW_MAJOR)
           .set_data_buffer("a", data_a_)

--- a/test/benchmarking/src/bench_large_io.cc
+++ b/test/benchmarking/src/bench_large_io.cc
@@ -160,9 +160,11 @@ class Benchmark : public BenchmarkBase {
           non_empty[1].second.first,
           non_empty[1].second.second};
 
+      auto max_elements = array.max_buffer_elements(subarray);
+      data_a_.resize(max_elements["a"].second);
+      sparse_coords_.resize(max_elements[TILEDB_COORDS].second);
+
       Query query(ctx_, array);
-      data_a_.resize(query.est_result_size("a"));
-      sparse_coords_.resize(query.est_result_size("TILEDB_COORDS"));
       query.set_subarray(subarray)
           .set_layout(TILEDB_ROW_MAJOR)
           .set_data_buffer("a", data_a_)

--- a/test/benchmarking/src/bench_sparse_read_large_tile.cc
+++ b/test/benchmarking/src/bench_sparse_read_large_tile.cc
@@ -97,13 +97,15 @@ class Benchmark : public BenchmarkBase {
         non_empty[0].second.second,
         non_empty[1].second.first,
         non_empty[1].second.second};
+
+    auto max_elements = array.max_buffer_elements(subarray_);
+    data_.resize(max_elements["a"].second);
+    coords_.resize(max_elements[TILEDB_COORDS].second);
   }
 
   virtual void run() {
     Array array(ctx_, array_uri_, TILEDB_READ);
     Query query(ctx_, array);
-    data_.resize(query.est_result_size("a"));
-    coords_.resize(query.est_result_size("TILEDB_COORDS"));
     query.set_subarray(subarray_)
         .set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_)

--- a/test/benchmarking/src/bench_sparse_read_large_tile.cc
+++ b/test/benchmarking/src/bench_sparse_read_large_tile.cc
@@ -97,15 +97,13 @@ class Benchmark : public BenchmarkBase {
         non_empty[0].second.second,
         non_empty[1].second.first,
         non_empty[1].second.second};
-
-    auto max_elements = array.max_buffer_elements(subarray_);
-    data_.resize(max_elements["a"].second);
-    coords_.resize(max_elements[TILEDB_COORDS].second);
   }
 
   virtual void run() {
     Array array(ctx_, array_uri_, TILEDB_READ);
     Query query(ctx_, array);
+    data_.resize(query.est_result_size("a"));
+    coords_.resize(query.est_result_size("TILEDB_COORDS"));
     query.set_subarray(subarray_)
         .set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_)

--- a/test/benchmarking/src/bench_sparse_read_small_tile.cc
+++ b/test/benchmarking/src/bench_sparse_read_small_tile.cc
@@ -97,13 +97,15 @@ class Benchmark : public BenchmarkBase {
         non_empty[0].second.second,
         non_empty[1].second.first,
         non_empty[1].second.second};
+
+    auto max_elements = array.max_buffer_elements(subarray_);
+    data_.resize(max_elements["a"].second);
+    coords_.resize(max_elements[TILEDB_COORDS].second);
   }
 
   virtual void run() {
     Array array(ctx_, array_uri_, TILEDB_READ);
     Query query(ctx_, array);
-    data_.resize(query.est_result_size("a"));
-    coords_.resize(query.est_result_size("TILEDB_COORDS"));
     query.set_subarray(subarray_)
         .set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_)

--- a/test/benchmarking/src/bench_sparse_read_small_tile.cc
+++ b/test/benchmarking/src/bench_sparse_read_small_tile.cc
@@ -97,15 +97,13 @@ class Benchmark : public BenchmarkBase {
         non_empty[0].second.second,
         non_empty[1].second.first,
         non_empty[1].second.second};
-
-    auto max_elements = array.max_buffer_elements(subarray_);
-    data_.resize(max_elements["a"].second);
-    coords_.resize(max_elements[TILEDB_COORDS].second);
   }
 
   virtual void run() {
     Array array(ctx_, array_uri_, TILEDB_READ);
     Query query(ctx_, array);
+    data_.resize(query.est_result_size("a"));
+    coords_.resize(query.est_result_size("TILEDB_COORDS"));
     query.set_subarray(subarray_)
         .set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_)

--- a/test/benchmarking/src/bench_sparse_tile_cache.cc
+++ b/test/benchmarking/src/bench_sparse_tile_cache.cc
@@ -108,11 +108,13 @@ class Benchmark : public BenchmarkBase {
         non_empty[1].second.first,
         non_empty[1].second.second};
 
+    auto max_elements = array.max_buffer_elements(subarray_);
+    data_.resize(max_elements["a"].second);
+    coords_.resize(max_elements[TILEDB_COORDS].second);
+
     // Read the array one time, populating the entire tile cache.
     Array read_array(*ctx_, array_uri_, TILEDB_READ);
     Query read_query(*ctx_, read_array);
-    data_.resize(read_query.est_result_size("a"));
-    coords_.resize(read_query.est_result_size("TILEDB_COORDS"));
     read_query.set_subarray(subarray_)
         .set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_)

--- a/test/benchmarking/src/bench_sparse_tile_cache.cc
+++ b/test/benchmarking/src/bench_sparse_tile_cache.cc
@@ -108,13 +108,11 @@ class Benchmark : public BenchmarkBase {
         non_empty[1].second.first,
         non_empty[1].second.second};
 
-    auto max_elements = array.max_buffer_elements(subarray_);
-    data_.resize(max_elements["a"].second);
-    coords_.resize(max_elements[TILEDB_COORDS].second);
-
     // Read the array one time, populating the entire tile cache.
     Array read_array(*ctx_, array_uri_, TILEDB_READ);
     Query read_query(*ctx_, read_array);
+    data_.resize(read_query.est_result_size("a"));
+    coords_.resize(read_query.est_result_size("TILEDB_COORDS"));
     read_query.set_subarray(subarray_)
         .set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_)


### PR DESCRIPTION
benchmark build failures are not failing CI, set -e not enough to break from &&'d, ||'d and other sequenced items, 
so break apart the &&'d expression into individual commands so setting of -e/errtrace will fail CI.

Background information on why set -e by itself did not work:
man bash
...
-e The shell does not exit if the command that fails is part of the command
list immediately following a while or until keyword, part of the test 
following the if or elif reserved words, part of any command executed in a && 
or || list except the command following the final && or  || ...
...
the expression itself does exit on command failure, but the shell does not exit, so explicitly capture exit status after sequence and check for failure returning that failure if found.

---
TYPE: BUG
DESC: address defiiciency of set -e for &&'d command sequence, breaking apart commands
