### PR TITLE
Add vfs.s3.config_source option

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -332,6 +332,7 @@ void check_save_to_file() {
   ss << "vfs.s3.use_multipart_upload true\n";
   ss << "vfs.s3.use_virtual_addressing true\n";
   ss << "vfs.s3.verify_ssl true\n";
+  ss << "vfs.s3.force_shared_cfg_only false\n";
 
   std::ifstream ifs("test_config.txt");
   std::stringstream ss_file;
@@ -722,6 +723,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.hdfs.name_node_uri"] = "";
   all_param_values["vfs.s3.bucket_canned_acl"] = "NOT_SET";
   all_param_values["vfs.s3.object_canned_acl"] = "NOT_SET";
+  all_param_values["vfs.s3.force_shared_cfg_only"] = "false";
 
   std::map<std::string, std::string> vfs_param_values;
   vfs_param_values["max_batch_size"] = "104857600";
@@ -785,6 +787,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["s3.no_sign_request"] = "false";
   vfs_param_values["s3.bucket_canned_acl"] = "NOT_SET";
   vfs_param_values["s3.object_canned_acl"] = "NOT_SET";
+  vfs_param_values["s3.force_shared_cfg_only"] = "false";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -846,6 +849,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   s3_param_values["no_sign_request"] = "false";
   s3_param_values["bucket_canned_acl"] = "NOT_SET";
   s3_param_values["object_canned_acl"] = "NOT_SET";
+  s3_param_values["force_shared_cfg_only"] = "false";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -313,6 +313,7 @@ void check_save_to_file() {
   ss << "vfs.read_ahead_cache_size 10485760\n";
   ss << "vfs.read_ahead_size 102400\n";
   ss << "vfs.s3.bucket_canned_acl NOT_SET\n";
+  ss << "vfs.s3.config_source auto\n";
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 10800\n";
@@ -332,7 +333,6 @@ void check_save_to_file() {
   ss << "vfs.s3.use_multipart_upload true\n";
   ss << "vfs.s3.use_virtual_addressing true\n";
   ss << "vfs.s3.verify_ssl true\n";
-  ss << "vfs.s3.force_shared_cfg_only false\n";
 
   std::ifstream ifs("test_config.txt");
   std::stringstream ss_file;
@@ -723,7 +723,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.hdfs.name_node_uri"] = "";
   all_param_values["vfs.s3.bucket_canned_acl"] = "NOT_SET";
   all_param_values["vfs.s3.object_canned_acl"] = "NOT_SET";
-  all_param_values["vfs.s3.force_shared_cfg_only"] = "false";
+  all_param_values["vfs.s3.config_source"] = "auto";
 
   std::map<std::string, std::string> vfs_param_values;
   vfs_param_values["max_batch_size"] = "104857600";
@@ -787,7 +787,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["s3.no_sign_request"] = "false";
   vfs_param_values["s3.bucket_canned_acl"] = "NOT_SET";
   vfs_param_values["s3.object_canned_acl"] = "NOT_SET";
-  vfs_param_values["s3.force_shared_cfg_only"] = "false";
+  vfs_param_values["s3.config_source"] = "auto";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -849,7 +849,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   s3_param_values["no_sign_request"] = "false";
   s3_param_values["bucket_canned_acl"] = "NOT_SET";
   s3_param_values["object_canned_acl"] = "NOT_SET";
-  s3_param_values["force_shared_cfg_only"] = "false";
+  s3_param_values["config_source"] = "auto";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -67,7 +67,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 61);
+  CHECK(names.size() == 62);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -515,6 +515,12 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *     Aws::S3::Model::ObjectCannedACL.) "aws_exec_read" "owner_read"
  *    "bucket_owner_full_control"
  *    **Default**: "NOT_SET"
+ * - `vfs.s3.force_shared_cfg_only` <br>
+ *    Force S3 SDK to only load options from the .aws/config file.
+ *    This option makes SDK ignore options found in environment variables and
+ *    EC2 metadata. Setting options such as aws_access_key_id in TileDB config
+ *    that can be found in .aws/config will result in an error. <br>
+ *    **Default**: false
  * - `vfs.hdfs.name_node_uri"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -515,12 +515,15 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *     Aws::S3::Model::ObjectCannedACL.) "aws_exec_read" "owner_read"
  *    "bucket_owner_full_control"
  *    **Default**: "NOT_SET"
- * - `vfs.s3.force_shared_cfg_only` <br>
- *    Force S3 SDK to only load options from the .aws/config file.
- *    This option makes SDK ignore options found in environment variables and
- *    EC2 metadata. Setting options such as aws_access_key_id in TileDB config
- *    that can be found in .aws/config will result in an error. <br>
- *    **Default**: false
+ * - `vfs.s3.config_source` <br>
+ *    Force S3 SDK to only load config options from a set source.
+ *    The supported options are
+ *    `auto` (TileDB config options are considered first,
+ *    then SDK-defined precedence: env vars, config files, ec2 metadata),
+ *    `config_files` (forces SDK to only consider options found in aws
+ *    config files).
+ *    **Default**: auto
+ *    <br>
  * - `vfs.hdfs.name_node_uri"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -215,6 +215,7 @@ const std::string Config::VFS_S3_VERIFY_SSL = "true";
 const std::string Config::VFS_S3_NO_SIGN_REQUEST = "false";
 const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
+const std::string Config::VFS_S3_FORCE_SHARED_CFG_ONLY = "false";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
@@ -443,6 +444,8 @@ const std::map<std::string, std::string> default_config_values = {
         "vfs.s3.bucket_canned_acl", Config::VFS_S3_BUCKET_CANNED_ACL),
     std::make_pair(
         "vfs.s3.object_canned_acl", Config::VFS_S3_OBJECT_CANNED_ACL),
+    std::make_pair(
+        "vfs.s3.force_shared_cfg_only", Config::VFS_S3_FORCE_SHARED_CFG_ONLY),
     std::make_pair("vfs.hdfs.name_node_uri", Config::VFS_HDFS_NAME_NODE_URI),
     std::make_pair("vfs.hdfs.username", Config::VFS_HDFS_USERNAME),
     std::make_pair(

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -215,7 +215,7 @@ const std::string Config::VFS_S3_VERIFY_SSL = "true";
 const std::string Config::VFS_S3_NO_SIGN_REQUEST = "false";
 const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
-const std::string Config::VFS_S3_FORCE_SHARED_CFG_ONLY = "false";
+const std::string Config::VFS_S3_CONFIG_SOURCE = "auto";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
@@ -444,8 +444,7 @@ const std::map<std::string, std::string> default_config_values = {
         "vfs.s3.bucket_canned_acl", Config::VFS_S3_BUCKET_CANNED_ACL),
     std::make_pair(
         "vfs.s3.object_canned_acl", Config::VFS_S3_OBJECT_CANNED_ACL),
-    std::make_pair(
-        "vfs.s3.force_shared_cfg_only", Config::VFS_S3_FORCE_SHARED_CFG_ONLY),
+    std::make_pair("vfs.s3.config_source", Config::VFS_S3_CONFIG_SOURCE),
     std::make_pair("vfs.hdfs.name_node_uri", Config::VFS_HDFS_NAME_NODE_URI),
     std::make_pair("vfs.hdfs.username", Config::VFS_HDFS_USERNAME),
     std::make_pair(

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -547,8 +547,15 @@ class Config {
   /** S3 default object canned ACL */
   static const std::string VFS_S3_OBJECT_CANNED_ACL;
 
-  /** S3 server side encryption method */
-  static const std::string VFS_S3_FORCE_SHARED_CFG_ONLY;
+  /**
+   * Force S3 SDK to only load config options from a set source.
+   * The supported options are
+   * - `auto` (TileDB config options are considered first,
+   *    then SDK-defined precedence: env vars, config files, ec2 metadata),
+   * - `config_files` (forces SDK to only consider options found in aws
+   *    config files).
+   */
+  static const std::string VFS_S3_CONFIG_SOURCE;
 
   /**
    * Specifies the size in bytes of the internal buffers used in the filestore

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -547,6 +547,9 @@ class Config {
   /** S3 default object canned ACL */
   static const std::string VFS_S3_OBJECT_CANNED_ACL;
 
+  /** S3 server side encryption method */
+  static const std::string VFS_S3_FORCE_SHARED_CFG_ONLY;
+
   /**
    * Specifies the size in bytes of the internal buffers used in the filestore
    * API. The size should be bigger than the minimum tile size filestore

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -692,6 +692,15 @@ class Config {
    *     Aws::S3::Model::ObjectCannedACL.) "aws_exec_read" "owner_read"
    *    "bucket_owner_full_control"
    *    **Default**: "NOT_SET"
+   * - `vfs.s3.config_source` <br>
+   *    Force S3 SDK to only load config options from a set source.
+   *    The supported options are
+   *    `auto` (TileDB config options are considered first,
+   *    then SDK-defined precedence: env vars, config files, ec2 metadata),
+   *    `config_files` (forces SDK to only consider options found in aws
+   *    config files).
+   *    **Default**: auto
+   *    <br>
    * - `vfs.hdfs.name_node_uri"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1355,6 +1355,9 @@ Status S3::init_client() const {
 
   std::lock_guard<std::mutex> lck(client_init_mtx_);
 
+  auto force_shared_cfg_only = config_.get<bool>(
+      "vfs.s3.force_shared_cfg_only", Config::MustFindMarker());
+
   auto aws_no_sign_request =
       config_.get<bool>("vfs.s3.no_sign_request", Config::MustFindMarker());
 
@@ -1503,7 +1506,7 @@ Status S3::init_client() const {
   } else {  // Check other authentication methods
     switch ((!aws_access_key_id.empty() ? 1 : 0) +
             (!aws_secret_access_key.empty() ? 2 : 0) +
-            (!aws_role_arn.empty() ? 4 : 0)) {
+            (!aws_role_arn.empty() ? 4 : 0) + (force_shared_cfg_only ? 8 : 0)) {
       case 0:
         break;
       case 1:
@@ -1543,13 +1546,27 @@ Status S3::init_client() const {
                 nullptr);
         break;
       }
-      default: {
+      case 7: {
         s3_tp_executor_->Stop();
 
         throw S3StatusException{
             "Ambiguous authentication credentials; both permanent and "
             "temporary "
             "authentication credentials are configured"};
+      }
+      case 8: {
+        credentials_provider_ =
+            make_shared<Aws::Auth::ProfileConfigFileAWSCredentialsProvider>(
+                HERE());
+        break;
+      }
+      default: {
+        s3_tp_executor_->Stop();
+
+        throw S3StatusException{
+            "Ambiguous authentification options; Setting "
+            "vfs.s3.force_shared_cfg_only is mutually exclusive with providing "
+            "either permanent or temporary credentials"};
       }
     }
   }


### PR DESCRIPTION
Forces SDK to only look into the .aws/config file for credentials.
Adds mutual exclusivity check with tiledb config provided key+secret / arn_role options.

Please merge https://github.com/TileDB-Inc/TileDB/pull/4130 first.

---
TYPE: NO_HISTORY | BUG
DESC: Add vfs.s3.force_shared_cfg_only option
