### PR TITLE
avoid narrowing conversion warning by [down]casting computed values

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1710,17 +1710,18 @@ std::string_view FragmentMetadata::get_tile_min_as<std::string_view>(
         "Trying to access tile min metadata that's not present");
   }
 
+  using size_cast = std::string_view::size_type;
   if (var_size) {
     auto tile_num = this->tile_num();
     auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
     auto min_offset = offsets[tile_idx];
     auto size = tile_idx == tile_num - 1 ?
-                    tile_min_var_buffer_[idx].size() - min_offset :
-                    offsets[tile_idx + 1] - min_offset;
+                    static_cast<size_cast>(tile_min_var_buffer_[idx].size() - min_offset) :
+                    static_cast<size_cast>(offsets[tile_idx + 1] - min_offset);
     char* min = &tile_min_var_buffer_[idx][min_offset];
     return {min, size};
   } else {
-    auto size = array_schema_->cell_size(name);
+    auto size = static_cast<size_cast>(array_schema_->cell_size(name));
     void* min = &tile_min_buffer_[idx][tile_idx * size];
     return {static_cast<char*>(min), size};
   }
@@ -1783,17 +1784,18 @@ std::string_view FragmentMetadata::get_tile_max_as<std::string_view>(
         "Trying to access tile max metadata that's not present");
   }
 
