### PR TITLE
Sparse global order reader: deletes and overflow can give wrong results.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1051,6 +1051,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
       if (!return_all_dups) {
         auto to_remove = tile_queue.top();
         deleted_dups =
+            !to_remove.tile_->has_post_dedup_bmp() ||
             to_remove.tile_->post_dedup_bitmap()[to_remove.pos_] != 0;
         update_frag_idx(to_remove.tile_, to_remove.pos_ + 1);
         tile_queue.pop();


### PR DESCRIPTION
This fixes a potential yet very difficult to hit issue in global order reads with no duplicates and deletes where the reader could give wrong results. The issue could arise if we hit a var size overflow while copying data to the user buffers and while reverting progress on the cell slab structure, we revert past a deleted cell with duplicates. In some cases, it would possible to revert the index in the read state for one of the duplicates that wasn't deleted in one fragment but not in the fragment where the cell was deleted. This would cause the earlier cell to show up in the results on the read continuation.

The fix is to add an empty cell slab for a deleted cell when it had non deleted duplicates so that when we revert progress past that cell, we update the index in the read state structure.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: deletes and overflow can give wrong results.
