### PR TITLE
[Backport release-2.15] Sparse unordered w/ dups: Fix incomplete queries w/ overlapping ranges. (#4027)

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -74,14 +74,10 @@ struct CSparseUnorderedWithDupsFx {
   void write_1d_fragment_string(
       int* coords,
       uint64_t* coords_size,
-      uint64_t* a1_offsets,
-      uint64_t* a1_offsets_size,
-      char* a1_data,
-      uint64_t* a1_data_size,
-      int64_t* a2_data,
-      uint64_t* a2_data_size,
-      uint8_t* a2_validity,
-      uint64_t* a2_validity_size);
+      uint64_t* offsets,
+      uint64_t* offsets_size,
+      char* data,
+      uint64_t* data_size);
   int32_t read(
       bool set_subarray,
       bool set_qc,
@@ -94,15 +90,12 @@ struct CSparseUnorderedWithDupsFx {
   int32_t read_strings(
       int* coords,
       uint64_t* coords_size,
-      char* a1_data,
-      uint64_t* a1_data_size,
-      uint64_t* a1_offsets,
-      uint64_t* a1_offsets_size,
-      int64_t* a2_data,
-      uint64_t* a2_data_size,
-      uint8_t* a2_validity,
-      uint64_t* a2_validity_size,
-      tiledb_query_t** query_ret = nullptr,
+      char* data,
+      uint64_t* data_size,
+      uint64_t* data_offsets,
+      uint64_t* data_offsets_size,
+      uint64_t num_subarrays = 0,
+      tiledb_query_t** query = nullptr,
       tiledb_array_t** array_ret = nullptr);
   void reset_config();
   void update_config();
@@ -347,14 +340,10 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_empty_strings(
 void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
     int* coords,
     uint64_t* coords_size,
-    uint64_t* a1_offsets,
-    uint64_t* a1_offsets_size,
-    char* a1_data,
-    uint64_t* a1_data_size,
-    int64_t* a2_data,
-    uint64_t* a2_data_size,
-    uint8_t* a2_validity,
-    uint64_t* a2_validity_size) {
+    uint64_t* offsets,
+    uint64_t* offsets_size,
+    char* data,
+    uint64_t* data_size) {
   // Open array for writing.
   tiledb_array_t* array;
   auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -368,15 +357,9 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, a1_data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_offsets_buffer(
-      ctx_, query, "a1", a1_offsets, a1_offsets_size);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a2", a2_data, a2_data_size);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_validity_buffer(
-      ctx_, query, "a2", a2_validity, a2_validity_size);
+  rc = tiledb_query_set_offsets_buffer(ctx_, query, "a", offsets, offsets_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   REQUIRE(rc == TILEDB_OK);
@@ -464,14 +447,11 @@ int32_t CSparseUnorderedWithDupsFx::read(
 int32_t CSparseUnorderedWithDupsFx::read_strings(
     int* coords,
     uint64_t* coords_size,
-    char* a1_data,
-    uint64_t* a1_data_size,
-    uint64_t* a1_offsets,
-    uint64_t* a1_offsets_size,
-    int64_t* a2_data,
-    uint64_t* a2_data_size,
-    uint8_t* a2_validity,
-    uint64_t* a2_validity_size,
+    char* data,
+    uint64_t* data_size,
+    uint64_t* data_offsets,
+    uint64_t* data_offsets_size,
+    uint64_t num_subarrays,
     tiledb_query_t** query_ret,
     tiledb_array_t** array_ret) {
   // Open array for reading.
@@ -486,23 +466,37 @@ int32_t CSparseUnorderedWithDupsFx::read_strings(
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
+  tiledb_subarray_t* subarray;
+  rc = tiledb_subarray_alloc(ctx_, array, &subarray);
+  CHECK(rc == TILEDB_OK);
+
+  for (uint64_t i = 0; i < num_subarrays; i++) {
+    // Create subarray for reading data.
+    int range[2] = {1, 20};
+    rc = tiledb_subarray_add_range(
+        ctx_, subarray, 0, &range[0], &range[1], NULL);
+    CHECK(rc == TILEDB_OK);
+  }
+
+  if (num_subarrays > 0) {
+    rc = tiledb_query_set_subarray_t(ctx_, query, subarray);
+    CHECK(rc == TILEDB_OK);
+  }
+
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, a1_data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_offsets_buffer(
-      ctx_, query, "a1", a1_offsets, a1_offsets_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a2", a2_data, a2_data_size);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_validity_buffer(
-      ctx_, query, "a2", a2_validity, a2_validity_size);
+      ctx_, query, "a", data_offsets, data_offsets_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   CHECK(rc == TILEDB_OK);
 
   // Submit query.
   auto ret = tiledb_query_submit(ctx_, query);
+
+  tiledb_subarray_free(&subarray);
 
   if (query_ret == nullptr || array_ret == nullptr) {
     // Clean up.
@@ -531,19 +525,6 @@ struct CSparseUnorderedWithDupsVarDataFx {
 
   tuple<tiledb_array_t*, std::vector<shared_ptr<FragmentMetadata>>>
   open_default_array_1d_with_fragments(uint64_t capacity = 5);
-
-  void compute_var_size_offsets_test(
-      uint64_t var_buffer_size,
-      std::vector<std::vector<uint64_t>>& bitmaps,
-      uint64_t capacity,
-      uint64_t num_tiles,
-      uint64_t first_tile_min_pos,
-      std::vector<uint64_t>& offsets_buffer,
-      std::vector<uint64_t>& cell_offsets,
-      bool expected_buffers_full,
-      std::vector<uint64_t>& expected_cell_offsets,
-      uint64_t expected_result_tiles_size,
-      uint64_t expected_var_buffer_size);
 
   CSparseUnorderedWithDupsVarDataFx();
   ~CSparseUnorderedWithDupsVarDataFx();
@@ -761,68 +742,6 @@ CSparseUnorderedWithDupsVarDataFx::open_default_array_1d_with_fragments(
   fragments.emplace_back(std::move(fragment));
 
   return {array, std::move(fragments)};
-}
-
-void CSparseUnorderedWithDupsVarDataFx::compute_var_size_offsets_test(
-    uint64_t var_buffer_size,
-    std::vector<std::vector<uint64_t>>& bitmaps,
-    uint64_t capacity,
-    uint64_t num_tiles,
-    uint64_t first_tile_min_pos,
-    std::vector<uint64_t>& offsets_buffer,
-    std::vector<uint64_t>& cell_offsets,
-    bool expected_buffers_full,
-    std::vector<uint64_t>& expected_cell_offsets,
-    uint64_t expected_result_tiles_size,
-    uint64_t expected_var_buffer_size) {
-  auto&& [array, fragments] = open_default_array_1d_with_fragments(capacity);
-
-  // Make a vector of tiles.
-  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
-  for (uint64_t t = 0; t < num_tiles; t++) {
-    rt.emplace_back(0, t, *fragments[0]);
-
-    // Allocate and set the bitmap if required.
-    if (bitmaps[t].size() > 0) {
-      rt.back().bitmap() = bitmaps[t];
-    }
-  }
-
-  // Create the result_tiles pointer vector.
-  std::vector<ResultTile*> result_tiles(rt.size());
-  for (uint64_t i = 0; i < rt.size(); i++) {
-    result_tiles[i] = &rt[i];
-  }
-
-  // Create a Query buffer.
-  tiledb::sm::QueryBuffer query_buffer;
-  uint64_t offsets_size = offsets_buffer.size() * sizeof(uint64_t);
-  query_buffer.buffer_ = offsets_buffer.data();
-  query_buffer.buffer_size_ = &offsets_size;
-  query_buffer.original_buffer_size_ = offsets_size;
-  uint64_t buffer_var_size = 0;
-  query_buffer.buffer_var_size_ = &buffer_var_size;
-  query_buffer.original_buffer_var_size_ = var_buffer_size;
-
-  // Call the function.
-  auto&& [buffers_full, var_buffer_size_ret, result_tiles_size] =
-      SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
-          uint64_t>(
-          &tiledb::test::g_helper_stats,
-          result_tiles,
-          first_tile_min_pos,
-          cell_offsets,
-          query_buffer);
-
-  // Validate results.
-  CHECK(expected_buffers_full == buffers_full);
-  CHECK(expected_cell_offsets == cell_offsets);
-  CHECK(expected_result_tiles_size == result_tiles_size);
-  CHECK(expected_var_buffer_size == var_buffer_size_ret);
-
-  // Clean up.
-  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
-  tiledb_array_free(&array);
 }
 
 /* ********************************* */
@@ -1712,18 +1631,55 @@ TEST_CASE_METHOD(
     expected_var_buffer_size = 14;
   }
 
-  compute_var_size_offsets_test(
-      var_buffer_size,
-      bitmaps,
-      capacity,
-      num_tiles,
-      first_tile_min_pos,
-      offsets_buffer,
-      cell_offsets,
-      expected_buffers_full,
-      expected_cell_offsets,
-      expected_result_tiles_size,
-      expected_var_buffer_size);
+  auto&& [array, fragments] = open_default_array_1d_with_fragments(capacity);
+
+  // Make a vector of tiles.
+  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
+  for (uint64_t t = 0; t < num_tiles; t++) {
+    rt.emplace_back(0, t, *fragments[0]);
+
+    // Allocate and set the bitmap if required.
+    if (bitmaps[t].size() > 0) {
+      rt.back().bitmap() = bitmaps[t];
+      rt.back().count_cells();
+    }
+  }
+
+  // Create the result_tiles pointer vector.
+  std::vector<ResultTile*> result_tiles(rt.size());
+  for (uint64_t i = 0; i < rt.size(); i++) {
+    result_tiles[i] = &rt[i];
+  }
+
+  // Create a Query buffer.
+  tiledb::sm::QueryBuffer query_buffer;
+  uint64_t offsets_size = offsets_buffer.size() * sizeof(uint64_t);
+  query_buffer.buffer_ = offsets_buffer.data();
+  query_buffer.buffer_size_ = &offsets_size;
+  query_buffer.original_buffer_size_ = offsets_size;
+  uint64_t buffer_var_size = 0;
+  query_buffer.buffer_var_size_ = &buffer_var_size;
+  query_buffer.original_buffer_var_size_ = var_buffer_size;
+
+  // Call the function.
+  auto&& [buffers_full, var_buffer_size_ret, result_tiles_size] =
+      SparseUnorderedWithDupsReader<uint64_t>::compute_var_size_offsets<
+          uint64_t>(
+          &tiledb::test::g_helper_stats,
+          result_tiles,
+          first_tile_min_pos,
+          cell_offsets,
+          query_buffer);
+
+  // Validate results.
+  CHECK(expected_buffers_full == buffers_full);
+  CHECK(expected_cell_offsets == cell_offsets);
+  CHECK(expected_result_tiles_size == result_tiles_size);
+  CHECK(expected_var_buffer_size == var_buffer_size_ret);
+
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
+  tiledb_array_free(&array);
 }
 
 TEST_CASE_METHOD(
@@ -1741,25 +1697,380 @@ TEST_CASE_METHOD(
 
   // Try to read.
   int coords_r[5];
-  char a1_data_r[5];
-  uint64_t a1_offsets_r[5];
-  int64_t a2_data_r[5];
-  uint8_t a2_validity_r[5];
+  char data_r[5];
+  uint64_t data_offsets_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t a1_data_r_size = sizeof(a1_data_r);
-  uint64_t a1_offsets_r_size = sizeof(a1_offsets_r);
-  uint64_t a2_data_r_size = sizeof(a2_data_r);
-  uint64_t a2_validity_r_size = sizeof(a2_validity_r);
+  uint64_t data_r_size = sizeof(data_r);
+  uint64_t data_offsets_r_size = sizeof(data_offsets_r);
   auto rc = read_strings(
       coords_r,
       &coords_r_size,
-      a1_data_r,
-      &a1_data_r_size,
-      a1_offsets_r,
-      &a1_offsets_r_size,
-      a2_data_r,
-      &a2_data_r_size,
-      a2_validity_r,
-      &a2_validity_r_size);
+      data_r,
+      &data_r_size,
+      data_offsets_r,
+      &data_offsets_r_size);
   CHECK(rc == TILEDB_OK);
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsVarDataFx,
+    "Sparse unordered with dups reader: test "
+    "resize_fixed_result_tiles_to_copy",
+    "[sparse-unordered-with-dups][resize_fixed_result_tiles_to_copy]") {
+  std::vector<std::vector<uint64_t>> bitmaps;
+  uint64_t capacity = 0;
+  uint64_t num_tiles = 0;
+  uint64_t max_num_cells = 0;
+  uint64_t initial_cell_offset = 0;
+  uint64_t first_tile_min_pos = 0;
+  bool expected_buffers_full = false;
+  std::vector<uint64_t> expected_cell_offsets;
+  uint64_t expected_result_tiles_size = 0;
+
+  SECTION("Basic all") {
+    SECTION("- No bitmap") {
+      bitmaps = {{}};
+    }
+
+    SECTION("- With bitmap") {
+      bitmaps = {{1, 1, 1, 1, 1}};
+    }
+
+    capacity = 5;
+    num_tiles = 1;
+    max_num_cells = 10;
+    initial_cell_offset = 0;
+    first_tile_min_pos = 0;
+    expected_buffers_full = false;
+    expected_cell_offsets = {0, 5};
+    expected_result_tiles_size = 1;
+  }
+
+  SECTION("Basic full") {
+    SECTION("- No bitmap") {
+      bitmaps = {{}};
+    }
+
+    SECTION("- With bitmap") {
+      bitmaps = {{1, 1, 1, 1, 1}};
+    }
+
+    capacity = 5;
+    num_tiles = 1;
+    max_num_cells = 3;
+    initial_cell_offset = 0;
+    first_tile_min_pos = 0;
+    expected_buffers_full = true;
+    expected_cell_offsets = {0, 3};
+    expected_result_tiles_size = 1;
+  }
+
+  SECTION("Basic last cell") {
+    SECTION("- No bitmap") {
+      bitmaps = {{}};
+    }
+
+    SECTION("- With bitmap") {
+      bitmaps = {{1, 1, 1, 1, 1}};
+    }
+
+    capacity = 5;
+    num_tiles = 1;
+    max_num_cells = 5;
+    initial_cell_offset = 0;
+    first_tile_min_pos = 0;
+    expected_buffers_full = true;
+    expected_cell_offsets = {0, 5};
+    expected_result_tiles_size = 1;
+  }
+
+  SECTION("Basic last cell, initial cell offset") {
+    SECTION("- No bitmap") {
+      bitmaps = {{}};
+    }
+
+    SECTION("- With bitmap") {
+      bitmaps = {{1, 1, 1, 1, 1}};
+    }
+
+    capacity = 5;
+    num_tiles = 1;
+    max_num_cells = 7;
+    initial_cell_offset = 2;
+    first_tile_min_pos = 0;
+    expected_buffers_full = true;
+    expected_cell_offsets = {2, 7};
+    expected_result_tiles_size = 1;
+  }
+
+  SECTION("Last cell with count doesn't fit") {
+    bitmaps = {{1, 1, 1, 1, 2}};
+    capacity = 5;
+    num_tiles = 1;
+    max_num_cells = 5;
+    initial_cell_offset = 0;
+    first_tile_min_pos = 0;
+    expected_buffers_full = true;
+    expected_cell_offsets = {0, 4};
+    expected_result_tiles_size = 1;
+  }
+
+  SECTION("First cell with count doesn't fit") {
+    bitmaps = {{1, 1, 1, 1, 1}, {2, 1, 1, 1, 1}};
+    capacity = 5;
+    num_tiles = 2;
+    max_num_cells = 6;
+    initial_cell_offset = 0;
+    first_tile_min_pos = 0;
+    expected_buffers_full = true;
+    expected_cell_offsets = {0, 5};
+    expected_result_tiles_size = 1;
+  }
+
+  SECTION("Resume, last cell with count doesn't fit") {
+    bitmaps = {{1, 1, 1, 1, 2}};
+    capacity = 5;
+    num_tiles = 1;
+    max_num_cells = 3;
+    initial_cell_offset = 0;
+    first_tile_min_pos = 2;
+    expected_buffers_full = true;
+    expected_cell_offsets = {0, 2};
+    expected_result_tiles_size = 1;
+  }
+
+  auto&& [array, fragments] = open_default_array_1d_with_fragments(capacity);
+
+  // Make a vector of tiles.
+  std::vector<UnorderedWithDupsResultTile<uint64_t>> rt;
+  for (uint64_t t = 0; t < num_tiles; t++) {
+    rt.emplace_back(0, t, *fragments[0]);
+
+    // Allocate and set the bitmap if required.
+    if (bitmaps[t].size() > 0) {
+      rt.back().bitmap() = bitmaps[t];
+      rt.back().count_cells();
+    }
+  }
+
+  // Create the result_tiles pointer vector.
+  std::vector<ResultTile*> result_tiles(rt.size());
+  for (uint64_t i = 0; i < rt.size(); i++) {
+    result_tiles[i] = &rt[i];
+  }
+
+  // Call the function.
+  auto&& [buffers_full, cell_offsets] =
+      SparseUnorderedWithDupsReader<uint64_t>::
+          resize_fixed_result_tiles_to_copy(
+              max_num_cells,
+              initial_cell_offset,
+              first_tile_min_pos,
+              result_tiles);
+
+  // Validate results.
+  CHECK(expected_buffers_full == buffers_full);
+  CHECK(expected_cell_offsets == cell_offsets);
+  CHECK(expected_result_tiles_size == result_tiles.size());
+
+  // Clean up.
+  REQUIRE(tiledb_array_close(ctx_, array) == TILEDB_OK);
+  tiledb_array_free(&array);
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsFx,
+    "Sparse unordered with dups reader: Cell offsets test",
+    "[sparse-unordered-with-dups][cell-offsets-test]") {
+  // Either vary the fixed buffer or the var buffer. Varying the fixed buffer
+  // will trigger the first overflow protection in
+  // resize_fixed_result_tiles_to_copy and varying the var buffer will trigger
+  // the second overflow protection in compute_var_size_offsets.
+  bool vary_fixed_buffer = GENERATE(true, false);
+
+  // Create default array.
+  reset_config();
+  create_default_array_1d_string(5);
+
+  // Write a fragment.
+  std::vector<int32_t> coords = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
+  uint64_t coords_size = coords.size() * sizeof(int32_t);
+  std::vector<uint64_t> offsets = {
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
+  std::string data = "123456789abcde";
+  uint64_t data_size = data.size();
+  write_1d_fragment_string(
+      coords.data(),
+      &coords_size,
+      offsets.data(),
+      &offsets_size,
+      data.data(),
+      &data_size);
+
+  tiledb_array_t* array = nullptr;
+  tiledb_query_t* query = nullptr;
+
+  // Try to read with every possible buffer sizes. When varying buffer, the
+  // minimum should fit the number of dups at a minimum. For fixed size data,
+  // that will use the size of int and for var size data 1 as we have one char
+  // per cell. Max will be num dups times the size of either the full coordinate
+  // data or the var size data depending.
+  uint64_t num_dups = 2;
+  uint64_t min_buffer_size =
+      vary_fixed_buffer ? num_dups * sizeof(int) : num_dups;
+  uint64_t max_buffer_size =
+      vary_fixed_buffer ? coords_size * num_dups : data_size * num_dups;
+  for (uint64_t buffer_size = min_buffer_size; buffer_size <= max_buffer_size;
+       buffer_size++) {
+    // Only make the coordinate buffer change, the rest of the buffers are big
+    // enough for everything.
+    std::vector<int> coords_r(vary_fixed_buffer ? buffer_size : 1000, 0);
+    std::string data_r(vary_fixed_buffer ? 1000 : buffer_size, 0);
+    std::vector<uint64_t> data_offsets_r(1000, 0);
+    uint64_t coords_r_size = coords_r.size() * sizeof(int32_t);
+    uint64_t data_r_size = data_r.size();
+    uint64_t data_offsets_r_size = data_offsets_r.size() * sizeof(uint64_t);
+    auto rc = read_strings(
+        coords_r.data(),
+        &coords_r_size,
+        data_r.data(),
+        &data_r_size,
+        data_offsets_r.data(),
+        &data_offsets_r_size,
+        num_dups,
+        &query,
+        &array);
+    CHECK(rc == TILEDB_OK);
+
+    // Get result count.
+    std::vector<uint64_t> counts(20, 0);
+
+    // Keep running the query until complete.
+    tiledb_query_status_t status;
+    tiledb_query_get_status(ctx_, query, &status);
+    for (uint64_t iter = 0; iter < 100; iter++) {
+      // Aggregate results.
+      for (uint64_t i = 0; i < coords_r_size / sizeof(int); i++) {
+        counts[coords_r[i]]++;
+      }
+
+      if (status == TILEDB_COMPLETED) {
+        break;
+      }
+
+      rc = tiledb_query_submit(ctx_, query);
+      REQUIRE(rc == TILEDB_OK);
+
+      tiledb_query_get_status(ctx_, query, &status);
+    }
+
+    // Validate we got every cell back.
+    for (uint64_t c = 0; c < counts.size(); c++) {
+      if (c > 0 && c < 15) {
+        CHECK(counts[c] == num_dups);
+      } else {
+        CHECK(counts[c] == 0);
+      }
+    }
+
+    // Clean up.
+    rc = tiledb_array_close(ctx_, array);
+    CHECK(rc == TILEDB_OK);
+    tiledb_array_free(&array);
+    tiledb_query_free(&query);
+  }
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsFx,
+    "Sparse unordered with dups reader: Increasing dups with overlapping range",
+    "[sparse-unordered-with-dups][dup-data-test][overlapping-ranges]") {
+  // Create default array.
+  reset_config();
+  int32_t extent = GENERATE(2, 7, 5, 10, 11);
+  create_default_array_1d_string(extent, extent * 2);
+
+  std::vector<int32_t> coords = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                                 11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
+  uint64_t coords_size = coords.size() * sizeof(int32_t);
+  std::vector<uint64_t> offsets = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                   10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
+  std::string data = "123456789abcdefghijk";
+  uint64_t data_size = data.size();
+  // Write dups for all cells up to capacity
+  uint64_t total_cells = 0;
+  for (int32_t i = 0; i < extent * 2; i++) {
+    write_1d_fragment_string(
+        coords.data(),
+        &coords_size,
+        offsets.data(),
+        &offsets_size,
+        data.data(),
+        &data_size);
+    total_cells += coords_size / sizeof(int32_t);
+  }
+  tiledb_array_t* array;
+  auto st = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  CHECK(st == TILEDB_OK);
+  st = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(st == TILEDB_OK);
+  tiledb_query_t* query;
+  st = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(st == TILEDB_OK);
+
+  tiledb_subarray_t* subarray;
+  st = tiledb_subarray_alloc(ctx_, array, &subarray);
+  CHECK(st == TILEDB_OK);
+  int64_t start = 1;
+  int64_t end = 20;
+  int64_t end_2 = 10;
+  // The first half of the array will be read twice, including dups.
+  total_cells += total_cells / 2;
+  st = tiledb_subarray_add_range(ctx_, subarray, 0, &start, &end, nullptr);
+  CHECK(st == TILEDB_OK);
+  st = tiledb_subarray_add_range(ctx_, subarray, 0, &start, &end_2, nullptr);
+  CHECK(st == TILEDB_OK);
+  st = tiledb_query_set_subarray_t(ctx_, query, subarray);
+  CHECK(st == TILEDB_OK);
+  st = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  CHECK(st == TILEDB_OK);
+
+  // Submit incomplete reads with varying number of duplicates.
+  tiledb_query_status_t status;
+  uint64_t total_cells_r = 0;
+  // Minimum buffer size should hold number of dups in a single cell.
+  uint64_t buffer_size = 2;
+  do {
+    std::vector<int32_t> coords_r(buffer_size, 0);
+    uint64_t coords_r_size = coords_r.size() * sizeof(int32_t);
+    std::vector<uint64_t> offsets_r(buffer_size, 0);
+    uint64_t offsets_r_size = offsets_r.size() * sizeof(uint64_t);
+    std::string data_r(buffer_size++, 0);
+    uint64_t data_r_size = data_r.size();
+
+    st = tiledb_query_set_data_buffer(
+        ctx_, query, "d", coords_r.data(), &coords_r_size);
+    CHECK(st == TILEDB_OK);
+    st = tiledb_query_set_offsets_buffer(
+        ctx_, query, "a", offsets_r.data(), &offsets_r_size);
+    CHECK(st == TILEDB_OK);
+    st = tiledb_query_set_data_buffer(
+        ctx_, query, "a", data_r.data(), &data_r_size);
+    CHECK(st == TILEDB_OK);
+    st = tiledb_query_submit(ctx_, query);
+    CHECK(st == TILEDB_OK);
+
+    st = tiledb_query_get_status(ctx_, query, &status);
+    CHECK(st == TILEDB_OK);
+    uint64_t cells_r = offsets_r_size / sizeof(uint64_t);
+    total_cells_r += cells_r;
+  } while (status == TILEDB_INCOMPLETE);
+  CHECK(total_cells_r == total_cells);
+  CHECK(status == TILEDB_COMPLETED);
+
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -74,10 +74,14 @@ struct CSparseUnorderedWithDupsFx {
   void write_1d_fragment_string(
       int* coords,
       uint64_t* coords_size,
-      uint64_t* offsets,
-      uint64_t* offsets_size,
-      char* data,
-      uint64_t* data_size);
+      uint64_t* a1_offsets,
+      uint64_t* a1_offsets_size,
+      char* a1_data,
+      uint64_t* a1_data_size,
+      int64_t* a2_data,
+      uint64_t* a2_data_size,
+      uint8_t* a2_validity,
+      uint64_t* a2_validity_size);
   int32_t read(
       bool set_subarray,
       bool set_qc,
@@ -90,12 +94,16 @@ struct CSparseUnorderedWithDupsFx {
   int32_t read_strings(
       int* coords,
       uint64_t* coords_size,
-      char* data,
-      uint64_t* data_size,
-      uint64_t* data_offsets,
-      uint64_t* data_offsets_size,
+      char* a1_data,
+      uint64_t* a1_data_size,
+      uint64_t* a1_offsets,
+      uint64_t* a1_offsets_size,
+      int64_t* a2_data,
+      uint64_t* a2_data_size,
+      uint8_t* a2_validity,
+      uint64_t* a2_validity_size,
       uint64_t num_subarrays = 0,
-      tiledb_query_t** query = nullptr,
+      tiledb_query_t** query_ret = nullptr,
       tiledb_array_t** array_ret = nullptr);
   void reset_config();
   void update_config();
@@ -340,10 +348,14 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_empty_strings(
 void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
     int* coords,
     uint64_t* coords_size,
-    uint64_t* offsets,
-    uint64_t* offsets_size,
-    char* data,
-    uint64_t* data_size) {
+    uint64_t* a1_offsets,
+    uint64_t* a1_offsets_size,
+    char* a1_data,
+    uint64_t* a1_data_size,
+    int64_t* a2_data,
+    uint64_t* a2_data_size,
+    uint8_t* a2_validity,
+    uint64_t* a2_validity_size) {
   // Open array for writing.
   tiledb_array_t* array;
   auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
@@ -357,9 +369,15 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, a1_data_size);
   REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_query_set_offsets_buffer(ctx_, query, "a", offsets, offsets_size);
+  rc = tiledb_query_set_offsets_buffer(
+      ctx_, query, "a1", a1_offsets, a1_offsets_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a2", a2_data, a2_data_size);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_validity_buffer(
+      ctx_, query, "a2", a2_validity, a2_validity_size);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   REQUIRE(rc == TILEDB_OK);
@@ -447,10 +465,14 @@ int32_t CSparseUnorderedWithDupsFx::read(
 int32_t CSparseUnorderedWithDupsFx::read_strings(
     int* coords,
     uint64_t* coords_size,
-    char* data,
-    uint64_t* data_size,
-    uint64_t* data_offsets,
-    uint64_t* data_offsets_size,
+    char* a1_data,
+    uint64_t* a1_data_size,
+    uint64_t* a1_offsets,
+    uint64_t* a1_offsets_size,
+    int64_t* a2_data,
+    uint64_t* a2_data_size,
+    uint8_t* a2_validity,
+    uint64_t* a2_validity_size,
     uint64_t num_subarrays,
     tiledb_query_t** query_ret,
     tiledb_array_t** array_ret) {
@@ -485,10 +507,15 @@ int32_t CSparseUnorderedWithDupsFx::read_strings(
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data, data_size);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a1", a1_data, a1_data_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_offsets_buffer(
-      ctx_, query, "a", data_offsets, data_offsets_size);
+      ctx_, query, "a1", a1_offsets, a1_offsets_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a2", a2_data, a2_data_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_validity_buffer(
+      ctx_, query, "a2", a2_validity, a2_validity_size);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords, coords_size);
   CHECK(rc == TILEDB_OK);
@@ -1697,18 +1724,26 @@ TEST_CASE_METHOD(
 
   // Try to read.
   int coords_r[5];
-  char data_r[5];
-  uint64_t data_offsets_r[5];
+  char a1_data_r[5];
+  uint64_t a1_offsets_r[5];
+  int64_t a2_data_r[5];
+  uint8_t a2_validity_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
-  uint64_t data_r_size = sizeof(data_r);
-  uint64_t data_offsets_r_size = sizeof(data_offsets_r);
+  uint64_t a1_data_r_size = sizeof(a1_data_r);
+  uint64_t a1_offsets_r_size = sizeof(a1_offsets_r);
+  uint64_t a2_data_r_size = sizeof(a2_data_r);
+  uint64_t a2_validity_r_size = sizeof(a2_validity_r);
   auto rc = read_strings(
       coords_r,
       &coords_r_size,
-      data_r,
-      &data_r_size,
-      data_offsets_r,
-      &data_offsets_r_size);
+      a1_data_r,
+      &a1_data_r_size,
+      a1_offsets_r,
+      &a1_offsets_r_size,
+      a2_data_r,
+      &a2_data_r_size,
+      a2_validity_r,
+      &a2_validity_r_size);
   CHECK(rc == TILEDB_OK);
 }
 
@@ -1895,49 +1930,67 @@ TEST_CASE_METHOD(
   // Write a fragment.
   std::vector<int32_t> coords = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14};
   uint64_t coords_size = coords.size() * sizeof(int32_t);
-  std::vector<uint64_t> offsets = {
+  std::vector<uint64_t> a1_offsets = {
       0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
-  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
-  std::string data = "123456789abcde";
-  uint64_t data_size = data.size();
+  uint64_t a1_offsets_size = a1_offsets.size() * sizeof(uint64_t);
+  std::string a1_data = "123456789abcde";
+  uint64_t a1_data_size = a1_data.size();
+  std::vector<int64_t> a2_data = {
+      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23};
+  uint64_t a2_data_size = a2_data.size() * sizeof(uint64_t);
+  std::vector<uint8_t> a2_validity = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  uint64_t a2_validity_size = a2_validity.size();
   write_1d_fragment_string(
       coords.data(),
       &coords_size,
-      offsets.data(),
-      &offsets_size,
-      data.data(),
-      &data_size);
+      a1_offsets.data(),
+      &a1_offsets_size,
+      a1_data.data(),
+      &a1_data_size,
+      a2_data.data(),
+      &a2_data_size,
+      a2_validity.data(),
+      &a2_validity_size);
 
   tiledb_array_t* array = nullptr;
   tiledb_query_t* query = nullptr;
 
-  // Try to read with every possible buffer sizes. When varying buffer, the
-  // minimum should fit the number of dups at a minimum. For fixed size data,
-  // that will use the size of int and for var size data 1 as we have one char
-  // per cell. Max will be num dups times the size of either the full coordinate
-  // data or the var size data depending.
-  uint64_t num_dups = 2;
+  // Try to read with every possible buffer sizes. When varying
+  // buffer, the minimum should fit the number of dups at a minimum.
+  // For fixed size data, that will use the size of int and for var
+  // size data 1 as we have one char per cell. Max will be num dups
+  // times the size of either the full coordinate data or the var size
+  // data depending.
+  uint64_t num_dups = GENERATE(1, 2);
   uint64_t min_buffer_size =
       vary_fixed_buffer ? num_dups * sizeof(int) : num_dups;
   uint64_t max_buffer_size =
-      vary_fixed_buffer ? coords_size * num_dups : data_size * num_dups;
+      vary_fixed_buffer ? coords_size * num_dups : a1_data_size * num_dups;
   for (uint64_t buffer_size = min_buffer_size; buffer_size <= max_buffer_size;
        buffer_size++) {
-    // Only make the coordinate buffer change, the rest of the buffers are big
-    // enough for everything.
+    // Only make the coordinate buffer change, the rest of the buffers
+    // are big enough for everything.
     std::vector<int> coords_r(vary_fixed_buffer ? buffer_size : 1000, 0);
-    std::string data_r(vary_fixed_buffer ? 1000 : buffer_size, 0);
-    std::vector<uint64_t> data_offsets_r(1000, 0);
+    std::string a1_data_r(vary_fixed_buffer ? 1000 : buffer_size, 0);
+    std::vector<uint64_t> a1_offsets_r(1000, 0);
+    std::vector<int64_t> a2_data_r(1000);
+    std::vector<uint8_t> a2_validity_r(1000);
     uint64_t coords_r_size = coords_r.size() * sizeof(int32_t);
-    uint64_t data_r_size = data_r.size();
-    uint64_t data_offsets_r_size = data_offsets_r.size() * sizeof(uint64_t);
+    uint64_t a1_data_r_size = a1_data_r.size();
+    uint64_t a1_offsets_r_size = a1_offsets_r.size() * sizeof(uint64_t);
+    uint64_t a2_data_r_size = a2_data_r.size() * sizeof(int64_t);
+    uint64_t a2_validity_r_size = a2_validity_r.size();
     auto rc = read_strings(
         coords_r.data(),
         &coords_r_size,
-        data_r.data(),
-        &data_r_size,
-        data_offsets_r.data(),
-        &data_offsets_r_size,
+        a1_data_r.data(),
+        &a1_data_r_size,
+        a1_offsets_r.data(),
+        &a1_offsets_r_size,
+        a2_data_r.data(),
+        &a2_data_r_size,
+        a2_validity_r.data(),
+        &a2_validity_r_size,
         num_dups,
         &query,
         &array);
@@ -1951,7 +2004,11 @@ TEST_CASE_METHOD(
     tiledb_query_get_status(ctx_, query, &status);
     for (uint64_t iter = 0; iter < 100; iter++) {
       // Aggregate results.
-      for (uint64_t i = 0; i < coords_r_size / sizeof(int); i++) {
+      uint64_t num_read = coords_r_size / sizeof(int);
+      CHECK(a1_offsets_r_size == num_read * sizeof(uint64_t));
+      CHECK(a2_data_r_size == num_read * sizeof(int64_t));
+      CHECK(a2_validity_r_size == num_read);
+      for (uint64_t i = 0; i < num_read; i++) {
         counts[coords_r[i]]++;
       }
 
@@ -1984,8 +2041,10 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CSparseUnorderedWithDupsFx,
-    "Sparse unordered with dups reader: Increasing dups with overlapping range",
-    "[sparse-unordered-with-dups][dup-data-test][overlapping-ranges]") {
+    "Sparse unordered with dups reader: Increasing dups with "
+    "overlapping range",
+    "[sparse-unordered-with-dups][dup-data-test][overlapping-"
+    "ranges]") {
   // Create default array.
   reset_config();
   int32_t extent = GENERATE(2, 7, 5, 10, 11);
@@ -1994,21 +2053,31 @@ TEST_CASE_METHOD(
   std::vector<int32_t> coords = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
                                  11, 12, 13, 14, 15, 16, 17, 18, 19, 20};
   uint64_t coords_size = coords.size() * sizeof(int32_t);
-  std::vector<uint64_t> offsets = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
-                                   10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
-  uint64_t offsets_size = offsets.size() * sizeof(uint64_t);
-  std::string data = "123456789abcdefghijk";
-  uint64_t data_size = data.size();
+  std::vector<uint64_t> a1_offsets = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                      10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+  uint64_t a1_offsets_size = a1_offsets.size() * sizeof(uint64_t);
+  std::string a1_data = "123456789abcdefghijk";
+  uint64_t a1_data_size = a1_data.size();
+  std::vector<int64_t> a2_data = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                  20, 21, 22, 23, 24, 25, 26, 27, 28, 29};
+  uint64_t a2_data_size = a2_data.size() * sizeof(uint64_t);
+  std::vector<uint8_t> a2_validity = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                      1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  uint64_t a2_validity_size = a2_validity.size();
   // Write dups for all cells up to capacity
   uint64_t total_cells = 0;
   for (int32_t i = 0; i < extent * 2; i++) {
     write_1d_fragment_string(
         coords.data(),
         &coords_size,
-        offsets.data(),
-        &offsets_size,
-        data.data(),
-        &data_size);
+        a1_offsets.data(),
+        &a1_offsets_size,
+        a1_data.data(),
+        &a1_data_size,
+        a2_data.data(),
+        &a2_data_size,
+        a2_validity.data(),
+        &a2_validity_size);
     total_cells += coords_size / sizeof(int32_t);
   }
   tiledb_array_t* array;
@@ -2054,10 +2123,10 @@ TEST_CASE_METHOD(
         ctx_, query, "d", coords_r.data(), &coords_r_size);
     CHECK(st == TILEDB_OK);
     st = tiledb_query_set_offsets_buffer(
-        ctx_, query, "a", offsets_r.data(), &offsets_r_size);
+        ctx_, query, "a1", offsets_r.data(), &offsets_r_size);
     CHECK(st == TILEDB_OK);
     st = tiledb_query_set_data_buffer(
-        ctx_, query, "a", data_r.data(), &data_r_size);
+        ctx_, query, "a1", data_r.data(), &data_r_size);
     CHECK(st == TILEDB_OK);
     st = tiledb_query_submit(ctx_, query);
     CHECK(st == TILEDB_OK);

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -173,7 +173,7 @@ void ResultTile::erase_tile(const std::string& name) {
 
   // Handle attribute tile
   for (auto& at : attr_tiles_) {
-    if (at.first == name) {
+    if (at.second.has_value() && at.first == name) {
       at.second.reset();
       return;
     }

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -930,7 +930,7 @@ class ResultTileWithBitmap : public ResultTile {
     uint64_t sum = 0;
     for (uint64_t c = start_pos; c < bitmap_.size(); c++) {
       sum += bitmap_[c];
-      if (sum == result_num) {
+      if (sum >= result_num) {
         return c;
       }
     }

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -1408,47 +1408,21 @@ Status SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
 }
 
 template <class BitmapType>
-std::vector<uint64_t>
-SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
-    const std::vector<std::string>& names,
+tuple<bool, std::vector<uint64_t>>
+SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_result_tiles_to_copy(
+    uint64_t max_num_cells,
+    uint64_t initial_cell_offset,
+    uint64_t first_tile_min_pos,
     std::vector<ResultTile*>& result_tiles) {
-  auto timer_se = stats_->start_timer("compute_fixed_results_to_copy");
-
+  bool buffers_full;
   std::vector<uint64_t> cell_offsets;
   cell_offsets.reserve(result_tiles.size() + 1);
-
-  // First try to limit the maximum number of cells we copy using the size
-  // of the output buffers for fixed sized attributes. Later we will validate
-  // the memory budget. This is the first line of defence used to try to
-  // prevent overflows when copying data.
-  auto max_num_cells = std::numeric_limits<uint64_t>::max();
-  for (const auto& it : buffers_) {
-    const auto& name = it.first;
-    const auto size = it.second.original_buffer_size_;
-    if (array_schema_.var_size(name)) {
-      auto temp_num_cells = size / constants::cell_var_offset_size;
-
-      if (offsets_extra_element_ && temp_num_cells > 0)
-        temp_num_cells--;
-
-      max_num_cells = std::min(max_num_cells, temp_num_cells);
-    } else {
-      auto temp_num_cells = size / array_schema_.cell_size(name);
-      max_num_cells = std::min(max_num_cells, temp_num_cells);
-    }
-  }
-
-  // User gave us some empty buffers, exit.
-  if (max_num_cells == 0) {
-    result_tiles.clear();
-    return cell_offsets;
-  }
 
   // Compute initial bound for result tiles by looking at what can fit into
   // the user's buffer. We use either the number of cells in the bitmap when
   // a subarray is set (or we have a query condition) or the number of cells
   // in the fragment metadata to do so.
-  uint64_t cell_offset = cells_copied(names);
+  uint64_t cell_offset = initial_cell_offset;
   for (uint64_t i = 0; i < result_tiles.size(); i++) {
     auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[i];
     auto cell_num = rt->result_num();
@@ -1456,10 +1430,7 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
     // First tile might have been partially copied. Adjust cell_num to account
     // for it.
     if (i == 0) {
-      if (read_state_.frag_idx_[rt->frag_idx()].tile_idx_ == rt->tile_idx()) {
-        auto pos = read_state_.frag_idx_[rt->frag_idx()].cell_idx_;
-        cell_num -= rt->result_num_between_pos(0, pos);
-      }
+      cell_num -= rt->result_num_between_pos(0, first_tile_min_pos);
     }
 
     if (cell_offset + cell_num > max_num_cells) {
@@ -1474,17 +1445,93 @@ SparseUnorderedWithDupsReader<BitmapType>::compute_fixed_results_to_copy(
   // later on. If not, add a partial tile at the end.
   if (cell_offset == max_num_cells ||
       cell_offsets.size() == result_tiles.size()) {
-    buffers_full_ = cell_offset == max_num_cells;
+    buffers_full = cell_offset == max_num_cells;
     cell_offsets.emplace_back(cell_offset);
   } else {
-    buffers_full_ = true;
+    buffers_full = true;
     cell_offsets.emplace_back(cell_offset);
-    cell_offsets.emplace_back(max_num_cells);
+
+    // For overlapping ranges, a cell might be included multiple times and we
+    // can only process it if we can include all of the values as the progress
+    // we save in the read state doesn't allow to track partial progress for a
+    // cell.
+    uint64_t rt_idx = cell_offsets.size() - 1;
+    auto rt = (ResultTileWithBitmap<BitmapType>*)result_tiles[rt_idx];
+    uint64_t min_pos = rt_idx == 0 ? first_tile_min_pos : 0;
+    uint64_t cells_to_copy = max_num_cells - cell_offset;
+
+    // Get the position of the cell that gets us to the desired number of
+    // cells.
+    uint64_t pos = rt->pos_with_given_result_sum(min_pos, cells_to_copy);
+
+    // Count the actual number of results.
+    uint64_t actual_cells_to_copy =
+        rt->result_num_between_pos(min_pos, pos + 1);
+
+    // If the last cell has a count > 1, it is possible to overflow the number
+    // of cells to copy. Don't include the last cell if that is the case.
+    if (cell_offset + actual_cells_to_copy > max_num_cells) {
+      actual_cells_to_copy = rt->result_num_between_pos(min_pos, pos);
+    }
+
+    // It is possible that the first cell of the partial tile doesn't fit. In
+    // that case, we don't include an extra cell offset.
+    if (actual_cells_to_copy != 0) {
+      cell_offsets.emplace_back(cell_offset + actual_cells_to_copy);
+    }
   }
 
   // Resize the result tiles vector.
   result_tiles.resize(cell_offsets.size() - 1);
 
+  return {buffers_full, cell_offsets};
+}
+
+template <class BitmapType>
+std::vector<uint64_t>
+SparseUnorderedWithDupsReader<BitmapType>::resize_fixed_results_to_copy(
+    const std::vector<std::string>& names,
+    std::vector<ResultTile*>& result_tiles) {
+  auto timer_se = stats_->start_timer("resize_fixed_results_to_copy");
+
+  // First try to limit the maximum number of cells we copy using the size
+  // of the output buffers for fixed sized attributes. Later we will validate
+  // the memory budget. This is the first line of defence used to try to
+  // prevent overflows when copying data.
+  auto max_num_cells = std::numeric_limits<uint64_t>::max();
+  for (const auto& it : buffers_) {
+    const auto& name = it.first;
+    const auto size = it.second.original_buffer_size_;
+    if (array_schema_.var_size(name)) {
+      // we only check the var-size buffer here because we enforce
+      // size(offsets_buf) == size(validity_buf) and/or
+      // size(validity_buf) == size(data_buf) in the Query:set calls
+      auto temp_num_cells = size / constants::cell_var_offset_size;
+
+      if (offsets_extra_element_ && temp_num_cells > 0) {
+        temp_num_cells--;
+      }
+
+      max_num_cells = std::min(max_num_cells, temp_num_cells);
+    } else {
+      auto temp_num_cells = size / array_schema_.cell_size(name);
+      max_num_cells = std::min(max_num_cells, temp_num_cells);
+    }
+  }
+
+  // User gave us some empty buffers, exit.
+  if (max_num_cells == 0) {
+    result_tiles.clear();
+    return std::vector<uint64_t>();
+  }
+
+  uint64_t initial_cell_offset = cells_copied(names);
+  uint64_t first_tile_min_pos =
+      read_state_.frag_idx_[result_tiles[0]->frag_idx()].cell_idx_;
+
+  auto&& [buffers_full, cell_offsets] = resize_fixed_result_tiles_to_copy(
+      max_num_cells, initial_cell_offset, first_tile_min_pos, result_tiles);
+  buffers_full_ |= buffers_full;
   return cell_offsets;
 }
 
@@ -1654,7 +1701,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
   // Vector for storing the cell offsets of each tiles into the user buffers.
   // This also stores the last offset to facilitate calculations later on.
   std::vector<uint64_t> cell_offsets =
-      compute_fixed_results_to_copy(names, result_tiles);
+      resize_fixed_results_to_copy(names, result_tiles);
 
   // Making sure we respect the memory budget for the copy operation.
   uint64_t memory_budget = memory_budget_ - memory_used_qc_tiles_total_ -
@@ -1678,7 +1725,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
     num_range_threads = 1 + ((num_threads - 1) / result_tiles.size());
   }
 
-  // Read a few attributes a a time.
+  // Read a few attributes at a time.
   uint64_t buffer_idx = 0;
   while (buffer_idx < names.size()) {
     // Read and unfilter as many attributes as can fit in the budget.
@@ -1739,7 +1786,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
       uint64_t var_buffer_size = 0;
 
       if (var_sized) {
-        auto first_tile_min_pos =
+        uint64_t first_tile_min_pos =
             read_state_.frag_idx_[result_tiles[0]->frag_idx()].cell_idx_;
 
         // Adjust the offsets buffer and make sure all data fits.
@@ -1753,8 +1800,8 @@ Status SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
         buffers_full_ |= buffers_full;
 
         // Clear tiles from memory and adjust result_tiles.
-        for (const auto& idx : *index_to_copy) {
-          const auto& name_to_clear = names[idx];
+        for (const auto& copy_idx : *index_to_copy) {
+          const auto& name_to_clear = names[copy_idx];
           const auto is_dim_to_clear = array_schema_.is_dim(name_to_clear);
           if (qc_loaded_attr_names_set_.count(name_to_clear) == 0 &&
               (!include_coords_ || !is_dim_to_clear)) {

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -107,6 +107,24 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       std::vector<uint64_t>& cell_offsets,
       QueryBuffer& query_buffer);
 
+  /**
+   * Compute the fixed result tiles to copy using the list of result tiles. This
+   * will resize the list of result tiles to the actual size we can copy.
+   *
+   * @param max_num_cells Max number of cells we can fit in the fixed size
+   * buffers.
+   * @param initial_cell_offset Initial cell offset in the user buffers.
+   * @param first_tile_min_pos Cell progress of the first tile.
+   * @param result_tiles Result tiles to process, might be truncated.
+   *
+   * @return buffers_full, cell_offsets.
+   */
+  static tuple<bool, std::vector<uint64_t>> resize_fixed_result_tiles_to_copy(
+      uint64_t max_num_cells,
+      uint64_t initial_cell_offset,
+      uint64_t first_tile_min_pos,
+      std::vector<ResultTile*>& result_tiles);
+
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
@@ -405,22 +423,22 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       QueryBuffer& query_buffer);
 
   /**
-   * Compute the maximum vector of result tiles to process and cell offsets for
-   * each tiles using the fixed size buffers from the user.
+   * Compute the maximum vector of result tiles to process and cell offsets
+   * for each tiles using the fixed size buffers from the user.
    *
    * @param names Attribute/dimensions to compute for.
    * @param result_tiles The result tiles to process.
    *
-   * @return Cell o
+   * @return Cell offsets.
    */
-  std::vector<uint64_t> compute_fixed_results_to_copy(
+  std::vector<uint64_t> resize_fixed_results_to_copy(
       const std::vector<std::string>& names,
       std::vector<ResultTile*>& result_tiles);
 
   /**
-   * Make sure we respect memory budget for copy operation by making sure that,
-   * for all attributes to be copied, the size of tiles in memory can fit into
-   * the budget.
+   * Make sure we respect memory budget for copy operation by making sure
+   * that, for all attributes to be copied, the size of tiles in memory can
+   * fit into the budget.
    *
    * @param names Attribute/dimensions to compute for.
    * @param memory_budget Memory budget allowed for copy operation.


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/bfcf4efbf69b8071b524709eadeebc1bcedd327e from https://github.com/TileDB-Inc/TileDB/pull/4027.

-------
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups: Fix incomplete queries w/ overlapping ranges.
