### PR TITLE
Sparse global order reader: defer tile deletion until end of merge.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -286,6 +286,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param rc Current result coords for the fragment.
    * @param result_tiles_it Iterator, per frag, in the list of retult tiles.
    * @param tile_queue Queue of one result coords, per fragment, sorted.
+   * @param to_delete List of tiles to delete.
    *
    * @return If more tiles are needed.
    */
@@ -293,7 +294,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   bool add_all_dups_to_queue(
       GlobalOrderResultCoords<BitmapType>& rc,
       std::vector<TileListIt>& result_tiles_it,
-      TileMinHeap<CompType>& tile_queue);
+      TileMinHeap<CompType>& tile_queue,
+      std::vector<TileListIt>& to_delete);
 
   /**
    * Add a cell (for a specific fragment) to the queue of cells currently being
@@ -302,6 +304,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param rc Current result coords for the fragment.
    * @param result_tiles_it Iterator, per frag, in the list of retult tiles.
    * @param tile_queue Queue of one result coords, per fragment, sorted.
+   * @param to_delete List of tiles to delete.
    *
    * @return If more tiles are needed.
    */
@@ -309,7 +312,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   bool add_next_cell_to_queue(
       GlobalOrderResultCoords<BitmapType>& rc,
       std::vector<TileListIt>& result_tiles_it,
-      TileMinHeap<CompType>& tile_queue);
+      TileMinHeap<CompType>& tile_queue,
+      std::vector<TileListIt>& to_delete);
 
   /**
    * Computes a tile's Hilbert values for a tile.


### PR DESCRIPTION
This fixes an issue in the sparse global order reader where an unused tile might be used after deletion. The problem arises when a fragment consolidated with timestamps has many duplicated cells. If the tile doesn't get used in the merge, it gets deleted when we process the last cell, but the problem is that there still might be other cells from the same tile in the tile queue as cells in the queue are not sorted depending on position.

The fix is to keep track of all the tiles to delete and delete them when the merge is done to prevent any use after free.

Note that this PR doesn't add unit tests for the issue as the randomness makes it very difficult to come up with any cases where this reproduces consistently.

---
TYPE: IMPROVEMENT
DESC: Sparse global order reader: defer tile deletion until end of merge.
