### PR TITLE
Install pkg-config for MacOS release CI

### DIFF
--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -10,6 +10,14 @@ steps:
   displayName: 'Print env'
 
 - bash: |
+    # This stage is needed until https://github.com/actions/runner-images/pull/7125 or similar is merged
+    # MacOS image 20230214.1 removed implicit installation of pkg-config
+    set -e pipefail
+    brew install pkg-config
+  condition: eq(variables['Agent.OS'], 'Darwin')
+  displayName: 'Install brew package for pkg-config (OSX only)'
+
+- bash: |
     set -e pipefail
     brew uninstall --ignore-dependencies libidn2 brotli rtmpdump
   condition: eq(variables['Agent.OS'], 'Darwin')


### PR DESCRIPTION
The github actions/azure devops MacOS image update `20230214.1` removed an implicit installation of pkg-config. This works around the issue but installing pkg-config from brew.

This can be removed if the CI images get an explicit install of pkg-config, i.e https://github.com/actions/runner-images/pull/7125 .

---
TYPE: NO_HISTORY
DESC: NO_HISTORY
