### PR TITLE
Deletes: Ensure objects cannot be reopened

### DIFF
--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -1984,28 +1984,19 @@ TEST_CASE_METHOD(
   // Check working directory after delete
   REQUIRE(vfs_.is_file(extraneous_file_path));
   CHECK(tiledb::test::num_fragments(SPARSE_ARRAY_NAME) == 0);
-  schemas =
-      vfs_.ls(array_name + "/" + tiledb::sm::constants::array_schema_dir_name);
-  CHECK(schemas.size() == 0);
-  meta = vfs_.ls(
-      array_name + "/" + tiledb::sm::constants::array_metadata_dir_name);
-  CHECK(meta.size() == 0);
-  auto frag_meta = vfs_.ls(
-      array_name + "/" + tiledb::sm::constants::array_fragment_meta_dir_name);
-  CHECK(frag_meta.size() == 0);
-
-  // Check commit directory after delete
-  if (consolidate) {
-    /* Note: An ignore file is written by delete_fragments if there are
-     * consolidated commits to be ignored by the delete. */
-    CommitsDirectory commits_dir(vfs_, SPARSE_ARRAY_NAME);
-    CHECK(
-        commits_dir.file_count(
-            tiledb::sm::constants::con_commits_file_suffix) == 1);
-    CHECK(
-        commits_dir.file_count(tiledb::sm::constants::ignore_file_suffix) == 1);
-  }
-  CHECK(tiledb::test::num_commits(array_name) == 0);
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" + tiledb::sm::constants::array_commits_dir_name));
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" + tiledb::sm::constants::array_fragment_meta_dir_name));
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" + tiledb::sm::constants::array_fragments_dir_name));
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" +
+      tiledb::sm::constants::array_dimension_labels_dir_name));
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" + tiledb::sm::constants::array_metadata_dir_name));
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" + tiledb::sm::constants::array_schema_dir_name));
 
   // Try to open array
   REQUIRE_THROWS_WITH(
@@ -2072,9 +2063,8 @@ TEST_CASE_METHOD(
     CHECK(!tiledb::sm::utils::parse::starts_with(uri, ok_prefix));
   }
   REQUIRE(vfs_.is_file(extraneous_file_path));
-  schemas =
-      vfs_.ls(array_name + "/" + tiledb::sm::constants::array_schema_dir_name);
-  CHECK(schemas.size() == 0);
+  REQUIRE(!vfs_.is_dir(
+      array_name + "/" + tiledb::sm::constants::array_schema_dir_name));
 
   remove_sparse_array();
 }

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -334,7 +334,10 @@ class Array {
   }
 
   /**
-   * Deletes the data written to the array with the input uri.
+   * Deletes all data written to the array with the input uri.
+   *
+   * @post This is destructive; the array may not be reopened after delete.
+   * @note Only consolidated commits may persist after this function call.
    */
   static void delete_array(const Context& ctx, const std::string& uri) {
     ctx.handle_error(tiledb_array_delete(ctx.ptr().get(), uri.c_str()));

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -336,6 +336,9 @@ class Array {
   /**
    * Deletes all data written to the array with the input uri.
    *
+   * @param ctx TileDB context
+   * @param uri The Array's URI
+   *
    * @post This is destructive; the array may not be reopened after delete.
    */
   static void delete_array(const Context& ctx, const std::string& uri) {
@@ -345,6 +348,11 @@ class Array {
   /**
    * Deletes the fragments written between the input timestamps of an array
    * with the input uri.
+   *
+   * @param uri The URI of the fragments' parent Array.
+   * @param timestamp_start The epoch start timestamp in milliseconds.
+   * @param timestamp_end The epoch end timestamp in milliseconds. Use
+   * UINT64_MAX for the current timestamp.
    */
   void delete_fragments(
       const std::string& uri,

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -337,7 +337,6 @@ class Array {
    * Deletes all data written to the array with the input uri.
    *
    * @post This is destructive; the array may not be reopened after delete.
-   * @note Only consolidated commits may persist after this function call.
    */
   static void delete_array(const Context& ctx, const std::string& uri) {
     ctx.handle_error(tiledb_array_delete(ctx.ptr().get(), uri.c_str()));

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -247,13 +247,14 @@ class Group {
   }
 
   /**
-   * Deletes written data from an open group. The group must
+   * Deletes all written data from an open group. The group must
    * be opened in MODIFY_EXCLUSIVE mode, otherwise the function will error out.
    *
    * @param uri The address of the group item to be deleted.
    * @param recursive True if all data inside the group is to be deleted.
    *
    * @note if recursive == false, data added to the group will be left as-is.
+   * @post This is destructive; the group may not be reopened after delete.
    */
   void delete_group(const std::string& uri, bool recursive = false) {
     auto& ctx = ctx_.get();

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -450,6 +450,18 @@ Status VFS::remove_dir(const URI& uri) const {
     return LOG_STATUS(
         Status_VFSError("Unsupported URI scheme: " + uri.to_string()));
   }
+}
+
+void VFS::remove_dirs(
+    ThreadPool* compute_tp, const std::vector<URI>& uris) const {
+  throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
+    bool is_dir;
+    RETURN_NOT_OK(this->is_dir(uris[i], &is_dir));
+    if (is_dir) {
+      RETURN_NOT_OK(remove_dir(uris[i]));
+    }
+    return Status::Ok();
+  }));
 }
 
 Status VFS::remove_file(const URI& uri) const {

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -257,6 +257,14 @@ class VFS {
    * @return Status
    */
   Status remove_dir(const URI& uri) const;
+
+  /**
+   * Deletes directories in parallel from the given vector of directories.
+   *
+   * @param compute_tp The compute-bound ThreadPool.
+   * @param uris The URIs of the directories.
+   */
+  void remove_dirs(ThreadPool* compute_tp, const std::vector<URI>& uris) const;
 
   /**
    * Deletes a file.

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -93,6 +93,15 @@ const std::string fragment_metadata_filename = "__fragment_metadata.tdb";
 /** The array dimension labels directory name. */
 const std::string array_dimension_labels_dir_name = "__labels";
 
+/** The array directory names. */
+const std::vector<std::string> array_dir_names = {
+    array_schema_dir_name,
+    array_metadata_dir_name,
+    array_fragment_meta_dir_name,
+    array_fragments_dir_name,
+    array_commits_dir_name,
+    array_dimension_labels_dir_name};
+
 /** The default tile capacity. */
 const uint64_t capacity = 10000;
 
@@ -260,6 +269,10 @@ const std::string group_detail_dir_name = "__group";
 
 /** The group metadata directory name. */
 const std::string group_metadata_dir_name = "__meta";
+
+/** The group directory names. */
+const std::vector<std::string> group_dir_names = {
+    group_detail_dir_name, group_metadata_dir_name};
 
 /** The maximum number of bytes written in a single I/O. */
 const uint64_t max_write_bytes = std::numeric_limits<int>::max();

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -36,6 +36,7 @@
 #include <array>
 #include <cinttypes>
 #include <string>
+#include <vector>
 
 #include "tiledb/common/common.h"
 
@@ -81,6 +82,9 @@ extern const std::string array_commits_dir_name;
 
 /** The array dimension labels directory name. */
 extern const std::string array_dimension_labels_dir_name;
+
+/** The array directory names. */
+extern const std::vector<std::string> array_dir_names;
 
 /** The default tile capacity. */
 extern const uint64_t capacity;
@@ -249,6 +253,9 @@ extern const std::string group_detail_dir_name;
 
 /** The group metadata directory name. */
 extern const std::string group_metadata_dir_name;
+
+/** The group directory names. */
+extern const std::vector<std::string> group_dir_names;
 
 /** The maximum number of bytes written in a single I/O. */
 extern const uint64_t max_write_bytes;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -448,6 +448,19 @@ void StorageManagerCanonical::delete_array(const char* array_name) {
   vfs()->remove_files(compute_tp(), array_dir.array_meta_uris());
   vfs()->remove_files(compute_tp(), array_dir.fragment_meta_uris());
   vfs()->remove_files(compute_tp(), array_dir.array_schema_uris());
+
+  // Delete all array child directories
+  // Note: using vfs()->ls() here could delete user data
+  std::vector<URI> dirs;
+  auto parent_dir = array_dir.uri().c_str();
+  dirs.emplace_back(URI(parent_dir + constants::array_commits_dir_name));
+  dirs.emplace_back(URI(parent_dir + constants::array_fragment_meta_dir_name));
+  dirs.emplace_back(URI(parent_dir + constants::array_fragments_dir_name));
+  dirs.emplace_back(
+      URI(parent_dir + constants::array_dimension_labels_dir_name));
+  dirs.emplace_back(URI(parent_dir + constants::array_metadata_dir_name));
+  dirs.emplace_back(URI(parent_dir + constants::array_schema_dir_name));
+  vfs()->remove_dirs(compute_tp(), dirs);
 }
 
 void StorageManagerCanonical::delete_fragments(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -449,7 +449,7 @@ void StorageManagerCanonical::delete_array(const char* array_name) {
   vfs()->remove_files(compute_tp(), array_dir.fragment_meta_uris());
   vfs()->remove_files(compute_tp(), array_dir.array_schema_uris());
 
-  // Delete all array child directories
+  // Delete all tiledb child directories
   // Note: using vfs()->ls() here could delete user data
   std::vector<URI> dirs;
   auto parent_dir = array_dir.uri().c_str();
@@ -525,6 +525,14 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
   vfs()->remove_files(compute_tp(), group_dir.group_meta_uris_to_vacuum());
   vfs()->remove_files(compute_tp(), group_dir.group_meta_vac_uris_to_vacuum());
   vfs()->remove_files(compute_tp(), group_dir.group_file_uris());
+
+  // Delete all tiledb child directories
+  // Note: using vfs()->ls() here could delete user data
+  std::vector<URI> dirs;
+  auto parent_dir = group_dir.uri().c_str();
+  dirs.emplace_back(URI(parent_dir + constants::group_detail_dir_name));
+  dirs.emplace_back(URI(parent_dir + constants::group_metadata_dir_name));
+  vfs()->remove_dirs(compute_tp(), dirs);
 }
 
 void StorageManagerCanonical::array_vacuum(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -453,13 +453,9 @@ void StorageManagerCanonical::delete_array(const char* array_name) {
   // Note: using vfs()->ls() here could delete user data
   std::vector<URI> dirs;
   auto parent_dir = array_dir.uri().c_str();
-  dirs.emplace_back(URI(parent_dir + constants::array_commits_dir_name));
-  dirs.emplace_back(URI(parent_dir + constants::array_fragment_meta_dir_name));
-  dirs.emplace_back(URI(parent_dir + constants::array_fragments_dir_name));
-  dirs.emplace_back(
-      URI(parent_dir + constants::array_dimension_labels_dir_name));
-  dirs.emplace_back(URI(parent_dir + constants::array_metadata_dir_name));
-  dirs.emplace_back(URI(parent_dir + constants::array_schema_dir_name));
+  for (auto array_dir_name : constants::array_dir_names) {
+    dirs.emplace_back(URI(parent_dir + array_dir_name));
+  }
   vfs()->remove_dirs(compute_tp(), dirs);
 }
 
@@ -530,8 +526,9 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
   // Note: using vfs()->ls() here could delete user data
   std::vector<URI> dirs;
   auto parent_dir = group_dir.uri().c_str();
-  dirs.emplace_back(URI(parent_dir + constants::group_detail_dir_name));
-  dirs.emplace_back(URI(parent_dir + constants::group_metadata_dir_name));
+  for (auto group_dir_name : constants::group_dir_names) {
+    dirs.emplace_back(URI(parent_dir + group_dir_name));
+  }
   vfs()->remove_dirs(compute_tp(), dirs);
 }
 


### PR DESCRIPTION
Remove all TileDB artifacts when performing Array and Group deletes. This change clears all TileDB-associated artifacts from array and group format subdirectories when performing a delete. Currently, a group URI can be opened after group_delete, even though there is no content; after this change, that will no longer be possible.

---
TYPE: IMPROVEMENT
DESC: Remove all TileDB artifacts when performing Array and Group deletes
