### PR TITLE
Refactor readers to use optional<QueryCondition>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ test/cpp_unit_webp.png
 test/inputs/arrays/read_compatibility_test*
 test/obj/*
 test/regression/foo1
+test/regression/reading_incomplete_array
 test/tiledb_test/*
 Doxyfile.log
 doxyfile.inc

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -155,7 +155,7 @@ TEST_CASE_METHOD(
   std::unordered_map<std::string, tiledb::sm::QueryBuffer> buffers;
   buffers.emplace(
       "a", tiledb::sm::QueryBuffer(nullptr, nullptr, &tmp_size, &tmp_size));
-  QueryCondition condition;
+  std::optional<QueryCondition> condition;
   ThreadPool tp_cpu(4), tp_io(4);
   Array array(URI(array_name_), context.storage_manager());
   CHECK(array.open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0)

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
@@ -60,7 +60,7 @@ class DeletesAndUpdates : public StrategyBase, public IQueryStrategy {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition,
+      std::optional<QueryCondition>& condition,
       std::vector<UpdateValue>& update_values,
       bool skip_checks_serialization = false);
 
@@ -102,7 +102,7 @@ class DeletesAndUpdates : public StrategyBase, public IQueryStrategy {
   /* ********************************* */
 
   /** The query condition. */
