### PR TITLE
Dense reader: adjust memory configuration parameters.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -277,7 +277,7 @@ void check_save_to_file() {
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition "
         "0.25\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges 0.1\n";
-  ss << "sm.mem.tile_memory_budget 2147483648\n";
+  ss << "sm.mem.tile_upper_memory_limit 2147483648\n";
   ss << "sm.mem.total_budget 10737418240\n";
   ss << "sm.memory_budget 5368709120\n";
   ss << "sm.memory_budget_var 10737418240\n";
@@ -615,7 +615,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.query.sparse_global_order.reader"] = "refactored";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
   all_param_values["sm.mem.malloc_trim"] = "true";
-  all_param_values["sm.mem.tile_memory_budget"] = "2147483648";
+  all_param_values["sm.mem.tile_upper_memory_limit"] = "2147483648";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_query_condition"] =

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -59,7 +59,7 @@ struct CDenseFx {
   std::string array_name_;
   const char* ARRAY_NAME = "test_dense_reader";
   std::string total_budget_;
-  std::string tile_memory_budget_;
+  std::string tile_upper_memory_limit_;
 
   void create_default_array_1d();
   void create_default_array_1d_string();
@@ -133,7 +133,7 @@ CDenseFx::~CDenseFx() {
 
 void CDenseFx::reset_config() {
   total_budget_ = "1048576";
-  tile_memory_budget_ = "1024";
+  tile_upper_memory_limit_ = "1024";
   update_config();
 }
 
@@ -161,7 +161,7 @@ void CDenseFx::update_config() {
       tiledb_config_set(
           config,
           "sm.mem.tile_memory_budget",
-          tile_memory_budget_.c_str(),
+          tile_upper_memory_limit_.c_str(),
           &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -631,35 +631,6 @@ void CDenseFx::read_fixed_strings(
 #define NUM_CELLS 20
 
 TEST_CASE_METHOD(
-    CDenseFx, "Dense reader: bad config", "[dense-reader][bad-config]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  // Write a fragment.
-  int subarray[] = {1, NUM_CELLS};
-  std::vector<int> data(NUM_CELLS);
-  std::iota(data.begin(), data.end(), 1);
-  uint64_t data_size = data.size() * sizeof(int);
-  write_1d_fragment(subarray, data.data(), &data_size);
-
-  // Each tile is 40 bytes, this will only allow to load one.
-  total_budget_ = "50";
-  tile_memory_budget_ = "100";
-  update_config();
-
-  // Try to read.
-  int data_r[NUM_CELLS] = {0};
-  uint64_t data_r_size = sizeof(data_r);
-  read(
-      subarray,
-      data_r,
-      &data_r_size,
-      false,
-      "DenseReader: sm.mem.tile_memory_budget > sm.mem.total_budget");
-}
-
-TEST_CASE_METHOD(
     CDenseFx,
     "Dense reader: budget too small",
     "[dense-reader][budget-too-small]") {
@@ -676,7 +647,7 @@ TEST_CASE_METHOD(
 
   // Each tile is 40 bytes, this will only allow to load one.
   total_budget_ = "50";
-  tile_memory_budget_ = "50";
+  tile_upper_memory_limit_ = "50";
   update_config();
 
   // Try to read.
@@ -708,7 +679,7 @@ TEST_CASE_METHOD(
   write_1d_fragment(subarray, data.data(), &data_size);
 
   // Each tile is 40 bytes, this will only allow to load one.
-  tile_memory_budget_ = "50";
+  tile_upper_memory_limit_ = "50";
   update_config();
 
   // Try to read.
@@ -738,7 +709,7 @@ TEST_CASE_METHOD(
   write_1d_fragment(subarray, data.data(), &data_size);
 
   total_budget_ = "420";
-  tile_memory_budget_ = "50";
+  tile_upper_memory_limit_ = "50";
   update_config();
 
   std::string error_expected =
@@ -778,7 +749,7 @@ TEST_CASE_METHOD(
 
   // Each tiles are 91 and 100 bytes respectively, this will only allow to
   // load one.
-  tile_memory_budget_ = "105";
+  tile_upper_memory_limit_ = "105";
   update_config();
 
   // Try to read.
@@ -821,7 +792,7 @@ TEST_CASE_METHOD(
   // Each tiles are 91 and 100 bytes respectively, this will only allow to
   // load one.
   total_budget_ = "460";
-  tile_memory_budget_ = "105";
+  tile_upper_memory_limit_ = "105";
   update_config();
 
   std::string error_expected =
@@ -867,7 +838,7 @@ TEST_CASE_METHOD(
       subarray, data.data(), &data_size, offsets.data(), &offsets_size);
 
   // Each tile is 40 bytes, this will only allow to load one.
-  tile_memory_budget_ = "50";
+  tile_upper_memory_limit_ = "50";
   update_config();
 
   // Try to read.
@@ -921,7 +892,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one. Fixed tiles are both 40 so they both fit in the budget.
   total_budget_ = "660";
-  tile_memory_budget_ = "105";
+  tile_upper_memory_limit_ = "105";
   update_config();
 
   // Try to read.
@@ -1037,7 +1008,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one. Fixed tiles are both 40 so they both fit in the budget.
   total_budget_ = "640";
-  tile_memory_budget_ = "105";
+  tile_upper_memory_limit_ = "105";
   update_config();
 
   // Try to read.
@@ -1139,7 +1110,7 @@ TEST_CASE_METHOD(
 
   // First var tiles is 91 and subequent are 100 bytes, this will only allow to
   // load two tiles the first loop and one on the subsequents.
-  tile_memory_budget_ = "192";
+  tile_upper_memory_limit_ = "192";
   update_config();
 
   // Try to read.

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -160,7 +160,7 @@ void CDenseFx::update_config() {
   REQUIRE(
       tiledb_config_set(
           config,
-          "sm.mem.tile_memory_budget",
+          "sm.mem.tile_upper_memory_limit",
           tile_upper_memory_limit_.c_str(),
           &error) == TILEDB_OK);
   REQUIRE(error == nullptr);

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -233,8 +233,16 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Should malloc_trim be called on context and query destruction? This might
  *    reduce residual memory usage. <br>
  *    **Default**: true
- * - `sm.mem.tile_memory_budget` <br>
- *    Tile memory budget, only respected in the dense reader for now. <br>
+ * - `sm.mem.tile_upper_memory_limit` <br>
+ *    **Experimental** <br>
+ *    This is the upper memory limit that is used when loading tiles. For now it
+ *    is only used in the dense reader but will be eventually used by all
+ *    readers. The readers using this value will use it as a way to limit the
+ *    amount of tile data that is brought into memory at once so that we don't
+ *    incur performance penalties during memory movement operations. It is a
+ *    soft limit that we might go over if a single tile doesn't fit into memory,
+ *    we will allow to load that tile if it still fits within
+ *    `sm.mem.total_budget`. <br>
  *    **Default**: 2GB
  * - `sm.mem.total_budget` <br>
  *    Memory budget for readers and writers. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -113,7 +113,7 @@ const std::string Config::SM_QUERY_SPARSE_GLOBAL_ORDER_READER = "refactored";
 const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
     "refactored";
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";
-const std::string Config::SM_TILE_MEMORY_BUDGET = "2147483648";  // 2GB
+const std::string Config::SM_UPPER_MEMORY_LIMIT = "2147483648";  // 2GB
 const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";   // 10GB
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION =
@@ -281,7 +281,8 @@ const std::map<std::string, std::string> default_config_values = {
         "sm.query.sparse_unordered_with_dups.reader",
         Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER),
     std::make_pair("sm.mem.malloc_trim", Config::SM_MEM_MALLOC_TRIM),
-    std::make_pair("sm.mem.tile_memory_budget", Config::SM_TILE_MEMORY_BUDGET),
+    std::make_pair(
+        "sm.mem.tile_upper_memory_limit", Config::SM_UPPER_MEMORY_LIMIT),
     std::make_pair("sm.mem.total_budget", Config::SM_MEM_TOTAL_BUDGET),
     std::make_pair(
         "sm.mem.reader.sparse_global_order.ratio_coords",

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -202,7 +202,7 @@ class Config {
   static const std::string SM_MEM_MALLOC_TRIM;
 
   /** Maximum tile memory budget for readers. */
-  static const std::string SM_TILE_MEMORY_BUDGET;
+  static const std::string SM_UPPER_MEMORY_LIMIT;
 
   /** Maximum memory budget for readers and writers. */
   static const std::string SM_MEM_TOTAL_BUDGET;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -414,9 +414,16 @@ class Config {
    *    Should malloc_trim be called on context and query destruction? This
    *    might reduce residual memory usage. <br>
    *    **Default**: true
-   * - `sm.mem.tile_memory_budget` <br>
-   *    Tile memory budget, only respected in the dense reader for now. <br>
-   *    **Default**: 2GB
+   * - `sm.mem.tile_upper_memory_limit` <br>
+   *    **Experimental** <br>
+   *    This is the upper memory limit that is used when loading tiles. For now
+   *    it is only used in the dense reader but will be eventually used by all
+   *    readers. The readers using this value will use it as a way to limit the
+   *    amount of tile data that is brought into memory at once so that we don't
+   *    incur performance penalties during memory movement operations. It is a
+   *    soft limit that we might go over if a single tile doesn't fit into
+   *    memory, we will allow to load that tile if it still fits within
+   *    `sm.mem.total_budget`. <br>
    * - `sm.mem.total_budget` <br>
    *    Memory budget for readers and writers. <br>
    *    **Default**: 10GB

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -162,8 +162,8 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   /** Total memory budget. */
   uint64_t memory_budget_;
 
-  /** Target memory budget for tiles. */
-  uint64_t tile_memory_budget_;
+  /** Target upper memory limit for tiles. */
+  uint64_t tile_upper_memory_limit_;
 
   /** Memory tracker object for the array. */
   MemoryTracker* array_memory_tracker_;


### PR DESCRIPTION
This change removes an unnecessary check in the dense reader that made queries fail on REST servers. At some point in the design of the new memory management for the dense reader, the check made sense but it is no longer required.

It also adjusts the new memory variable for the dense reader name to be more intuitive. The variable is a limit to how much tile data we will load into memory at once before we process what we have and then load more data but it is not a memory budget. If a single tile doesn't fit in that upper limit, we might still allow to load it if it is still possible to load it into memory without busting the `sm.mem.total_budget` considering everything else loaded at the time.

Finally, it moves the added `sm.mem.tile_upper_memory_limit` to experimental as it is only exposed for the moment to allow us to guide users to potentially tweak their queries if we need to but we don't want to commit to support this setting moving forward as a way to optimize queries long term.

---
TYPE: IMPROVEMENT
DESC: Dense reader: adjust memory configuration parameters.
