### PR TITLE
Silence warnings on unqualified calls to std::move

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,14 @@ else()
   if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-literal-suffix>)
   endif()
+
+  # Disable newer Apple Clang warnings about unqualified calls to std::move
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "14.0.3")
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-unqualified-std-cast-call>)
+    endif()
+  endif()
+
 endif()
 
 # Definitions for all targets


### PR DESCRIPTION
This is a new compiler warning add to at least Apple Clang. For now we're choosing to silence the warning until at least other compilers come to an agreement on whether this should be a warning.

---
TYPE: IMPROVEMENT
DESC: Silence warnings about unqualified calls to std::move on Apple Clang
