### PR TITLE
Lums/sc 26634/basic mimo

### DIFF
--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -38,7 +38,7 @@ add_subdirectory(tiledb)
 #
 # Test-compile of object library ensures link-completeness
 #
-add_executable(compile_experimental EXCLUDE_FROM_ALL)
+add_executable(compile_experimental EXCLUDE_FROM_ALL tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc)
 add_dependencies(all_link_complete compile_experimental)
 target_sources(compile_experimental PRIVATE
         test/compile_experimental_main.cc

--- a/experimental/CMakeLists.txt
+++ b/experimental/CMakeLists.txt
@@ -38,7 +38,7 @@ add_subdirectory(tiledb)
 #
 # Test-compile of object library ensures link-completeness
 #
-add_executable(compile_experimental EXCLUDE_FROM_ALL tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc)
+add_executable(compile_experimental EXCLUDE_FROM_ALL)
 add_dependencies(all_link_complete compile_experimental)
 target_sources(compile_experimental PRIVATE
         test/compile_experimental_main.cc

--- a/experimental/tiledb/common/dag/edge/edge.h
+++ b/experimental/tiledb/common/dag/edge/edge.h
@@ -68,17 +68,20 @@ class Edge;
  * Deduction guides for `Edge`.
  */
 template <template <class> class Mover_T, class Block>
-Edge(Source<Mover_T, Block>&, Sink<Mover_T, Block>&)->Edge<Mover_T, Block>;
+Edge(Source<Mover_T, Block>&, Sink<Mover_T, Block>&) -> Edge<Mover_T, Block>;
 
 template <template <class> class Mover_T, class Block>
-Edge(std::shared_ptr<Source<Mover_T, Block>>&, Sink<Mover_T, Block>&)->Edge<Mover_T, Block>;
+Edge(std::shared_ptr<Source<Mover_T, Block>>&, Sink<Mover_T, Block>&)
+    -> Edge<Mover_T, Block>;
 
 template <template <class> class Mover_T, class Block>
-Edge(Source<Mover_T, Block>&, std::shared_ptr<Sink<Mover_T, Block>>&)->Edge<Mover_T, Block>;
+Edge(Source<Mover_T, Block>&, std::shared_ptr<Sink<Mover_T, Block>>&)
+    -> Edge<Mover_T, Block>;
 
 template <template <class> class Mover_T, class Block>
-Edge(std::shared_ptr<Source<Mover_T, Block>>&, std::shared_ptr<Sink<Mover_T, Block>>&)->Edge<Mover_T, Block>;
-
+Edge(
+    std::shared_ptr<Source<Mover_T, Block>>&,
+    std::shared_ptr<Sink<Mover_T, Block>>&) -> Edge<Mover_T, Block>;
 
 /**
  * An edge in a task graph.

--- a/experimental/tiledb/common/dag/edge/edge.h
+++ b/experimental/tiledb/common/dag/edge/edge.h
@@ -117,7 +117,7 @@ class Edge : public GraphEdge {
     attach(from, to, item_mover_);
   }
 
-  // Warning!! For ctad to work, the shared ptrs cannot be references
+  // Warning!! For CTAD to work, the shared ptrs cannot be references
   Edge(std::shared_ptr<source_type> from, sink_type& to) {
     item_mover_ = std::make_shared<mover_type>();
     attach(*from, to, item_mover_);

--- a/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
@@ -258,11 +258,13 @@ TEST_CASE("Resume functions", "[duffs]") {
 
   SECTION("Emulate Pulling Data, with Some Blocking") {
     auto z = c->resume();  // pull
-    CHECK(c->get_program_counter() == 0); // wait decrements the program counter
+    CHECK(
+        c->get_program_counter() == 0);  // wait decrements the program counter
     CHECK(str(z) == "sink_wait");
 
     auto y = f->resume();  // pull
-    CHECK(c->get_program_counter() == 0); // wait decrements the program counter
+    CHECK(
+        c->get_program_counter() == 0);  // wait decrements the program counter
     CHECK(str(z) == "sink_wait");
 
     // Inject datum

--- a/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
@@ -88,7 +88,9 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(p->get_program_counter() == 3);
     CHECK(str(x) == "notify_sink");
     x = p->resume();
-    CHECK(p->get_program_counter() == 5);
+
+    // Recall that wait decrements the program counter
+    CHECK(p->get_program_counter() == 4);
     CHECK(str(x) == "source_wait");
     // Don't resume further after wait
   }
@@ -96,14 +98,18 @@ TEST_CASE("Resume functions", "[duffs]") {
   SECTION("Test Consumer in Isolation ") {
     // One pass through node operation
     auto x = c->resume();
-    CHECK(c->get_program_counter() == 1);
+
+    // Recall that wait decrements the program counter
+    CHECK(c->get_program_counter() == 0);
     CHECK(str(x) == "sink_wait");
   }
 
   SECTION("Test Function in Isolation ") {
     // One pass through node operation
     auto x = f->resume();
-    CHECK(f->get_program_counter() == 1);
+
+    // Recall that wait decrements the program counter
+    CHECK(f->get_program_counter() == 0);
     CHECK(str(x) == "sink_wait");
   }
 
@@ -154,8 +160,8 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(str(z) == "notify_source");
 
     z = c->resume();
-    CHECK(c->get_program_counter() == 6);
-    CHECK(str(z) == "sink_wait");
+    CHECK(c->get_program_counter() == 0);
+    CHECK(str(z) == "yield");
   }
 
   SECTION("Emulate Passing Data, with Some Blocking") {
@@ -178,7 +184,9 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(p->get_program_counter() == 3);
     CHECK(str(x) == "notify_sink");
     x = p->resume();
-    CHECK(p->get_program_counter() == 5);
+
+    // Recall that wait decrements the program counter
+    CHECK(p->get_program_counter() == 4);
     CHECK(str(x) == "source_wait");
 
     // Move datum to next node
@@ -216,7 +224,9 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(str(y) == "notify_sink");
 
     y = f->resume();  // push
-    CHECK(f->get_program_counter() == 9);
+
+    // Recall that wait decrements the program counter
+    CHECK(f->get_program_counter() == 8);
     CHECK(str(y) == "source_wait");
 
     auto z = c->resume();  // pull
@@ -229,12 +239,12 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(str(z) == "notify_source");
 
     z = c->resume();
-    CHECK(c->get_program_counter() == 6);
-    CHECK(str(z) == "noop");
+    CHECK(c->get_program_counter() == 0);
+    CHECK(str(z) == "yield");
 
     z = c->resume();  // pull
     CHECK(c->get_program_counter() == 1);
-    CHECK(str(z) == "yield");
+    CHECK(str(z) == "noop");
 
     // Move datum to last node
     z = c->resume();  // drain
@@ -242,17 +252,17 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(str(z) == "notify_source");
 
     z = c->resume();
-    CHECK(c->get_program_counter() == 6);
-    CHECK(str(z) == "sink_wait");
+    CHECK(c->get_program_counter() == 0);
+    CHECK(str(z) == "yield");
   }
 
   SECTION("Emulate Pulling Data, with Some Blocking") {
     auto z = c->resume();  // pull
-    CHECK(c->get_program_counter() == 1);
+    CHECK(c->get_program_counter() == 0); // wait decrements the program counter
     CHECK(str(z) == "sink_wait");
 
     auto y = f->resume();  // pull
-    CHECK(c->get_program_counter() == 1);
+    CHECK(c->get_program_counter() == 0); // wait decrements the program counter
     CHECK(str(z) == "sink_wait");
 
     // Inject datum
@@ -265,6 +275,10 @@ TEST_CASE("Resume functions", "[duffs]") {
     x = p->resume();
     CHECK(p->get_program_counter() == 0);
     CHECK(str(x) == "yield");
+
+    y = f->resume();  // pull (successful)
+    CHECK(f->get_program_counter() == 1);
+    CHECK(str(y) == "noop");
 
     y = f->resume();  // drain
     CHECK(f->get_program_counter() == 3);
@@ -283,13 +297,17 @@ TEST_CASE("Resume functions", "[duffs]") {
     CHECK(str(y) == "yield");
 
     // Move datum to last node
+    z = c->resume();  // pull (successful)
+    CHECK(c->get_program_counter() == 1);
+    CHECK(str(z) == "noop");
+
     z = c->resume();  // drain
     CHECK(c->get_program_counter() == 3);
     CHECK(str(z) == "notify_source");
 
-    z = c->resume();  // pull
-    CHECK(c->get_program_counter() == 6);
-    CHECK(str(z) == "sink_wait");
+    z = c->resume();  // yield
+    CHECK(c->get_program_counter() == 0);
+    CHECK(str(z) == "yield");
   }
 }
 

--- a/experimental/tiledb/common/dag/graph/taskgraph.h
+++ b/experimental/tiledb/common/dag/graph/taskgraph.h
@@ -43,9 +43,23 @@
 #include "experimental/tiledb/common/dag/execution/task_traits.h"
 #include "experimental/tiledb/common/dag/nodes/node_traits.h"
 #include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
 #include "experimental/tiledb/common/dag/utility/print_types.h"
 
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h"
+
 namespace tiledb::common {
+
+
+template <class... R, class... T>
+auto aaa(std::function<void(std::tuple<R...>, std::tuple<T...>)>&& f) {
+  // using U... = std::remove_cv_t<std::remove_reference_t<T...>>;
+  auto tmp = mimo_node<DuffsMover3, std::remove_cv_t<std::remove_reference_t<T>>..., DuffsMover3, R...>{f};
+  return tmp;
+}
+
+
+
 
 template <class Scheduler>
 class TaskGraph {
@@ -109,6 +123,29 @@ class TaskGraph {
    * @todo: Add mechanism to support bind expressions.
    */
   template <class Function>
+  auto initial_mimo(Function&& f) {
+    using T = std::invoke_result_t<Function, std::stop_source&>;
+    auto tmp = producer_mimo<DuffsMover3, T>(std::forward<Function>(f));
+    nodes_.emplace_back(tmp);
+    return tmp;
+  }
+
+  /**
+   * Create a producer node and add it to the graph.
+   *
+   * @param f The function to store in the node.
+   *
+   * @tparam Function The type of function to be stored by the node.  The
+   * function must take as input an `std::stop_source` and return an item to be
+   * processed by the next node in the graph. The function calls
+   * `std::stop_source::request_stop()` to signal that the function will not
+   * produce any more items.
+   *
+   * @todo: With CTAD we don't need separate kinds of node functions.
+   *
+   * @todo: Add mechanism to support bind expressions.
+   */
+  template <class Function>
   auto initial_node(Function&& f) {
     auto tmp = producer_node<
         DuffsMover3,
@@ -117,6 +154,7 @@ class TaskGraph {
     nodes_.emplace_back(tmp);
     return tmp;
   }
+
 
   /**
    * Create a function node and add it to the graph.
@@ -140,6 +178,27 @@ class TaskGraph {
     return transform_node(std::function{std::forward<Function>(f)});
   }
 
+  template <template <class> class a, class b, template <class> class c, class d>
+  class e : public mimo_node<a, b, c, d> {};
+
+/**
+   * Create a multi-input, multi-output function node and add it to the graph.
+   *
+   * @param f The function to store in the node.
+   *
+   * @tparam Function The type of function to be held by the node.
+   * The function must take an item as input
+   * and return an item as output.
+   */
+   template <class... R, class... T>
+   auto mimo(std::function<std::tuple<R...>(const std::tuple<T...>&)>&& f ){
+     // using U... = std::remove_cv_t<std::remove_reference_t<T...>>;
+    auto tmp = mimo_node<DuffsMover3, std::tuple<std::remove_cv_t<std::remove_reference_t<T>>...>, DuffsMover3, std::tuple<R...>> {f};
+    nodes_.emplace_back(tmp);
+    return tmp;
+   }
+
+
   /**
    * Create a multi-input, multi-output function node and add it to the graph.
    *
@@ -150,7 +209,8 @@ class TaskGraph {
    * and return an item as output.
    */
   template <class Function>
-  auto mimo_node([[maybe_unused]] Function&& f) {
+  auto mimo(Function&& f) {
+    return mimo(std::function{std::forward<Function>(f)});
   }
 
   /**
@@ -184,6 +244,37 @@ class TaskGraph {
     return terminal_node(std::function{std::forward<Func>(f)});
   }
 
+
+  /**
+   * Create a terminal node and add it to the graph.
+   *
+   * @param f The function to store in the node.
+   *
+   * @tparam Function The type of function to be held by the node.
+   * The function must take an item as input
+   * and return void.
+   */
+  template <class T>
+  auto terminal_mimo(std::function<void(T)>&& f) {
+    using U = std::remove_cv_t<std::remove_reference_t<T>>;
+    auto tmp = consumer_mimo<DuffsMover3, U>(f);
+    nodes_.emplace_back(tmp);
+    return tmp;
+  }
+  /**
+   * Trampoline function to match a function to an std::function so that we
+   * can use CTAD to deduce the input argument type.
+   *
+   * @tparam Func The type of function to be held by the node.
+   * @param f The function to store in the node.
+   *
+   * @return A handle to the created node.
+   */
+  template <class Func>
+  auto terminal_mimo(Func&& f) {
+    return terminal_mimo(std::function{std::forward<Func>(f)});
+  }
+
   /**
    * Connect node `from` to node `to` with an edge.
    * An `Edge` connecting the `Source` of `from` to the `Sink` of `to` will be
@@ -196,10 +287,44 @@ class TaskGraph {
    * @param from A node supplying data to `to`.
    * @param to A node receiving data from `from`.
    */
+#if 0
   template <class From, class To>
   void make_edge(From& from, To& to) {
     connect(from, to);
-    edges_.emplace_back(std::make_shared<GraphEdge>(Edge(*from, *to)));
+    // edges_.emplace_back(std::make_shared<GraphEdge>(Edge(*from, *to)));
+    edges_.emplace_back(std::make_shared<GraphEdge>(Edge(from, to)));
+  }
+#endif
+
+
+
+  template <class From, class To>
+  std::enable_if_t<(!is_proxy_v<From> && !is_proxy_v<To>), void>
+  make_edge(From& from, To& to){
+    connect(from, to);
+    Edge(from, to);
+  }
+
+  template <class From, class To>
+  std::enable_if_t<!is_proxy_v<std::remove_reference_t<From>> && is_proxy_v<std::remove_reference_t<To>>, void>
+  make_edge(From&& from, To&& to){
+    connect(from, *(to.node_ptr_));
+    Edge(from, std::get<std::remove_reference_t<To>::portnum_>((*(to.node_ptr_))->get_input_ports()));
+  }
+
+  template <class From, class To>
+  std::enable_if_t<(is_proxy_v<std::remove_reference_t<From>> && !is_proxy_v<std::remove_reference_t<To>>), void>
+  make_edge(From&& from, To&& to){
+    connect(*(from.node_ptr_), to);
+    Edge(std::get<std::remove_reference_t<From>::portnum_>((*(from.node_ptr_))->get_output_ports()), to);
+  }
+
+  template <class From, class To>
+  std::enable_if_t<is_proxy_v<std::remove_reference_t<From>> && is_proxy_v<std::remove_reference_t<To>>, void>
+  make_edge(From&& from, To&& to){
+    connect(*(from.node_ptr_), *(to.node_ptr_));
+    Edge(std::get<std::remove_reference_t<From>::portnum_>((*(from.node_ptr_))->get_output_ports()),
+         std::get<std::remove_reference_t<To>::portnum_>((*(to.node_ptr_))->get_input_ports()));
   }
 
   /**
@@ -262,6 +387,16 @@ auto initial_node(Graph& graph, Function&& f) {
 }
 
 /**
+ * @ brief Add an initial node to a graph.
+ * @tparam Function
+ * @param f
+ */
+template <class Graph, class Function>
+auto initial_mimo(Graph& graph, Function&& f) {
+  return graph.initial_mimo(std::forward<Function>(f));
+}
+
+/**
  * @ brief Add a function node to a graph.
  * @tparam Function
  * @param f
@@ -277,8 +412,8 @@ auto transform_node(Graph& graph, Function&& f) {
  * @param f
  */
 template <class Graph, class Function>
-auto mimo_node(Graph& graph, Function&& f) {
-  return graph.mimo_node(std::forward<Function>(f));
+auto mimo(Graph& graph, Function&& f) {
+  return graph.mimo(std::forward<Function>(f));
 }
 
 /**
@@ -291,8 +426,18 @@ auto terminal_node(Graph& graph, Function&& f) {
   return graph.terminal_node(std::forward<Function>(f));
 }
 
+/**
+ * @ brief Add a terminal node to a graph.
+ * @tparam Function
+ * @param f
+ */
+template <class Graph, class Function>
+auto terminal_mimo(Graph& graph, Function&& f) {
+  return graph.terminal_mimo(std::forward<Function>(f));
+}
+
 template <class Graph, class From, class To>
-void make_edge(Graph& graph, From& from, To& to) {
+void make_edge(Graph& graph, From&& from, To&& to) {
   graph.make_edge(from, to);
 }
 

--- a/experimental/tiledb/common/dag/graph/taskgraph.h
+++ b/experimental/tiledb/common/dag/graph/taskgraph.h
@@ -50,17 +50,6 @@
 
 namespace tiledb::common {
 
-template <class... R, class... T>
-auto aaa(std::function<void(std::tuple<R...>, std::tuple<T...>)>&& f) {
-  // using U... = std::remove_cv_t<std::remove_reference_t<T...>>;
-  auto tmp = mimo_node<
-      DuffsMover3,
-      std::remove_cv_t<std::remove_reference_t<T>>...,
-      DuffsMover3,
-      R...>{f};
-  return tmp;
-}
-
 template <class Scheduler>
 class TaskGraph {
   using node_base_type = node_base;
@@ -161,8 +150,7 @@ class TaskGraph {
    * @param f The function to store in the node.
    *
    * @tparam Function The type of function to be held by the node.
-   * The function must take an item as input
-   * and return an item as output.
+   * The function must take an item as input and return an item as output.
    */
   template <class R, class T>
   auto transform_node(std::function<R(T)>&& f) {
@@ -192,12 +180,10 @@ class TaskGraph {
    * @param f The function to store in the node.
    *
    * @tparam Function The type of function to be held by the node.
-   * The function must take an item as input
-   * and return an item as output.
+   * The function must take an item as input and return an item as output.
    */
   template <class... R, class... T>
   auto mimo(std::function<std::tuple<R...>(const std::tuple<T...>&)>&& f) {
-    // using U... = std::remove_cv_t<std::remove_reference_t<T...>>;
     auto tmp = mimo_node<
         DuffsMover3,
         std::tuple<std::remove_cv_t<std::remove_reference_t<T>>...>,
@@ -213,8 +199,7 @@ class TaskGraph {
    * @param f The function to store in the node.
    *
    * @tparam Function The type of function to be held by the node.
-   * The function must take an item as input
-   * and return an item as output.
+   * The function must take an item as input and return an item as output.
    */
   template <class Function>
   auto mimo(Function&& f) {
@@ -227,8 +212,7 @@ class TaskGraph {
    * @param f The function to store in the node.
    *
    * @tparam Function The type of function to be held by the node.
-   * The function must take an item as input
-   * and return void.
+   * The function must take an item as input and return void.
    */
   template <class T>
   auto terminal_node(std::function<void(T)>&& f) {
@@ -258,8 +242,7 @@ class TaskGraph {
    * @param f The function to store in the node.
    *
    * @tparam Function The type of function to be held by the node.
-   * The function must take an item as input
-   * and return void.
+   * The function must take an item as input and return void.
    */
   template <class T>
   auto terminal_mimo(std::function<void(T)>&& f) {
@@ -268,6 +251,7 @@ class TaskGraph {
     nodes_.emplace_back(tmp);
     return tmp;
   }
+
   /**
    * Trampoline function to match a function to an std::function so that we
    * can use CTAD to deduce the input argument type.
@@ -298,7 +282,6 @@ class TaskGraph {
   template <class From, class To>
   void make_edge(From& from, To& to) {
     connect(from, to);
-    // edges_.emplace_back(std::make_shared<GraphEdge>(Edge(*from, *to)));
     edges_.emplace_back(std::make_shared<GraphEdge>(Edge(from, to)));
   }
 #endif

--- a/experimental/tiledb/common/dag/graph/test/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/graph/test/CMakeLists.txt
@@ -30,4 +30,5 @@
 # Define unit tests
 #
 dag_add_header_only_unit_test(taskgraph)
+dag_add_header_only_unit_test(mimo_taskgraph)
 dag_add_header_only_unit_test(graph_sieve)

--- a/experimental/tiledb/common/dag/graph/test/unit_graph_sieve.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_graph_sieve.cc
@@ -83,6 +83,7 @@
 #include "experimental/tiledb/common/dag/execution/throw_catch.h"
 #include "experimental/tiledb/common/dag/graph/taskgraph.h"
 #include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "experimental/tiledb/common/dag/utility/print_types.h"
 
 using namespace tiledb::common;
 using namespace std::placeholders;

--- a/experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -265,34 +265,40 @@ TEST_CASE("mimo_node: Verify making simple mimo nodes", "[mimo_taskgraph]") {
     auto v = transform_node(graph, dummy_function);
     auto w = terminal_node(graph, dummy_sink);
   }
+
   SECTION("function") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, dummy_mimo_function);
     auto w = terminal_node(graph, dummy_sink);
   }
+
   SECTION("lambda") {
     auto l = [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; };
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, l);
     auto w = terminal_node(graph, dummy_sink);
   }
+
   SECTION("inline lambda") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(
         graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
     auto w = terminal_node(graph, dummy_sink);
   }
+
   SECTION("function object") {
     auto x = dummy_mimo_function_class{};
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, x);
     auto w = terminal_node(graph, dummy_sink);
   }
+
   SECTION("inline function object") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, dummy_mimo_function_class{});
     auto w = terminal_node(graph, dummy_sink);
   }
+
   SECTION("M by N") {
     auto u = mimo(graph, dummy_mimo_function);          // 1 by 1
     auto u_3_2 = mimo(graph, dummy_mimo_function_3_2);  // 3 by 2
@@ -316,6 +322,7 @@ TEST_CASE(
     make_edge(graph, u, v);
     make_edge(graph, v, w);
   }
+
   SECTION("mimo function, graph.make_edge member function") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, dummy_mimo_function);
@@ -324,6 +331,7 @@ TEST_CASE(
     graph.make_edge(u, make_proxy<0>(v));
     graph.make_edge(make_proxy<0>(v), w);
   }
+
   SECTION("mimo function, make_edge free function") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, dummy_mimo_function);
@@ -332,6 +340,7 @@ TEST_CASE(
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
   }
+
   SECTION("lambda") {
     auto l = [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; };
     auto u = initial_node(graph, dummy_source);
@@ -340,6 +349,7 @@ TEST_CASE(
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
   }
+
   SECTION("inline lambda") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(
@@ -348,6 +358,7 @@ TEST_CASE(
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
   }
+
   SECTION("function object") {
     auto x = dummy_mimo_function_class{};
     auto u = initial_node(graph, dummy_source);
@@ -356,6 +367,7 @@ TEST_CASE(
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
   }
+
   SECTION("inline function object") {
     auto u = initial_node(graph, dummy_source);
     auto v = mimo(graph, dummy_mimo_function_class{});
@@ -363,6 +375,7 @@ TEST_CASE(
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
   }
+
   SECTION("M by N") {
     auto u = mimo(graph, dummy_mimo_function);  // 1 by 1, size_t
     auto i32 = initial_mimo(graph, [](std::stop_source) {

--- a/experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
@@ -1,45 +1,45 @@
 /**
-* @file experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
-*
-* @section LICENSE
-*
-* The MIT License
-*
-* @copyright Copyright (c) 2022 TileDB, Inc.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-* @section DESCRIPTION
-*/
+ * @file experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
 
-#include "unit_taskgraph.h"
+#include <cstdint>
+#include <initializer_list>
+#include <iostream>
+#include <memory>
+#include <tuple>
+#include <type_traits>
 #include "experimental/tiledb/common/dag/execution/duffs.h"
 #include "experimental/tiledb/common/dag/graph/taskgraph.h"
-#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
-#include "experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h"
 #include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
-#include <tuple>
-#include <cstdint>
-#include <iostream>
-#include <initializer_list>
-#include <memory>
-#include <type_traits>
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h"
+#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "unit_taskgraph.h"
 
 using namespace tiledb::common;
 
@@ -109,15 +109,20 @@ TEST_CASE("mimo_node: Verify various Proxy API approaches", "[proxy]") {
       DuffsMover3,
       std::tuple<size_t, double>>
       x{};
-  auto u = initial_node(graph, [](std::stop_source&) {return std::tuple<char*, double>{};});
-  auto v = mimo(graph, [](const std::tuple<char*, double>&){return std::tuple<size_t, size_t, char>{};});
-  auto w = terminal_node(graph, [](const std::tuple<size_t, size_t, char>&){});
+  auto u = initial_node(
+      graph, [](std::stop_source&) { return std::tuple<char*, double>{}; });
+  auto v = mimo(graph, [](const std::tuple<char*, double>&) {
+    return std::tuple<size_t, size_t, char>{};
+  });
+  auto w = terminal_node(graph, [](const std::tuple<size_t, size_t, char>&) {});
 
-  auto y = initial_node(graph, [](std::stop_source&) {return std::tuple<char*, double>{};});
-  auto z = terminal_node(graph, [](const std::tuple<char*, double>&){});
+  auto y = initial_node(
+      graph, [](std::stop_source&) { return std::tuple<char*, double>{}; });
+  auto z = terminal_node(graph, [](const std::tuple<char*, double>&) {});
 
-  auto s = initial_mimo(graph, [](std::stop_source&) {return std::tuple<char*, double>{};});
-  auto t = terminal_mimo(graph, [](const std::tuple<char*, double>&){});
+  auto s = initial_mimo(
+      graph, [](std::stop_source&) { return std::tuple<char*, double>{}; });
+  auto t = terminal_mimo(graph, [](const std::tuple<char*, double>&) {});
 
   SECTION("Very Simple connect") {
     connect(u, v);
@@ -129,7 +134,6 @@ TEST_CASE("mimo_node: Verify various Proxy API approaches", "[proxy]") {
   }
 }
 
-
 TEST_CASE(
     "mimo_node: Verify construction with simple function", "[segmented_mimo]") {
   [[maybe_unused]] mimo_node<
@@ -137,23 +141,22 @@ TEST_CASE(
       std::tuple<size_t, size_t>,
       DuffsMover3,
       std::tuple<size_t, char*>>
-      x{[](std::tuple<size_t, size_t>) {return std::tuple<size_t, char*>{};}};
+      x{[](std::tuple<size_t, size_t>) { return std::tuple<size_t, char*>{}; }};
 }
 
-TEST_CASE(
-    "TaskGraph: Very simple mimo compilation",
-    "[taskgraph]") {
+TEST_CASE("TaskGraph: Very simple mimo compilation", "[taskgraph]") {
   auto graph = TaskGraph<DuffsScheduler<node>>();
 
-
   SECTION("One in one out mimo") {
-    auto aa = [](const std::tuple<size_t>&) {return std::tuple<size_t>{};};
+    auto aa = [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; };
     auto bb = std::function<std::tuple<size_t>(const std::tuple<size_t>&)>{};
 
     auto fun0 = graph.mimo(bb);
-    auto fun1 = graph.mimo([](const std::tuple<size_t>&) {return  std::tuple<size_t>{};});
+    auto fun1 = graph.mimo(
+        [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
     auto fun3 = graph.mimo(aa);
-    auto fun2 = mimo(graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{};});
+    auto fun2 = mimo(
+        graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
     auto fun4 = mimo(graph, aa);
   }
 
@@ -190,7 +193,7 @@ auto dummy_mimo_function_2_3(
 
 auto dummy_mimo_function_3_2(
     [[maybe_unused]] const std::tuple<size_t, uint32_t, uint16_t>& in) {
-    return std::tuple<uint32_t, size_t>{};
+  return std::tuple<uint32_t, size_t>{};
 }
 
 size_t dummy_function(const size_t& in) {
@@ -213,7 +216,7 @@ class dummy_source_class {
 class dummy_mimo_function_class {
  public:
   auto operator()(const std::tuple<size_t>& in) const {
-    return std::tuple<size_t> (in);
+    return std::tuple<size_t>(in);
   }
 };
 
@@ -221,16 +224,14 @@ class dummy_mimo_function_class_3_2 {
  public:
   auto operator()(
       [[maybe_unused]] const std::tuple<size_t, uint32_t, uint16_t>& in) {
-
-      return std::tuple<uint32_t, size_t>{};
+    return std::tuple<uint32_t, size_t>{};
   }
 };
 
 class dummy_mimo_function_class_2_3 {
  public:
-  auto operator()(
-      [[maybe_unused]] const std::tuple<size_t, uint32_t>& in){
-      return std::tuple<uint16_t, uint32_t, size_t> {};
+  auto operator()([[maybe_unused]] const std::tuple<size_t, uint32_t>& in) {
+    return std::tuple<uint16_t, uint32_t, size_t>{};
   }
 };
 
@@ -277,7 +278,8 @@ TEST_CASE("mimo_node: Verify making simple mimo nodes", "[mimo_taskgraph]") {
   }
   SECTION("inline lambda") {
     auto u = initial_node(graph, dummy_source);
-    auto v = mimo(graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
+    auto v = mimo(
+        graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
     auto w = terminal_node(graph, dummy_sink);
   }
   SECTION("function object") {
@@ -302,8 +304,9 @@ TEST_CASE("mimo_node: Verify making simple mimo nodes", "[mimo_taskgraph]") {
   }
 }
 
-
-TEST_CASE("mimo_node: Verify making simple mimo nodes with edges", "[mimo_taskgraph]") {
+TEST_CASE(
+    "mimo_node: Verify making simple mimo nodes with edges",
+    "[mimo_taskgraph]") {
   auto graph = TaskGraph<DuffsScheduler<node>>();
 
   SECTION("plain function") {
@@ -339,7 +342,8 @@ TEST_CASE("mimo_node: Verify making simple mimo nodes with edges", "[mimo_taskgr
   }
   SECTION("inline lambda") {
     auto u = initial_node(graph, dummy_source);
-    auto v = mimo(graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
+    auto v = mimo(
+        graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
     auto w = terminal_node(graph, dummy_sink);
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
@@ -360,14 +364,26 @@ TEST_CASE("mimo_node: Verify making simple mimo nodes with edges", "[mimo_taskgr
     make_edge(graph, make_proxy<0>(v), w);
   }
   SECTION("M by N") {
-    auto u = mimo(graph, dummy_mimo_function);          // 1 by 1, size_t
-    auto i32 = initial_mimo(graph, [](std::stop_source){ return std::tuple<uint32_t>{}; });  // 0 by 1, uint32_t
-    auto i16 = initial_mimo(graph, [](std::stop_source){ return std::tuple<uint16_t>{}; });  // 0 by 1, uint16_t
-    auto o32 = terminal_mimo(graph, [](const std::tuple<uint32_t>&){ });  // 1 by 0, uint32_t
-    auto o16 = terminal_mimo(graph, [](const std::tuple<uint16_t>&){ });  // 1 by 0, uint16_t
-    auto u32 = mimo(graph, [](const std::tuple<uint32_t>&){ return std::tuple<uint32_t>{}; });  // 0 by 1, uint32_t
-    auto u_3_2 = mimo(graph, dummy_mimo_function_3_2);  // 3 by 2  size_t, uint32_t, uint16_t -> uint32_t, size_t
-    auto u_2_3 = mimo(graph, dummy_mimo_function_2_3);  // 2 by 3  size_t, uint32_t -> uint16_t, uint32_t, size_t
+    auto u = mimo(graph, dummy_mimo_function);  // 1 by 1, size_t
+    auto i32 = initial_mimo(graph, [](std::stop_source) {
+      return std::tuple<uint32_t>{};
+    });  // 0 by 1, uint32_t
+    auto i16 = initial_mimo(graph, [](std::stop_source) {
+      return std::tuple<uint16_t>{};
+    });  // 0 by 1, uint16_t
+    auto o32 = terminal_mimo(
+        graph, [](const std::tuple<uint32_t>&) {});  // 1 by 0, uint32_t
+    auto o16 = terminal_mimo(
+        graph, [](const std::tuple<uint16_t>&) {});  // 1 by 0, uint16_t
+    auto u32 = mimo(graph, [](const std::tuple<uint32_t>&) {
+      return std::tuple<uint32_t>{};
+    });  // 0 by 1, uint32_t
+    auto u_3_2 =
+        mimo(graph, dummy_mimo_function_3_2);  // 3 by 2  size_t, uint32_t,
+                                               // uint16_t -> uint32_t, size_t
+    auto u_2_3 =
+        mimo(graph, dummy_mimo_function_2_3);  // 2 by 3  size_t, uint32_t ->
+                                               // uint16_t, uint32_t, size_t
 
     SECTION("u_3_2 out") {
       make_edge(graph, make_proxy<0>(u), make_proxy<0>(u_3_2));
@@ -414,7 +430,6 @@ TEST_CASE("mimo_node: Verify making simple mimo nodes with edges", "[mimo_taskgr
   }
 }
 
-
 TEST_CASE("mimo_node: Run a simple graph", "[mimo_taskgraph]") {
   auto graph = TaskGraph<DuffsScheduler<node>>();
 
@@ -429,18 +444,19 @@ TEST_CASE("mimo_node: Run a simple graph", "[mimo_taskgraph]") {
       return 0UL;
     });
 
-    auto v = mimo(graph,
-                  [](const std::tuple<size_t>& t) {
-                    return std::tuple<size_t>{std::get<0>(t) + 1};
-                  });
-    auto w = terminal_node(graph, [&vec](const size_t& t) {
-      vec.push_back(t);
+    auto v = mimo(graph, [](const std::tuple<size_t>& t) {
+      return std::tuple<size_t>{std::get<0>(t) + 1};
     });
+    auto w =
+        terminal_node(graph, [&vec](const size_t& t) { vec.push_back(t); });
     make_edge(graph, u, make_proxy<0>(v));
     make_edge(graph, make_proxy<0>(v), w);
 
     graph.sync_wait();
-    CHECK(std::equal(vec.begin(), vec.end(), std::vector<size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.begin()));
+    CHECK(std::equal(
+        vec.begin(),
+        vec.end(),
+        std::vector<size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.begin()));
   }
 
   SECTION("execute simple pipeline all mimo") {
@@ -454,10 +470,9 @@ TEST_CASE("mimo_node: Run a simple graph", "[mimo_taskgraph]") {
       return std::make_tuple(0UL);
     });
 
-    auto v = mimo(graph,
-                  [](const std::tuple<size_t>& t) {
-                    return std::tuple<size_t>{std::get<0>(t) + 1};
-                  });
+    auto v = mimo(graph, [](const std::tuple<size_t>& t) {
+      return std::tuple<size_t>{std::get<0>(t) + 1};
+    });
     auto w = terminal_mimo(graph, [&vec](const std::tuple<size_t>& t) {
       vec.push_back(std::get<0>(t));
     });
@@ -465,7 +480,9 @@ TEST_CASE("mimo_node: Run a simple graph", "[mimo_taskgraph]") {
     make_edge(graph, make_proxy<0>(v), make_proxy<0>(w));
 
     graph.sync_wait();
-    CHECK(std::equal(vec.begin(), vec.end(), std::vector<size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.begin()));
+    CHECK(std::equal(
+        vec.begin(),
+        vec.end(),
+        std::vector<size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.begin()));
   }
-
 }

--- a/experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
@@ -1,0 +1,471 @@
+/**
+* @file experimental/tiledb/common/dag/graph/test/unit_mimo_taskgraph.cc
+*
+* @section LICENSE
+*
+* The MIT License
+*
+* @copyright Copyright (c) 2022 TileDB, Inc.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @section DESCRIPTION
+*/
+
+#include "unit_taskgraph.h"
+#include "experimental/tiledb/common/dag/execution/duffs.h"
+#include "experimental/tiledb/common/dag/graph/taskgraph.h"
+#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h"
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
+#include <tuple>
+#include <cstdint>
+#include <iostream>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+
+using namespace tiledb::common;
+
+TEST_CASE("mimo_node: Verify various API approaches", "[segmented_mimo]") {
+  [[maybe_unused]] mimo_node<
+      DuffsMover3,
+      std::tuple<size_t, int>,
+      DuffsMover3,
+      std::tuple<size_t, double>>
+      x{};
+}
+#if 0
+template <class MimoNode, size_t portnum>
+struct Proxy {
+  constexpr static const size_t portnum_ {portnum};
+  MimoNode* node_ptr_;
+  Proxy(MimoNode& node) : node_ptr_{&node} {}
+};
+
+template <size_t N, class T>
+auto make_proxy(const T& u) {
+  return Proxy<std::remove_reference_t<decltype(u)>, N>(u);
+}
+template<typename T>
+struct is_proxy: std::false_type {};
+
+template<typename T, size_t portnum>
+struct is_proxy<Proxy<T, portnum>> : std::true_type {};
+
+template <class T>
+constexpr const bool is_proxy_v {is_proxy<T>::value};
+
+template <class From, class To>
+std::enable_if_t<(!is_proxy_v<From> && !is_proxy_v<To>), void>
+make_edge(From& from, To& to){
+  connect(from, to);
+  Edge(from, to);
+}
+
+template <class From, class To>
+std::enable_if_t<!is_proxy_v<From> && is_proxy_v<To>, void>
+make_edge(From&& from, To&& to){
+  connect(from, *(to.node_ptr_));
+  Edge(from, std::get<To::portnum_>((*(to.node_ptr_))->get_input_ports()));
+}
+
+template <class From, class To>
+std::enable_if_t<(is_proxy_v<From> && !is_proxy_v<To>), void>
+make_edge(From&& from, To&& to){
+  connect(*(from.node_ptr_), to);
+  Edge(std::get<From::portnum_>((*(from.node_ptr_))->get_output_ports()), to);
+}
+
+template <class From, class To>
+std::enable_if_t<is_proxy_v<From> && is_proxy_v<To>, void>
+make_edge(From&& from, To&& to){
+  connect(*(from.node_ptr_), *(to.node_ptr_));
+  Edge(std::get<From::portnum_>((*(from.node_ptr_))->get_output_ports()),
+                  std::get<To::portnum_>((*(to.node_ptr_))->get_input_ports()));
+}
+#endif
+TEST_CASE("mimo_node: Verify various Proxy API approaches", "[proxy]") {
+  auto graph = TaskGraph<DuffsScheduler<node>>();
+  [[maybe_unused]] mimo_node<
+      DuffsMover3,
+      std::tuple<size_t, int>,
+      DuffsMover3,
+      std::tuple<size_t, double>>
+      x{};
+  auto u = initial_node(graph, [](std::stop_source&) {return std::tuple<char*, double>{};});
+  auto v = mimo(graph, [](const std::tuple<char*, double>&){return std::tuple<size_t, size_t, char>{};});
+  auto w = terminal_node(graph, [](const std::tuple<size_t, size_t, char>&){});
+
+  auto y = initial_node(graph, [](std::stop_source&) {return std::tuple<char*, double>{};});
+  auto z = terminal_node(graph, [](const std::tuple<char*, double>&){});
+
+  auto s = initial_mimo(graph, [](std::stop_source&) {return std::tuple<char*, double>{};});
+  auto t = terminal_mimo(graph, [](const std::tuple<char*, double>&){});
+
+  SECTION("Very Simple connect") {
+    connect(u, v);
+    connect(v, w);
+  }
+  SECTION("Simple make_proxy") {
+    make_proxy<0>(v);
+    make_proxy<1>(v);
+  }
+}
+
+
+TEST_CASE(
+    "mimo_node: Verify construction with simple function", "[segmented_mimo]") {
+  [[maybe_unused]] mimo_node<
+      DuffsMover2,
+      std::tuple<size_t, size_t>,
+      DuffsMover3,
+      std::tuple<size_t, char*>>
+      x{[](std::tuple<size_t, size_t>) {return std::tuple<size_t, char*>{};}};
+}
+
+TEST_CASE(
+    "TaskGraph: Very simple mimo compilation",
+    "[taskgraph]") {
+  auto graph = TaskGraph<DuffsScheduler<node>>();
+
+
+  SECTION("One in one out mimo") {
+    auto aa = [](const std::tuple<size_t>&) {return std::tuple<size_t>{};};
+    auto bb = std::function<std::tuple<size_t>(const std::tuple<size_t>&)>{};
+
+    auto fun0 = graph.mimo(bb);
+    auto fun1 = graph.mimo([](const std::tuple<size_t>&) {return  std::tuple<size_t>{};});
+    auto fun3 = graph.mimo(aa);
+    auto fun2 = mimo(graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{};});
+    auto fun4 = mimo(graph, aa);
+  }
+
+  SECTION("Two in three out mimo") {
+    auto aa = [](const std::tuple<size_t, double>&) {
+      return std::tuple<float, char*, int>{};
+    };
+
+    auto fun3 = graph.mimo(aa);
+    auto fun4 = mimo(graph, aa);
+  }
+}
+
+/**
+ * Some dummy functions and classes to test node constructors
+ * with.
+ */
+size_t dummy_source(std::stop_source&) {
+  return size_t{};
+}
+
+auto dummy_mimo_source(std::stop_source) {
+  return std::tuple<size_t>{};
+}
+
+auto dummy_mimo_function(const std::tuple<size_t>& in) {
+  return in;
+}
+
+auto dummy_mimo_function_2_3(
+    [[maybe_unused]] const std::tuple<size_t, uint32_t>& in) {
+  return std::tuple<uint16_t, uint32_t, size_t>{};
+}
+
+auto dummy_mimo_function_3_2(
+    [[maybe_unused]] const std::tuple<size_t, uint32_t, uint16_t>& in) {
+    return std::tuple<uint32_t, size_t>{};
+}
+
+size_t dummy_function(const size_t& in) {
+  return in;
+}
+
+void dummy_sink(size_t) {
+}
+
+void dummy_mimo_sink(const std::tuple<size_t>&) {
+}
+
+class dummy_source_class {
+ public:
+  size_t operator()(std::stop_source&) {
+    return size_t{};
+  }
+};
+
+class dummy_mimo_function_class {
+ public:
+  auto operator()(const std::tuple<size_t>& in) const {
+    return std::tuple<size_t> (in);
+  }
+};
+
+class dummy_mimo_function_class_3_2 {
+ public:
+  auto operator()(
+      [[maybe_unused]] const std::tuple<size_t, uint32_t, uint16_t>& in) {
+
+      return std::tuple<uint32_t, size_t>{};
+  }
+};
+
+class dummy_mimo_function_class_2_3 {
+ public:
+  auto operator()(
+      [[maybe_unused]] const std::tuple<size_t, uint32_t>& in){
+      return std::tuple<uint16_t, uint32_t, size_t> {};
+  }
+};
+
+class dummy_function_class {
+ public:
+  size_t operator()(const size_t&) {
+    return size_t{};
+  }
+  auto operator()(const std::tuple<size_t>& in) {
+    return in;
+  }
+};
+
+class dummy_sink_class {
+ public:
+  void operator()(size_t) {
+  }
+};
+
+class dummy_mimo_sink_class {
+ public:
+  void operator()(std::tuple<size_t>&) {
+  }
+};
+
+TEST_CASE("mimo_node: Verify making simple mimo nodes", "[mimo_taskgraph]") {
+  auto graph = TaskGraph<DuffsScheduler<node>>();
+
+  SECTION("plain function") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = transform_node(graph, dummy_function);
+    auto w = terminal_node(graph, dummy_sink);
+  }
+  SECTION("function") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, dummy_mimo_function);
+    auto w = terminal_node(graph, dummy_sink);
+  }
+  SECTION("lambda") {
+    auto l = [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; };
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, l);
+    auto w = terminal_node(graph, dummy_sink);
+  }
+  SECTION("inline lambda") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
+    auto w = terminal_node(graph, dummy_sink);
+  }
+  SECTION("function object") {
+    auto x = dummy_mimo_function_class{};
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, x);
+    auto w = terminal_node(graph, dummy_sink);
+  }
+  SECTION("inline function object") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, dummy_mimo_function_class{});
+    auto w = terminal_node(graph, dummy_sink);
+  }
+  SECTION("M by N") {
+    auto u = mimo(graph, dummy_mimo_function);          // 1 by 1
+    auto u_3_2 = mimo(graph, dummy_mimo_function_3_2);  // 3 by 2
+    auto u_2_3 = mimo(graph, dummy_mimo_function_2_3);  // 2 by 3
+
+    auto v = mimo(graph, dummy_mimo_function_class{});          // 1 by 1
+    auto v_3_2 = mimo(graph, dummy_mimo_function_class_3_2{});  // 3 by 2
+    auto v_2_3 = mimo(graph, dummy_mimo_function_class_2_3{});  // 2 by 3
+  }
+}
+
+
+TEST_CASE("mimo_node: Verify making simple mimo nodes with edges", "[mimo_taskgraph]") {
+  auto graph = TaskGraph<DuffsScheduler<node>>();
+
+  SECTION("plain function") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = transform_node(graph, dummy_function);
+    auto w = terminal_node(graph, dummy_sink);
+    make_edge(graph, u, v);
+    make_edge(graph, v, w);
+  }
+  SECTION("mimo function, graph.make_edge member function") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, dummy_mimo_function);
+    auto w = terminal_node(graph, dummy_sink);
+
+    graph.make_edge(u, make_proxy<0>(v));
+    graph.make_edge(make_proxy<0>(v), w);
+  }
+  SECTION("mimo function, make_edge free function") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, dummy_mimo_function);
+    auto w = terminal_node(graph, dummy_sink);
+
+    make_edge(graph, u, make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), w);
+  }
+  SECTION("lambda") {
+    auto l = [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; };
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, l);
+    auto w = terminal_node(graph, dummy_sink);
+    make_edge(graph, u, make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), w);
+  }
+  SECTION("inline lambda") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, [](const std::tuple<size_t>&) { return std::tuple<size_t>{}; });
+    auto w = terminal_node(graph, dummy_sink);
+    make_edge(graph, u, make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), w);
+  }
+  SECTION("function object") {
+    auto x = dummy_mimo_function_class{};
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, x);
+    auto w = terminal_node(graph, dummy_sink);
+    make_edge(graph, u, make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), w);
+  }
+  SECTION("inline function object") {
+    auto u = initial_node(graph, dummy_source);
+    auto v = mimo(graph, dummy_mimo_function_class{});
+    auto w = terminal_node(graph, dummy_sink);
+    make_edge(graph, u, make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), w);
+  }
+  SECTION("M by N") {
+    auto u = mimo(graph, dummy_mimo_function);          // 1 by 1, size_t
+    auto i32 = initial_mimo(graph, [](std::stop_source){ return std::tuple<uint32_t>{}; });  // 0 by 1, uint32_t
+    auto i16 = initial_mimo(graph, [](std::stop_source){ return std::tuple<uint16_t>{}; });  // 0 by 1, uint16_t
+    auto o32 = terminal_mimo(graph, [](const std::tuple<uint32_t>&){ });  // 1 by 0, uint32_t
+    auto o16 = terminal_mimo(graph, [](const std::tuple<uint16_t>&){ });  // 1 by 0, uint16_t
+    auto u32 = mimo(graph, [](const std::tuple<uint32_t>&){ return std::tuple<uint32_t>{}; });  // 0 by 1, uint32_t
+    auto u_3_2 = mimo(graph, dummy_mimo_function_3_2);  // 3 by 2  size_t, uint32_t, uint16_t -> uint32_t, size_t
+    auto u_2_3 = mimo(graph, dummy_mimo_function_2_3);  // 2 by 3  size_t, uint32_t -> uint16_t, uint32_t, size_t
+
+    SECTION("u_3_2 out") {
+      make_edge(graph, make_proxy<0>(u), make_proxy<0>(u_3_2));
+      make_edge(graph, make_proxy<0>(u32), make_proxy<1>(u_3_2));
+      make_edge(graph, make_proxy<0>(i16), make_proxy<2>(u_3_2));
+    }
+
+    SECTION("u_2_3 out") {
+      make_edge(graph, make_proxy<0>(u), make_proxy<0>(u_2_3));
+      make_edge(graph, make_proxy<0>(u32), make_proxy<1>(u_2_3));
+    }
+
+    SECTION("u_2_3 in") {
+      make_edge(graph, make_proxy<0>(u_2_3), make_proxy<0>(o16));
+      make_edge(graph, make_proxy<1>(u_2_3), make_proxy<0>(o32));
+      make_edge(graph, make_proxy<2>(u_2_3), make_proxy<0>(u));
+    }
+
+    SECTION("u_3_2 in") {
+      make_edge(graph, make_proxy<0>(u_3_2), make_proxy<0>(u32));
+      make_edge(graph, make_proxy<1>(u_3_2), make_proxy<0>(u));
+    }
+
+    SECTION("u_2_3  x u_3_2") {
+      make_edge(graph, make_proxy<0>(u_2_3), make_proxy<2>(u_3_2));
+      make_edge(graph, make_proxy<1>(u_2_3), make_proxy<1>(u_3_2));
+      make_edge(graph, make_proxy<2>(u_2_3), make_proxy<0>(u_3_2));
+    }
+
+    SECTION("u_3_2  x u_2_3") {
+      make_edge(graph, make_proxy<0>(u_3_2), make_proxy<1>(u_2_3));
+      make_edge(graph, make_proxy<1>(u_3_2), make_proxy<0>(u_2_3));
+    }
+
+    SECTION("function to function_class") {
+      auto u = mimo(graph, dummy_mimo_function);
+      auto v = mimo(graph, dummy_mimo_function_class{});
+      make_edge(graph, make_proxy<0>(u), make_proxy<0>(v));
+    }
+
+    auto v = mimo(graph, dummy_mimo_function_class{});          // 1 by 1
+    auto v_3_2 = mimo(graph, dummy_mimo_function_class_3_2{});  // 3 by 2
+    auto v_2_3 = mimo(graph, dummy_mimo_function_class_2_3{});  // 2 by 3
+  }
+}
+
+
+TEST_CASE("mimo_node: Run a simple graph", "[mimo_taskgraph]") {
+  auto graph = TaskGraph<DuffsScheduler<node>>();
+
+  SECTION("execute simple pipeline") {
+    std::vector<size_t> vec;
+    auto u = initial_node(graph, [](std::stop_source stop) {
+      static size_t i = 0;
+      if (i < 10) {
+        return i++;
+      }
+      stop.request_stop();
+      return 0UL;
+    });
+
+    auto v = mimo(graph,
+                  [](const std::tuple<size_t>& t) {
+                    return std::tuple<size_t>{std::get<0>(t) + 1};
+                  });
+    auto w = terminal_node(graph, [&vec](const size_t& t) {
+      vec.push_back(t);
+    });
+    make_edge(graph, u, make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), w);
+
+    graph.sync_wait();
+    CHECK(std::equal(vec.begin(), vec.end(), std::vector<size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.begin()));
+  }
+
+  SECTION("execute simple pipeline all mimo") {
+    std::vector<size_t> vec;
+    auto u = initial_mimo(graph, [](std::stop_source stop) {
+      static size_t i = 0;
+      if (i < 10) {
+        return std::make_tuple(i++);
+      }
+      stop.request_stop();
+      return std::make_tuple(0UL);
+    });
+
+    auto v = mimo(graph,
+                  [](const std::tuple<size_t>& t) {
+                    return std::tuple<size_t>{std::get<0>(t) + 1};
+                  });
+    auto w = terminal_mimo(graph, [&vec](const std::tuple<size_t>& t) {
+      vec.push_back(std::get<0>(t));
+    });
+    make_edge(graph, make_proxy<0>(u), make_proxy<0>(v));
+    make_edge(graph, make_proxy<0>(v), make_proxy<0>(w));
+
+    graph.sync_wait();
+    CHECK(std::equal(vec.begin(), vec.end(), std::vector<size_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.begin()));
+  }
+
+}

--- a/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
@@ -372,6 +372,16 @@ TEST_CASE("TaskGraph: Schedule", "[taskgraph]") {
   sync_wait(graph);
 }
 
+
+TEST_CASE("TaskGraph: Different types along graph", "[taskgraph]") {
+  auto graph = TaskGraph<DuffsScheduler<node>>();
+  auto aa = initial_node(graph, [](std::stop_source) { return 0UL; });
+  auto bb = transform_node(graph, [](size_t){ return double{};});
+  //auto cc = terminal_node(graph, [](const size_t&){ });
+  make_edge(graph, aa, bb);
+}
+
+
 TEST_CASE("TaskGraph: Run Passing Integers", "[taskgraph]") {
   auto graph = TaskGraph<DuffsScheduler<node>>();
 

--- a/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
@@ -372,15 +372,13 @@ TEST_CASE("TaskGraph: Schedule", "[taskgraph]") {
   sync_wait(graph);
 }
 
-
 TEST_CASE("TaskGraph: Different types along graph", "[taskgraph]") {
   auto graph = TaskGraph<DuffsScheduler<node>>();
   auto aa = initial_node(graph, [](std::stop_source) { return 0UL; });
-  auto bb = transform_node(graph, [](size_t){ return double{};});
-  //auto cc = terminal_node(graph, [](const size_t&){ });
+  auto bb = transform_node(graph, [](size_t) { return double{}; });
+  // auto cc = terminal_node(graph, [](const size_t&){ });
   make_edge(graph, aa, bb);
 }
-
 
 TEST_CASE("TaskGraph: Run Passing Integers", "[taskgraph]") {
   auto graph = TaskGraph<DuffsScheduler<node>>();

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/consumer.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/consumer.h
@@ -91,7 +91,6 @@ class consumer_node_impl : public node_base, public Sink<Mover, T> {
     return *reinterpret_cast<SinkBase*>(this);
   }
 
-
   /** Utility functions for indicating what kind of node and state of the ports
    * being used.
    *

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/consumer.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/consumer.h
@@ -87,6 +87,11 @@ class consumer_node_impl : public node_base, public Sink<Mover, T> {
       , consumed_items_{0} {
   }
 
+  auto get_input_port() {
+    return *reinterpret_cast<SinkBase*>(this);
+  }
+
+
   /** Utility functions for indicating what kind of node and state of the ports
    * being used.
    *
@@ -194,8 +199,14 @@ class consumer_node_impl : public node_base, public Sink<Mover, T> {
   scheduler_event_type resume() override {
     auto mover = SinkBase::get_mover();
 
+    // #ifdef __clang__
+    // #pragma clang diagnostic push
+    // #pragma ide diagnostic ignored "UnreachableCode"
+    // #endif
+
     switch (this->program_counter_) {
       /*
+       * @todo: don't do this -- case 0 shold be executed on all calls
        * case 0 is executed only on the very first call to resume.
        */
       case 0: {
@@ -249,6 +260,7 @@ class consumer_node_impl : public node_base, public Sink<Mover, T> {
       }
         [[fallthrough]];
 
+#if 0
         // @todo Should skip yield if pull waited;
       case 5: {
         ++this->program_counter_;
@@ -267,17 +279,23 @@ class consumer_node_impl : public node_base, public Sink<Mover, T> {
       }
 
         [[fallthrough]];
+#endif
 
       // @todo Where is the best place to yield?
-      case 6: {
-        this->program_counter_ = 1;
-        // this->task_yield(*this); ??
+      case 5: {
+        this->program_counter_ = 0;
         return scheduler_event_type::yield;
       }
+
       default: {
         break;
       }
     }
+
+    // #ifdef __clang__
+    // #pragma clang diagnostic pop
+    // #endif
+
     return scheduler_event_type::error;
   }
 

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
@@ -1,0 +1,77 @@
+/**
+* @file   experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
+*
+* @section LICENSE
+*
+* The MIT License
+*
+* @copyright Copyright (c) 2022 TileDB, Inc.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @section DESCRIPTION
+*/
+
+
+#ifndef TILEDB_DAG_NODES_EDGE_NODE_CTAD_H
+#define TILEDB_DAG_NODES_EDGE_NODE_CTAD_H
+
+#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "experimental/tiledb/common/dag/edge/edge.h"
+
+namespace tiledb::common {
+
+template <template <class> class Mover, class T>
+Edge(producer_node<Mover, T>, consumer_node<Mover, T>) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(producer_node<Mover, T>&, Sink<Mover, T>) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, Sink<Mover, T>) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(Source<Mover, T>, consumer_node<Mover, T>&) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(Source<Mover, T>, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<function_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(std::shared_ptr<function_node_impl<Mover, T>>&, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+
+template <template <class> class Mover, class T>
+Edge(std::shared_ptr<function_node_impl<Mover, T>>&, std::shared_ptr<function_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+
+template <template <class> class SinkMover, class T, template <class> class SourceMover, class U>
+Edge(std::shared_ptr<mimo_node_impl<SinkMover, T, SourceMover, T>>&,
+     std::shared_ptr<mimo_node_impl<SourceMover, T, SinkMover, U>>&) -> Edge<SourceMover, T>;
+
+template <template <class> class SinkMover, class T, template <class> class SourceMover, class U>
+Edge(std::shared_ptr<producer_node_impl<SourceMover, T>>&,
+     std::shared_ptr<mimo_node_impl<SourceMover, T, SinkMover, U>>&) -> Edge<SourceMover, T>;
+
+}
+
+#endif  // TILEDB_DAG_NODES_EDGE_NODE_CTAD_H

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
@@ -55,14 +55,14 @@ Edge(Source<Mover, T>, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<M
 template <template <class> class Mover, class T>
 Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
 
-template <template <class> class Mover, class T>
-Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<function_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+template <template <class> class Mover, class T, template <class> class Mover2, class T2>
+Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&) -> Edge<Mover, T>;
 
-template <template <class> class Mover, class T>
-Edge(std::shared_ptr<function_node_impl<Mover, T>>&, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+template <template <class> class Mover, class T, template <class> class Mover2, class T2>
+Edge(std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&, std::shared_ptr<consumer_node_impl<Mover2, T2>>&) -> Edge<Mover2, T2>;
 
-template <template <class> class Mover, class T>
-Edge(std::shared_ptr<function_node_impl<Mover, T>>&, std::shared_ptr<function_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+template <template <class> class Mover, class T, template <class> class Mover2, class T2, template <class> class Mover3, class T3>
+Edge(std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&, std::shared_ptr<function_node_impl<Mover2, T2, Mover3, T3>>&) -> Edge<Mover2, T2>;
 
 template <template <class> class SinkMover, class T, template <class> class SourceMover, class U>
 Edge(std::shared_ptr<mimo_node_impl<SinkMover, T, SourceMover, T>>&,

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
@@ -1,39 +1,38 @@
 /**
-* @file   experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
-*
-* @section LICENSE
-*
-* The MIT License
-*
-* @copyright Copyright (c) 2022 TileDB, Inc.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-* @section DESCRIPTION
-*/
-
+ * @file experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
 
 #ifndef TILEDB_DAG_NODES_EDGE_NODE_CTAD_H
 #define TILEDB_DAG_NODES_EDGE_NODE_CTAD_H
 
-#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
 #include "experimental/tiledb/common/dag/edge/edge.h"
+#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
 
 namespace tiledb::common {
 
@@ -44,34 +43,83 @@ template <template <class> class Mover, class T>
 Edge(producer_node<Mover, T>&, Sink<Mover, T>) -> Edge<Mover, T>;
 
 template <template <class> class Mover, class T>
-Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, Sink<Mover, T>) -> Edge<Mover, T>;
+Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, Sink<Mover, T>)
+    -> Edge<Mover, T>;
 
 template <template <class> class Mover, class T>
 Edge(Source<Mover, T>, consumer_node<Mover, T>&) -> Edge<Mover, T>;
 
 template <template <class> class Mover, class T>
-Edge(Source<Mover, T>, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+Edge(Source<Mover, T>, std::shared_ptr<consumer_node_impl<Mover, T>>&)
+    -> Edge<Mover, T>;
 
 template <template <class> class Mover, class T>
-Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
+Edge(
+    std::shared_ptr<producer_node_impl<Mover, T>>&,
+    std::shared_ptr<consumer_node_impl<Mover, T>>&) -> Edge<Mover, T>;
 
-template <template <class> class Mover, class T, template <class> class Mover2, class T2>
-Edge(std::shared_ptr<producer_node_impl<Mover, T>>&, std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&) -> Edge<Mover, T>;
+template <
+    template <class>
+    class Mover,
+    class T,
+    template <class>
+    class Mover2,
+    class T2>
+Edge(
+    std::shared_ptr<producer_node_impl<Mover, T>>&,
+    std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&)
+    -> Edge<Mover, T>;
 
-template <template <class> class Mover, class T, template <class> class Mover2, class T2>
-Edge(std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&, std::shared_ptr<consumer_node_impl<Mover2, T2>>&) -> Edge<Mover2, T2>;
+template <
+    template <class>
+    class Mover,
+    class T,
+    template <class>
+    class Mover2,
+    class T2>
+Edge(
+    std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&,
+    std::shared_ptr<consumer_node_impl<Mover2, T2>>&) -> Edge<Mover2, T2>;
 
-template <template <class> class Mover, class T, template <class> class Mover2, class T2, template <class> class Mover3, class T3>
-Edge(std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&, std::shared_ptr<function_node_impl<Mover2, T2, Mover3, T3>>&) -> Edge<Mover2, T2>;
+template <
+    template <class>
+    class Mover,
+    class T,
+    template <class>
+    class Mover2,
+    class T2,
+    template <class>
+    class Mover3,
+    class T3>
+Edge(
+    std::shared_ptr<function_node_impl<Mover, T, Mover2, T2>>&,
+    std::shared_ptr<function_node_impl<Mover2, T2, Mover3, T3>>&)
+    -> Edge<Mover2, T2>;
 
-template <template <class> class SinkMover, class T, template <class> class SourceMover, class U>
-Edge(std::shared_ptr<mimo_node_impl<SinkMover, T, SourceMover, T>>&,
-     std::shared_ptr<mimo_node_impl<SourceMover, T, SinkMover, U>>&) -> Edge<SourceMover, T>;
+template <
+    template <class>
+    class SinkMover,
+    class T,
+    template <class>
+    class SourceMover,
+    class U>
+Edge(
+    std::shared_ptr<mimo_node_impl<SinkMover, T, SourceMover, T>>&,
+    std::shared_ptr<mimo_node_impl<SourceMover, T, SinkMover, U>>&)
+    -> Edge<SourceMover, T>;
 
-template <template <class> class SinkMover, class T, template <class> class SourceMover, class U>
-Edge(std::shared_ptr<producer_node_impl<SourceMover, T>>&,
-     std::shared_ptr<mimo_node_impl<SourceMover, T, SinkMover, U>>&) -> Edge<SourceMover, T>;
+template <
+    template <class>
+    class SinkMover,
+    class T,
+    template <class>
+    class SourceMover,
+    class U>
+Edge(
+    std::shared_ptr<producer_node_impl<SourceMover, T>>&,
+    std::shared_ptr<mimo_node_impl<SourceMover, T, SinkMover, U>>&)
+    -> Edge<SourceMover, T>;
 
-}
+}  // namespace tiledb::common
 
 #endif  // TILEDB_DAG_NODES_EDGE_NODE_CTAD_H

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
@@ -227,6 +227,11 @@ class function_node_impl : public node_base,
     auto source_mover = SourceBase::get_mover();
     auto sink_mover = SinkBase::get_mover();
 
+    // #ifdef __clang__
+    // #pragma clang diagnostic push
+    // #pragma ide diagnostic ignored "UnreachableCode"
+    // #endif
+
     switch (this->program_counter_) {
       // pull / extract drain
       case 0: {
@@ -280,8 +285,8 @@ auto post_state = sink_mover->state();
       case 3: {
         ++this->program_counter_;
 
-        assert(this->source_correspondent() != nullptr);
-        assert(this->sink_correspondent() != nullptr);
+        // assert(this->source_correspondent() != nullptr);
+        // assert(this->sink_correspondent() != nullptr);
       }
         [[fallthrough]];
 
@@ -333,6 +338,11 @@ auto post_state = sink_mover->state();
         break;
       }
     }
+
+    // #ifdef __clang__
+    // #pragma clang diagnostic pop
+    // #endif
+
     return scheduler_event_type::error;
   }
   // #pragma clang diagnostic pop
@@ -358,8 +368,8 @@ template <
     template <class>
     class SinkMover,
     class BlockIn,
-    template <class> class SourceMover = SinkMover,
-    class BlockOut = BlockIn>
+    template <class> class SourceMover,
+    class BlockOut>
 struct function_node
     : public std::shared_ptr<
           function_node_impl<SinkMover, BlockIn, SourceMover, BlockOut>> {

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
@@ -368,7 +368,8 @@ template <
     template <class>
     class SinkMover,
     class BlockIn,
-    template <class> class SourceMover,
+    template <class>
+    class SourceMover,
     class BlockOut>
 struct function_node
     : public std::shared_ptr<

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
@@ -284,9 +284,6 @@ auto post_state = sink_mover->state();
 
       case 3: {
         ++this->program_counter_;
-
-        // assert(this->source_correspondent() != nullptr);
-        // assert(this->sink_correspondent() != nullptr);
       }
         [[fallthrough]];
 

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h
@@ -245,6 +245,9 @@ class mimo_node_impl<
    * @note Elements are processed in order from 0 to sizeof(Ts)-1
    *
    * @pre sizeof(Ts) == sizeof(Us)
+   *
+   * @todo Use std::conjunction?
+   *
    */
   template <size_t I = 0, class... Ts, class... Us>
   constexpr void extract_all(std::tuple<Ts...>& in, std::tuple<Us...>& out) {

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h
@@ -183,8 +183,7 @@ class mimo_node_impl<
   std::tuple<BlocksOut...> output_items_;
 
   /**
-   * Helper function to deal with tuples.
-   * Applies the same single input single
+   * Helper function to deal with tuples. Applies the same single input single
    * output function to elements of an input tuple to set values of an output
    * tuple.
    *
@@ -198,7 +197,7 @@ class mimo_node_impl<
       std::is_same_v<decltype(output_items_), std::tuple<>>};
 
   /**
-   * Helper function to deal with tuples.  Applies the same single input single
+   * Helper function to deal with tuples. Applies the same single input single
    * output function to elements of an input tuple to set values of an output
    * tuple.
    *
@@ -220,9 +219,7 @@ class mimo_node_impl<
 
   template <size_t I = 0, class Op, class Fn, class... Ts>
   constexpr auto tuple_fold(Op&& op, Fn&& f, const std::tuple<Ts...>& in) {
-    // static_assert(I == 0);
     static_assert(I >= 0);
-    // static_assert(sizeof...(Ts) > 0 && sizeof...(Ts) < 10);
     if constexpr (I == sizeof...(Ts) - 1) {
       return f(std::get<I>(in));
     } else {
@@ -239,7 +236,7 @@ class mimo_node_impl<
   }
 
   /**
-   * Helper function to deal with tuples.  A tuple version of simple nodes
+   * Helper function to deal with tuples. A tuple version of simple nodes
    * extract.  Copies items from inputs_ (Sinks) to a tuple of input_items.
    *
    * @note Elements are processed in order from 0 to sizeof(Ts)-1
@@ -264,7 +261,7 @@ class mimo_node_impl<
   }
 
   /**
-   * Helper function to deal with tuples.  A tuple version of simple node
+   * Helper function to deal with tuples. A tuple version of simple node
    * inject. Copies items from tuple of output_items to outputs_ (Sources).
    *
    * @note Elements are processed in order from 0 to sizeof(Ts)-1
@@ -626,7 +623,6 @@ class mimo_node_impl<
         this->program_counter_ = 0;
         return scheduler_event_type::yield;
       }
-        // [[fallthrough]];
 
       default: {
         break;

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/producer.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/producer.h
@@ -108,6 +108,10 @@ struct producer_node_impl : public node_base, public Source<Mover, T> {
 
   producer_node_impl(producer_node_impl&& rhs) noexcept = default;
 
+  auto get_output_port() {
+    return *reinterpret_cast<SourceBase*>(this);
+  }
+
   /** Utility functions for indicating what kind of node and state of the ports
    * being used.
    *
@@ -221,6 +225,10 @@ struct producer_node_impl : public node_base, public Source<Mover, T> {
     std::stop_source stop_source_;
     assert(!stop_source_.stop_requested());
 
+
+// #pragma clang diagnostic push
+// #pragma ide diagnostic ignored "UnreachableCode"
+
     switch (this->program_counter_) {
       case 0: {
         ++this->program_counter_;
@@ -277,6 +285,11 @@ struct producer_node_impl : public node_base, public Source<Mover, T> {
       default:
         break;
     }
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#endif
+
     return scheduler_event_type::error;
   }
 
@@ -293,7 +306,8 @@ struct producer_node_impl : public node_base, public Source<Mover, T> {
 /** A producer node is a shared pointer to the implementation class */
 template <template <class> class Mover, class T>
 struct producer_node : public std::shared_ptr<producer_node_impl<Mover, T>> {
-  using Base = std::shared_ptr<producer_node_impl<Mover, T>>;
+  using PreBase = producer_node_impl<Mover, T>;
+  using Base = std::shared_ptr<PreBase>;
   using Base::Base;
 
   using node_type = node_t<producer_node_impl<Mover, T>>;
@@ -301,7 +315,7 @@ struct producer_node : public std::shared_ptr<producer_node_impl<Mover, T>> {
 
   template <class Function>
   explicit producer_node(Function&& f)
-      : Base{std::make_shared<producer_node_impl<Mover, T>>(
+      : Base{std::make_shared<PreBase>(
             std::forward<Function>(f))} {
   }
 

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/producer.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/producer.h
@@ -225,9 +225,8 @@ struct producer_node_impl : public node_base, public Source<Mover, T> {
     std::stop_source stop_source_;
     assert(!stop_source_.stop_requested());
 
-
-// #pragma clang diagnostic push
-// #pragma ide diagnostic ignored "UnreachableCode"
+    // #pragma clang diagnostic push
+    // #pragma ide diagnostic ignored "UnreachableCode"
 
     switch (this->program_counter_) {
       case 0: {
@@ -315,8 +314,7 @@ struct producer_node : public std::shared_ptr<producer_node_impl<Mover, T>> {
 
   template <class Function>
   explicit producer_node(Function&& f)
-      : Base{std::make_shared<PreBase>(
-            std::forward<Function>(f))} {
+      : Base{std::make_shared<PreBase>(std::forward<Function>(f))} {
   }
 
   explicit producer_node(producer_node_impl<Mover, T>& impl)

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/segmented_fwd.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/segmented_fwd.h
@@ -61,8 +61,8 @@ template <
     class SinkMover,
     class BlockIn,
     template <class>
-    class SourceMover,
-    class BlockOut>
+    class SourceMover = SinkMover,
+    class BlockOut = BlockIn>
 struct function_node;
 
 }  // namespace tiledb::common

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/segmented_fwd.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/segmented_fwd.h
@@ -60,8 +60,7 @@ template <
     template <class>
     class SinkMover,
     class BlockIn,
-    template <class>
-    class SourceMover = SinkMover,
+    template <class> class SourceMover = SinkMover,
     class BlockOut = BlockIn>
 struct function_node;
 

--- a/experimental/tiledb/common/dag/nodes/detail/simple/mimo.h
+++ b/experimental/tiledb/common/dag/nodes/detail/simple/mimo.h
@@ -215,7 +215,7 @@ class GeneralFunctionNode<
       std::is_same_v<decltype(output_items_), std::tuple<>>};
 
   /**
-   * Helper function to deal with tuples.  Applies the same single input single
+   * Helper function to deal with tuples. Applies the same single input single
    * output function to elements of an input tuple to set values of an output
    * tuple.
    *
@@ -236,7 +236,7 @@ class GeneralFunctionNode<
   }
 
   /**
-   * Helper function to deal with tuples.  A tuple version of simple nodes
+   * Helper function to deal with tuples. A tuple version of simple nodes
    * extract.  Copies items from inputs_ (Sinks) to a tuple of input_items.
    *
    * @note Elements are processed in order from 0 to sizeof(Ts)-1
@@ -258,7 +258,7 @@ class GeneralFunctionNode<
   }
 
   /**
-   * Helper function to deal with tuples.  A tuple version of simple node
+   * Helper function to deal with tuples. A tuple version of simple node
    * inject. Copies items from tuple of output_items to outputs_ (Sources).
    *
    * @note Elements are processed in order from 0 to sizeof(Ts)-1

--- a/experimental/tiledb/common/dag/nodes/segmented_nodes.h
+++ b/experimental/tiledb/common/dag/nodes/segmented_nodes.h
@@ -34,13 +34,15 @@
  * allowing the node to yield control back to the scheduler and return execution
  * where it left off.
  *
- * There are three types of segmented nodes:
+ * There are four types of segmented nodes:
  *   - Producer, which encapsulates a producer function that produces a single
  * result.
  *   - Consumer, which encapsulates a consumer function that consumes a single
  * result.
  *   - Function, which encapsulates a function that produces and consumes a
  * single result.
+ *   - MIMO, which encapsulates a function that produces and consumes
+ * results with arbitrary cardinality.
  *
  * The function encapsulated in the producer node may issue a stop request, in
  * which case the producer node will begin shutting down the task graph.
@@ -69,6 +71,7 @@
 #include "detail/segmented/consumer.h"
 #include "detail/segmented/function.h"
 #include "detail/segmented/producer.h"
+#include "detail/segmented/mimo.h"
 #include "node_traits.h"
 
 namespace tiledb::common {

--- a/experimental/tiledb/common/dag/nodes/segmented_nodes.h
+++ b/experimental/tiledb/common/dag/nodes/segmented_nodes.h
@@ -70,8 +70,8 @@
 
 #include "detail/segmented/consumer.h"
 #include "detail/segmented/function.h"
-#include "detail/segmented/producer.h"
 #include "detail/segmented/mimo.h"
+#include "detail/segmented/producer.h"
 #include "node_traits.h"
 
 namespace tiledb::common {

--- a/experimental/tiledb/common/dag/nodes/test/unit_nodes_sieve.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_nodes_sieve.cc
@@ -515,8 +515,8 @@ auto sieve_async_block(
      * Connect the nodes in the graph.  We try to keep the edges from going out
      * of scope by putting them into a vector.
      */
-    edges.emplace_back(std::move(
-        Edge(std::get<0>(graph.back()), std::get<1>(graph.back()), debug)));
+    edges.emplace_back(
+        std::move(Edge(std::get<0>(graph.back()), std::get<1>(graph.back()))));
     edges.emplace_back(
         std::move(Edge(std::get<1>(graph.back()), std::get<2>(graph.back()))));
     edges.emplace_back(

--- a/experimental/tiledb/common/dag/nodes/test/unit_segmented_mimo_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_segmented_mimo_nodes.cc
@@ -1,5 +1,5 @@
 /**
- * @file unit_segmented_mimo_nodes.cc
+ * @file unit_osegmented_mimo_nodes.cc
  *
  * @section LICENSE
  *
@@ -28,10 +28,13 @@
  * @section DESCRIPTION
  *
  * Tests the segmented mimo node class
+ *
+ * @todo: Need to get better syntax for Edge with shared_ptr
  */
 
 #include "unit_segmented_mimo_nodes.h"
 
+#include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/nodes/generators.h"
 #include "experimental/tiledb/common/dag/nodes/terminals.h"
 
@@ -39,6 +42,11 @@
 #include "experimental/tiledb/common/dag/state_machine/test/types.h"
 
 #include "experimental/tiledb/common/dag/nodes/detail/segmented/mimo.h"
+#include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
+#include "experimental/tiledb/common/dag/utility/print_types.h"
+
 
 using namespace tiledb::common;
 
@@ -49,37 +57,43 @@ TEST_CASE("mimo_node: Verify various API approaches", "[segmented_mimo]") {
       AsyncMover3,
       std::tuple<size_t, double>>
       x{};
+  CHECK(x->num_inputs() == 2);
+  CHECK(x->num_outputs() == 2);
   [[maybe_unused]] mimo_node<
       AsyncMover2,
       std::tuple<int>,
       AsyncMover3,
       std::tuple<size_t, double>>
       y{};
+  CHECK(y->num_inputs() == 1);
+  CHECK(y->num_outputs() == 2);
   [[maybe_unused]] mimo_node<
       AsyncMover2,
       std::tuple<char*>,
       AsyncMover3,
       std::tuple<size_t, std::tuple<int, float>>>
       z{};
+  CHECK(z->num_inputs() == 1);
+  CHECK(z->num_outputs() == 2);
   [[maybe_unused]] mimo_node<
       AsyncMover2,
       std::tuple<int, char, double, double, double>,
       AsyncMover3,
       std::tuple<int>>
       a{};
+  CHECK(a->num_inputs() == 5);
+  CHECK(a->num_outputs() == 1);
 }
 
 TEST_CASE(
     "mimo_node: Verify construction with simple function", "[segmented_mimo]") {
   [[maybe_unused]] mimo_node<
       AsyncMover2,
-      std::tuple<size_t>,
+      std::tuple<size_t, size_t>,
       AsyncMover3,
-      std::tuple<size_t>>
-      x{[](std::tuple<size_t>, std::tuple<size_t>) {}};
+      std::tuple<size_t, char*>>
+      x{[](const std::tuple<size_t, size_t>&){ return std::tuple<size_t, char*> {};} };
 }
-
-#if 0
 
 
 
@@ -89,8 +103,18 @@ TEST_CASE(
       AsyncMover2,
       std::tuple<size_t, int>,
       AsyncMover3,
-      std::tuple<size_t, double>>
-      x{[](std::tuple<size_t, int>, std::tuple<size_t, double>) {}};
+      std::tuple<size_t, double, float>>
+      x{[](std::tuple<size_t, int>) { return std::tuple<size_t, double, float>{};}};
+  CHECK(x->num_inputs() == 2);
+  CHECK(x->num_outputs() == 3);
+}
+
+
+template <class... R, class... T>
+auto mimo(std::function<void(std::tuple<R...>, std::tuple<T...>)>&& f) {
+  // using U... = std::remove_cv_t<std::remove_reference_t<T...>>;
+  auto tmp = mimo_node<AsyncMover3, std::remove_cv_t<std::remove_reference_t<T>>..., AsyncMover3, R...>{f};
+  return tmp;
 }
 
 template <class T>
@@ -98,6 +122,17 @@ struct foo {
   void operator()() {
   }
 };
+
+
+TEST_CASE("mimo_node: Verify use of (void) template arguments for producer",
+          "[segmented_mimo]") {
+  mimo_node<foo, std::tuple<>, AsyncMover3, std::tuple<size_t, double>> x{
+      [](std::stop_source) { return std::tuple<size_t, double> {};}};
+  mimo_node<AsyncMover3, std::tuple<size_t, double>, foo, std::tuple<>> y{
+      [](std::tuple<size_t, double>) {}};
+  mimo_node<AsyncMover3, std::tuple<char*>, foo, std::tuple<>> z{
+      [](std::tuple<char*>) {}};
+}
 
 /*
  * @note Cannot use void for SinkMover_T nor SourceMover_T, because that must be
@@ -114,26 +149,27 @@ using GeneralProducerNode =
     mimo_node<foo, std::tuple<>, SourceMover_T, BlocksOut...>;
 
 template <template <class> class SinkMover_T, class... BlocksIn>
-using GeneralConsumerNode =
+using GeneralConsumerNode  =
     mimo_node<SinkMover_T, BlocksIn..., foo, std::tuple<>>;
 
 TEST_CASE(
     "mimo_node: Verify use of (void) template arguments for "
     "producer/consumer [general]") {
   GeneralProducerNode<AsyncMover3, std::tuple<size_t, double>> x{
-      [](std::tuple<size_t, double>) {}};
-  GeneralConsumerNode<AsyncMover3, std::tuple<size_t, double>> y{
+      [](std::stop_source) { return  std::tuple<size_t, double> {};}};
+  GeneralConsumerNode <AsyncMover3, std::tuple<size_t, double>> y{
       [](std::tuple<size_t, double>) {}};
 }
 
-TEST_CASE("mimo_node: Connect void-created Producer and Consumer [segmented_mimo]") {
+TEST_CASE(
+    "mimo_node: Connect void-created Producer and Consumer [segmented_mimo]") {
   GeneralProducerNode<AsyncMover3, std::tuple<size_t, double>> x{
-      [](std::tuple<size_t, double>) {}};
-  GeneralConsumerNode<AsyncMover3, std::tuple<double, size_t>> y{
+      [](std::stop_source) { return  std::tuple<size_t, double> {};}};
+  GeneralConsumerNode <AsyncMover3, std::tuple<double, size_t>> y{
       [](std::tuple<double, size_t>) {}};
 
-  Edge g{std::get<0>(x.outputs_), std::get<1>(y.inputs_)};
-  Edge h{std::get<1>(x.outputs_), std::get<0>(y.inputs_)};
+  Edge g{std::get<0>(x->outputs_), std::get<1>(y->inputs_)};
+  Edge h{std::get<1>(x->outputs_), std::get<0>(y->inputs_)};
 }
 
 TEST_CASE(
@@ -143,18 +179,25 @@ TEST_CASE(
   size_t ext2{0};
 
   GeneralProducerNode<AsyncMover3, std::tuple<size_t, double>> x{
-      [](std::tuple<size_t, double>& a) { a = std::make_tuple(5UL, 3.14159); }};
+      [](std::stop_source) { auto a = std::make_tuple(5UL, 3.14159); return a; }};
   GeneralConsumerNode<AsyncMover3, std::tuple<double, size_t>> y{
       [&ext1, &ext2](const std::tuple<double, size_t>& b) {
         ext1 = std::get<0>(b);
         ext2 = std::get<1>(b);
       }};
 
-  Edge g{std::get<0>(x.outputs_), std::get<1>(y.inputs_)};
-  Edge h{std::get<1>(x.outputs_), std::get<0>(y.inputs_)};
+  Edge g{std::get<0>(x->outputs_), std::get<1>(y->inputs_)};
+  Edge h{std::get<1>(x->outputs_), std::get<0>(y->inputs_)};
 
-  x.resume();
-  y.resume();
+
+  [[maybe_unused]] auto foo = x->resume();
+  [[maybe_unused]] auto bar = y->resume();
+  foo = x->resume();
+  bar = y->resume();
+  foo = x->resume();
+  bar = y->resume();
+  foo = x->resume();
+  bar = y->resume();
 
   CHECK(ext1 == 3.14159);
   CHECK(ext2 == 5);
@@ -164,20 +207,27 @@ TEST_CASE(
  * Some dummy functions and classes to test node constructors
  * with.
  */
-size_t dummy_source() {
+size_t dummy_source(std::stop_source&) {
   return size_t{};
 }
 
-void dummy_function(const std::tuple<size_t>& in, std::tuple<size_t>& out) {
-  out = in;
+auto dummy_general_source(std::stop_source) {
+  return std::tuple<size_t>{};
+}
+
+auto dummy_function(const std::tuple<size_t>& in) {
+  return in;
 }
 
 void dummy_sink(size_t) {
 }
 
+void dummy_general_sink(const std::tuple<size_t>&) {
+}
+
 class dummy_source_class {
  public:
-  size_t operator()() {
+  size_t operator()(std::stop_source&) {
     return size_t{};
   }
 };
@@ -187,8 +237,8 @@ class dummy_function_class {
   size_t operator()(const size_t&) {
     return size_t{};
   }
-  void operator()(const std::tuple<size_t>& in, std::tuple<size_t>& out) {
-    out = in;
+  auto operator()(const std::tuple<size_t>& in) {
+    return in;
   }
 };
 
@@ -198,84 +248,95 @@ class dummy_sink_class {
   }
 };
 
-size_t dummy_bind_source(double) {
+size_t dummy_bind_source(std::stop_source&, double) {
   return size_t{};
 }
 
-void dummy_bind_function(
-    double, float, const std::tuple<size_t>& in, std::tuple<size_t>& out) {
-  out = in;
+auto dummy_bind_function(
+    double, float, const std::tuple<size_t>& in) {
+  return in;
 }
 
 void dummy_bind_sink(size_t, float, const int&) {
 }
 
+
 TEST_CASE("mimo_node: Verify simple connections", "[segmented_mimo]") {
   SECTION("function") {
-    ProducerNode<AsyncMover3, size_t> a{dummy_source};
+    GeneralProducerNode<AsyncMover3, std::tuple<size_t>> a{dummy_general_source};
 
-    mimo_node<
-        AsyncMover3,
-        std::tuple<size_t>,
-        AsyncMover3,
-        std::tuple<size_t>>
+    mimo_node<AsyncMover3, std::tuple<size_t>, AsyncMover3, std::tuple<size_t>>
         b{dummy_function};
-    ConsumerNode<AsyncMover3, size_t> c{dummy_sink};
+    GeneralConsumerNode<AsyncMover3, std::tuple<size_t>> c{dummy_general_sink};
 
-    ProducerNode<AsyncMover2, size_t> d{dummy_source};
+    producer_node<AsyncMover2, size_t> d{dummy_source};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{dummy_function};
-    ConsumerNode<AsyncMover2, size_t> f{dummy_sink};
+    consumer_node<AsyncMover2, size_t> f{dummy_sink};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{std::get<0>(a->outputs_), std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), std::get<0>(c->inputs_)};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    // @todo: Why were we trying this?
+    Edge<AsyncMover2, size_t> i{*d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
+
+    {
+      producer_node_impl<AsyncMover2, size_t> x{dummy_source};
+      consumer_node_impl<AsyncMover2, size_t> y{dummy_sink};
+      // Edge<AsyncMover2, size_t> bb{x, y};
+      Edge cc{x, y};
+
+      auto foo = std::make_shared<producer_node_impl<AsyncMover2, size_t>>(dummy_source);
+      auto bar = std::make_shared<consumer_node_impl<AsyncMover2, size_t>>(dummy_sink);
+
+      // Edge<AsyncMover2, size_t> dd{foo, bar};
+      Edge dd{foo, bar};
+    }
+
   }
 
   SECTION("lambda") {
-    auto dummy_source_lambda = []() { return 0UL; };
-    auto dummy_function_lambda = [](const std::tuple<size_t>& in,
-                                    std::tuple<size_t>& out) { out = in; };
+    auto dummy_source_lambda = [](std::stop_source&) { return 0UL; };
+    auto dummy_function_lambda = [](const std::tuple<size_t>& in){ return in; };
     auto dummy_sink_lambda = [](size_t) {};
 
-    ProducerNode<AsyncMover3, size_t> a{dummy_source_lambda};
+    producer_node<AsyncMover3, size_t> a{dummy_source_lambda};
     mimo_node<AsyncMover3, std::tuple<size_t>> b{
         dummy_function_lambda};
-    ConsumerNode<AsyncMover3, size_t> c{dummy_sink_lambda};
+    consumer_node <AsyncMover3, size_t> c{dummy_sink_lambda};
 
-    ProducerNode<AsyncMover2, size_t> d{dummy_source_lambda};
+    producer_node <AsyncMover2, size_t> d{dummy_source_lambda};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{
         dummy_function_lambda};
-    ConsumerNode<AsyncMover2, size_t> f{dummy_sink_lambda};
+    consumer_node <AsyncMover2, size_t> f{dummy_sink_lambda};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    // Edge i{d, std::get<0>(e->inputs_)};
+    // Edge j{std::get<0>(e->outputs_), f};
   }
 
   SECTION("inline lambda") {
-    ProducerNode<AsyncMover3, size_t> a([]() { return 0UL; });
+    producer_node <AsyncMover3, size_t> a([](std::stop_source&) { return 0UL; });
     mimo_node<AsyncMover3, std::tuple<size_t>> b(
-        [](const std::tuple<size_t>& in, std::tuple<size_t>& out) {
-          out = in;
+        [](const std::tuple<size_t>& in) {
+          return in;
         });
-    ConsumerNode<AsyncMover3, size_t> c([](size_t) {});
+    consumer_node <AsyncMover3, size_t> c([](size_t) {});
 
-    ProducerNode<AsyncMover2, size_t> d([]() { return 0UL; });
+    producer_node <AsyncMover2, size_t> d([](std::stop_source&) { return 0UL; });
     mimo_node<AsyncMover2, std::tuple<size_t>> e(
-        [](const std::tuple<size_t>& in, std::tuple<size_t>& out) {
-          out = in;
+        [](const std::tuple<size_t>& in) {
+          return in;
         });
-    ConsumerNode<AsyncMover2, size_t> f([](size_t) {});
+    consumer_node <AsyncMover2, size_t> f([](size_t) {});
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    Edge i{d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
   }
 
   SECTION("function object") {
@@ -283,66 +344,65 @@ TEST_CASE("mimo_node: Verify simple connections", "[segmented_mimo]") {
     dummy_function_class fc{};
     dummy_sink_class dc{};
 
-    ProducerNode<AsyncMover3, size_t> a{ac};
+    producer_node <AsyncMover3, size_t> a{ac};
     mimo_node<AsyncMover3, std::tuple<size_t>> b{fc};
-    ConsumerNode<AsyncMover3, size_t> c{dc};
+    consumer_node <AsyncMover3, size_t> c{dc};
 
-    ProducerNode<AsyncMover2, size_t> d{ac};
+    producer_node <AsyncMover2, size_t> d{ac};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{fc};
-    ConsumerNode<AsyncMover2, size_t> f{dc};
+    consumer_node <AsyncMover2, size_t> f{dc};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    Edge i{d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
   }
 
   SECTION("inline function object") {
-    ProducerNode<AsyncMover3, size_t> a{dummy_source_class{}};
+    producer_node <AsyncMover3, size_t> a{dummy_source_class{}};
     mimo_node<AsyncMover3, std::tuple<size_t>> b{
         dummy_function_class{}};
-    ConsumerNode<AsyncMover3, size_t> c{dummy_sink_class{}};
+    consumer_node <AsyncMover3, size_t> c{dummy_sink_class{}};
 
-    ProducerNode<AsyncMover2, size_t> d{dummy_source_class{}};
+    producer_node <AsyncMover2, size_t> d{dummy_source_class{}};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{
         dummy_function_class{}};
-    ConsumerNode<AsyncMover2, size_t> f{dummy_sink_class{}};
+    consumer_node <AsyncMover2, size_t> f{dummy_sink_class{}};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    Edge i{d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
   }
-
+#if 1
   SECTION("bind") {
     double x = 0.01;
     float y = -0.001;
     int z = 8675309;
 
-    auto ac = std::bind(dummy_bind_source, x);
+    auto ac = std::bind(dummy_bind_source, std::placeholders::_1, x);
     auto dc = std::bind(dummy_bind_sink, y, std::placeholders::_1, z);
     auto fc = std::bind(
         dummy_bind_function,
         x,
         y,
-        std::placeholders::_1,
-        std::placeholders::_2);
+        std::placeholders::_1);
 
-    ProducerNode<AsyncMover3, size_t> a{ac};
+    producer_node <AsyncMover3, size_t> a{ac};
     mimo_node<AsyncMover3, std::tuple<size_t>> b{fc};
-    ConsumerNode<AsyncMover3, size_t> c{dc};
+    consumer_node <AsyncMover3, size_t> c{dc};
 
-    ProducerNode<AsyncMover2, size_t> d{ac};
+    producer_node <AsyncMover2, size_t> d{ac};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{fc};
-    ConsumerNode<AsyncMover2, size_t> f{dc};
+    consumer_node <AsyncMover2, size_t> f{dc};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    Edge i{d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
   }
 
   SECTION("inline bind") {
@@ -350,31 +410,29 @@ TEST_CASE("mimo_node: Verify simple connections", "[segmented_mimo]") {
     float y = -0.001;
     int z = 8675309;
 
-    ProducerNode<AsyncMover3, size_t> a{std::bind(dummy_bind_source, x)};
+    producer_node <AsyncMover3, size_t> a{std::bind(dummy_bind_source, std::placeholders::_1, x)};
     mimo_node<AsyncMover3, std::tuple<size_t>> b{std::bind(
         dummy_bind_function,
         x,
         y,
-        std::placeholders::_1,
-        std::placeholders::_2)};
-    ConsumerNode<AsyncMover3, size_t> c{
+        std::placeholders::_1)};
+    consumer_node <AsyncMover3, size_t> c{
         std::bind(dummy_bind_sink, y, std::placeholders::_1, z)};
 
-    ProducerNode<AsyncMover2, size_t> d{std::bind(dummy_bind_source, x)};
+    producer_node <AsyncMover2, size_t> d{std::bind(dummy_bind_source, std::placeholders::_1, x)};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{std::bind(
         dummy_bind_function,
         x,
         y,
-        std::placeholders::_1,
-        std::placeholders::_2)};
-    ConsumerNode<AsyncMover2, size_t> f{
+        std::placeholders::_1)};
+    consumer_node <AsyncMover2, size_t> f{
         std::bind(dummy_bind_sink, y, std::placeholders::_1, z)};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    Edge i{d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
   }
 
   SECTION("bind with move") {
@@ -382,59 +440,57 @@ TEST_CASE("mimo_node: Verify simple connections", "[segmented_mimo]") {
     float y = -0.001;
     int z = 8675309;
 
-    auto ac = std::bind(dummy_bind_source, std::move(x));
+    auto ac = std::bind(dummy_bind_source, std::placeholders::_1, std::move(x));
     auto dc = std::bind(
         dummy_bind_sink, std::move(y), std::placeholders::_1, std::move(z));
     auto fc = std::bind(
         dummy_bind_function,
         std::move(x),
         std::move(y),
-        std::placeholders::_1,
-        std::placeholders::_2);
+        std::placeholders::_1);
 
-    ProducerNode<AsyncMover3, size_t> a{std::move(ac)};
+    producer_node <AsyncMover3, size_t> a{std::move(ac)};
     mimo_node<AsyncMover3, std::tuple<size_t>> b{std::move(fc)};
-    ConsumerNode<AsyncMover3, size_t> c{std::move(dc)};
+    consumer_node <AsyncMover3, size_t> c{std::move(dc)};
 
-    ProducerNode<AsyncMover2, size_t> d{std::move(ac)};
+    producer_node <AsyncMover2, size_t> d{std::move(ac)};
     mimo_node<AsyncMover2, std::tuple<size_t>> e{std::move(fc)};
-    ConsumerNode<AsyncMover2, size_t> f{std::move(dc)};
+    consumer_node <AsyncMover2, size_t> f{std::move(dc)};
 
-    Edge g{a, std::get<0>(b.inputs_)};
-    Edge h{std::get<0>(b.outputs_), c};
+    Edge g{a, std::get<0>(b->inputs_)};
+    Edge h{std::get<0>(b->outputs_), c};
 
-    Edge i{d, std::get<0>(e.inputs_)};
-    Edge j{std::get<0>(e.outputs_), f};
+    Edge i{d, std::get<0>(e->inputs_)};
+    Edge j{std::get<0>(e->outputs_), f};
   }
+#endif
 }
 
 TEST_CASE("mimo_node: Verify compound connections", "[segmented_mimo]") {
   SECTION("inline lambda") {
-    ProducerNode<AsyncMover3, size_t> a1([]() { return 0UL; });
-    ProducerNode<AsyncMover3, double> a2([]() { return 0.0; });
+    producer_node <AsyncMover3, size_t> a1([](std::stop_source&) { return 0UL; });
+    producer_node <AsyncMover3, double> a2([](std::stop_source&) { return 0.0; });
     mimo_node<AsyncMover3, std::tuple<size_t, double>> b(
-        [](const std::tuple<size_t, double>& in,
-           std::tuple<size_t, double>& out) { out = in; });
-    ConsumerNode<AsyncMover3, size_t> c1([](size_t) {});
-    ConsumerNode<AsyncMover3, double> c2([](double) {});
+        [](const std::tuple<size_t, double>& in) { return in; });
+    consumer_node <AsyncMover3, size_t> c1([](size_t) {});
+    consumer_node <AsyncMover3, double> c2([](double) {});
 
-    ProducerNode<AsyncMover2, size_t> d1([]() { return 0UL; });
-    ProducerNode<AsyncMover2, double> d2([]() { return 0.0; });
+    producer_node <AsyncMover2, size_t> d1([](std::stop_source&) { return 0UL; });
+    producer_node <AsyncMover2, double> d2([](std::stop_source&) { return 0.0; });
     mimo_node<AsyncMover2, std::tuple<size_t, double>> e(
-        [](const std::tuple<size_t, double>& in,
-           std::tuple<size_t, double>& out) { out = in; });
-    ConsumerNode<AsyncMover2, size_t> f1([](size_t) {});
-    ConsumerNode<AsyncMover2, double> f2([](double) {});
+        [](const std::tuple<size_t, double>& in) { return in; });
+    consumer_node <AsyncMover2, size_t> f1([](size_t) {});
+    consumer_node <AsyncMover2, double> f2([](double) {});
 
-    Edge g1{a1, std::get<0>(b.inputs_)};
-    Edge g2{a2, std::get<1>(b.inputs_)};
-    Edge h1{std::get<0>(b.outputs_), c1};
-    Edge h2{std::get<1>(b.outputs_), c2};
+    Edge g1{a1, std::get<0>(b->inputs_)};
+    Edge g2{a2, std::get<1>(b->inputs_)};
+    Edge h1{std::get<0>(b->outputs_), c1};
+    Edge h2{std::get<1>(b->outputs_), c2};
 
-    Edge i1{d1, std::get<0>(e.inputs_)};
-    Edge i2{d2, std::get<1>(e.inputs_)};
-    Edge j1{std::get<0>(e.outputs_), f1};
-    Edge j2{std::get<1>(e.outputs_), f2};
+    Edge i1{d1, std::get<0>(e->inputs_)};
+    Edge i2{d2, std::get<1>(e->inputs_)};
+    Edge j1{std::get<0>(e->outputs_), f1};
+    Edge j2{std::get<1>(e->outputs_), f2};
   }
 }
 
@@ -446,36 +502,66 @@ TEST_CASE(
     "Nodes: Manually pass some data in a chain with a one component general "
     "function node [segmented_mimo]") {
   size_t i{0UL};
-  ProducerNode<AsyncMover2, size_t> q([&]() { return i++; });
+  producer_node <AsyncMover2, size_t> q([&](std::stop_source) { return i++; });
 
   mimo_node<AsyncMover2, std::tuple<size_t>> r(
-      [&](const std::tuple<std::size_t>& in, std::tuple<std::size_t>& out) {
-        std::get<0>(out) = 2 * std::get<0>(in);
+      [&](const std::tuple<std::size_t>& in) {
+        return std::make_tuple(2 * std::get<0>(in))   ;
       });
 
   std::vector<size_t> v;
-  ConsumerNode<AsyncMover2, size_t> s([&](size_t i) { v.push_back(i); });
+  consumer_node <AsyncMover2, size_t> s([&](size_t i) { v.push_back(i); });
 
-  Edge g{q, std::get<0>(r.inputs_)};
-  Edge h{std::get<0>(r.outputs_), s};
+  Edge g{q, std::get<0>(r->inputs_)};
+  Edge h{std::get<0>(r->outputs_), s};
+  connect(q, r);
+  connect(r, s);
 
-  q.resume();
-  r.resume();
-  s.resume();
+  q->resume();  // fill  10 / 00
+  q->resume();  // push  01 / 00
+  q->resume();  // yield 01 / 00
+  q->resume();  // fill  11
+
+  r->resume();  // pull   11 / 00
+  r->resume();  // drain  10 / 00
+  r->resume();  // fill   10 / 10
+  r->resume();  // push   10 / 01
+  r->resume();  // yield  10 / 01
+  r->resume();  // pull   01 / 01
+  r->resume();  // drain  00 / 01
+  r->resume();  // fill   00 / 11
+
+  s->resume();  // pull    00 / 11
+  s->resume();  // drain   00 / 10
+  s->resume();  // yield
 
   CHECK(v.size() == 1);
 
-  q.resume();
-  r.reset();
-  r.resume();
-  s.resume();
+  q->resume();  // push  00 / 01
+  r->resume();  // push  00 / 01
+  s->resume();  // pull  00 / 01
+  s->resume();  // drain 00 / 00
+  s->resume();  // yield
 
   CHECK(v.size() == 2);
 
-  q.resume();
-  r.reset();
-  r.resume();
-  s.resume();
+  q->resume();  // yield 00 / 00
+  r->resume();  // yield 00 / 00
+
+  q->resume(); // fill  10 / 00
+  q->resume(); // push  01 / 00
+  q->resume(); // yield 01 / 00
+
+  r->resume(); // pull  01 / 00
+  r->resume(); // drain 00 / 00
+  r->resume(); // fill  00 / 10
+
+  s->resume(); // pull  00 / 01
+  s->resume(); // drain 00 / 00
+
+  CHECK(v.size() == 2);
+
+  s->resume(); // yield
 
   CHECK(v.size() == 3);
 
@@ -493,66 +579,129 @@ TEST_CASE(
     "function node [segmented_mimo]") {
   size_t i{0UL};
   double j{0.0};
-  ProducerNode<AsyncMover2, size_t> q1([&]() { return i++; });
-  ProducerNode<AsyncMover2, double> q2([&]() { return j++; });
+  producer_node <AsyncMover2, size_t> q1([&](std::stop_source&) { return i++; });
+  producer_node <AsyncMover2, double> q2([&](std::stop_source&) { return j++; });
 
   mimo_node<
       AsyncMover2,
       std::tuple<size_t, double>,
       AsyncMover2,
       std::tuple<double, size_t>>
-      r([&](const std::tuple<size_t, double>& in,
-            std::tuple<double, std::size_t>& out) {
-        std::get<1>(out) = 2 * std::get<0>(in);
-        std::get<0>(out) = 3.0 * std::get<1>(in);
+      r([&](const std::tuple<size_t, double>& in) {
+        return std::make_tuple(2 * std::get<0>(in), 3.0 * std::get<1>(in));
       });
 
   std::vector<double> v;
   std::vector<size_t> w;
-  ConsumerNode<AsyncMover2, double> s1([&](size_t i) { v.push_back(i); });
-  ConsumerNode<AsyncMover2, size_t> s2([&](size_t i) { w.push_back(i); });
+  consumer_node <AsyncMover2, double> s1([&](double i) { v.push_back(i); });
+  consumer_node <AsyncMover2, size_t> s2([&](size_t i) { w.push_back(i); });
 
-  Edge g1{q1, std::get<0>(r.inputs_)};
-  Edge g2{q2, std::get<1>(r.inputs_)};
-  Edge h1{std::get<0>(r.outputs_), s1};
-  Edge h2{std::get<1>(r.outputs_), s2};
+  Edge g1{q1, std::get<0>(r->inputs_)};
+  Edge g2{q2, std::get<1>(r->inputs_)};
 
-  q1.resume();
-  q2.resume();
-  r.resume();
-  s1.resume();
-  s2.resume();
+  // print_types(r->outputs_, std::get<0>(r->outputs_), std::get<1>(r->outputs_),s1, s2);
+
+  Edge h1{std::get<0>(r->outputs_), s1};
+  Edge h2{std::get<1>(r->outputs_), s2};
+  connect(q1, r);
+  connect(q2, r);
+  connect(r, s1);
+  connect(r, s2);
+
+  q1->resume(); // fill  10 / 00
+  q2->resume(); // fill  10 : 10 / 00 : 00
+  r->resume();  // pull  01 : 01 / 00 : 00
+  r->resume();  // drain 00 : 00 / 00 : 00
+  r->resume();  // fill  00 : 00 / 10 : 10
+
+  s1->resume(); // pull  00 : 00 / 01 : 10
+  s2->resume(); // pull  00 : 00 / 01 : 01
+  s1->resume(); // drain 00 : 00 / 00 : 01
+  s1->resume(); // yield 00 : 00 / 00 : 01
+
+  CHECK(v.size() == 1);
+  CHECK(w.size() == 0);
+
+  s2->resume(); // drain 00 : 00 / 00 : 00
+  s2->resume(); // yield 00 : 00 / 00 : 00
 
   CHECK(v.size() == 1);
   CHECK(w.size() == 1);
 
-  q1.resume();
-  q2.resume();
-  r.reset();
-  r.resume();
-  s1.resume();
-  s2.resume();
+  q1->resume(); // push  00 : 00 / 00 : 00
+  q1->resume(); // yield 00 : 00 / 00 : 00
+  q1->resume(); // fill  10 : 00 / 00 : 00
+  q1->resume(); // push  01 : 00 / 00 : 00
+  q1->resume(); // yield 01 : 00 / 00 : 00
+
+  q2->resume(); // push  01 : 00 / 00 : 00
+  q2->resume(); // yield 01 : 00 / 00 : 00
+  q2->resume(); // fill  01 : 10 / 00 : 00
+
+  r->resume();  // push  01 : 10 / 00 : 00
+  r->resume();  // yield 01 : 10 / 00 : 00
+  r->resume();  // pull  01 : 01 / 00 : 00
+  r->resume();  // drain 00 : 00 / 00 : 00
+  r->resume();  // fill  00 : 00 / 10 : 10
+  s1->resume(); // pull  00 : 00 / 01 : 10
+  r->resume();  // push  00 : 00 / 01 : 01
+  r->resume();  // yield 00 : 00 / 01 : 01
+
+  CHECK(v.size() == 1);
+  CHECK(w.size() == 1);
+
+  s2->resume(); // pull  00 : 00 / 01 : 01
+  s2->resume(); // drain 00 : 00 / 01 : 00
+  s2->resume(); // yield 00 : 00 / 01 : 00
+  s1->resume(); // drain 00 : 00 / 00 : 00
+  s1->resume(); // yield 00 : 00 / 00 : 00
 
   CHECK(v.size() == 2);
   CHECK(w.size() == 2);
 
-  q1.resume();
-  q2.resume();
-  r.reset();
-  r.resume();
-  s1.resume();
-  s2.resume();
+  q1->resume(); // fill  10 : 00 / 00 : 00
+  q2->resume(); // push  10 : 00 / 00 : 00
+  q2->resume(); // yield 10 : 00 / 00 : 00
+  q2->resume(); // fill  10 : 10 / 00 : 00
+  r->resume();  // pull  01 : 01 / 00 : 00
+  r->resume();  // drain 00 : 00 / 00 : 00
+  r->resume();  // fill  00 : 00 / 10 : 10
+
+  s1->resume(); // pull  00 : 00 / 01 : 10
+  s2->resume(); // pull  00 : 00 / 01 : 01
+  s1->resume(); // drain 00 : 00 / 00 : 01
+  s1->resume(); // yield 00 : 00 / 00 : 01
+
+  CHECK(v.size() == 3);
+  CHECK(w.size() == 2);
+
+  s2->resume(); // drain 00 : 00 / 00 : 00
+  s2->resume(); // yield 00 : 00 / 00 : 00
 
   CHECK(v.size() == 3);
   CHECK(w.size() == 3);
 
   CHECK(w[0] == 0);
-  CHECK(w[1] == 2);
-  CHECK(w[2] == 4);
+  CHECK(w[1] == 3);
+  CHECK(w[2] == 6);
   CHECK(v[0] == 0.0);
-  CHECK(v[1] == 3.0);
-  CHECK(v[2] == 6.0);
+  CHECK(v[1] == 2.0);
+  CHECK(v[2] == 4.0);
 }
+
+
+template <class Node>
+auto run_for(Node& node, size_t rounds) {
+  return [&node, rounds]() {
+    size_t N = rounds;
+    while (N) {
+      auto code = node->resume();
+      if (code == SchedulerAction::yield)
+        --N;
+    }
+  };
+}
+
 
 /**
  * Test that we can asynchronously send data from a producer to an attached
@@ -577,14 +726,14 @@ void asynchronous_with_function_node(
   std::vector<size_t> w;
   size_t i{0};
 
-  ProducerNode<AsyncMover2, size_t> q1([&]() {
+  producer_node <AsyncMover2, size_t> q1([&](std::stop_source&) {
     if constexpr (delay) {
       std::this_thread::sleep_for(std::chrono::microseconds(
           static_cast<size_t>(qwt * random_us(1234))));
     }
     return i++;
   });
-  ProducerNode<AsyncMover2, double> q2([&]() {
+  producer_node <AsyncMover2, double> q2([&](std::stop_source&) {
     if constexpr (delay) {
       std::this_thread::sleep_for(std::chrono::microseconds(
           static_cast<size_t>(qwt * random_us(1234))));
@@ -597,24 +746,22 @@ void asynchronous_with_function_node(
       std::tuple<size_t, double>,
       AsyncMover2,
       std::tuple<double, size_t>>
-      r([&](const std::tuple<size_t, double>& in,
-            std::tuple<double, size_t>& out) {
+      r([&](const std::tuple<size_t, double>& in) {
         if constexpr (delay) {
           std::this_thread::sleep_for(std::chrono::microseconds(
               static_cast<size_t>(rwt * random_us(1234))));
         }
-        std::get<0>(out) = 3 * std::get<1>(in);
-        std::get<1>(out) = 5.0 * std::get<0>(in);
+        return std::make_tuple(3 * std::get<1>(in), 5.0 * std::get<0>(in));
       });
 
-  ConsumerNode<AsyncMover2, size_t> s1([&](size_t i) {
+  consumer_node <AsyncMover2, size_t> s1([&](size_t i) {
     v.push_back(i);
     if constexpr (delay) {
       std::this_thread::sleep_for(std::chrono::microseconds(
           static_cast<size_t>(swt * random_us(1234))));
     }
   });
-  ConsumerNode<AsyncMover2, double> s2([&](double i) {
+  consumer_node <AsyncMover2, double> s2([&](double i) {
     w.push_back(i);
     if constexpr (delay) {
       std::this_thread::sleep_for(std::chrono::microseconds(
@@ -622,45 +769,20 @@ void asynchronous_with_function_node(
     }
   });
 
-  Edge g1{q1, std::get<0>(r.inputs_)};
-  Edge g2{q2, std::get<1>(r.inputs_)};
-  Edge h1{std::get<1>(r.outputs_), s1};
-  Edge h2{std::get<0>(r.outputs_), s2};
+  Edge g1{q1, std::get<0>(r->inputs_)};
+  Edge g2{q2, std::get<1>(r->inputs_)};
+  Edge h1{std::get<1>(r->outputs_), s1};
+  Edge h2{std::get<0>(r->outputs_), s2};
+  connect(q1, r);
+  connect(q2, r);
+  connect(r, s1);
+  connect(r, s2);
 
-  auto fun_a1 = [&]() {
-    size_t N = rounds;
-    while (N--) {
-      q1.resume();
-    }
-  };
-  auto fun_a2 = [&]() {
-    size_t N = rounds;
-    while (N--) {
-      q2.resume();
-    }
-  };
-
-  auto fun_b = [&]() {
-    size_t N = rounds;
-    while (N--) {
-      r.resume();
-      r.reset();
-    }
-  };
-
-  auto fun_c1 = [&]() {
-    size_t N = rounds;
-    while (N--) {
-      s1.resume();
-    }
-  };
-
-  auto fun_c2 = [&]() {
-    size_t N = rounds;
-    while (N--) {
-      s2.resume();
-    }
-  };
+  auto fun_a1 = run_for(q1, rounds);
+  auto fun_a2 = run_for(q2, rounds);
+  auto fun_b = run_for(r, rounds);
+  auto fun_c1 = run_for(s1, rounds);
+  auto fun_c2 = run_for(s2, rounds);
 
   CHECK(v.size() == 0);
   CHECK(w.size() == 0);
@@ -752,16 +874,41 @@ TEST_CASE("Nodes: Asynchronous with function node and delay", "[nodes]") {
   }
 }
 
+
 /**
  * Test that we can correctly pass a sequence of integers from producer node to
  * consumer node.
  */
-TEST_CASE(
+class zero{};
+class one{};
+class two{};
+class three{};
+
+TEMPLATE_TEST_CASE(
     "Nodes: Async pass n integers, three nodes, "
     "three stage",
-    "[nodes]") {
+    "[nodes]",
+        (std::tuple<producer_node <AsyncMover3, size_t>,
+        producer_node <AsyncMover3, double>,
+        consumer_node <AsyncMover3, double>,
+         consumer_node <AsyncMover3, size_t>, zero>),
+        (std::tuple<producer_node <AsyncMover3, size_t>,
+                    producer_node <AsyncMover3, double>,
+                    consumer_node <AsyncMover3, double>,
+                    consumer_node <AsyncMover3, size_t>, one>)/*,
+    (std::tuple<GeneralProducerNode <AsyncMover3, std::tuple<size_t>>,
+                GeneralProducerNode <AsyncMover3, std::tuple<double>>,
+                GeneralConsumerNode <AsyncMover3, std::tuple<double>>,
+                GeneralConsumerNode <AsyncMover3, std::tuple<size_t>>, two>)*/
+){
   size_t rounds = GENERATE(0, 1, 2, 5, 3379);
   size_t offset = GENERATE(0, 1, 2, 5);
+
+  using P1 = std::tuple_element_t<0, TestType>;
+  using P2 = std::tuple_element_t<1, TestType>;
+  using C1 = std::tuple_element_t<2, TestType>;
+  using C2 = std::tuple_element_t<3, TestType>;
+  using NO = std::tuple_element_t<4, TestType>;
 
   [[maybe_unused]] constexpr bool debug = false;
 
@@ -789,35 +936,48 @@ TEST_CASE(
     CHECK(std::equal(input2.begin(), input2.end(), output2.begin()) == false);
   }
 
-  ProducerNode<AsyncMover3, size_t> source_node1(generators{19});
-  ProducerNode<AsyncMover3, double> source_node2(generators{337});
+  // Can't do this because generator returns its result,
+  // whereas the mimo node takes the result by reference.
+  P1 source_node1(generators{19});
+  P2 source_node2(generators{337});
 
   mimo_node<
       AsyncMover3,
       std::tuple<size_t, double>,
       AsyncMover3,
       std::tuple<double, size_t>>
-      mid_node([](const std::tuple<size_t, double>& in,
-                  std::tuple<double, size_t>& out) {
-        std::get<0>(out) = std::get<1>(in);
-        std::get<1>(out) = std::get<0>(in);
+      mid_node([](const std::tuple<size_t, double>& in) {
+        return std::make_tuple(std::get<1>(in), std::get<0>(in));
       });
 
-  ConsumerNode<AsyncMover3, double> sink_node1(
+  C1 sink_node1(
       terminal<decltype(j1), double>{j1});
-  ConsumerNode<AsyncMover3, size_t> sink_node2(
+  C2 sink_node2(
       terminal<decltype(j2), size_t>{j2});
 
-  Edge(source_node1, std::get<0>(mid_node.inputs_));
-  Edge(source_node2, std::get<1>(mid_node.inputs_));
-  Edge(std::get<0>(mid_node.outputs_), sink_node1);
-  Edge(std::get<1>(mid_node.outputs_), sink_node2);
 
-  auto source1 = [&]() { source_node1.run_for(rounds); };
-  auto source2 = [&]() { source_node2.run_for(rounds); };
-  auto mid = [&]() { mid_node.run_for(rounds + offset); };
-  auto sink1 = [&]() { sink_node1.run_for(rounds); };
-  auto sink2 = [&]() { sink_node2.run_for(rounds); };
+  auto source1 = run_for(source_node1, rounds);
+  auto source2 = run_for(source_node2, rounds);
+  auto mid = run_for(mid_node, rounds);
+  auto sink1 = run_for(sink_node1, rounds);
+  auto sink2 = run_for(sink_node2, rounds);
+
+  if constexpr(std::is_same_v<NO, zero>  || std::is_same_v<NO, one>){
+    Edge(source_node1, std::get<0>(mid_node->inputs_));
+    Edge(source_node2, std::get<1>(mid_node->inputs_));
+    Edge(std::get<0>(mid_node->outputs_), sink_node1);
+    Edge(std::get<1>(mid_node->outputs_), sink_node2);
+  } else {
+    Edge(std::get<0>(source_node1->outputs_), std::get<0>(mid_node->inputs_));
+    Edge(std::get<0>(source_node2->outputs_), std::get<1>(mid_node->inputs_));
+    Edge(std::get<0>(mid_node->outputs_), std::get<0>(sink_node1->inputs_));
+    Edge(std::get<1>(mid_node->outputs_), std::get<0>(sink_node2->inputs_));
+  }
+
+  connect(source_node1, mid_node);
+  connect(source_node2, mid_node);
+  connect(mid_node, sink_node1);
+  connect(mid_node, sink_node2);
 
   SECTION(
       "test source launch, sink launch, source "
@@ -948,4 +1108,18 @@ TEST_CASE(
   CHECK(std::equal(input1.begin(), i1, output2.begin()));
   CHECK(std::equal(input2.begin(), i2, output1.begin()));
 }
+
+#if 0
+// Repeat one of the tests above but with one-sided mimo nodes
+// Annoying -- required different interface than special-purpose nodes
+// @todo: fix this
+// Best solution is probably to give mimo nodes the same
+// interface as special-purpose nodes
+
+// Repeat one of the tests above but with mimo connected to mimo and
+// with differen cardinalities on input and output
+
+// Repeat one of the tests above but with stop token
+
+
 #endif

--- a/experimental/tiledb/common/dag/nodes/test/unit_segmented_mimo_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_segmented_mimo_nodes.cc
@@ -1,5 +1,5 @@
 /**
- * @file unit_osegmented_mimo_nodes.cc
+ * @file unit_segmented_mimo_nodes.cc
  *
  * @section LICENSE
  *
@@ -113,7 +113,6 @@ TEST_CASE(
 
 template <class... R, class... T>
 auto mimo(std::function<void(std::tuple<R...>, std::tuple<T...>)>&& f) {
-  // using U... = std::remove_cv_t<std::remove_reference_t<T...>>;
   auto tmp = mimo_node<
       AsyncMover3,
       std::remove_cv_t<std::remove_reference_t<T>>...,
@@ -319,9 +318,6 @@ TEST_CASE("mimo_node: Verify simple connections", "[segmented_mimo]") {
 
     Edge g{a, std::get<0>(b->inputs_)};
     Edge h{std::get<0>(b->outputs_), c};
-
-    // Edge i{d, std::get<0>(e->inputs_)};
-    // Edge j{std::get<0>(e->outputs_), f};
   }
 
   SECTION("inline lambda") {
@@ -593,9 +589,6 @@ TEST_CASE(
 
   Edge g1{q1, std::get<0>(r->inputs_)};
   Edge g2{q2, std::get<1>(r->inputs_)};
-
-  // print_types(r->outputs_, std::get<0>(r->outputs_),
-  // std::get<1>(r->outputs_),s1, s2);
 
   Edge h1{std::get<0>(r->outputs_), s1};
   Edge h2{std::get<1>(r->outputs_), s2};
@@ -892,12 +885,7 @@ TEMPLATE_TEST_CASE(
         producer_node<AsyncMover3, double>,
         consumer_node<AsyncMover3, double>,
         consumer_node<AsyncMover3, size_t>,
-        one>)/*,
-(std::tuple<GeneralProducerNode <AsyncMover3, std::tuple<size_t>>,
-GeneralProducerNode <AsyncMover3, std::tuple<double>>,
-GeneralConsumerNode <AsyncMover3, std::tuple<double>>,
-GeneralConsumerNode <AsyncMover3, std::tuple<size_t>>, two>)*/
-) {
+        one>)) {
   size_t rounds = GENERATE(0, 1, 2, 5, 3379);
   size_t offset = GENERATE(0, 1, 2, 5);
 

--- a/experimental/tiledb/common/dag/nodes/test/unit_segmented_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_segmented_nodes.cc
@@ -36,6 +36,7 @@
 #include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/nodes/generators.h"
 #include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
 #include "experimental/tiledb/common/dag/nodes/terminals.h"
 #include "experimental/tiledb/common/dag/state_machine/test/types.h"
 #include "experimental/tiledb/common/dag/utility/print_types.h"
@@ -152,6 +153,13 @@ size_t dummy_function(size_t) {
 void dummy_sink(size_t) {
 }
 
+size_t dummy_const_function(const size_t&) {
+  return size_t{};
+}
+
+void dummy_const_sink(const size_t&) {
+}
+
 class dummy_source_class {
  public:
   size_t operator()(std::stop_source&) {
@@ -259,6 +267,25 @@ TEMPLATE_TEST_CASE(
     C c{dummy_sink};
     Edge g{*b, *c};
   }
+
+  SECTION("function with const reference") {
+    P b{dummy_source};
+    C c{dummy_const_sink};
+    Edge g{*b, *c};
+  }
+
+  SECTION("function, no star") {
+    P b{dummy_source};
+    C c{dummy_sink};
+    Edge g{b, c};
+  }
+
+  SECTION("function with const reference, no star") {
+    P b{dummy_source};
+    C c{dummy_const_sink};
+    Edge g{b, c};
+  }
+
 
   SECTION("lambda") {
     auto dummy_source_lambda = [](std::stop_source&) { return 0UL; };

--- a/experimental/tiledb/common/dag/nodes/test/unit_segmented_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_segmented_nodes.cc
@@ -34,9 +34,9 @@
 #include <type_traits>
 #include <variant>
 #include "experimental/tiledb/common/dag/edge/edge.h"
+#include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
 #include "experimental/tiledb/common/dag/nodes/generators.h"
 #include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
-#include "experimental/tiledb/common/dag/nodes/detail/segmented/edge_node_ctad.h"
 #include "experimental/tiledb/common/dag/nodes/terminals.h"
 #include "experimental/tiledb/common/dag/state_machine/test/types.h"
 #include "experimental/tiledb/common/dag/utility/print_types.h"
@@ -285,7 +285,6 @@ TEMPLATE_TEST_CASE(
     C c{dummy_const_sink};
     Edge g{b, c};
   }
-
 
   SECTION("lambda") {
     auto dummy_source_lambda = [](std::stop_source&) { return 0UL; };

--- a/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
@@ -1553,9 +1553,6 @@ TEMPLATE_TEST_CASE(
   CHECK(std::equal(input.begin(), i, output.begin()));
 }
 
-// We don't have simple mimo nodes as of yet
-#if 1
-
 TEST_CASE("mimo_node: Verify various API approaches", "[segmented_mimo]") {
   [[maybe_unused]] GeneralFunctionNode<
       AsyncMover2,
@@ -1593,5 +1590,3 @@ TEST_CASE(
       std::tuple<size_t>>
       x{[](std::tuple<size_t>, std::tuple<size_t>) {}};
 }
-
-#endif

--- a/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
@@ -1552,3 +1552,46 @@ TEMPLATE_TEST_CASE(
   CHECK(std::distance(output.begin(), j) == static_cast<long>(rounds));
   CHECK(std::equal(input.begin(), i, output.begin()));
 }
+
+// We don't have simple mimo nodes as of yet
+#if 1
+
+TEST_CASE("mimo_node: Verify various API approaches", "[segmented_mimo]") {
+  [[maybe_unused]] GeneralFunctionNode<
+      AsyncMover2,
+      std::tuple<size_t, int>,
+      AsyncMover3,
+      std::tuple<size_t, double>>
+      x{};
+  [[maybe_unused]] GeneralFunctionNode<
+      AsyncMover2,
+      std::tuple<int>,
+      AsyncMover3,
+      std::tuple<size_t, double>>
+      y{};
+  [[maybe_unused]] GeneralFunctionNode<
+      AsyncMover2,
+      std::tuple<char*>,
+      AsyncMover3,
+      std::tuple<size_t, std::tuple<int, float>>>
+      z{};
+  [[maybe_unused]] GeneralFunctionNode<
+      AsyncMover2,
+      std::tuple<int, char, double, double, double>,
+      AsyncMover3,
+      std::tuple<int>>
+      a{};
+}
+
+TEST_CASE(
+    "GeneralFunctionNode: Verify construction with simple function",
+    "[segmented_mimo]") {
+  [[maybe_unused]] GeneralFunctionNode<
+      AsyncMover2,
+      std::tuple<size_t>,
+      AsyncMover3,
+      std::tuple<size_t>>
+      x{[](std::tuple<size_t>, std::tuple<size_t>) {}};
+}
+
+#endif

--- a/experimental/tiledb/common/dag/state_machine/doc/fsm2.md
+++ b/experimental/tiledb/common/dag/state_machine/doc/fsm2.md
@@ -201,7 +201,7 @@ However, in addition to the await, `push` includes a data transfer step (a "move
 ```
 This represents moving a data item from the `Source` to the `Sink`.  Note that both the state machine `state` and the actual data items being held are (atomically) changed in the move.
 
-Based on these properties of the `push`, we have the following valide states that can occur directly following a `push`:
+Based on these properties of the `push`, we have the following valid states that can occur directly following a `push`:
 ```C
      /* { state = 00 ∧ items = 00 } ∨ */
      /* { state = 01 ∧ items = 01 }   */
@@ -313,7 +313,7 @@ Asynchronous operation of the `Source` can change this predicate to
 
 #### Final Sink Proof Outline
 
-Thus, the complete `Sink` proof outline iw
+Thus, the complete `Sink` proof outline is
 
 ```C
    while (not done) {


### PR DESCRIPTION
The current task graph supports producer, consumer, and function nodes that take a single input and produce a single output, meaning task graphs would be restricted simply to pipelines.  The basic mimo node implemented for this PR encloses a function that takes a tuple as input and produces a tuple as output.  When each of the inputs is ready, the enclosed function will be invoked on a tuple constructed with one element taken from each of the inputs.  The tuple returned from the enclosed function will be sent to the outputs, one tuple element per output port.

The `make_edge` function is still used to connect the ports of mimo nodes to the ports of other nodes (which may be mimo).  To indicate which port to use from the mimo node, we use a proxy class, e.g., suppose we have three nodes, a producer, a mimo, and a consumer.  
```
    auto u = initial_node(graph, dummy_source);
    auto v = mimo(graph, dummy_mimo_function);
    auto w = terminal_node(graph, dummy_sink);
```

The following will connect the source to input port number 3 of the mimo node and connect output port number 2 of the mimo node to the output node.
```
    make_edge(graph, u, make_proxy<3>(v));
    make_edge(graph, make_proxy<2>(v), w);
```

Deduction guides to enable the edges to be created without the need for specification of template parameters were put into the file `dag/nodes/detail/segmented/edge_node_ctad.h` (though there may be a better location for those deduction guides).

Still to be done: 
  - different rules for invoking the enclosed function (i.e., not just conjunction)
  - specialized n-1, 1-n nodes (with conjunction and disjunction)
  - adding state

---
TYPE: FEATURE 
DESC: Add support for basic mimo node to TileDB task graph
