### PR TITLE
Sparse unordered w/ dups: fix error on double var size overflow.

### DIFF
--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -92,7 +92,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * user buffer.
    *
    * @param stats Stats.
-   * @param fragment_metadata Fragment metadata.
    * @param result_tiles Result tiles to process, might be truncated.
    * @param first_tile_min_pos Cell progress of the first tile.
    * @param cell_offsets Cell offset per result tile.
@@ -103,7 +102,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   template <class OffType>
   static tuple<bool, uint64_t, uint64_t> compute_var_size_offsets(
       stats::Stats* stats,
-      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       const std::vector<ResultTile*>& result_tiles,
       const uint64_t first_tile_min_pos,
       std::vector<uint64_t>& cell_offsets,


### PR DESCRIPTION
This fixes a rare issue where, while copying data, a first var size overflow occurs on an attribute, then later, another overflow happens for another attribute on the same exact tile, where exactly only the last cell cannot fit the buffer. The computation was using the cell number from the fragment metadata instead of using the already truncated computed cell offset. Since there is no offset in the user buffer for the last cell, the computation woudln't stop and we would think we can fit the whole tile.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups: fix error on double var size overflow.
