### PR TITLE
Introduce "vfs.s3.no_sign_request"

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -321,6 +321,7 @@ void check_save_to_file() {
   ss << "vfs.s3.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
   ss << "vfs.s3.multipart_part_size 5242880\n";
+  ss << "vfs.s3.no_sign_request false\n";
   ss << "vfs.s3.object_canned_acl NOT_SET\n";
   ss << "vfs.s3.proxy_port 0\n";
   ss << "vfs.s3.proxy_scheme http\n";
@@ -719,6 +720,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.s3.proxy_scheme"] = "http";
   all_param_values["vfs.s3.proxy_username"] = "";
   all_param_values["vfs.s3.verify_ssl"] = "true";
+  all_param_values["vfs.s3.no_sign_request"] = "false";
   all_param_values["vfs.hdfs.username"] = "stavros";
   all_param_values["vfs.hdfs.kerb_ticket_cache_path"] = "";
   all_param_values["vfs.hdfs.name_node_uri"] = "";
@@ -782,6 +784,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["s3.proxy_scheme"] = "http";
   vfs_param_values["s3.proxy_username"] = "";
   vfs_param_values["s3.verify_ssl"] = "true";
+  vfs_param_values["s3.no_sign_request"] = "false";
   vfs_param_values["s3.bucket_canned_acl"] = "NOT_SET";
   vfs_param_values["s3.object_canned_acl"] = "NOT_SET";
   vfs_param_values["hdfs.username"] = "stavros";
@@ -840,6 +843,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   s3_param_values["proxy_scheme"] = "http";
   s3_param_values["proxy_username"] = "";
   s3_param_values["verify_ssl"] = "true";
+  s3_param_values["no_sign_request"] = "false";
   s3_param_values["bucket_canned_acl"] = "NOT_SET";
   s3_param_values["object_canned_acl"] = "NOT_SET";
 

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -67,7 +67,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 58);
+  CHECK(names.size() == 59);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -483,6 +483,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `vfs.s3.verify_ssl` <br>
  *    Enable HTTPS certificate verification. <br>
  *    **Default**: true""
+ * - `vfs.s3.no_sign_request` <br>
+ *    Make unauthenticated requests to s3. <br>
+ *    **Default**: false
  * - `vfs.s3.sse` <br>
  *    The server-side encryption algorithm to use. Supported non-empty
  *    values are "aes256" and "kms" (AWS key management service). <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -214,6 +214,7 @@ const std::string Config::VFS_S3_PROXY_USERNAME = "";
 const std::string Config::VFS_S3_PROXY_PASSWORD = "";
 const std::string Config::VFS_S3_LOGGING_LEVEL = "Off";
 const std::string Config::VFS_S3_VERIFY_SSL = "true";
+const std::string Config::VFS_S3_NO_SIGN_REQUEST = "false";
 const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
@@ -441,6 +442,7 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair("vfs.s3.proxy_password", Config::VFS_S3_PROXY_PASSWORD),
     std::make_pair("vfs.s3.logging_level", Config::VFS_S3_LOGGING_LEVEL),
     std::make_pair("vfs.s3.verify_ssl", Config::VFS_S3_VERIFY_SSL),
+    std::make_pair("vfs.s3.no_sign_request", Config::VFS_S3_NO_SIGN_REQUEST),
     std::make_pair(
         "vfs.s3.bucket_canned_acl", Config::VFS_S3_BUCKET_CANNED_ACL),
     std::make_pair(
@@ -777,6 +779,8 @@ Status Config::sanity_check(
   } else if (param == "vfs.s3.proxy_port") {
     RETURN_NOT_OK(utils::parse::convert(value, &vint64));
   } else if (param == "vfs.s3.verify_ssl") {
+    RETURN_NOT_OK(utils::parse::convert(value, &v));
+  } else if (param == "vfs.s3.no_sign_request") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (
       (chkno = 1, param == "vfs.s3.bucket_canned_acl") ||

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -535,6 +535,9 @@ class Config {
   /** Verify TLS/SSL certificates (true). */
   static const std::string VFS_S3_VERIFY_SSL;
 
+  /** Force making an unsigned request to s3 (false). */
+  static const std::string VFS_S3_NO_SIGN_REQUEST;
+
   /** HDFS default kerb ticket cache path. */
   static const std::string VFS_HDFS_KERB_TICKET_CACHE_PATH;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -659,6 +659,9 @@ class Config {
    * - `vfs.s3.verify_ssl` <br>
    *    Enable HTTPS certificate verification. <br>
    *    **Default**: true
+   * - `vfs.s3.no_sign_request` <br>
+   *    Make unauthenticated requests to s3. <br>
+   *    **Default**: false
    * - `vfs.s3.sse` <br>
    *    The server-side encryption algorithm to use. Supported non-empty
    *    values are "aes256" and "kms" (AWS key management service). <br>


### PR DESCRIPTION
This option allows the user to make anonymous s3 API requests similar to the "--no-sign-request" for the aws cli. This is handy when a user wants to access a public s3 bucket and does not have credentials defined.

Fixes #3951

---
TYPE: FEATURE
DESC: Introduce "vfs.s3.no_sign_request" to allow unsigned s3 API calls, useful for anonymous s3 bucket access.
