### PR TITLE
Sparse readers: extract transient read state as a separate class.

### DIFF
--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -816,8 +816,7 @@ class ResultTileWithBitmap : public ResultTile {
       unsigned frag_idx, uint64_t tile_idx, const FragmentMetadata& frag_md)
       : ResultTile(frag_idx, tile_idx, *frag_md.array_schema().get())
       , cell_num_(frag_md.cell_num(tile_idx))
-      , result_num_(cell_num_)
-      , coords_loaded_(false) {
+      , result_num_(cell_num_) {
   }
 
   /** Move constructor. */
@@ -841,22 +840,6 @@ class ResultTileWithBitmap : public ResultTile {
   /* ********************************* */
   /*          PUBLIC METHODS           */
   /* ********************************* */
-
-  /**
-   * Returns true if the coordinates were loaded for this result tile.
-   *
-   * @return 'true' if the coords are loaded.
-   */
-  inline bool coords_loaded() {
-    return coords_loaded_;
-  }
-
-  /**
-   * Specifies coords are loaded for this result tile.
-   */
-  inline void set_coords_loaded() {
-    coords_loaded_ = true;
-  }
 
   /**
    * Returns the number of results in the bitmap.
@@ -965,7 +948,6 @@ class ResultTileWithBitmap : public ResultTile {
     std::swap(bitmap_, tile.bitmap_);
     std::swap(cell_num_, tile.cell_num_);
     std::swap(result_num_, tile.result_num_);
-    std::swap(coords_loaded_, tile.coords_loaded_);
   }
 
  protected:
@@ -980,9 +962,6 @@ class ResultTileWithBitmap : public ResultTile {
 
   /** Number of cells in this bitmap. */
   uint64_t result_num_;
-
-  /** Were the coordinates loaded for this tile. */
-  bool coords_loaded_;
 };
 
 /** Global order result tile. */

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -93,7 +93,7 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
           condition,
           skip_checks_serialization,
           true)
-    , result_tiles_(array->fragment_metadata().size())
+    , result_tiles_leftover_(array->fragment_metadata().size())
     , memory_used_for_coords_(array->fragment_metadata().size())
     , consolidation_with_timestamps_(consolidation_with_timestamps)
     , last_cells_(array->fragment_metadata().size())
@@ -133,12 +133,9 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
   auto timer_se = stats_->start_timer("dowork");
   stats_->add_counter("loop_num", 1);
 
-  // For easy reference.
-  auto fragment_num = fragment_metadata_.size();
-
   // Check that the query condition is valid.
   if (condition_.has_value()) {
-    RETURN_NOT_OK(condition_->check(array_schema_));
+    throw_if_not_ok(condition_->check(array_schema_));
   }
 
   get_dim_attr_stats();
@@ -153,7 +150,7 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
   }
 
   // Load initial data, if not loaded already.
-  RETURN_NOT_OK(load_initial_data());
+  throw_if_not_ok(load_initial_data());
   purge_deletes_consolidation_ = !deletes_consolidation_no_purge_ &&
                                  consolidation_with_timestamps_ &&
                                  !delete_and_update_conditions_.empty();
@@ -172,101 +169,83 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
     names.emplace_back(buffer.first);
   }
 
-  buffers_full_ = false;
+  bool user_buffers_full = false;
+  std::vector<ResultTilesList> result_tiles = std::move(result_tiles_leftover_);
   do {
     stats_->add_counter("internal_loop_num", 1);
 
     // Create the result tiles we are going to process.
-    auto tiles_found = create_result_tiles();
+    auto created_tiles = create_result_tiles(result_tiles);
 
-    if (tiles_found) {
-      // Maintain a temporary vector with pointers to result tiles for calling
-      // read_and_unfilter_coords.
-      std::vector<ResultTile*> tmp_result_tiles;
-      for (auto& rt_list : result_tiles_) {
-        for (auto& result_tile : rt_list) {
-          if (!result_tile.coords_loaded()) {
-            result_tile.set_coords_loaded();
-            tmp_result_tiles.emplace_back(&result_tile);
-          }
-        }
-      }
-
+    if (created_tiles.size() > 0) {
       // Read and unfilter coords.
-      RETURN_NOT_OK(read_and_unfilter_coords(tmp_result_tiles));
+      throw_if_not_ok(read_and_unfilter_coords(created_tiles));
 
       // Compute the tile bitmaps.
-      RETURN_NOT_OK(compute_tile_bitmaps<BitmapType>(tmp_result_tiles));
+      compute_tile_bitmaps<BitmapType>(created_tiles);
 
       // Apply query condition.
-      auto st =
-          apply_query_condition<GlobalOrderResultTile<BitmapType>, BitmapType>(
-              tmp_result_tiles);
-      RETURN_NOT_OK(st);
+      apply_query_condition<GlobalOrderResultTile<BitmapType>, BitmapType>(
+          created_tiles);
 
       // Run deduplication for tiles with timestamps, if required.
-      RETURN_NOT_OK(dedup_tiles_with_timestamps(tmp_result_tiles));
+      dedup_tiles_with_timestamps(created_tiles);
 
       // Compute hilbert values.
       if (array_schema_.cell_order() == Layout::HILBERT) {
-        RETURN_NOT_OK(compute_hilbert_values(tmp_result_tiles));
+        compute_hilbert_values(created_tiles);
       }
 
       // Clear result tiles that are not necessary anymore.
-      std::mutex ignored_tiles_mutex;
-      auto status = parallel_for(
-          storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
-            auto it = result_tiles_[f].begin();
-            while (it != result_tiles_[f].end()) {
-              if (it->result_num() == 0) {
-                {
-                  std::unique_lock<std::mutex> lck(ignored_tiles_mutex);
-                  ignored_tiles_.emplace(f, it->tile_idx());
-                }
-                RETURN_NOT_OK(remove_result_tile(f, it++));
-              } else {
-                it++;
-              }
-            }
-
-            return Status::Ok();
-          });
-      RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
+      clean_tile_list(result_tiles);
     }
 
     // For fragments with timestamps, check first and last cell of every tiles
     // and if they have the same coordinates, only keep the cell with the
     // greater timestamp.
-    RETURN_NOT_OK(dedup_fragments_with_timestamps());
+    dedup_fragments_with_timestamps(result_tiles);
 
     // Compute RCS.
-    auto&& [st_rcs, result_cell_slabs] = compute_result_cell_slab();
-    RETURN_NOT_OK(st_rcs);
+    std::vector<ResultCellSlab> result_cell_slabs;
+    if (array_schema_.cell_order() == Layout::HILBERT) {
+      auto&& [user_buffs_full, rcs] =
+          merge_result_cell_slabs<HilbertCmpReverse>(
+              max_num_cells_to_copy(), result_tiles);
+      user_buffers_full = user_buffs_full;
+      result_cell_slabs = std::move(rcs);
+    } else {
+      auto&& [user_buffs_full, rcs] = merge_result_cell_slabs<GlobalCmpReverse>(
+          max_num_cells_to_copy(), result_tiles);
+      user_buffers_full = user_buffs_full;
+      result_cell_slabs = std::move(rcs);
+    }
 
     // No more tiles to process, done.
-    if (result_cell_slabs.has_value() && !result_cell_slabs->empty()) {
+    if (!result_cell_slabs.empty()) {
       // Copy cell slabs.
       if (offsets_bitsize_ == 64) {
-        RETURN_NOT_OK(process_slabs<uint64_t>(names, *result_cell_slabs));
+        process_slabs<uint64_t>(names, result_cell_slabs, user_buffers_full);
       } else {
-        RETURN_NOT_OK(process_slabs<uint32_t>(names, *result_cell_slabs));
+        process_slabs<uint32_t>(names, result_cell_slabs, user_buffers_full);
       }
     }
 
     // End the iteration.
-    RETURN_NOT_OK(end_iteration());
-  } while (!buffers_full_ && incomplete());
+    end_iteration(result_tiles);
+  } while (!user_buffers_full && incomplete());
+
+  result_tiles_leftover_ = std::move(result_tiles);
 
   // Fix the output buffer sizes.
   const auto cells = cells_copied(names);
   stats_->add_counter("result_num", cells);
-  RETURN_NOT_OK(resize_output_buffers(cells));
+  resize_output_buffers(cells);
 
   if (offsets_extra_element_) {
-    RETURN_NOT_OK(add_extra_offset());
+    add_extra_offset();
   }
 
-  stats_->add_counter("ignored_tiles", ignored_tiles_.size());
+  stats_->add_counter("ignored_tiles", tmp_read_state_.num_ignored_tiles());
 
   return Status::Ok();
 }
