### PR TITLE
Fix clang-format version line

### DIFF
--- a/scripts/run-clang-format.sh
+++ b/scripts/run-clang-format.sh
@@ -27,7 +27,7 @@ shift
 APPLY_FIXES=$1
 shift
 
-echo "Running clang-format version: " `$CLANG_FORMAT --version`
+echo "Running clang-format version:" `$CLANG_FORMAT --version`
 
 # clang format will only find its configuration if we are in
 # the source tree or in a path relative to the source tree


### PR DESCRIPTION
There was an extra space. It finally annoyed me enough to make a PR.

Pretty sure this is a NO_HISTORY PR, let me know if not.

---
TYPE: NO_HISTORY
DESC: Remove extra space when displaying clang-format version line.