+  using size_cast = std::string_view::size_type;
   if (var_size) {
     auto tile_num = this->tile_num();
     auto offsets = (uint64_t*)tile_max_buffer_[idx].data();
     auto max_offset = offsets[tile_idx];
     auto size = tile_idx == tile_num - 1 ?
-                    tile_max_var_buffer_[idx].size() - max_offset :
-                    offsets[tile_idx + 1] - max_offset;
+                    static_cast<size_cast>(tile_max_var_buffer_[idx].size() - max_offset):
+                    static_cast<size_cast>(offsets[tile_idx + 1] - max_offset);
     char* max = &tile_max_var_buffer_[idx][max_offset];
     return {max, size};
   } else {
-    auto size = array_schema_->cell_size(name);
+    auto size = static_cast<size_cast>(array_schema_->cell_size(name));
     void* max = &tile_max_buffer_[idx][tile_idx * size];
     return {static_cast<char*>(max), size};
   }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1715,10 +1715,11 @@ std::string_view FragmentMetadata::get_tile_min_as<std::string_view>(
     auto tile_num = this->tile_num();
     auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
     auto min_offset = offsets[tile_idx];
-    auto size = tile_idx == tile_num - 1 ?
-                    static_cast<sv_size_cast>(
-                        tile_min_var_buffer_[idx].size() - min_offset) :
-                    static_cast<sv_size_cast>(offsets[tile_idx + 1] - min_offset);
+    auto size =
+        tile_idx == tile_num - 1 ?
+            static_cast<sv_size_cast>(
+                tile_min_var_buffer_[idx].size() - min_offset) :
+            static_cast<sv_size_cast>(offsets[tile_idx + 1] - min_offset);
     char* min = &tile_min_var_buffer_[idx][min_offset];
     return {min, size};
   } else {
@@ -1790,10 +1791,11 @@ std::string_view FragmentMetadata::get_tile_max_as<std::string_view>(
     auto tile_num = this->tile_num();
     auto offsets = (uint64_t*)tile_max_buffer_[idx].data();
     auto max_offset = offsets[tile_idx];
-    auto size = tile_idx == tile_num - 1 ?
-                    static_cast<sv_size_cast>(
-                        tile_max_var_buffer_[idx].size() - max_offset) :
-                    static_cast<sv_size_cast>(offsets[tile_idx + 1] - max_offset);
+    auto size =
+        tile_idx == tile_num - 1 ?
+            static_cast<sv_size_cast>(
+                tile_max_var_buffer_[idx].size() - max_offset) :
+            static_cast<sv_size_cast>(offsets[tile_idx + 1] - max_offset);
     char* max = &tile_max_var_buffer_[idx][max_offset];
     return {max, size};
   } else {

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1716,7 +1716,8 @@ std::string_view FragmentMetadata::get_tile_min_as<std::string_view>(
     auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
     auto min_offset = offsets[tile_idx];
     auto size = tile_idx == tile_num - 1 ?
-                    static_cast<size_cast>(tile_min_var_buffer_[idx].size() - min_offset) :
+                    static_cast<size_cast>(
+                        tile_min_var_buffer_[idx].size() - min_offset) :
                     static_cast<size_cast>(offsets[tile_idx + 1] - min_offset);
     char* min = &tile_min_var_buffer_[idx][min_offset];
     return {min, size};
@@ -1790,7 +1791,8 @@ std::string_view FragmentMetadata::get_tile_max_as<std::string_view>(
     auto offsets = (uint64_t*)tile_max_buffer_[idx].data();
     auto max_offset = offsets[tile_idx];
     auto size = tile_idx == tile_num - 1 ?
-                    static_cast<size_cast>(tile_max_var_buffer_[idx].size() - max_offset):
+                    static_cast<size_cast>(
+                        tile_max_var_buffer_[idx].size() - max_offset) :
                     static_cast<size_cast>(offsets[tile_idx + 1] - max_offset);
     char* max = &tile_max_var_buffer_[idx][max_offset];
     return {max, size};

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1710,19 +1710,19 @@ std::string_view FragmentMetadata::get_tile_min_as<std::string_view>(
         "Trying to access tile min metadata that's not present");
   }
 
-  using size_cast = std::string_view::size_type;
+  using sv_size_cast = std::string_view::size_type;
   if (var_size) {
     auto tile_num = this->tile_num();
     auto offsets = (uint64_t*)tile_min_buffer_[idx].data();
     auto min_offset = offsets[tile_idx];
     auto size = tile_idx == tile_num - 1 ?
-                    static_cast<size_cast>(
+                    static_cast<sv_size_cast>(
                         tile_min_var_buffer_[idx].size() - min_offset) :
-                    static_cast<size_cast>(offsets[tile_idx + 1] - min_offset);
+                    static_cast<sv_size_cast>(offsets[tile_idx + 1] - min_offset);
     char* min = &tile_min_var_buffer_[idx][min_offset];
     return {min, size};
   } else {
-    auto size = static_cast<size_cast>(array_schema_->cell_size(name));
+    auto size = static_cast<sv_size_cast>(array_schema_->cell_size(name));
     void* min = &tile_min_buffer_[idx][tile_idx * size];
     return {static_cast<char*>(min), size};
   }
@@ -1785,19 +1785,19 @@ std::string_view FragmentMetadata::get_tile_max_as<std::string_view>(
         "Trying to access tile max metadata that's not present");
   }
 
-  using size_cast = std::string_view::size_type;
+  using sv_size_cast = std::string_view::size_type;
   if (var_size) {
     auto tile_num = this->tile_num();
     auto offsets = (uint64_t*)tile_max_buffer_[idx].data();
     auto max_offset = offsets[tile_idx];
     auto size = tile_idx == tile_num - 1 ?
-                    static_cast<size_cast>(
+                    static_cast<sv_size_cast>(
                         tile_max_var_buffer_[idx].size() - max_offset) :
-                    static_cast<size_cast>(offsets[tile_idx + 1] - max_offset);
+                    static_cast<sv_size_cast>(offsets[tile_idx + 1] - max_offset);
     char* max = &tile_max_var_buffer_[idx][max_offset];
     return {max, size};
   } else {
-    auto size = static_cast<size_cast>(array_schema_->cell_size(name));
+    auto size = static_cast<sv_size_cast>(array_schema_->cell_size(name));
     void* max = &tile_max_buffer_[idx][tile_idx * size];
     return {static_cast<char*>(max), size};
   }


### PR DESCRIPTION
avoid narrowing conversion warning in 32bit build by [down]casting computed values to type needed for std::string_view construction

---
TYPE: BUG
DESC: avoid narrowing conversion warning by [down]casting computed values
