### PR TITLE
Increase Azure CI timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ stages:
       BACKWARDS_COMPATIBILITY_ARRAYS: OFF
     jobs:
     - job:
-      timeoutInMinutes: 90
+      timeoutInMinutes: 120
       strategy:
         matrix:
           macOS_azure:


### PR DESCRIPTION
The ASAN job continues to randomly timeout by running slower. We should increase the CI timeout while we work to move the job to github actions.


---
TYPE: NO_HISTORY
DESC: NO_HISTORY
