### PR TITLE
Avoid storing a separate vector of tiles in `StorageManager::load_group_from_all_uris`.

### DIFF
--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -37,6 +37,7 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/tile/filtered_buffer.h"
+#include "tiledb/storage_format/serialization/serializers.h"
 
 #include <cinttypes>
 
@@ -433,6 +434,20 @@ class WriterTile : public TileBase {
    * to override the value in tests.
    */
   static uint64_t max_tile_chunk_size_;
+};
+
+/**
+ * A deserializer that owns a Tile.
+ */
+class TileDeserializer : public Deserializer {
+ public:
+  explicit TileDeserializer(Tile&& tile)
+      : Deserializer(tile.data(), tile.size())
+      , tile_(std::move(tile)) {
+  }
+
+ private:
+  Tile tile_;
 };
 
 }  // namespace sm


### PR DESCRIPTION
This PR introduces a descendant of `Deserializer` called `TileDeserializer` that owns a `Tile`, simplifying the latter's lifetime management by no longer necessitating to store it in a separate vector.

[SC-26595](https://app.shortcut.com/tiledb-inc/story/26595/refactor-buffer-usage-in-sm-load-group-from-all-uris)

---
TYPE: IMPROVEMENT
DESC: Avoid storing a separate vector of tiles when loading groups.