### PR TITLE
Fix example code in the dimension labels API.

### DIFF
--- a/tiledb/api/c_api/dimension_label/dimension_label_api_external.h
+++ b/tiledb/api/c_api/dimension_label/dimension_label_api_external.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 /**
- * C API carrier for a TileDB dimensin label
+ * C API carrier for a TileDB dimension label
  */
 typedef struct tiledb_dimension_label_handle_t tiledb_dimension_label_t;
 
@@ -77,7 +77,7 @@ TILEDB_EXPORT capi_return_t tiledb_dimension_label_get_dimension_index(
     uint32_t* dim_index) TILEDB_NOEXCEPT;
 
 /**
- * Returns the name of the dimension label.
+ * Returns the name of the attribute the label data is stored under.
  *
  * @param[in] ctx TileDB context.
  * @param[in] dim_label The target dimension label.
@@ -148,7 +148,7 @@ TILEDB_EXPORT capi_return_t tiledb_dimension_label_get_name(
  *
  * @param[in] ctx TileDB context.
  * @param[in] dim_label The target dimension label.
- * @param[out] uri The uri of the dimension label.
+ * @param[out] uri The uri of the dimension label array.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_dimension_label_get_uri(

--- a/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
+++ b/tiledb/sm/c_api/tiledb_dimension_label_experimental.h
@@ -51,7 +51,7 @@ extern "C" {
  *     array_schema,
  *     0,
  *     "label",
- *     TILEDB_INCREASING_LABELS,
+ *     TILEDB_INCREASING_DATA,
  *     TILEDB_FLOAT64);
  * @endcode
  *
@@ -160,7 +160,7 @@ TILEDB_EXPORT capi_return_t tiledb_array_schema_set_dimension_label_filter_list(
  *     array_schema,
  *     0,
  *     "label",
- *     TILEDB_INCREASING_LABELS,
+ *     TILEDB_INCREASING_DATA,
  *     TILEDB_FLOAT64);
  * tiledb_array_schema_set_dimension_label_tile_extent(
  *     ctx, array_schema, "label", TILEDB_INT64, &tile_extent);


### PR DESCRIPTION
---
TYPE: NO_HISTORY
DESC: Fix example code in the dimension labels API.