### PR TITLE
Fix path list argument in ExternalProject_Add

### DIFF
--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -18,10 +18,14 @@ set(FORWARD_EP_CMAKE_ARGS)
 # as a part of the superbuild.
 set(TILEDB_EXTERNAL_PROJECTS)
 
+# Passing lists through ExternalProject_Add requires using a separator
+# character other than a semicolon.
+list(JOIN CMAKE_PREFIX_PATH "|" CMAKE_PREFIX_PATH_STR)
+
 # Forward any additional CMake args to the non-superbuild.
 set(INHERITED_CMAKE_ARGS
   -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-  -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+  -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH_STR}
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
   -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
@@ -155,6 +159,7 @@ ExternalProject_Add(tiledb
   INSTALL_COMMAND ""
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/tiledb
   DEPENDS ${TILEDB_EXTERNAL_PROJECTS}
+  LIST_SEPARATOR "|"
 )
 
 ############################################################


### PR DESCRIPTION
Our list of paths argument was being misinterpreted as a set of arguments to the cmake CLI. Previously, when invoking the child cmake process it was passing `-DCMAKE_PREFIX_PATH=/path1 /path2 /path3` which then led to warnings about ignoring the extra paths /path2 and /path3.

This change uses the documented option for instructing ExternalProject_Add to use a separate list combining character instead of the default `;` which it uses internally.

---
TYPE: BUILD
DESC: Fix VCPKG debug builds
