### PR TITLE
Remove `TILEDB_EXPORT` from private C API functions.

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1293,7 +1293,7 @@ int32_t tiledb_array_schema_evolution_drop_attribute(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(
+int32_t tiledb_array_schema_evolution_set_timestamp_range(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     uint64_t lo,
@@ -5205,7 +5205,7 @@ int32_t tiledb_fragment_info_dump(
 /*          EXPERIMENTAL APIs        */
 /* ********************************* */
 
-TILEDB_EXPORT int32_t tiledb_query_get_status_details(
+int32_t tiledb_query_get_status_details(
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_query_status_details_t* status) {
@@ -5222,7 +5222,7 @@ TILEDB_EXPORT int32_t tiledb_query_get_status_details(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_consolidation_plan_create_with_mbr(
+int32_t tiledb_consolidation_plan_create_with_mbr(
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t fragment_size,

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -68,7 +68,7 @@ std::pair<std::string, std::string> strip_file_extension(const char* file_uri);
 std::pair<Status, optional<uint64_t>> get_buffer_size_from_config(
     const Context& context, uint64_t tile_extent);
 
-TILEDB_EXPORT int32_t tiledb_filestore_schema_create(
+int32_t tiledb_filestore_schema_create(
     tiledb_ctx_t* ctx, const char* uri, tiledb_array_schema_t** array_schema) {
   if (sanity_check(ctx) == TILEDB_ERR) {
     *array_schema = nullptr;
@@ -154,7 +154,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_schema_create(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_uri_import(
+int32_t tiledb_filestore_uri_import(
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     const char* file_uri,
@@ -341,7 +341,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_uri_import(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_uri_export(
+int32_t tiledb_filestore_uri_export(
     tiledb_ctx_t* ctx, const char* file_uri, const char* filestore_array_uri) {
   if (sanity_check(ctx) == TILEDB_ERR || !filestore_array_uri || !file_uri) {
     return TILEDB_ERR;
@@ -429,7 +429,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_uri_export(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_buffer_import(
+int32_t tiledb_filestore_buffer_import(
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     void* buf,
@@ -511,7 +511,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_buffer_import(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_buffer_export(
+int32_t tiledb_filestore_buffer_export(
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     size_t offset,
@@ -559,7 +559,7 @@ TILEDB_EXPORT int32_t tiledb_filestore_buffer_export(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t tiledb_filestore_size(
+int32_t tiledb_filestore_size(
     tiledb_ctx_t* ctx, const char* filestore_array_uri, size_t* size) {
   if (sanity_check(ctx) == TILEDB_ERR || !filestore_array_uri || !size) {
     return TILEDB_ERR;
@@ -589,16 +589,16 @@ TILEDB_EXPORT int32_t tiledb_filestore_size(
   return TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t
-tiledb_mime_type_to_str(tiledb_mime_type_t mime_type, const char** str) {
+int32_t tiledb_mime_type_to_str(
+    tiledb_mime_type_t mime_type, const char** str) {
   const auto& strval =
       tiledb::sm::mime_type_str((tiledb::sm::MimeType)mime_type);
   *str = strval.c_str();
   return strval.empty() ? TILEDB_ERR : TILEDB_OK;
 }
 
-TILEDB_EXPORT int32_t
-tiledb_mime_type_from_str(const char* str, tiledb_mime_type_t* mime_type) {
+int32_t tiledb_mime_type_from_str(
+    const char* str, tiledb_mime_type_t* mime_type) {
   tiledb::sm::MimeType val = tiledb::sm::MimeType::MIME_AUTODETECT;
   if (!tiledb::sm::mime_type_enum(str, &val).ok())
     return TILEDB_ERR;


### PR DESCRIPTION
We have been incorrectly applying the `TILEDB_EXPORT` macro to some functions in the internal `tiledb::api` and `tiledb::common::internal` namespaces, resulting in functions with mangled C++ names being exported from the dynamic library.

![image](https://github.com/TileDB-Inc/TileDB/assets/12659251/a4ad5e4c-b2db-45fe-aa05-8626b211af0f)

This PR stops exporting them. I wouldn't call it a breaking change; these APIs are already available through their public, stable, documented and unmangled names; no one using our headers should be calling the mangled functions.

The only mangled function that was kept is `tiledb::impl::tiledb_query_submit_async_func` which is used as an implementation detail in the C++ API. It might still cause linking problems (like when the C++ compilers of the Core and the application are different) but `submit_async` is deprecated and will be gone soon either way.

---
TYPE: BUG
DESC: Remove `TILEDB_EXPORT` from private C API functions.