### PR TITLE
Sparse unordered w/ dups: smaller units of work.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -270,12 +270,9 @@ void check_save_to_file() {
   ss << "sm.mem.malloc_trim true\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_coords 0.5\n";
-  ss << "sm.mem.reader.sparse_global_order.ratio_query_condition 0.25\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_tile_ranges 0.1\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_coords 0.5\n";
-  ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition "
-        "0.25\n";
   ss << "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges 0.1\n";
   ss << "sm.mem.tile_upper_memory_limit 2147483648\n";
   ss << "sm.mem.total_budget 10737418240\n";
@@ -618,17 +615,12 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.mem.tile_upper_memory_limit"] = "2147483648";
   all_param_values["sm.mem.total_budget"] = "10737418240";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_coords"] = "0.5";
-  all_param_values["sm.mem.reader.sparse_global_order.ratio_query_condition"] =
-      "0.25";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_tile_ranges"] =
       "0.1";
   all_param_values["sm.mem.reader.sparse_global_order.ratio_array_data"] =
       "0.1";
   all_param_values["sm.mem.reader.sparse_unordered_with_dups.ratio_coords"] =
       "0.5";
-  all_param_values
-      ["sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition"] =
-          "0.25";
   all_param_values
       ["sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges"] = "0.1";
   all_param_values

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -62,7 +62,6 @@ struct CSparseGlobalOrderFx {
   std::string ratio_tile_ranges_;
   std::string ratio_array_data_;
   std::string ratio_coords_;
-  std::string ratio_query_condition_;
 
   void create_default_array_1d(bool allow_dups = false);
   void write_1d_fragment(
@@ -108,7 +107,6 @@ void CSparseGlobalOrderFx::reset_config() {
   ratio_tile_ranges_ = "0.1";
   ratio_array_data_ = "0.1";
   ratio_coords_ = "0.5";
-  ratio_query_condition_ = "0.25";
   update_config();
 }
 
@@ -159,14 +157,6 @@ void CSparseGlobalOrderFx::update_config() {
           config,
           "sm.mem.reader.sparse_global_order.ratio_coords",
           ratio_coords_.c_str(),
-          &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
-      tiledb_config_set(
-          config,
-          "sm.mem.reader.sparse_global_order.ratio_query_condition",
-          ratio_query_condition_.c_str(),
           &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -536,151 +526,6 @@ TEST_CASE_METHOD(
 
   std::string error_str(msg);
   CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseGlobalOrderFx,
-    "Sparse global order reader: qc budget too small",
-    "[sparse-global-order][qc-budget][too-small]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
-
-  // One qc tile (8) will be bigger than the budget (5).
-  total_budget_ = "10000";
-  ratio_query_condition_ = "0.0005";
-  update_config();
-
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
-  CHECK(rc == TILEDB_ERR);
-
-  // Check we hit the correct error.
-  tiledb_error_t* error = NULL;
-  rc = tiledb_ctx_get_last_error(ctx_, &error);
-  CHECK(rc == TILEDB_OK);
-
-  const char* msg;
-  rc = tiledb_error_message(error, &msg);
-  CHECK(rc == TILEDB_OK);
-
-  std::string error_str(msg);
-  CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseGlobalOrderFx,
-    "Sparse global order reader: qc budget forcing one tile at a time",
-    "[sparse-global-order][small-qc-budget]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  int num_frags = 0;
-  SECTION("- No subarray") {
-    use_subarray = false;
-    SECTION("- Two fragments") {
-      num_frags = 2;
-    }
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-    SECTION("- One fragment") {
-      num_frags = 1;
-    }
-    SECTION("- Two fragments") {
-      num_frags = 2;
-    }
-  }
-
-  for (int i = 0; i < num_frags; i++) {
-    // Write a fragment.
-    int coords[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
-    uint64_t coords_size = sizeof(coords);
-    int data[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
-    uint64_t data_size = sizeof(data);
-    write_1d_fragment(coords, &coords_size, data, &data_size);
-  }
-
-  // Two qc tile (16) will be bigger than the budget (10).
-  total_budget_ = "10000";
-  ratio_query_condition_ = num_frags == 1 ? "0.001" : "0.002";
-  update_config();
-
-  tiledb_array_t* array = nullptr;
-  tiledb_query_t* query = nullptr;
-
-  uint32_t rc;
-  uint64_t coords_r_size;
-  uint64_t data_r_size;
-
-  // Try to read.
-  int coords_r[10];
-  int data_r[10];
-  coords_r_size = sizeof(coords_r);
-  data_r_size = sizeof(data_r);
-
-  rc = read(
-      use_subarray,
-      true,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
-  CHECK(rc == TILEDB_OK);
-
-  // Check the internal loop count against expected value.
-  auto stats =
-      ((sm::SparseGlobalOrderReader<uint8_t>*)query->query_->strategy())
-          ->stats();
-  REQUIRE(stats != nullptr);
-  auto counters = stats->counters();
-  REQUIRE(counters != nullptr);
-  auto loop_num =
-      counters->find("Context.StorageManager.Query.Reader.loop_num");
-  CHECK(2 + (uint64_t)num_frags == loop_num->second);
-
-  // Check incomplete query status.
-  tiledb_query_status_t status;
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_COMPLETED);
-
-  CHECK(uint64_t(num_frags * 20) == data_r_size);
-  CHECK(uint64_t(num_frags * 20) == coords_r_size);
-
-  int coords_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  int data_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Clean up.
-  rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
-  tiledb_query_free(&query);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -949,8 +949,9 @@ TEST_CASE_METHOD(
   uint64_t data_size = sizeof(data);
   write_1d_fragment(coords, &coords_size, data, &data_size);
 
-  // One result tile (~505) will be bigger than the budget (5).
-  total_budget_ = "10000";
+  // One result tile (~505) will be larger than leftover memory.
+  total_budget_ = "800";
+  ratio_array_data_ = "0.99";
   ratio_coords_ = "0.0005";
   update_config();
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -63,7 +63,6 @@ struct CSparseUnorderedWithDupsFx {
   std::string ratio_tile_ranges_;
   std::string ratio_array_data_;
   std::string ratio_coords_;
-  std::string ratio_query_condition_;
   std::string partial_tile_offsets_loading_;
 
   void create_default_array_1d();
@@ -118,7 +117,6 @@ void CSparseUnorderedWithDupsFx::reset_config() {
   ratio_tile_ranges_ = "0.1";
   ratio_array_data_ = "0.1";
   ratio_coords_ = "0.5";
-  ratio_query_condition_ = "0.25";
   partial_tile_offsets_loading_ = "false";
   update_config();
 }
@@ -170,14 +168,6 @@ void CSparseUnorderedWithDupsFx::update_config() {
           config,
           "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
           ratio_coords_.c_str(),
-          &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
-      tiledb_config_set(
-          config,
-          "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition",
-          ratio_query_condition_.c_str(),
           &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -984,150 +974,6 @@ TEST_CASE_METHOD(
 
   std::string error_str(msg);
   CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: qc budget too small",
-    "[sparse-unordered-with-dups][qc-budget][too-small]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  SECTION("- No subarray") {
-    use_subarray = false;
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-  }
-
-  // Write a fragment.
-  int coords[] = {1, 2, 3, 4, 5};
-  uint64_t coords_size = sizeof(coords);
-  int data[] = {1, 2, 3, 4, 5};
-  uint64_t data_size = sizeof(data);
-  write_1d_fragment(coords, &coords_size, data, &data_size);
-
-  // One qc tile (8) will be bigger than the budget (5).
-  total_budget_ = "10000";
-  ratio_query_condition_ = "0.0005";
-  update_config();
-
-  // Try to read.
-  int coords_r[5];
-  int data_r[5];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
-  CHECK(rc == TILEDB_ERR);
-
-  // Check we hit the correct error.
-  tiledb_error_t* error = NULL;
-  rc = tiledb_ctx_get_last_error(ctx_, &error);
-  CHECK(rc == TILEDB_OK);
-
-  const char* msg;
-  rc = tiledb_error_message(error, &msg);
-  CHECK(rc == TILEDB_OK);
-
-  std::string error_str(msg);
-  CHECK(error_str.find("Cannot load a single tile") != std::string::npos);
-}
-
-TEST_CASE_METHOD(
-    CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: qc budget forcing one tile at a time",
-    "[sparse-unordered-with-dups][small-qc-budget]") {
-  // Create default array.
-  reset_config();
-  create_default_array_1d();
-
-  bool use_subarray = false;
-  int num_frags = 0;
-  SECTION("- No subarray") {
-    use_subarray = false;
-    SECTION("- One fragment") {
-      num_frags = 1;
-    }
-    SECTION("- Two fragments") {
-      num_frags = 2;
-    }
-  }
-  SECTION("- Subarray") {
-    use_subarray = true;
-    SECTION("- One fragment") {
-      num_frags = 1;
-    }
-    SECTION("- Two fragments") {
-      num_frags = 2;
-    }
-  }
-
-  for (int i = 0; i < num_frags; i++) {
-    // Write a fragment.
-    int coords[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
-    uint64_t coords_size = sizeof(coords);
-    int data[] = {1 + i * 5, 2 + i * 5, 3 + i * 5, 4 + i * 5, 5 + i * 5};
-    uint64_t data_size = sizeof(data);
-    write_1d_fragment(coords, &coords_size, data, &data_size);
-  }
-
-  // Two qc tile (16) will be bigger than the budget (10).
-  total_budget_ = "10000";
-  ratio_query_condition_ = "0.001";
-  update_config();
-
-  tiledb_array_t* array = nullptr;
-  tiledb_query_t* query = nullptr;
-
-  // Try to read.
-  int coords_r[10];
-  int data_r[10];
-  uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-
-  auto rc = read(
-      use_subarray,
-      true,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
-  CHECK(rc == TILEDB_OK);
-
-  // Check the internal loop count against expected value.
-  auto stats =
-      ((SparseUnorderedWithDupsReader<uint8_t>*)query->query_->strategy())
-          ->stats();
-  REQUIRE(stats != nullptr);
-  auto counters = stats->counters();
-  REQUIRE(counters != nullptr);
-  auto loop_num =
-      counters->find("Context.StorageManager.Query.Reader.loop_num");
-  CHECK(uint64_t(num_frags * 3) == loop_num->second);
-
-  // Check query status.
-  tiledb_query_status_t status;
-  tiledb_query_get_status(ctx_, query, &status);
-  CHECK(status == TILEDB_COMPLETED);
-
-  CHECK(uint64_t(num_frags * 20) == data_r_size);
-  CHECK(uint64_t(num_frags * 20) == coords_r_size);
-
-  int coords_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  int data_c[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  CHECK(!std::memcmp(coords_c, coords_r, coords_r_size));
-  CHECK(!std::memcmp(data_c, data_r, data_r_size));
-
-  // Clean up.
-  rc = tiledb_array_close(ctx_, array);
-  CHECK(rc == TILEDB_OK);
-  tiledb_array_free(&array);
-  tiledb_query_free(&query);
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -235,14 +235,14 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: true
  * - `sm.mem.tile_upper_memory_limit` <br>
  *    **Experimental** <br>
- *    This is the upper memory limit that is used when loading tiles. For now it
- *    is only used in the dense reader but will be eventually used by all
- *    readers. The readers using this value will use it as a way to limit the
- *    amount of tile data that is brought into memory at once so that we don't
- *    incur performance penalties during memory movement operations. It is a
- *    soft limit that we might go over if a single tile doesn't fit into memory,
- *    we will allow to load that tile if it still fits within
- *    `sm.mem.total_budget`. <br>
+ *    This is the upper memory limit that is used when loading tiles. For now
+ *    it is only used in the dense reader and sparse unordered with duplicates
+ *    reader but will be eventually used by all readers. The readers using
+ *    this value will use it as a way to limit the amount of tile data that is
+ *    brought into memory at once so that we don't incur performance penalties
+ *    during memory movement operations. It is a soft limit that we might go
+ *    over if a single tile doesn't fit into memory, we will allow to load
+ *    that tile if it still fits within `sm.mem.total_budget`. <br>
  *    **Default**: 2GB
  * - `sm.mem.total_budget` <br>
  *    Memory budget for readers and writers. <br>
@@ -251,10 +251,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Ratio of the budget allocated for coordinates in the sparse global
  *    order reader. <br>
  *    **Default**: 0.5
- * - `sm.mem.reader.sparse_global_order.ratio_query_condition` <br>
- *    Ratio of the budget allocated for the query condition in the sparse
- *    global order reader. <br>
- *    **Default**: 0.25
  * - `sm.mem.reader.sparse_global_order.ratio_tile_ranges` <br>
  *    Ratio of the budget allocated for tile ranges in the sparse global
  *    order reader. <br>
@@ -267,10 +263,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Ratio of the budget allocated for coordinates in the sparse unordered
  *    with duplicates reader. <br>
  *    **Default**: 0.5
- * - `sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition` <br>
- *    Ratio of the budget allocated for the query condition in the sparse
- *    unordered with duplicates reader. <br>
- *    **Default**: 0.25
  * - `sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges` <br>
  *    Ratio of the budget allocated for tile ranges in the sparse unordered
  *    with duplicates reader. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -116,14 +116,10 @@ const std::string Config::SM_MEM_MALLOC_TRIM = "true";
 const std::string Config::SM_UPPER_MEMORY_LIMIT = "2147483648";  // 2GB
 const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";   // 10GB
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
-const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION =
-    "0.25";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES = "0.1";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA = "0.1";
 const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS =
     "0.5";
-const std::string
-    Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION = "0.25";
 const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES =
     "0.1";
 const std::string Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_ARRAY_DATA =
@@ -288,9 +284,6 @@ const std::map<std::string, std::string> default_config_values = {
         "sm.mem.reader.sparse_global_order.ratio_coords",
         Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS),
     std::make_pair(
-        "sm.mem.reader.sparse_global_order.ratio_query_condition",
-        Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION),
-    std::make_pair(
         "sm.mem.reader.sparse_global_order.ratio_tile_ranges",
         Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES),
     std::make_pair(
@@ -299,9 +292,6 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "sm.mem.reader.sparse_unordered_with_dups.ratio_coords",
         Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS),
-    std::make_pair(
-        "sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition",
-        Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION),
     std::make_pair(
         "sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges",
         Config::SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_TILE_RANGES),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -210,11 +210,6 @@ class Config {
   /** Ratio of the sparse global order reader budget used for coords. */
   static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS;
 
-  /**
-   * Ratio of the sparse global order reader budget used for query condition.
-   */
-  static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_QUERY_CONDITION;
-
   /** Ratio of the sparse global order reader budget used for tile ranges. */
   static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES;
 
@@ -223,13 +218,6 @@ class Config {
 
   /** Ratio of the sparse unordered with dups reader budget used for coords. */
   static const std::string SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_COORDS;
-
-  /**
-   * Ratio of the sparse unordered with dups reader budget used for query
-   * condition.
-   */
-  static const std::string
-      SM_MEM_SPARSE_UNORDERED_WITH_DUPS_RATIO_QUERY_CONDITION;
 
   /**
    * Ratio of the sparse unordered with dups reader budget used for tile

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -417,13 +417,13 @@ class Config {
    * - `sm.mem.tile_upper_memory_limit` <br>
    *    **Experimental** <br>
    *    This is the upper memory limit that is used when loading tiles. For now
-   *    it is only used in the dense reader but will be eventually used by all
-   *    readers. The readers using this value will use it as a way to limit the
-   *    amount of tile data that is brought into memory at once so that we don't
-   *    incur performance penalties during memory movement operations. It is a
-   *    soft limit that we might go over if a single tile doesn't fit into
-   *    memory, we will allow to load that tile if it still fits within
-   *    `sm.mem.total_budget`. <br>
+   *    it is only used in the dense reader and sparse unordered with duplicates
+   *    reader but will be eventually used by all readers. The readers using
+   *    this value will use it as a way to limit the amount of tile data that is
+   *    brought into memory at once so that we don't incur performance penalties
+   *    during memory movement operations. It is a soft limit that we might go
+   *    over if a single tile doesn't fit into memory, we will allow to load
+   *    that tile if it still fits within `sm.mem.total_budget`. <br>
    * - `sm.mem.total_budget` <br>
    *    Memory budget for readers and writers. <br>
    *    **Default**: 10GB
@@ -431,10 +431,6 @@ class Config {
    *    Ratio of the budget allocated for coordinates in the sparse global
    *    order reader. <br>
    *    **Default**: 0.5
-   * - `sm.mem.reader.sparse_global_order.ratio_query_condition` <br>
-   *    Ratio of the budget allocated for the query condition in the sparse
-   *    global order reader. <br>
-   *    **Default**: 0.25
    * - `sm.mem.reader.sparse_global_order.ratio_tile_ranges` <br>
    *    Ratio of the budget allocated for tile ranges in the sparse global
    *    order reader. <br>
@@ -447,10 +443,6 @@ class Config {
    *    Ratio of the budget allocated for coordinates in the sparse unordered
    *    with duplicates reader. <br>
    *    **Default**: 0.5
-   * - `sm.mem.reader.sparse_unordered_with_dups.ratio_query_condition` <br>
-   *    Ratio of the budget allocated for the query condition in the sparse
-   *    unordered with duplicates reader. <br>
-   *    **Default**: 0.25
    * - `sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges` <br>
    *    Ratio of the budget allocated for tile ranges in the sparse unordered
    *    with duplicates reader. <br>

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -92,7 +92,6 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
           condition)
     , result_tiles_(array->fragment_metadata().size())
     , memory_used_for_coords_(array->fragment_metadata().size())
-    , memory_used_for_qc_tiles_(array->fragment_metadata().size())
     , consolidation_with_timestamps_(consolidation_with_timestamps)
     , last_cells_(array->fragment_metadata().size())
     , tile_offsets_loaded_(false) {
@@ -138,11 +137,6 @@ void SparseGlobalOrderReader<BitmapType>::initialize_memory_budget() {
   throw_if_not_ok(config_.get<double>(
       "sm.mem.reader.sparse_global_order.ratio_coords",
       &memory_budget_ratio_coords_,
-      &found));
-  assert(found);
-  throw_if_not_ok(config_.get<double>(
-      "sm.mem.reader.sparse_global_order.ratio_query_condition",
-      &memory_budget_ratio_query_condition_,
       &found));
   assert(found);
   throw_if_not_ok(config_.get<double>(
@@ -323,15 +317,14 @@ void SparseGlobalOrderReader<BitmapType>::load_all_tile_offsets() {
 }
 
 template <class BitmapType>
-std::pair<uint64_t, uint64_t>
-SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
+uint64_t SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
     unsigned dim_num, unsigned f, uint64_t t) {
-  auto tiles_sizes =
+  auto tiles_size =
       SparseIndexReaderBase::get_coord_tiles_size<BitmapType>(dim_num, f, t);
   auto frag_meta = fragment_metadata_[f];
 
   // Add the result tile structure size.
-  tiles_sizes.first += sizeof(GlobalOrderResultTile<BitmapType>);
+  tiles_size += sizeof(GlobalOrderResultTile<BitmapType>);
 
   // Account for hilbert data.
   if (array_schema_.cell_order() == Layout::HILBERT) {
@@ -343,7 +336,7 @@ SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
   const bool dups = array_schema_.allows_dups();
   if (subarray_.is_set() || process_partial_timestamps(*frag_meta) ||
       (dups && has_post_deduplication_conditions(*frag_meta))) {
-    tiles_sizes.first += frag_meta->cell_num(t) * sizeof(BitmapType);
+    tiles_size += frag_meta->cell_num(t) * sizeof(BitmapType);
   }
 
   // Add the extra bitmap size if there is a condition to process and no dups.
@@ -351,17 +344,16 @@ SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
   // condition results.
   if ((!dups && has_post_deduplication_conditions(*frag_meta)) ||
       deletes_consolidation_no_purge_) {
-    tiles_sizes.first += frag_meta->cell_num(t) * sizeof(BitmapType);
+    tiles_size += frag_meta->cell_num(t) * sizeof(BitmapType);
   }
 
-  return tiles_sizes;
+  return tiles_size;
 }
 
 template <class BitmapType>
 bool SparseGlobalOrderReader<BitmapType>::add_result_tile(
     const unsigned dim_num,
     const uint64_t memory_budget_coords_tiles,
-    const uint64_t memory_budget_qc_tiles,
     const unsigned f,
     const uint64_t t,
     const FragmentMetadata& frag_md) {
@@ -370,13 +362,10 @@ bool SparseGlobalOrderReader<BitmapType>::add_result_tile(
   }
 
   // Calculate memory consumption for this tile.
-  auto tiles_sizes = get_coord_tiles_size(dim_num, f, t);
-  auto tiles_size = tiles_sizes.first;
-  auto tiles_size_qc = tiles_sizes.second;
+  auto tiles_size = get_coord_tiles_size(dim_num, f, t);
 
   // Don't load more tiles than the memory budget.
-  if (memory_used_for_coords_[f] + tiles_size > memory_budget_coords_tiles ||
-      memory_used_for_qc_tiles_[f] + tiles_size_qc > memory_budget_qc_tiles) {
+  if (memory_used_for_coords_[f] + tiles_size > memory_budget_coords_tiles) {
     return true;
   }
 
@@ -384,12 +373,10 @@ bool SparseGlobalOrderReader<BitmapType>::add_result_tile(
   {
     std::unique_lock<std::mutex> lck(mem_budget_mtx_);
     memory_used_for_coords_total_ += tiles_size;
-    memory_used_qc_tiles_total_ += tiles_size_qc;
   }
 
   // Adjust per fragment memory used.
   memory_used_for_coords_[f] += tiles_size;
-  memory_used_for_qc_tiles_[f] += tiles_size_qc;
 
   // Add the tile.
   result_tiles_[f].emplace_back(
@@ -418,9 +405,6 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
 
   per_fragment_memory_ =
       memory_budget_ * memory_budget_ratio_coords_ / num_fragments_to_process;
-  per_fragment_qc_memory_ = memory_budget_ *
-                            memory_budget_ratio_query_condition_ /
-                            num_fragments_to_process;
 
   // Create result tiles.
   bool tiles_found = false;
@@ -433,12 +417,7 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
             auto& range = result_tile_ranges_[f].back();
             for (t = range.first; t <= range.second; t++) {
               auto budget_exceeded = add_result_tile(
-                  dim_num,
-                  per_fragment_memory_,
-                  per_fragment_qc_memory_,
-                  f,
-                  t,
-                  *fragment_metadata_[f]);
+                  dim_num, per_fragment_memory_, f, t, *fragment_metadata_[f]);
               tiles_found = true;
 
               if (budget_exceeded) {
@@ -449,15 +428,14 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                     t);
 
                 if (result_tiles_[f].empty()) {
-                  auto tile_sizes = get_coord_tiles_size(dim_num, f, t);
+                  auto tiles_size = get_coord_tiles_size(dim_num, f, t);
                   throw SparseGlobalOrderReaderStatusException(
                       "Cannot load a single tile for fragment, increase memory "
                       "budget, tile size : " +
-                      std::to_string(tile_sizes.first) +
-                      ", per fragment memory " +
+                      std::to_string(tiles_size) + ", per fragment memory " +
                       std::to_string(per_fragment_memory_) + ", total budget " +
                       std::to_string(memory_budget_) +
-                      " , num fragments to process " +
+                      ", num fragments to process " +
                       std::to_string(num_fragments_to_process));
                 }
                 return Status::Ok();
@@ -488,12 +466,7 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
 
           for (t = start; t < tile_num; t++) {
             auto budget_exceeded = add_result_tile(
-                dim_num,
-                per_fragment_memory_,
-                per_fragment_qc_memory_,
-                f,
-                t,
-                *fragment_metadata_[f]);
+                dim_num, per_fragment_memory_, f, t, *fragment_metadata_[f]);
             tiles_found = true;
 
             if (budget_exceeded) {
@@ -503,15 +476,14 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                   t);
 
               if (result_tiles_[f].empty()) {
-                auto tile_sizes = get_coord_tiles_size(dim_num, f, t);
+                auto tiles_size = get_coord_tiles_size(dim_num, f, t);
                 return logger_->status(Status_SparseGlobalOrderReaderError(
                     "Cannot load a single tile for fragment, increase memory "
                     "budget, tile size : " +
-                    std::to_string(tile_sizes.first) +
-                    ", per fragment memory " +
+                    std::to_string(tiles_size) + ", per fragment memory " +
                     std::to_string(per_fragment_memory_) + ", total budget " +
                     std::to_string(memory_budget_) +
-                    " , num fragments to process " +
+                    ", num fragments to process " +
                     std::to_string(num_fragments_to_process)));
               }
               return Status::Ok();
@@ -1662,9 +1634,9 @@ template <class BitmapType>
 tuple<Status, optional<std::vector<uint64_t>>>
 SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
     const std::vector<std::string>& names,
-    const uint64_t memory_budget,
     std::vector<ResultCellSlab>& result_cell_slabs) {
   // Process all attributes in parallel.
+  const uint64_t memory_budget = available_memory();
   uint64_t max_cs_idx = result_cell_slabs.size();
   std::mutex max_cs_idx_mtx;
   std::vector<uint64_t> total_mem_usage_per_attr(names.size());
@@ -1865,12 +1837,8 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
 
   // Calculating the initial copy bound and making sure we respect the memory
   // budget for the copy operation.
-  uint64_t memory_budget = memory_budget_ - memory_used_qc_tiles_total_ -
-                           memory_used_for_coords_total_ -
-                           memory_used_result_tile_ranges_ -
-                           array_memory_tracker_->get_memory_usage();
   auto&& [st, mem_usage_per_attr] =
-      respect_copy_memory_budget(names, memory_budget, result_cell_slabs);
+      respect_copy_memory_budget(names, result_cell_slabs);
   RETURN_NOT_OK(st);
 
   // There is no space for any tiles in the user buffer, exit.
@@ -1896,7 +1864,7 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
   while (buffer_idx < names.size()) {
     // Read and unfilter as many attributes as can fit in the budget.
     auto&& [st, index_to_copy] = read_and_unfilter_attributes(
-        memory_budget, names, *mem_usage_per_attr, &buffer_idx, result_tiles);
+        names, *mem_usage_per_attr, &buffer_idx, result_tiles);
     RETURN_NOT_OK(st);
 
     for (const auto& idx : *index_to_copy) {
@@ -2021,20 +1989,16 @@ Status SparseGlobalOrderReader<BitmapType>::remove_result_tile(
     const unsigned frag_idx, TileListIt rt) {
   // Remove coord tile size from memory budget.
   auto tile_idx = rt->tile_idx();
-  auto tiles_sizes =
+  auto tiles_size =
       get_coord_tiles_size(array_schema_.dim_num(), frag_idx, tile_idx);
-  auto tiles_size = tiles_sizes.first;
-  auto tiles_size_qc = tiles_sizes.second;
 
   // Adjust per fragment memory usage.
   memory_used_for_coords_[frag_idx] -= tiles_size;
-  memory_used_for_qc_tiles_[frag_idx] -= tiles_size_qc;
 
   // Adjust total memory usage.
   {
     std::unique_lock<std::mutex> lck(mem_budget_mtx_);
     memory_used_for_coords_total_ -= tiles_size;
-    memory_used_qc_tiles_total_ -= tiles_size_qc;
   }
 
   // Delete the tile.
@@ -2063,7 +2027,6 @@ Status SparseGlobalOrderReader<BitmapType>::end_iteration() {
 
   if (!incomplete()) {
     assert(memory_used_for_coords_total_ == 0);
-    assert(memory_used_qc_tiles_total_ == 0);
     assert(memory_used_result_tile_ranges_ == 0);
   }
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -328,7 +328,7 @@ uint64_t SparseGlobalOrderReader<BitmapType>::get_coord_tiles_size(
 
   // Account for hilbert data.
   if (array_schema_.cell_order() == Layout::HILBERT) {
-    tiles_sizes.first += fragment_metadata_[f]->cell_num(t) * sizeof(uint64_t);
+    tiles_size += fragment_metadata_[f]->cell_num(t) * sizeof(uint64_t);
   }
 
   // Add the tile bitmap size if there is a subarray or pre query condition to

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -146,12 +146,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** Memory budget per fragment. */
   double per_fragment_memory_;
 
-  /** Memory used for qc tiles per fragment. */
-  std::vector<uint64_t> memory_used_for_qc_tiles_;
-
-  /** Memory budget per fragment for qc tiles. */
-  double per_fragment_qc_memory_;
-
   /** Enables consolidation with timestamps or not. */
   bool consolidation_with_timestamps_;
 
@@ -209,17 +203,15 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param f Fragment index.
    * @param t Tile index.
    *
-   * @return Tiles_size, tiles_size_qc.
+   * @return Tiles size.
    */
-  std::pair<uint64_t, uint64_t> get_coord_tiles_size(
-      unsigned dim_num, unsigned f, uint64_t t);
+  uint64_t get_coord_tiles_size(unsigned dim_num, unsigned f, uint64_t t);
 
   /**
    * Add a result tile to process, making sure maximum budget is respected.
    *
    * @param dim_num Number of dimensions.
    * @param memory_budget_coords_tiles Memory budget for coordinate tiles.
-   * @param memory_budget_qc_tiles Memory budget for query condition tiles.
    * @param f Fragment index.
    * @param t Tile index.
    * @param frag_md Fragment metadata.
@@ -229,7 +221,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   bool add_result_tile(
       const unsigned dim_num,
       const uint64_t memory_budget_coords_tiles,
-      const uint64_t memory_budget_qc_tiles,
       const unsigned f,
       const uint64_t t,
       const FragmentMetadata& frag_md);
@@ -476,14 +467,12 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * the budget.
    *
    * @param names Attribute/dimensions to compute for.
-   * @param memory_budget Memory budget allowed for copy operation.
    * @param result_cell_slabs Result cell slabs to process, might be truncated.
    *
    * @return Status, total_mem_usage_per_attr.
    */
   tuple<Status, optional<std::vector<uint64_t>>> respect_copy_memory_budget(
       const std::vector<std::string>& names,
-      const uint64_t memory_budget,
       std::vector<ResultCellSlab>& result_cell_slabs);
 
   /**

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -86,10 +86,8 @@ SparseIndexReaderBase::SparseIndexReaderBase(
     , memory_budget_(0)
     , array_memory_tracker_(array->memory_tracker())
     , memory_used_for_coords_total_(0)
-    , memory_used_qc_tiles_total_(0)
     , memory_used_result_tile_ranges_(0)
     , memory_budget_ratio_coords_(0.5)
-    , memory_budget_ratio_query_condition_(0.25)
     , memory_budget_ratio_tile_ranges_(0.1)
     , memory_budget_ratio_array_data_(0.1)
     , buffers_full_(false)
@@ -160,6 +158,12 @@ void SparseIndexReaderBase::init(bool skip_checks_serialization) {
 
   // Check the validity buffer sizes.
   check_validity_buffer_sizes();
+}
+
+uint64_t SparseIndexReaderBase::available_memory() {
+  return memory_budget_ - memory_used_for_coords_total_ -
+         memory_used_result_tile_ranges_ -
+         array_memory_tracker_->get_memory_usage();
 }
 
 std::vector<uint64_t> SparseIndexReaderBase::tile_offset_sizes() {
@@ -286,7 +290,7 @@ uint64_t SparseIndexReaderBase::cells_copied(
 }
 
 template <class BitmapType>
-std::pair<uint64_t, uint64_t> SparseIndexReaderBase::get_coord_tiles_size(
+uint64_t SparseIndexReaderBase::get_coord_tiles_size(
     unsigned dim_num, unsigned f, uint64_t t) {
   uint64_t tiles_size = 0;
 
@@ -312,15 +316,14 @@ std::pair<uint64_t, uint64_t> SparseIndexReaderBase::get_coord_tiles_size(
   }
 
   // Compute query condition tile sizes.
-  uint64_t tiles_size_qc = 0;
   if (!qc_loaded_attr_names_.empty()) {
     for (auto& name : qc_loaded_attr_names_) {
       // Calculate memory consumption for this tile.
-      tiles_size_qc += get_attribute_tile_size(name, f, t);
+      tiles_size += get_attribute_tile_size(name, f, t);
     }
   }
 
-  return std::make_pair(tiles_size, tiles_size_qc);
+  return tiles_size;
 }
 
 Status SparseIndexReaderBase::load_initial_data() {
@@ -845,12 +848,12 @@ Status SparseIndexReaderBase::apply_query_condition(
 
 tuple<Status, optional<std::vector<uint64_t>>>
 SparseIndexReaderBase::read_and_unfilter_attributes(
-    const uint64_t memory_budget,
     const std::vector<std::string>& names,
     const std::vector<uint64_t>& mem_usage_per_attr,
     uint64_t* buffer_idx,
     std::vector<ResultTile*>& result_tiles) {
   auto timer_se = stats_->start_timer("read_and_unfilter_attributes");
+  const uint64_t memory_budget = available_memory();
 
   std::vector<std::string> names_to_read;
   std::vector<uint64_t> index_to_copy;
@@ -975,11 +978,9 @@ void SparseIndexReaderBase::remove_result_tile_range(uint64_t f) {
 }
 
 // Explicit template instantiations
-template std::pair<uint64_t, uint64_t>
-SparseIndexReaderBase::get_coord_tiles_size<uint64_t>(
+template uint64_t SparseIndexReaderBase::get_coord_tiles_size<uint64_t>(
     unsigned, unsigned, uint64_t);
-template std::pair<uint64_t, uint64_t>
-SparseIndexReaderBase::get_coord_tiles_size<uint8_t>(
+template uint64_t SparseIndexReaderBase::get_coord_tiles_size<uint8_t>(
     unsigned, unsigned, uint64_t);
 template Status SparseIndexReaderBase::apply_query_condition<
     UnorderedWithDupsResultTile<uint64_t>,

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -276,23 +276,20 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Memory used for coordinates tiles. */
   uint64_t memory_used_for_coords_total_;
 
-  /** Memory used for query condition tiles. */
-  uint64_t memory_used_qc_tiles_total_;
-
   /** Memory used for result tile ranges. */
   uint64_t memory_used_result_tile_ranges_;
 
   /** How much of the memory budget is reserved for coords. */
   double memory_budget_ratio_coords_;
 
-  /** How much of the memory budget is reserved for query condition. */
-  double memory_budget_ratio_query_condition_;
-
   /** How much of the memory budget is reserved for tile ranges. */
   double memory_budget_ratio_tile_ranges_;
 
   /** How much of the memory budget is reserved for array data. */
   double memory_budget_ratio_array_data_;
+
+  /** Target upper memory limit for tiles. */
+  uint64_t tile_upper_memory_limit_;
 
   /** Are we in elements mode. */
   bool elements_mode_;
@@ -324,6 +321,9 @@ class SparseIndexReaderBase : public ReaderBase {
   /* ********************************* */
   /*         PROTECTED METHODS         */
   /* ********************************* */
+
+  /** @return Available memory. */
+  uint64_t available_memory();
 
   /**
    * Computes the required size for loading tile offsets, per fragments.
@@ -360,11 +360,10 @@ class SparseIndexReaderBase : public ReaderBase {
    * @param f Fragment index.
    * @param t Tile index.
    *
-   * @return Tiles_size, tiles_size_qc.
+   * @return Tiles size.
    */
   template <class BitmapType>
-  std::pair<uint64_t, uint64_t> get_coord_tiles_size(
-      unsigned dim_num, unsigned f, uint64_t t);
+  uint64_t get_coord_tiles_size(unsigned dim_num, unsigned f, uint64_t t);
 
   /**
    * Load result tile ranges and dimension/attributes to load tile offsets for.
@@ -423,7 +422,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * return the names loaded in 'names_to_copy'. Also keep the 'buffer_idx'
    * updated to keep track of progress.
    *
-   * @param memory_budget Memory budget allowed for this operation.
    * @param names Attribute/dimensions to compute for.
    * @param mem_usage_per_attr Computed per attribute memory usage.
    * @param buffer_idx Stores/return the current buffer index in process.
@@ -432,7 +430,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * @return Status, index_to_copy.
    */
   tuple<Status, optional<std::vector<uint64_t>>> read_and_unfilter_attributes(
-      const uint64_t memory_budget,
       const std::vector<std::string>& names,
       const std::vector<uint64_t>& mem_usage_per_attr,
       uint64_t* buffer_idx,

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -184,17 +184,14 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param f Fragment index.
    * @param t Tile index.
    *
-   * @return Tiles_size, tiles_size_qc.
+   * @return Tiles size.
    */
-  std::pair<uint64_t, uint64_t> get_coord_tiles_size(
-      unsigned dim_num, unsigned f, uint64_t t);
+  uint64_t get_coord_tiles_size(unsigned dim_num, unsigned f, uint64_t t);
 
   /**
    * Add a result tile to process, making sure maximum budget is respected.
    *
    * @param dim_num Number of dimensions.
-   * @param memory_budget_qc_tiles Memory budget for query condition tiles.
-   * @param memory_budget_coords_tiles Memory budget for coordinate tiles.
    * @param f Fragment index.
    * @param t Tile index.
    * @param last_t Last tile index.
@@ -204,8 +201,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    */
   bool add_result_tile(
       const unsigned dim_num,
-      const uint64_t memory_budget_qc_tiles,
-      const uint64_t memory_budget_coords_tiles,
       const unsigned f,
       const uint64_t t,
       const uint64_t last_t,
@@ -425,14 +420,12 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * the budget.
    *
    * @param names Attribute/dimensions to compute for.
-   * @param memory_budget Memory budget allowed for copy operation.
    * @param result_tiles Result tiles to process, might be truncated.
    *
    * @return Status, total_mem_usage_per_attr.
    */
   tuple<Status, optional<std::vector<uint64_t>>> respect_copy_memory_budget(
       const std::vector<std::string>& names,
-      const uint64_t memory_budget,
       std::vector<ResultTile*>& result_tiles);
 
   /**


### PR DESCRIPTION
This change processes smaller units of work for the sparse unordered with duplicates reader the same way the dense reader does to limit memory movement performance penalties during the unfiltering and copy operations.

Also in this change we get rid of the memory budget ratio for query condition. We already treat query condition tiles as coordinates so we can merge the ratio for coordinates and the one for query condition into one.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups: smaller units of work.

TYPE: CONFIG
DESC: Removed `sm.mem.reader.sparse_global_order.ratio_query_condition` config option
