### PR TITLE
Adjust a config buffer parameter for two tests for success in both 32bit and 64bit environments

### DIFF
--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -763,7 +763,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "10000");
+  cfg.set("sm.mem.total_budget", "9000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.4");
   ctx_ = Context(cfg);
 
@@ -821,7 +821,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "10000");
+  cfg.set("sm.mem.total_budget", "9000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.4");
   ctx_ = Context(cfg);
 


### PR DESCRIPTION
Adjust a config buffer parameter so that the CHECK(stats.find()) in tests
```
CPP API: Test consolidation with timestamps, global read, all cells same coords, with memory budget
CPP API: Test consolidation with timestamps, global read, same cells across tiles, with memory budget
```
passes on both 32bit and 64bit builds.

---
TYPE: IMPROVEMENT
DESC:  Adjust a config buffer parameter for two tests for success in both 32bit and 64bit environments
