### PR TITLE
Improve support for multi-config CMake generators.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,47 +192,35 @@ if (MSVC)
   add_compile_options(/wd4996)
   # Disable GDI (which we don't need, and causes some macro
   # re-definition issues if wingdi.h is included)
-  add_compile_options(/DNOGDI)
+  add_compile_definitions("NOGDI")
   # Add /MPn flag from CMake invocation (if defined).
   add_compile_options(${MSVC_MP_FLAG})
   # Build-specific flags
-  if (CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(/DDEBUG /Od /Zi /bigobj)
-  elseif (CMAKE_BUILD_TYPE MATCHES "Release")
-    add_compile_options(/DNDEBUG /Ox)
-  elseif (CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
-    add_compile_options(/DNDEBUG /Ox /Zi)
-  endif()
+  add_compile_definitions("$<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>")
+  add_compile_options(
+    "$<$<CONFIG:Debug>:/Od;/Zi;/bigobj>"
+    "$<$<CONFIG:Release,RelWithDebInfo>:/Ox>"
+    "$<$<CONFIG:RelWithDebInfo>:/Zi>")
 else()
   add_compile_options(-Wall -Wextra)
   if (TILEDB_WERROR)
     add_compile_options(-Werror)
   endif()
   # Build-specific flags
-  if (CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(-DDEBUG -O0 -g3 -ggdb3 -gdwarf-3)
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-      add_compile_options(-fstandalone-debug)
-    endif()
-  elseif (CMAKE_BUILD_TYPE MATCHES "Release")
-    add_compile_options(-O3)
-  elseif (CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo")
-    add_compile_options(-DNDEBUG -O3 -g3 -ggdb3 -gdwarf-3)
-  elseif (CMAKE_BUILD_TYPE MATCHES "Coverage")
-    add_compile_options(-DDEBUG -g3 -gdwarf-3 --coverage)
-  endif()
+  add_compile_definitions("$<IF:$<CONFIG:Debug,Coverage>,DEBUG,NDEBUG>")
+  add_compile_options(
+    "$<$<CONFIG:Debug>:-O0;-g3;-ggdb3;-gdwarf-3>"
+    "$<$<CONFIG:Coverage>:-g3;-gdwarf-3;--coverage>"
+    "$<$<CONFIG:Release,RelWithDebInfo>:-O3>"
+    "$<$<CONFIG:RelWithDebInfo>:-g3;-ggdb3;-gdwarf-3>")
+  add_compile_options("$<$<CONFIG:Debug>:-DDBUG;>")
+  add_compile_options("$<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:Clang>>:-fstandalone-debug>")
 
   # Use -Wno-literal-suffix on Linux with C++ sources.
-  if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-literal-suffix>)
-  endif()
+  add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang>>:-Wno-literal-suffix>")
 
   # Disable newer Apple Clang warnings about unqualified calls to std::move
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    if (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "14.0.3")
-      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-unqualified-std-cast-call>)
-    endif()
-  endif()
+  add_compile_options("$<$<AND:$<CXX_COMPILER_ID:AppleClang>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0.3>,$<COMPILE_LANGUAGE:CXX>>:-Wno-unqualified-std-cast-call>")
 
 endif()
 

--- a/cmake/Options/TileDBAssertions.cmake
+++ b/cmake/Options/TileDBAssertions.cmake
@@ -8,10 +8,10 @@ if(TILEDB_ASSERTIONS)
   endif()
   # On non-Debug builds cmake automatically defines NDEBUG, so we
   # explicitly undefine it:
+  add_compile_options($<$<AND:$<NOT:$<CONFIG:Debug>>,$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>>:-UNDEBUG>)
   if( NOT CMAKE_BUILD_TYPE STREQUAL "Debug" )
     # NOTE: use `add_compile_options` rather than `add_definitions` since
     # `add_definitions` does not support generator expressions.
-    add_compile_options($<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-UNDEBUG>)
     if (MSVC)
       # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
       foreach (flags_var_to_scrub
@@ -24,6 +24,6 @@ if(TILEDB_ASSERTIONS)
         string (REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
           "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
       endforeach()
-     endif()
+    endif()
   endif()
 endif()


### PR DESCRIPTION
To set specific compiler options for Release or Debug mode, we have been checking the value of the `CMAKE_BUILD_TYPE` variable.

Howeber that variable applies only to single-file CMake generators (Makefiles and Ninja). We still use it for multi-config generators like MSBuild on Windows with the `-EnableDebug` option, but this is non-standard and invalidates the concept of multi-config since the same compiler options will be applied to all configurations.

We fix this by varying the compiler options with the help of CMake generator expressions like [`$<CONFIG>`](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#configuration-expressions). The ultimate goal of this is to make the `-EnableDebug` option in the Windows bootstrap script unnecessary but will not happen in this PR because of superbuild-related complications I did not investigate (but in my branch that has the superbuild disabled; I ran `../bootstrap.ps1 -EnableDebug; cmake --build . --config Release` and it succeeded, proving that `-EnableDebug` becomes meaningless).

---
TYPE: IMPROVEMENT
DESC: Improve support for multi-config CMake generators.