### PR TITLE
Rename result_buffer_elements_labels and update doxygen

### DIFF
--- a/test/src/test-cppapi-dense-array-dimension-label.cc
+++ b/test/src/test-cppapi-dense-array-dimension-label.cc
@@ -313,7 +313,8 @@ class DenseArrayExample {
     query.submit();
     CHECK(query.query_status() == tiledb::Query::Status::COMPLETE);
     // Check result buffer elements.
-    auto results = tiledb::QueryExperimental::result_buffer_elements(query);
+    auto results =
+        tiledb::QueryExperimental::result_buffer_elements_labels(query);
     CHECK(std::get<0>(results["a"]) == 0);  // Fixed size attribute.
     CHECK(std::get<1>(results["a"]) == attr_data.size());
     CHECK(std::get<0>(results["x"]) == 0);  // Fixed size label.
@@ -373,7 +374,8 @@ class DenseArrayExample {
 
     // Check result buffer elements.
     auto results =
-        tiledb::QueryExperimental::result_buffer_elements_nullable(query);
+        tiledb::QueryExperimental::result_buffer_elements_nullable_labels(
+            query);
     CHECK(std::get<0>(results["a"]) == attr_offsets.size());
     CHECK(std::get<1>(results["a"]) == attr_data.size());
     CHECK(std::get<2>(results["a"]) == 0);  // No validity buffer.

--- a/tiledb/sm/cpp_api/query_experimental.h
+++ b/tiledb/sm/cpp_api/query_experimental.h
@@ -242,9 +242,9 @@ class QueryExperimental {
    * from a read query. This is a map from the dimension label name to a pair of
    * values.
    *
-   * The first is number of elements (offsets) for var size labels second is
-   * number of elements in the data buffer. For fixed sized labels, the first is
-   * always 0.
+   * The first is number of elements (offsets) for var size labels, and the
+   * second is number of elements in the data buffer. For fixed sized labels,
+   * the first is always 0.
    *
    * For variable sized labels the first value is the number of cells read, i.e.
    * the number of offsets read for the dimension label. The second value is the

--- a/tiledb/sm/cpp_api/query_experimental.h
+++ b/tiledb/sm/cpp_api/query_experimental.h
@@ -241,6 +241,11 @@ class QueryExperimental {
    * Returns the number of elements in the result buffers from a read query.
    * This is a map from the attribute name to a pair of values.
    *
+   * For fixed size dimension labels the non-experimental API will return the
+   * same results. This experimental variant uses ArraySchemaExperimental to
+   * check if the dim label is variable size and includes offset elements if
+   * needed.
+   *
    * The first is number of elements (offsets) for var size attributes, and the
    * second is number of elements in the data buffer. For fixed sized attributes
    * (and coordinates), the first is always 0.
@@ -262,7 +267,7 @@ class QueryExperimental {
    * If the query has not been submitted, an empty map is returned.
    */
   static std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
-  result_buffer_elements(const Query& query) {
+  result_buffer_elements_labels(const Query& query) {
     // Query hasn't been submitted
     if (query.buff_sizes_.empty()) {
       return {};
@@ -294,6 +299,11 @@ class QueryExperimental {
    * Returns the number of elements in the result buffers from a read query.
    * This is a map from the attribute name to a tuple of values.
    *
+   * For fixed size dimension labels the non-experimental API will return the
+   * same results. This experimental variant uses ArraySchemaExperimental to
+   * check if the dim label is variable size and includes offset elements if
+   * needed.
+   *
    * The first is number of elements (offsets) for var size attributes, and the
    * second is number of elements in the data buffer. For fixed sized attributes
    * (and coordinates), the first is always 0. The third element is the size of
@@ -317,7 +327,7 @@ class QueryExperimental {
    */
   static std::
       unordered_map<std::string, std::tuple<uint64_t, uint64_t, uint64_t>>
-      result_buffer_elements_nullable(const Query& query) {
+      result_buffer_elements_nullable_labels(const Query& query) {
     // Query hasn't been submitted
     if (query.buff_sizes_.empty()) {
       return {};

--- a/tiledb/sm/cpp_api/query_experimental.h
+++ b/tiledb/sm/cpp_api/query_experimental.h
@@ -238,31 +238,28 @@ class QueryExperimental {
   }
 
   /**
-   * Returns the number of elements in the result buffers from a read query.
-   * This is a map from the attribute name to a pair of values.
+   * Returns the number of elements for dimension labels in the result buffers
+   * from a read query. This is a map from the dimension label name to a pair of
+   * values.
    *
-   * For fixed size dimension labels the non-experimental API will return the
-   * same results. This experimental variant uses ArraySchemaExperimental to
-   * check if the dim label is variable size and includes offset elements if
-   * needed.
+   * The first is number of elements (offsets) for var size labels second is
+   * number of elements in the data buffer. For fixed sized labels, the first is
+   * always 0.
    *
-   * The first is number of elements (offsets) for var size attributes, and the
-   * second is number of elements in the data buffer. For fixed sized attributes
-   * (and coordinates), the first is always 0.
+   * For variable sized labels the first value is the number of cells read, i.e.
+   * the number of offsets read for the dimension label. The second value is the
+   * total number of elements in the data buffer. For example, a read query on a
+   * variable-length `float` dimension label that reads three cells would return
+   * 3 for the first number in the pair. If the total amount of `floats` read
+   * across the three cells was 10, then the second number in the pair would be
+   * 10.
    *
-   * For variable sized attributes: the first value is the
-   * number of cells read, i.e. the number of offsets read for the attribute.
-   * The second value is the total number of elements in the data buffer. For
-   * example, a read query on a variable-length `float` attribute that reads
-   * three cells would return 3 for the first number in the pair. If the total
-   * amount of `floats` read across the three cells was 10, then the second
-   * number in the pair would be 10.
-   *
-   * For fixed-length attributes, the first value is always 0. The second value
-   * is the total number of elements in the data buffer. For example, a read
-   * query on a single `float` attribute that reads three cells would return 3
-   * for the second value. A read query on a `float` attribute with cell_val_num
-   * 2 that reads three cells would return 3 * 2 = 6 for the second value.
+   * For fixed-length labels, the first value is always 0. The second value is
+   * the total number of elements in the data buffer. For example, a read query
+   * on a single `float` dimension label that reads three cells would return 3
+   * for the second value. A read query on a `float` dimension label with
+   * cell_val_num 2 that reads three cells would return 3 * 2 = 6 for the second
+   * value.
    *
    * If the query has not been submitted, an empty map is returned.
    */
@@ -297,31 +294,27 @@ class QueryExperimental {
 
   /**
    * Returns the number of elements in the result buffers from a read query.
-   * This is a map from the attribute name to a tuple of values.
+   * This is a map from the dimension label name to a tuple of values.
    *
-   * For fixed size dimension labels the non-experimental API will return the
-   * same results. This experimental variant uses ArraySchemaExperimental to
-   * check if the dim label is variable size and includes offset elements if
-   * needed.
+   * The first is number of elements (offsets) for var size labels, and the
+   * second is number of elements in the data buffer. For fixed sized labels,
+   * the first is always 0. The third element is the size of the validity
+   * bytemap buffer.
    *
-   * The first is number of elements (offsets) for var size attributes, and the
-   * second is number of elements in the data buffer. For fixed sized attributes
-   * (and coordinates), the first is always 0. The third element is the size of
-   * the validity bytemap buffer.
-   *
-   * For variable sized attributes: the first value is the
-   * number of cells read, i.e. the number of offsets read for the attribute.
-   * The second value is the total number of elements in the data buffer. For
-   * example, a read query on a variable-length `float` attribute that reads
-   * three cells would return 3 for the first number in the pair. If the total
-   * amount of `floats` read across the three cells was 10, then the second
-   * number in the pair would be 10.
-   *
-   * For fixed-length attributes, the first value is always 0. The second value
+   * For variable sized labels: the first value is the number of cells read,
+   * i.e. the number of offsets read for the dimension label. The second value
    * is the total number of elements in the data buffer. For example, a read
-   * query on a single `float` attribute that reads three cells would return 3
-   * for the second value. A read query on a `float` attribute with cell_val_num
-   * 2 that reads three cells would return 3 * 2 = 6 for the second value.
+   * query on a variable-length `float` dimension label that reads three cells
+   * would return 3 for the first number in the pair. If the total amount of
+   * `floats` read across the three cells was 10, then the second number in the
+   * pair would be 10.
+   *
+   * For fixed-length labels, the first value is always 0. The second value is
+   * the total number of elements in the data buffer. For example, a read query
+   * on a single `float` dimension label that reads three cells would return 3
+   * for the second value. A read query on a `float` dimension label with
+   * cell_val_num 2 that reads three cells would return 3 * 2 = 6 for the second
+   * value.
    *
    * If the query has not been submitted, an empty map is returned.
    */

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -131,7 +131,7 @@ class ArrayDimensionLabelQueries {
    * Throws if there is no label data query on dim_idx.
    *
    * @param dim_idx Dimension index for label data query.
-   * @returns Vector of  DimensionLabelQuery on dim_idx
+   * @returns Vector of DimensionLabelQuery on dim_idx
    */
   std::vector<DimensionLabelQuery*> get_data_query(
       dimension_size_type dim_idx) const;


### PR DESCRIPTION
Rename `result_buffer_elements_labels` and update doxygen from review on #4142 

---
TYPE: IMPROVEMENT
DESC: Rename `result_buffer_elements_labels` and update doxygen from review on #4142 
