### PR TITLE
Fix logger level initialization

### DIFF
--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -47,7 +47,10 @@ namespace tiledb::common {
 /* ********************************* */
 
 Logger::Logger(
-    const std::string& name, const Logger::Format format, const bool root)
+    const std::string& name,
+    const Logger::Level level,
+    const Logger::Format format,
+    const bool root)
     : name_(name)
     , root_(root) {
   logger_ = spdlog::get(name_);
@@ -64,7 +67,7 @@ Logger::Logger(
     logger_->set_pattern("{\n \"log\": [");
     logger_->critical("");
   }
-  set_level(Logger::Level::ERR);
+  set_level(level);
   set_format(format);
 }
 
@@ -289,7 +292,7 @@ Logger& global_logger(Logger::Format format) {
       (format == Logger::Format::JSON) ?
           "\"" + std::to_string(ts_micro) + "-Global\":\"1\"" :
           std::to_string(ts_micro) + "-Global";
-  static Logger l(name, format, true);
+  static Logger l(name, Logger::Level::ERR, format, true);
   return l;
 }
 

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -75,6 +75,7 @@ class Logger {
   /** Constructors */
   Logger(
       const std::string& name,
+      const Logger::Level level = Logger::Level::ERR,
       const Logger::Format format = Logger::Format::DEFAULT,
       const bool root = false);
 

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -40,6 +40,8 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+static common::Logger::Level get_log_level(const Config& config);
+
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -49,7 +51,9 @@ namespace sm {
 Context::Context(const Config& config)
     : last_error_(nullopt)
     , logger_(make_shared<Logger>(
-          HERE(), logger_prefix_ + std::to_string(++logger_id_)))
+          HERE(),
+          logger_prefix_ + std::to_string(++logger_id_),
+          get_log_level(config)))
     , resources_(
           config,
           logger_,
@@ -230,6 +234,25 @@ Status Context::init_loggers(const Config& config) {
   logger_->set_level(static_cast<Logger::Level>(level));
 
   return Status::Ok();
+}
+
+common::Logger::Level get_log_level(const Config& config) {
+  auto cfg_level = config.get<std::string>("config.logging_level");
+  if (cfg_level == "0") {
+    return Logger::Level::FATAL;
+  } else if (cfg_level == "1") {
+    return Logger::Level::ERR;
+  } else if (cfg_level == "2") {
+    return Logger::Level::WARN;
+  } else if (cfg_level == "3") {
+    return Logger::Level::INFO;
+  } else if (cfg_level == "4") {
+    return Logger::Level::DBG;
+  } else if (cfg_level == "5") {
+    return Logger::Level::TRACE;
+  } else {
+    return Logger::Level::ERR;
+  }
 }
 
 }  // namespace sm

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -34,6 +34,7 @@
 #define TILEDB_CONTEXT_H
 
 #include "tiledb/common/exception/exception.h"
+#include "tiledb/common/logger.h"
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/stats/global_stats.h"


### PR DESCRIPTION
This is a quick fix to pass a user configured log level to the logger before the StorageManager is constructed so that early log messages can be displayed.

---
TYPE: BUG
DESC: Fix logger initialization