-  QueryCondition& condition_;
+  std::optional<QueryCondition>& condition_;
 
   /** The update values, owned by the query. */
   std::vector<UpdateValue>& update_values_;

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -112,7 +112,7 @@ Reader::Reader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition,
+    std::optional<QueryCondition>& condition,
     bool skip_checks_serialization)
     : ReaderBase(
           stats,
@@ -201,7 +201,9 @@ Status Reader::dowork() {
   auto timer_se = stats_->start_timer("dowork");
 
   // Check that the query condition is valid.
-  RETURN_NOT_OK(condition_.check(array_schema_));
+  if (condition_.has_value()) {
+    RETURN_NOT_OK(condition_->check(array_schema_));
+  }
 
   if (buffers_.count(constants::delete_timestamps) != 0) {
     return logger_->status(
@@ -307,8 +309,8 @@ Status Reader::load_initial_data() {
   RETURN_CANCEL_OR_ERROR(generate_timestamped_conditions());
 
   // Make a list of dim/attr that will be loaded for query condition.
-  if (!condition_.empty()) {
-    qc_loaded_attr_names_set_.merge(condition_.field_names());
+  if (condition_.has_value()) {
+    qc_loaded_attr_names_set_.merge(condition_->field_names());
   }
   for (auto delete_and_update_condition : delete_and_update_conditions_) {
     qc_loaded_attr_names_set_.merge(delete_and_update_condition.field_names());
@@ -332,7 +334,7 @@ Status Reader::apply_query_condition(
     std::vector<ResultTile*>& result_tiles,
     Subarray& subarray,
     uint64_t stride) {
-  if ((condition_.empty() && delete_and_update_conditions_.empty()) ||
+  if ((!condition_.has_value() && delete_and_update_conditions_.empty()) ||
       result_cell_slabs.empty()) {
     return Status::Ok();
   }
@@ -356,8 +358,8 @@ Status Reader::apply_query_condition(
   if (stride == UINT64_MAX)
     stride = 1;
 
-  if (!condition_.empty()) {
-    RETURN_NOT_OK(condition_.apply(
+  if (condition_.has_value()) {
+    RETURN_NOT_OK(condition_->apply(
         array_schema_, fragment_metadata_, result_cell_slabs, stride));
   }
 
@@ -2227,7 +2229,7 @@ tuple<Status, optional<bool>> Reader::fill_dense_coords(
   // Query conditions mutate the result cell slabs to filter attributes.
   // This path does not use result cell slabs, which will fill coordinates
   // for cells that should be filtered out.
-  if (!condition_.empty()) {
+  if (condition_.has_value()) {
     return {
         logger_->status(Status_ReaderError(
             "Cannot read dense coordinates; dense coordinate "

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -73,7 +73,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition,
+      std::optional<QueryCondition>& condition,
       bool skip_checks_serialization = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1,4 +1,4 @@
-/**
+/*
  * @file   query.cc
  *
  * @section LICENSE
@@ -718,7 +718,7 @@ void Query::init() {
 
     // Create dimension label queries and remove labels from subarray.
     if (uses_dimension_labels()) {
-      if (!condition_.empty()) {
+      if (condition_.has_value()) {
         throw QueryStatusException(
             "Cannot init query; Using query conditions and dimension labels "
             "together is not supported.");
@@ -784,7 +784,7 @@ Layout Query::layout() const {
   return layout_;
 }
 
-const QueryCondition& Query::condition() const {
+const std::optional<QueryCondition>& Query::condition() const {
   if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
     throw std::runtime_error(
         "Query condition is not available for write or modify exclusive "
@@ -1605,7 +1605,12 @@ Status Query::set_condition(const QueryCondition& condition) {
         "to write queries"));
   }
 
+  if (condition.empty()) {
+    throw std::invalid_argument("Query conditions must not be empty");
+  }
+
   condition_ = condition;
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -350,7 +350,7 @@ class Query {
    * Returns the condition for filtering results in a read query.
    * @return QueryCondition
    */
-  const QueryCondition& condition() const;
+  const std::optional<QueryCondition>& condition() const;
 
   /**
    * Returns the update values for an update query.
@@ -733,7 +733,7 @@ class Query {
   std::vector<WrittenFragmentInfo> written_fragment_info_;
 
   /** The query condition. */
-  QueryCondition condition_;
+  std::optional<QueryCondition> condition_;
 
   /** The update values. */
   std::vector<UpdateValue> update_values_;

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -96,7 +96,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition,
+      std::optional<QueryCondition>& condition,
       bool skip_checks_serialization = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -75,7 +75,7 @@ OrderedDimLabelReader::OrderedDimLabelReader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition,
+    std::optional<QueryCondition>& condition,
     bool increasing_labels,
     bool skip_checks_serialization)
     : ReaderBase(
@@ -135,7 +135,7 @@ OrderedDimLabelReader::OrderedDimLabelReader(
         "Cannot initialize ordered dim label reader; Subarray is set");
   }
 
-  if (!condition_.empty()) {
+  if (condition_.has_value()) {
     throw OrderedDimLabelReaderStatusException(
         "Ordered dimension laber reader cannot process query condition");
   }

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -258,7 +258,7 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition,
+      std::optional<QueryCondition>& condition,
       bool increasing_order,
       bool skip_checks_serialization);
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -79,7 +79,7 @@ ReaderBase::ReaderBase(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition)
+    std::optional<QueryCondition>& condition)
     : StrategyBase(
           stats,
           logger,

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -117,7 +117,7 @@ class ReaderBase : public StrategyBase {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition);
+      std::optional<QueryCondition>& condition);
 
   /** Destructor. */
   ~ReaderBase() = default;
@@ -173,7 +173,7 @@ class ReaderBase : public StrategyBase {
   /* ********************************* */
 
   /** The query condition. */
-  QueryCondition& condition_;
+  std::optional<QueryCondition>& condition_;
 
   /**
    * The delete and update conditions.

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -77,7 +77,7 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition,
+    std::optional<QueryCondition>& condition,
     bool consolidation_with_timestamps,
     bool skip_checks_serialization)
     : SparseIndexReaderBase(
@@ -160,7 +160,9 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
   auto fragment_num = fragment_metadata_.size();
 
   // Check that the query condition is valid.
-  RETURN_NOT_OK(condition_.check(array_schema_));
+  if (condition_.has_value()) {
+    RETURN_NOT_OK(condition_->check(array_schema_));
+  }
 
   get_dim_attr_stats();
 
@@ -2091,7 +2093,7 @@ template SparseGlobalOrderReader<uint8_t>::SparseGlobalOrderReader(
     std::unordered_map<std::string, QueryBuffer>&,
     Subarray&,
     Layout,
-    QueryCondition&,
+    std::optional<QueryCondition>&,
     bool,
     bool);
 template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
@@ -2103,7 +2105,7 @@ template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
     std::unordered_map<std::string, QueryBuffer>&,
     Subarray&,
     Layout,
-    QueryCondition&,
+    std::optional<QueryCondition>&,
     bool,
     bool);
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -75,7 +75,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition,
+      std::optional<QueryCondition>& condition,
       bool consolidation_with_timestamps,
       bool skip_checks_serialization = false);
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -198,7 +198,7 @@ class SparseIndexReaderBase : public ReaderBase {
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition);
+      std::optional<QueryCondition>& condition);
 
   /** Destructor. */
   ~SparseIndexReaderBase() = default;

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -75,7 +75,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
     std::unordered_map<std::string, QueryBuffer>& buffers,
     Subarray& subarray,
     Layout layout,
-    QueryCondition& condition,
+    std::optional<QueryCondition>& condition,
     bool skip_checks_serialization)
     : SparseIndexReaderBase(
           stats,
@@ -180,7 +180,9 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   }
 
   // Check that the query condition is valid.
-  RETURN_NOT_OK(condition_.check(array_schema_));
+  if (condition_.has_value()) {
+    RETURN_NOT_OK(condition_->check(array_schema_));
+  }
 
   get_dim_attr_stats();
 
@@ -1884,7 +1886,7 @@ template SparseUnorderedWithDupsReader<uint8_t>::SparseUnorderedWithDupsReader(
     std::unordered_map<std::string, QueryBuffer>&,
     Subarray&,
     Layout,
-    QueryCondition&,
+    std::optional<QueryCondition>&,
     bool);
 template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
     stats::Stats*,
@@ -1895,7 +1897,7 @@ template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
     std::unordered_map<std::string, QueryBuffer>&,
     Subarray&,
     Layout,
-    QueryCondition&,
+    std::optional<QueryCondition>&,
     bool);
 
 }  // namespace sm

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -74,7 +74,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       std::unordered_map<std::string, QueryBuffer>& buffers,
       Subarray& subarray,
       Layout layout,
-      QueryCondition& condition,
+      std::optional<QueryCondition>& condition,
       bool skip_checks_serialization = false);
 
   /** Destructor. */

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -800,9 +800,9 @@ Status reader_to_capnp(
   RETURN_NOT_OK(read_state_to_capnp(array_schema, reader, reader_builder));
 
   const auto& condition = query.condition();
-  if (!condition.empty()) {
+  if (condition.has_value()) {
     auto condition_builder = reader_builder->initCondition();
-    RETURN_NOT_OK(condition_to_capnp(condition, &condition_builder));
+    RETURN_NOT_OK(condition_to_capnp(condition.value(), &condition_builder));
   }
 
   // If stats object exists set its cap'n proto object
@@ -834,9 +834,9 @@ Status index_reader_to_capnp(
   RETURN_NOT_OK(index_read_state_to_capnp(reader.read_state(), reader_builder));
 
   const auto& condition = query.condition();
-  if (!condition.empty()) {
+  if (condition.has_value()) {
     auto condition_builder = reader_builder->initCondition();
-    RETURN_NOT_OK(condition_to_capnp(condition, &condition_builder));
+    RETURN_NOT_OK(condition_to_capnp(condition.value(), &condition_builder));
   }
 
   // If stats object exists set its cap'n proto object
@@ -869,9 +869,9 @@ Status dense_reader_to_capnp(
       dense_read_state_to_capnp(array_schema, reader, reader_builder));
 
   const auto& condition = query.condition();
-  if (!condition.empty()) {
+  if (condition.has_value()) {
     auto condition_builder = reader_builder->initCondition();
-    RETURN_NOT_OK(condition_to_capnp(condition, &condition_builder));
+    RETURN_NOT_OK(condition_to_capnp(condition.value(), &condition_builder));
   }
 
   // If stats object exists set its cap'n proto object
@@ -1138,9 +1138,9 @@ Status delete_to_capnp(
     DeletesAndUpdates& delete_strategy,
     capnp::Delete::Builder* delete_builder) {
   auto condition = query.condition();
-  if (!condition.empty()) {
+  if (condition.has_value()) {
     auto condition_builder = delete_builder->initCondition();
-    RETURN_NOT_OK(condition_to_capnp(condition, &condition_builder));
+    RETURN_NOT_OK(condition_to_capnp(condition.value(), &condition_builder));
   }
 
   // If stats object exists set its cap'n proto object


### PR DESCRIPTION
Refactor readers to use `std::optional<QueryCondition>`

---
TYPE: IMPROVEMENT
DESC: Refactor readers to use `std::optional<QueryCondition>`
