### PR TITLE
[Backport release-2.15] Sparse readers: fixing null count on incomplete queries. (#4037)

### DIFF
--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -442,7 +442,8 @@ void create_array(
     tiledb_layout_t cell_order,
     uint64_t capacity,
     bool allows_dups,
-    bool serialize_array_schema) {
+    bool serialize_array_schema,
+    const optional<std::vector<bool>>& nullable) {
   // For easy reference
   auto dim_num = dim_names.size();
   auto attr_num = attr_names.size();
@@ -502,6 +503,12 @@ void create_array(
     REQUIRE(rc == TILEDB_OK);
     rc = tiledb_attribute_set_cell_val_num(ctx, a, cell_val_num[i]);
     REQUIRE(rc == TILEDB_OK);
+
+    if (nullable != nullopt) {
+      rc = tiledb_attribute_set_nullable(ctx, a, nullable.value()[i]);
+      REQUIRE(rc == TILEDB_OK);
+    }
+
     rc = tiledb_array_schema_add_attribute(ctx, array_schema, a);
     REQUIRE(rc == TILEDB_OK);
     tiledb_attribute_free(&a);

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -266,8 +266,9 @@ int array_create_wrapper(
  * @param cell_order The cell order.
  * @param capacity The tile capacity.
  * @param allows_dups Whether the array allows coordinate duplicates.
- * @param serialize_array_schema whether to round-trip through serialization or
- * not
+ * @param serialize_array_schema Whether to round-trip through serialization or
+ * not.
+ * @param nullable Whether the attributes are nullable or not.
  */
 
 void create_array(
@@ -286,7 +287,8 @@ void create_array(
     tiledb_layout_t cell_order,
     uint64_t capacity,
     bool allows_dups = false,
-    bool serialize_array_schema = false);
+    bool serialize_array_schema = false,
+    const optional<std::vector<bool>>& nullable = nullopt);
 
 /**
  * Helper method to create an encrypted array.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -923,10 +923,10 @@ Status SparseIndexReaderBase::resize_output_buffers(uint64_t cells_copied) {
     }
 
     // Always adjust validity vector size, if present.
-    if (num_cells > cells_copied) {
+    if (array_schema_.is_nullable(name)) {
       if (it.second.validity_vector_.buffer_size() != nullptr)
         *(it.second.validity_vector_.buffer_size()) =
-            num_cells * constants::cell_validity_size;
+            cells_copied * constants::cell_validity_size;
     }
   }
 


### PR DESCRIPTION
* Sparse readers: fixing null count on incomplete queries.

This fixes an issue when hitting a var size overflow with nullable attributes. It was possible that the returned validity buffer has the wrong size.

---
TYPE: BUG
DESC: Sparse readers: fixing null count on incomplete queries.
