### PR TITLE
Fixup vcpkg CI caching

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -59,21 +59,32 @@ jobs:
             submodules: true
             fetch-depth: 0
 
+      - name: Generate vcpkg cache key data
+        run: |
+          echo "${CC}" > $GITHUB_WORKSPACE/vcpkg-cache-key.data
+          echo "${CXX}" >> $GITHUB_WORKSPACE/vcpkg-cache-key.data
+          echo "${bootstrap_args}" >> $GITHUB_WORKSPACE/vcpkg-cache-key.data
+        shell: bash
+
+      - name: Create vcpkg cache key
+        id: vcpkg_cache_key
+        run: echo "value=${{ hashFiles('vcpkg-cache-key.data') }}" >> $GITHUB_OUTPUT
+
       - name: Restore artifacts, or setup vcpkg for building artifacts
         uses: lukka/run-vcpkg@v10
         id: runvcpkg
         with:
           vcpkgJsonGlob: 'vcpkg.json'
           vcpkgDirectory: '${{ github.workspace }}/external/vcpkg'
-
-      - name: List $GITHUB_WORKSPACE before build
-        run: find $GITHUB_WORKSPACE
-        shell: bash
+          prependedCacheKey: 'tiledb-${{steps.vcpkg_cache_key.outputs.value}}'
 
       - name: Prints output of run-vcpkg's action.
-        run: echo "root='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_ROOT_OUT }}', triplet='${{ steps.runvcpkg.outputs.RUNVCPKG_VCPKG_DEFAULT_TRIPLET_OUT }}' "
-      - name: Work around vcpkg default # https://github.com/microsoft/vcpkg/issues/143#issuecomment-705778244 ¯\_(ツ)_/¯
-        run:  find $GITHUB_WORKSPACE/external/vcpkg/triplets/* -type f -exec sh -c "echo \"\nset(VCPKG_BUILD_TYPE release)\n\" >> {}" \;
+        run: |
+          echo "run-vcpkg outputs:"
+          echo "${{ toJSON(steps.runvcpkg.outputs) }}"
+
+      - name: Prevent vpckg from building debug variants
+        run: ./scripts/ci/posix/patch_vcpkg_triplets.sh
 
       - name: 'Ubuntu Prelim'
         if: ${{ startsWith(matrix.os, 'ubuntu-') == true }}
@@ -86,6 +97,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+
       - name: 'Set up Python dependencies'
         run: |
           set -e pipefail
@@ -96,9 +108,9 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos-') == true }}
         run: |
           set -e pipefail
-          brew install pkg-config
+          brew install automake pkg-config
 
-      - name: 'Configure libtiledb build'
+      - name: 'Configure libtiledb'
         id: configure
         shell: bash
         run: |
@@ -110,8 +122,19 @@ jobs:
 
           source $GITHUB_WORKSPACE/scripts/ci/bootstrap_libtiledb.sh
 
-      - name: 'Build and test libtiledb'
-        id: build_and_test
+      - name: 'Build libtiledb'
+        id: build
+        shell: bash
+        run: |
+          set -e pipefail
+
+          #####################################################
+          # Build libtiledb using previous bootstrap
+
+          source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
+
+      - name: 'Test libtiledb'
+        id: test
         shell: bash
         run: |
           set -e pipefail
@@ -127,10 +150,10 @@ jobs:
           source $GITHUB_WORKSPACE/scripts/ci/posix/build-services-start.sh
 
           #####################################################
-          # Build libtiledb using bootstrap set above
+          # Jump to our build directory after starting object
+          # store mock servers
 
-          source $GITHUB_WORKSPACE/scripts/ci/bootstrap_libtiledb.sh
-          source $GITHUB_WORKSPACE/scripts/ci/build_libtiledb.sh
+          cd $GITHUB_WORKSPACE/build
 
           ###################################################
           # Run tests
@@ -184,7 +207,7 @@ jobs:
           # tiledb_unit is configured to set a  variable TILEDB_CI_SUCCESS=1
           # following the test run. If this variable is not set, the build should fail.
           # see https://github.com/TileDB-Inc/TileDB/pull/1400 (5f0623f4d3)
-          if [[ "${{ steps.build_and_test.outputs.TILEDB_CI_SUCCESS }}" -ne 1 ]]; then
+          if [[ "${{ steps.test.outputs.TILEDB_CI_SUCCESS }}" -ne 1 ]]; then
             exit 1;
           fi
 


### PR DESCRIPTION
I noticed that the vcpkg caching was broken after we merged. This work fixes up the two main issues. The first issue was that run-vcpkg's default hash keys were non-unique across our builders. Adding the hashed contents of the CC, CXX, and bootstrap_args to the key fixes this issue.

The second issue is that the patch we're applying to triplet files changes the generated package hashes which means that our caches were never used. We just have to add a bit of conditional logic to prevent multiple applications.

Lastly, this also includes a number of other useful fixes I found while working out the two issues above.

---
TYPE: IMPROVEMENT
DESC: Fix vcpkg caching in CI
