### PR TITLE
Support GCS in the `--vfs` option of `tiledb_unit`.

### DIFF
--- a/test/src/unit.cc
+++ b/test/src/unit.cc
@@ -20,7 +20,8 @@ int main(const int argc, char** const argv) {
   Catch::Session session;
 
   // Define acceptable VFS values.
-  const std::vector<std::string> vfs_fs = {"native", "s3", "hdfs", "azure"};
+  const std::vector<std::string> vfs_fs = {
+      "native", "s3", "hdfs", "azure", "gcs"};
 
   // Build a pipe-separated string of acceptable VFS values.
   std::ostringstream vfs_fs_oss;


### PR DESCRIPTION
I noticed that `gcs` is missing from the allowed `--vfs` options of `tiledb_unit`. This PR fixes it.

---
TYPE: NO_HISTORY
DESC: Support GCS in the `--vfs` option of `tiledb_unit`.