### PR TITLE
Refactor the thread pool and remove its dependency on statuses.

### DIFF
--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -95,26 +95,21 @@ size_t random_ms(size_t max = 3) {
   return distribution(generator);
 }
 
-template <class R>
-bool wait_one(ThreadPool& pool, std::future<R>& task) {
-  REQUIRE_NOTHROW(pool.wait(task));
+bool wait_one(ThreadPool& pool, std::future<void>& task) {
+  pool.wait(task);
   return true;
 }
 
-template <>
-bool wait_one<Status>(ThreadPool& pool, std::future<Status>& task) {
+bool wait_one(ThreadPool& pool, std::future<Status>& task) {
   return pool.wait(task).ok();
 }
 
-template <class R>
-bool wait_all(ThreadPool& pool, std::vector<std::future<R>>& tasks) {
-  REQUIRE_NOTHROW(pool.wait_all(tasks));
+bool wait_all(ThreadPool& pool, std::vector<std::future<void>>& tasks) {
+  pool.wait_all(tasks);
   return true;
 }
 
-template <>
-bool wait_all<Status>(
-    ThreadPool& pool, std::vector<std::future<Status>>& task) {
+bool wait_all(ThreadPool& pool, std::vector<std::future<Status>>& task) {
   return pool.wait_all(task).ok();
 }
 
@@ -184,7 +179,9 @@ TEST_CASE("ThreadPool: Test empty", "[threadpool][empty]") {
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "ThreadPool: Test single thread", "[threadpool][single-thread]", VoidTaskTypes) {
+    "ThreadPool: Test single thread",
+    "[threadpool][single-thread]",
+    VoidTaskTypes) {
   bool use_wait = GENERATE(true, false);
   std::atomic<int> result = 0;  // needs to be atomic b/c scavenging thread can
                                 // run in addition to thread pool
@@ -208,7 +205,9 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "ThreadPool: Test multiple threads", "[threadpool][multi-thread]", VoidTaskTypes) {
+    "ThreadPool: Test multiple threads",
+    "[threadpool][multi-thread]",
+    VoidTaskTypes) {
   bool use_wait = GENERATE(true, false);
   std::atomic<int> result(0);
   std::vector<std::future<TestType>> results;
@@ -450,7 +449,9 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "ThreadPool: Test recursion, two pools", "[threadpool]", VoidTaskTypes) {
+    "ThreadPool: Test recursion, two pools",
+    "[threadpool][recursion][two-pools]",
+    VoidTaskTypes) {
   bool use_wait = GENERATE(true, false);
   size_t num_threads = 0;
 

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -194,7 +194,9 @@ TEMPLATE_LIST_TEST_CASE(
   for (int i = 0; i < 100; i++) {
     auto task = pool.execute([&result]() {
       result++;
-      return TestType{};
+      if constexpr (std::is_same_v<TestType, Status>) {
+        return Status::Ok();
+      }
     });
 
     REQUIRE(task.valid());
@@ -214,7 +216,9 @@ TEMPLATE_LIST_TEST_CASE(
   for (int i = 0; i < 100; i++) {
     results.push_back(pool.execute([&result]() {
       result++;
-      return TestType{};
+      if constexpr (std::is_same_v<TestType, Status>) {
+        return Status::Ok();
+      }
     }));
   }
   wait_all(pool, use_wait, results);
@@ -341,12 +345,16 @@ TEMPLATE_LIST_TEST_CASE(
     auto b = pool.execute([&result]() {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
       ++result;
-      return TestType{};
+      if constexpr (std::is_same_v<TestType, Status>) {
+        return Status::Ok();
+      }
     });
     REQUIRE(b.valid());
     tasks.emplace_back(std::move(b));
     wait_all(pool, use_wait, tasks);
-    return TestType{};
+    if constexpr (std::is_same_v<TestType, Status>) {
+      return Status::Ok();
+    }
   });
   REQUIRE(a.valid());
   tasks.emplace_back(std::move(a));
@@ -384,14 +392,18 @@ TEMPLATE_LIST_TEST_CASE(
         auto inner_task = pool.execute([&]() {
           std::this_thread::sleep_for(std::chrono::milliseconds(random_ms()));
           ++result;
-          return TestType{};
+          if constexpr (std::is_same_v<TestType, Status>) {
+            return Status::Ok();
+          }
         });
 
         inner_tasks.emplace_back(std::move(inner_task));
       }
 
       wait_all(pool, use_wait, inner_tasks);
-      return TestType{};
+      if constexpr (std::is_same_v<TestType, Status>) {
+        return Status::Ok();
+      }
     });
 
     REQUIRE(task.valid());
@@ -414,11 +426,15 @@ TEMPLATE_LIST_TEST_CASE(
           if (--result == 0) {
             cv.notify_all();
           }
-          return TestType{};
+          if constexpr (std::is_same_v<TestType, Status>) {
+            return Status::Ok();
+          }
         });
       }
 
-      return TestType{};
+      if constexpr (std::is_same_v<TestType, Status>) {
+        return Status::Ok();
+      }
     });
 
     REQUIRE(task.valid());
@@ -477,21 +493,27 @@ TEMPLATE_LIST_TEST_CASE(
                 std::this_thread::sleep_for(
                     std::chrono::milliseconds(random_ms()));
                 ++result;
-                return TestType{};
+                if constexpr (std::is_same_v<TestType, Status>) {
+                  return Status::Ok();
+                }
               });
 
               tasks_c.emplace_back(std::move(task_c));
             }
 
             wait_all(pool_a, use_wait, tasks_c);
