### PR TITLE
Use `std::map::insert_or_assign` to replace values in maps.

### DIFF
--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -226,9 +226,7 @@ Status Metadata::put(
     value_struct.value_.resize(value_size);
     std::memcpy(value_struct.value_.data(), value, value_size);
   }
-  metadata_map_.erase(std::string(key));
-  metadata_map_.emplace(
-      std::make_pair(std::string(key), std::move(value_struct)));
+  metadata_map_.insert_or_assign(key, std::move(value_struct));
   build_metadata_index();
 
   return Status::Ok();


### PR DESCRIPTION
[SC-27291](https://app.shortcut.com/tiledb-inc/story/27291/audit-usage-of-map-insert-emplace-for-replacement-semantics)

This is the only case of replacing a value in a map that I found. I searched for `insert(` and `emplace(` calls and then narrowed them town to `std::(unordered_)?map` using VSCode's Find All References.

---
TYPE: IMPROVEMENT
DESC: Use `std::map::insert_or_assign` to replace values in maps.