### PR TITLE
Depend on libxml2 only when Azure is enabled.

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,12 +12,7 @@
         },
         "spdlog",
         "zlib",
-        "zstd",
-        {
-          "name": "libxml2",
-          "features": ["lzma", "zlib"],
-          "default-features": false
-        }
+        "zstd"
     ],
     "features": {
         "abseil": {
@@ -35,6 +30,11 @@
                 {
                     "name": "azure-storage-blobs-cpp",
                     "version>=": "12.6.1"
+                },
+                {
+                    "name": "libxml2",
+                    "features": ["lzma", "zlib"],
+                    "default-features": false
                 }
             ]
         },


### PR DESCRIPTION
Our vcpkg manifest includes libxml2 to remove its default dependency on iconv. We don't directly use libxml2; the Azure SDK uses it. This PR moves the libxml2 dependency under the azure vcpkg feature.

---
TYPE: IMPROVEMENT
DESC: Depend on libxml2 only when Azure is enabled.