-            return TestType{};
+            if constexpr (std::is_same_v<TestType, Status>) {
+              return Status::Ok();
+            }
           });
 
           tasks_b.emplace_back(std::move(task_b));
         }
 
         wait_all(pool_b, use_wait, tasks_b);
-        return TestType{};
+        if constexpr (std::is_same_v<TestType, Status>) {
+          return Status::Ok();
+        }
       });
 
       REQUIRE(task_a.valid());
@@ -519,21 +541,27 @@ TEMPLATE_LIST_TEST_CASE(
                   std::unique_lock<std::mutex> ul(cv_mutex);
                   cv.notify_all();
                 }
-                return TestType{};
+                if constexpr (std::is_same_v<TestType, Status>) {
+                  return Status::Ok();
+                }
               });
 
               tasks_c.emplace_back(std::move(task_c));
             }
 
             wait_all(pool_a, use_wait, tasks_c);
-            return TestType{};
+            if constexpr (std::is_same_v<TestType, Status>) {
+              return Status::Ok();
+            }
           });
 
           tasks_b.emplace_back(std::move(task_b));
         }
 
         wait_all(pool_b, use_wait, tasks_b);
-        return TestType{};
+        if constexpr (std::is_same_v<TestType, Status>) {
+          return Status::Ok();
+        }
       });
 
       REQUIRE(task_a.valid());
@@ -692,6 +720,10 @@ TEST_CASE("ThreadPool: Test Exceptions", "[threadpool]") {
 TEMPLATE_LIST_TEST_CASE(
     "ThreadPool: Deferred futures", "[threadpool][deferred]", VoidTaskTypes) {
   ThreadPool tp{1};
-  auto future{std::async(std::launch::deferred, []() { return TestType{}; })};
+  auto future{std::async(std::launch::deferred, []() {
+    if constexpr (std::is_same_v<TestType, Status>) {
+      return Status::Ok();
+    }
+  })};
   CHECK(wait_one(tp, future));
 }

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -36,6 +36,7 @@
 #include <test/support/tdb_catch.h>
 #include <atomic>
 #include <cstdio>
+#include <future>
 #include <iostream>
 #include <vector>
 
@@ -654,4 +655,13 @@ TEST_CASE("ThreadPool: Test Exceptions", "[threadpool]") {
         unbaked_potato_status.to_string());
     REQUIRE(result == 207);
   }
