### PR TITLE
Fix S3 testing on Ubuntu 22.04

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -35,6 +35,7 @@ jobs:
       ci_backend: AZURE
       matrix_image: ubuntu-20.04
       bootstrap_args: '--enable-azure --enable-release-symbols'
+
   ci2:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
@@ -42,6 +43,7 @@ jobs:
       matrix_image: ubuntu-20.04
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
+
   ci3:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
@@ -65,6 +67,7 @@ jobs:
       matrix_image: macos-11
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
+
   ci6:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
@@ -80,8 +83,17 @@ jobs:
       matrix_image: ubuntu-22.04
       bootstrap_args: '--enable=experimental-features,serialization --enable-release-symbols'
 
+  ci8:
+    uses: ./.github/workflows/ci-linux_mac.yml
+    with:
+      ci_backend: S3
+      matrix_image: ubuntu-22.04
+      timeout: 120
+      bootstrap_args: '--enable-s3 --enable-release-symbols'
+
   ci_msvc:
     uses: ./.github/workflows/build-windows.yml
+
   ci_mingw_r:
     uses: ./.github/workflows/build-rtools40.yml
 
@@ -96,7 +108,20 @@ jobs:
 
   # dummy job for branch protection check
   full_ci_passed:
-    needs: [ci1, ci2, ci2, ci3, ci4, ci5, ci6, ci7, ci_msvc, backward_compatibility, standalone]
+    needs: [
+        ci1,
+        ci2,
+        ci2,
+        ci3,
+        ci4,
+        ci5,
+        ci6,
+        ci7,
+        ci8,
+        ci_msvc,
+        backward_compatibility,
+        standalone
+      ]
     runs-on: ubuntu-22.04
     steps:
       - name: ''

--- a/ports/aws-sdk-cpp/006-pjd-fix-compiler-warnings.patch
+++ b/ports/aws-sdk-cpp/006-pjd-fix-compiler-warnings.patch
@@ -1,0 +1,39 @@
+diff --git a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+index 5e6c8fc379..5d46008aef 100644
+--- a/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
++++ b/aws-cpp-sdk-core/source/http/curl/CurlHttpClient.cpp
+@@ -362,7 +362,7 @@ void SetOptCodeForHttpMethod(CURL* requestHandle, const std::shared_ptr<HttpRequ
+             }
+             else
+             {
+-                curl_easy_setopt(requestHandle, CURLOPT_PUT, 1L);
++                curl_easy_setopt(requestHandle, CURLOPT_UPLOAD, 1L);
+             }
+             break;
+         case HttpMethod::HTTP_HEAD:
+diff --git a/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp b/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
+index f70a6c88f6..053ff938d4 100644
+--- a/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
++++ b/aws-cpp-sdk-core/source/utils/event/EventStreamDecoder.cpp
+@@ -72,9 +72,7 @@ namespace Aws
+                 assert(handler);
+                 if (!handler)
+                 {
+-                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but decoder encountered internal errors before."
+-                        "ErrorCode: " << EventStreamErrorsMapper::GetNameForError(handler->GetInternalError()) << ", "
+-                        "ErrorMessage: " << handler->GetEventPayloadAsString());
++                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but handler is null.");
+                     return;
+                 }
+                 handler->WriteMessageEventPayload(static_cast<unsigned char*>(payload->buffer), payload->len);
+@@ -129,9 +127,7 @@ namespace Aws
+                 assert(handler);
+                 if (!handler)
+                 {
+-                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Payload received, but decoder encountered internal errors before."
+-                        "ErrorCode: " << EventStreamErrorsMapper::GetNameForError(handler->GetInternalError()) << ", "
+-                        "ErrorMessage: " << handler->GetEventPayloadAsString());
++                    AWS_LOGSTREAM_ERROR(EVENT_STREAM_DECODER_CLASS_TAG, "Header received, but handler is null.");
+                     return;
+                 }
+

--- a/ports/aws-sdk-cpp/portfile.cmake
+++ b/ports/aws-sdk-cpp/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         003-fix-AWSSDKCONFIG.patch
         004-fix-check-c-source-runs.patch
         005-fix-cjson-sprintf.patch
