### PR TITLE
Fix vac files to include relative file names.

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -965,7 +965,7 @@ std::string ArrayDirectory::get_full_vac_uri(
   } else {
     size_t last_slash_pos = vac_uri.find_last_of('/');
     if (last_slash_pos == std::string::npos) {
-      throw std::logic_error("Invalid URI");
+      throw std::logic_error("Invalid URI: " + vac_uri);
     }
 
     vac_uri = vac_uri.substr(last_slash_pos + 1);

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -954,6 +954,26 @@ std::vector<URI> ArrayDirectory::compute_fragment_meta_uris(
   return ret;
 }
 
+std::string ArrayDirectory::get_full_vac_uri(
+    std::string base, std::string vac_uri) {
+  size_t frag_pos = vac_uri.find(constants::array_fragments_dir_name);
+  if (frag_pos != std::string::npos) {
+    vac_uri = vac_uri.substr(frag_pos);
+  } else if (
+      vac_uri.find(constants::array_metadata_dir_name) != std::string::npos) {
+    vac_uri = vac_uri.substr(vac_uri.find(constants::array_metadata_dir_name));
+  } else {
+    size_t last_slash_pos = vac_uri.find_last_of('/');
+    if (last_slash_pos == std::string::npos) {
+      throw std::logic_error("Invalid URI");
+    }
+
+    vac_uri = vac_uri.substr(last_slash_pos + 1);
+  }
+
+  return base + vac_uri;
+}
+
 bool ArrayDirectory::timestamps_overlap(
     const std::pair<uint64_t, uint64_t> fragment_timestamp_range,
     const bool consolidation_with_timestamps) const {
@@ -1022,6 +1042,8 @@ ArrayDirectory::compute_uris_to_vacuum(
     std::stringstream ss(names);
     bool vacuum_vac_file = true;
     for (std::string uri_str; std::getline(ss, uri_str);) {
+      uri_str =
+          get_full_vac_uri(uri_.add_trailing_slash().to_string(), uri_str);
       auto it = uris_map.find(uri_str);
       if (it != uris_map.end())
         to_vacuum_vec[it->second] = 1;

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -335,6 +335,17 @@ class ArrayDirectory {
       const EncryptionKey& encryption_key);
 
   /**
+   * Get the full vac uri using the base URI and a vac uri that might be
+   * relative or not. It also fixes URIs that were not relative and the array
+   * has moved since consolidation.
+   *
+   * @param base Base URI for the array.
+   * @param vac_uri The vac URI that might or not be relative to the array.
+   * @return std::string Full vac URI.
+   */
+  static std::string get_full_vac_uri(std::string base, std::string vac_uri);
+
+  /**
    * Loads the latest schema of an array from persistent storage into memory.
    *
    * @param array_dir The ArrayDirectory object used to retrieve the

--- a/tiledb/sm/array/test/unit_array_directory.cc
+++ b/tiledb/sm/array/test/unit_array_directory.cc
@@ -122,3 +122,17 @@ TEST_CASE(
   CHECK(wb_array_dir.timestamps_overlap(
       array_dir, std::pair<uint64_t, uint64_t>(2, 4), true));
 }
+
+TEST_CASE("Array directory: Vac file fix", "[array-directory][vac-file-fix]") {
+  CHECK(
+      ArrayDirectory::get_full_vac_uri(
+          "base/", "file://not/related/__fragments/test.vac") ==
+      "base/__fragments/test.vac");
+  CHECK(
+      ArrayDirectory::get_full_vac_uri(
+          "base/", "file://not/related/__meta/test.vac") ==
+      "base/__meta/test.vac");
+  CHECK(
+      ArrayDirectory::get_full_vac_uri(
+          "base/", "file://not/related/test.vac") == "base/test.vac");
+}

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -133,9 +133,19 @@ Status ArrayMetaConsolidator::consolidate(
   // Write vacuum file
   URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
 
+  size_t base_uri_size = 0;
+
+  // Write vac files relative to the array URI. This was fixed for reads in
+  // version 19 so only do this for arrays starting with version 19.
+  if (array_for_reads.array_schema_latest_ptr() == nullptr ||
+      array_for_reads.array_schema_latest().write_version() >= 19) {
+    base_uri_size = array_for_reads.array_uri().to_string().size();
+  }
+
   std::stringstream ss;
-  for (const auto& uri : to_vacuum)
-    ss << uri.to_string() << "\n";
+  for (const auto& uri : to_vacuum) {
+    ss << uri.to_string().substr(base_uri_size) << "\n";
+  }
 
   auto data = ss.str();
   RETURN_NOT_OK(

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -464,7 +464,11 @@ Status FragmentConsolidator::consolidate_internal(
   }
 
   // Write vacuum file
-  st = write_vacuum_file(vac_uri, to_consolidate);
+  st = write_vacuum_file(
+      array_for_reads->array_schema_latest().write_version(),
+      array_for_reads->array_uri(),
+      vac_uri,
+      to_consolidate);
   if (!st.ok()) {
     tdb_delete(query_r);
     tdb_delete(query_w);
@@ -950,11 +954,22 @@ Status FragmentConsolidator::set_config(const Config& config) {
 }
 
 Status FragmentConsolidator::write_vacuum_file(
+    const format_version_t write_version,
+    const URI& array_uri,
     const URI& vac_uri,
     const std::vector<TimestampedURI>& to_consolidate) const {
   std::stringstream ss;
-  for (const auto& timestampedURI : to_consolidate)
-    ss << timestampedURI.uri_.to_string() << "\n";
+  size_t base_uri_size = 0;
+
+  // Write vac files relative to the array URI. This was fixed for reads in
+  // version 19 so only do this for arrays starting with version 19.
+  if (write_version >= 19) {
+    base_uri_size = array_uri.to_string().size();
+  }
+
+  for (const auto& timestampedURI : to_consolidate) {
+    ss << timestampedURI.uri_.to_string().substr(base_uri_size) << "\n";
+  }
 
   auto data = ss.str();
   RETURN_NOT_OK(

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -324,6 +324,8 @@ class FragmentConsolidator : public Consolidator {
   /** Writes the vacuum file that contains the URIs of the consolidated
    * fragments. */
   Status write_vacuum_file(
+      const format_version_t write_version,
+      const URI& array_uri,
       const URI& vac_uri,
       const std::vector<TimestampedURI>& to_consolidate) const;
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -637,7 +637,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization base format version number. */
-const format_version_t base_format_version = 18;
+const format_version_t base_format_version = 19;
 
 /**
  * The TileDB serialization format version number.


### PR DESCRIPTION
This changes the .vac files to have relative paths. It also fixes the routines loading them to process old vac files that might have paths non-relative to the array.

SC-27341.

---
TYPE: IMPROVEMENT
DESC: Fix vac files to include relative file names.