### PR TITLE
Remove `ValidityVector::init_bytemap`.

### DIFF
--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -308,10 +308,6 @@ inline Status Status_BufferError(const std::string& msg) {
 inline Status Status_QueryError(const std::string& msg) {
   return {"[TileDB::Query] Error", msg};
 }
-/** Return a ValidityVector error class Status with a given message **/
-inline Status Status_ValidityVectorError(const std::string& msg) {
-  return {"[TileDB::ValidityVector] Error", msg};
-}
 /** Return a Status_VFSError error class Status with a given message **/
 inline Status Status_VFSError(const std::string& msg) {
   return {"[TileDB::VFS] Error", msg};

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1272,17 +1272,14 @@ Status Query::set_validity_buffer(
     const bool serialization_allow_new_attr) {
   RETURN_NOT_OK(check_set_fixed_buffer(name));
 
-  ValidityVector validity_vector;
-  RETURN_NOT_OK(validity_vector.init_bytemap(
-      buffer_validity_bytemap, buffer_validity_bytemap_size));
   // Check validity buffer
-  if (check_null_buffers && validity_vector.buffer() == nullptr) {
+  if (check_null_buffers && buffer_validity_bytemap == nullptr) {
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer is null"));
   }
 
   // Check validity buffer size
-  if (check_null_buffers && validity_vector.buffer_size() == nullptr) {
+  if (check_null_buffers && buffer_validity_bytemap_size == nullptr) {
     return logger_->status(Status_QueryError(
         "Cannot set buffer; " + name + " validity buffer size is null"));
   }
@@ -1331,7 +1328,8 @@ Status Query::set_validity_buffer(
   }
 
   // Set attribute/dimension buffer
-  buffers_[name].set_validity_buffer(std::move(validity_vector));
+  buffers_[name].set_validity_buffer(
+      {buffer_validity_bytemap, buffer_validity_bytemap_size});
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1293,7 +1293,8 @@ Status Query::set_validity_buffer(
           "' is not nullable"));
     }
 
-    aggregate_buffers_[name].set_validity_buffer(std::move(validity_vector));
+    aggregate_buffers_[name].set_validity_buffer(
+        {buffer_validity_bytemap, buffer_validity_bytemap_size});
 
     return Status::Ok();
   }

--- a/tiledb/sm/query/test/unit_validity_vector.cc
+++ b/tiledb/sm/query/test/unit_validity_vector.cc
@@ -56,8 +56,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < bytemap_size; ++i)
     bytemap[i] = i % 2;
 
-  ValidityVector validity_vector1;
-  REQUIRE(validity_vector1.init_bytemap(bytemap, &bytemap_size).ok());
+  ValidityVector validity_vector1{bytemap, &bytemap_size};
 
   ValidityVector validity_vector2(std::move(validity_vector1));
 
@@ -75,8 +74,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < bytemap_size; ++i)
     bytemap[i] = i % 2;
 
-  ValidityVector validity_vector1;
-  REQUIRE(validity_vector1.init_bytemap(bytemap, &bytemap_size).ok());
+  ValidityVector validity_vector1{bytemap, &bytemap_size};
 
   ValidityVector validity_vector2 = std::move(validity_vector1);
 
@@ -93,8 +91,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < bytemap_size; ++i)
     bytemap[i] = i % 2;
 
-  ValidityVector validity_vector;
-  REQUIRE(validity_vector.init_bytemap(bytemap, &bytemap_size).ok());
+  ValidityVector validity_vector{bytemap, &bytemap_size};
 
   REQUIRE(validity_vector.bytemap() == bytemap);
   REQUIRE(validity_vector.bytemap_size() == &bytemap_size);

--- a/tiledb/sm/query/test/unit_validity_vector.cc
+++ b/tiledb/sm/query/test/unit_validity_vector.cc
@@ -83,18 +83,3 @@ TEST_CASE(
   REQUIRE(validity_vector2.buffer() == bytemap);
   REQUIRE(validity_vector2.buffer_size() == &bytemap_size);
 }
-
-TEST_CASE(
-    "ValidityVector: Test init_bytemap", "[ValidityVector][init_bytemap]") {
-  uint8_t bytemap[10];
-  uint64_t bytemap_size = sizeof(bytemap);
-  for (uint64_t i = 0; i < bytemap_size; ++i)
-    bytemap[i] = i % 2;
-
-  ValidityVector validity_vector{bytemap, &bytemap_size};
-
-  REQUIRE(validity_vector.bytemap() == bytemap);
-  REQUIRE(validity_vector.bytemap_size() == &bytemap_size);
-  REQUIRE(validity_vector.buffer() == bytemap);
-  REQUIRE(validity_vector.buffer_size() == &bytemap_size);
-}

--- a/tiledb/sm/query/validity_vector.h
+++ b/tiledb/sm/query/validity_vector.h
@@ -36,7 +36,6 @@
 #include <vector>
 
 #include "tiledb/common/macros.h"
-#include "tiledb/common/status.h"
 
 using namespace tiledb::common;
 
@@ -96,26 +95,6 @@ class ValidityVector {
   /* ********************************* */
   /*                API                */
   /* ********************************* */
-
-  /**
-   * Initializes the validity vector with a bytemap. This does
-   * not take ownership of the bytemap. Each non-zero byte represents
-   * a valid attribute value.
-   *
-   * @param bytemap The byte map.
-   * @param bytemap_size The byte size of `bytemap`.
-   * @return Status
-   */
-  Status init_bytemap(uint8_t* const bytemap, uint64_t* bytemap_size) {
-    if (buffer_ != nullptr)
-      return Status_ValidityVectorError(
-          "ValidityVector instance already initialized");
-
-    buffer_ = bytemap;
-    buffer_size_ = bytemap_size;
-
-    return Status::Ok();
-  }
 
   /** Returns the bytemap that this instance was initialized with. */
   uint8_t* bytemap() const {

--- a/tiledb/sm/query/validity_vector.h
+++ b/tiledb/sm/query/validity_vector.h
@@ -37,8 +37,6 @@
 
 #include "tiledb/common/macros.h"
 
-using namespace tiledb::common;
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/validity_vector.h
+++ b/tiledb/sm/query/validity_vector.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_VALIDITY_VECTOR_H
 #define TILEDB_VALIDITY_VECTOR_H
 
+#include <cstdint>
 #include <vector>
 
 #include "tiledb/common/macros.h"


### PR DESCRIPTION
In its place we directly use `ValidityVector`'s constructor that takes pointers to the buffer and the length.

---
TYPE: IMPROVEMENT
DESC: Remove the internal `ValidityVector::init_bytemap` method.