### PR TITLE
Fix VFS is_empty_bucket cpp api

### DIFF
--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -30,6 +30,7 @@
  * Tests the C++ API for the VFS functionality.
  */
 
+#include <test/support/src/helpers.h>
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
 
@@ -231,6 +232,24 @@ TEST_CASE(
   vfs.remove_dir(path);
 
 #endif
+}
+
+TEST_CASE(
+    "C++ API: Test VFS is_bucket", "[cppapi][cppapi-vfs][vfs-is-bucket]") {
+  tiledb::Config config;
+#ifndef TILEDB_TESTS_AWS_S3_CONFIG
+  REQUIRE_NOTHROW(config.set("vfs.s3.endpoint_override", "localhost:9999"));
+  REQUIRE_NOTHROW(config.set("vfs.s3.scheme", "https"));
+  REQUIRE_NOTHROW(config.set("vfs.s3.use_virtual_addressing", "false"));
+  REQUIRE_NOTHROW(config.set("vfs.s3.verify_ssl", "false"));
+#endif
+  tiledb::Context ctx(config);
+  tiledb::VFS vfs(ctx);
+  std::string bucket_name = "s3://" + tiledb::test::random_name("tiledb") + "/";
+  vfs.create_bucket(bucket_name);
+  CHECK(vfs.is_empty_bucket(bucket_name) == true);
+  vfs.touch(bucket_name + "/test.txt");
+  CHECK(vfs.is_empty_bucket(bucket_name) == false);
 }
 
 TEST_CASE(

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -416,10 +416,10 @@ class VFS {
   /** Check if an object store bucket is empty **/
   bool is_empty_bucket(const std::string& bucket) const {
     auto& ctx = ctx_.get();
-    int empty;
+    int is_empty;
     ctx.handle_error(tiledb_vfs_is_empty_bucket(
-        ctx.ptr().get(), vfs_.get(), bucket.c_str(), &empty));
-    return empty == 0;
+        ctx.ptr().get(), vfs_.get(), bucket.c_str(), &is_empty));
+    return is_empty;
   }
 
   /** Creates a directory with the input URI. */


### PR DESCRIPTION
`VFS::is_empty_bucket()` returns `!tiledb_vfs_is_empty_bucket()` 

---
TYPE: BUG
DESC: Fix VFS is_empty_bucket cpp api
