### PR TITLE
[vcpkg] Remove iconv from dependencies of libxml2

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,7 +13,11 @@
         "spdlog",
         "zlib",
         "zstd",
-        "libxml2"
+        {
+          "name": "libxml2",
+          "features": ["lzma", "zlib"],
+          "default-features": false
+        }
     ],
     "features": {
         "abseil": {


### PR DESCRIPTION
Fixes sc-29927

---
TYPE: NO_HISTORY
