### PR TITLE
Fix bug when setting var sized dimension buffers

### DIFF
--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 if (TILEDB_CPP_API)
   list(APPEND SOURCES targets/sc-19240_cppapi-vfs-exception.cc)
   list(APPEND SOURCES targets/sc-24079.cc)
+  list(APPEND SOURCES targets/sc-25116.cc)
 endif()
 
 add_executable(tiledb_regression

--- a/test/regression/targets/sc-25116.cc
+++ b/test/regression/targets/sc-25116.cc
@@ -1,0 +1,79 @@
+#include <tiledb/tiledb>
+
+#include <test/support/tdb_catch.h>
+
+using namespace tiledb;
+
+static std::string array_name("reading_incomplete_array");
+
+std::vector<std::vector<std::string>> permute(std::vector<std::string>& elems);
+
+static void remove_array() {
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}
+
+static void create_array() {
+  // Create a TileDB context.
+  Context ctx;
+
+  auto rows =
+      Dimension::create(ctx, "rows", TILEDB_STRING_ASCII, nullptr, nullptr);
+  auto cols =
+      Dimension::create(ctx, "cols", TILEDB_STRING_ASCII, nullptr, nullptr);
+
+  Domain domain(ctx);
+  domain.add_dimensions(rows, cols);
+
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.set_domain(domain);
+
+  auto a1 = Attribute::create<int32_t>(ctx, "a1");
+  schema.add_attribute(Attribute::create<int>(ctx, "a1"));
+
+  Array::create(array_name, schema);
+}
+
+static void write_array() {
+  Context ctx;
+
+  std::string row_data = "abbcccddddeeeee";
+  std::vector<uint64_t> row_offsets = {0, 1, 3, 6, 10};
+
+  std::string col_data = "jjjjjiiiihhhggf";
+  std::vector<uint64_t> col_offsets = {0, 5, 9, 12, 14};
+
+  std::vector<int> a1_data = {1, 2, 3, 4, 5};
+
+  Array array(ctx, array_name, TILEDB_WRITE);
+
+  Query query(ctx, array);
+  query.set_layout(TILEDB_UNORDERED)
+      .set_data_buffer("rows", row_data)
+      .set_offsets_buffer("rows", row_offsets)
+      .set_offsets_buffer("cols", col_offsets)
+      .set_data_buffer("cols", col_data)
+      .set_data_buffer("a1", a1_data);
+
+  REQUIRE(query.submit() == Query::Status::COMPLETE);
+  query.finalize();
+  array.close();
+}
+
+TEST_CASE(
+    "C++ API: Bug in set_offsets_buffer call ordering",
+    "[cppapi][regression][set-offsets-call-order][sc25116]") {
+  remove_array();
+  create_array();
+  write_array();
+
+  Context ctx;
+  FragmentInfo fi(ctx, array_name);
+  fi.load();
+  REQUIRE(fi.fragment_num() == 1);
+}

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1338,7 +1338,8 @@ Status Query::set_data_buffer(
       return set_coords_buffer(buffer, buffer_size);
   }
 
-  if (is_dim &&
+  const bool is_var = array_schema_->var_size(name);
+  if (is_dim && !is_var &&
       (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE)) {
     // Check number of coordinates
     uint64_t coords_num = *buffer_size / array_schema_->cell_size(name);
@@ -1365,7 +1366,7 @@ Status Query::set_data_buffer(
   has_coords_buffer_ |= is_dim;
 
   // Set attribute/dimension buffer on the appropriate buffer
-  if (!array_schema_->var_size(name))
+  if (!is_var)
     // Fixed size data buffer
     buffers_[name].set_data_buffer(buffer, buffer_size);
   else


### PR DESCRIPTION
This fixes a bug when checking the number of coordinates on each dimension. Previously, when a variable sized dimension's data buffer was set via `set_data_buffer` we were accidentally overwriting `coords_info_.coord_num_` with zero. Thus, if the last dimension data buffer set is for a variable sized dimension, the writer would think there was no data to write.

The root cause here was that by not checking whether the dimension is variable sized, we calculated the number of coordinates in `set_data_buffer` as `buffer_size / UINT64_MAX` which is zero for all values of `utin64_t` except `UINT64_MAX`.

The fix is to not attempt to check the number of coordinates in `set_data_buffer` for variable sized dimensions and instead rely on the check in `set_offsets_buffer`.

---
TYPE: BUG
DESC: Fix bug when setting variable sized dimension buffers last