### PR TITLE
Don't throw an exception from the Group destructor

### DIFF
--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -815,3 +815,72 @@ TEST_CASE_METHOD(
   group2.close();
   remove_temp_dir(temp_dir);
 }
+
+/** Test Exception For Assertability */
+class GroupDtorDoesntThrowException : public std::exception {
+ public:
+  explicit GroupDtorDoesntThrowException()
+      : std::exception() {
+  }
+};
+
+TEST_CASE("C++ API: Group close group with error", "[cppapi][group][error]") {
+  tiledb::Context ctx;
+  tiledb::VFS vfs(ctx);
+  std::vector<std::string> dnames = {"main_group", "main_group_renamed"};
+
+  auto cleaner = [&]() -> void {
+    for (auto dir : dnames) {
+      if (vfs.is_dir(dir)) {
+        vfs.remove_dir(dir);
+      }
+    }
+  };
+  cleaner();
+
+  // This test is a bit subtle in that we're attempting to assert that a
+  // destructor doesn't throw. Since throwing from a destructor is perfectly
+  // valid (although extremely discouraged outside of extremely niche cases)
+  // we have to force a situation such that an exception thrown from the
+  // destructor would cause some other observable behavior.
+  //
+  // For this test, I'm using the case where throwing an exception while the
+  // stack is already being unwound being C++ mandated as a call to
+  // std::terminate which will fail this test quite hard.
+  //
+  // The GroupDtroDoesntThrowException is a specific class so that we know
+  // we've caught the exception we expect. The thrown_correctly assertion
+  // is mostly for show since the real failure would be the std::terminate
+  // which is unrecoverable.
+
+  bool thrown_correctly = false;
+
+  try {
+    // Create our group preliminaries
+    tiledb::create_group(ctx, "main_group");
+    tiledb::create_group(ctx, "main_group/sub_group");
+
+    tiledb::Group group(ctx, "main_group", TILEDB_WRITE);
+    group.add_member("main_group/sub_group", false, "sub_group");
+
+    // Muck with the filesystem so that when the group.close() is called it
+    // throws an exception due to missing paths
+    REQUIRE(rename("main_group", "main_group_renamed") == 0);
+
+    // Check that group.close() actually throws
+    REQUIRE_THROWS(group.close());
+
+    // By throwing here, Group will go out of scope calling close. If this
+    // throws we end up with the exact reason why throwing from a destructor
+    // is a bad idea because throwing an exception while the stack is
+    // unwinding is specified by the language to call std::terminate
+    throw GroupDtorDoesntThrowException();
+
+  } catch (GroupDtorDoesntThrowException& exc) {
+    thrown_correctly = true;
+  }
+
+  REQUIRE(thrown_correctly);
+
+  cleaner();
+}

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -207,6 +207,21 @@ int32_t tiledb_serialization_type_from_str(
 }
 
 /* ********************************* */
+/*             LOGGING               */
+/* ********************************* */
+
+capi_return_t tiledb_log_warn(tiledb_ctx_t* ctx, const char* message) {
+  if (message == nullptr) {
+    return TILEDB_ERR;
+  }
+
+  auto logger = ctx->storage_manager()->logger();
+  logger->warn(message);
+
+  return TILEDB_OK;
+}
+
+/* ********************************* */
 /*            ATTRIBUTE              */
 /* ********************************* */
 
@@ -5477,6 +5492,14 @@ void tiledb_version(int32_t* major, int32_t* minor, int32_t* rev) noexcept {
   *major = tiledb::sm::constants::library_version[0];
   *minor = tiledb::sm::constants::library_version[1];
   *rev = tiledb::sm::constants::library_version[2];
+}
+
+/* ********************************* */
+/*             LOGGING               */
+/* ********************************* */
+
+capi_return_t tiledb_log_warn(tiledb_ctx_t* ctx, const char* message) {
+  return api_entry<tiledb::api::tiledb_log_warn>(ctx, message);
 }
 
 /* ********************************* */

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -53,12 +53,32 @@
 extern "C" {
 #endif
 
-/** A TileDB array schema. */
-typedef struct tiledb_array_schema_evolution_t tiledb_array_schema_evolution_t;
+/* ********************************* */
+/*             LOGGING               */
+/* ********************************* */
+
+/**
+ * Log a message at WARN level using TileDB's internal logging mechanism
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_log_warn(ctx, "This is a log message.");
+ * @endcode
+ *
+ * @param ctx The TileDB Context.
+ * @param message The message to log
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t
+tiledb_log_warn(tiledb_ctx_t* ctx, const char* message);
 
 /* ********************************* */
 /*      ARRAY SCHEMA EVOLUTION       */
 /* ********************************* */
+
+/** A TileDB array schema. */
+typedef struct tiledb_array_schema_evolution_t tiledb_array_schema_evolution_t;
 
 /**
  * Creates a TileDB schema evolution object.

--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -134,33 +134,44 @@ class Context {
    * @param rc If != TILEDB_OK, calls error handler
    */
   void handle_error(int rc) const {
-    // Do nothing if there is not error
+    // Do nothing if there is no error
     if (rc == TILEDB_OK)
       return;
 
+    error_handler_(get_last_error_message());
+  }
+
+  /**
+   * Get the message of the last error that occurred.
+   *
+   * @return The last error message
+   */
+  std::string get_last_error_message() const noexcept {
     // Get error
     const auto& ctx = ctx_.get();
     tiledb_error_t* err = nullptr;
-    const char* msg = nullptr;
-    rc = tiledb_ctx_get_last_error(ctx, &err);
+
+    auto rc = tiledb_ctx_get_last_error(ctx, &err);
     if (rc != TILEDB_OK) {
       tiledb_error_free(&err);
-      error_handler_("[TileDB::C++API] Error: Non-retrievable error occurred");
+      return "[TileDB::C++API] Error: Non-retrievable error occurred";
     }
 
-    // Get error message
+    // Get the error message
+    const char* msg = nullptr;
     rc = tiledb_error_message(err, &msg);
     if (rc != TILEDB_OK) {
       tiledb_error_free(&err);
-      error_handler_("[TileDB::C++API] Error: Non-retrievable error occurred");
+      return "[TileDB::C++API] Error: Non-retrievable error occurred";
     }
-    auto msg_str = std::string(msg);
 
-    // Clean up
+    // Create a copy of the error
+    std::string msg_str(msg);
+
+    // Cleanup error struct
     tiledb_error_free(&err);
 
-    // Throw exception
-    error_handler_(msg_str);
+    return msg_str;
   }
 
   /** Returns the C TileDB context object. */


### PR DESCRIPTION
The Group destructor in the C++ API header library calls Group::close() which can throw in various normal situations. We maintain the behavior of calling close() but with exceptions logged instead of being thrown.

Fixes #4101

---
TYPE: BUG
DESC: Don't throw an exception from the Group destructor
