### PR TITLE
Fix logger initialization

### DIFF
--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -47,7 +47,10 @@ namespace tiledb::common {
 /* ********************************* */
 
 Logger::Logger(
-    const std::string& name, const Logger::Format format, const bool root)
+    const std::string& name,
+    const Logger::Level level,
+    const Logger::Format format,
+    const bool root)
     : name_(name)
     , root_(root) {
   logger_ = spdlog::get(name_);
@@ -64,7 +67,7 @@ Logger::Logger(
     logger_->set_pattern("{\n \"log\": [");
     logger_->critical("");
   }
-  set_level(Logger::Level::ERR);
+  set_level(level);
   set_format(format);
 }
 
@@ -289,7 +292,7 @@ Logger& global_logger(Logger::Format format) {
       (format == Logger::Format::JSON) ?
           "\"" + std::to_string(ts_micro) + "-Global\":\"1\"" :
           std::to_string(ts_micro) + "-Global";
-  static Logger l(name, format, true);
+  static Logger l(name, Logger::Level::ERR, format, true);
   return l;
 }
 

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -75,6 +75,7 @@ class Logger {
   /** Constructors */
   Logger(
       const std::string& name,
+      const Logger::Level level = Logger::Level::ERR,
       const Logger::Format format = Logger::Format::DEFAULT,
       const bool root = false);
 

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -49,7 +49,9 @@ namespace sm {
 Context::Context(const Config& config)
     : last_error_(nullopt)
     , logger_(make_shared<Logger>(
-          HERE(), logger_prefix_ + std::to_string(++logger_id_)))
+          HERE(),
+          logger_prefix_ + std::to_string(++logger_id_),
+          get_log_level(config)))
     , resources_(
           config,
           logger_,
@@ -199,6 +201,25 @@ size_t Context::get_io_thread_count(const Config& config) {
 
   return static_cast<size_t>(
       std::max(config_thread_count, io_concurrency_level));
+}
+
+common::Logger::Level Context::get_log_level(const Config& config) {
+  auto cfg_level = config.get<std::string>("config.logging_level");
+  if (cfg_level == "0") {
+    return Logger::Level::FATAL;
+  } else if (cfg_level == "1") {
+    return Logger::Level::ERR;
+  } else if (cfg_level == "2") {
+    return Logger::Level::WARN;
+  } else if (cfg_level == "3") {
+    return Logger::Level::INFO;
+  } else if (cfg_level == "4") {
+    return Logger::Level::DBG;
+  } else if (cfg_level == "5") {
+    return Logger::Level::TRACE;
+  } else {
+    return Logger::Level::ERR;
+  }
 }
 
 Status Context::init_loggers(const Config& config) {

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -34,6 +34,7 @@
 #define TILEDB_CONTEXT_H
 
 #include "tiledb/common/exception/exception.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/stats/global_stats.h"
@@ -178,6 +179,14 @@ class Context {
    * @return IO thread count.
    */
   size_t get_io_thread_count(const Config& config);
+
+  /**
+   * Get the configured log level
+   *
+   * @param config The config to look up the log leve information from.
+   * @return Log level
+   */
+  common::Logger::Level get_log_level(const Config& config);
 
   /**
    * Initializes global and local logger.


### PR DESCRIPTION
Due to the order of initialization there were log statements that would never actually emit log statements because they ran before the logger level was changed from the default ERR level to what a user had configured in the Config. This changes the Logger constructor to accept a level argument which is then set during construction.

Originally reported by @johnkerl  in an excellent bug report containing a root cause analysis.

---
TYPE: BUG
DESC: Fig logger initialization ordering
