### PR TITLE
Refactor ReaderBase::unfilter_tile

### DIFF
--- a/test/benchmarking/benchmark.py
+++ b/test/benchmarking/benchmark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import glob
@@ -162,7 +162,7 @@ def run_benchmarks(args):
                 output_json = subprocess.check_output([exe, 'run'],
                                                       cwd=benchmark_build_dir)
                 result = json.loads(output_json)
-                times_ms.append(result['ms'])
+                times_ms.append(result['runtime_ms'])
             results[b] = times_ms
 
             subprocess.check_output([exe, 'teardown'], cwd=benchmark_build_dir)

--- a/test/benchmarking/src/CMakeLists.txt
+++ b/test/benchmarking/src/CMakeLists.txt
@@ -65,6 +65,7 @@ set(BENCHMARKS
   bench_dense_write_large_tile
   bench_dense_write_small_tile
   bench_large_io
+  bench_reader_base_unfilter_tile
   bench_sparse_read_large_tile
   bench_sparse_read_small_tile
   bench_sparse_tile_cache

--- a/test/benchmarking/src/bench_reader_base_unfilter_tile.cc
+++ b/test/benchmarking/src/bench_reader_base_unfilter_tile.cc
@@ -1,0 +1,117 @@
+/**
+ * @file   bench_reader_base_unfilter_tile.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Benchmark ReaderBase::unfilter_tile
+ */
+
+#include <numeric>
+
+#include <tiledb/tiledb>
+
+#include "benchmark.h"
+
+using namespace tiledb;
+
+class Benchmark : public BenchmarkBase {
+ protected:
+  virtual void setup() {
+    auto dim = Dimension::create<uint32_t>(ctx_, "d", {{1, max_rows_}}, 1000);
+    auto attr = Attribute::create<uint32_t>(ctx_, "a");
+
+    Domain dom(ctx_);
+    dom.add_dimension(dim);
+
+    ArraySchema schema(ctx_, TILEDB_SPARSE);
+    schema.set_domain(dom)
+        .add_attribute(attr)
+        .set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}})
+        .set_capacity(1000);
+
+    Array::create(uri_, schema);
+
+    dim_data_.resize(max_rows_);
+    std::iota(dim_data_.begin(), dim_data_.end(), 1);
+
+    attr_data_.resize(max_rows_);
+    std::iota(attr_data_.begin(), attr_data_.end(), 1);
+
+    Array array_w(ctx_, uri_, TILEDB_WRITE);
+    Query query_w(ctx_, array_w, TILEDB_WRITE);
+    query_w.set_layout(TILEDB_UNORDERED)
+        .set_data_buffer("d", dim_data_)
+        .set_data_buffer("a", attr_data_);
+    query_w.submit();
+    array_w.close();
+  }
+
+  virtual void teardown() {
+    VFS vfs(ctx_);
+    if (vfs.is_dir(uri_)) {
+      vfs.remove_dir(uri_);
+    }
+  }
+
+  virtual void pre_run() {
+    dim_data_.resize(max_rows_);
+    attr_data_.resize(max_rows_);
+  }
+
+  virtual void run() {
+    for (int i = 0; i < 5; i++) {
+      Array array(ctx_, uri_, TILEDB_READ);
+      auto ned = array.non_empty_domain<uint32_t>();
+      std::vector<uint32_t> subarray = {
+          ned[0].second.first,
+          ned[0].second.second,
+          ned[1].second.first,
+          ned[1].second.second};
+
+      Query query(ctx_, array);
+      query.set_layout(TILEDB_ROW_MAJOR)
+          .set_data_buffer("d", dim_data_)
+          .set_data_buffer("a", attr_data_);
+      query.submit();
+      array.close();
+    }
+  }
+
+ private:
+  const std::string uri_ = "bench_reader_base_unfilter_tiles";
+  const uint32_t max_rows_ = 5000;
+
+  Context ctx_;
+
+  std::vector<uint32_t> dim_data_;
+  std::vector<uint32_t> attr_data_;
+};
+
+int main(int argc, char** argv) {
+  Benchmark bench;
+  return bench.main(argc, argv);
+}

--- a/test/benchmarking/src/benchmark.cc
+++ b/test/benchmarking/src/benchmark.cc
@@ -133,10 +133,10 @@ void BenchmarkBase::print_task(
     const std::vector<uint64_t>* const mem_samples_mb,
     const uint64_t baseline_mem_mb) {
   std::cout << "{\n";
-  std::cout << "  \"phase\": \"" << name << "\"\n";
+  std::cout << "  \"phase\": \"" << name << "\",\n";
 
   if (runtime_ms) {
-    std::cout << "  \"runtime_ms\": \"" << *runtime_ms << "\"\n";
+    std::cout << "  \"runtime_ms\": " << *runtime_ms << ",\n";
   }
 
   if (mem_samples_mb) {
@@ -164,8 +164,8 @@ void BenchmarkBase::print_task(
     peak_mem_mb = (peak_mem_mb > sample_size) ? peak_mem_mb - sample_size : 0;
     avg_mem_mb = (avg_mem_mb > sample_size) ? avg_mem_mb - sample_size : 0;
 
-    std::cout << "  \"baseline_mem_mb\": \"" << baseline_mem_mb << "\"\n";
-    std::cout << "  \"peak_mem_mb\": \"" << peak_mem_mb << "\"\n";
+    std::cout << "  \"baseline_mem_mb\": \"" << baseline_mem_mb << "\",\n";
+    std::cout << "  \"peak_mem_mb\": \"" << peak_mem_mb << "\",\n";
     std::cout << "  \"avg_mem_mb\": \"" << static_cast<uint64_t>(avg_mem_mb)
               << "\"\n";
   }


### PR DESCRIPTION
Refactor ReaderBase::unfilter_tile

This condenses the four variations on `unfilter_tile` into a single function. For now, this is just a "I was reading code and this looked possible to remove a couple hundred lines of code" type of PR.

---
TYPE: IMPROVEMENT
DESC: Refactor ReaderBase::unfilter_tile
