### PR TITLE
Remove CMAKE_TOOLCHAIN from windows nightly matrix, fixes #3958

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -57,7 +57,6 @@ jobs:
         if: contains(matrix.os, 'windows')
         env:
           CXXFLAGS: ${{ matrix.cxxflags }}
-          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/.github/misc/github_windows_toolchain.cmake
         run: |
           cmake -B build -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION

---
TYPE: NO_HISTORY