### PR TITLE
install rtools40 if needed

### DIFF
--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+      - name: Install rtools40 if needed
+        uses: r-windows/install-rtools@master
       - name: Building TileDB with Rtools40
         run: |
           cd ${GITHUB_WORKSPACE}/.github/workflows/mingw-w64-tiledb


### PR DESCRIPTION
rtools40 will soon not be preinstalled anymore on GHA, this installs it if needed.