+}
+
+TEST_CASE("ThreadPool: Deferred futures", "[threadpool][deferred]") {
+  ThreadPool tp{1};
+
+  SECTION("Returning Status") {
+    auto future{
+        std::async(std::launch::deferred, []() { return Status::Ok(); })};
+    CHECK(tp.wait(future).ok());
 }

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -220,10 +220,9 @@ TEST_CASE("ThreadPool: Test no wait", "[threadpool]") {
     ThreadPool pool{4};
     auto ptr = tdb::make_shared<AtomicHolder>(HERE(), 0);
     for (int i = 0; i < 5; i++) {
-      ThreadPool::Task task = pool.execute([result = ptr]() {
+      auto task = pool.execute([result = ptr]() {
         result->val_++;
         std::this_thread::sleep_for(std::chrono::milliseconds(random_ms(1000)));
-        return Status::Ok();
       });
       REQUIRE(task.valid());
     }
@@ -664,4 +663,10 @@ TEST_CASE("ThreadPool: Deferred futures", "[threadpool][deferred]") {
     auto future{
         std::async(std::launch::deferred, []() { return Status::Ok(); })};
     CHECK(tp.wait(future).ok());
+  }
+
+  SECTION("Returning void") {
+    auto future{std::async(std::launch::deferred, []() {})};
+    CHECK_NOTHROW(tp.wait(future));
+  }
 }

--- a/tiledb/common/thread_pool/test/unit_thread_pool.cc
+++ b/tiledb/common/thread_pool/test/unit_thread_pool.cc
@@ -177,14 +177,14 @@ uint64_t wait_all_num_status(
   return num_ok;
 }
 
-TEST_CASE("ThreadPool: Test empty", "[threadpool]") {
+TEST_CASE("ThreadPool: Test empty", "[threadpool][empty]") {
   for (int i = 0; i < 10; i++) {
     ThreadPool pool{4};
   }
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "ThreadPool: Test single thread", "[threadpool]", VoidTaskTypes) {
+    "ThreadPool: Test single thread", "[threadpool][single-thread]", VoidTaskTypes) {
   bool use_wait = GENERATE(true, false);
   std::atomic<int> result = 0;  // needs to be atomic b/c scavenging thread can
                                 // run in addition to thread pool
@@ -208,7 +208,7 @@ TEMPLATE_LIST_TEST_CASE(
 }
 
 TEMPLATE_LIST_TEST_CASE(
-    "ThreadPool: Test multiple threads", "[threadpool]", VoidTaskTypes) {
+    "ThreadPool: Test multiple threads", "[threadpool][multi-thread]", VoidTaskTypes) {
   bool use_wait = GENERATE(true, false);
   std::atomic<int> result(0);
   std::vector<std::future<TestType>> results;
@@ -225,7 +225,7 @@ TEMPLATE_LIST_TEST_CASE(
   REQUIRE(result == 100);
 }
 
-TEST_CASE("ThreadPool: Test wait status", "[threadpool]") {
+TEST_CASE("ThreadPool: Test wait status", "[threadpool][wait][status]") {
   bool use_wait = GENERATE(true, false);
   std::atomic<int> result(0);
   std::vector<ThreadPool::Task> results;
@@ -247,7 +247,7 @@ struct AtomicHolder {
   std::atomic<int> val_;
 };
 
-TEST_CASE("ThreadPool: Test no wait", "[threadpool]") {
+TEST_CASE("ThreadPool: Test no wait", "[threadpool][no-wait]") {
   {
     ThreadPool pool{4};
     auto ptr = tdb::make_shared<AtomicHolder>(HERE(), 0);
@@ -332,7 +332,7 @@ TEST_CASE(
 
 TEMPLATE_LIST_TEST_CASE(
     "ThreadPool: Test recursion, simplest case",
-    "[threadpool]",
+    "[threadpool][recursion][simple]",
     VoidTaskTypes) {
   bool use_wait = GENERATE(true, false);
   ThreadPool pool{1};

--- a/tiledb/common/thread_pool/thread_pool.cc
+++ b/tiledb/common/thread_pool/thread_pool.cc
@@ -170,8 +170,8 @@ std::vector<Status> ThreadPool::wait_all_status(std::vector<Task>& tasks) {
       statuses[task_id] = Status_ThreadPoolError("Invalid task future");
       LOG_STATUS_NO_RETURN_VALUE(statuses[task_id]);
     } else if (
-        task.wait_for(std::chrono::milliseconds(0)) ==
-        std::future_status::ready) {
+        task.wait_for(std::chrono::milliseconds(0)) !=
+        std::future_status::timeout) {
       // Task is completed, get result, handling possible exceptions
 
       Status st = [&task] {
@@ -220,8 +220,8 @@ Status ThreadPool::wait(Task& task) {
     if (!task.valid()) {
       return Status_ThreadPoolError("Invalid task future");
     } else if (
-        task.wait_for(std::chrono::milliseconds(0)) ==
-        std::future_status::ready) {
+        task.wait_for(std::chrono::milliseconds(0)) !=
+        std::future_status::timeout) {
       // Task is completed, get result, handling possible exceptions
 
       Status st = [&task] {

--- a/tiledb/common/thread_pool/thread_pool.cc
+++ b/tiledb/common/thread_pool/thread_pool.cc
@@ -102,7 +102,15 @@ ThreadPool::ThreadPool(size_t n)
 bool ThreadPool::pump() {
   auto val = task_queue_.pop();
   if (val) {
-    (**val)();
+    try {
+      (*val)();
+    } catch (const std::exception& e) {
+      LOG_ERROR(
+          "Unhandled exception when running thread pool task: " +
+          std::string(e.what()));
+    } catch (...) {
+      LOG_ERROR("Unhandled exception when running thread pool task.");
+    }
     return true;
   } else {
     return false;

--- a/tiledb/common/thread_pool/thread_pool.h
+++ b/tiledb/common/thread_pool/thread_pool.h
@@ -180,7 +180,7 @@ class ThreadPool {
     auto log_exception = [&exceptions](const char* message) {
       // If this is the first exception, add an intro message.
       if (exceptions.tellp() <= 0) {
-        exceptions << "One or more errors occured";
+        exceptions << "One or more errors occurred";
       }
       exceptions << "\n * " << message;
     };

--- a/tiledb/common/thread_pool/thread_pool.h
+++ b/tiledb/common/thread_pool/thread_pool.h
@@ -46,44 +46,6 @@
 
 namespace tiledb::common {
 
-namespace threadpool_impl {
-/**
- * Evaluates std::future<T> values and accumulates their result into a vector.
- */
-template <class T>
-struct ResultAccumulator {
-  using collection_type = std::vector<T>;
-  ResultAccumulator(size_t capacity)
-      : results_(capacity) {
-  }
-  void add(size_t index, std::future<T>& task) {
-    results_[index] = task.get();
-  }
-  collection_type results() {
-    return results_;
-  }
-
- private:
-  collection_type results_;
-};
-
-/**
- * Specialization of ResultAccumulator for void, which does not accumulate
- * anything.
- */
-template <>
-struct ResultAccumulator<void> {
-  using collection_type = void;
-  ResultAccumulator(size_t) {
-  }
-  void add(size_t, std::future<void>& task) {
-    task.get();
-  }
-  collection_type results() {
-  }
-};
-}  // namespace threadpool_impl
-
 class ThreadPool {
  public:
   using Task = std::future<Status>;
@@ -160,10 +122,7 @@ class ThreadPool {
   }
 
   /**
-   * Wait on all the given tasks to complete, returning a vector of their
-   * results.  Exceptions caught while waiting are aggregated and rethrown as a
-   * StatusException. Results are saved at the same index in the return vector
-   * as the corresponding task in the input vector.
+   * Wait on all the given void-returning futures to complete.
    *
    * This function is safe to call recursively and may execute pending tasks
    * with the calling thread while waiting.
@@ -171,73 +130,7 @@ class ThreadPool {
    * @param tasks Task list to wait on
    * @return Vector of each task's result or void if the tasks return void.
    */
-  template <class R>
-  typename threadpool_impl::ResultAccumulator<R>::collection_type wait_all(
-      std::vector<std::future<R>>& tasks) {
-    threadpool_impl::ResultAccumulator<R> results(tasks.size());
-    std::stringstream exceptions;
-
-    auto log_exception = [&exceptions](const char* message) {
-      // If this is the first exception, add an intro message.
-      if (exceptions.tellp() <= 0) {
-        exceptions << "One or more errors occurred";
-      }
-      exceptions << "\n * " << message;
-    };
-
-    std::queue<size_t> pending_tasks;
-
-    // Create queue of ids of all the pending tasks for processing
-    for (size_t i = 0; i < tasks.size(); ++i) {
-      pending_tasks.push(i);
-    }
-
-    // Process tasks in the pending queue
-    while (!pending_tasks.empty()) {
-      auto task_id = pending_tasks.front();
-      pending_tasks.pop();
-      auto& task = tasks[task_id];
-
-      if (!task.valid()) {
-        log_exception("Invalid task future");
-      } else if (
-          task.wait_for(std::chrono::milliseconds(0)) !=
-          std::future_status::timeout) {
-        // Task is completed, get result, handling possible exceptions
-        try {
-          results.add(task_id, task);
-        } catch (const std::exception& e) {
-          log_exception(e.what());
-        } catch (const std::string& msg) {
-          log_exception(msg.c_str());
-        } catch (...) {
-          log_exception("Unknown exception");
-        }
-      } else {
-        // If the task is not completed, try again later
-        pending_tasks.push(task_id);
-
-        // In the meantime, try to do something useful to make progress (and
-        // avoid deadlock)
-        if (!pump()) {
-          // If nothing useful to do, yield so we don't burn cycles
-          // going through the task list over and over (thereby slowing down
-          // other threads).
-          std::this_thread::yield();
-
-          // (An alternative would be to wait some amount of time)
-          // task.wait_for(std::chrono::milliseconds(10));
-        }
-      }
-    }
-
-    // If exceptions is not empty, at least one of the tasks has failed. We
-    // throw an exception containing all exception messages.
-    if (exceptions.tellp() > 0) {
-      throw StatusException(Status_ThreadPoolError(exceptions.str()));
-    }
-    return results.results();
-  }
+  void wait_all(std::vector<std::future<void>>& tasks);
 
   /**
    * Wait on all the given tasks to complete. This function is safe to call
@@ -266,29 +159,16 @@ class ThreadPool {
   std::vector<Status> wait_all_status(std::vector<Task>& tasks);
 
   /**
-   * Wait on a single task to complete. This function is safe to call
-   * recursively and may execute pending tasks on the calling thread while
-   * waiting. This method will throw the future's exception if it fails.
+   * Wait on a single void-returning task to complete.
+   *
+   * This function is safe to call recursively and may execute pending tasks on
+   * the calling thread while waiting. This method will throw the future's
+   * exception if it fails.
    *
    * @param task Task to wait on.
    * @return The task's result.
    */
-  template <class R>
-  R wait(std::future<R>& task) {
-    if (!task.valid()) {
-      throw std::runtime_error("Invalid task future");
-    }
-    while (task.wait_for(std::chrono::milliseconds(0)) ==
-           std::future_status::timeout) {
-      // Until the task completes, try to do something useful to make progress
-      // (and avoid deadlock)
-      if (!pump()) {
-        std::this_thread::yield();
-      }
-    }
-    // Task is completed, get result, throwing possible exceptions
-    return task.get();
-  }
+  void wait(std::future<void>& task);
 
   /**
    * Wait on a single task returning Status to complete. This function is safe

--- a/tiledb/common/thread_pool/thread_pool.h
+++ b/tiledb/common/thread_pool/thread_pool.h
@@ -186,8 +186,12 @@ class ThreadPool {
   /* ********************************* */
 
  private:
-  /** Tries to run a queued task. Returns whether such task was found. */
-  bool pump();
+  /** Tries to run a queued task. Returns whether such task was found.
+   *
+   * @param worker Whether the caller is a worker thread. In that case, the
+   * method will block until a task is available or the thread pool is shutdown.
+   */
+  bool pump(bool worker);
 
   /** The worker thread routine */
   void worker();

--- a/tiledb/sm/misc/parallel_functions.h
+++ b/tiledb/sm/misc/parallel_functions.h
@@ -71,7 +71,7 @@ void parallel_sort(
 
   // Calculate the maximum height of the recursive call stack tree
   // where each leaf node can be assigned to a single level of
-  // concurrency on the thread pool. The motiviation is to stop the
+  // concurrency on the thread pool. The motivation is to stop the
   // recursion when all concurrency levels are utilized. When all
   // concurrency levels have their own subrange to operate on, we
   // will stop the quicksort and invoke std::sort() to sort the


### PR DESCRIPTION
This PR refactors the thread pool to support working with futures of arbitrary return types, instead of only statuses. This is achieved by adding generic variants to existing methods, and changing the producer-consumer queue to store `std::function<void()>`s instead of `std::shared_ptr<std::packaged_task<Status()>>`es. The existing `Status` overloads remain for compatibility.

While not many things outside the thread pool are affected, this will make future "unstatusing" work easier.

## TODO

- [x] Add ~~generic~~ `void` overloads of `wait_all`.
- [x] "Unstatus" `parallel_sort` as a proof of concept; it's trivial since it never returns a failing status.

---
TYPE: IMPROVEMENT
DESC: Refactor the thread pool.