### PR TITLE
Fix Query Conditions for Boolean Attributes

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -2600,7 +2600,7 @@ TEST_CASE(
   wquery.submit();
   warray.close();
 
-  // Read the data with query condition on the string dimension.
+  // Read the data with query condition on the Boolean attribute.
   Array rarray(ctx, array_name, TILEDB_READ);
   const std::vector<int> subarray = {1, 10};
   std::vector<int> rrows(10);
@@ -2615,7 +2615,7 @@ TEST_CASE(
   rarray.close();
   CHECK(rquery.query_status() == Query::Status::COMPLETE);
 
-  // Check the query for accuracy. The query results should contain 1 element.
+  // Check the query for accuracy.
   auto table = rquery.result_buffer_elements();
   CHECK(table.size() == 2);
   CHECK(table["rows"].first == 0);

--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -2624,7 +2624,7 @@ TEST_CASE(
   CHECK(table["labs"].second == 10);
 
   for (size_t i = 0; i < table["labs"].second; ++i) {
-    CHECK(rlabs[i] == wlabs[i]);
+    CHECK(rlabs[i] == !!wlabs[i]);
   }
 
   if (vfs.is_dir(array_name)) {

--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -2567,3 +2567,67 @@ TEST_CASE(
     vfs.remove_dir(array_name);
   }
 }
+
+TEST_CASE(
+    "Testing read query with simple QC, condition on attribute, bool attr",
+    "[query][query-condition][dimension]") {
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{1, 10}}, 10));
+
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain)
+      .set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}})
+      .add_attribute(Attribute::create<bool>(ctx, "labs"));
+  Array::create(array_name, schema);
+
+  // Write some initial data and close the array.
+  std::vector<int> wrows{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  bool wlabs[10] = {
+      false, true, false, true, true, false, false, true, false, false};
+
+  Array warray(ctx, array_name, TILEDB_WRITE);
+  Query wquery(ctx, warray, TILEDB_WRITE);
+  wquery.set_layout(TILEDB_UNORDERED)
+      .set_data_buffer("rows", wrows)
+      .set_data_buffer("labs", wlabs, 10);
+  wquery.submit();
+  warray.close();
+
+  // Read the data with query condition on the string dimension.
+  Array rarray(ctx, array_name, TILEDB_READ);
+  const std::vector<int> subarray = {1, 10};
+  std::vector<int> rrows(10);
+  std::vector<uint8_t> rlabs(10);
+
+  Query rquery(ctx, rarray, TILEDB_READ);
+  rquery.set_subarray(subarray)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("rows", rrows)
+      .set_data_buffer("labs", rlabs);
+  rquery.submit();  // Submit the query and close the array.
+  rarray.close();
+  CHECK(rquery.query_status() == Query::Status::COMPLETE);
+
+  // Check the query for accuracy. The query results should contain 1 element.
+  auto table = rquery.result_buffer_elements();
+  CHECK(table.size() == 2);
+  CHECK(table["rows"].first == 0);
+  CHECK(table["rows"].second == 10);
+  CHECK(table["labs"].first == 0);
+  CHECK(table["labs"].second == 10);
+
+  for (size_t i = 0; i < table["labs"].second; ++i) {
+    CHECK(rlabs[i] == wlabs[i]);
+  }
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -94,6 +94,13 @@ struct type_to_tiledb<std::byte> {
 };
 
 template <>
+struct type_to_tiledb<bool> {
+  using type = bool;
+  static const tiledb_datatype_t tiledb_type = TILEDB_BOOL;
+  static constexpr const char* name = "BOOL";
+};
+
+template <>
 struct type_to_tiledb<int8_t> {
   using type = int8_t;
   static const tiledb_datatype_t tiledb_type = TILEDB_INT8;

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -812,6 +812,7 @@ void QueryCondition::apply_ast_node(
           combination_op,
           result_cell_bitmap);
     } break;
+    case Datatype::BOOL:
     case Datatype::UINT8: {
       apply_ast_node<uint8_t, CombinationOp>(
           node,


### PR DESCRIPTION
* Originally caught by https://github.com/single-cell-data/TileDB-SOMA/issues/1262
* By default in `type_to_tiledb`, all trivially copyable types are converted to `TILEDB_STRING_ASCII`. This caused Boolean types to erroneously map to `TILEDB_STRING_ASCII`. The addition of `type_to_tiledb<bool>` now correctly maps to `TILEDB_BOOL`.
* In `apply_ast_node()`, the `Datatype::BOOL` case was missing. This maps to the same case as `Datatype::UINT8`.
---
TYPE: BUG
DESC: Fix Query Conditions for Boolean Attributes
