### PR TITLE
Correct a one-char typo in help text for bootstrap option

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,7 +34,7 @@ Configuration:
     --help                          print this message
     --prefix=PREFIX                 install files in tree rooted at PREFIX
                                     ['"${default_prefix}"']
-    --enable-vcpkg                  use vcpkg for downloading and building dependnecies
+    --enable-vcpkg                  use vcpkg for downloading and building dependencies
     --dependency=DIRs               specify the dependencies at DIRs, separated by colon
                                     ['"${default_dependency}"']
     --force-build-all-deps          force building of all dependencies, even those


### PR DESCRIPTION
The help display for the `--enable-vcpkg` option has two characters reversed

---
TYPE: IMPROVEMENT
DESC: Correct help text typo in build script
