### PR TITLE
make s3threadpoolexecutor destructor stop first

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -469,10 +469,7 @@ Status S3::disconnect() {
   }
 
   if (s3_tp_executor_) {
-    const Status st = s3_tp_executor_->Stop();
-    if (!st.ok()) {
-      ret_st = st;
-    }
+    s3_tp_executor_->Stop();
   }
 
   state_ = State::DISCONNECTED;
@@ -1537,11 +1534,14 @@ Status S3::init_client() const {
                 nullptr);
         break;
       }
-      default:
-        return Status_S3Error(
+      default: {
+        s3_tp_executor_->Stop();
+
+        throw S3StatusException{
             "Ambiguous authentication credentials; both permanent and "
             "temporary "
-            "authentication credentials are configured");
+            "authentication credentials are configured"};
+      }
     }
   }
 

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -50,23 +50,20 @@ S3ThreadPoolExecutor::S3ThreadPoolExecutor(ThreadPool* const thread_pool)
 }
 
 S3ThreadPoolExecutor::~S3ThreadPoolExecutor() {
-  throw_if_not_ok(Stop());
   assert(state_ == State::STOPPED);
   assert(outstanding_tasks_ == 0);
 }
 
-Status S3ThreadPoolExecutor::Stop() {
+void S3ThreadPoolExecutor::Stop() {
   std::unique_lock<std::mutex> lock_guard(lock_);
 
   if (state_ != State::RUNNING)
-    return Status::Ok();
+    return;
 
   state_ = State::STOPPING;
   while (outstanding_tasks_ != 0)
     cv_.wait(lock_guard);
   state_ = State::STOPPED;
-
-  return Status::Ok();
 }
 
 bool S3ThreadPoolExecutor::SubmitToThread(std::function<void()>&& fn) {

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.cc
@@ -50,6 +50,7 @@ S3ThreadPoolExecutor::S3ThreadPoolExecutor(ThreadPool* const thread_pool)
 }
 
 S3ThreadPoolExecutor::~S3ThreadPoolExecutor() {
+  throw_if_not_ok(Stop());
   assert(state_ == State::STOPPED);
   assert(outstanding_tasks_ == 0);
 }

--- a/tiledb/sm/filesystem/s3_thread_pool_executor.h
+++ b/tiledb/sm/filesystem/s3_thread_pool_executor.h
@@ -66,7 +66,7 @@ class S3ThreadPoolExecutor : public Aws::Utils::Threading::Executor {
    *
    * @return Status
    */
-  Status Stop();
+  void Stop();
 
  protected:
   /** Derived from base class. */


### PR DESCRIPTION
Failed assertion in s3.cc when both role_arn and key+secret auth are provided.
Prerequisite for ch29589

---
TYPE: NO_HISTORY | BUG
DESC: make s3threadpoolexecutor destructor stop first