+        006-pjd-fix-compiler-warnings.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_CRT_LINKAGE}" "dynamic" FORCE_SHARED_CRT)

--- a/tiledb/platform/CMakeLists.txt
+++ b/tiledb/platform/CMakeLists.txt
@@ -28,6 +28,14 @@ include(common NO_POLICY_SCOPE)
 include(object_library)
 
 #
+# `cert_file` object library
+#
+commence(object_library cert_file)
+    this_target_sources(cert_file.cc)
+    this_target_link_libraries(baseline)
+conclude(object_library)
+
+#
 # `platform` object library
 #
 commence(object_library platform)

--- a/tiledb/platform/cert_file.h
+++ b/tiledb/platform/cert_file.h
@@ -38,7 +38,6 @@
 #include <string>
 #include <system_error>
 
-#include "tiledb/common/logger.h"
 #include "tiledb/platform/os.h"
 
 // We can remove this preprocessor block once our minimum

--- a/tiledb/platform/test/compile_cert_file_main.cc
+++ b/tiledb/platform/test/compile_cert_file_main.cc
@@ -1,0 +1,34 @@
+/**
+ * @file compile_cert_file_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../cert_file.h"
+
+int main() {
+  tiledb::platform::PlatformCertFile::get();
+  return 0;
+}

--- a/tiledb/sm/filesystem/CMakeLists.txt
+++ b/tiledb/sm/filesystem/CMakeLists.txt
@@ -31,10 +31,33 @@ include(object_library)
 # `vfs` object library
 #
 commence(object_library vfs)
-    this_target_sources(
-        vfs.cc vfs_file_handle.cc mem_filesystem.cc path_win.cc posix.cc win.cc uri.cc)
+    list(APPEND VFS_SOURCES
+        mem_filesystem.cc
+        path_win.cc
+        posix.cc
+        uri.cc
+        vfs.cc
+        vfs_file_handle.cc
+        win.cc
+    )
+    if (TILEDB_S3)
+        list(APPEND VFS_SOURCES
+            s3.cc
+            s3_thread_pool_executor.cc
+        )
+    endif()
+    this_target_sources(${VFS_SOURCES})
     this_target_object_libraries(
-        baseline buffer cancelable_tasks config math stats stringx thread_pool)
+        baseline
+        buffer
+        cancelable_tasks
+        cert_file
+        config
+        math
+        stats
+        stringx
+        thread_pool
+    )
     if(WIN32)
         if(MSVC)
             find_library(SHLWAPI_LIBRARY shlwapi)
@@ -43,6 +66,24 @@ commence(object_library vfs)
         else()
             message(STATUS "Linking to Win32 lib shlwapi")
             this_target_link_libraries(-lshlwapi)
+        endif()
+    endif()
+    # Add S3 dependencies
+    if (TILEDB_S3)
+        if (TILEDB_VCPKG)
+            find_package(AWSSDK_EP REQUIRED COMPONENTS s3)
+            target_link_libraries(vfs INTERFACE ${AWSSDK_LINK_LIBRARIES})
+        else()
+            find_package(AWSSDK_EP REQUIRED COMPONENTS s3)
+            target_link_libraries(vfs INTERFACE
+                AWSSDK::aws-cpp-sdk-s3
+                AWSSDK::aws-cpp-sdk-core
+                AWSSDK::aws-c-event-stream
+                AWSSDK::aws-checksums
+                AWSSDK::aws-c-common
+                AWSSDK::aws-cpp-sdk-identity-management
+                AWSSDK::aws-cpp-sdk-sts
+            )
         endif()
     endif()
 conclude(object_library)


### PR DESCRIPTION
Fix compiler warnings on Ubuntu 22.04 when compiling aws-sdk-cpp

Three minor issues. Two of which are vaguely surprising in that gcc detected a nullptr dereference.

---
TYPE: IMPROVEMENT
DESC: Fix building aws-sdk-cpp on Ubuntu 22.04
