### PR TITLE
[superbuild] Set Curl CA path on Darwin

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -135,6 +135,10 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       set(WITH_ZLIB "--with-zlib")
     endif()
 
+    if (APPLE)
+      set(WITH_CA_BUNDLE "--with-ca-bundle=/etc/ssl/cert.pem")
+    endif()
+
     if (TARGET ep_zstd)
       list(APPEND DEPENDS ep_zstd)
       set(WITH_ZLIB "--with-zstd=${TILEDB_EP_INSTALL_PREFIX}")
@@ -200,6 +204,7 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
           ${WITH_SSL}
           ${WITH_ZLIB}
           ${WITH_ZSTD}
+          ${WITH_CA_BUNDLE}
           ${CURL_CROSS_COMPILATION_FLAGS}
       BUILD_IN_SOURCE TRUE
       BUILD_COMMAND $(MAKE)

--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -24,12 +24,6 @@ steps:
 
 - bash: |
     set -e pipefail
-    brew uninstall --ignore-dependencies libidn2 brotli rtmpdump
-  condition: eq(variables['Agent.OS'], 'Darwin')
-  displayName: 'Uninstall brew packages for curl (OSX only)'
-
-- bash: |
-    set -e pipefail
     $SUDO rm -Rf /Library/Developer/CommandLineTools/SDKs/* # Remove SDKs without ARM support
 
   condition: eq(variables['Agent.OS'], 'Darwin')

--- a/scripts/azure-linux_mac-release.yml
+++ b/scripts/azure-linux_mac-release.yml
@@ -18,9 +18,9 @@ steps:
     # This stage is needed until https://github.com/actions/runner-images/pull/7125 or similar is merged
     # MacOS image 20230214.1 removed implicit installation of pkg-config
     set -e pipefail
-    brew install pkg-config
+    brew install pkg-config autoconf automake
   condition: eq(variables['Agent.OS'], 'Darwin')
-  displayName: 'Install brew package for pkg-config (OSX only)'
+  displayName: 'Install brew packages for macOS build'
 
 - bash: |
     set -e pipefail


### PR DESCRIPTION
Fixes SSL in macOS-arm64 builds, which is currently broken because Curl does not do CA path detection when cross-compiling:
```
configure:27034: WARNING: skipped the ca-cert path detection when cross-compiling
```

Our release builds are done on x86_64 and treated by Curl as cross-compilation (to arm64), thus the default CA path is not set in the Curl library.

Note: we do not need to set this option for vcpkg buidls in `ports/curl`, because
      that build uses the Curl CMake build, which makes CA file auto-detection
      conditional on `CMAKE_CROSSCOMPILING`. This variable is set to false on
      macOS-arm64 builds [1].

Fixes SC-28095.

[1] https://gitlab.kitware.com/cmake/cmake/-/issues/21885

---
TYPE: IMPROVEMENT
DESC: [superbuild] Set Curl CA path on Darwin