### PR TITLE
Global order writer: don't try to delete the current fragment if it had failed to be created.

### DIFF
--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -517,6 +517,7 @@ Status GlobalOrderWriter::check_global_order_hilbert() const {
 void GlobalOrderWriter::clean_up() {
   if (global_write_state_ != nullptr) {
     const auto& uri = global_write_state_->frag_meta_->fragment_uri();
+
     // Cleanup the fragment we are currently writing. There is a chance that the
     // URI is empty if creating the first fragment had failed.
     if (!uri.empty()) {

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -198,8 +198,6 @@ Status GlobalOrderWriter::alloc_global_write_state() {
 }
 
 Status GlobalOrderWriter::init_global_write_state() {
-  auto uri = global_write_state_->frag_meta_->fragment_uri();
-
   // Initialize global write state for attribute and coordinates
   for (const auto& it : buffers_) {
     // Initialize last tiles
@@ -518,9 +516,12 @@ Status GlobalOrderWriter::check_global_order_hilbert() const {
 
 void GlobalOrderWriter::clean_up() {
   if (global_write_state_ != nullptr) {
-    auto meta = global_write_state_->frag_meta_;
-    const auto& uri = meta->fragment_uri();
-    throw_if_not_ok(storage_manager_->vfs()->remove_dir(uri));
+    const auto& uri = global_write_state_->frag_meta_->fragment_uri();
+    // Cleanup the fragment we are currently writing. There is a chance that the
+    // URI is empty if creating the first fragment had failed.
+    if (!uri.empty()) {
+      throw_if_not_ok(storage_manager_->vfs()->remove_dir(uri));
+    }
     global_write_state_.reset(nullptr);
 
     // Cleanup all fragments pending commit.


### PR DESCRIPTION
If during a global order write we fail to create a fragment directory, we throw and `GlobalOrderWriter::clean_up` tries to delete the new fragment. But because we had not yet assigned a URI to a fragment, we try to delete the empty string and get an `Error: Unsupported URI scheme: ` on Unix and `Error: Failed to delete path ''; not a valid path.` on Windows, masking the real issue.

This PR modifies `clean_up` to not delete the directory if it is empty, allowing the right error to surface. It's a bit hacky - ideally `FragmentMetadata` would be C.41 compliant and an empty URI would not be possible, but that would require more extensive refactorings and delay the bug fix. The other writers are not susceptible to this bug; they write only one fragment and their clean-up logic is simpler and takes care of that.

Fixes #4041.

[SC-27681](https://app.shortcut.com/tiledb-inc/story/27681/clearly-expose-write-permissions-failure)

Verified on my machine that the right error message is displayed.

---
TYPE: BUG
DESC: Global order writer: don't try to delete the current fragment if it had failed to be created.