### PR TITLE
Add Subarray::add_range to core stats

### DIFF
--- a/examples/cpp_api/using_tiledb_stats.cc
+++ b/examples/cpp_api/using_tiledb_stats.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,34 +89,6 @@ void read_array() {
   Stats::enable();
   query.submit();
   Stats::dump(stdout);
-
-  // Check stats.
-  std::string stats;
-  Stats::dump(&stats);
-  if (stats.find("\"Context.StorageManager.subSubarray.add_range\": 2") ==
-      std::string::npos) {
-    throw std::logic_error("Invalid counter for add_range");
-  }
-
-  // Ensure additional calls to Query::submit have no effect on the stats
-  query.submit();
-  query.submit();
-  Stats::dump(&stats);
-  if (stats.find("\"Context.StorageManager.subSubarray.add_range\": 2") ==
-      std::string::npos) {
-    throw std::logic_error("Invalid counter for add_range");
-  }
-
-  // Invoke add_range and check the stats again.
-  // #TODO Update After removal of deprecated Query::add_range
-  query.add_range(0, (uint32_t)0, (uint32_t)3);
-  query.add_range(1, (uint32_t)0, (uint32_t)3);
-  query.submit();
-  Stats::dump(&stats);
-  if (stats.find("\"Context.StorageManager.subSubarray.add_range\": 4") ==
-      std::string::npos) {
-    throw std::logic_error("Invalid counter for add_range");
-  }
   Stats::disable();
 }
 

--- a/examples/cpp_api/using_tiledb_stats.cc
+++ b/examples/cpp_api/using_tiledb_stats.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/examples/cpp_api/using_tiledb_stats.cc
+++ b/examples/cpp_api/using_tiledb_stats.cc
@@ -89,6 +89,34 @@ void read_array() {
   Stats::enable();
   query.submit();
   Stats::dump(stdout);
+
+  // Check stats.
+  std::string stats;
+  Stats::dump(&stats);
+  if (stats.find("\"Context.StorageManager.subSubarray.add_range\": 2") ==
+      std::string::npos) {
+    throw std::logic_error("Invalid counter for add_range");
+  }
+
+  // Ensure additional calls to Query::submit have no effect on the stats
+  query.submit();
+  query.submit();
+  Stats::dump(&stats);
+  if (stats.find("\"Context.StorageManager.subSubarray.add_range\": 2") ==
+      std::string::npos) {
+    throw std::logic_error("Invalid counter for add_range");
+  }
+
+  // Invoke add_range and check the stats again.
+  // #TODO Update After removal of deprecated Query::add_range
+  query.add_range(0, (uint32_t)0, (uint32_t)3);
+  query.add_range(1, (uint32_t)0, (uint32_t)3);
+  query.submit();
+  Stats::dump(&stats);
+  if (stats.find("\"Context.StorageManager.subSubarray.add_range\": 4") ==
+      std::string::npos) {
+    throw std::logic_error("Invalid counter for add_range");
+  }
   Stats::disable();
 }
 

