### PR TITLE
Add new and delete to DataBlock so it can be used with std::allocator

### DIFF
--- a/experimental/tiledb/common/dag/data_block/data_block.h
+++ b/experimental/tiledb/common/dag/data_block/data_block.h
@@ -122,12 +122,15 @@ class DataBlockImpl {
 
 #endif
 
-  // @todo: make allocator_ static constexpr, etc.
-  void* operator new (size_t size) {
-    return reinterpret_cast<void*> (allocator_t{}.allocate());
+  // @todo: Do some initialization here.
+  // @todo: Default initialize?
+  // Although there is a "size" argument, we don't actually do anything with it.
+  // We always return a single datablock of size chunk_size_.
+  void* operator new(size_t) {
+    return reinterpret_cast<void*>(allocator_t{}.allocate());
   }
 
-  void operator delete (void* ptr) {
+  void operator delete(void* ptr) {
     allocator_t{}.deallocate(reinterpret_cast<std::byte*>(ptr));
   }
 
@@ -137,7 +140,7 @@ class DataBlockImpl {
    * `shared_ptr` constructor.  It is expected that his deleter will simply
    * return the chunk to the pool.  See pool_allocator.h for details.
    */
-    DataBlockImpl(size_t init_size = 0UL)
+  DataBlockImpl(size_t init_size = 0UL)
               : capacity_{chunk_size_}
       , size_{init_size}
       , storage_{allocator_t{}.allocate(),
@@ -285,7 +288,6 @@ class DataBlockImpl {
     return storage_.use_count();
   }
 };
-
 
 /**
  * The `DataBlock` class is the `DataBlockImpl` above, specialized to the

--- a/experimental/tiledb/common/dag/data_block/data_block.h
+++ b/experimental/tiledb/common/dag/data_block/data_block.h
@@ -50,9 +50,6 @@ namespace tiledb::common {
 /**
  * The fixed size (in bytes) of each `DataBlock`.
  */
-namespace {
-constexpr static const size_t chunk_size_ = 4'194'304;  // 4M
-}
 
 /**
  * A fixed size block, an untyped carrier (of `std::byte`) for data to
@@ -76,15 +73,16 @@ constexpr static const size_t chunk_size_ = 4'194'304;  // 4M
  * The `DataBlockImpl` class provides the interface for `DataBlock`, but is also
  * parameterized by`Allocator`.
  */
-template <class Allocator>
+template <size_t chunk_size = 64 * 1'024>
 class DataBlockImpl {
-  static Allocator allocator_;
+  constexpr static const size_t chunk_size_ = chunk_size;
 
   /**
    * Type aliases for `DataBlock` storage.  The underlying storage for the
    * `DataBlock` is a chunk of `std::byte`.  The `DataBlock` maintains this
    * storage as a `shared_ptr<std::byte>`.
    */
+  using allocator_t = PoolAllocator<chunk_size_>;
   using storage_t = std::shared_ptr<std::byte>;
   using span_t = tcb::span<std::byte>;
   using pointer_t = std::byte*;
@@ -101,10 +99,12 @@ class DataBlockImpl {
    * The actual stored chunk.  The `storage_` is the `shared_ptr` to the chunk,
    * while `data_` is a pointer to the actual bytes.
    */
+
   storage_t storage_;
   pointer_t data_{nullptr};
 
  public:
+#if 0
   /**
    * Constructor used if the `Allocator` is `std::allocator` of `std::byte`.
    */
@@ -120,21 +120,28 @@ class DataBlockImpl {
       , data_{storage_.get()} {
   }
 
+#endif
+
+  // @todo: make allocator_ static constexpr, etc.
+  void* operator new (size_t size) {
+    return reinterpret_cast<void*> (allocator_t{}.allocate());
+  }
+
+  void operator delete (void* ptr) {
+    allocator_t{}.deallocate(reinterpret_cast<std::byte*>(ptr));
+  }
+
   /**
    * Constructor used if the `Allocator` is the fixed-size pool allocator.  Note
    * that we pass the deleter associated with the `PoolAllocator` to to the
    * `shared_ptr` constructor.  It is expected that his deleter will simply
    * return the chunk to the pool.  See pool_allocator.h for details.
    */
-  template <class R = Allocator>
-  explicit DataBlockImpl(
-      size_t init_size = 0UL,
-      typename std::enable_if<
-          std::is_same_v<R, PoolAllocator<chunk_size_>>>::type* = nullptr)
-      : capacity_{chunk_size_}
+    DataBlockImpl(size_t init_size = 0UL)
+              : capacity_{chunk_size_}
       , size_{init_size}
-      , storage_{allocator_.allocate(),
-                 [&](auto px) { allocator_.deallocate(px); }}
+      , storage_{allocator_t{}.allocate(),
+                 [&](auto px) { allocator_t{}.deallocate(px); }}
       , data_{storage_.get()} {
   }
 
@@ -161,7 +168,7 @@ class DataBlockImpl {
   using DataBlockConstIterator = span_t::iterator;
 
   using value_type = span_t::value_type;
-  using allocator_type = SingletonPoolAllocator<chunk_size_>;
+  using allocator_type = allocator_t;
   using size_type = std::size_t;
   using difference_type = std::ptrdiff_t;
   using reference = value_type&;
@@ -279,21 +286,23 @@ class DataBlockImpl {
   }
 };
 
-template <class Allocator>
-Allocator DataBlockImpl<Allocator>::allocator_;
 
 /**
  * The `DataBlock` class is the `DataBlockImpl` above, specialized to the
  * PoolAllocator with chunk size specified by our defined `chunk_size_`.
  */
-using DataBlock = DataBlockImpl<PoolAllocator<chunk_size_>>;
+template <size_t block_size = 64 * 1'024>
+class DataBlock : public DataBlockImpl<block_size> {
+  using Base = DataBlockImpl<block_size>;
+  using Base::Base;
+};
 
 /**
  * Function for getting new `DataBlock`s
  */
-[[maybe_unused]] static DataBlock make_data_block(size_t init_size) {
-  return DataBlock{init_size};
-}
+// [[maybe_unused]] static DataBlock make_data_block() {
+//   return new DataBlock;
+// }
 
 }  // namespace tiledb::common
 

--- a/experimental/tiledb/common/dag/data_block/data_block.h
+++ b/experimental/tiledb/common/dag/data_block/data_block.h
@@ -104,24 +104,6 @@ class DataBlockImpl {
   pointer_t data_{nullptr};
 
  public:
-#if 0
-  /**
-   * Constructor used if the `Allocator` is `std::allocator` of `std::byte`.
-   */
-  template <class R = Allocator>
-  explicit DataBlockImpl(
-      size_t init_size = 0UL,
-      typename std::enable_if<
-          std::is_same_v<R, std::allocator<std::byte>>>::type* = 0)
-      : capacity_{chunk_size_}
-      , size_{init_size}
-      , storage_{allocator_.allocate(chunk_size_),
-                 [&](auto px) { allocator_.deallocate(px, chunk_size_); }}
-      , data_{storage_.get()} {
-  }
-
-#endif
-
   // @todo: Do some initialization here.
   // @todo: Default initialize?
   // Although there is a "size" argument, we don't actually do anything with it.
@@ -298,13 +280,6 @@ class DataBlock : public DataBlockImpl<block_size> {
   using Base = DataBlockImpl<block_size>;
   using Base::Base;
 };
-
-/**
- * Function for getting new `DataBlock`s
- */
-// [[maybe_unused]] static DataBlock make_data_block() {
-//   return new DataBlock;
-// }
 
 }  // namespace tiledb::common
 

--- a/experimental/tiledb/common/dag/data_block/pool_allocator.h
+++ b/experimental/tiledb/common/dag/data_block/pool_allocator.h
@@ -209,7 +209,7 @@ class PoolAllocatorImpl {
      */
     auto aligned_start{reinterpret_cast<std::byte*>(
         reinterpret_cast<ptrdiff_t>(new_bytes + sizeof(pointer) + (align - 1)) &
-        reinterpret_cast<ptrdiff_t>(page_mask))};
+        static_cast<ptrdiff_t>(page_mask))};
 
     for (size_t i = 0; i < chunks_per_array; ++i) {
       push_chunk(aligned_start + i * chunk_size);
@@ -403,19 +403,20 @@ template <size_t chunk_size>
 class PoolAllocator {
  public:
   using value_type = typename SingletonPoolAllocator<chunk_size>::value_type;
+  using pointer_type = value_type*;
   PoolAllocator() = default;
-  value_type* allocate() {
+  pointer_type allocate() {
     return _allocator<chunk_size>.allocate();
   }
-  value_type* allocate(size_t) {
-    return _allocator<chunk_size>.allocate();
-  }
-  void deallocate(value_type* a) {
+  void deallocate(pointer_type a) {
     return _allocator<chunk_size>.deallocate(a);
   }
-  void deallocate(value_type* a, size_t) {
-    return _allocator<chunk_size>.deallocate(a);
-  }
+  // value_type* allocate(size_t) {
+  //  return _allocator<chunk_size>.allocate();
+  // }
+  // void deallocate(value_type* a, size_t) {
+  //  return _allocator<chunk_size>.deallocate(a);
+  //}
   size_t num_instances() {
     return _allocator<chunk_size>.num_instances();
   }

--- a/experimental/tiledb/common/dag/data_block/pool_allocator.h
+++ b/experimental/tiledb/common/dag/data_block/pool_allocator.h
@@ -411,12 +411,6 @@ class PoolAllocator {
   void deallocate(pointer_type a) {
     return _allocator<chunk_size>.deallocate(a);
   }
-  // value_type* allocate(size_t) {
-  //  return _allocator<chunk_size>.allocate();
-  // }
-  // void deallocate(value_type* a, size_t) {
-  //  return _allocator<chunk_size>.deallocate(a);
-  //}
   size_t num_instances() {
     return _allocator<chunk_size>.num_instances();
   }

--- a/experimental/tiledb/common/dag/data_block/test/unit_data_block.cc
+++ b/experimental/tiledb/common/dag/data_block/test/unit_data_block.cc
@@ -40,8 +40,8 @@
 
 #include "unit_data_block.h"
 #include <algorithm>
-#include <list>
 #include <forward_list>
+#include <list>
 
 /**
  * @todo Use proper checks for preprocessor directives to selectively include
@@ -58,8 +58,8 @@
 #include "experimental/tiledb/common/dag/utility/range_join.h"
 using namespace tiledb::common;
 
-
-TEST_CASE("DataBlock: Test create DataBlock with constructors", "[data_block]") {
+TEST_CASE(
+    "DataBlock: Test create DataBlock with constructors", "[data_block]") {
   [[maybe_unused]] auto da = DataBlock<4'096>{};
   CHECK(da.size() == 0);
   CHECK(da.capacity() == 4096);
@@ -204,7 +204,6 @@ void db_test_1(const DB& db) {
   CHECK(a <= g);
 }
 
-
 /**
  * Invoke simple API tests with a basic `DataBlock`
  */
@@ -213,7 +212,6 @@ TEST_CASE("DataBlock: Test API of variously sized DataBlock", "[data_block]") {
   size_t chunk_size_ = 4'096;
 
   SECTION("Specific size constructed") {
-
     auto db = DataBlock{1};
     db_test_0(db);
     db_test_1(db);
@@ -250,7 +248,6 @@ TEST_CASE("DataBlock: Test API of variously sized DataBlock", "[data_block]") {
   }
 }
 
-
 /**
  * Test iterating through a `DataBlock`
  */
@@ -284,9 +281,6 @@ TEST_CASE("DataBlock: Iterate through data_block", "[data_block]") {
   db_test_2(dc);
 }
 
-
-
-
 /**
  * Run iteration test on multiple DataBlocks, again allocated with
  * `std::allocator` and with our `PoolAllocator`.
@@ -303,14 +297,11 @@ TEST_CASE("DataBlock: Iterate through 8 data_blocks", "[data_block]") {
   }
 }
 
-
-
 /**
  * Verify some properties of `DataBlock`s
  */
 TEST_CASE("DataBlock: Get span", "[data_block]") {
-using DataBlock = DataBlock<4'194'304>;
-
+  using DataBlock = DataBlock<4'194'304>;
 
   auto a = DataBlock{};
   auto b = DataBlock{};
@@ -385,7 +376,6 @@ TEST_CASE("DataBlock: Test resize", "[data_block]") {
 }
 
 TEST_CASE("DataBlock: Test (shallow) copying", "[data_block]") {
-
   using DataBlock = DataBlock<4'194'304>;
 
   auto a = DataBlock{DataBlock::max_size()};
@@ -589,7 +579,6 @@ TEST_CASE(
 TEST_CASE(
     "DataBlock: Test DataBlock allocation/deallocation from pool, etc",
     "[data_block]") {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -632,7 +621,6 @@ TEST_CASE(
 TEST_CASE(
     "DataBlock: Test DataBlock allocation/deallocation on copying, etc",
     "[data_block]") {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -729,7 +717,6 @@ TEST_CASE(
  * `std::fill` algorithm.
  */
 void test_std_fill(size_t test_size) {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -805,9 +792,7 @@ void test_std_fill(size_t test_size) {
  * `std::fill` algorithm.
  */
 TEST_CASE("DataBlock: Fill with std::fill", "[data_block]") {
-
   constexpr size_t chunk_size_ = 4'194'304;
-  using DataBlock = DataBlock<chunk_size_>;
 
   SECTION("chunk_size") {
     test_std_fill(chunk_size_);
@@ -824,7 +809,6 @@ TEST_CASE("DataBlock: Fill with std::fill", "[data_block]") {
  * Verify some properties of joined `DataBlock`s.
  */
 void test_join(size_t test_size) {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -888,9 +872,7 @@ void test_join(size_t test_size) {
 }
 
 TEST_CASE("DataBlock: Join data_blocks (join view)", "[data_block]") {
-
   constexpr size_t chunk_size_ = 4'194'304;
-  using DataBlock = DataBlock<chunk_size_>;
 
   SECTION("chunk_size") {
     test_join(chunk_size_);
@@ -908,7 +890,6 @@ TEST_CASE("DataBlock: Join data_blocks (join view)", "[data_block]") {
  * library algorithms.
  */
 void test_join_std_fill(size_t test_size) {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -948,9 +929,7 @@ void test_join_std_fill(size_t test_size) {
 }
 
 TEST_CASE("DataBlock: Join data_blocks std::fill", "[data_block]") {
-
   constexpr size_t chunk_size_ = 4'194'304;
-  using DataBlock = DataBlock<chunk_size_>;
 
   SECTION("chunk_size") {
     test_join_std_fill(chunk_size_);
@@ -967,7 +946,6 @@ TEST_CASE("DataBlock: Join data_blocks std::fill", "[data_block]") {
  * Test `operator[]` of joined `DataBlock`s.
  */
 void test_join_operator_bracket(size_t test_size) {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -1013,9 +991,7 @@ void test_join_operator_bracket(size_t test_size) {
 }
 
 TEST_CASE("DataBlock: Join data_blocks operator[]", "[data_block]") {
-
   constexpr size_t chunk_size_ = 4'194'304;
-  using DataBlock = DataBlock<chunk_size_>;
 
   SECTION("chunk_size") {
     test_join_operator_bracket(chunk_size_);
@@ -1032,7 +1008,6 @@ TEST_CASE("DataBlock: Join data_blocks operator[]", "[data_block]") {
  * Additional standard library uses of joined `DataBlock`s.
  */
 void test_operator_bracket_loops(size_t test_size) {
-
   constexpr size_t chunk_size_ = 4'194'304;
   using DataBlock = DataBlock<chunk_size_>;
 
@@ -1113,7 +1088,6 @@ void test_operator_bracket_loops(size_t test_size) {
 
 TEST_CASE("DataBlock: Join data_blocks loops operator[]", "[data_block]") {
   constexpr size_t chunk_size_ = 4'194'304;
-  using DataBlock = DataBlock<chunk_size_>;
 
   SECTION("chunk_size") {
     test_operator_bracket_loops(chunk_size_);

--- a/experimental/tiledb/common/dag/data_block/test/unit_pool_allocator.cc
+++ b/experimental/tiledb/common/dag/data_block/test/unit_pool_allocator.cc
@@ -368,19 +368,6 @@ TEST_CASE(
 }
 
 /**
- * Test allocator interface for `PoolAllocator`.  It should be conformant, but
- * g++ seems to be kind of persnickety.
- */
-#ifndef __GNUG__
-TEST_CASE(
-    "Pool Allocator: Allocate vector with PoolAllocator - compile only",
-    "[PoolAllocator]") {
-  std::vector<std::byte, PoolAllocator<1024 * 1024>> v(10);
-  CHECK(v.size() == 10);
-}
-#endif
-
-/**
  * Allocate a large number of chunks.
  */
 template <class T>


### PR DESCRIPTION
This PR changes the notion of `DataBlock` slightly.  We now consider the `DataBlock` to be a single thing that is allocated.  According, we no longer consider `PoolAllocator` as an actual allocator.  Rather, we overload `new` and `delete` in `DataBlockImpl` so that `DataBlock`s can be used directly with `std::allocator`.

---
TYPE: NO_HISTORY
DESC: Add new and delete to DataBlock so it can be used with std::allocator
