### PR TITLE
Move cmake prefix overrides for CI out of toolchain file

### DIFF
--- a/.github/misc/github_actions_override.cmake
+++ b/.github/misc/github_actions_override.cmake
@@ -1,0 +1,9 @@
+if (WIN32)
+  # This override causes CMake to ignore strawberry perl paths in the Github Actions images
+  # due to incompatible, mingw-built libraries which are picked up by find_package
+  # - upstream issue: https://github.com/actions/runner-images/issues/6627
+  # - likely due to changes in CMake 3.25
+
+  set(CMAKE_IGNORE_PREFIX_PATH "C:/Strawberry")
+  set(CMAKE_IGNORE_PATH "C:/Strawberry/perl/bin;C:/Strawberry/c/lib")
+endif()

--- a/.github/misc/github_windows_toolchain.cmake
+++ b/.github/misc/github_windows_toolchain.cmake
@@ -1,7 +1,0 @@
-# This is an auxiliary file intended to be included by CMake via CMAKE_TOOLCHAIN_FILE
-# The purpose is to force CMake to Ignore strawberry perl paths in the Github Actions images
-# due to incompatible libraries which are now picked up by find_package
-# (possibly due to changes in CMake 3.25)
-
-set(CMAKE_IGNORE_PREFIX_PATH "C:/Strawberry")
-set(CMAKE_IGNORE_PATH "C:/Strawberry/perl/bin;C:/Strawberry/c/lib")

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -178,9 +178,6 @@ jobs:
             $bootstrapOptions = $bootstrapOptions + " -DisableWebP"
           }
 
-          # Use toolchain hack to ignore strawberry perl path in GHA images
-          $env:CMAKE_TOOLCHAIN_FILE = "$env:BUILD_SOURCESDIRECTORY/.github/misc/github_windows_toolchain.cmake"
-
           $bootstrapExpression = "& $env:BUILD_SOURCESDIRECTORY\bootstrap.ps1 " + $bootstrapOptions
           Write-Host "bootstrapExpression: $bootstrapExpression"
           Invoke-Expression $bootstrapExpression

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Options")
 
+include(CIConfig)
 include(BuildOptions)
 include(global-policies NO_POLICY_SCOPE)
 include(TileDBToolchain)

--- a/cmake/CIConfig.cmake
+++ b/cmake/CIConfig.cmake
@@ -1,0 +1,3 @@
+if ($ENV{GITHUB_ACTIONS} STREQUAL "true")
+  include("${CMAKE_SOURCE_DIR}/.github/misc/github_actions_override.cmake")
+endif()

--- a/cmake/CIConfig.cmake
+++ b/cmake/CIConfig.cmake
@@ -1,3 +1,3 @@
-if ($ENV{GITHUB_ACTIONS} STREQUAL "true")
+if (DEFINED ENV{GITHUB_ACTIONS})
   include("${CMAKE_SOURCE_DIR}/.github/misc/github_actions_override.cmake")
 endif()


### PR DESCRIPTION
See inline comment for the rationale for this override.

Now that we are using CMAKE_TOOLCHAIN_FILE for vcpkg, we cannot set the prefix overrides there.

x-ref: https://github.com/TileDB-Inc/TileDB/pull/3694

---
TYPE: NO_HISTORY