### PR TITLE
[Backport release-2.11] Sparse unordered w/ dups: fix error on double var size overflow. (#3963)

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1346,7 +1346,6 @@ TEST_CASE_METHOD(
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
-          fragments,
           result_tiles,
           0,
           cell_offsets,
@@ -1408,7 +1407,6 @@ TEST_CASE_METHOD(
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
-          fragments,
           result_tiles,
           0,
           cell_offsets,
@@ -1475,9 +1473,74 @@ TEST_CASE_METHOD(
       SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
           uint64_t>(
           &tiledb::test::g_helper_stats,
-          fragments,
           result_tiles,
           2,
+          cell_offsets,
+          query_buffer);
+
+  // Validate results.
+  CHECK(buffers_full == true);
+  CHECK(cell_offsets[1] == 2);
+  CHECK(result_tiles_size == 1);
+  CHECK(var_buffer_size == 4);
+
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsVarDataFx,
+    "Sparse unordered with dups reader: test compute_var_size_offsets "
+    "last cell",
+    "[sparse-unordered-with-dups][compute_var_size_offsets][last cell]") {
+  auto&& [array, fragments] = open_default_array_1d_with_fragments();
+
+  // Make a vector of tiles.
+  UnorderedWithDupsResultTile<uint64_t> result_tile(
+      0, 0, array->array_->array_schema_latest());
+  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
+  rt.push_back(std::move(result_tile));
+
+  SECTION("- No bitmap") {
+  }
+
+  SECTION("- With bitmap") {
+    rt[0].bitmap_.resize(5, 1);
+  }
+
+  // Create the result_tiles pointer vector.
+  std::vector<ResultTile*> result_tiles(rt.size());
+  for (uint64_t i = 0; i < rt.size(); i++) {
+    result_tiles[i] = &rt[i];
+  }
+
+  // Create the cell_offsets vector.
+  std::vector<uint64_t> cell_offsets(rt.size() + 1);
+  uint64_t offset = 0;
+  for (uint64_t i = 0; i < rt.size(); i++) {
+    cell_offsets[i] = offset;
+    offset += 3;
+  }
+  cell_offsets[rt.size()] = offset;
+
+  // Create a Query buffer.
+  tiledb::sm::QueryBuffer query_buffer;
+  uint64_t offsets[] = {2, 2, 2, 0, 0};
+  uint64_t offsets_size = sizeof(offsets);
+  query_buffer.buffer_ = offsets;
+  query_buffer.buffer_size_ = &offsets_size;
+  uint64_t buffer_var_size = 0;
+  query_buffer.buffer_var_size_ = &buffer_var_size;
+  query_buffer.original_buffer_var_size_ = 5;
+
+  // Call the function.
+  auto&& [buffers_full, var_buffer_size, result_tiles_size] =
+      SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
+          uint64_t>(
+          &tiledb::test::g_helper_stats,
+          result_tiles,
+          0,
           cell_offsets,
           query_buffer);
 

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -1335,7 +1335,6 @@ template <class OffType>
 tuple<bool, uint64_t, uint64_t>
 SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
     stats::Stats* stats,
-    const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
     const std::vector<ResultTile*>& result_tiles,
     const uint64_t first_tile_min_pos,
     std::vector<uint64_t>& cell_offsets,
@@ -1371,19 +1370,17 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
       auto last_tile = (UnorderedWithDupsResultTile<BitmapType>*)
           result_tiles[new_result_tiles_size];
 
-      auto last_tile_num_cells =
-          fragment_metadata[last_tile->frag_idx()]->cell_num(
-              last_tile->tile_idx());
-
       new_result_tiles_size++;
+      auto last_tile_num_cells = cell_offsets[new_result_tiles_size] -
+                                 cell_offsets[new_result_tiles_size - 1];
       cell_offsets[new_result_tiles_size] =
           new_result_tiles_size > 0 ? cell_offsets[new_result_tiles_size - 1] :
                                       0;
 
       const bool has_bmp = last_tile->has_bmp();
       const auto min_pos = new_result_tiles_size == 1 ? first_tile_min_pos : 0;
-      for (uint64_t c = min_pos; c < last_tile_num_cells - 1; c++) {
-        auto cell_count = has_bmp ? last_tile->bitmap_[c] : 1;
+      for (uint64_t c = 0; c < last_tile_num_cells - 1; c++) {
+        auto cell_count = has_bmp ? last_tile->bitmap_[c + min_pos] : 1;
         auto new_size =
             ((OffType*)query_buffer
                  .buffer_)[cell_offsets[new_result_tiles_size] + cell_count];
@@ -1503,7 +1500,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
         auto&& [buffers_full, new_var_buffer_size, new_result_tiles_size] =
             compute_var_size_offsets<OffType>(
                 stats_,
-                fragment_metadata_,
                 result_tiles,
                 first_tile_min_pos,
                 cell_offsets,

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -91,7 +91,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * user buffer.
    *
    * @param stats Stats.
-   * @param fragment_metadata Fragment metadata.
    * @param result_tiles Result tiles to process, might be truncated.
    * @param first_tile_min_pos Cell progress of the first tile.
    * @param cell_offsets Cell offset per result tile.
@@ -102,7 +101,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   template <class OffType>
   static tuple<bool, uint64_t, uint64_t> compute_var_size_offsets(
       stats::Stats* stats,
-      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       const std::vector<ResultTile*>& result_tiles,
       const uint64_t first_tile_min_pos,
       std::vector<uint64_t>& cell_offsets,


### PR DESCRIPTION
Backport c3a0abf60e8f5fde8c535b17ef16614bd76b07f4 from #3963.

TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups: fix error on double var size overflow.