@@ -345,8 +324,9 @@ bool SparseGlobalOrderReader<BitmapType>::add_result_tile(
     const uint64_t memory_budget_coords_tiles,
     const unsigned f,
     const uint64_t t,
-    const FragmentMetadata& frag_md) {
-  if (ignored_tiles_.count(IgnoredTile(f, t))) {
+    const FragmentMetadata& frag_md,
+    std::vector<ResultTilesList>& result_tiles) {
+  if (tmp_read_state_.is_ignored_tile(f, t)) {
     return false;
   }
 
@@ -368,7 +348,7 @@ bool SparseGlobalOrderReader<BitmapType>::add_result_tile(
   memory_used_for_coords_[f] += tiles_size;
 
   // Add the tile.
-  result_tiles_[f].emplace_back(
+  result_tiles[f].emplace_back(
       f,
       t,
       array_schema_.allows_dups(),
@@ -379,36 +359,45 @@ bool SparseGlobalOrderReader<BitmapType>::add_result_tile(
 }
 
 template <class BitmapType>
-bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
+std::vector<ResultTile*>
+SparseGlobalOrderReader<BitmapType>::create_result_tiles(
+    std::vector<ResultTilesList>& result_tiles) {
   auto timer_se = stats_->start_timer("create_result_tiles");
 
   // For easy reference.
   auto fragment_num = fragment_metadata_.size();
   auto dim_num = array_schema_.dim_num();
 
-  // Get the number of fragments to process.
-  unsigned num_fragments_to_process = 0;
-  for (auto all_loaded : all_tiles_loaded_) {
-    num_fragments_to_process += !all_loaded;
-  }
-
+  // Get the number of fragments to process and compute per fragment memory.
+  uint64_t num_fragments_to_process =
+      tmp_read_state_.num_fragments_to_process();
   per_fragment_memory_ = memory_budget_.total_budget() *
                          memory_budget_.ratio_coords() /
                          num_fragments_to_process;
 
+  // Save which result tile list is empty.
+  std::vector<uint64_t> rt_list_num_tiles(result_tiles.size());
+  for (uint64_t i = 0; i < result_tiles.size(); i++) {
+    rt_list_num_tiles[i] = result_tiles[i].size();
+  }
+
   // Create result tiles.
-  bool tiles_found = false;
   if (subarray_.is_set()) {
     // Load as many tiles as the memory budget allows.
-    auto status = parallel_for(
+    throw_if_not_ok(parallel_for(
         storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
           uint64_t t = 0;
-          while (!result_tile_ranges_[f].empty()) {
-            auto& range = result_tile_ranges_[f].back();
+          auto& tile_ranges = tmp_read_state_.tile_ranges(f);
+          while (!tile_ranges.empty()) {
+            auto& range = tile_ranges.back();
             for (t = range.first; t <= range.second; t++) {
               auto budget_exceeded = add_result_tile(
-                  dim_num, per_fragment_memory_, f, t, *fragment_metadata_[f]);
-              tiles_found = true;
+                  dim_num,
+                  per_fragment_memory_,
+                  f,
+                  t,
+                  *fragment_metadata_[f],
+                  result_tiles);
 
               if (budget_exceeded) {
                 logger_->debug(
@@ -417,10 +406,11 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
                     f,
                     t);
 
-                if (result_tiles_[f].empty()) {
+                if (result_tiles[f].empty()) {
                   auto tiles_size = get_coord_tiles_size(dim_num, f, t);
                   throw SparseGlobalOrderReaderStatusException(
-                      "Cannot load a single tile for fragment, increase memory "
+                      "Cannot load a single tile for fragment, increase "
+                      "memory "
                       "budget, tile size : " +
                       std::to_string(tiles_size) + ", per fragment memory " +
                       std::to_string(per_fragment_memory_) + ", total budget " +
@@ -434,38 +424,43 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
               range.first++;
             }
 
-            remove_result_tile_range(f);
+            tmp_read_state_.remove_tile_range(f);
           }
 
-          all_tiles_loaded_[f] = true;
+          tmp_read_state_.set_all_tiles_loaded(f);
+
           return Status::Ok();
-        });
-    throw_if_not_ok(status);
+        }));
   } else {
     // Load as many tiles as the memory budget allows.
-    auto status = parallel_for(
+    throw_if_not_ok(parallel_for(
         storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
           uint64_t t = 0;
           auto tile_num = fragment_metadata_[f]->tile_num();
 
           // Figure out the start index.
           auto start = read_state_.frag_idx_[f].tile_idx_;
-          if (!result_tiles_[f].empty()) {
-            start = std::max(start, result_tiles_[f].back().tile_idx() + 1);
+          if (!result_tiles[f].empty()) {
+            start = std::max(start, result_tiles[f].back().tile_idx() + 1);
           }
 
           for (t = start; t < tile_num; t++) {
             auto budget_exceeded = add_result_tile(
-                dim_num, per_fragment_memory_, f, t, *fragment_metadata_[f]);
-            tiles_found = true;
+                dim_num,
+                per_fragment_memory_,
+                f,
+                t,
+                *fragment_metadata_[f],
+                result_tiles);
 
             if (budget_exceeded) {
               logger_->debug(
-                  "Budget exceeded adding result tiles, fragment {0}, tile {1}",
+                  "Budget exceeded adding result tiles, fragment {0}, tile "
+                  "{1}",
                   f,
                   t);
 
-              if (result_tiles_[f].empty()) {
+              if (result_tiles[f].empty()) {
                 auto tiles_size = get_coord_tiles_size(dim_num, f, t);
                 return logger_->status(Status_SparseGlobalOrderReaderError(
                     "Cannot load a single tile for fragment, increase memory "
@@ -480,17 +475,16 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
             }
           }
 
-          all_tiles_loaded_[f] = true;
+          tmp_read_state_.set_all_tiles_loaded(f);
+
           return Status::Ok();
-        });
-    throw_if_not_ok(status);
+        }));
   }
 
-  bool done_adding_result_tiles = true;
+  bool done_adding_result_tiles = tmp_read_state_.done_adding_result_tiles();
   uint64_t num_rt = 0;
   for (unsigned int f = 0; f < fragment_num; f++) {
-    num_rt += result_tiles_[f].size();
-    done_adding_result_tiles &= all_tiles_loaded_[f] != 0;
+    num_rt += result_tiles[f].size();
   }
 
   logger_->debug("Done adding result tiles, num result tiles {0}", num_rt);
@@ -500,22 +494,58 @@ bool SparseGlobalOrderReader<BitmapType>::create_result_tiles() {
   }
 
   read_state_.done_adding_result_tiles_ = done_adding_result_tiles;
-  return tiles_found;
+
+  // Return the list of tiles added.
+  std::vector<ResultTile*> created_tiles;
+  for (uint64_t i = 0; i < result_tiles.size(); i++) {
+    TileListIt it = result_tiles[i].begin();
+    std::advance(it, rt_list_num_tiles[i]);
+    for (; it != result_tiles[i].end(); ++it) {
+      created_tiles.emplace_back(&*it);
+    }
+  }
+
+  return created_tiles;
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
+void SparseGlobalOrderReader<BitmapType>::clean_tile_list(
+    std::vector<ResultTilesList>& result_tiles) {
+  // Clear result tiles that are not necessary anymore.
+  auto fragment_num = fragment_metadata_.size();
+  std::mutex ignored_tiles_mutex;
+  throw_if_not_ok(parallel_for(
+      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+        auto it = result_tiles[f].begin();
+        while (it != result_tiles[f].end()) {
+          if (it->result_num() == 0) {
+            {
+              std::unique_lock<std::mutex> lck(ignored_tiles_mutex);
+              tmp_read_state_.add_ignored_tile(*it);
+            }
+            remove_result_tile(f, it++, result_tiles);
+          } else {
+            it++;
+          }
+        }
+
+        return Status::Ok();
+      }));
+}
+
+template <class BitmapType>
+void SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
     std::vector<ResultTile*>& result_tiles) {
   // For consolidation with timestamps or arrays with duplicates, no need to
   // do deduplication.
   if (consolidation_with_timestamps_ || array_schema_.allows_dups()) {
-    return Status::Ok();
+    return;
   }
 
   auto timer_se = stats_->start_timer("dedup_tiles_with_timestamps");
 
   // Process all tiles in parallel.
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
         const auto f = result_tiles[t]->frag_idx();
         if (fragment_metadata_[f]->has_timestamps()) {
@@ -573,19 +603,18 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
+      }));
 
   logger_->debug("Done processing fragments with timestamps");
-  return Status::Ok();
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
+void SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps(
+    std::vector<ResultTilesList>& result_tiles) {
   // For consolidation with timestamps or arrays with duplicates, no need to
   // do deduplication.
   if (consolidation_with_timestamps_ || array_schema_.allows_dups()) {
-    return Status::Ok();
+    return;
   }
 
   auto timer_se = stats_->start_timer("dedup_fragments_with_timestamps");
@@ -593,17 +622,17 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
   // Run all fragments in parallel.
   std::mutex ignored_tiles_mutex;
   auto fragment_num = fragment_metadata_.size();
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
         // Run only for fragments with timestamps.
         if (fragment_metadata_[f]->has_timestamps()) {
           // Process all tiles.
-          auto it = result_tiles_[f].begin();
-          while (it != result_tiles_[f].end()) {
+          auto it = result_tiles[f].begin();
+          while (it != result_tiles[f].end()) {
             // Compare the current tile to the next.
             auto next_tile = it;
             next_tile++;
-            if (next_tile == result_tiles_[f].end()) {
+            if (next_tile == result_tiles[f].end()) {
               // No more tiles, save the last cell for this fragment for later
               // processing.
               last_cells_[f] =
@@ -625,9 +654,9 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
                     // Stay on this tile as we will compare to the new next.
                     {
                       std::unique_lock<std::mutex> lck(ignored_tiles_mutex);
-                      ignored_tiles_.emplace(f, next_tile->tile_idx());
+                      tmp_read_state_.add_ignored_tile(*next_tile);
                     }
-                    throw_if_not_ok(remove_result_tile(f, next_tile));
+                    remove_result_tile(f, next_tile, result_tiles);
                   } else {
                     // Remove the cell in the bitmap and move to the next tile.
                     next_tile->clear_cell(first);
@@ -641,9 +670,9 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
                     it++;
                     {
                       std::unique_lock<std::mutex> lck(ignored_tiles_mutex);
-                      ignored_tiles_.emplace(f, to_delete->tile_idx());
+                      tmp_read_state_.add_ignored_tile(*to_delete);
                     }
-                    throw_if_not_ok(remove_result_tile(f, to_delete));
+                    remove_result_tile(f, to_delete, result_tiles);
                   } else {
                     // Remove the cell in the bitmap and move to the next tile.
                     it->clear_cell(last);
@@ -656,16 +685,12 @@ Status SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps() {
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
-tuple<Status, optional<std::vector<ResultCellSlab>>>
-SparseGlobalOrderReader<BitmapType>::compute_result_cell_slab() {
-  auto timer_se = stats_->start_timer("compute_result_cell_slab");
+uint64_t SparseGlobalOrderReader<BitmapType>::max_num_cells_to_copy() {
+  auto timer_se = stats_->start_timer("max_num_cells_to_copy");
 
   // First try to limit the maximum number of cells we copy using the size
   // of the output buffers for fixed sized attributes. Later we will validate
@@ -688,17 +713,7 @@ SparseGlobalOrderReader<BitmapType>::compute_result_cell_slab() {
     }
   }
 
-  // User gave us some empty buffers, exit.
-  if (num_cells == 0) {
-    buffers_full_ = true;
-    return {Status::Ok(), nullopt};
-  }
-
-  if (array_schema_.cell_order() == Layout::HILBERT) {
-    return merge_result_cell_slabs<HilbertCmpReverse>(num_cells);
-  } else {
-    return merge_result_cell_slabs<GlobalCmpReverse>(num_cells);
-  }
+  return num_cells;
 }
 
 template <class BitmapType>
@@ -706,6 +721,7 @@ template <class CompType>
 bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
     GlobalOrderResultCoords<BitmapType>& rc,
     std::vector<TileListIt>& result_tiles_it,
+    const std::vector<ResultTilesList>& result_tiles,
     TileMinHeap<CompType>& tile_queue,
     std::vector<TileListIt>& to_delete) {
   auto frag_idx = rc.tile_->frag_idx();
@@ -727,7 +743,8 @@ bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
 
     // For arrays with no duplicates, we cannot use the last cell of a
     // fragment with timestamps if not all tiles are loaded.
-    if (!dups && last_in_memory_cell_of_consolidated_fragment(frag_idx, rc)) {
+    if (!dups && last_in_memory_cell_of_consolidated_fragment(
+                     frag_idx, rc, result_tiles)) {
       return true;
     }
 
@@ -735,7 +752,7 @@ bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
     if (rc.pos_ == last_cell_pos) {
       auto next_tile = result_tiles_it[frag_idx];
       next_tile++;
-      if (next_tile != result_tiles_[frag_idx].end()) {
+      if (next_tile != result_tiles[frag_idx].end()) {
         tile_queue.emplace(rc.tile_, rc.pos_, false);
         GlobalOrderResultCoords rc2(&*next_tile, 0);
 
@@ -748,8 +765,7 @@ bool SparseGlobalOrderReader<BitmapType>::add_all_dups_to_queue(
         if (rc.same_coords(rc2)) {
           // Remove the current tile if not used.
           if (!rc.tile_->used()) {
-            ignored_tiles_.emplace(
-                frag_idx, result_tiles_it[frag_idx]->tile_idx());
+            tmp_read_state_.add_ignored_tile(*result_tiles_it[frag_idx]);
             to_delete.emplace_back(result_tiles_it[frag_idx]);
           }
 
@@ -768,6 +784,7 @@ template <class CompType>
 bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
     GlobalOrderResultCoords<BitmapType>& rc,
     std::vector<TileListIt>& result_tiles_it,
+    const std::vector<ResultTilesList>& result_tiles,
     TileMinHeap<CompType>& tile_queue,
     std::vector<TileListIt>& to_delete) {
   auto frag_idx = rc.tile_->frag_idx();
@@ -788,12 +805,12 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
 
     // Remove the tile from result tiles if it wasn't used at all.
     if (!rc.tile_->used()) {
-      ignored_tiles_.emplace(frag_idx, to_delete_it->tile_idx());
+      tmp_read_state_.add_ignored_tile(*to_delete_it);
       to_delete.push_back(to_delete_it);
     }
 
     // Try to find a new tile.
-    if (result_tiles_it[frag_idx] != result_tiles_[frag_idx].end()) {
+    if (result_tiles_it[frag_idx] != result_tiles[frag_idx].end()) {
       // Find a cell in the current result tile.
       rc = GlobalOrderResultCoords(&*result_tiles_it[frag_idx], 0);
 
@@ -804,13 +821,13 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
     } else {
       // Increment the tile index, which should clear all tiles in
       // end_iteration.
-      if (!result_tiles_[frag_idx].empty()) {
+      if (!result_tiles[frag_idx].empty()) {
         read_state_.frag_idx_[frag_idx].tile_idx_++;
         read_state_.frag_idx_[frag_idx].cell_idx_ = 0;
       }
 
       // This fragment has more tiles potentially.
-      if (!all_tiles_loaded_[frag_idx]) {
+      if (!tmp_read_state_.all_tiles_loaded(frag_idx)) {
         // Return we need more tiles.
         return true;
       }
@@ -824,7 +841,8 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
   {
     // For arrays with no duplicates, we cannot use the last cell of a fragment
     //  with timestamps if not all tiles are loaded.
-    if (!dups && last_in_memory_cell_of_consolidated_fragment(frag_idx, rc)) {
+    if (!dups && last_in_memory_cell_of_consolidated_fragment(
+                     frag_idx, rc, result_tiles)) {
       return true;
     }
     std::unique_lock<std::mutex> ul(tile_queue_mutex_);
@@ -833,7 +851,8 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
     // for purge deletes with no dups mode.
     if (purge_deletes_no_dups_mode_ &&
         fragment_metadata_[frag_idx]->has_timestamps()) {
-      if (add_all_dups_to_queue(rc, result_tiles_it, tile_queue, to_delete)) {
+      if (add_all_dups_to_queue(
+              rc, result_tiles_it, result_tiles, tile_queue, to_delete)) {
         return true;
       }
     }
@@ -845,7 +864,7 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
+void SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
     std::vector<ResultTile*>& result_tiles) {
   auto timer_se = stats_->start_timer("compute_hilbert_values");
 
@@ -858,7 +877,7 @@ Status SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
   auto max_bucket_val = ((uint64_t)1 << bits) - 1;
 
   // Parallelize on tiles.
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
         auto tile =
             static_cast<GlobalOrderResultTile<BitmapType>*>(result_tiles[t]);
@@ -884,10 +903,7 @@ Status SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
@@ -903,10 +919,16 @@ void SparseGlobalOrderReader<BitmapType>::update_frag_idx(
 
 template <class BitmapType>
 template <class CompType>
-tuple<Status, optional<std::vector<ResultCellSlab>>>
+tuple<bool, std::vector<ResultCellSlab>>
 SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
-    uint64_t num_cells) {
+    uint64_t num_cells, std::vector<ResultTilesList>& result_tiles) {
   auto timer_se = stats_->start_timer("merge_result_cell_slabs");
+
+  // User gave us some empty buffers, exit.
+  if (num_cells == 0) {
+    return {true, std::vector<ResultCellSlab>()};
+  }
+
   std::vector<ResultCellSlab> result_cell_slabs;
   CompType cmp_max_slab_length(
       array_schema_.domain(), false, &fragment_metadata_);
@@ -919,7 +941,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
 
   // A tile min heap, contains one GlobalOrderResultCoords per fragment.
   std::vector<GlobalOrderResultCoords<BitmapType>> container;
-  container.reserve(result_tiles_.size());
+  container.reserve(result_tiles.size());
   CompType cmp(
       array_schema_.domain(),
       !array_schema_.allows_dups(),
@@ -930,15 +952,15 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
   bool need_more_tiles = false;
 
   // Tile iterators, per fragments.
-  std::vector<TileListIt> rt_it(result_tiles_.size());
+  std::vector<TileListIt> rt_it(result_tiles.size());
 
   // For all fragments, get the first tile in the sorting queue.
   std::vector<TileListIt> to_delete;
-  auto status = parallel_for(
-      storage_manager_->compute_tp(), 0, result_tiles_.size(), [&](uint64_t f) {
-        if (result_tiles_[f].size() > 0) {
+  throw_if_not_ok(parallel_for(
+      storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t f) {
+        if (result_tiles[f].size() > 0) {
           // Initialize the iterator for this fragment.
-          rt_it[f] = result_tiles_[f].begin();
+          rt_it[f] = result_tiles[f].begin();
 
           // Add the tile to the queue.
           uint64_t cell_idx =
@@ -946,7 +968,8 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
                   read_state_.frag_idx_[f].cell_idx_ :
                   0;
           GlobalOrderResultCoords rc(&*(rt_it[f]), cell_idx);
-          bool res = add_next_cell_to_queue(rc, rt_it, tile_queue, to_delete);
+          bool res = add_next_cell_to_queue(
+              rc, rt_it, result_tiles, tile_queue, to_delete);
           {
             std::unique_lock<std::mutex> ul(tile_queue_mutex_);
             need_more_tiles |= res;
@@ -954,13 +977,12 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE_TUPLE(
-      status, logger_->status_no_return_value(status), nullopt);
+      }));
 
   const bool non_overlapping_ranges = std::is_same<BitmapType, uint8_t>::value;
 
   // Process all elements.
+  bool user_buffers_full = false;
   while (!tile_queue.empty() && !need_more_tiles && num_cells > 0) {
     auto to_process = tile_queue.top();
     auto tile = to_process.tile_;
@@ -1021,14 +1043,14 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
         tile_queue.pop();
 
         // Put the next cell from the processed tile in the queue.
-        need_more_tiles =
-            add_next_cell_to_queue(to_remove, rt_it, tile_queue, to_delete);
+        need_more_tiles = add_next_cell_to_queue(
+            to_remove, rt_it, result_tiles, tile_queue, to_delete);
       } else {
         update_frag_idx(tile, to_process.pos_ + 1);
 
         // Put the next cell from the processed tile in the queue.
-        need_more_tiles =
-            add_next_cell_to_queue(to_process, rt_it, tile_queue, to_delete);
+        need_more_tiles = add_next_cell_to_queue(
+            to_process, rt_it, result_tiles, tile_queue, to_delete);
 
         to_process = tile_queue.top();
         tile_queue.pop();
@@ -1079,7 +1101,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
         // Make sure we don't process the last in memory cell of a consolidated
         // with timestamps fragment if there are more tiles for that fragment.
         if (last_in_memory_cell_of_consolidated_fragment(
-                frag_idx, to_process)) {
+                frag_idx, to_process, result_tiles)) {
           length--;
           to_process.pos_--;
         }
@@ -1113,11 +1135,11 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
     }
 
     // Put the next cell in the queue.
-    need_more_tiles =
-        add_next_cell_to_queue(to_process, rt_it, tile_queue, to_delete);
+    need_more_tiles = add_next_cell_to_queue(
+        to_process, rt_it, result_tiles, tile_queue, to_delete);
   }
 
-  buffers_full_ = num_cells == 0;
+  user_buffers_full = num_cells == 0;
 
   // Remove empty cell slab at the end of the structure to prevent copy issues.
   while (result_cell_slabs.size() > 0 &&
@@ -1128,18 +1150,18 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
   logger_->debug(
       "Done merging result cell slabs, num slabs {0}, buffers full {1}",
       result_cell_slabs.size(),
-      buffers_full_);
+      user_buffers_full);
 
   // Delete tiles that were marked for deletion. Make one last check on the used
   // variable as one duplicate cell might have been merged and changed the
   // status.
   for (auto& it : to_delete) {
     if (!it->used()) {
-      throw_if_not_ok(remove_result_tile(it->frag_idx(), it));
+      remove_result_tile(it->frag_idx(), it, result_tiles);
     }
   }
 
-  return {Status::Ok(), std::move(result_cell_slabs)};
+  return {user_buffers_full, std::move(result_cell_slabs)};
 };
 
 template <class BitmapType>
@@ -1169,7 +1191,7 @@ SparseGlobalOrderReader<BitmapType>::compute_parallelization_parameters(
 
 template <class BitmapType>
 template <class OffType>
-Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
+void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
     const std::string& name,
     const uint64_t num_range_threads,
     const bool nullable,
@@ -1181,7 +1203,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
   auto timer_se = stats_->start_timer("copy_offsets_tiles");
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_cell_slabs.size(),
@@ -1280,15 +1302,12 @@ Status SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
 template <class OffType>
-Status SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
+void SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
     const uint64_t num_range_threads,
     const OffType offset_div,
     const uint64_t var_buffer_size,
@@ -1302,7 +1321,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
   auto var_data_buffer = static_cast<uint8_t*>(query_buffer.buffer_var_);
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_cell_slabs.size(),
@@ -1356,14 +1375,11 @@ Status SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
+void SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
     const std::string& name,
     const uint64_t num_range_threads,
     const bool is_dim,
@@ -1376,7 +1392,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
   auto timer_se = stats_->start_timer("copy_fixed_data_tiles");
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_cell_slabs.size(),
@@ -1464,14 +1480,11 @@ Status SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
+void SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
     const uint64_t num_range_threads,
     const std::vector<ResultCellSlab>& result_cell_slabs,
     const std::vector<uint64_t>& cell_offsets,
@@ -1479,7 +1492,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
   auto timer_se = stats_->start_timer("copy_timestamps_tiles");
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_cell_slabs.size(),
@@ -1527,14 +1540,11 @@ Status SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::copy_delete_meta_tiles(
+void SparseGlobalOrderReader<BitmapType>::copy_delete_meta_tiles(
     const uint64_t num_range_threads,
     const std::vector<ResultCellSlab>& result_cell_slabs,
     const std::vector<uint64_t>& cell_offsets,
@@ -1549,7 +1559,7 @@ Status SparseGlobalOrderReader<BitmapType>::copy_delete_meta_tiles(
   }
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_cell_slabs.size(),
@@ -1644,23 +1654,21 @@ Status SparseGlobalOrderReader<BitmapType>::copy_delete_meta_tiles(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
-tuple<Status, optional<std::vector<uint64_t>>>
+std::vector<uint64_t>
 SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
     const std::vector<std::string>& names,
-    std::vector<ResultCellSlab>& result_cell_slabs) {
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    bool& user_buffers_full) {
   // Process all attributes in parallel.
   const uint64_t memory_budget = available_memory();
   uint64_t max_cs_idx = result_cell_slabs.size();
   std::mutex max_cs_idx_mtx;
   std::vector<uint64_t> total_mem_usage_per_attr(names.size());
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, names.size(), [&](uint64_t i) {
         // For easy reference.
         const auto& name = names[i];
@@ -1731,19 +1739,15 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE_TUPLE(
-      status, logger_->status_no_return_value(status), nullopt);
+      }));
 
   if (max_cs_idx == 0) {
-    return {
-        Status_SparseUnorderedWithDupsReaderError(
-            "Unable to copy one slab with current budget/buffers"),
-        nullopt};
+    throw SparseGlobalOrderReaderStatusException(
+        "Unable to copy one slab with current budget/buffers");
   }
 
   // Resize the result tiles vector.
-  buffers_full_ &= max_cs_idx == result_cell_slabs.size();
+  user_buffers_full &= max_cs_idx == result_cell_slabs.size();
   while (result_cell_slabs.size() > max_cs_idx) {
     // Revert progress for this slab in read state, and pop it.
     auto& last_rcs = result_cell_slabs.back();
@@ -1752,12 +1756,13 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
     result_cell_slabs.pop_back();
   }
 
-  return {Status::Ok(), std::move(total_mem_usage_per_attr)};
+  return total_mem_usage_per_attr;
 }
 
 template <class BitmapType>
 template <class OffType>
-uint64_t SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
+tuple<bool, uint64_t>
+SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
     stats::Stats* stats,
     std::vector<ResultCellSlab>& result_cell_slabs,
     std::vector<uint64_t>& cell_offsets,
@@ -1765,6 +1770,7 @@ uint64_t SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
   auto timer_se = stats->start_timer("switch_sizes_to_offsets");
 
   auto new_var_buffer_size = *query_buffer.buffer_var_size_;
+  bool user_buffers_full = false;
 
   // Switch offsets buffer from cell size to offsets.
   auto offsets_buff = (OffType*)query_buffer.buffer_;
@@ -1778,7 +1784,7 @@ uint64_t SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
   // Make sure var size buffer can fit the data.
   if (query_buffer.original_buffer_var_size_ < new_var_buffer_size) {
     // Buffers are full.
-    buffers_full_ = true;
+    user_buffers_full = true;
 
     // Make sure that the start of the last RCS can fit the buffers. If not,
     // pop the last slab until it does.
@@ -1825,14 +1831,15 @@ uint64_t SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
     }
   }
 
-  return new_var_buffer_size;
+  return {user_buffers_full, new_var_buffer_size};
 }
 
 template <class BitmapType>
 template <class OffType>
-Status SparseGlobalOrderReader<BitmapType>::process_slabs(
+void SparseGlobalOrderReader<BitmapType>::process_slabs(
     std::vector<std::string>& names,
-    std::vector<ResultCellSlab>& result_cell_slabs) {
+    std::vector<ResultCellSlab>& result_cell_slabs,
+    bool& user_buffers_full) {
   auto timer_se = stats_->start_timer("process_slabs");
 
   // Compute parallelization parameters.
@@ -1857,13 +1864,12 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
 
   // Calculating the initial copy bound and making sure we respect the memory
   // budget for the copy operation.
-  auto&& [st, mem_usage_per_attr] =
-      respect_copy_memory_budget(names, result_cell_slabs);
-  RETURN_NOT_OK(st);
+  auto mem_usage_per_attr =
+      respect_copy_memory_budget(names, result_cell_slabs, user_buffers_full);
 
   // There is no space for any tiles in the user buffer, exit.
   if (result_cell_slabs.empty()) {
-    return Status::Ok();
+    return;
   }
 
   // Make a list of unique result tiles.
@@ -1885,11 +1891,10 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
   uint64_t buffer_idx = 0;
   while (buffer_idx < names.size()) {
     // Read and unfilter as many attributes as can fit in the budget.
-    auto&& [st, index_to_copy] = read_and_unfilter_attributes(
-        names, *mem_usage_per_attr, &buffer_idx, result_tiles);
-    RETURN_NOT_OK(st);
+    auto index_to_copy = read_and_unfilter_attributes(
+        names, mem_usage_per_attr, &buffer_idx, result_tiles);
 
-    for (const auto& idx : *index_to_copy) {
+    for (const auto& idx : index_to_copy) {
       // For easy reference.
       const auto& name = names[idx];
       const auto is_dim = array_schema_.is_dim(name);
@@ -1923,14 +1928,14 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
       OffType offset_div =
           elements_mode_ ? datatype_size(array_schema_.type(name)) : 1;
       if (name == constants::timestamps) {
-        RETURN_NOT_OK(copy_timestamps_tiles(
-            num_range_threads, result_cell_slabs, cell_offsets, query_buffer));
+        copy_timestamps_tiles(
+            num_range_threads, result_cell_slabs, cell_offsets, query_buffer);
       } else if (name == constants::delete_condition_index) {
         // Copy fixed size data.
-        RETURN_NOT_OK(copy_delete_meta_tiles(
-            num_range_threads, result_cell_slabs, cell_offsets, query_buffer));
+        copy_delete_meta_tiles(
+            num_range_threads, result_cell_slabs, cell_offsets, query_buffer);
       } else if (var_sized) {
-        RETURN_NOT_OK(copy_offsets_tiles<OffType>(
+        copy_offsets_tiles<OffType>(
             name,
             num_range_threads,
             nullable,
@@ -1938,9 +1943,9 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
             result_cell_slabs,
             cell_offsets,
             query_buffer,
-            var_data));
+            var_data);
       } else {
-        RETURN_NOT_OK(copy_fixed_data_tiles(
+        copy_fixed_data_tiles(
             name,
             num_range_threads,
             is_dim,
@@ -1949,24 +1954,27 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
             cell_size,
             result_cell_slabs,
             cell_offsets,
-            query_buffer));
+            query_buffer);
       }
 
       uint64_t var_buffer_size = 0;
       if (var_sized) {
         // Adjust the offsets buffer and make sure all data fits.
-        var_buffer_size = compute_var_size_offsets<OffType>(
-            stats_, result_cell_slabs, cell_offsets, query_buffer);
+        auto&& [user_buffs_full, var_buff_size] =
+            compute_var_size_offsets<OffType>(
+                stats_, result_cell_slabs, cell_offsets, query_buffer);
+        user_buffers_full |= user_buffs_full;
+        var_buffer_size = var_buff_size;
 
         // Now copy the var size data.
-        RETURN_NOT_OK(copy_var_data_tiles(
+        copy_var_data_tiles(
             num_range_threads,
             offset_div,
             var_buffer_size,
             result_cell_slabs,
             cell_offsets,
             query_buffer,
-            var_data));
+            var_data);
       }
 
       // Adjust buffer sizes.
@@ -2002,13 +2010,14 @@ Status SparseGlobalOrderReader<BitmapType>::process_slabs(
     }
   }
 
-  logger_->debug("Done copying tiles, buffers full {0}", buffers_full_);
-  return Status::Ok();
+  logger_->debug("Done copying tiles, buffers full {0}", user_buffers_full);
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::remove_result_tile(
-    const unsigned frag_idx, TileListIt rt) {
+void SparseGlobalOrderReader<BitmapType>::remove_result_tile(
+    const unsigned frag_idx,
+    TileListIt rt,
+    std::vector<ResultTilesList>& result_tiles) {
   // Remove coord tile size from memory budget.
   auto tile_idx = rt->tile_idx();
   auto tiles_size =
@@ -2024,43 +2033,40 @@ Status SparseGlobalOrderReader<BitmapType>::remove_result_tile(
   }
 
   // Delete the tile.
-  result_tiles_[frag_idx].erase(rt);
-
-  return Status::Ok();
+  result_tiles[frag_idx].erase(rt);
 }
 
 template <class BitmapType>
-Status SparseGlobalOrderReader<BitmapType>::end_iteration() {
+void SparseGlobalOrderReader<BitmapType>::end_iteration(
+    std::vector<ResultTilesList>& result_tiles) {
   // For easy reference.
   auto fragment_num = fragment_metadata_.size();
 
   // Clear fully processed tiles in each fragments.
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
-        while (!result_tiles_[f].empty() &&
-               result_tiles_[f].front().tile_idx() <
+        while (!result_tiles[f].empty() &&
+               result_tiles[f].front().tile_idx() <
                    read_state_.frag_idx_[f].tile_idx_) {
-          RETURN_NOT_OK(remove_result_tile(f, result_tiles_[f].begin()));
+          remove_result_tile(f, result_tiles[f].begin(), result_tiles);
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
+      }));
 
   if (!incomplete()) {
     assert(memory_used_for_coords_total_ == 0);
-    assert(memory_used_result_tile_ranges_ == 0);
+    assert(tmp_read_state_.memory_used_tile_ranges() == 0);
   }
 
   uint64_t num_rt = 0;
   for (unsigned int f = 0; f < fragment_num; f++) {
-    num_rt += result_tiles_[f].size();
+    num_rt += result_tiles[f].size();
   }
 
   logger_->debug("Done with iteration, num result tiles {0}", num_rt);
 
   array_memory_tracker_->set_budget(std::numeric_limits<uint64_t>::max());
-  return Status::Ok();
 }
 
 // Explicit template instantiations

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -61,6 +61,8 @@ template <class BitmapType>
 class SparseGlobalOrderReader : public SparseIndexReaderBase,
                                 public IQueryStrategy {
  public:
+  typedef std::list<GlobalOrderResultTile<BitmapType>> ResultTilesList;
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -114,8 +116,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
 
   /**
    * Initialize the memory budget variables.
-   *
-   * @return Status.
    */
   void refresh_config();
 
@@ -140,8 +140,11 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
-  /** The result tiles currently loaded. */
-  std::vector<std::list<GlobalOrderResultTile<BitmapType>>> result_tiles_;
+  /**
+   * Result tiles currently for which we loaded coordinates but couldn't
+   * process in the previous iteration.
+   */
+  std::vector<ResultTilesList> result_tiles_leftover_;
 
   /** Memory used for coordinates tiles per fragment. */
   std::vector<uint64_t> memory_used_for_coords_;
@@ -189,8 +192,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       CompType>;
 
   /** Tile list iterator. */
-  using TileListIt =
-      typename std::list<GlobalOrderResultTile<BitmapType>>::iterator;
+  using TileListIt = typename ResultTilesList::iterator;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -218,6 +220,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param f Fragment index.
    * @param t Tile index.
    * @param frag_md Fragment metadata.
+   * @param result_tiles Result tiles per fragment.
    *
    * @return buffers_full.
    */
@@ -226,39 +229,47 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       const uint64_t memory_budget_coords_tiles,
       const unsigned f,
       const uint64_t t,
-      const FragmentMetadata& frag_md);
+      const FragmentMetadata& frag_md,
+      std::vector<ResultTilesList>& result_tiles);
 
   /**
    * Create the result tiles.
    *
-   * @return Tiles_found.
+   * @param result_tiles Result tiles per fragment.
+   * @return Newly created tiles.
    */
-  bool create_result_tiles();
+  std::vector<ResultTile*> create_result_tiles(
+      std::vector<ResultTilesList>& result_tiles);
+
+  /**
+   * Clean tiles that have 0 results from the tile lists.
+   *
+   * @param result_tiles Result tiles vector.
+   */
+  void clean_tile_list(std::vector<ResultTilesList>& result_tiles);
 
   /**
    * Process tiles with timestamps to deduplicate entries.
    *
    * @param result_tiles Result tiles to process.
-   *
-   * @return Status.
    */
-  Status dedup_tiles_with_timestamps(std::vector<ResultTile*>& result_tiles);
+  void dedup_tiles_with_timestamps(std::vector<ResultTile*>& result_tiles);
 
   /**
    * Process fragments with timestamps to deduplicate entries.
    * This removes cells across tiles.
    *
-   * @return Status.
+   * @param result_tiles Result tiles per fragment.
    */
-  Status dedup_fragments_with_timestamps();
+  void dedup_fragments_with_timestamps(
+      std::vector<ResultTilesList>& result_tiles);
 
   /**
-   * Populate a result cell slab to process.
+   * Compute the number of cells possible to merge from user buffers.
    *
-   * @return Status, result_cell_slab.
+   * @return Number of cells possible to merge from user buffers.
    */
-  tuple<Status, optional<std::vector<ResultCellSlab>>>
-  compute_result_cell_slab();
+  uint64_t max_num_cells_to_copy();
 
   /**
    * Is the result coord the last cell of a consolidated fragment with
@@ -266,16 +277,18 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @param frag_idx Fragment index for the result coords.
    * @param rc Result coords.
+   * @param result_tiles Result tiles per fragment.
    *
    * @return true if the result coords is the last cell of a consolidated
    * fragment with timestamps.
    */
   inline bool last_in_memory_cell_of_consolidated_fragment(
       const unsigned int frag_idx,
-      const GlobalOrderResultCoords<BitmapType>& rc) const {
-    return !all_tiles_loaded_[frag_idx] &&
+      const GlobalOrderResultCoords<BitmapType>& rc,
+      const std::vector<ResultTilesList>& result_tiles) const {
+    return !tmp_read_state_.all_tiles_loaded(frag_idx) &&
            fragment_metadata_[frag_idx]->has_timestamps() &&
-           rc.tile_ == &result_tiles_[frag_idx].back() &&
+           rc.tile_ == &result_tiles[frag_idx].back() &&
            rc.tile_->tile_idx() == last_cells_[frag_idx].tile_idx_ &&
            rc.pos_ == last_cells_[frag_idx].cell_idx_;
   }
@@ -285,6 +298,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @param rc Current result coords for the fragment.
    * @param result_tiles_it Iterator, per frag, in the list of retult tiles.
+   * @param result_tiles Result tiles per fragment.
    * @param tile_queue Queue of one result coords, per fragment, sorted.
    * @param to_delete List of tiles to delete.
    *
@@ -294,6 +308,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   bool add_all_dups_to_queue(
       GlobalOrderResultCoords<BitmapType>& rc,
       std::vector<TileListIt>& result_tiles_it,
+      const std::vector<ResultTilesList>& result_tiles,
       TileMinHeap<CompType>& tile_queue,
       std::vector<TileListIt>& to_delete);
 
@@ -303,6 +318,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @param rc Current result coords for the fragment.
    * @param result_tiles_it Iterator, per frag, in the list of retult tiles.
+   * @param result_tiles Result tiles per fragment.
    * @param tile_queue Queue of one result coords, per fragment, sorted.
    * @param to_delete List of tiles to delete.
    *
@@ -312,6 +328,7 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   bool add_next_cell_to_queue(
       GlobalOrderResultCoords<BitmapType>& rc,
       std::vector<TileListIt>& result_tiles_it,
+      const std::vector<ResultTilesList>& result_tiles,
       TileMinHeap<CompType>& tile_queue,
       std::vector<TileListIt>& to_delete);
 
@@ -319,10 +336,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * Computes a tile's Hilbert values for a tile.
    *
    * @param result_tiles Result tiles to process.
-   *
-   * @return Status.
    */
-  Status compute_hilbert_values(std::vector<ResultTile*>& result_tiles);
+  void compute_hilbert_values(std::vector<ResultTile*>& result_tiles);
 
   /**
    * Update the fragment index to the larger between current one and the one
@@ -337,12 +352,13 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * Compute the result cell slabs once tiles are loaded.
    *
    * @param num_cells Number of cells that can be copied in the user buffer.
+   * @param result_tiles Result tiles per fragment.
    *
-   * @return Status, result_cell_slabs.
+   * @return user_buffers_full, result_cell_slabs.
    */
   template <class CompType>
-  tuple<Status, optional<std::vector<ResultCellSlab>>> merge_result_cell_slabs(
-      uint64_t num_cells);
+  tuple<bool, std::vector<ResultCellSlab>> merge_result_cell_slabs(
+      uint64_t num_cells, std::vector<ResultTilesList>& result_tiles);
 
   /**
    * Compute parallelization parameters for a tile copy operation.
@@ -373,11 +389,9 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
    * @param var_data Stores pointers to var data cell values.
-   *
-   * @return Status.
    */
   template <class OffType>
-  Status copy_offsets_tiles(
+  void copy_offsets_tiles(
       const std::string& name,
       const uint64_t num_range_threads,
       const bool nullable,
@@ -397,11 +411,9 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
    * @param var_data Stores pointers to var data cell values.
-   *
-   * @return Status.
    */
   template <class OffType>
-  Status copy_var_data_tiles(
+  void copy_var_data_tiles(
       const uint64_t num_range_threads,
       const OffType offset_div,
       const uint64_t var_buffer_size,
@@ -422,10 +434,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param result_cell_slabs Result cell slabs to process.
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
-   *
-   * @return Status.
    */
-  Status copy_fixed_data_tiles(
+  void copy_fixed_data_tiles(
       const std::string& name,
       const uint64_t num_range_threads,
       const bool is_dim,
@@ -443,10 +453,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param result_cell_slabs Result cell slabs to process.
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
-   *
-   * @return Status.
    */
-  Status copy_timestamps_tiles(
+  void copy_timestamps_tiles(
       const uint64_t num_range_threads,
       const std::vector<ResultCellSlab>& result_cell_slabs,
       const std::vector<uint64_t>& cell_offsets,
@@ -459,10 +467,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param result_cell_slabs Result cell slabs to process.
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
-   *
-   * @return Status.
    */
-  Status copy_delete_meta_tiles(
+  void copy_delete_meta_tiles(
       const uint64_t num_range_threads,
       const std::vector<ResultCellSlab>& result_cell_slabs,
       const std::vector<uint64_t>& cell_offsets,
@@ -475,12 +481,16 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @param names Attribute/dimensions to compute for.
    * @param result_cell_slabs Result cell slabs to process, might be truncated.
+   * @param user_buffers_full Boolean that indicates if the user buffers are
+   * full or not. If this comes in as `true`, it might be reset to `false` if
+   * the results were truncated.
    *
-   * @return Status, total_mem_usage_per_attr.
+   * @return total_mem_usage_per_attr.
    */
-  tuple<Status, optional<std::vector<uint64_t>>> respect_copy_memory_budget(
+  std::vector<uint64_t> respect_copy_memory_budget(
       const std::vector<std::string>& names,
-      std::vector<ResultCellSlab>& result_cell_slabs);
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      bool& user_buffers_full);
 
   /**
    * Compute the var size offsets and make sure all the data can fit in the
@@ -491,10 +501,10 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
    *
-   * @return new_var_buffer_size.
+   * @return user_buffers_full, new_var_buffer_size.
    */
   template <class OffType>
-  uint64_t compute_var_size_offsets(
+  tuple<bool, uint64_t> compute_var_size_offsets(
       stats::Stats* stats,
       std::vector<ResultCellSlab>& result_cell_slabs,
       std::vector<uint64_t>& cell_offsets,
@@ -505,31 +515,34 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    *
    * @param names Attribute/dimensions to compute for.
    * @param result_cell_slabs The result cell slabs to process.
-   *
-   * @return Status.
+   * @param user_buffers_full Boolean that indicates if the user buffers are
+   * full or not.
    */
   template <class OffType>
-  Status process_slabs(
+  void process_slabs(
       std::vector<std::string>& names,
-      std::vector<ResultCellSlab>& result_cell_slabs);
+      std::vector<ResultCellSlab>& result_cell_slabs,
+      bool& user_buffers_full);
 
   /**
    * Remove a result tile from memory
    *
    * @param frag_idx Fragment index.
    * @param rt Iterator to the result tile to remove.
-   *
-   * @return Status.
+   * @param result_tiles Result tiles per fragment.
    */
-  Status remove_result_tile(const unsigned frag_idx, TileListIt rt);
+  void remove_result_tile(
+      const unsigned frag_idx,
+      TileListIt rt,
+      std::vector<ResultTilesList>& result_tiles);
 
   /**
    * Clean up processed data after copying and get ready for the next
    * iteration.
    *
-   * @return Status.
+   * @param result_tiles Result tiles per fragment.
    */
-  Status end_iteration();
+  void end_iteration(std::vector<ResultTilesList>& result_tiles);
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -50,6 +50,9 @@ class ArraySchema;
 class MemoryTracker;
 class Subarray;
 
+/**
+ * Simple class that stores the progress for a fragment as a tile/cell index.
+ */
 class FragIdx {
  public:
   /* ********************************* */
@@ -205,6 +208,10 @@ class MemoryBudget {
   std::mutex used_memory_mtx_;
 };
 
+/**
+ * Simple class that stores the fragment/tile index of a tile that will be
+ * ignored by further iterations as we deteremined it has no results.
+ */
 class IgnoredTile {
  public:
   /* ********************************* */
@@ -274,20 +281,212 @@ struct ignored_tile_hash {
   }
 };
 
-/** Processes read queries. */
+/**
+ * Processes sparse read queries by keeping progress in fragments as indexes.
+ */
 class SparseIndexReaderBase : public ReaderBase {
  public:
   /* ********************************* */
   /*          TYPE DEFINITIONS         */
   /* ********************************* */
 
-  /** The state for a read sparse global order query. */
+  /**
+   * The state for an index query. This read state cannot be reconstructed as it
+   * contains progress for data that was copied to the user buffers and returned
+   * to the user. The progress is saved, per fragment, as a tile and cell index.
+   *
+   * TBD: done_adding_result_tiles_ might be moved from here. We have to see if
+   * it is really required to determine if a query is incomplete from the client
+   * side of a cloud request.
+   */
   struct ReadState {
     /** The tile index inside of each fragments. */
     std::vector<FragIdx> frag_idx_;
 
     /** Is the reader done with the query. */
     bool done_adding_result_tiles_;
+  };
+
+  /**
+   * Temporary read state that can be recomputed using just the read state. This
+   * contains information about the tile ranges that still need to be processed
+   * if a subarray is set (with memory used) and for which fragments we loaded
+   * all tiles into memory. It also contains which tiles contains no results so
+   * they should be ignored by further iterations. It should be used in
+   * conjunction with the loaded tiles in the respective readers. Eventually,
+   * those will also move to this class but that requires the removal of
+   * every memory allocated things from result tiles into separate objects so
+   * that the list of result tiles is only a fragment/tile index and the objects
+   * are not different anymore.
+   */
+  class TransientReadState : public ITileRange {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+
+    TransientReadState() = delete;
+
+    TransientReadState(uint64_t num_frags)
+        : tile_ranges_(num_frags)
+        , memory_used_tile_ranges_(0)
+        , all_tiles_loaded_(num_frags, false) {
+    }
+
+    DISABLE_COPY_AND_COPY_ASSIGN(TransientReadState);
+    DISABLE_MOVE_AND_MOVE_ASSIGN(TransientReadState);
+
+    /* ********************************* */
+    /*          PUBLIC METHODS           */
+    /* ********************************* */
+
+    /**
+     * Return the tile ranges vector for a particular fragment.
+     *
+     * @param f Fragment index.
+     * @return Tile ranges.
+     */
+    std::vector<std::pair<uint64_t, uint64_t>>& tile_ranges(const unsigned f) {
+      return tile_ranges_[f];
+    }
+
+    /**
+     * Return if all tiles are loaded for a fragment.
+     *
+     * @param f Fragment index.
+     * @return All tiles loaded.
+     */
+    bool all_tiles_loaded(const unsigned f) const {
+      return all_tiles_loaded_[f];
+    }
+
+    /**
+     * Set the all tiles loaded for a fragment.
+     *
+     * @param f Fragment index.
+     */
+    void set_all_tiles_loaded(const unsigned f) {
+      all_tiles_loaded_[f] = true;
+    }
+
+    /** @return Number of fragments left to process. */
+    unsigned num_fragments_to_process() const {
+      unsigned num = 0;
+      for (auto all_loaded : all_tiles_loaded_) {
+        num += !all_loaded;
+      }
+
+      return num;
+    }
+
+    /** @return Are we done adding all result tiles to the list. */
+    bool done_adding_result_tiles() const {
+      bool ret = true;
+      for (auto& b : all_tiles_loaded_) {
+        ret &= b != 0;
+      }
+
+      return ret;
+    }
+
+    /**
+     * Remove the last tile range for a fragment.
+     *
+     * @param f Fragment index.
+     */
+    void remove_tile_range(unsigned f) {
+      tile_ranges_[f].pop_back();
+      {
+        std::unique_lock<std::mutex> lck(memory_used_tile_ranges_mtx_);
+        memory_used_tile_ranges_ -= sizeof(std::pair<uint64_t, uint64_t>);
+      }
+    }
+
+    /** @ereturn Memory usage for the tile ranges. */
+    uint64_t memory_used_tile_ranges() const {
+      return memory_used_tile_ranges_;
+    }
+
+    /** Clears all tile ranges data. */
+    void clear_tile_ranges() override {
+      for (auto& tr : tile_ranges_) {
+        tr.clear();
+      }
+      memory_used_tile_ranges_ = 0;
+    }
+
+    /**
+     * Add a tile range for a fragment.
+     *
+     * @param f Fragment index.
+     * @param min Min tile index for the range.
+     * @param max Max tile index for the range.
+     */
+    void add_tile_range(unsigned f, uint64_t min, uint64_t max) override {
+      tile_ranges_[f].emplace_back(min, max);
+    }
+
+    /** Signals we are done adding tile ranges. */
+    void done_adding_tile_ranges() override {
+      // Compute the size of the tile ranges structure and mark empty fragments
+      // as fully loaded.
+      for (uint64_t i = 0; i < tile_ranges_.size(); i++) {
+        memory_used_tile_ranges_ +=
+            tile_ranges_[i].size() * sizeof(std::pair<uint64_t, uint64_t>);
+        if (tile_ranges_[i].size() == 0) {
+          all_tiles_loaded_[i] = true;
+        }
+      }
+    }
+
+    /**
+     * Add a tile that should be ignored by later iterations because it contains
+     * no results.
+     *
+     * @param rt Result tile.
+     */
+    void add_ignored_tile(ResultTile& rt) {
+      ignored_tiles_.emplace(rt.frag_idx(), rt.tile_idx());
+    }
+
+    /**
+     * Returns true if the tile should be ignored.
+     *
+     * @param f Fragment index.
+     * @param t Tile index.
+     * @return If the tile should be ignored or not.
+     */
+    bool is_ignored_tile(unsigned f, uint64_t t) {
+      return ignored_tiles_.count(IgnoredTile(f, t)) != 0;
+    }
+
+    /** @return number of ignored tiles. */
+    bool num_ignored_tiles() {
+      return ignored_tiles_.size();
+    }
+
+   private:
+    /* ********************************* */
+    /*        PRIVATE ATTRIBUTES         */
+    /* ********************************* */
+
+    /**
+     * Reverse sorted vector, per fragments, of tiles ranges in the subarray, if
+     * set.
+     */
+    std::vector<std::vector<std::pair<uint64_t, uint64_t>>> tile_ranges_;
+
+    /** Memory used for tile ranges. */
+    uint64_t memory_used_tile_ranges_;
+
+    /** Mutex protecting memory_used_tile_ranges_. */
+    std::mutex memory_used_tile_ranges_mtx_;
+
+    /** Have we loaded all tiles for this fragment. */
+    std::vector<uint8_t> all_tiles_loaded_;
+
+    /** List of tiles to ignore. */
+    std::unordered_set<IgnoredTile, ignored_tile_hash> ignored_tiles_;
   };
 
   /* ********************************* */
@@ -331,13 +530,18 @@ class SparseIndexReaderBase : public ReaderBase {
   ReadState* read_state();
 
   /**
+   * Initializes the reader.
+   *
+   * @param skip_checks_serialization Skip checks during serialization.
+   */
+  void init(bool skip_checks_serialization);
+
+  /**
    * Resize the output buffers to the correct size after copying.
    *
    * @param cells_copied Number of cells copied.
-   *
-   * @return Status.
    */
-  Status resize_output_buffers(uint64_t cells_copied);
+  void resize_output_buffers(uint64_t cells_copied);
 
  protected:
   /* ********************************* */
@@ -347,11 +551,11 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Read state. */
   ReadState read_state_;
 
+  /** Transient read state. */
+  TransientReadState tmp_read_state_;
+
   /** Memory budget. */
   MemoryBudget memory_budget_;
-
-  /** Have we loaded all tiles for this fragment. */
-  std::vector<uint8_t> all_tiles_loaded_;
 
   /** Include coordinates when loading tiles. */
   bool include_coords_;
@@ -362,12 +566,6 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Are dimensions var sized. */
   std::vector<bool> is_dim_var_size_;
 
-  /**
-   * Reverse sorted vector, per fragments, of tiles ranges in the subarray, if
-   * set.
-   */
-  std::vector<std::vector<std::pair<uint64_t, uint64_t>>> result_tile_ranges_;
-
   /** Mutex protecting memory budget variables. */
   std::mutex used_memory_mtx_;
 
@@ -377,25 +575,16 @@ class SparseIndexReaderBase : public ReaderBase {
   /** Memory used for coordinates tiles. */
   uint64_t memory_used_for_coords_total_;
 
-  /** Memory used for result tile ranges. */
-  uint64_t memory_used_result_tile_ranges_;
-
   /** Are we in elements mode. */
   bool elements_mode_;
 
   /** Names of dim/attr loaded for query condition. */
   std::vector<std::string> qc_loaded_attr_names_;
 
-  /* Are the users buffers full. */
-  bool buffers_full_;
-
-  /** List of tiles to ignore. */
-  std::unordered_set<IgnoredTile, ignored_tile_hash> ignored_tiles_;
-
   /** Are we doing deletes consolidation (without purge option). */
   bool deletes_consolidation_no_purge_;
 
-  /** Do we allo partial tile offset loading for this query? */
+  /** Do we allow partial tile offset loading for this query? */
   bool partial_tile_offsets_loading_;
 
   /** Var dimensions/attributes for which to load tile var sizes. */
@@ -490,21 +679,17 @@ class SparseIndexReaderBase : public ReaderBase {
    * Compute tile bitmaps.
    *
    * @param result_tiles Result tiles to process.
-   *
-   * @return Status.
-   * */
+   */
   template <class BitmapType>
-  Status compute_tile_bitmaps(std::vector<ResultTile*>& result_tiles);
+  void compute_tile_bitmaps(std::vector<ResultTile*>& result_tiles);
 
   /**
    * Apply query condition.
    *
    * @param result_tiles Result tiles to process.
-   *
-   * @return Status.
    */
   template <class ResultTileType, class BitmapType>
-  Status apply_query_condition(std::vector<ResultTile*>& result_tiles);
+  void apply_query_condition(std::vector<ResultTile*>& result_tiles);
 
   /**
    * Read and unfilter as many attributes as can fit in the memory budget and
@@ -516,9 +701,9 @@ class SparseIndexReaderBase : public ReaderBase {
    * @param buffer_idx Stores/return the current buffer index in process.
    * @param result_tiles Result tiles to process.
    *
-   * @return Status, index_to_copy.
+   * @return index_to_copy.
    */
-  tuple<Status, optional<std::vector<uint64_t>>> read_and_unfilter_attributes(
+  std::vector<uint64_t> read_and_unfilter_attributes(
       const std::vector<std::string>& names,
       const std::vector<uint64_t>& mem_usage_per_attr,
       uint64_t* buffer_idx,
@@ -527,17 +712,8 @@ class SparseIndexReaderBase : public ReaderBase {
   /**
    * Adds an extra offset in the end of the offsets buffer indicating the
    * returned data size if an attribute is var-sized.
-   *
-   * @return Status.
    */
-  Status add_extra_offset();
-
-  /**
-   * Remove a result tile range for a specific fragment.
-   *
-   * @param f Fragment index.
-   */
-  void remove_result_tile_range(uint64_t f);
+  void add_extra_offset();
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -1847,10 +1847,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
   auto tiles_size =
       get_coord_tiles_size(array_schema_.dim_num(), frag_idx, tile_idx);
 
-  {
-    std::unique_lock<std::mutex> lck(used_memory_mtx_);
-    memory_used_for_coords_total_ -= tiles_size;
-  }
+  memory_used_for_coords_total_ -= tiles_size;
 
   // Delete the tile.
   result_tiles.erase(rt);

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -115,7 +115,8 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
 
 template <class BitmapType>
 bool SparseUnorderedWithDupsReader<BitmapType>::incomplete() const {
-  return !read_state_.done_adding_result_tiles_ || !result_tiles_.empty();
+  return !read_state_.done_adding_result_tiles_ ||
+         !result_tiles_leftover_.empty();
 }
 
 template <class BitmapType>
@@ -129,7 +130,7 @@ SparseUnorderedWithDupsReader<BitmapType>::status_incomplete_reason() const {
     return QueryStatusDetailsReason::REASON_NONE;
   }
 
-  return result_tiles_.empty() ?
+  return result_tiles_leftover_.empty() ?
              QueryStatusDetailsReason::REASON_MEMORY_BUDGET :
              QueryStatusDetailsReason::REASON_USER_BUFFER_SIZE;
 }
@@ -155,7 +156,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
 
   // Check that the query condition is valid.
   if (condition_.has_value()) {
-    RETURN_NOT_OK(condition_->check(array_schema_));
+    throw_if_not_ok(condition_->check(array_schema_));
   }
 
   get_dim_attr_stats();
@@ -174,7 +175,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
 
   // Load initial data, if not loaded already. Coords are only included if the
   // subarray is set.
-  RETURN_NOT_OK(load_initial_data());
+  throw_if_not_ok(load_initial_data());
 
   // Attributes names to process.
   std::vector<std::string> names;
@@ -185,100 +186,77 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     names.emplace_back(buffer.first);
   }
 
-  buffers_full_ = false;
+  bool user_buffers_full = false;
   do {
     stats_->add_counter("internal_loop_num", 1);
 
     // Load as much tile offsets data in memory as possible.
     load_tile_offsets_data();
 
-    // Create the result tiles we are going to process.
-    create_result_tiles();
+    ResultTilesList result_tiles;
+    std::vector<ResultTile*> result_tiles_ptr;
+    if (result_tiles_leftover_.size() == 0) {
+      // Create the result tiles we are going to process or use the ones from a
+      // previous iteration.
+      result_tiles = create_result_tiles();
 
-    // No more tiles to process, done.
-    if (result_tiles_.empty()) {
-      assert(read_state_.done_adding_result_tiles_);
-      break;
-    }
-
-    // Generate the list of created/loaded result tiles.
-    std::vector<ResultTile*> result_tiles_created;
-    std::vector<ResultTile*> result_tiles_loaded;
-    for (auto& result_tile : result_tiles_) {
-      if (!result_tile.coords_loaded()) {
-        result_tile.set_coords_loaded();
-        result_tiles_created.emplace_back(&result_tile);
-      } else {
-        result_tiles_loaded.emplace_back(&result_tile);
+      // No more tiles to process, done.
+      if (result_tiles.empty()) {
+        assert(read_state_.done_adding_result_tiles_);
+        break;
       }
-    }
 
-    if (!result_tiles_created.empty()) {
+      for (auto& result_tile : result_tiles) {
+        result_tiles_ptr.emplace_back(&result_tile);
+      }
+
       // Read and unfilter coords.
-      RETURN_NOT_OK(read_and_unfilter_coords(result_tiles_created));
+      throw_if_not_ok(read_and_unfilter_coords(result_tiles_ptr));
 
       // Compute the tile bitmaps.
-      RETURN_NOT_OK(compute_tile_bitmaps<BitmapType>(result_tiles_created));
+      compute_tile_bitmaps<BitmapType>(result_tiles_ptr);
 
       // Apply query condition.
-      auto st = apply_query_condition<
+      apply_query_condition<
           UnorderedWithDupsResultTile<BitmapType>,
-          BitmapType>(result_tiles_created);
-      RETURN_NOT_OK(st);
+          BitmapType>(result_tiles_ptr);
 
-      // Clear result tiles that are not necessary anymore.
-      uint64_t current = 0;
-      for (uint64_t i = 0; i < result_tiles_created.size(); i++) {
-        if (((ResultTileWithBitmap<uint64_t>*)result_tiles_created[i])
-                ->result_num() != 0) {
-          result_tiles_created[current++] = result_tiles_created[i];
-        }
+      clean_tile_list(result_tiles, result_tiles_ptr);
+
+      // No more tiles to process, continue.
+      if (result_tiles.empty()) {
+        continue;
       }
-      result_tiles_created.resize(current);
+    } else {
+      result_tiles = std::move(result_tiles_leftover_);
+      result_tiles_leftover_.clear();
 
-      // Clear result tiles that are not necessary anymore, part 2.
-      auto it = result_tiles_.begin();
-      while (it != result_tiles_.end()) {
-        auto f = it->frag_idx();
-        if (it->result_num() == 0) {
-          RETURN_NOT_OK(remove_result_tile(f, it++));
-        } else {
-          it++;
-        }
+      for (auto& result_tile : result_tiles) {
+        result_tiles_ptr.emplace_back(&result_tile);
       }
-
-      result_tiles_loaded.insert(
-          result_tiles_loaded.end(),
-          result_tiles_created.begin(),
-          result_tiles_created.end());
-    }
-
-    // No more tiles to process, continue.
-    if (result_tiles_.empty()) {
-      continue;
     }
 
     // Copy tiles.
     if (offsets_bitsize_ == 64) {
-      RETURN_NOT_OK(process_tiles<uint64_t>(names, result_tiles_loaded));
+      user_buffers_full = process_tiles<uint64_t>(names, result_tiles_ptr);
     } else {
-      RETURN_NOT_OK(process_tiles<uint32_t>(names, result_tiles_loaded));
+      user_buffers_full = process_tiles<uint32_t>(names, result_tiles_ptr);
     }
 
     // End the iteration.
-    RETURN_NOT_OK(end_iteration());
-  } while (!buffers_full_ && incomplete());
+    end_iteration(result_tiles);
+  } while (!user_buffers_full && incomplete());
 
   // Fix the output buffer sizes.
   const auto cells = cells_copied(names);
   stats_->add_counter("result_num", cells);
-  RETURN_NOT_OK(resize_output_buffers(cells));
+  resize_output_buffers(cells);
 
   if (offsets_extra_element_) {
-    RETURN_NOT_OK(add_extra_offset());
+    add_extra_offset();
   }
 
-  stats_->add_counter("ignored_tiles", ignored_tiles_.size());
+  stats_->add_counter("ignored_tiles", tmp_read_state_.num_ignored_tiles());
 
   return Status::Ok();
 }
@@ -329,7 +307,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::load_tile_offsets_data() {
     }
   } else {
     if (initial_load ||
-        (all_tiles_loaded_[tile_offsets_max_frag_idx_ - 1] &&
+        (tmp_read_state_.all_tiles_loaded(tile_offsets_max_frag_idx_ - 1) &&
          tile_offsets_max_frag_idx_ != fragment_metadata_.size())) {
       // For the initial load the min index is 0. Otherwise, it is max + 1.
       if (initial_load) {
@@ -410,7 +388,8 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
     const unsigned f,
     const uint64_t t,
     const uint64_t last_t,
-    const FragmentMetadata& frag_md) {
+    const FragmentMetadata& frag_md,
+    ResultTilesList& result_tiles) {
   // Use either the coordinate portion of the total budget or the tile upper
   // memory limit as the upper memory limit, whichever is smaller.
   const uint64_t upper_memory_limit = std::min<uint64_t>(
@@ -424,7 +403,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
   if (memory_used_for_coords_total_ + tiles_size > upper_memory_limit) {
     // If we don't have any tiles loaded and the new tile still can fit in the
     // available memory, allow loading it so we can make progress.
-    if (!result_tiles_.empty() || tiles_size > available_memory()) {
+    if (!result_tiles.empty() || tiles_size > available_memory()) {
       logger_->debug(
           "Budget exceeded adding result tiles, fragment {0}, tile "
           "{1}",
@@ -432,7 +411,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
           t);
 
       // Make sure we can add at least one tile.
-      if (result_tiles_.empty()) {
+      if (result_tiles.empty()) {
         throw SparseUnorderedWithDupsReaderStatusException(
             "Cannot load a single tile, increase memory budget");
       }
@@ -445,22 +424,24 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
   memory_used_for_coords_total_ += tiles_size;
 
   // Add the result tile.
-  result_tiles_.emplace_back(f, t, frag_md);
+  result_tiles.emplace_back(f, t, frag_md);
 
   // Are all tiles loaded for this fragment.
   if (t == last_t) {
-    all_tiles_loaded_[f] = true;
+    tmp_read_state_.set_all_tiles_loaded(f);
   }
 
   return false;
 }
 
 template <class BitmapType>
-void SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
+std::list<UnorderedWithDupsResultTile<BitmapType>>
+SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
   auto timer_se = stats_->start_timer("create_result_tiles");
 
+  ResultTilesList result_tiles;
+
   // For easy reference.
-  const auto fragment_num = fragment_metadata_.size();
   const auto dim_num = array_schema_.dim_num();
 
   // Create result tiles.
@@ -469,16 +450,20 @@ void SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
     bool budget_exceeded = false;
     unsigned int f = 0;
     while (f < tile_offsets_max_frag_idx_ && !budget_exceeded) {
-      if (!all_tiles_loaded_[f]) {
-        all_tiles_loaded_[f] = result_tile_ranges_[f].empty();
-        while (!result_tile_ranges_[f].empty()) {
-          auto& range = result_tile_ranges_[f].back();
-          const auto last_t = result_tile_ranges_[f].front().second;
+      auto& tile_ranges = tmp_read_state_.tile_ranges(f);
+      if (!tmp_read_state_.all_tiles_loaded(f)) {
+        if (tile_ranges.empty()) {
+          tmp_read_state_.set_all_tiles_loaded(f);
+        }
+
+        while (!tile_ranges.empty()) {
+          auto& range = tile_ranges.back();
+          const auto last_t = tile_ranges.front().second;
 
           // Add all tiles for this range.
           for (uint64_t t = range.first; t <= range.second; t++) {
-            budget_exceeded =
-                add_result_tile(dim_num, f, t, last_t, *fragment_metadata_[f]);
+            budget_exceeded = add_result_tile(
+                dim_num, f, t, last_t, *fragment_metadata_[f], result_tiles);
             if (budget_exceeded) {
               break;
             }
@@ -490,7 +475,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
             break;
           }
 
-          remove_result_tile_range(f);
+          tmp_read_state_.remove_tile_range(f);
         }
       }
 
@@ -501,20 +486,25 @@ void SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
     bool budget_exceeded = false;
     unsigned int f = 0;
     while (f < tile_offsets_max_frag_idx_ && !budget_exceeded) {
-      if (!all_tiles_loaded_[f]) {
+      if (!tmp_read_state_.all_tiles_loaded(f)) {
         auto tile_num = fragment_metadata_[f]->tile_num();
 
         // Figure out the start index.
         auto start = read_state_.frag_idx_[f].tile_idx_;
-        if (!result_tiles_.empty() && result_tiles_.back().frag_idx() == f) {
-          start = std::max(start, result_tiles_.back().tile_idx() + 1);
-        }
 
         // Add all tiles for this fragment.
-        all_tiles_loaded_[f] = start == tile_num;
+        if (start == tile_num) {
+          tmp_read_state_.set_all_tiles_loaded(f);
+        }
+
         for (uint64_t t = start; t < tile_num; t++) {
           budget_exceeded = add_result_tile(
-              dim_num, f, t, tile_num - 1, *fragment_metadata_[f]);
+              dim_num,
+              f,
+              t,
+              tile_num - 1,
+              *fragment_metadata_[f],
+              result_tiles);
           if (budget_exceeded) {
             break;
           }
@@ -525,19 +515,43 @@ void SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
   }
 
   // Check if we are done adding result tiles.
-  bool done_adding_result_tiles = true;
-  for (unsigned int f = 0; f < fragment_num; f++) {
-    done_adding_result_tiles &= all_tiles_loaded_[f] != 0;
-  }
+  bool done_adding_result_tiles = tmp_read_state_.done_adding_result_tiles();
 
   logger_->debug(
-      "Done adding result tiles, num result tiles {0}", result_tiles_.size());
+      "Done adding result tiles, num result tiles {0}", result_tiles.size());
 
   if (done_adding_result_tiles) {
     logger_->debug("All result tiles loaded");
   }
 
   read_state_.done_adding_result_tiles_ = done_adding_result_tiles;
+
+  return result_tiles;
+}
+
+template <class BitmapType>
+void SparseUnorderedWithDupsReader<BitmapType>::clean_tile_list(
+    ResultTilesList& result_tiles, std::vector<ResultTile*>& result_tiles_ptr) {
+  // Clear result tiles that are not necessary anymore.
+  uint64_t current = 0;
+  for (uint64_t i = 0; i < result_tiles_ptr.size(); i++) {
+    if (((ResultTileWithBitmap<BitmapType>*)result_tiles_ptr[i])
+            ->result_num() != 0) {
+      result_tiles_ptr[current++] = result_tiles_ptr[i];
+    }
+  }
+  result_tiles_ptr.resize(current);
+
+  // Clear result tiles that are not necessary anymore, part 2.
+  auto it = result_tiles.begin();
+  while (it != result_tiles.end()) {
+    auto f = it->frag_idx();
+    if (it->result_num() == 0) {
+      remove_result_tile(f, result_tiles, it++);
+    } else {
+      it++;
+    }
+  }
 }
 
 template <class BitmapType>
@@ -578,7 +592,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_parallelization_parameters(
 /** Copy offsets with a result count bitmap. */
 template <>
 template <class OffType>
-Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
+void SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
     const std::string& name,
     const bool nullable,
     const OffType offset_div,
@@ -669,14 +683,12 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
       }
     }
   }
-
-  return Status::Ok();
 }
 
 /** Copy offsets with a result bitmap. */
 template <>
 template <class OffType>
-Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
+void SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
     const std::string& name,
     const bool nullable,
     const OffType offset_div,
@@ -790,13 +802,11 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
       }
     }
   }
-
-  return Status::Ok();
 }
 
 template <class BitmapType>
 template <class OffType>
-Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
+void SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
     const std::string& name,
     const uint64_t num_range_threads,
     const bool nullable,
@@ -812,7 +822,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
   auto val_buffer = query_buffer.validity_vector_.buffer();
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_tiles.size(),
@@ -851,7 +861,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
         }
 
         // Copy tile.
-        RETURN_NOT_OK(copy_offsets_tile<OffType>(
+        copy_offsets_tile<OffType>(
             name,
             nullable,
             offset_div,
@@ -860,19 +870,16 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
             src_max_pos,
             buffer + dest_cell_offset,
             val_buffer + dest_cell_offset,
-            &var_data[dest_cell_offset - cell_offsets[0]]));
+            &var_data[dest_cell_offset - cell_offsets[0]]);
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 /** Copy Var data. */
 template <class BitmapType>
 template <class OffType>
-Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tile(
+void SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tile(
     const bool last_partition,
     const uint64_t var_data_offset,
     const uint64_t offset_div,
@@ -902,13 +909,11 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tile(
           (var_buffer_size - offsets_buffer[src_max_pos - 1]) * offset_div);
     }
   }
-
-  return Status::Ok();
 }
 
 template <class BitmapType>
 template <class OffType>
-Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
+void SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
     const uint64_t num_range_threads,
     const OffType offset_div,
     const uint64_t var_buffer_size,
@@ -923,7 +928,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
   auto var_data_buffer = (uint8_t*)query_buffer.buffer_var_;
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_tiles.size(),
@@ -946,7 +951,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
           return Status::Ok();
         }
 
-        RETURN_NOT_OK(copy_var_data_tile(
+        copy_var_data_tile(
             last_tile && src_max_pos == max_pos_tile,
             dest_cell_offset - cell_offsets[0],
             offset_div,
@@ -955,18 +960,15 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
             src_max_pos,
             (const void**)var_data.data(),
             offsets_buffer + dest_cell_offset,
-            var_data_buffer));
+            var_data_buffer);
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 /** Copy fixed data with a result count bitmap. */
 template <>
-Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
+void SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
     const std::string& name,
     const bool is_dim,
     const bool nullable,
@@ -1044,13 +1046,11 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_fixed_data_tile(
       }
     }
   }
-
-  return Status::Ok();
 }
 
 /** Copy fixed data with a result bitmap. */
 template <>
-Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
+void SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
     const std::string& name,
     const bool is_dim,
     const bool nullable,
@@ -1175,12 +1175,10 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_fixed_data_tile(
       memcpy(val_buffer, src_val_buff + src_min_pos, src_max_pos - src_min_pos);
     }
   }
-
-  return Status::Ok();
 }
 
 template <>
-Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
+void SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
     UnorderedWithDupsResultTile<uint64_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
@@ -1214,11 +1212,10 @@ Status SparseUnorderedWithDupsReader<uint64_t>::copy_timestamp_data_tile(
       }
     }
   }
-  return Status::Ok();
 }
 
 template <>
-Status SparseUnorderedWithDupsReader<uint8_t>::copy_timestamp_data_tile(
+void SparseUnorderedWithDupsReader<uint8_t>::copy_timestamp_data_tile(
     UnorderedWithDupsResultTile<uint8_t>* rt,
     const uint64_t src_min_pos,
     const uint64_t src_max_pos,
@@ -1283,12 +1280,10 @@ Status SparseUnorderedWithDupsReader<uint8_t>::copy_timestamp_data_tile(
           buffer, timestamps.data(), (src_max_pos - src_min_pos) * cell_size);
     }
   }
-
-  return Status::Ok();
 }
 
 template <class BitmapType>
-Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
+void SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
     const std::string& name,
     const uint64_t num_range_threads,
     const bool is_dim,
@@ -1305,7 +1300,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
   auto val_buffer = query_buffer.validity_vector_.buffer();
 
   // Process all tiles/cells in parallel.
-  auto status = parallel_for_2d(
+  throw_if_not_ok(parallel_for_2d(
       storage_manager_->compute_tp(),
       0,
       result_tiles.size(),
@@ -1344,14 +1339,14 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
         }
 
         if (name == constants::timestamps) {
-          RETURN_NOT_OK(copy_timestamp_data_tile(
+          copy_timestamp_data_tile(
               &*rt,
               src_min_pos,
               src_max_pos,
-              buffer + dest_cell_offset * cell_size));
+              buffer + dest_cell_offset * cell_size);
         } else {
           // Copy tile.
-          RETURN_NOT_OK(copy_fixed_data_tile(
+          copy_fixed_data_tile(
               name,
               is_dim,
               nullable,
@@ -1361,14 +1356,11 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
               src_min_pos,
               src_max_pos,
               buffer + dest_cell_offset * cell_size,
-              val_buffer + dest_cell_offset));
+              val_buffer + dest_cell_offset);
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
-
-  return Status::Ok();
+      }));
 }
 
 template <class BitmapType>
@@ -1378,7 +1370,7 @@ SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_result_tiles_to_copy(
     uint64_t initial_cell_offset,
     uint64_t first_tile_min_pos,
     std::vector<ResultTile*>& result_tiles) {
-  bool buffers_full;
+  bool user_buffers_full;
   std::vector<uint64_t> cell_offsets;
   cell_offsets.reserve(result_tiles.size() + 1);
 
@@ -1409,10 +1401,10 @@ SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_result_tiles_to_copy(
   // later on. If not, add a partial tile at the end.
   if (cell_offset == max_num_cells ||
       cell_offsets.size() == result_tiles.size()) {
-    buffers_full = cell_offset == max_num_cells;
+    user_buffers_full = cell_offset == max_num_cells;
     cell_offsets.emplace_back(cell_offset);
   } else {
-    buffers_full = true;
+    user_buffers_full = true;
     cell_offsets.emplace_back(cell_offset);
 
     // For overlapping ranges, a cell might be included multiple times and we
@@ -1448,11 +1440,11 @@ SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_result_tiles_to_copy(
   // Resize the result tiles vector.
   result_tiles.resize(cell_offsets.size() - 1);
 
-  return {buffers_full, cell_offsets};
+  return {user_buffers_full, cell_offsets};
 }
 
 template <class BitmapType>
-std::vector<uint64_t>
+tuple<bool, std::vector<uint64_t>>
 SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_results_to_copy(
     const std::vector<std::string>& names,
     std::vector<ResultTile*>& result_tiles) {
@@ -1486,24 +1478,23 @@ SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_results_to_copy(
   // User gave us some empty buffers, exit.
   if (max_num_cells == 0) {
     result_tiles.clear();
-    return std::vector<uint64_t>();
+    return {false, std::vector<uint64_t>()};
   }
 
   uint64_t initial_cell_offset = cells_copied(names);
   uint64_t first_tile_min_pos =
       read_state_.frag_idx_[result_tiles[0]->frag_idx()].cell_idx_;
 
-  auto&& [buffers_full, cell_offsets] = resize_fixed_result_tiles_to_copy(
+  return resize_fixed_result_tiles_to_copy(
       max_num_cells, initial_cell_offset, first_tile_min_pos, result_tiles);
-  buffers_full_ |= buffers_full;
-  return cell_offsets;
 }
 
 template <class BitmapType>
-tuple<Status, optional<std::vector<uint64_t>>>
+std::vector<uint64_t>
 SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
     const std::vector<std::string>& names,
-    std::vector<ResultTile*>& result_tiles) {
+    std::vector<ResultTile*>& result_tiles,
+    bool& user_buffers_full) {
   // Use either the tile upper memory limit, or the available memory as the
   // upper memory limit, whichever is smaller.
   uint64_t upper_memory_limit =
@@ -1513,7 +1504,7 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
   uint64_t max_rt_idx = result_tiles.size();
   std::mutex max_rt_idx_mtx;
   std::vector<uint64_t> total_mem_usage_per_attr(names.size());
-  auto status = parallel_for(
+  throw_if_not_ok(parallel_for(
       storage_manager_->compute_tp(), 0, names.size(), [&](uint64_t i) {
         // For easy reference.
         const auto& name = names[i];
@@ -1570,21 +1561,18 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
         }
 
         return Status::Ok();
-      });
-  RETURN_NOT_OK_ELSE_TUPLE(
-      status, logger_->status_no_return_value(status), nullopt);
+      }));
 
-  if (max_rt_idx == 0)
-    return {
-        Status_SparseUnorderedWithDupsReaderError(
-            "Unable to copy one tile with current budget/buffers"),
-        nullopt};
+  if (max_rt_idx == 0) {
+    throw SparseUnorderedWithDupsReaderStatusException(
+        "Unable to copy one tile with current budget/buffers");
+  }
 
   // Resize the result tiles vector.
-  buffers_full_ &= max_rt_idx == result_tiles.size();
+  user_buffers_full &= max_rt_idx == result_tiles.size();
   result_tiles.resize(max_rt_idx);
 
-  return {Status::Ok(), std::move(total_mem_usage_per_attr)};
+  return total_mem_usage_per_attr;
 }
 
 template <class BitmapType>
@@ -1600,7 +1588,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
 
   auto new_var_buffer_size = *query_buffer.buffer_var_size_;
   auto new_result_tiles_size = result_tiles.size();
-  bool buffers_full = false;
+  bool user_buffers_full = false;
 
   // Switch offsets buffer from cell size to offsets.
   auto offsets_buff = (OffType*)query_buffer.buffer_;
@@ -1614,7 +1602,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
   // Make sure var size buffer can fit the data.
   if (query_buffer.original_buffer_var_size_ < new_var_buffer_size) {
     // Buffers are full.
-    buffers_full = true;
+    user_buffers_full = true;
 
     // First find the last full result tile that we can fit.
     while (query_buffer.original_buffer_var_size_ < new_var_buffer_size) {
@@ -1661,28 +1649,27 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_var_size_offsets(
     }
   }
 
-  return {buffers_full, new_var_buffer_size, new_result_tiles_size};
+  return {user_buffers_full, new_var_buffer_size, new_result_tiles_size};
 }
 
 template <class BitmapType>
 template <class OffType>
-Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
+bool SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
     std::vector<std::string>& names, std::vector<ResultTile*>& result_tiles) {
   auto timer_se = stats_->start_timer("process_tiles");
 
   // Vector for storing the cell offsets of each tiles into the user buffers.
   // This also stores the last offset to facilitate calculations later on.
-  std::vector<uint64_t> cell_offsets =
+  auto&& [user_buffers_full, cell_offsets] =
       resize_fixed_results_to_copy(names, result_tiles);
 
   // Making sure we respect the memory budget for the copy operation.
-  auto&& [st, mem_usage_per_attr] =
-      respect_copy_memory_budget(names, result_tiles);
-  RETURN_NOT_OK(st);
+  auto mem_usage_per_attr =
+      respect_copy_memory_budget(names, result_tiles, user_buffers_full);
 
   // There is no space for any tiles in the user buffer, exit.
   if (result_tiles.empty()) {
-    return Status::Ok();
+    return user_buffers_full;
   }
 
   // Compute parallelization parameters.
@@ -1697,12 +1684,11 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   uint64_t buffer_idx = 0;
   while (buffer_idx < names.size()) {
     // Read and unfilter as many attributes as can fit in the budget.
-    auto&& [st, index_to_copy] = read_and_unfilter_attributes(
-        names, *mem_usage_per_attr, &buffer_idx, result_tiles);
-    RETURN_NOT_OK(st);
+    auto index_to_copy = read_and_unfilter_attributes(
+        names, mem_usage_per_attr, &buffer_idx, result_tiles);
 
     // Copy one attribute at a time for buffers in memory.
-    for (const auto& idx : *index_to_copy) {
+    for (const auto& idx : index_to_copy) {
       // For easy reference.
       const auto& name = names[idx];
       const auto is_dim = array_schema_.is_dim(name);
@@ -1729,7 +1715,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
       OffType offset_div =
           elements_mode_ ? datatype_size(array_schema_.type(name)) : 1;
       if (var_sized) {
-        RETURN_NOT_OK(copy_offsets_tiles<OffType>(
+        copy_offsets_tiles<OffType>(
             name,
             num_range_threads,
             nullable,
@@ -1737,9 +1723,9 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
             result_tiles,
             cell_offsets,
             query_buffer,
-            var_data));
+            var_data);
       } else {
-        RETURN_NOT_OK(copy_fixed_data_tiles(
+        copy_fixed_data_tiles(
             name,
             num_range_threads,
             is_dim,
@@ -1748,27 +1734,26 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
             cell_size,
             result_tiles,
             cell_offsets,
-            query_buffer));
+            query_buffer);
       }
 
       uint64_t var_buffer_size = 0;
-
       if (var_sized) {
         uint64_t first_tile_min_pos =
             read_state_.frag_idx_[result_tiles[0]->frag_idx()].cell_idx_;
 
         // Adjust the offsets buffer and make sure all data fits.
-        auto&& [buffers_full, new_var_buffer_size, new_result_tiles_size] =
+        auto&& [user_buffs_full, new_var_buffer_size, new_result_tiles_size] =
             compute_var_size_offsets<OffType>(
                 stats_,
                 result_tiles,
                 first_tile_min_pos,
                 cell_offsets,
                 query_buffer);
-        buffers_full_ |= buffers_full;
+        user_buffers_full |= user_buffs_full;
 
         // Clear tiles from memory and adjust result_tiles.
-        for (const auto& copy_idx : *index_to_copy) {
+        for (const auto& copy_idx : index_to_copy) {
           const auto& name_to_clear = names[copy_idx];
           const auto is_dim_to_clear = array_schema_.is_dim(name_to_clear);
           if (qc_loaded_attr_names_set_.count(name_to_clear) == 0 &&
@@ -1779,14 +1764,14 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
         result_tiles.resize(new_result_tiles_size);
 
         // Now copy the var size data.
-        RETURN_NOT_OK(copy_var_data_tiles(
+        copy_var_data_tiles(
             num_range_threads,
             offset_div,
             new_var_buffer_size,
             result_tiles,
             cell_offsets,
             query_buffer,
-            var_data));
+            var_data);
 
         var_buffer_size = new_var_buffer_size;
       }
@@ -1849,13 +1834,14 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   }
 
   logger_->debug("Done copying tiles");
-  return Status::Ok();
+  return user_buffers_full;
 }
 
 template <class BitmapType>
-Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
+void SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
     const unsigned frag_idx,
-    typename std::list<UnorderedWithDupsResultTile<BitmapType>>::iterator rt) {
+    ResultTilesList& result_tiles,
+    typename ResultTilesList::iterator rt) {
   // Remove coord tile size from memory budget.
   const auto tile_idx = rt->tile_idx();
   auto tiles_size =
@@ -1867,35 +1853,34 @@ Status SparseUnorderedWithDupsReader<BitmapType>::remove_result_tile(
   }
 
   // Delete the tile.
-  result_tiles_.erase(rt);
-
-  return Status::Ok();
+  result_tiles.erase(rt);
 }
 
 template <class BitmapType>
-Status SparseUnorderedWithDupsReader<BitmapType>::end_iteration() {
+void SparseUnorderedWithDupsReader<BitmapType>::end_iteration(
+    ResultTilesList& result_tiles) {
   // Clear result tiles that are not necessary anymore.
-  while (
-      !result_tiles_.empty() &&
-      result_tiles_.front().tile_idx() <
-          read_state_.frag_idx_[result_tiles_.front().frag_idx()].tile_idx_) {
-    const auto f = result_tiles_.front().frag_idx();
+  while (!result_tiles.empty() &&
+         result_tiles.front().tile_idx() <
+             read_state_.frag_idx_[result_tiles.front().frag_idx()].tile_idx_) {
+    const auto f = result_tiles.front().frag_idx();
 
-    RETURN_NOT_OK(remove_result_tile(f, result_tiles_.begin()));
+    remove_result_tile(f, result_tiles, result_tiles.begin());
   }
+
+  result_tiles_leftover_ = std::move(result_tiles);
 
   // Validate memory usage.
   if (!incomplete()) {
     assert(memory_used_for_coords_total_ == 0);
-    assert(memory_used_result_tile_ranges_ == 0);
+    assert(tmp_read_state_.memory_used_tile_ranges() == 0);
   }
 
   logger_->debug(
-      "Done with iteration, num result tiles {0}", result_tiles_.size());
+      "Done with iteration, num result tiles {0}", result_tiles.size());
 
   const auto uint64_t_max = std::numeric_limits<uint64_t>::max();
   array_memory_tracker_->set_budget(uint64_t_max);
-  return Status::Ok();
 }
 
 // Explicit template instantiations

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -60,6 +60,8 @@ template <class BitmapType>
 class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
                                       public IQueryStrategy {
  public:
+  typedef std::list<UnorderedWithDupsResultTile<BitmapType>> ResultTilesList;
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -97,7 +99,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
    *
-   * @return buffers_full, new_var_buffer_size, new_result_tiles_size.
+   * @return user_buffers_full, new_var_buffer_size, new_result_tiles_size.
    */
   template <class OffType>
   static tuple<bool, uint64_t, uint64_t> compute_var_size_offsets(
@@ -117,7 +119,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param first_tile_min_pos Cell progress of the first tile.
    * @param result_tiles Result tiles to process, might be truncated.
    *
-   * @return buffers_full, cell_offsets.
+   * @return user_buffers_full, cell_offsets.
    */
   static tuple<bool, std::vector<uint64_t>> resize_fixed_result_tiles_to_copy(
       uint64_t max_num_cells,
@@ -180,9 +182,11 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;
 
-  /** Result tiles currently loaded. */
-  std::list<UnorderedWithDupsResultTile<BitmapType>> result_tiles_;
-
+  /**
+   * Result tiles currently for which we loaded coordinates but couldn't
+   * process in the previous iteration.
+   */
+  std::list<UnorderedWithDupsResultTile<BitmapType>> result_tiles_leftover_;
   /** Minimum fragment index for loaded tile offsets data. */
   unsigned tile_offsets_min_frag_idx_;
 
@@ -215,18 +219,30 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param t Tile index.
    * @param last_t Last tile index.
    * @param frag_md Fragment metadata.
+   * @param result_tiles Result tile list to add to.
    *
-   * @return buffers_full.
+   * @return user_buffers_full.
    */
   bool add_result_tile(
       const unsigned dim_num,
       const unsigned f,
       const uint64_t t,
       const uint64_t last_t,
-      const FragmentMetadata& frag_md);
+      const FragmentMetadata& frag_md,
+      ResultTilesList& result_tiles);
 
   /** Create the result tiles. */
-  void create_result_tiles();
+  ResultTilesList create_result_tiles();
+
+  /**
+   * Clean tiles that have 0 results from the tile lists.
+   *
+   * @param result_tiles Result tiles list.
+   * @param result_tiles_ptr Result tile pointers vectors.
+   */
+  void clean_tile_list(
+      ResultTilesList& result_tiles,
+      std::vector<ResultTile*>& result_tiles_ptr);
 
   /**
    * Compute parallelization parameters for a tile copy operation.
@@ -260,11 +276,9 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param buffer Offsets buffer.
    * @param val_buffer Validity buffer.
    * @param var_data Stores pointers to var data cell values.
-   *
-   * @return Status.
    */
   template <class OffType>
-  Status copy_offsets_tile(
+  void copy_offsets_tile(
       const std::string& name,
       const bool nullable,
       const OffType offset_div,
@@ -286,11 +300,9 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
    * @param var_data Stores pointers to var data cell values.
-   *
-   * @return Status.
    */
   template <class OffType>
-  Status copy_offsets_tiles(
+  void copy_offsets_tiles(
       const std::string& name,
       const uint64_t num_range_threads,
       const bool nullable,
@@ -312,11 +324,9 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param var_data Stores pointers to var data cell values.
    * @param offsets_buffer Offsets buffer.
    * @param var_data_buffer Var data buffer.
-   *
-   * @return Status.
    */
   template <class OffType>
-  Status copy_var_data_tile(
+  void copy_var_data_tile(
       const bool last_partition,
       const uint64_t var_data_offset,
       const uint64_t offset_div,
@@ -337,11 +347,9 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
    * @param var_data Stores pointers to var data cell values.
-   *
-   * @return Status.
    */
   template <class OffType>
-  Status copy_var_data_tiles(
+  void copy_var_data_tiles(
       const uint64_t num_range_threads,
       const OffType offset_div,
       const uint64_t var_buffer_size,
@@ -363,10 +371,8 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param src_max_pos Maximum cell position to copy.
    * @param buffer Offsets buffer.
    * @param val_buffer Validity buffer.
-   *
-   * @return Status.
    */
-  Status copy_fixed_data_tile(
+  void copy_fixed_data_tile(
       const std::string& name,
       const bool is_dim,
       const bool nullable,
@@ -385,10 +391,8 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param src_min_pos Minimum cell position to copy.
    * @param src_max_pos Maximum cell position to copy.
    * @param buffer Offsets buffer.
-   *
-   * @return Status.
    */
-  Status copy_timestamp_data_tile(
+  void copy_timestamp_data_tile(
       UnorderedWithDupsResultTile<BitmapType>* rt,
       const uint64_t src_min_pos,
       const uint64_t src_max_pos,
@@ -406,10 +410,8 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param result_tiles Result tiles to process.
    * @param cell_offsets Cell offset per result tile.
    * @param query_buffer Query buffer to operate on.
-   *
-   * @return Status.
    */
-  Status copy_fixed_data_tiles(
+  void copy_fixed_data_tiles(
       const std::string& name,
       const uint64_t num_range_threads,
       const bool is_dim,
@@ -427,9 +429,9 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param names Attribute/dimensions to compute for.
    * @param result_tiles The result tiles to process.
    *
-   * @return Cell offsets.
+   * @return user_buffers_full, cell_offsets.
    */
-  std::vector<uint64_t> resize_fixed_results_to_copy(
+  tuple<bool, std::vector<uint64_t>> resize_fixed_results_to_copy(
       const std::vector<std::string>& names,
       std::vector<ResultTile*>& result_tiles);
 
@@ -440,12 +442,16 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    *
    * @param names Attribute/dimensions to compute for.
    * @param result_tiles Result tiles to process, might be truncated.
+   * @param user_buffers_full Boolean that indicates if the user buffers are
+   * full or not. If this comes in as `true`, it might be reset to `false` if
+   * the results were truncated.
    *
-   * @return Status, total_mem_usage_per_attr.
+   * @return total_mem_usage_per_attr.
    */
-  tuple<Status, optional<std::vector<uint64_t>>> respect_copy_memory_budget(
+  std::vector<uint64_t> respect_copy_memory_budget(
       const std::vector<std::string>& names,
-      std::vector<ResultTile*>& result_tiles);
+      std::vector<ResultTile*>& result_tiles,
+      bool& user_buffers_full);
 
   /**
    * Copy tiles.
@@ -453,31 +459,31 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param names Attribute/dimensions to compute for.
    * @param result_tiles The result tiles to process.
    *
-   * @return Status.
+   * @return user_buffers_full.
    */
   template <class OffType>
-  Status process_tiles(
+  bool process_tiles(
       std::vector<std::string>& names, std::vector<ResultTile*>& result_tiles);
 
   /**
-   * Remove a result tile from memory
+   * Remove a result tile from memory.
    *
    * @param frag_idx Fragment index.
+   * @param result_tiles List of result tiles.
    * @param rt Iterator to the result tile to remove.
-   *
-   * @return Status.
    */
-  Status remove_result_tile(
+  void remove_result_tile(
       const unsigned frag_idx,
-      typename std::list<UnorderedWithDupsResultTile<BitmapType>>::iterator rt);
+      ResultTilesList& result_tiles,
+      typename ResultTilesList::iterator rt);
 
   /**
    * Clean up processed data after copying and get ready for the next
    * iteration.
    *
-   * @return Status.
+   * @param result_tiles List of result tiles.
    */
-  Status end_iteration();
+  void end_iteration(ResultTilesList& result_tiles);
 };
 
 }  // namespace sm

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2625,18 +2625,15 @@ Status Subarray::precompute_tile_overlap(
 Status Subarray::precompute_all_ranges_tile_overlap(
     ThreadPool* const compute_tp,
     std::vector<FragIdx>& frag_tile_idx,
-    std::vector<std::vector<std::pair<uint64_t, uint64_t>>>*
-        result_tile_ranges) {
+    ITileRange* tile_ranges) {
   auto timer_se = stats_->start_timer("read_compute_simple_tile_overlap");
 
   // For easy reference.
   const auto meta = array_->fragment_metadata();
-  const auto fragment_num = meta.size();
   const auto dim_num = array_->array_schema_latest().dim_num();
 
   // Get the results ready.
-  result_tile_ranges->clear();
-  result_tile_ranges->resize(fragment_num);
+  tile_ranges->clear_tile_ranges();
 
   compute_range_offsets();
 
@@ -2716,7 +2713,7 @@ Status Subarray::precompute_all_ranges_tile_overlap(
 
           if (!comb) {
             if (length != 0) {
-              result_tile_ranges->at(f).emplace_back(end + 1 - length, end);
+              tile_ranges->add_tile_range(f, end + 1 - length, end);
               length = 0;
             }
 
@@ -2727,12 +2724,15 @@ Status Subarray::precompute_all_ranges_tile_overlap(
         }
 
         // Push the last result tile range.
-        if (length != 0)
-          result_tile_ranges->at(f).emplace_back(end + 1 - length, end);
+        if (length != 0) {
+          tile_ranges->add_tile_range(f, end + 1 - length, end);
+        }
 
         return Status::Ok();
       });
   RETURN_NOT_OK(status);
+
+  tile_ranges->done_adding_tile_ranges();
 
   return Status::Ok();
 }

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -78,6 +78,31 @@ enum class Layout : uint8_t;
 enum class QueryType : uint8_t;
 
 /**
+ * Interface to implement for a class that can store tile ranges computed by
+ * this class.
+ */
+class ITileRange {
+ public:
+  /** Destructor. */
+  virtual ~ITileRange() = default;
+
+  /** Clears all tile ranges data. */
+  virtual void clear_tile_ranges() = 0;
+
+  /**
+   * Add a tile range for a fragment.
+   *
+   * @param f Fragment index.
+   * @param min Min tile index for the range.
+   * @param max Max tile index for the range.
+   */
+  virtual void add_tile_range(unsigned f, uint64_t min, uint64_t max) = 0;
+
+  /** Signals we are done adding tile ranges. */
+  virtual void done_adding_tile_ranges() = 0;
+};
+
+/**
  * A Subarray object is associated with an array, and
  * is oriented by a set of 1D ranges per dimension over the array
  * domain. The ranges may overlap. The subarray essentially represents
@@ -637,13 +662,12 @@ class Subarray {
    *
    * @param compute_tp The compute thread pool.
    * @param frag_tile_idx The current tile index, per fragment.
-   * @param result_tile_ranges The resulting tile ranges.
+   * @param tile_ranges The resulting tile ranges.
    */
   Status precompute_all_ranges_tile_overlap(
       ThreadPool* const compute_tp,
       std::vector<FragIdx>& frag_tile_idx,
-      std::vector<std::vector<std::pair<uint64_t, uint64_t>>>*
-          result_tile_ranges);
+      ITileRange* tile_ranges);
 
   /**
    * Computes the estimated result size (calibrated using the maximum size)


### PR DESCRIPTION
While trying to extract the unfiltered buffers to a separate object, it became clear that this would introduce yet another transient object to the readers that would be persisted across multiple query submits. This refactors all the transient read state related to tiles into a separate class that will eventually contain the unfiltered tile data.

This also simplifies the way the sparse unordered deals with leftover tiles from a previous iteration by not loading more tiles into memory until the next internal loop. That way the reader can fully process the leftover state before loading more data which will make the class holding unfiltered data simpler. The sparse global order reader will also need some simplifications but that will come in a further refactor.

---
TYPE: IMPROVEMENT
DESC: Sparse readers: extract transient read state as a separate class.
