### PR TITLE
Add unit_platform tests

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -53,6 +53,7 @@ find_package(Threads REQUIRED)
 
 add_subdirectory(api)
 add_subdirectory(common)
+add_subdirectory(platform)
 add_subdirectory(type)
 add_subdirectory(sm)
 add_subdirectory(storage_format)

--- a/tiledb/platform/CMakeLists.txt
+++ b/tiledb/platform/CMakeLists.txt
@@ -1,0 +1,37 @@
+#
+# tiledb/platform/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2021-2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common NO_POLICY_SCOPE)
+include(object_library)
+
+#
+# `platform` object library
+#
+commence(object_library platform)
+    this_target_sources(platform.cc)
+conclude(object_library)
+
+add_test_subdirectory()

--- a/tiledb/platform/platform.cc
+++ b/tiledb/platform/platform.cc
@@ -1,0 +1,33 @@
+/**
+ * @file   tiledb/platform/platform.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Empty source file for object library creation
+ */
+
+#include "tiledb/platform/platform.h"

--- a/tiledb/platform/test/CMakeLists.txt
+++ b/tiledb/platform/test/CMakeLists.txt
@@ -1,0 +1,33 @@
+#
+# tiledb/platform/test/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2021-2022 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(unit_test)
+
+commence(unit_test platform)
+    this_target_sources(main.cc unit_platform.cc)
+    this_target_compile_definitions(PLATFORM_OS_NAME="${CMAKE_SYSTEM_NAME}")
+    this_target_object_libraries(platform)
+conclude(unit_test)

--- a/tiledb/platform/test/compile_platform_main.cc
+++ b/tiledb/platform/test/compile_platform_main.cc
@@ -1,0 +1,38 @@
+/**
+ * @file compile_platfrom_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../platform.h"
+
+int main() {
+  // PJD: We really don't like using sizeof to prove linkage, but
+  // in this particular case there's actually nothing to link
+  // against. If/when we add more to platform.h we'll want to
+  // update this test as soon as something is linkable.
+  (void)sizeof(tiledb::platform::is_os_linux);
+  return 0;
+}

--- a/tiledb/platform/test/main.cc
+++ b/tiledb/platform/test/main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file tiledb/platform/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a test `main()`
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "unit_platform.h"

--- a/tiledb/platform/test/unit_platform.cc
+++ b/tiledb/platform/test/unit_platform.cc
@@ -1,0 +1,59 @@
+/**
+ * @file tiledb/platform/test/unit_platform.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the platform header.
+ */
+
+#include <iostream>
+
+#include "tiledb/platform/platform.h"
+#include "unit_platform.h"
+
+using namespace tiledb;
+
+TEST_CASE("Platform: Test OS constexpr flags", "[platform][os_flags]") {
+  std::string os_name(PLATFORM_OS_NAME);
+
+  if (os_name == "Windows") {
+    REQUIRE(platform::is_os_windows);
+    REQUIRE(!platform::is_os_macosx);
+    REQUIRE(!platform::is_os_linux);
+  } else if (os_name == "Darwin") {
+    REQUIRE(!platform::is_os_windows);
+    REQUIRE(platform::is_os_macosx);
+    REQUIRE(!platform::is_os_linux);
+  } else if (os_name == "Linux") {
+    REQUIRE(!platform::is_os_windows);
+    REQUIRE(!platform::is_os_macosx);
+    REQUIRE(platform::is_os_linux);
+  } else {
+    std::cerr << "Warning: Unknown OS name reported by CMake: "
+              << PLATFORM_OS_NAME << std::endl;
+  }
+}

--- a/tiledb/platform/test/unit_platform.h
+++ b/tiledb/platform/test/unit_platform.h
@@ -1,0 +1,31 @@
+/**
+ * @file tiledb/platform/test/unit_platform.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <test/support/tdb_catch.h>


### PR DESCRIPTION
I tried using platform.h in a separate PR which broke the build on Windows from what was apparently an incorrectly set `is_os_windows` setting. I'm adding these tests to assert that OS type is correctly identified.

Note that I'm relying on CMake's `CMAKE_SYSTEM_NAME` variable here to do platform detection. This means that our OS detection is only as good as CMake's detection which I have no reason to distrust. Secondly, I'm ignoring any platform that isn't Windows, macOS, or Linux and just logging an error. This is on purpose so that these don't suddenly break a bunch of downstream package builds.

---
TYPE: IMPROVEMENT
DESC: Add unit tests for tiledb/common/platform.h
