### PR TITLE
Use temporary directories from the OS in tests.

### DIFF
--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -32,11 +32,6 @@
 
 #include <test/support/tdb_catch.h>
 #include "test/support/src/helpers.h"
-#ifdef _WIN32
-#include "tiledb/sm/filesystem/win.h"
-#else
-#include "tiledb/sm/filesystem/posix.h"
-#endif
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/misc/utils.h"
 
@@ -49,15 +44,7 @@ using namespace tiledb::test;
 
 class NullableArrayFx {
  public:
-#ifdef _WIN32
-  const string FILE_URI_PREFIX = "";
-  const string FILE_TEMP_DIR =
-      tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
-#else
-  const string FILE_URI_PREFIX = "file://";
-  const string FILE_TEMP_DIR =
-      tiledb::sm::Posix::current_dir() + "/tiledb_test/";
-#endif
+  const string& FILE_TEMP_DIR = tiledb::test::get_temp_path();
 
   // Serialization parameters
   bool serialize_ = false;

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/misc/utils.h"
 
-#include <filesystem>
 #include <iostream>
 #include <vector>
 

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -33,15 +33,11 @@
 
 #include <test/support/tdb_catch.h>
 #include "test/support/src/helpers.h"
-#ifdef _WIN32
-#include "tiledb/sm/filesystem/win.h"
-#else
-#include "tiledb/sm/filesystem/posix.h"
-#endif
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/misc/utils.h"
 
+#include <filesystem>
 #include <iostream>
 #include <vector>
 
@@ -53,15 +49,7 @@ static const char encryption_key[] = "unittestunittestunittestunittest";
 
 class SmokeTestFx {
  public:
-#ifdef _WIN32
-  const string FILE_URI_PREFIX = "";
-  const string FILE_TEMP_DIR =
-      tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
-#else
-  const string FILE_URI_PREFIX = "file://";
-  const string FILE_TEMP_DIR =
-      tiledb::sm::Posix::current_dir() + "/tiledb_test/";
-#endif
+  const string& FILE_TEMP_DIR = tiledb::test::get_temp_path();
 
   /**
    * Wraps data to build a dimension with the C-API.

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -56,14 +56,7 @@ struct VFSFx {
   const std::string AZURE_CONTAINER =
       AZURE_PREFIX + random_name("tiledb") + "/";
   const std::string AZURE_TEMP_DIR = AZURE_CONTAINER + "tiledb_test/";
-#ifdef _WIN32
-  const std::string FILE_TEMP_DIR =
-      tiledb::sm::Win::current_dir() + "\\tiledb_test\\";
-#else
-  const std::string FILE_TEMP_DIR = std::string("file://") +
-                                    tiledb::sm::Posix::current_dir() +
-                                    "/tiledb_test/";
-#endif
+  const std::string FILE_TEMP_DIR = tiledb::test::get_temp_path();
   const std::string MEMFS_TEMP_DIR = std::string("mem://tiledb_test/");
 
   // TileDB context and vfs

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -56,7 +56,11 @@ struct VFSFx {
   const std::string AZURE_CONTAINER =
       AZURE_PREFIX + random_name("tiledb") + "/";
   const std::string AZURE_TEMP_DIR = AZURE_CONTAINER + "tiledb_test/";
-  const std::string FILE_TEMP_DIR = tiledb::test::get_temp_path();
+  const std::string FILE_TEMP_DIR =
+#ifndef _WIN32
+      "file://" +
+#endif
+      tiledb::test::get_temp_path();
   const std::string MEMFS_TEMP_DIR = std::string("mem://tiledb_test/");
 
   // TileDB context and vfs

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -33,6 +33,7 @@
 #ifdef _WIN32
 
 #include <test/support/tdb_catch.h>
+#include "test/support/src/helpers.h"
 
 #include <cassert>
 #include "tiledb/common/status.h"
@@ -57,7 +58,7 @@ static bool ends_with(const std::string& value, const std::string& suffix) {
 }
 
 struct WinFx {
-  const std::string TEMP_DIR = Win::current_dir() + "/";
+  const std::string& TEMP_DIR = tiledb::test::get_temp_path();
   Win win_;
   ThreadPool thread_pool_{4};
   Config vfs_config_;

--- a/test/src/unit-win-filesystem.cc
+++ b/test/src/unit-win-filesystem.cc
@@ -182,17 +182,19 @@ TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
   CHECK(st.ok());
 
   const unsigned buffer_size = 100000;
-  auto write_buffer = new char[buffer_size];
+  std::vector<char> write_buffer(buffer_size);
   for (unsigned i = 0; i < buffer_size; i++) {
     write_buffer[i] = 'a' + (i % 26);
   }
-  st = win_.write(test_file.to_path(), write_buffer, buffer_size);
+  st =
+      win_.write(test_file.to_path(), write_buffer.data(), write_buffer.size());
   CHECK(st.ok());
   st = win_.sync(test_file.to_path());
   CHECK(st.ok());
 
-  auto read_buffer = new char[26];
-  st = win_.read(test_file.to_path(), 0, read_buffer, 26);
+  std::vector<char> read_buffer(26);
+  st =
+      win_.read(test_file.to_path(), 0, read_buffer.data(), read_buffer.size());
   CHECK(st.ok());
 
   bool allok = true;
@@ -204,7 +206,8 @@ TEST_CASE_METHOD(WinFx, "Test Windows filesystem", "[windows]") {
   }
   CHECK(allok == true);
 
-  st = win_.read(test_file.to_path(), 11, read_buffer, 26);
+  st = win_.read(
+      test_file.to_path(), 11, read_buffer.data(), read_buffer.size());
   CHECK(st.ok());
 
   allok = true;

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -56,8 +56,9 @@ namespace tiledb {
 namespace test {
 
 const std::string& get_temp_path() {
+  // Ensure the path has a trailing delimiter.
   static std::string temp_path =
-      (std::filesystem::temp_directory_path() / "tiledb_test").string();
+      (std::filesystem::temp_directory_path() / "tiledb_test" / "").string();
 
   return temp_path;
 }

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -30,8 +30,10 @@
  * This file defines some test suite helper functions.
  */
 
-#include "helpers.h"
+#include <filesystem>
+
 #include <test/support/tdb_catch.h>
+#include "helpers.h"
 #include "serialization_wrappers.h"
 #include "tiledb/api/c_api/buffer/buffer_api_internal.h"
 #include "tiledb/api/c_api/context/context_api_external.h"
@@ -52,6 +54,13 @@ std::mutex catch2_macro_mutex;
 
 namespace tiledb {
 namespace test {
+
+const std::string& get_temp_path() {
+  static std::string temp_path =
+      (std::filesystem::temp_directory_path() / "tiledb_test").string();
+
+  return temp_path;
+}
 
 // Command line arguments.
 std::string g_vfs;

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -31,6 +31,12 @@
  */
 
 #include <filesystem>
+#if _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
+#include <unistd.h>
+#endif
 
 #include <test/support/tdb_catch.h>
 #include "helpers.h"
@@ -58,7 +64,9 @@ namespace test {
 const std::string& get_temp_path() {
   // Ensure the path has a trailing delimiter.
   static std::string temp_path =
-      (std::filesystem::temp_directory_path() / "tiledb_test" / "").string();
+      (std::filesystem::temp_directory_path() /
+       ("tiledb_test_" + std::to_string(getpid())) / "")
+          .string();
 
   return temp_path;
 }

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -84,6 +84,8 @@ static tiledb::sm::stats::Stats g_helper_stats("test");
 // objects that require a parent `Logger` object.
 shared_ptr<Logger> g_helper_logger(void);
 
+const std::string& get_temp_path();
+
 // For easy reference
 typedef std::pair<tiledb_filter_type_t, int> Compressor;
 template <class T>


### PR DESCRIPTION
This PR changes the temporary directories of test fixtures to be inside `std::filesystem::temp_directory_path()` instead of the current dictionary. Also some platform-specific stuff was removed.

[SC-25581](https://app.shortcut.com/tiledb-inc/story/25581/change-smoketestfx-fixture-to-use-proper-temp-directory)

---
TYPE: IMPROVEMENT
DESC: Use temporary directories from the OS in tests.