--- a/test/src/unit-capi-serialized_queries_using_subarray.cc
+++ b/test/src/unit-capi-serialized_queries_using_subarray.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -149,7 +149,24 @@ struct SerializationFx {
     auto loop_num =
         counters->find("Context.StorageManager.Query.Writer.attr_num");
     REQUIRE((loop_num != counters->end()));
+
     REQUIRE(loop_num->second > 0);
+  }
+
+  static void check_subarray_stats(int dim0_expected, int dim1_expected) {
+    Stats::enable();
+    std::string stats;
+    Stats::dump(&stats);
+    // Note: if these checks fail, use Stats::dump(stdout) to validate counters
+    CHECK(
+        stats.find(
+            "\"Context.StorageManager.subSubarray.add_range_dim_0\": " +
+            std::to_string(dim0_expected)) != std::string::npos);
+    CHECK(
+        stats.find(
+            "\"Context.StorageManager.subSubarray.add_range_dim_1\": " +
+            std::to_string(dim1_expected)) != std::string::npos);
+    Stats::disable();
   }
 
   void create_array(tiledb_array_type_t type) {
@@ -376,6 +393,7 @@ TEST_CASE_METHOD(
   refactored_query_v2_ = GENERATE(true, false);
   create_array(TILEDB_DENSE);
   auto expected_results = write_dense_array();
+  check_subarray_stats(2, 2);
 
   SECTION("- Read all") {
     Array array(ctx, array_uri, TILEDB_READ);
@@ -396,6 +414,9 @@ TEST_CASE_METHOD(
     query.set_data_buffer("a3", a3_data);
     query.set_offsets_buffer("a3", a3_offsets);
 
+    // Check stats before serialization
+    check_subarray_stats(3, 3);
+
     // Submit query
     auto rc = submit_query_wrapper(
         ctx,
@@ -407,6 +428,10 @@ TEST_CASE_METHOD(
         finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
+
+    // Check stats after serialization
+    // #TODO Revisit after Stats serialization is reworked
+    check_subarray_stats(5, 5);
 
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 100);
@@ -454,6 +479,7 @@ TEST_CASE_METHOD(
 
     // The deserialized query should also include the write stats
     check_read_stats(query);
+    check_subarray_stats(5, 5);
 
     // We expect all cells where `a1` >= `cmp_value` to be filtered
     // out. For the refactored reader, filtered out means the value is
@@ -520,6 +546,7 @@ TEST_CASE_METHOD(
         finalize_);
     REQUIRE(rc == TILEDB_OK);
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
+    check_subarray_stats(5, 5);
 
     auto result_el = query.result_buffer_elements_nullable();
     REQUIRE(std::get<1>(result_el["a1"]) == 4);
@@ -561,6 +588,7 @@ TEST_CASE_METHOD(
         refactored_query_v2_,
         finalize_);
     REQUIRE(rc == TILEDB_OK);
+    check_subarray_stats(5, 5);
 
     REQUIRE(query.query_status() == Query::Status::INCOMPLETE);
     auto result_el = query.result_buffer_elements_nullable();
@@ -581,6 +609,7 @@ TEST_CASE_METHOD(
         refactored_query_v2_,
         finalize_);
     REQUIRE(rc == TILEDB_OK);
+    check_subarray_stats(7, 7);
 
     REQUIRE(query.query_status() == Query::Status::INCOMPLETE);
     result_el = query.result_buffer_elements_nullable();
@@ -601,6 +630,7 @@ TEST_CASE_METHOD(
         refactored_query_v2_,
         finalize_);
     REQUIRE(rc == TILEDB_OK);
+    check_subarray_stats(9, 9);
 
     REQUIRE(query.query_status() == Query::Status::COMPLETE);
     result_el = query.result_buffer_elements_nullable();

--- a/test/src/unit-capi-serialized_queries_using_subarray.cc
+++ b/test/src/unit-capi-serialized_queries_using_subarray.cc
@@ -149,7 +149,6 @@ struct SerializationFx {
     auto loop_num =
         counters->find("Context.StorageManager.Query.Writer.attr_num");
     REQUIRE((loop_num != counters->end()));
-
     REQUIRE(loop_num->second > 0);
   }
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -307,9 +307,9 @@ Status Subarray::add_range(
   if (oob_warning.has_value())
     LOG_WARN(oob_warning.value() + " on dimension '" + dim_name + "'");
 
-  // Update is default and stats counter
+  // Update is default and stats counter.
   is_default_[dim_idx] = range_subset_[dim_idx].is_implicitly_initialized();
-  stats_->add_counter("add_range", 1);
+  stats_->add_counter("add_range_dim_" + std::to_string(dim_idx), 1);
   return Status::Ok();
 }
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -307,8 +307,9 @@ Status Subarray::add_range(
   if (oob_warning.has_value())
     LOG_WARN(oob_warning.value() + " on dimension '" + dim_name + "'");
 
-  // Update is default.
+  // Update is default and stats counter
   is_default_[dim_idx] = range_subset_[dim_idx].is_implicitly_initialized();
+  stats_->add_counter("add_range", 1);
   return Status::Ok();
 }
 


### PR DESCRIPTION
Add `Subarray::add_range` to core stats.
Note that additional `add_*_range(s)` APIs in the `Subarray` class ultimately invoke `Subarray::add_range` so those APIs needn't their own stats counters. 
Note that `Query::add_range` is marked as deprecated and until it's removed, can affect the counter if invoked.

---
TYPE: IMPROVEMENT
DESC: Add Subarray::add_range to core stats
