### PR TITLE
Disable clang-format in generated capnp directories

### DIFF
--- a/tiledb/sm/serialization/posix/.clang-format
+++ b/tiledb/sm/serialization/posix/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never

--- a/tiledb/sm/serialization/win32/.clang-format
+++ b/tiledb/sm/serialization/win32/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
Disable clang-format in generated capnp directories

---
TYPE: NO_HISTORY
