### PR TITLE
Remove uses of 'noxcept' in C API implementation code; update to Catch2 3.3.2

### DIFF
--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -73,8 +73,8 @@ if (NOT Catch2_FOUND AND TILEDB_SUPERBUILD)
     PREFIX "externals"
     # Set download name to avoid collisions with only the version number in the filename
     DOWNLOAD_NAME ep_catch.zip
-    URL "https://github.com/catchorg/Catch2/archive/v3.1.0.zip"
-    URL_HASH SHA1=b23753594a743feabd4e30f83b31ebb31081092a
+    URL "https://github.com/catchorg/Catch2/archive/v3.3.2.zip"
+    URL_HASH SHA1=ab23bef93b3c5ddf696d8855f34a3e882e71c64b
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2042,7 +2042,7 @@ int32_t tiledb_query_add_update_value(
     tiledb_query_t* query,
     const char* field_name,
     const void* update_value,
-    uint64_t update_value_size) noexcept {
+    uint64_t update_value_size) {
   // Sanity check
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, query) == TILEDB_ERR) {
@@ -5274,7 +5274,7 @@ void tiledb_consolidation_plan_free(
 int32_t tiledb_consolidation_plan_get_num_nodes(
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
-    uint64_t* num_nodes) noexcept {
+    uint64_t* num_nodes) {
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, consolidation_plan) == TILEDB_ERR) {
     return TILEDB_ERR;
@@ -5288,7 +5288,7 @@ int32_t tiledb_consolidation_plan_get_num_fragments(
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t node_index,
-    uint64_t* num_fragments) noexcept {
+    uint64_t* num_fragments) {
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, consolidation_plan) == TILEDB_ERR) {
     return TILEDB_ERR;
@@ -5312,7 +5312,7 @@ int32_t tiledb_consolidation_plan_get_fragment_uri(
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t node_index,
     uint64_t fragment_index,
-    const char** uri) noexcept {
+    const char** uri) {
   if (sanity_check(ctx) == TILEDB_ERR ||
       sanity_check(ctx, consolidation_plan) == TILEDB_ERR) {
     return TILEDB_ERR;


### PR DESCRIPTION
Remove uses of 'noxcept' in C API implementation code.

Stragglers. GCC 13.1 is apparently stricter about this.

Fixes: https://github.com/TileDB-Inc/TileDB/issues/4100
Fixes: sc-29481

---
TYPE: NO_HISTORY
DESC: Remove uses of 'noxcept' in C API implementation code

---
TYPE: NO_HISTORY
DESC: Update Catch2 for compatibility with GCC 13