### PR TITLE
Sparse readers: fixing null count on incomplete queries.

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1811,9 +1811,8 @@ TEST_CASE_METHOD(
   uint64_t num_dups = GENERATE(1, 2);
   uint64_t min_buffer_size =
       vary_fixed_buffer ? num_dups * sizeof(int) : num_dups;
-  uint64_t max_buffer_size = min_buffer_size;
-  // vary_fixed_buffer ? coords_size * num_dups : data_size *
-  // num_dups;
+  uint64_t max_buffer_size =
+      vary_fixed_buffer ? coords_size * num_dups : a1_data_size * num_dups;
   for (uint64_t buffer_size = min_buffer_size; buffer_size <= max_buffer_size;
        buffer_size++) {
     // Only make the coordinate buffer change, the rest of the buffers

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -73,10 +73,14 @@ struct CSparseUnorderedWithDupsFx {
   void write_1d_fragment_string(
       int* coords,
       uint64_t* coords_size,
-      uint64_t* offsets,
-      uint64_t* offsets_size,
-      char* data,
-      uint64_t* data_size);
+      uint64_t* a1_offsets,
+      uint64_t* a1_offsets_size,
+      char* a1_data,
+      uint64_t* a1_data_size,
+      int64_t* a2_data,
+      uint64_t* a2_data_size,
+      uint8_t* a2_validity,
+      uint64_t* a2_validity_size);
   int32_t read(
       bool set_subarray,
       bool set_qc,
@@ -89,12 +93,16 @@ struct CSparseUnorderedWithDupsFx {
   int32_t read_strings(
       int* coords,
       uint64_t* coords_size,
-      char* data,
-      uint64_t* data_size,
-      uint64_t* data_offsets,
-      uint64_t* data_offsets_size,
+      char* a1_data,
+      uint64_t* a1_data_size,
+      uint64_t* a1_offsets,
+      uint64_t* a1_offsets_size,
+      int64_t* a2_data,
+      uint64_t* a2_data_size,
+      uint8_t* a2_validity,
+      uint64_t* a2_validity_size,
       uint64_t num_subarrays = 0,
-      tiledb_query_t** query = nullptr,
+      tiledb_query_t** query_ret = nullptr,
       tiledb_array_t** array_ret = nullptr);
   void reset_config();
   void update_config();
@@ -227,14 +235,17 @@ void CSparseUnorderedWithDupsFx::create_default_array_1d_string(
       {TILEDB_INT32},
       {domain},
       {&tile_extent},
-      {"a"},
-      {TILEDB_STRING_ASCII},
-      {TILEDB_VAR_NUM},
-      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
+      {"a1", "a2"},
+      {TILEDB_STRING_ASCII, TILEDB_INT64},
+      {TILEDB_VAR_NUM, 1},
+      {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1),
+       tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
       TILEDB_ROW_MAJOR,
       TILEDB_ROW_MAJOR,
       capacity,
-      true);  // allows dups.
+      true,
+      false,
+      optional<std::vector<bool>>({false, true}));  // allows dups.
 }
 
 void CSparseUnorderedWithDupsFx::write_1d_fragment(
@@ -281,10 +292,15 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_empty_strings(
   rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
-  char data[1];
-  uint64_t data_size = 0;
-  std::vector<uint64_t> data_offsets(num_cells, 0);
-  uint64_t data_offsets_size = num_cells * sizeof(uint64_t);
+  char a1_data[1];
+  uint64_t a1_data_size = 0;
+  std::vector<uint64_t> a1_offsets(num_cells, 0);
+  uint64_t a1_offsets_size = num_cells * sizeof(uint64_t);
+
+  std::vector<int64_t> a2_data(num_cells, 0);
+  uint64_t a2_data_size = num_cells * sizeof(int64_t);
+  std::vector<uint8_t> a2_validity(num_cells, 0);
+  uint64_t a2_validity_size = num_cells;
 
   // Create the query.
   tiledb_query_t* query;
@@ -292,10 +308,16 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_empty_strings(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, &data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, &a1_data_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_offsets_buffer(
-      ctx_, query, "a", data_offsets.data(), &data_offsets_size);
+      ctx_, query, "a1", a1_offsets.data(), &a1_offsets_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(
+      ctx_, query, "a2", a2_data.data(), &a2_data_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_validity_buffer(
+      ctx_, query, "a2", a2_validity.data(), &a2_validity_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   REQUIRE(rc == TILEDB_OK);
@@ -316,10 +338,14 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_empty_strings(
 void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
     int* coords,
     uint64_t* coords_size,
-    uint64_t* offsets,
-    uint64_t* offsets_size,
-    char* data,
-    uint64_t* data_size) {
+    uint64_t* a1_offsets,
+    uint64_t* a1_offsets_size,
+    char* a1_data,
+    uint64_t* a1_data_size,
+    int64_t* a2_data,
+    uint64_t* a2_data_size,
+    uint8_t* a2_validity,
+    uint64_t* a2_validity_size) {
   // Open array for writing.
   tiledb_array_t* array;
   auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -333,9 +359,15 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, a1_data_size);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_offsets_buffer(ctx_, query, "a", offsets, offsets_size);
+  rc = tiledb_query_set_offsets_buffer(
+      ctx_, query, "a1", a1_offsets, a1_offsets_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a2", a2_data, a2_data_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_validity_buffer(
+      ctx_, query, "a2", a2_validity, a2_validity_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   REQUIRE(rc == TILEDB_OK);
@@ -423,10 +455,14 @@ int32_t CSparseUnorderedWithDupsFx::read(
 int32_t CSparseUnorderedWithDupsFx::read_strings(
     int* coords,
     uint64_t* coords_size,
-    char* data,
-    uint64_t* data_size,
-    uint64_t* data_offsets,
-    uint64_t* data_offsets_size,
+    char* a1_data,
+    uint64_t* a1_data_size,
+    uint64_t* a1_offsets,
+    uint64_t* a1_offsets_size,
+    int64_t* a2_data,
+    uint64_t* a2_data_size,
+    uint8_t* a2_validity,
+    uint64_t* a2_validity_size,
     uint64_t num_subarrays,
     tiledb_query_t** query_ret,
     tiledb_array_t** array_ret) {
@@ -461,10 +497,15 @@ int32_t CSparseUnorderedWithDupsFx::read_strings(
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, a1_data_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_offsets_buffer(
-      ctx_, query, "a", data_offsets, data_offsets_size);
+      ctx_, query, "a1", a1_offsets, a1_offsets_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a2", a2_data, a2_data_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_validity_buffer(
+      ctx_, query, "a2", a2_validity, a2_validity_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   CHECK(rc == TILEDB_OK);
@@ -1530,18 +1571,26 @@ TEST_CASE_METHOD(
 
   // Try to read.
   int coords_r[5];
-  char data_r[5];
-  uint64_t data_offsets_r[5];
+  char a1_data_r[5];
+  uint64_t a1_offsets_r[5];
+  int64_t a2_data_r[5];
+  uint8_t a2_validity_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  uint64_t data_offsets_r_size = sizeof(data_offsets_r);
+  uint64_t a1_data_r_size = sizeof(a1_data_r);
+  uint64_t a1_offsets_r_size = sizeof(a1_offsets_r);
+  uint64_t a2_data_r_size = sizeof(a2_data_r);
+  uint64_t a2_validity_r_size = sizeof(a2_validity_r);
   auto rc = read_strings(
       coords_r,
       &coords_r_size,
-      data_r,
-      &data_r_size,
-      data_offsets_r,
-      &data_offsets_r_size);
+      a1_data_r,
+      &a1_data_r_size,
+      a1_offsets_r,
+      &a1_offsets_r_size,
+      a2_data_r,
+      &a2_data_r_size,
+      a2_validity_r,
+      &a2_validity_r_size);
   CHECK(rc == TILEDB_OK);
 }
 
@@ -1728,49 +1777,68 @@ TEST_CASE_METHOD(
   // Write a fragment.
   std::vector<int32_t> coords = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
   uint64_t coords_size = coords.size() * sizeof(int32_t);
-  std::vector<uint64_t> offsets = {
+  std::vector<uint64_t> a1_offsets = {
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
-  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
-  std::string data = "123456789abcde";
-  uint64_t data_size = data.size();
+  uint64_t a1_offsets_size = a1_offsets.size() * sizeof(uint64_t);
+  std::string a1_data = "123456789abcde";
+  uint64_t a1_data_size = a1_data.size();
+  std::vector<int64_t> a2_data = {
+      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+  uint64_t a2_data_size = a2_data.size() * sizeof(uint64_t);
+  std::vector<uint8_t> a2_validity = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  uint64_t a2_validity_size = a2_validity.size();
   write_1d_fragment_string(
       coords.data(),
       &coords_size,
-      offsets.data(),
-      &offsets_size,
-      data.data(),
-      &data_size);
+      a1_offsets.data(),
+      &a1_offsets_size,
+      a1_data.data(),
+      &a1_data_size,
+      a2_data.data(),
+      &a2_data_size,
+      a2_validity.data(),
+      &a2_validity_size);
 
   tiledb_array_t* array = nullptr;
   tiledb_query_t* query = nullptr;
 
-  // Try to read with every possible buffer sizes. When varying buffer, the
-  // minimum should fit the number of dups at a minimum. For fixed size data,
-  // that will use the size of int and for var size data 1 as we have one char
-  // per cell. Max will be num dups times the size of either the full coordinate
-  // data or the var size data depending.
-  uint64_t num_dups = 2;
+  // Try to read with every possible buffer sizes. When varying
+  // buffer, the minimum should fit the number of dups at a minimum.
+  // For fixed size data, that will use the size of int and for var
+  // size data 1 as we have one char per cell. Max will be num dups
+  // times the size of either the full coordinate data or the var size
+  // data depending.
+  uint64_t num_dups = GENERATE(1, 2);
   uint64_t min_buffer_size =
       vary_fixed_buffer ? num_dups * sizeof(int) : num_dups;
-  uint64_t max_buffer_size =
-      vary_fixed_buffer ? coords_size * num_dups : data_size * num_dups;
+  uint64_t max_buffer_size = min_buffer_size;
+  // vary_fixed_buffer ? coords_size * num_dups : data_size *
+  // num_dups;
   for (uint64_t buffer_size = min_buffer_size; buffer_size <= max_buffer_size;
        buffer_size++) {
-    // Only make the coordinate buffer change, the rest of the buffers are big
-    // enough for everything.
+    // Only make the coordinate buffer change, the rest of the buffers
+    // are big enough for everything.
     std::vector<int> coords_r(vary_fixed_buffer ? buffer_size : 1000, 0);
-    std::string data_r(vary_fixed_buffer ? 1000 : buffer_size, 0);
-    std::vector<uint64_t> data_offsets_r(1000, 0);
+    std::string a1_data_r(vary_fixed_buffer ? 1000 : buffer_size, 0);
+    std::vector<uint64_t> a1_offsets_r(1000, 0);
+    std::vector<int64_t> a2_data_r(1000);
+    std::vector<uint8_t> a2_validity_r(1000);
     uint64_t coords_r_size = coords_r.size() * sizeof(int32_t);
-    uint64_t data_r_size = data_r.size();
-    uint64_t data_offsets_r_size = data_offsets_r.size() * sizeof(uint64_t);
+    uint64_t a1_data_r_size = a1_data_r.size();
+    uint64_t a1_offsets_r_size = a1_offsets_r.size() * sizeof(uint64_t);
+    uint64_t a2_data_r_size = a2_data_r.size() * sizeof(int64_t);
+    uint64_t a2_validity_r_size = a2_validity_r.size();
     auto rc = read_strings(
         coords_r.data(),
         &coords_r_size,
-        data_r.data(),
-        &data_r_size,
-        data_offsets_r.data(),
-        &data_offsets_r_size,
+        a1_data_r.data(),
+        &a1_data_r_size,
+        a1_offsets_r.data(),
+        &a1_offsets_r_size,
+        a2_data_r.data(),
+        &a2_data_r_size,
+        a2_validity_r.data(),
+        &a2_validity_r_size,
         num_dups,
         &query,
         &array);
@@ -1784,7 +1852,11 @@ TEST_CASE_METHOD(
     tiledb_query_get_status(ctx_, query, &status);
     for (uint64_t iter = 0; iter < 100; iter++) {
       // Aggregate results.
-      for (uint64_t i = 0; i < coords_r_size / sizeof(int); i++) {
+      uint64_t num_read = coords_r_size / sizeof(int);
+      CHECK(a1_offsets_r_size == num_read * sizeof(uint64_t));
+      CHECK(a2_data_r_size == num_read * sizeof(int64_t));
+      CHECK(a2_validity_r_size == num_read);
+      for (uint64_t i = 0; i < num_read; i++) {
         counts[coords_r[i]]++;
       }
 
@@ -1817,8 +1889,10 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: Increasing dups with overlapping range",
-    "[sparse-unordered-with-dups][dup-data-test][overlapping-ranges]") {
+    "Sparse unordered with dups reader: Increasing dups with "
+    "overlapping range",
+    "[sparse-unordered-with-dups][dup-data-test][overlapping-"
+    "ranges]") {
   // Create default array.
   reset_config();
   int32_t extent = GENERATE(2, 7, 5, 10, 11);
@@ -1827,21 +1901,31 @@ TEST_CASE_METHOD(
   std::vector<int32_t> coords = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
                                  11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
   uint64_t coords_size = coords.size() * sizeof(int32_t);
-  std::vector<uint64_t> offsets = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
-                                   10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
-  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
-  std::string data = "123456789abcdefghijk";
-  uint64_t data_size = data.size();
+  std::vector<uint64_t> a1_offsets = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                      10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+  uint64_t a1_offsets_size = a1_offsets.size() * sizeof(uint64_t);
+  std::string a1_data = "123456789abcdefghijk";
+  uint64_t a1_data_size = a1_data.size();
+  std::vector<int64_t> a2_data = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                  20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+  uint64_t a2_data_size = a2_data.size() * sizeof(uint64_t);
+  std::vector<uint8_t> a2_validity = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                      1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  uint64_t a2_validity_size = a2_validity.size();
   // Write dups for all cells up to capacity
   uint64_t total_cells = 0;
   for (int32_t i = 0; i < extent * 2; i++) {
     write_1d_fragment_string(
         coords.data(),
         &coords_size,
-        offsets.data(),
-        &offsets_size,
-        data.data(),
-        &data_size);
+        a1_offsets.data(),
+        &a1_offsets_size,
+        a1_data.data(),
+        &a1_data_size,
+        a2_data.data(),
+        &a2_data_size,
+        a2_validity.data(),
+        &a2_validity_size);
     total_cells += coords_size / sizeof(int32_t);
   }
   tiledb_array_t* array;
@@ -1887,10 +1971,10 @@ TEST_CASE_METHOD(
         ctx_, query, "d", coords_r.data(), &coords_r_size);
     CHECK(st == TILEDB_OK);
     st = tiledb_query_set_offsets_buffer(
-        ctx_, query, "a", offsets_r.data(), &offsets_r_size);
+        ctx_, query, "a1", offsets_r.data(), &offsets_r_size);
     CHECK(st == TILEDB_OK);
     st = tiledb_query_set_data_buffer(
-        ctx_, query, "a", data_r.data(), &data_r_size);
+        ctx_, query, "a1", data_r.data(), &data_r_size);
     CHECK(st == TILEDB_OK);
     st = tiledb_query_submit(ctx_, query);
     CHECK(st == TILEDB_OK);

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -460,7 +460,8 @@ void create_array(
     tiledb_layout_t cell_order,
     uint64_t capacity,
     bool allows_dups,
-    bool serialize_array_schema) {
+    bool serialize_array_schema,
+    const optional<std::vector<bool>>& nullable) {
   // For easy reference
   auto dim_num = dim_names.size();
   auto attr_num = attr_names.size();
@@ -520,6 +521,12 @@ void create_array(
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_attribute_set_cell_val_num(ctx, a, cell_val_num[i]);
     REQUIRE(rc == TILEDB_OK);
+
+    if (nullable != nullopt) {
+      rc = tiledb_attribute_set_nullable(ctx, a, nullable.value()[i]);
+      REQUIRE(rc == TILEDB_OK);
+    }
+
     rc = tiledb_array_schema_add_attribute(ctx, array_schema, a);
     REQUIRE(rc == TILEDB_OK);
     tiledb_attribute_free(&a);

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -268,8 +268,9 @@ int array_create_wrapper(
  * @param cell_order The cell order.
  * @param capacity The tile capacity.
  * @param allows_dups Whether the array allows coordinate duplicates.
- * @param serialize_array_schema whether to round-trip through serialization or
- * not
+ * @param serialize_array_schema Whether to round-trip through serialization or
+ * not.
+ * @param nullable Whether the attributes are nullable or not.
  */
 
 void create_array(
@@ -288,7 +289,8 @@ void create_array(
     tiledb_layout_t cell_order,
     uint64_t capacity,
     bool allows_dups = false,
-    bool serialize_array_schema = false);
+    bool serialize_array_schema = false,
+    const optional<std::vector<bool>>& nullable = nullopt);
 
 /**
  * Helper method to create an encrypted array.

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -173,7 +173,7 @@ void ResultTile::erase_tile(const std::string& name) {
 
   // Handle attribute tile
   for (auto& at : attr_tiles_) {
-    if (at.second.has_value() && at.first == name) {
+    if (at.first == name) {
       at.second.reset();
       return;
     }

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -926,10 +926,10 @@ Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
     }
 
     // Always adjust validity vector size, if present.
-    if (num_cells > cells_copied) {
+    if (array_schema_.is_nullable(name)) {
       if (it.second.validity_vector_.buffer_size() != nullptr)
         *(it.second.validity_vector_.buffer_size()) =
-            num_cells * constants::cell_validity_size;
+            cells_copied * constants::cell_validity_size;
     }
   }
 


### PR DESCRIPTION
This fixes an issue when hitting a var size overflow with nullable attributes. It was possible that the returned validity buffer has the wrong size.

---
TYPE: IMPROVEMENT
DESC: Sparse readers: fixing null count on incomplete queries.