### PR TITLE
Initial skeleton for `flow_graph`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,6 +59,7 @@ IncludeCategories:
     Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
@@ -76,6 +77,8 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments:  true
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
 SortIncludes:    true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true

--- a/cmake/object_library.cmake
+++ b/cmake/object_library.cmake
@@ -169,6 +169,7 @@ macro(TileDB_Environment_object_library_end)
     # ----------------------------------
     # Sources and object library dependencies, compile definitions
     target_sources(${TileDB_Environment_object_library_end_Library} PRIVATE ${TileDB_Environment_object_library_end_Sources})
+    target_include_directories(${TileDB_Environment_object_library_end_Library} PUBLIC ${CMAKE_SOURCE_DIR})
     foreach(Object_Library IN LISTS TileDB_Environment_object_library_end_OL_Dependencies)
         target_link_libraries(${TileDB_Environment_object_library_end_Library} PUBLIC ${Object_Library} $<TARGET_OBJECTS:${Object_Library}>)
     endforeach()

--- a/cmake/unit_test.cmake
+++ b/cmake/unit_test.cmake
@@ -168,6 +168,8 @@ macro(TileDB_Environment_unit_test_end)
     # Catch2 is always a dependency of our unit tests
     find_package(Catch_EP REQUIRED)
     target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC Catch2::Catch2WithMain)
+    target_include_directories(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC ${CMAKE_SOURCE_DIR})
+    target_include_directories(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC "${CMAKE_SOURCE_DIR}/test/support/" "${CMAKE_SOURCE_DIR}/test_support/")
     foreach(Object_Library IN LISTS TileDB_Environment_unit_test_end_OL_Dependencies)
         target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC ${Object_Library})
     endforeach()

--- a/test/external/src/absl_link_test.cc
+++ b/test/external/src/absl_link_test.cc
@@ -81,10 +81,10 @@ cloud\testing_util\CMakeLists.txt:        PUBLIC absl::symbolize absl::failure_s
 #include <absl/container/fixed_array.h>  // absl::fixed_array
 #include <absl/hash/hash.h>              // absl::flat_hash_map
 #include <absl/memory/memory.h>
-#include <absl/meta/type_traits.h>  // absl::function_ref
-#include <absl/numeric/int128.h>    // absl::numeric
+#include <absl/meta/type_traits.h>       // absl::function_ref
+#include <absl/numeric/int128.h>         // absl::numeric
 #include <absl/strings/numbers.h>
-#include <absl/strings/str_format.h>  // absl::str_format
+#include <absl/strings/str_format.h>     // absl::str_format
 #include <absl/strings/string_view.h>
 #include <absl/time/clock.h>
 #include <absl/types/optional.h>  // absl::optional

--- a/test/src/unit-azure.cc
+++ b/test/src/unit-azure.cc
@@ -209,9 +209,9 @@ TEST_CASE_METHOD(AzureFx, "Test Azure filesystem, file management", "[azure]") {
   REQUIRE(azure_.is_dir(URI(file4), &is_dir).ok());
   REQUIRE(!is_dir);  // Not a dir
   REQUIRE(azure_.is_dir(URI(dir), &is_dir).ok());
-  REQUIRE(is_dir);  // This is viewed as a dir
+  REQUIRE(is_dir);   // This is viewed as a dir
   REQUIRE(azure_.is_dir(URI(TEST_DIR + "dir"), &is_dir).ok());
-  REQUIRE(is_dir);  // This is viewed as a dir
+  REQUIRE(is_dir);   // This is viewed as a dir
 
   // ls_with_sizes
   std::string s = "abcdef";

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -610,7 +610,7 @@ void ArraySchemaFx::create_array(const std::string& path) {
       ctx_, DIM2_NAME, TILEDB_INT64, &DIM_DOMAIN[2], &TILE_EXTENTS[1], &d2);
   REQUIRE(rc == TILEDB_OK);
   int dim_domain_int[] = {0, 10};
-  tiledb_dimension_t* d3;  // This will be an invalid dimension
+  tiledb_dimension_t* d3;       // This will be an invalid dimension
   int tile_extent = 10000;
   rc = tiledb_dimension_alloc(  // This will not even be created
       ctx_,

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -1093,8 +1093,8 @@ TEST_CASE_METHOD(
       CHECK(
           size_off == (uint64_t)((2.0 / 3 + 2.0 / 6) * (2 * sizeof(uint64_t))));
       CHECK(
-          size_val ==
-          (uint64_t)((2.0 / 3) * (3 * sizeof(int)) + (2.0 / 6) * (6 * sizeof(int))));
+          size_val == (uint64_t)((2.0 / 3) * (3 * sizeof(int)) +
+                                 (2.0 / 6) * (6 * sizeof(int))));
     }
 
     SECTION("-- Partial overlap, 2 ranges") {
@@ -1223,8 +1223,8 @@ TEST_CASE_METHOD(
       CHECK(
           size_off == (uint64_t)((2.0 / 3 + 2.0 / 6) * (2 * sizeof(uint64_t))));
       CHECK(
-          size_val ==
-          (uint64_t)((2.0 / 3) * (3 * sizeof(int)) + (2.0 / 6) * (6 * sizeof(int))));
+          size_val == (uint64_t)((2.0 / 3) * (3 * sizeof(int)) +
+                                 (2.0 / 6) * (6 * sizeof(int))));
     }
 
     SECTION("-- Partial overlap, 2 ranges") {

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -69,12 +69,12 @@ struct CPPArrayFx {
     auto d2 = Dimension::create<int>(ctx, "d2", {{0, 100}}, d2_tile);
     domain.add_dimensions(d1, d2);
 
-    auto a1 = Attribute::create<int>(ctx, "a1");          // (int, 1)
-    auto a2 = Attribute::create<std::string>(ctx, "a2");  // (char, VAR_NUM)
+    auto a1 = Attribute::create<int>(ctx, "a1");              // (int, 1)
+    auto a2 = Attribute::create<std::string>(ctx, "a2");      // (char, VAR_NUM)
     auto a3 =
         Attribute::create<std::array<double, 2>>(ctx, "a3");  // (double, 2)
     auto a4 =
-        Attribute::create<std::vector<Point>>(ctx, "a4");  // (char, VAR_NUM)
+        Attribute::create<std::vector<Point>>(ctx, "a4");     // (char, VAR_NUM)
     auto a5 = Attribute::create<Point>(ctx, "a5");  // (char, sizeof(Point))
     FilterList filters(ctx);
     filters.add_filter({ctx, TILEDB_FILTER_LZ4});

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -2774,7 +2774,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
     offset += sizeof(uint32_t);  // First chunk orig size
     offset += sizeof(uint32_t);  // First chunk filtered size
     auto filter_metadata_size = tile.filtered_buffer().value_at_as<uint32_t>(
-        offset);  // First chunk metadata size
+        offset);                 // First chunk metadata size
     offset += sizeof(uint32_t);
 
     auto max_win_size =

--- a/test/src/unit-gcs.cc
+++ b/test/src/unit-gcs.cc
@@ -195,9 +195,9 @@ TEST_CASE_METHOD(GCSFx, "Test GCS filesystem, file management", "[gcs]") {
   REQUIRE(gcs_.is_dir(URI(file4), &is_dir).ok());
   REQUIRE(!is_dir);  // Not a dir
   REQUIRE(gcs_.is_dir(URI(dir), &is_dir).ok());
-  REQUIRE(is_dir);  // This is viewed as a dir
+  REQUIRE(is_dir);   // This is viewed as a dir
   REQUIRE(gcs_.is_dir(URI(TEST_DIR + "dir"), &is_dir).ok());
-  REQUIRE(is_dir);  // This is viewed as a dir
+  REQUIRE(is_dir);   // This is viewed as a dir
 
   // ls_with_sizes
   std::string s = "abcdef";

--- a/test/src/unit-gs.cc
+++ b/test/src/unit-gs.cc
@@ -180,9 +180,9 @@ TEST_CASE_METHOD(GSFx, "Test GS filesystem, file management", "[gs]") {
   REQUIRE(gcs_.is_dir(URI(file4), &is_dir).ok());
   REQUIRE(!is_dir);  // Not a dir
   REQUIRE(gcs_.is_dir(URI(dir), &is_dir).ok());
-  REQUIRE(is_dir);  // This is viewed as a dir
+  REQUIRE(is_dir);   // This is viewed as a dir
   REQUIRE(gcs_.is_dir(URI(TEST_DIR + "dir"), &is_dir).ok());
-  REQUIRE(is_dir);  // This is viewed as a dir
+  REQUIRE(is_dir);   // This is viewed as a dir
 
   // Move file
   REQUIRE(gcs_.move_object(URI(file5), URI(file6)).ok());

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -181,9 +181,9 @@ TEST_CASE_METHOD(S3Fx, "Test S3 filesystem, file management", "[s3]") {
   CHECK(s3_.is_dir(URI(file4), &is_dir).ok());
   CHECK(!is_dir);  // Not a dir
   CHECK(s3_.is_dir(URI(dir), &is_dir).ok());
-  CHECK(is_dir);  // This is viewed as a dir
+  CHECK(is_dir);   // This is viewed as a dir
   CHECK(s3_.is_dir(URI(TEST_DIR + "dir"), &is_dir).ok());
-  CHECK(is_dir);  // This is viewed as a dir
+  CHECK(is_dir);   // This is viewed as a dir
 
   // ls_with_sizes
   std::string s = "abcdef";
@@ -479,9 +479,9 @@ TEST_CASE_METHOD(S3Fx, "Test S3 use Bucket/Object CannedACL", "[s3]") {
     CHECK(s3_.is_dir(URI(file4), &is_dir).ok());
     CHECK(!is_dir);  // Not a dir
     CHECK(s3_.is_dir(URI(dir), &is_dir).ok());
-    CHECK(is_dir);  // This is viewed as a dir
+    CHECK(is_dir);   // This is viewed as a dir
     CHECK(s3_.is_dir(URI(TEST_DIR + "dir"), &is_dir).ok());
-    CHECK(is_dir);  // This is viewed as a dir
+    CHECK(is_dir);   // This is viewed as a dir
 
     // Move file
     CHECK(s3_.move_object(URI(file5), URI(file6)).ok());

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -53,6 +53,7 @@ find_package(Threads REQUIRED)
 
 add_subdirectory(api)
 add_subdirectory(common)
+add_subdirectory(flow_graph)
 add_subdirectory(platform)
 add_subdirectory(type)
 add_subdirectory(sm)

--- a/tiledb/flow_graph/CMakeLists.txt
+++ b/tiledb/flow_graph/CMakeLists.txt
@@ -1,0 +1,37 @@
+#
+# flow_graph/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(common-root)
+include(object_library)
+
+#
+# Allow advance use of `concept` and `import` before the rest of the code base
+#
+set(CMAKE_CXX_STANDARD 20)
+
+add_subdirectory(library)
+
+add_test_subdirectory()

--- a/tiledb/flow_graph/DIRECTORY.md
+++ b/tiledb/flow_graph/DIRECTORY.md
@@ -1,0 +1,28 @@
+# Flow Graph
+
+## Directories
+
+### `flow_graph`
+
+The root `flow_graph` directory focuses on clean support for the most common use
+cases with flow graphs:
+
+* Specifying a node by means of its node body: `flow_graph/node.h`
+* Specifying a flow graph: `flow_graph/graph.h`
+* Creating and running a flow graph: `flow_graph/system.h`
+
+Other headers are relegated to subdirectories.
+
+### `flow_graph/system`
+
+This directory contains all the elements that define the subsystem boundaries.
+Primarily these definitions are in the form of `concept` definitions.
+
+### `flow_graph/library`
+
+This directory contains behind-the-scenes code required to implement the visible
+parts.
+
+### `flow_graph/test`
+
+Top level tests of integrated flow graph components.

--- a/tiledb/flow_graph/FLOW_GRAPH.md
+++ b/tiledb/flow_graph/FLOW_GRAPH.md
@@ -1,0 +1,33 @@
+# Flow Graph
+
+## Designated use cases
+
+The `flow_graph` directory focuses on clean support for the most common use
+cases with flow graphs:
+
+* Defining a node body.
+* Specifying a flow graph.
+* Creating a flow graph for execution.
+* Running a flow graph.
+
+### Defining a node body
+
+The header `flow_graph/node.h` contains all the concepts needed to define a node
+body.
+
+A node body is the middle layer of a node. The bottom layer contains node
+services; the top layer contains the node class itself. Each node body contains
+a template argument of concept `flow_graph::node_services`. Each node body
+instance must satisfy the concept `flow_graph::node_body`. These two concepts
+comprise the entirety of the node body interface.
+
+### Specifying a flow graph
+
+The header `flow_graph/graph.h` contains support classes and all the concepts
+need to specify a graph, either statically or dynamically.
+
+### Flow graph execution objects
+
+The header `flow_graph/system.h` contains a standard system object that provides
+a way of creating an execution graph from a graph specification and for
+executing the resulting object.

--- a/tiledb/flow_graph/general_factory.h
+++ b/tiledb/flow_graph/general_factory.h
@@ -1,0 +1,284 @@
+/**
+ * @file flow_graph/generic_factory.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Generic factory classes
+ */
+
+#ifndef TILEDB_GENERIC_FACTORY
+#define TILEDB_GENERIC_FACTORY
+
+#include <memory>  // for `shared_ptr`
+
+namespace tiledb {
+
+//-------------------------------------------------------
+// GeneralFactory
+//-------------------------------------------------------
+/*
+ * The `GeneralFactory` is a fully generic factory for both classes and class
+ * templates. It provides type erasure to the classes it can produce, and so
+ * can produce multiple object types.
+ *
+ * On the front end, the class presents a production function with an
+ * argument signature common to all classes the factory can produce. A generic
+ * factory cannot return its produced objects by any kind of value or reference,
+ * so it has `void` return and takes a placement argument.
+ *
+ * On the back end, the class forwards production calls to type-specific
+ * factories and wraps them with a consistent placement interface.
+ *
+ * Life Cycle: Objects constructed in place require explicit calls to their
+ * destructors. `GeneralFactory` does not have any requirements on the classes
+ * it produces. It is thus incumbent on the user to ensure proper life cycle
+ * behavior. There are two ordinary situations where this is straightforward:
+ *   1. The class has a trivial destructor. In this case the destructor does not
+ *     need to be called at all.
+ *   2. The class is derived from a common base class with a virtual destructor.
+ *     In this case it's a simple matter to make a type-safe wrapper around the
+ *     factory.
+ * There's another possibility available with C++23:
+ *   3. Each produced class has a destructor with an explicit object parameter.
+ *     In such cases a pointer to the destructor is an ordinary pointer to
+ *     function, which can be recorded with the produced object and called to
+ *     destroy the object. This is something akin to manually creating virtual
+ *     destructor.
+ */
+
+/**
+ * Marker class for constructing `GenericFactory` objects.
+ * @tparam T
+ */
+template <class T>
+struct ForClassT {
+  ForClassT() = default;
+};
+
+template <class T>
+constexpr ForClassT<T> ForClass{ForClassT<T>{}};
+
+/**
+ * Marker class for constructing `GenericFactory` objects.
+ * @tparam T
+ */
+template <template <class> class T>
+struct ForClassTemplateT {
+  ForClassTemplateT() = default;
+};
+
+template <template <class> class T>
+constexpr ForClassTemplateT<T> ForClassTemplate{ForClassTemplateT<T>{}};
+
+/**
+ * Generic class declared but not defined; for specialization only.
+ */
+template <auto f>
+class GeneralFactoryImplBase;
+
+/**
+ * Abstract base class for factory implementations.
+ *
+ * The abstract factory only has an argument `f` for the factory signature; it
+ * does not have the type actually constructed.
+ *
+ * @tparam f the function from which the signature of `make` will be drawn
+ */
+template <class... Args, void (*f)(Args...)>
+class GeneralFactoryImplBase<f> {
+  /**
+   * The size of the class is common to all factories.
+   */
+  const size_t size_of_class_;
+
+ public:
+  explicit constexpr GeneralFactoryImplBase(size_t size)
+      : size_of_class_(size){};
+  virtual void make(void*, Args&&...) const = 0;
+  /**
+   * The size of the class that a factory creates.
+   */
+  [[nodiscard]] size_t size_of_class() const {
+    return size_of_class_;
+  }
+};
+
+/**
+ * Generic class declared but not defined; for specialization only.
+ */
+template <auto f, class P>
+class GeneralFactoryImpl;
+
+/**
+ * Factory implementation.
+ *
+ * The implementation function has both a signature argument `f` and a type
+ * `T` for the constructor. The class `T` must have a constructor whose
+ * signature matches the arguments of `f`.
+ *
+ * @tparam f the function from which the signature of `make` will be drawn
+ * @tparam P the policy class that contains a typed factory
+ */
+template <class... Args, void (*f)(Args...), class P>
+class GeneralFactoryImpl<f, P> : public GeneralFactoryImplBase<f> {
+  using Base = GeneralFactoryImplBase<f>;
+  using produced_type = P::produced_type;
+
+ public:
+  GeneralFactoryImpl()
+      : Base(sizeof(produced_type)) {
+  }
+  void make(void* p, Args&&... args) const override {
+    new (p) produced_type{P::make(std::forward<Args>(args)...)};
+  }
+};
+
+/**
+ * Generic class declared but not defined; for specialization only.
+ */
+template <auto f>
+class GeneralFactory;
+
+/**
+ * A type-erased factory class.
+ *
+ * The type of the class to be constructed is erased, but its constructor
+ * signature is not. Template arguments for `GeneralFactory` define the
+ * signature of its factory function. If a class has a constructor whose
+ * function arguments match that of the factory, then the factory can produce
+ * it.
+ *
+ * @tparam f the function that defines the signature of the factory function
+ */
+template <class... Args, void (*f)(Args...)>
+class GeneralFactory<f> {
+  /**
+   * Pointer to implementation of the factory.
+   *
+   * `shared_ptr` is used here to enable copy construction.
+   *
+   * This member would be well-suited for `derived_variant`. None of the
+   * derived classes add any state over the base class.
+   */
+  std::shared_ptr<GeneralFactoryImplBase<f>> factory_;
+
+ public:
+  template <class P>
+  explicit GeneralFactory(ForClassT<P>)
+      : factory_(std::make_shared<GeneralFactoryImpl<f, P>>()) {
+  }
+
+  /**
+   * The factory function uses a placement signature.
+   *
+   * @param p The address at which to construct the object
+   * @param args Constructor arguments
+   */
+  void make(void* p, Args&&... args) const {
+    factory_->make(p, std::forward<Args>(args)...);
+  }
+
+  [[nodiscard]] size_t size_of_class() const {
+    return factory_->size_of_class();
+  }
+  /**
+   * Copy constructor
+   */
+  GeneralFactory(const GeneralFactory&) = default;
+  /**
+   * Copy constructor
+   */
+  GeneralFactory(GeneralFactory&&) noexcept = default;
+  /**
+   * No assignment
+   */
+  GeneralFactory& operator=(const GeneralFactory&) = delete;
+  /**
+   * No assignment
+   */
+  GeneralFactory& operator=(GeneralFactory&&) = delete;
+};
+
+//-------------------------------------------------------
+// ClassFactory and ClassTemplateFactory
+//-------------------------------------------------------
+
+template <class T>
+struct SingleClassFactoryPolicy {
+  using produced_type = T;
+
+  template <class... Args>
+  static T make(Args&&... args) {
+    return {std::forward<Args>(args)...};
+  }
+};
+
+/**
+ * Generic class declared but not defined; for specialization only.
+ */
+template <auto f>
+class ClassFactory;
+
+/**
+ * A type-erased factory class.
+ *
+ * The type of the class to be constructed is erased, but its constructor
+ * signature is not. The template argument for `ClassFactory` defines the
+ * signature of its factory function. If a class has a constructor whose
+ * function arguments match that of the factory, then the factory can produce
+ * it.
+ *
+ * @tparam f the function that defines the signature of the factory function
+ */
+template <class... Args, void (*f)(Args...)>
+class ClassFactory<f> : public GeneralFactory<f> {
+  using Base = GeneralFactory<f>;
+
+ public:
+  template <class T>
+  explicit ClassFactory(ForClassT<T>)
+      : Base{ForClass<SingleClassFactoryPolicy<T>>} {
+  }
+};
+
+/**
+ * Generic class declared but not defined; for specialization only.
+ */
+template <auto f, class T>
+class ClassTemplateFactory;
+
+template <class... Args, void (*f)(Args...), class T>
+class ClassTemplateFactory<f, T> : public GeneralFactory<f> {
+  using Base = GeneralFactory<f>;
+
+ public:
+  template <template <class> class TT>
+  explicit ClassTemplateFactory(ForClassTemplateT<TT>)
+      : Base{ForClass<SingleClassFactoryPolicy<TT<T>>>} {
+  }
+};
+
+}  // namespace tiledb
+#endif

--- a/tiledb/flow_graph/graph.h
+++ b/tiledb/flow_graph/graph.h
@@ -1,0 +1,41 @@
+/**
+ * @file flow_graph/node_body.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Everything an ordinary user needs to define a a flow
+ * graph.
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_GRAPH_H
+#define TILEDB_FLOW_GRAPH_GRAPH_H
+
+#include "system/graph_static_specification.h"
+
+namespace tiledb::flow_graph {
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_GRAPH_H

--- a/tiledb/flow_graph/library/CMakeLists.txt
+++ b/tiledb/flow_graph/library/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# flow_graph/library/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+add_subdirectory(static)
+add_subdirectory(dynamic)
+add_subdirectory(platform)
+add_subdirectory(graph)
+add_subdirectory(scheduler)

--- a/tiledb/flow_graph/library/DIRECTORY.md
+++ b/tiledb/flow_graph/library/DIRECTORY.md
@@ -1,0 +1,25 @@
+# Library of Flow Graph Elements
+
+The `flow_graph` breaks down into stages, each defined by an overarching
+concept. These top-level concepts are complex internally but with simple final
+result. Each of the stages is fully separated by concepts; there are no class
+references across stage boundaries. As a result, each of the top-level concepts
+has multiple possible instantiations that can be selected independently. None
+of the classes that satisfy these concepts are necessary; any can be replaced.
+Most of the code in the flow graph system, therefore, is library code.
+
+The library is arranged in sections according to top-level concept. The
+directory names are abbreviations for the concepts
+1. concept `graph_static_specification`, directory `static`
+2. concept `execution_platform`, directory `platform`
+3. concept `graph_dynamic_specification`, directory `dynamic`
+4. concept `execution_graph`, directory `graph`
+5. concept `graph_scheduler`, director `scheduler`
+
+More specifically, each subdirectory contains what is produced for that stage,
+regardless of its dependency. For example, `ToDynamicReference` produces dynamic
+specifications, so it's in that directory.
+
+There is no single unit test for the library as a whole, and only sometimes for
+the stages. The `execution_platform` stage, in particular, is (that is, _will
+be_) quite extensive and not suitable for a single unit test.

--- a/tiledb/flow_graph/library/dynamic/CMakeLists.txt
+++ b/tiledb/flow_graph/library/dynamic/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# flow_graph/library/dynamic/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+add_test_subdirectory()

--- a/tiledb/flow_graph/library/dynamic/dynamic_zero_graph.h
+++ b/tiledb/flow_graph/library/dynamic/dynamic_zero_graph.h
@@ -1,0 +1,78 @@
+/**
+ * @file flow_graph/test/zero_graph.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <exception>
+#include "../../system/graph_dynamic_specification.h"
+
+namespace tiledb::flow_graph::dynamic_specification {
+
+/**
+ * The zero graph has no nodes and no edges. It's a valid graph, and we want to
+ * ensure that the flow graph system supports it.
+ */
+class ZeroGraph {
+ public:
+  constexpr static struct invariant_type {
+    constexpr static bool i_am_graph_dynamic_specification{true};
+  } invariants;
+
+  using nodes_size_type = uint8_t;
+  using edges_size_type = uint8_t;
+  using ports_size_type = uint8_t;
+
+  ZeroGraph() = default;
+
+  [[nodiscard]] constexpr uint8_t nodes_size() const {
+    return 0;
+  }
+  [[nodiscard]] constexpr uint8_t edges_size() const {
+    return 0;
+  }
+  [[nodiscard]] constexpr const void* nodes() const {
+    return nullptr;
+  }
+  [[nodiscard]] constexpr const void* edges() const {
+    return nullptr;
+  }
+  void make_node(uint8_t) const {
+    throw std::runtime_error("There is no node");
+  }
+  void make_edge(uint8_t) const {
+    throw std::runtime_error("There is no edge");
+  }
+};
+static_assert(graph_dynamic_specification<ZeroGraph>);
+
+// template <>
+// struct TestGraphTraits<DummyTestGraph<void>> {
+//   static constexpr std::string_view name{"ZeroGraph"};
+// };
+
+}  // namespace tiledb::flow_graph::test

--- a/tiledb/flow_graph/library/dynamic/test/CMakeLists.txt
+++ b/tiledb/flow_graph/library/dynamic/test/CMakeLists.txt
@@ -1,0 +1,32 @@
+#
+# flow_graph/library/dynamic/test/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+include(unit_test)
+
+commence(unit_test fgl_dynamic)
+this_target_sources(
+    main.cc
+)
+conclude(unit_test)

--- a/tiledb/flow_graph/library/dynamic/test/main.cc
+++ b/tiledb/flow_graph/library/dynamic/test/main.cc
@@ -1,0 +1,51 @@
+/**
+ * @file flow_graph/library/dynamic/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "tdb_catch.h"
+
+#include "../../platform/minimal_execution_platform.h"
+#include "../../static/static_zero_graph.h"
+#include "../dynamic_zero_graph.h"
+#include "../to_dynamic_reference.h"
+
+using namespace tiledb::flow_graph;
+using namespace tiledb::flow_graph::dynamic_specification;
+
+TEST_CASE("Dynamic ZeroGraph, valid specification") {
+  STATIC_CHECK(graph<ZeroGraph>);
+}
+
+TEST_CASE("ToDynamic, valid specification") {
+  using ZG2 = ToDynamicReference<
+      static_specification::ZeroGraph,
+      MinimalExecutionPlatform>;
+  STATIC_CHECK(graph<ZG2>);
+}

--- a/tiledb/flow_graph/library/dynamic/to_dynamic_reference.h
+++ b/tiledb/flow_graph/library/dynamic/to_dynamic_reference.h
@@ -1,0 +1,356 @@
+/**
+ * @file flow_graph/library/dynamic/to_dynamic_reference.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Static and dynamic graph specification. Conversion of
+ * static specifications to dynamic ones.
+ */
+
+/**
+ * @section Static vs. Dynamic Specification
+ *
+ * Common Graph Specification
+ * - A graph class may optionally specify a global state type.
+ *   (Not yet implemented)
+ *   - If specified, the graph requires a constructor that takes either a
+ *     global state value or a reference to a global state object.
+ *   - If absent, the graph requires a default constructor.
+ * - Specification nodes and edges are factories for execution nodes and edges.
+ * - Specification ports are accessors into execution ports.
+ *   - The means of access change
+ *
+ * Static Graph Specification
+ * - Each graph class specifies a graph with a fixed set of nodes and edges.
+ *   - All graph objects have the same underlying graph.
+ * - Each node may be of a different type.
+ * - Ports on nodes are referenced by a member pointer of the node.
+ * - Each edge may be of a different type.
+ * - Each node is a specification node member variable of the graph.
+ *   - A specification node has a static tuple of its input and output ports.
+ * - The graph contains a static tuple of nodes references.
+ * - Edges are anonymous by default
+ *   - Nothing in the framework requires a named edge.
+ * - The graph contains a static tuple of edges.
+ *
+ * Dynamic Graph Specification
+ * - Each graph object specifies a graph with a fixed set of nodes and edges.
+ *   - Each constructor must supply the parameters needed to fully specify the
+ *     underling graph.
+ * - Each node is of the same type, as defined by the graph class
+ *   - Since node implementation class are all different, this requires some
+ *     kind of type erasure mechanism with derivation from a common base
+ *     class and possibly adapter classes or an adapter class template.
+ * - Ports on nodes are referenced by index.
+ *   - The index type is an unsigned integral type defined by the graph class.
+ *   - Indices need not be contiguous.
+ * - Each edge is of the same type, as defined by the graph class
+ *   - Edges can be the same type based on typed-erased nodes, or they might
+ *     use type erasure analogously as the nodes do.
+ * - Nodes and edges are anonymous.
+ *   - The dynamic framework uses neither node names nor edge names.
+ * - Each graph object has two forward-iterable containers: one for nodes and
+ *   one for edges
+ * - Edge tails and heads are specified as a pair: an iterator reference to a
+ *   node and a port index.
+ *
+ * Canonical conversion of static specification to dynamic specification
+ * - The framework provides adapter class templates for static specification
+ *   nodes and edges.
+ * - The node and edge lists generate an array of adapter objects.
+ * - The port lists of nodes are already accessible by index.
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_LIBRARY_DYNAMIC_TO_DYNAMIC_REFERENCE_H
+#define TILEDB_FLOW_GRAPH_LIBRARY_DYNAMIC_TO_DYNAMIC_REFERENCE_H
+
+#include <concepts>
+#include <tuple>
+#include <vector>
+
+#include "../../general_factory.h"
+#include "../../system/execution_platform.h"
+#include "../../system/graph_dynamic_specification.h"
+#include "../../system/graph_static_specification.h"
+#include "../../system/graph_type.h"
+
+namespace tiledb::flow_graph {
+//-------------------------------------------------------
+// ToDynamicReference
+//-------------------------------------------------------
+/*
+ * The class template `ToDynamic` is a particular way of creating dynamic
+ * specifications from static specifications. Static specifications are complete
+ * about the topology of their graphs but are incomplete about the specific
+ * types involved. There are two particular ways in which static specifications
+ * are incomplete:
+ *   1. A node body in a static specification has an abstract I/O interface
+ *     to the graph as a whole. A node body requires a node services template
+ *     argument and itself is a template argument to a full node class.
+ *   2. An edge in a static specification has its connectivity information and
+ *     perhaps certain parameters, but not a specific edge class. The edge
+ *     information provides arguments to the edge constructor and to the graph
+ *     builder.
+ *
+ * Both kinds of information are left out of static specifications in service of
+ * a consistent system of data flow within the graph. This structure allows the
+ * separation of two important concerns:
+ *   1. What the graph does. This includes the behaviors of nodes, the graph
+ *     topology, and what data flows across edges.
+ *   2. How the data moves. This includes the classes for edges, classes for
+ *     ports, and how node bodies perform I/O on their ports.
+ *
+ * In order to accomplish this separation, the template argument of `ToDynamic`
+ * is a policy class that specifies all the parameters needed to construct an
+ * executable flow graph. This template argument is called an execution
+ * platform.
+ */
+namespace detail::to_dynamic {
+
+using nodes_size_type = size_t;
+using edges_size_type = size_t;
+using ports_size_type = size_t;
+
+/**
+ * The only required datum for an input port is the size of its flow type.
+ */
+class TDRInputPortSpecification {
+  size_t flow_type_size_;
+
+ public:
+  explicit TDRInputPortSpecification(size_t flow_type_size)
+      : flow_type_size_(flow_type_size) {
+  }
+};
+
+/*
+ * The only required datum for an output port is the size of its flow type.
+ */
+class TDROutputPortSpecification {
+  size_t flow_type_size_;
+
+ public:
+  explicit TDROutputPortSpecification(size_t flow_type_size)
+      : flow_type_size_(flow_type_size) {
+  }
+};
+
+/**
+ * A function declared to be used as a template argument for `GenericFactory`.
+ * This function has no arguments, so the factory uses the default constructor.
+ *
+ * The function is not defined and should not be referenced other than as a
+ * template argument to generic factories. In those templates it's only used
+ * for template argument deduction and not called.
+ */
+void node_factory_prototype();
+
+/**
+ * Node specification within ToDynamic.
+ *
+ * @tparam EP
+ */
+template <execution_platform EP>
+class TDRNodeSpecification {
+  std::vector<TDRInputPortSpecification> inputs_{};
+  std::vector<TDROutputPortSpecification> outputs_{};
+  ClassFactory<node_factory_prototype> factory_;
+  const ports_size_type inputs_size_;
+  const ports_size_type outputs_size_;
+  const size_t size_of_node_;
+
+ public:
+  template <class U>
+  using node_body_type =
+      EP::template node_body_adapter<U::template node_body_template>;
+
+  template <node_static_specification V>
+  explicit constexpr TDRNodeSpecification(const V& static_spec)
+      : inputs_size_{number_of_input_ports<V>}
+      , outputs_size_{number_of_output_ports<V>}
+      , factory_{ForClass<node_body_type<V>>}
+      , size_of_node_{sizeof(node_body_type<V>)} {
+    // Node factory
+
+    // Input ports
+    if constexpr (number_of_input_ports<V> > 0) {
+      [&static_spec]<std::size_t... I>(
+          std::vector<TDRInputPortSpecification>& inputs,
+          std::index_sequence<I...>) {
+        (inputs.emplace_back(TDRInputPortSpecification{
+             flow_size(std::get<I>(static_spec.input_ports))}),
+         ...);
+      }(inputs_, std::make_index_sequence<number_of_input_ports<V>>{});
+    }
+
+    // Output ports
+    if constexpr (number_of_output_ports<V> > 0) {
+      [&static_spec]<std::size_t... I>(
+          std::vector<TDROutputPortSpecification>& outputs,
+          std::index_sequence<I...>) {
+        (outputs.emplace_back(TDROutputPortSpecification{
+             flow_size(std::get<I>(static_spec.output_ports))}),
+         ...);
+      }(outputs_, std::make_index_sequence<number_of_output_ports<V>>{});
+    }
+  }
+
+  [[nodiscard]] constexpr ports_size_type inputs_size() const {
+    return inputs_size_;
+  }
+  [[nodiscard]] constexpr ports_size_type outputs_size() const {
+    return outputs_size_;
+  }
+  [[nodiscard]] const TDRInputPortSpecification* inputs() const {
+    return inputs_.data();
+  }
+  [[nodiscard]] const TDROutputPortSpecification* outputs() const {
+    return outputs_.data();
+  }
+  [[nodiscard]] constexpr size_t size_of_node() const {
+    return size_of_node_;
+  }
+  /**
+   * Precondition:
+   */
+  void make(void* p) const {
+    factory_.make(p);
+  }
+};
+
+template <class EP>
+class TDREdgeSpecification {
+  /*
+   * Obviously these initializations are wrong.
+   */
+  nodes_size_type tail_node_{0};
+  nodes_size_type head_node_{0};
+  ports_size_type tail_port_{0};
+  ports_size_type head_port_{0};
+
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_edge_dynamic_specification{true};
+  } invariants;
+  template <edge_static_specification T>
+  TDREdgeSpecification(size_t, const T&) {
+  }
+  [[nodiscard]] nodes_size_type tail_node() const {
+    return tail_node_;
+  }
+  [[nodiscard]] nodes_size_type head_node() const {
+    return head_node_;
+  }
+  [[nodiscard]] ports_size_type tail_port() const {
+    return tail_port_;
+  }
+  [[nodiscard]] ports_size_type head_port() const {
+    return head_port_;
+  }
+};
+
+}  // namespace detail::to_dynamic
+
+/**
+ * Adapter that presents a static specification graph as a dynamic one.
+ *
+ * Invariant: For all `graph_static_specification T`, `ToDynamic<T>` satisfies
+ * the concept `graph_dynamic_specification`.
+ *
+ * This is an early implementation. It does not attempt to avoid allocating and
+ * copying. For simplicity it uses `std::vector`. The main goal at the outset
+ * is to ensure that we have a graph construction discipline that passes through
+ * a dynamic specification that uses integral indices. Other goals are secondary
+ * at this stage.
+ *
+ * That said, all the data (indices, sizes, etc.) needed for a dynamic
+ * specification could be generated as `constexpr` and then presented in a way
+ * that satisfies the dynamic specification concept.
+ *
+ * @tparam G a static graph specification
+ * @tparam EP an execution platform
+ */
+template <graph_static_specification G, class EP>
+class ToDynamicReference {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_graph_dynamic_specification{true};
+  } invariants;
+
+  using execution_platform_type = EP;
+  using nodes_size_type = detail::to_dynamic::nodes_size_type;
+  using edges_size_type = detail::to_dynamic::edges_size_type;
+  using ports_size_type = detail::to_dynamic::ports_size_type;
+
+ private:
+  /*
+   * The user only references the components of a dynamic specification through
+   * the concept and types them using `auto`. Component classes don't
+   * need public-facing names. These aliases are private.
+   */
+  using node_type = detail::to_dynamic::TDRNodeSpecification<EP>;
+  using edge_spec = detail::to_dynamic::TDREdgeSpecification<EP>;
+
+  constexpr static auto nodes_size_{std::tuple_size_v<decltype(G::nodes)>};
+  constexpr static auto edges_size_{std::tuple_size_v<decltype(G::edges)>};
+  std::vector<node_type> nodes_{};
+  std::vector<edge_spec> edges_{};
+
+ public:
+  template <class... Args>
+  explicit constexpr ToDynamicReference(Args&&...) {
+    []<std::size_t... I>(
+        std::vector<node_type>& nodes, std::index_sequence<I...>) {
+      (nodes.emplace_back(node_type{std::get<I>(G::nodes)}), ...);
+    }(nodes_, std::make_index_sequence<nodes_size_>{});
+    []<std::size_t... I>(
+        std::vector<edge_spec>& edges, std::index_sequence<I...>) {
+      (edges.emplace_back(edge_spec{I, std::get<I>(G::edges)}), ...);
+    }(edges_, std::make_index_sequence<edges_size_>{});
+  }
+  [[nodiscard]] nodes_size_type nodes_size() const {
+    return nodes_size_;
+  }
+  [[nodiscard]] edges_size_type edges_size() const {
+    return edges_size_;
+  }
+  [[nodiscard]] const node_type* nodes() const {
+    return nodes_.data();
+  }
+  [[nodiscard]] const edge_spec* edges() const {
+    return edges_.data();
+  }
+
+  [[nodiscard]] EP::node_type make_node(nodes_size_type i) const {
+    return typename EP::node_type{i, nodes_[i]};
+  }
+
+  EP::edge_type make_edge(edges_size_type i) const {
+    return typename EP::edge_type{i, edges_[i]};
+  }
+};
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_LIBRARY_DYNAMIC_TO_DYNAMIC_REFERENCE_H

--- a/tiledb/flow_graph/library/graph/CMakeLists.txt
+++ b/tiledb/flow_graph/library/graph/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# flow_graph/library/graph/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#

--- a/tiledb/flow_graph/library/graph/flow_graph_reference.h
+++ b/tiledb/flow_graph/library/graph/flow_graph_reference.h
@@ -1,0 +1,169 @@
+/**
+ * @file flow_graph/basic/basic_graph.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_LIBRARY_GRAPH_FLOW_GRAPH_H
+#define TILEDB_FLOW_GRAPH_LIBRARY_GRAPH_FLOW_GRAPH_H
+
+#include <memory>
+#include <vector>
+
+#include "../../system/graph_dynamic_specification.h"
+
+namespace tiledb::flow_graph {
+/**
+ * The reference flow graph class.
+ *
+ * As a reference implementation, it's not meant to be optimal in any particular
+ * way. For example, it does not use allocated memory particularly efficiently.
+ * Because graphs are of variable size, we need to make at least one allocation.
+ * This class makes no effort to make effort to make exactly one allocation,
+ * which would require precomputing all the object sizes and offsets, allocating
+ * an internal pool with the total size, and constructing objects within the
+ * pool. Instead, each object is allocated separately.
+ *
+ * The constructor of this class relies on an execution platform with a
+ * particular construction and connection policy, specifically (a) to make nodes
+ * and edges first, and (b) to connect them after construction. If a reference
+ * implementation is desired for execution platforms with other policies, this
+ * can gain a constraint on its execution platform as derived from its template
+ * argument `G`.
+ *
+ * @tparam EP Execution platform class
+ */
+template <graph_dynamic_specification G>
+class FlowGraphReference {
+  using EP = G::execution_platform_type;
+
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_execution_graph{true};
+  } invariants;
+
+  /**
+   * The node type of this execution graph is that of its platform parameter.
+   */
+  using node_type = EP::node_type;
+  /**
+   * The edge type of this execution graph is that of its platform parameter.
+   */
+  using edge_type = EP::edge_type;
+  /**
+   * node_list_type must satisfy (future) concept `ExecutionNodeListType`
+   *
+   * `ExecutionNodeListType` means `size()` returns `nodes_size_type`
+   * `ExecutionNodeListType` means `operator[]` returns `ExecutionNodeType`
+   */
+  using node_list_type = std::vector<std::reference_wrapper<node_type>>;
+  /**
+   * edge_list_type must satisfy (future) concept `ExecutionEdgeListType`
+   *
+   * `ExecutionEdgeListType` means `size()` returns `edges_size_type`
+   * `ExecutionEdgeListType` means `operator[]` returns `ExecutionEdgeType`
+   */
+  using edge_list_type = std::vector<std::reference_wrapper<edge_type>>;
+
+ private:
+  std::vector<std::shared_ptr<node_type>> node_storage_{};
+  std::vector<std::reference_wrapper<node_type>> nodes_{};
+
+  std::vector<std::shared_ptr<edge_type>> edge_storage_{};
+  std::vector<std::reference_wrapper<edge_type>> edges_{};
+
+ public:
+  /**
+   * Ordinary constructor builds from a dynamic specification graph. Upon
+   * return, all nodes are in their initial state and all edges are empty.
+   *
+   * @tparam G A dynamic graph specification type
+   * @param g a graph specification
+   */
+  explicit FlowGraphReference(const G& g) {
+    // Note that all containers are initialized empty in their declarations.
+    const auto edges{g.edges()};
+    const typename G::nodes_size_type nn{g.nodes_size()};
+    const typename G::edges_size_type ne{g.edges_size()};
+    /*
+     * Create nodes. The node type has the responsibility for constructing a
+     * full execution node from its specification.
+     */
+    nodes_.reserve(nn);
+    for (typename G::nodes_size_type i = 0; i < nn; ++i) {
+      auto node_ptr{node_storage_.emplace_back(
+          std::make_shared<node_type>(g.make_node(i)))};
+      nodes_.emplace_back(std::ref(*node_ptr));
+    }
+    /*
+     * Create and connect edges. The edge type has the responsibility for
+     * constructing an execution edge from a specification. The platform has the
+     * responsibility for connecting it to ports according to its specification.
+     */
+    edges_.reserve(ne);
+    for (typename G::edges_size_type i = 0; i < ne; ++i) {
+      const auto e_spec{edges[i]};
+      const auto edge_ptr{edge_storage_.emplace_back(
+          std::make_shared<edge_type>(g.make_edge(i)))};
+      auto edge{edges_.emplace_back(std::ref(*edge_ptr))};
+
+      /*
+       * Needs edge data initialization for this not to crash. Can't index
+       * correctly into port lists without it.
+       */
+      /*
+      EP::connect_tail(
+          edge, nodes_[e_spec.tail_node()].get().outputs()[e_spec.tail_port()]);
+      EP::connect_head(
+          edge, nodes_[e_spec.head_node()].get().inputs()[e_spec.head_port()]);
+       */
+      /*
+       * Not doing it by passing containers and indices as arguments:
+       * ```
+       *   EP::connect_tail(??, i, e_spec.tail_node(), e_spec.tail_port());
+       *   EP::connect_head(??, i, e_spec.head_node(), e_spec.head_port());
+       * ```
+       * The problem is how to get a node list and an edge list into a
+       * platform-defined function. Regardless of how we might do it, it's
+       * injecting a type dependency into a platform function, which sets up a
+       * form of cyclic dependency. We're avoiding that issue entirely by
+       * passing object references.
+       */
+    }
+  }
+
+  [[nodiscard]] const node_list_type& nodes() const {
+    return nodes_;
+  }
+  [[nodiscard]] const edge_list_type& edges() const {
+    return edges_;
+  }
+};
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_LIBRARY_GRAPH_FLOW_GRAPH_H

--- a/tiledb/flow_graph/library/platform/CMakeLists.txt
+++ b/tiledb/flow_graph/library/platform/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# flow_graph/execution_platform/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#

--- a/tiledb/flow_graph/library/platform/basic_execution_platform.h
+++ b/tiledb/flow_graph/library/platform/basic_execution_platform.h
@@ -1,0 +1,467 @@
+/**
+ * @file flow_graph/library/basic/basic_execution_platform.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_BASIC_EXECUTION_PLATFORM_H
+#define TILEDB_FLOW_GRAPH_BASIC_EXECUTION_PLATFORM_H
+
+#include <memory>
+#include "../../system/edge_dynamic_specification.h"
+#include "../../system/node_body.h"
+#include "../../system/node_dynamic_specification.h"
+
+namespace tiledb::flow_graph {
+
+//-------------------------------------------------------
+// Type erasure in the graph construction process
+//-------------------------------------------------------
+/*
+ * Flow graphs have multiple types of data flowing across edges to multiple
+ * kinds of nodes. The behavior of a scheduler, however, does not depend upon
+ * these types. The scheduler depends upon the coroutine state of each node and
+ * and it depends on the I/O states of the nodes and edges. These states are
+ * independent of the flow types and individual nodes.
+ *
+ * Somewhere between the initial specification and final execution objects, all
+ * the types irrelevant to scheduling must be encapsulated and erased in the
+ * final objects. This flow graph system uses a few fundamental conventions:
+ *
+ * (1) Each specification object holds all the variation needed to construct an
+ * underlying execution object. It does this by providing factories for these
+ * objects.
+ *
+ * (2) Underlying objects are uniformly adaptable. The manifestation of this
+ * principle is that each underlying component (port, node, edge, etc.) satisfy
+ * an appropriate concept. Each adapter has a template argument of this concept
+ * type. A set of thin adapter classes provide a uniform interface to execution
+ * classes.
+ *
+ * (3) Constructors for execution objects take a specification object as an
+ * argument. Internally, these constructor call the specification factory,
+ * wrap it in an adapter, and store the wrapped underlying object as a member
+ * variable.
+ *
+ * The end result of this is that a single scheduler class can control multiple
+ * different graphs. If this were not the case, schedulers would have to be
+ * compiled with at least some of the type variation present in the
+ * specification. This would lead to object code bloat, as there would be a
+ * compiled scheduler for each graph.
+ */
+
+//-------------------------------------------------------
+// Execution Platform
+//-------------------------------------------------------
+/*
+ * A execution platform consists of all elements necessary to instantiate nodes
+ * and graphs from their specifications.
+ *
+ * The essence of a graph are its nodes and the topology of their connections.
+ * This skeleton, however, needs to be fleshed out with all the supporting
+ * classes that perform the generic parts of flow graph execution. The design
+ * decision is to define these parts uniformly across a graph. Thus, for
+ * example, all edges derive from the same class template.
+ *
+ * An alternative might allow variation in platform classes, say, having
+ * different edges of different types. While this is technically possible, it
+ * makes writing schedulers to deal with such non-uniformity far more difficult.
+ * Furthermore, allowing such variety has a strong tendency toward object code
+ * bloat as scheduling code is duplicated for each graph that's executed.
+ *
+ * The node and edge classes in an execution platform cannot all be C.41
+ * compliant. Consider a node and an edge that are connected. Either the node
+ * constructor or edge constructor must run first. An object cannot be fully
+ * initialized before it's connected, and it can't be connected before the
+ * object it's being connected to exists. Thus at least one of these classes
+ * can't be C.41 compliant.
+ *
+ * Given this situation, there are three kinds of platform conventions around
+ * construction.
+ *   1. Construct nodes and edges independently and connect them with explicit
+ *     function calls.
+ *   2. Construct nodes first. Pass a pair of node references or identifiers to
+ *     edge constructors.
+ *   3. Construct edges first. Pass a list of edge references or identifiers to
+ *     node constructors.
+ * The graph constructor and the platform must use the same convention.
+ *
+ * The initial versions of the  classes `BasicExecutionPlatform` and `FlowGraph`
+ * implement the first convention. This design selection is somewhat arbitrary;
+ * any of these could be made to work. The decision was to pick the one with the
+ * clearest code and the simplest declarations.
+ */
+
+//-------------------------------------------------------
+// BasicExecutionPlatform
+//-------------------------------------------------------
+namespace basic_execution_parameter {
+using nodes_size_type = size_t;
+using edges_size_type = size_t;
+using ports_size_type = size_t;
+};  // namespace basic_execution_parameter
+
+// Forward declaration enables friend class declarations.
+class BasicExecutionPlatform;
+
+/**
+ * Maturity Note: This class does not execute. It's only function at present is
+ * to exercise the graph construction regime. It captures topological
+ * information in order to test that graph topology passes faithfully from
+ * specification to execution.
+ */
+class BasicExecutionInputPort {
+  friend class BasicExecutionPlatform;
+
+  /**
+   * The index of the node containing this port.
+   *
+   * The index is into the node list within the execution graph that contains
+   * the node that contains this port. It's initialized at construction by the
+   * node constructor.
+   */
+  basic_execution_parameter::nodes_size_type node_index_;
+
+  /**
+   * The index of this port within its node.
+   *
+   * The index is into the port list within the execution node that contains
+   * this port. It's initialized at construction by the node constructor.
+   */
+  basic_execution_parameter::ports_size_type port_index_;
+
+  /**
+   * The index of the edge whose head is attached to this port.
+   *
+   * The index is into the edge list within the execution graph that contains
+   * the node that contains this port. It's initialized during graph
+   * construction immediately upon construction of the edge.
+   */
+  basic_execution_parameter::edges_size_type edge_index_;
+
+ public:
+  template <input_port_dynamic_specification T>
+  explicit BasicExecutionInputPort(
+      basic_execution_parameter::nodes_size_type node_index,
+      basic_execution_parameter::ports_size_type port_index,
+      const T&)
+      : node_index_(node_index)
+      , port_index_(port_index)
+      , edge_index_(std::numeric_limits<decltype(edge_index_)>::max()){};
+
+  [[nodiscard]] decltype(node_index_) node_index() const {
+    return node_index_;
+  }
+  [[nodiscard]] decltype(edge_index_) edge_index() const {
+    return edge_index_;
+  }
+};
+
+/**
+ * Maturity Note: This class does not execute. It's only function at present is
+ * to exercise the graph construction regime. It captures topological
+ * information in order to test that graph topology passes faithfully from
+ * specification to execution.
+ */
+class BasicExecutionOutputPort {
+  friend class BasicExecutionPlatform;
+
+  /**
+   * The index of the node containing this port.
+   *
+   * The index is into the node list within the execution graph that contains
+   * the node that contains this port. It's initialized at construction by the
+   * node constructor.
+   */
+  basic_execution_parameter::nodes_size_type node_index_;
+
+  /**
+   * The index of this port within its node.
+   *
+   * The index is into the port list within the execution node that contains
+   * this port. It's initialized at construction by the node constructor.
+   */
+  basic_execution_parameter::ports_size_type port_index_;
+
+  /**
+   * The index of the edge whose head is attached to this port.
+   *
+   * The index is into the edge list within the execution graph that contains
+   * the node that contains this port. It's initialized during graph
+   * construction immediately upon construction of the edge.
+   */
+  basic_execution_parameter::edges_size_type edge_index_;
+
+ public:
+  template <output_port_dynamic_specification T>
+  explicit BasicExecutionOutputPort(
+      basic_execution_parameter::nodes_size_type node_index,
+      basic_execution_parameter::ports_size_type port_index,
+      const T&)
+      : node_index_(node_index)
+      , port_index_(port_index)
+      , edge_index_(std::numeric_limits<decltype(edge_index_)>::max()){};
+
+  [[nodiscard]] decltype(node_index_) node_index() const {
+    return node_index_;
+  }
+  [[nodiscard]] decltype(edge_index_) edge_index() const {
+    return edge_index_;
+  }
+};
+
+/**
+ * This nody body class is the nexus for type erasure of node specifications.
+ *
+ * All node bodies need to derive from this base or be adapted to it with some
+ * standard adapter. It's the responsibility of a dynamic specification to use
+ * an adapter if needed.
+ */
+class BasicExecutionNodeBody {
+ public:
+  virtual ~BasicExecutionNodeBody() = default;
+  /**
+   * Coroutine-style body function. This signature is a placeholder for the
+   * actual one we'll use in the future.
+   */
+  virtual void operator()() {
+  }
+};
+
+template <template <class> class T>
+  requires node_body<T>
+class BasicExecutionNodeBodyAdapter;
+
+/**
+ * Adapter for trivially destructible node bodies.
+ *
+ * @tparam T
+ */
+template <template <class> class T>
+  requires execution::node_body_trivially_destructible<T>
+class BasicExecutionNodeBodyAdapter<T> : public BasicExecutionNodeBody {
+ public:
+  BasicExecutionNodeBodyAdapter() = default;
+  /**
+   * Destructor doesn't need to do anything because it's adapting a class with
+   * a trivial destructor.
+   */
+  ~BasicExecutionNodeBodyAdapter() = default;
+};
+
+/**
+ * Adapter for node bodies with a virtual destructor.
+ * NOT YET IMPLEMENTED
+ *
+ * @tparam T
+ */
+template <template <class> class T>
+  requires execution::node_body_with_virtual_destructor<T>
+class BasicExecutionNodeBodyAdapter<T> : public BasicExecutionNodeBody {};
+
+/**
+ * The execution node within `BasicExecutionPlatform`.
+ *
+ * This class is not C.41-compliant in isolation. It's a component class of
+ * `BasicExecutionPlatform` and needs to be constructed accordingly.
+ * Specifically, an instance of this class has unconnected ports upon
+ * construction. Unconnected ports are inoperable and not fully initialized.
+ * Connecting an edge to a port completes the initialization of that port
+ * object. Initializing all ports within an instance of this class completes the
+ * initialization of the node object.
+ *
+ * Maturity Note: This version only deals with construction order. It does not
+ * even begin to implement anything about the actual I/O system.
+ */
+class BasicExecutionNode {
+  friend class BasicExecutionPlatform;
+
+  /**
+   * The index of the node within its graph.
+   *
+   * The index is into the node list within the execution graph that contains
+   * this node. It's initialized at construction by the node constructor.
+   */
+  basic_execution_parameter::nodes_size_type node_index_;
+
+ public:
+  using input_list_type =
+      std::vector<std::reference_wrapper<BasicExecutionInputPort>>;
+  using output_list_type =
+      std::vector<std::reference_wrapper<BasicExecutionOutputPort>>;
+
+ private:
+  input_list_type inputs_{};
+  output_list_type outputs_{};
+
+  /**
+   * Storage for a node body is typed as a byte array that can be default
+   * initialized for overwrite by the actual object.
+   */
+  std::shared_ptr<std::byte[]> node_body_ptr_;
+
+  /**
+   * Reference to the node body is an interpretation of the raw storage in
+   * `node_body_ptr` as a typed object.
+   */
+  BasicExecutionNodeBody& node_body_;
+
+ public:
+  template <node_dynamic_specification T>
+  explicit BasicExecutionNode(
+      basic_execution_parameter::nodes_size_type, const T& node_spec)
+      : node_body_ptr_{std::make_shared_for_overwrite<std::byte[]>(
+            node_spec.size_of_node())}
+      // Caveat: node_body_ is not valid until after the factory returns
+      , node_body_(
+            *reinterpret_cast<BasicExecutionNodeBody*>(node_body_ptr_.get())) {
+    /*
+     * Construct the node body in the place allocated for it.
+     */
+    node_spec.make(&node_body_);
+  }
+
+  ~BasicExecutionNode() {
+    /*
+     * We must explicitly call the `node_body_` destructor because there's
+     * nothing declared that will call it implicitly.
+     */
+    node_body_.~BasicExecutionNodeBody();
+  }
+
+  [[nodiscard]] const input_list_type& inputs() const {
+    return inputs_;
+  }
+  [[nodiscard]] const output_list_type& outputs() const {
+    return outputs_;
+  }
+};
+
+/**
+ * Node services class of the basic execution platform
+ *
+ * Maturity Note: This class does not have anything. All it needs to do for the
+ * moment is exist.
+ */
+class BasicExecutionNodeServices {};
+
+/**
+ * The execution edge within `BasicExecutionPlatform`.
+ *
+ * This class is not C.41-compliant in isolation. It's a component class of
+ * `BasicExecutionPlatform` and needs to be constructed accordingly.
+ * Specifically, an instance of this class has an unconnected head and an
+ * unconnected tail upon construction. The head and tail are inoperable and the
+ * edge is not fully initialized. Connecting the head to an input port and the
+ * tail to an output port completes the initialization of the edge.
+ */
+class BasicExecutionEdge {
+  friend class BasicExecutionPlatform;
+
+  /**
+   * The index of the edge within its graph.
+   *
+   * The index is into the edge list within the execution graph that this edge.
+   * It's initialized at construction.
+   */
+  basic_execution_parameter::edges_size_type edge_index_;
+
+  /**
+   * The index of the node containing the port connected to the tail of this
+   * edge.
+   *
+   * The index is into the node list within the execution graph that contains
+   * this edge. It's initialized after construction.
+   */
+  basic_execution_parameter::nodes_size_type tail_node_index_;
+
+  /**
+   * The index of the port within the tail node.
+   *
+   * The index is into the port list of the tail node. It's initialized after
+   * construction.
+   */
+  basic_execution_parameter::ports_size_type tail_port_index_;
+
+  /**
+   * The index of the node containing the port connected to the head of this
+   * edge.
+   *
+   * The index is into the node list within the execution graph that contains
+   * this edge. It's initialized after construction.
+   */
+  basic_execution_parameter::nodes_size_type head_node_index_;
+
+  /**
+   * The index of the port within the head node.
+   *
+   * The index is into the port list of the head node. It's initialized after
+   * construction.
+   */
+  basic_execution_parameter::ports_size_type head_port_index_;
+
+ public:
+  template <edge_dynamic_specification T>
+  explicit BasicExecutionEdge(
+      basic_execution_parameter::edges_size_type edge_index, const T&)
+      : edge_index_(edge_index) {
+  }
+
+  [[nodiscard]] basic_execution_parameter::edges_size_type edge_index() const {
+    return edge_index_;
+  }
+};
+
+/**
+ * The basic execution platform is a reference implementation of the execution
+ * platform concept.
+ *
+ * The `connect_head` and `connect_tail` functions are defined in the platform,
+ * rather than in a graph component, in order to allow a platform to remain
+ * agnostic about how the connection is made. It might be a member function
+ * either on the edge or the port, or it might operate directly on the edge and
+ * port simultaneously.
+ */
+class BasicExecutionPlatform {
+ public:
+  using node_type = BasicExecutionNode;
+  template <template <class> class T>
+    requires node_body<T>
+  using node_body_adapter = BasicExecutionNodeBodyAdapter<T>;
+  using node_services_type = BasicExecutionNodeServices;
+  using edge_type = BasicExecutionEdge;
+  template <class Edge, class Port>
+  static void connect_head(Edge&, Port&) {
+  }
+  template <class Edge, class Port>
+  static void connect_tail(Edge&, Port&) {
+  }
+};
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_BASIC_EXECUTION_PLATFORM_H

--- a/tiledb/flow_graph/library/platform/minimal_execution_platform.h
+++ b/tiledb/flow_graph/library/platform/minimal_execution_platform.h
@@ -1,0 +1,48 @@
+/**
+ * @file flow_graph/library/basic/basic_execution_platform.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_MINIMAL_EXECUTION_PLATFORM_H
+#define TILEDB_FLOW_GRAPH_MINIMAL_EXECUTION_PLATFORM_H
+
+#include "basic_execution_platform.h"
+
+namespace tiledb::flow_graph {
+
+/**
+ * The minimal execution platform provides a placeholder for concept checking.
+ *
+ * Maturity Note: As is obvious from the definition, this definition is not
+ * yet minimal.
+ */
+using MinimalExecutionPlatform = BasicExecutionPlatform;
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_MINIMAL_EXECUTION_PLATFORM_H

--- a/tiledb/flow_graph/library/scheduler/CMakeLists.txt
+++ b/tiledb/flow_graph/library/scheduler/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# flow_graph/library/scheduler/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#

--- a/tiledb/flow_graph/library/static/CMakeLists.txt
+++ b/tiledb/flow_graph/library/static/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# flow_graph/library/static/test/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+add_test_subdirectory()

--- a/tiledb/flow_graph/library/static/bit_bucket.h
+++ b/tiledb/flow_graph/library/static/bit_bucket.h
@@ -1,0 +1,85 @@
+/**
+ * @file flow_graph/library/nodes/bit_bucket.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION A bit bucket node that discards all inflowing data
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_BIT_BUCKET_H
+#define TILEDB_FLOW_GRAPH_BIT_BUCKET_H
+
+#include "../../node.h"
+
+namespace tiledb::flow_graph::library {
+
+template <class T, node_services NS>
+class BitBucket {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_body = true;
+  } invariants;
+  class InputPort {
+  } input;
+  void operator()() {
+  }
+};
+
+template <class T>
+class BitBucketInputPortSpecification {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_input_port_static_specification{true};
+  } invariants;
+  using flow_type = T;
+};
+
+template <class T>
+struct BitBucketSpecification {
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_static_specification = true;
+  } invariants;
+  static constexpr BitBucketInputPortSpecification<T> input;
+  static constexpr std::tuple input_ports{input};
+  static constexpr std::tuple output_ports{};
+  BitBucketSpecification() = default;
+  template <node_services NS>
+  using node_body_template = BitBucket<T, NS>;
+};
+
+namespace {
+class Opaque;  // placeholder for an arbitrary and unknown flow type
+}
+static_assert(
+    node_body<BitBucketSpecification<Opaque>::node_body_template>,
+    "`BitBucket` is supposed to be node body");
+
+static_assert(
+    node_static_specification<BitBucketSpecification<Opaque>>,
+    "`BitBucketSpecification` is supposed to be a node specification");
+
+}  // namespace tiledb::flow_graph::library
+
+#endif  // TILEDB_FLOW_GRAPH_BIT_BUCKET_H

--- a/tiledb/flow_graph/library/static/dummy.h
+++ b/tiledb/flow_graph/library/static/dummy.h
@@ -1,0 +1,208 @@
+/**
+ * @file flow_graph/library/dummy/dummy.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_DUMMY_H
+#define TILEDB_FLOW_GRAPH_DUMMY_H
+
+#include "../../node.h"
+
+namespace tiledb::flow_graph {
+
+//----------------------------------
+// Ports
+//----------------------------------
+template <class T>
+class DummyOutputPortSpecification {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_output_port_static_specification{true};
+  } invariants;
+  using flow_type = T;
+};
+
+template <class T>
+class DummyInputPortSpecification {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_input_port_static_specification{true};
+  } invariants;
+  using flow_type = T;
+};
+
+//----------------------------------
+// Node State
+//----------------------------------
+/**
+ * Dummy specification nodes would ordinarily have no storage, because they
+ * don't do anything and thus don't have internal state. Static specification
+ * nodes may be `constexpr` and need something to distinguish them in order to
+ * implement `operator==`. This class is a placeholder with "state" that does
+ * nothing, but requires objects of this class to have different addresses. This
+ * allows implementing `operator==` with an address equality.
+ */
+class DummyNodeState {
+  [[maybe_unused]] bool useless_{false};
+
+ public:
+  DummyNodeState() = default;
+};
+
+//----------------------------------
+// Output Node
+//----------------------------------
+/**
+ * The dummy output node has a single output node of the designated type.
+ *
+ * @tparam T flow type of the output port
+ */
+template <class T, node_services NS>
+class DummyOutputNode {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_body{true};
+  } invariants;
+  void operator()(){};
+};
+
+/**
+ * Regular specification for the dummy output Node.
+ *
+ * @tparam T flow type of the output port
+ */
+template <class T>
+class DummyOutputNodeSpecification {
+  using self = DummyOutputNodeSpecification;
+  [[maybe_unused]] DummyNodeState unused_;
+
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_static_specification{true};
+  } invariants;
+  static constexpr DummyOutputPortSpecification<T> output{};
+  static constexpr reference_tuple input_ports{};
+  static constexpr reference_tuple output_ports{output};
+  template <node_services NS>
+  using node_body_template = DummyOutputNode<T, NS>;
+};
+
+//----------------------------------
+// Input Node
+//----------------------------------
+/**
+ * The dummy output node has a single output node of the designated type.
+ *
+ * @tparam T flow type of the output port
+ */
+template <class T, node_services NS>
+class DummyInputNode {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_body{true};
+  } invariants;
+  void operator()(){};
+};
+
+/**
+ * Regular specification for the dummy output Node.
+ *
+ * @tparam T flow type of the output port
+ */
+template <class T>
+class DummyInputNodeSpecification {
+  using self = DummyInputNodeSpecification;
+  [[maybe_unused]] DummyNodeState unused_;
+
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_static_specification{true};
+  } invariants;
+  static constexpr DummyInputPortSpecification<T> input{};
+  static constexpr reference_tuple input_ports{input};
+  static constexpr reference_tuple output_ports{};
+  template <node_services NS>
+  using node_body_template = DummyInputNode<T, NS>;
+};
+
+//----------------------------------
+// Edge
+//----------------------------------
+/**
+ * Edge from node reference and port reference
+ *
+ * @tparam TailNode The type of the tail node
+ * @tparam TailPort The type of an output port
+ * @tparam HeadNode The type of the head node
+ * @tparam HeadPort The type of an input port
+ */
+template <class TailNode, class TailPort, class HeadNode, class HeadPort>
+class DummyEdgeSpecification {
+  using self = DummyEdgeSpecification;
+
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_edge_static_specification{true};
+  } invariants;
+  const TailNode& tail_node;
+  const TailPort& tail_port;
+  const HeadNode& head_node;
+  const HeadPort& head_port;
+  using tail_node_type = TailNode;
+  using tail_port_type = TailPort;
+  using head_node_type = HeadNode;
+  using head_port_type = HeadPort;
+  constexpr DummyEdgeSpecification(
+      const TailNode& tn,
+      const TailPort& tp,
+      const HeadNode& hn,
+      const HeadPort& hp)
+      : tail_node{tn}
+      , tail_port{tp}
+      , head_node{hn}
+      , head_port{hp} {
+  }
+};
+template <
+    class TailNode,
+    class TailPortPointer,
+    class HeadNode,
+    class HeadPortPointer>
+DummyEdgeSpecification(
+    const TailNode&,
+    const TailPortPointer&,
+    const HeadNode&,
+    const HeadPortPointer&)
+    -> DummyEdgeSpecification<
+        TailNode,
+        TailPortPointer,
+        HeadNode,
+        HeadPortPointer>;
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_DUMMY_H

--- a/tiledb/flow_graph/library/static/single_element_generator.h
+++ b/tiledb/flow_graph/library/static/single_element_generator.h
@@ -1,0 +1,59 @@
+//
+// Created by EH on 4/27/2023.
+//
+
+#ifndef TILEDB_SINGLE_ELEMENT_GENERATOR_H
+#define TILEDB_SINGLE_ELEMENT_GENERATOR_H
+
+#include "../../node.h"
+
+namespace tiledb::flow_graph::library {
+
+/*
+ * This class is named "single element generator". What's here at present is
+ * hard-coded to a monostate, a type that can only be default-constructed. That
+ * may be all that's needed for such a test class. It may also be desirable to
+ * specify a type and constructor arguments if needed.
+ */
+
+template <node_services NS>
+class SingleMonostateGenerator {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_body = true;
+  } invariants;
+  class OutputPort {
+  } output;
+  void operator()(){};
+};
+
+class MonostateOutputPortSpecification {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_output_port_static_specification{true};
+  } invariants;
+  using flow_type = std::monostate;
+};
+
+struct SingleMonostateGeneratorSpecification {
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_static_specification = true;
+  } invariants;
+  SingleMonostateGeneratorSpecification() = default;
+  static constexpr MonostateOutputPortSpecification output;
+  static constexpr std::tuple input_ports{};
+  static constexpr std::tuple output_ports{output};
+  template <node_services NS>
+  using node_body_template = SingleMonostateGenerator<NS>;
+};
+
+static_assert(
+    node_body<SingleMonostateGenerator>,
+    "SingleMonostateGenerator is supposed to be an execution node");
+static_assert(
+    node_static_specification<SingleMonostateGeneratorSpecification>,
+    "SingleMonostateGeneratorSpecification is supposed to be a specification "
+    "node");
+
+}  // namespace tiledb::flow_graph::library
+#endif  // TILEDB_SINGLE_ELEMENT_GENERATOR_H

--- a/tiledb/flow_graph/library/static/static_zero_graph.h
+++ b/tiledb/flow_graph/library/static/static_zero_graph.h
@@ -1,0 +1,54 @@
+/**
+ * @file flow_graph/test/zero_graph.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_STATIC_ZERO_GRAPH_H
+#define TILEDB_FLOW_GRAPH_STATIC_ZERO_GRAPH_H
+
+#include "../../graph.h"
+
+namespace tiledb::flow_graph::static_specification {
+
+/**
+ * The zero graph has no nodes and no edges. It's a valid graph, and we want to
+ * ensure that the flow graph system supports it.
+ */
+class ZeroGraph {
+ public:
+  constexpr static struct invariant_type {
+    constexpr static bool i_am_graph_static_specification{true};
+  } invariants;
+  constexpr static reference_tuple nodes{};
+  constexpr static std::tuple edges{};
+};
+static_assert(graph_static_specification<ZeroGraph>);
+
+}  // namespace tiledb::flow_graph::test
+
+#endif

--- a/tiledb/flow_graph/library/static/test/CMakeLists.txt
+++ b/tiledb/flow_graph/library/static/test/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# flow_graph/library/static/test/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# @section Description
+#
+# The dummy library consists of flow graph elements that don't do anything.
+# * Coroutines start off in the "completed" state.
+# * Output ports never produce any data.
+# * Input ports never consume any data nor ask for data.
+# * Edges don't move any data.
+#
+# In every other way the elements are well behaved. This library is targeted for
+# testing, principally the construction of specification graphs. A graph
+# composed entirely of dummies should immediately terminate when executed.
+#
+include(unit_test)
+commence(unit_test fgl_static)
+  this_target_sources(main.cc test_dummy.cc)
+conclude(unit_test)

--- a/tiledb/flow_graph/library/static/test/main.cc
+++ b/tiledb/flow_graph/library/static/test/main.cc
@@ -1,0 +1,62 @@
+/**
+ * @file flow_graph/library/static/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "tdb_catch.h"
+
+//---------------------
+// Nodes not yet tested elsewhere
+//---------------------
+/*
+ * The bit bucket and the single element generator are test nodes. They're not
+ * really used in any tests yet. Their headers are included here to ensure they
+ * continue to compile as the code evolves. The tests only check construction.
+ */
+#include "../../../system/node_services.h"  // for MinimalNodeServices
+#include "../bit_bucket.h"
+#include "../single_element_generator.h"
+
+using namespace tiledb::flow_graph::library;
+using MNS = tiledb::flow_graph::execution::MinimalNodeServices;
+
+TEST_CASE("library bit_bucket, instances") {
+  [[maybe_unused]] BitBucketSpecification<void> bbs{};
+  [[maybe_unused]] BitBucketInputPortSpecification<void> bbips{};
+  [[maybe_unused]] BitBucket<void, MNS> bb{};
+}
+
+TEST_CASE("library single monostate generator, instances") {
+  [[maybe_unused]] SingleMonostateGeneratorSpecification smgs{};
+  [[maybe_unused]] MonostateOutputPortSpecification mops{};
+  [[maybe_unused]] SingleMonostateGenerator<MNS> smg{};
+}
+
+//----------------------------------
+//-------------------------------------------------------

--- a/tiledb/flow_graph/library/static/test/test_dummy.cc
+++ b/tiledb/flow_graph/library/static/test/test_dummy.cc
@@ -1,0 +1,211 @@
+/**
+ * @file flow_graph/library/dummy/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <variant>  // for std::monostate
+
+#include "tdb_catch.h"
+
+#include "../../../system/edge_static_specification.h"
+#include "../dummy.h"
+
+using namespace tiledb::flow_graph;
+
+//----------------------------------
+// Test types
+//----------------------------------
+/*
+ * We want to ensure that graph elements instantiate correctly with all kinds
+ * of types that might be encountered:
+ * - `std::monostate` (similar semantics as `void`)
+ * - intrinsic: int, char, float
+ * - class, union
+ *   - with various constructibilities
+ */
+class TestFlowTypeClassDefaultConstructible {
+  int x_{};
+
+ public:
+  TestFlowTypeClassDefaultConstructible() = default;
+};
+class TestFlowTypeClassPrivateConstructible {
+  int x_{};
+  TestFlowTypeClassPrivateConstructible() = default;
+};
+class TestFlowTypeClassNotDefaultConstructible {
+  int x_;
+
+ public:
+  TestFlowTypeClassNotDefaultConstructible() = delete;
+};
+union TestFlowTypeUnionDefaultConstructible {
+ public:
+  std::monostate x_;
+  [[maybe_unused]] int y_;
+  TestFlowTypeUnionDefaultConstructible() = default;
+};
+union TestFlowTypeUnionPrivateConstructible {
+  TestFlowTypeUnionPrivateConstructible() = default;
+
+ public:
+  std::monostate x_;
+  [[maybe_unused]] int y_;
+};
+union TestFlowTypeUnionNotDefaultConstructible {
+ public:
+  std::monostate x_;
+  [[maybe_unused]] int y_;
+  TestFlowTypeUnionNotDefaultConstructible() = delete;
+};
+
+/**
+ * Type list for checking that ports and nodes may be instantiated with
+ * arbitrary types.
+ */
+using FlowTypes = std::tuple<
+    std::monostate,
+    int,
+    char,
+    float,
+    TestFlowTypeClassDefaultConstructible,
+    TestFlowTypeClassPrivateConstructible,
+    TestFlowTypeClassNotDefaultConstructible,
+    TestFlowTypeUnionDefaultConstructible,
+    TestFlowTypeUnionPrivateConstructible,
+    TestFlowTypeUnionNotDefaultConstructible>;
+/*
+ * Note: We test the dummy elements with `void` and the type list separately. We
+ * don't expect actually functioning nodes to instantiate with `void`, but the
+ * dummies are fine with it.
+ */
+
+//----------------------------------
+// Output Port
+//----------------------------------
+TEST_CASE("dummy output port instance, void", "[fgl][dummy]") {
+  static_assert(
+      output_port_static_specification<DummyOutputPortSpecification<void>>,
+      "It's supposed to be a specification node");
+  (void)DummyOutputPortSpecification<void>{};
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy output port instance, type list", "[fgl][dummy]", FlowTypes) {
+  static_assert(
+      output_port_static_specification<DummyOutputPortSpecification<TestType>>,
+      "It's supposed to be a specification node");
+  (void)DummyOutputPortSpecification<TestType>{};
+}
+
+//----------------------------------
+// Input Port
+//----------------------------------
+TEST_CASE("dummy input port instance, void", "[fgl][dummy]") {
+  static_assert(
+      input_port_static_specification<DummyInputPortSpecification<void>>,
+      "It's supposed to be a specification node");
+  (void)DummyInputPortSpecification<void>{};
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy input port instance, type list", "[fgl][dummy]", FlowTypes) {
+  static_assert(
+      input_port_static_specification<DummyInputPortSpecification<TestType>>,
+      "It's supposed to be a specification node");
+  (void)DummyInputPortSpecification<TestType>{};
+}
+
+//----------------------------------
+// Output Node
+//----------------------------------
+TEST_CASE("dummy output node instance, void", "[fgl][dummy]") {
+  (void)DummyOutputNodeSpecification<void>{};
+  static_assert(
+      node_static_specification<DummyOutputNodeSpecification<void>>,
+      "It's supposed to be a specification node");
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy output node instance, type list", "[fgl][dummy]", FlowTypes) {
+  static_assert(
+      node_static_specification<DummyOutputNodeSpecification<TestType>>,
+      "It's supposed to be a specification node");
+  (void)DummyOutputNodeSpecification<TestType>{};
+}
+
+//----------------------------------
+// Input Node
+//----------------------------------
+TEST_CASE("dummy input node instance, void", "[fgl][dummy]") {
+  static_assert(
+      node_static_specification<DummyInputNodeSpecification<void>>,
+      "It's supposed to be a specification node");
+  (void)DummyInputNodeSpecification<void>{};
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy input node instance, type list", "[fgl][dummy]", FlowTypes) {
+  static_assert(
+      node_static_specification<DummyInputNodeSpecification<TestType>>,
+      "It's supposed to be a specification node");
+  (void)DummyInputNodeSpecification<TestType>{};
+}
+
+//----------------------------------
+// Edge
+//----------------------------------
+TEST_CASE("dummy edge instance, void", "[fgl][dummy]") {
+  DummyOutputNodeSpecification<void> a{};
+  DummyInputNodeSpecification<void> b{};
+
+  static_specification::validator<DummyEdgeSpecification<
+      DummyOutputNodeSpecification<void>,
+      DummyOutputPortSpecification<void>,
+      DummyInputNodeSpecification<void>,
+      DummyInputPortSpecification<void>>>();
+  static_assert(
+      edge_static_specification<DummyEdgeSpecification<
+          DummyOutputNodeSpecification<void>,
+          DummyOutputPortSpecification<void>,
+          DummyInputNodeSpecification<void>,
+          DummyInputPortSpecification<void>>>,
+      "It's supposed to be a specification edge");
+  // Construct with fully qualified type
+  (void)DummyEdgeSpecification<
+      DummyOutputNodeSpecification<void>,
+      DummyOutputPortSpecification<void>,
+      DummyInputNodeSpecification<void>,
+      DummyInputPortSpecification<void>>{a, a.output, b, b.input};
+  // Construct with user-defined deduction guide
+  (void)DummyEdgeSpecification{a, a.output, b, b.input};
+}
+
+//---------------------
+//----------------------------------
+//-------------------------------------------------------

--- a/tiledb/flow_graph/node.h
+++ b/tiledb/flow_graph/node.h
@@ -1,0 +1,45 @@
+/**
+ * @file flow_graph/node_body.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Everything an ordinary user needs to define nodes in
+ * a flow graph.
+ */
+
+/*
+ * TODO: rename to "node.h" and adjust .md
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_NODE_BODY_H
+#define TILEDB_FLOW_GRAPH_NODE_BODY_H
+
+#include "system/node_static_specification.h"
+
+namespace tiledb::flow_graph {
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_NODE_BODY_H

--- a/tiledb/flow_graph/system.h
+++ b/tiledb/flow_graph/system.h
@@ -1,0 +1,61 @@
+/**
+ * @file flow_graph/flow_graph.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_FLOW_GRAPH_H
+#define TILEDB_FLOW_GRAPH_FLOW_GRAPH_H
+
+#include "library/dynamic/to_dynamic_reference.h"
+#include "library/graph/flow_graph_reference.h"
+#include "library/platform/basic_execution_platform.h"
+#include "system/flow_graph_system.h"
+
+namespace tiledb::flow_graph {
+
+/**
+ * A reference system that consists of all the reference implementations.
+ */
+struct ReferenceSystem {
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_flow_graph_system{true};
+  } invariants;
+
+  template <graph_static_specification GSS, execution_platform EP>
+  using static_to_dynamic_transformer = ToDynamicReference<GSS, EP>;
+
+  using execution_platform = BasicExecutionPlatform;
+
+  template <graph_dynamic_specification GDS>
+  using dynamic_to_execution_transformer = FlowGraphReference<GDS>;
+};
+static_assert(flow_graph_system<ReferenceSystem>);
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_FLOW_GRAPH_H

--- a/tiledb/flow_graph/system/discrete_coroutine.h
+++ b/tiledb/flow_graph/system/discrete_coroutine.h
@@ -1,0 +1,41 @@
+/**
+ * @file flow_graph/discrete_coroutine.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_DISCRETE_COROUTINE
+#define TILEDB_FLOW_GRAPH_DISCRETE_COROUTINE
+
+/**
+ * Stub implementation of a discrete coroutine class. All it requires for now
+ * is that `operator()` be defined, and not with any particular signature.
+ */
+template <class T>
+concept discrete_coroutine = requires(T x) { x(); };
+
+#endif  // TILEDB_FLOW_GRAPH_DISCRETE_COROUTINE

--- a/tiledb/flow_graph/system/edge_dynamic_specification.h
+++ b/tiledb/flow_graph/system/edge_dynamic_specification.h
@@ -1,0 +1,69 @@
+/**
+ * @file flow_graph/system/edge_dynamic_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_EDGE_DYNAMIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_EDGE_DYNAMIC_SPECIFICATION_H
+
+#include "graph_type.h"
+#include "tiledb/flow_graph/system/node_dynamic_specification.h"
+#include "tiledb/flow_graph/system/port_dynamic_specification.h"
+
+namespace tiledb::flow_graph::dynamic_specification {
+/**
+ * The class declares itself as an edge static specification.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept self_declared_as_edge_dynamic_specification =
+    requires(T x) { x.invariants.i_am_edge_dynamic_specification; };
+
+
+/**
+ * Stub for a future edge dynamic specification
+ *
+ * @tparam T a potential edge dynamic specification class
+ */
+template <class T>
+concept edge = self_declared_as_edge_dynamic_specification<T>;
+}  // namespace tiledb::flow_graph::dynamic_specification
+
+namespace tiledb::flow_graph {
+
+/**
+ * An edge static specification.
+ *
+ * @tparam T a potential edge dynamic specification class
+ */
+template <class T>
+concept edge_dynamic_specification = dynamic_specification::edge<T>;
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_EDGE_DYNAMIC_SPECIFICATION_H

--- a/tiledb/flow_graph/system/edge_static_specification.h
+++ b/tiledb/flow_graph/system/edge_static_specification.h
@@ -1,0 +1,272 @@
+/**
+ * @file flow_graph/system/edge_static_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_EDGE_STATIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_EDGE_STATIC_SPECIFICATION_H
+
+#include "graph_type.h"
+#include "tiledb/flow_graph/system/node_static_specification.h"
+#include "tiledb/flow_graph/system/port_static_specification.h"
+
+namespace tiledb::flow_graph::static_specification {
+
+/**
+ * The class declares itself as an edge static specification.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept self_declared_as_edge_static_specification =
+    requires(T x) { x.invariants.i_am_edge_static_specification; };
+
+/**
+ * The class declares a type of a tail node.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept declares_tail_node_type = requires(T) { typename T::tail_node_type; };
+
+/**
+ * The tail node type is a node specification.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept tail_node_type_is_node =
+    declares_tail_node_type<T> && node<typename T::tail_node_type>;
+
+/**
+ * The class defines a tail node.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept defines_tail_node = requires(T x) { x.tail_node; };
+
+/**
+ * The tail node class matches its declared type.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept has_tail_node =
+    tail_node_type_is_node<T> && defines_tail_node<T> &&
+    std::same_as<decltype(T::tail_node), const typename T::tail_node_type&>;
+
+/**
+ * The class declares a type for its tail port.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept declares_tail_port_type = requires(T) { typename T::tail_port_type; };
+
+/**
+ * The type of the tail port is an output port.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept tail_port_type_is_port =
+    declares_tail_port_type<T> && output_port<typename T::tail_port_type>;
+
+/**
+ * The class defines a tail port.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept defines_tail_port = requires(T x) { x.tail_port; };
+
+/**
+ * The tail port class matches its declared type.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept has_tail_port =
+    defines_tail_port<T> &&
+    std::same_as<decltype(T::tail_port), const typename T::tail_port_type&>;
+
+/**
+ * The tail port is an output port of the tail node.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept has_tail = has_tail_node<T> && has_tail_port<T> && requires(T x) {
+  is_reference_element_of(x.tail_port, x.tail_node.output_ports);
+};
+
+/**
+ * The class declares a type of a head node.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept declares_head_node_type = requires(T) { typename T::head_node_type; };
+
+/**
+ * The head node type is a node specification.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept head_node_type_is_node =
+    declares_head_node_type<T> && node<typename T::head_node_type>;
+
+/**
+ * The class defines a head node.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept defines_head_node = requires(T x) { x.head_node; };
+
+/**
+ * The head node class matches its declared type.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept has_head_node =
+    head_node_type_is_node<T> && defines_head_node<T> &&
+    std::same_as<decltype(T::head_node), const typename T::head_node_type&>;
+
+/**
+ * The class declares a type for its head port.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept declares_head_port_type = requires(T) { typename T::head_port_type; };
+
+/**
+ * The type of the head port is an output port.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept head_port_type_is_port =
+    declares_head_port_type<T> &&
+    input_port_static_specification<typename T::head_port_type>;
+
+/**
+ * The class defines a head port.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept defines_head_port = requires(T x) { x.head_port; };
+
+/**
+ * The head port class matches its declared type.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept has_head_port =
+    defines_tail_port<T> &&
+    std::same_as<decltype(T::head_port), const typename T::head_port_type&>;
+
+/**
+ * The head port is an output port of the tail node.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept has_head = has_head_node<T> && has_head_port<T> && requires(T x) {
+  is_reference_element_of(x.head_port, x.head_node.input_ports);
+};
+
+/**
+ * An edge static specification is self-declared. It has a well-defined head and
+ * tail whose flow types match.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept edge = self_declared_as_edge_static_specification<T> && has_tail<T> &&
+               has_head<T> &&
+               std::same_as<
+                   typename T::tail_port_type::flow_type,
+                   typename T::head_port_type::flow_type>;
+
+/**
+ * Compile-time class function validates that class is an edge static
+ * specification.
+ *
+ * This function contains a static assertion for each concept that feeds into
+ * `edge`. If the concept fails, this validator will also fail, but with a line
+ * number that identifies which elements are failing. Such errors messages may
+ * be more legible than those from a concept failure.
+ */
+template <class T>
+  requires self_declared_as_edge_static_specification<T>
+void validator() {
+  // tail
+  static_assert(declares_tail_node_type<T>);
+  static_assert(tail_node_type_is_node<T>);
+  static_assert(defines_tail_node<T>);
+  static_assert(has_tail_node<T>);
+  static_assert(declares_tail_port_type<T>);
+  static_assert(tail_port_type_is_port<T>);
+  static_assert(defines_tail_port<T>);
+  static_assert(has_tail_port<T>);
+  static_assert(has_tail<T>);
+  // head
+  static_assert(declares_head_node_type<T>);
+  static_assert(head_node_type_is_node<T>);
+  static_assert(defines_head_node<T>);
+  static_assert(has_head_node<T>);
+  static_assert(declares_head_port_type<T>);
+  static_assert(head_port_type_is_port<T>);
+  static_assert(defines_head_port<T>);
+  static_assert(has_head_port<T>);
+  static_assert(has_head<T>);
+  // edge
+  static_assert(edge<T>);
+}
+
+}  // namespace tiledb::flow_graph::static_specification
+
+namespace tiledb::flow_graph {
+
+/**
+ * An edge static specification.
+ *
+ * @tparam T a potential edge static specification class
+ */
+template <class T>
+concept edge_static_specification = static_specification::edge<T>;
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_SPECIFICATION_EDGE_H

--- a/tiledb/flow_graph/system/execution_graph.h
+++ b/tiledb/flow_graph/system/execution_graph.h
@@ -1,0 +1,65 @@
+/**
+ * @file flow_graph/execution_graph.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_SYSTEM_EXECUTION_GRAPH_H
+#define TILEDB_FLOW_GRAPH_SYSTEM_EXECUTION_GRAPH_H
+
+namespace tiledb::flow_graph::execution {
+/**
+ * Execution graphs must declare themselves as such.
+ *
+ * @tparam T a potential specification graph class
+ */
+template <class T>
+concept self_declared_as_graph =
+    requires(T x) { x.invariants.i_am_execution_graph; };
+
+template <class T>
+concept graph = self_declared_as_graph<T>;
+
+}  // namespace tiledb::flow_graph::execution
+
+namespace tiledb::flow_graph {
+
+/**
+ * This concept is the interface between a scheduler and a flow graph.Any
+ * scheduler can run an execution graph.
+ *
+ * Maturity Note: This is a stub. There are no schedulers in the `flow_graph`
+ * directory yet. This concept should be modeled on `class FlowGraph`.
+ *
+ * @tparam T a potential specification graph class
+ */
+template <class T>
+concept execution_graph = execution::graph<T>;
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_SYSTEM_EXECUTION_GRAPH_H

--- a/tiledb/flow_graph/system/execution_platform.h
+++ b/tiledb/flow_graph/system/execution_platform.h
@@ -1,0 +1,40 @@
+/**
+ * @file flow_graph/system/execution_platform.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_EXECUTION_PLATFORM_H
+#define TILEDB_FLOW_GRAPH_EXECUTION_PLATFORM_H
+
+namespace tiledb::flow_graph {
+
+template <class T>
+concept execution_platform = true;
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_EXECUTION_PLATFORM_H

--- a/tiledb/flow_graph/system/flow_graph_system.h
+++ b/tiledb/flow_graph/system/flow_graph_system.h
@@ -1,0 +1,101 @@
+/**
+ * @file flow_graph/system/flow_graph_system.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_SYSTEM_FLOW_GRAPH_SYSTEM_H
+#define TILEDB_FLOW_GRAPH_SYSTEM_FLOW_GRAPH_SYSTEM_H
+
+#include "../library/dynamic/dynamic_zero_graph.h"
+#include "../library/platform/minimal_execution_platform.h"
+#include "../library/static/static_zero_graph.h"
+#include "execution_platform.h"
+#include "graph_static_specification.h"
+
+namespace tiledb::flow_graph {
+
+namespace {
+using SZG = static_specification::ZeroGraph;
+using DZG = dynamic_specification::ZeroGraph;
+}  // namespace
+
+/**
+ * Class declares itself as a flow graph system.
+ *
+ * @tparam T a potential flow graph system
+ */
+template <class T>
+concept self_declared_as_flow_graph_system =
+    requires(T x) { x.invariants.i_am_flow_graph_system; };
+
+/**
+ * Class declares a transformer from a graph static specification to a graph
+ * dynamic specification with a given execution platform.
+ *
+ * @tparam T a potential flow graph system
+ */
+template <class T>
+concept declares_static_to_dynamic_transformer = requires(T) {
+  typename T::
+      template static_to_dynamic_transformer<SZG, MinimalExecutionPlatform>;
+};
+
+/**
+ * Class declares an execution platform.
+ *
+ * @tparam T a potential flow graph system
+ */
+template <class T>
+concept declares_execution_platform = requires(T) {
+  typename T::execution_platform;
+} && execution_platform<typename T::execution_platform>;
+
+/**
+ * Class declares a transformer from a dynamic specification to an execution
+ * graph.
+ *
+ * @tparam T a potential flow graph system
+ */
+template <class T>
+concept declares_dynamic_to_execution_graph_transformer =
+    requires(T) { typename T::template dynamic_to_execution_transformer<DZG>; };
+
+/**
+ * A flow graph system is a selection of particular implementations of the top-
+ * level concepts.
+ *
+ * @tparam T a potential flow graph system
+ */
+template <class T>
+concept flow_graph_system = self_declared_as_flow_graph_system<T> &&
+                            declares_static_to_dynamic_transformer<T> &&
+                            declares_execution_platform<T> &&
+                            declares_dynamic_to_execution_graph_transformer<T>;
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_SYSTEM_FLOW_GRAPH_SYSTEM_H

--- a/tiledb/flow_graph/system/graph_dynamic_specification.h
+++ b/tiledb/flow_graph/system/graph_dynamic_specification.h
@@ -1,0 +1,96 @@
+/**
+ * @file flow_graph/system/graph_dynamic_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_DYNAMIC_GRAPH_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_DYNAMIC_GRAPH_SPECIFICATION_H
+
+#include <concepts>
+
+#include "graph_type.h"
+
+//-------------------------------------------------------
+// Dynamic specification of a graph
+//-------------------------------------------------------
+/*
+ * The dynamic specification is the most general specification. It's named as
+ * "dynamic" in contradistinction to static graph specifications.
+ *
+ * A graph specification contains all the information to build a graph without
+ * actually being the graph. A flow graph suitable for execution must have
+ * memory allocated to it (however allocated, on the heap or otherwise) for all
+ * the graph state, but a graph specification does not require this.
+ *
+ * The dynamic specification is responsible for type erasure. It contains within
+ * it all the types needed to fully instantiate an execution graph, but presents
+ * a type-erased interface to them. References to the graph elements (nodes,
+ * ports, edges), are all based on integral indices. Given an index, a dynamic
+ * specification must be able to construct an appropriate object.
+ *
+ * The concept of a dynamic specification is the graph as a whole; it is not a
+ * concept for graph operations such as adding or removing nodes and edges. It
+ * is expected that most dynamic specifications will be generated from static
+ * information rather than constructed directly. Classes that satisfy the
+ * dynamic specification concept might contain such graph operations. If they
+ * do, though, they're entirely internal to those classes and are not used by
+ * the system as a whole. This remains true even for so-called "wide" nodes and
+ * other kinds of graph topologies that might at some future point be mutable
+ * during execution.
+ */
+
+namespace tiledb::flow_graph::dynamic_specification {
+/**
+ * A class declares itself as a graph dynamic specification.
+ *
+ * @tparam T a potential specification graph class
+ */
+template <class T>
+concept self_declared_as_graph_dynamic_specification =
+    requires(T x) { x.invariants.i_am_graph_dynamic_specification; };
+
+/**
+ * Concept that a class is valid as graph specification. Graph specifications in
+ * general must be dynamic to allow graphs specified with parameters.
+ *
+ * Maturity Note: At this time there's only one kind of dynamic specification.
+ * It's `ToDynamic`, which adapts static specifications into the dynamic ones.
+ * As such, there's not yet any pressing need to work out the details of a
+ * concept for dynamic specifications.
+ *
+ * @tparam T a potential dynamic graph specification
+ */
+template <class T>
+concept graph = self_declared_as_graph_dynamic_specification<T>;
+}  // namespace tiledb::flow_graph::dynamic_specification
+
+namespace tiledb::flow_graph {
+template <class T>
+concept graph_dynamic_specification = dynamic_specification::graph<T>;
+}
+#endif  // TILEDB_FLOW_GRAPH_DYNAMIC_GRAPH_SPECIFICATION_H

--- a/tiledb/flow_graph/system/graph_static_specification.h
+++ b/tiledb/flow_graph/system/graph_static_specification.h
@@ -1,0 +1,180 @@
+/**
+ * @file flow_graph/system/graph_static_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_GRAPH_STATIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_GRAPH_STATIC_SPECIFICATION_H
+
+#include <concepts>
+#include <tuple>
+
+#include "graph_type.h"
+#include "tiledb/flow_graph/system/edge_static_specification.h"
+#include "tiledb/flow_graph/system/node_static_specification.h"
+#include "tiledb/flow_graph/system/port_static_specification.h"
+
+namespace tiledb::flow_graph::static_specification {
+
+/**
+ * A class declares itself as a graph static specification.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept self_declared_as_graph =
+    requires(T x) { x.invariants.i_am_graph_static_specification; };
+
+/**
+ * Class declares a member variable `nodes`.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept declares_node_list = requires(T) { T::nodes; };
+
+/**
+ * Class member variable `nodes` is tuple-like
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept node_list_is_tuple =
+    declares_node_list<T> && applicable<decltype(T::nodes)>;
+
+/**
+ * Each element of class member variable 'nodes' is an lvalue reference.
+ *
+ * The requirement for lvalue references is to implement the equality operator
+ * as address equality instead of some other mechanism that would not have
+ * compiler support.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept node_list_contains_lvalue_references =
+    node_list_is_tuple<T> &&
+    requires(T x) { contains_lvalue_references_v(x.nodes); };
+
+/**
+ * Each element of class member variable 'nodes' is an lvalue reference to
+ * a node static specification.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept has_node_list =
+    node_list_contains_lvalue_references<T> && requires(T x) {
+      []<class... U>(std::tuple<U...>)
+        requires(node<std::remove_reference_t<U>> && ...)
+      {}
+      (x.nodes);
+    };
+
+/**
+ * Class declares a member variable `edges`.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept declares_edge_list = requires(T) { T::edges; };
+
+/**
+ * Class member variable `edges` is tuple-like.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept edge_list_is_tuple =
+    declares_edge_list<T> && requires(T x) { applicable<decltype(x.edges)>; };
+
+/**
+ * Each element of class member variable 'edges' is an edge static
+ * specification.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept has_edge_list = edge_list_is_tuple<T> && requires(T x) {
+  []<class... U>(std::tuple<U...>)
+    requires(edge<U> && ...)
+  {}
+  (x.edges);
+};
+
+/**
+ * Stub.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept edge_tails_are_in_graph = true;
+
+/**
+ * Stub.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept edge_heads_are_in_graph = true;
+
+/**
+ * A specification graph is self-declared. It has a node list and an edge list.
+ * The heads and tails of all the edges are within the nodes of the graph.
+ *
+ * Maturity Note: There is as yet no requirement that each port be connected to
+ * something. This will need to be added before leaving the initial development
+ * phase. There are two ordinary possibilities that needs to be accounted for:
+ *   1. The graph is sealed. There are no inflows or outflows to the graph.
+ *   2. The graph is ported. The graph has input ports and/or output ports.
+ * Only a sealed graph can be scheduled. A ported graph can be used as a
+ * subcomponent of another graph through a standard transformation to a node. At
+ * present there are no concepts for ported graphs; all graphs are considered
+ * sealed.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept graph =
+    self_declared_as_graph<T> && has_node_list<T> && has_edge_list<T> &&
+    edge_tails_are_in_graph<T> && edge_heads_are_in_graph<T>;
+
+}  // namespace tiledb::flow_graph::static_specification
+
+namespace tiledb::flow_graph {
+/**
+ * A graph static specification provides the essential information for
+ * constructing a flow graph: nodes and edge connections.
+ *
+ * @tparam T a potential graph static specification class
+ */
+template <class T>
+concept graph_static_specification = static_specification::graph<T>;
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_GRAPH_STATIC_SPECIFICATION_H

--- a/tiledb/flow_graph/system/graph_type.h
+++ b/tiledb/flow_graph/system/graph_type.h
@@ -1,0 +1,588 @@
+/**
+ * @file flow_graph/graph_type.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_GRAPH_TYPE_H
+#define TILEDB_FLOW_GRAPH_GRAPH_TYPE_H
+
+#include <tuple>
+
+namespace tiledb::flow_graph {
+
+//-------------------------------------------------------
+/*
+ * Product type support
+ *
+ * C++ has something of a product type in `std::tuple` and the beginnings of
+ * product type support with `std::apply`. These mechanisms are not part of a
+ * unified approach to dealing with product types. The code here moves in that
+ * direction, however modest and incomplete the effort.
+ *
+ * We take `std::tuple` as a canonical product type, but not the only one. We
+ * want every product type to be tuple-like, however, in the sense that we
+ * require it be a valid argument to `std::apply`.
+ *
+ * We also require that product types have a fixed number of factors. An
+ * alternative would allow a variable number of factors, such as `vector<any>`.
+ * In other words, the product types here are definite products rather than
+ * indefinite products. This choice rests on the C++ type system, which can only
+ * deal with variable-length lists of types at compile type, not at run-time.
+ * There is no run-time representation of a type, unlike, say, languages based
+ * on a virtual machine.
+ */
+//-------------------------------------------------------
+
+/**
+ * A type is applicable if it may usefully appear as the second argument in
+ * `std::apply`. The documentation for `std::apply` calls this "tuple-like".
+ *
+ * A class is tuple-like if it supports `std::get` and `std::tuple_size`. The
+ * phrase "usefully appear" is key, as every class may appear as the second
+ * argument of `apply`, but if the class is not tuple-like, `apply` will invoke
+ * its function with exactly one argument.
+ *
+ * @tparam T a candidate tuple-like type
+ */
+template <class T>
+concept applicable = requires(T) {
+  []<size_t n>(T& x) { std::get<n>(x); };
+  { std::tuple_size_v<T> } -> std::convertible_to<size_t>;
+};
+
+/**
+ * Concept that `T` is instantiated from `std::tuple`.
+ *
+ * @tparam T A possible `std::tuple` class
+ */
+template <class T>
+concept is_tuple = requires(T x) { []<class... U>(std::tuple<U...>) {}(x); };
+
+/**
+ * Concept that a type declares a tuple type.
+ *
+ * @tparam T A possible product type
+ */
+template <class T>
+concept declares_tuple_traits = requires { typename T::type_tuple; };
+
+/**
+ * Traits class for product types.
+ *
+ * Note that the traits class is defined only for classes meeting the conceptual
+ * criteria. Independent specializations are not supported at this time.
+ *
+ * @tparam T
+ */
+template <class T>
+  requires is_tuple<T> || declares_tuple_traits<T>
+struct product_traits;
+
+/**
+ * Traits class for product types that are not `std::tuple`
+ *
+ * @tparam T A possible product type
+ */
+template <declares_tuple_traits T>
+struct product_traits<T> {
+  using type_tuple = T::type_tuple;
+};
+
+/**
+ * Traits class for `std::tuple` as a product type.
+ *
+ * @tparam X parameter pack for matching `std::tuple` template arguments
+ */
+template <class... X>
+struct product_traits<std::tuple<X...>> {
+  using type_tuple = std::tuple<X...>;
+  static_assert(is_tuple<std::tuple<X...>>);
+};
+
+/**
+ * Concept that a type has a `type_tuple` trait.
+ *
+ * @tparam T A possible product type
+ */
+template <class T>
+concept has_product_traits = requires {
+  // At this time `type_tuple` is the only trait.
+  typename product_traits<std::remove_cv_t<T>>::type_tuple;
+};
+
+/**
+ * A type is a product type if it may usefully appear as the second argument in
+ * `std::apply` and if we can obtain a tuple of its factor types.
+ *
+ * @tparam T a candidate product type
+ */
+template <class T>
+concept product_type = applicable<T> && has_product_traits<T>;
+
+//----------------------------------
+// `sizeof` for product types
+//----------------------------------
+
+/**
+ * The number of factors in a product type.
+ *
+ * @tparam T a product type
+ * @return number of factors of 'T'
+ */
+template <product_type T>
+constexpr size_t factor_sizeof() {
+  return std::tuple_size_v<T>;
+}
+
+/**
+ * The number of factors in a product type.
+ *
+ * This function takes an argument, but only to infer the type from it. The
+ * number of factors is defined by the type itself. All objects of this type
+ * have the same number of factors.
+ *
+ * @tparam T a product type
+ * @return number of factors of 'T'
+ */
+template <product_type T>
+constexpr size_t factor_sizeof(const T&) {
+  return std::tuple_size_v<T>;
+}
+
+/**
+ * Concept that a product type has no factors.
+ *
+ * @tparam T a product type
+ */
+template <class T>
+concept empty_product_type = product_type<T> && (factor_sizeof<T>() == 0);
+
+//----------------------------------
+//----------------------------------
+
+/**
+ * Predicate that a type is product type whose members are all lvalue
+ * references.
+ */
+template <class T>
+concept contains_lvalue_references = product_type<T> && requires(T y) {
+  std::apply(
+      []<class... U>(U...) { return (std::is_lvalue_reference_v<U> && ...); },
+      y);
+};
+
+/**
+ * Predicate that the type of an object passed as an argument is an applicable
+ * type whose members are all lvalue references.
+ */
+template <product_type TT>
+constexpr bool contains_lvalue_references_v(const TT& x) {
+  struct wrapper {
+    static constexpr bool value(const TT&) {
+      return contains_lvalue_references<TT>;
+    }
+  };
+  return wrapper::value(std::forward<const TT&>(x));
+}
+
+//-------------------------------------------------------
+// invocation over a product
+//-------------------------------------------------------
+/*
+ * Invoking a function over a product means invoking a function on each factor
+ * of the product and then doing something with the results. Both these aspects,
+ * the multiple invocations and the results, have their own kinds of variation.
+ *
+ * As notation, suppose a product type `TT`, a value `xx` of that type, and a
+ * function `F`. From this, suppose that `TT` has factor types `T_1, ..., T_n,`,
+ * that `xx` is equivalent to `{x_1, ..., x_n}`, that the calls are captured as
+ * (named) temporary variables `y_1, ..., y_n`, that functions `F_1, ..., F_n`
+ * are called, and the types of the return values are `R_1, ..., R_n`.
+ * ```
+ * // for i from 1 to n
+ * R_i y_i = F_i(x_i);
+ * ```
+ *
+ * The first variation is with the multiple functions `F_i` invoked and their
+ * relation to `F`. The essence of the variation is that each invocation has
+ * a different argument type `T_i`. That type ultimately appears somewhere as
+ * a template argument, both the kind of template may vary.
+ *
+ * As a first hypothetical, suppose that `T_i` is an argument of a function
+ * template.
+ * ```
+ * template <class T_i>
+ * R_i F_i<T_i&&>;
+ * ```
+ * As of C++20, function class templates may not be passed as template
+ * arguments, so we can't support this kind of function at this time. Thus we
+ * may assume that `F` is always a class. Then `T_i` is a template argument
+ * either of the class or one of its member functions. For definiteness, we'll
+ * assume that the function is always `operator()`. (It would be possible to
+ * have class with a factory returning pointers to functions or pointers to
+ * function objects; we do not consider them here. Such a thing would be best
+ * considered as a pointer to a callable thing rather than a callable thing
+ * itself.) Henceforth we may assume that `T_i` is always an argument within
+ * the context of some class.
+ *
+ * As a second hypothetical, suppose that `T_i` is  an argument on the class `F`
+ * itself.
+ * ```
+ *   template<class T>
+ *   struct F {
+ *     R operator()(T&&);
+ *   };
+ * ```
+ * The problem with this is that the standard library operates entirely on
+ * function objects, not on function classes. Although it's possible to invoke
+ * these, the design decision for the standard library is not to use them.
+ * Therefore we won't either.
+ *
+ * As a side note, the standard library always uses `class F` to declare
+ * function classes. If the template argument were on the class, it would have
+ * to be declared `template<class> class F`. The syntax of C++ does not allow a
+ * template argument to be either `class` or `template<class> class`. To do
+ * otherwise would require duplication of all the apparatus for a second kind
+ * of function class or changes to the language.
+ *
+ * The third case is not hypothetical. Here `T_i` is deduced from an object
+ * parameter.
+ * ```
+ *   struct F {
+ *     template<class T>
+ *     R operator()(T&&);             // required in C++20
+ *     // template<class T>
+ *     // static R operator()(T&&);   // allowed in C++23
+ *   };
+ * ```
+ * Invocation with this definition requires an object, so there are no
+ * particular construction requirements (although of course it must be
+ * constructible somehow).
+ *
+ * There is far too much variation for a single apply-to-product function to
+ * make sense. In all cases, the types `R_i` of return values may depend on the
+ * type argument `T_i`. `F` might return a product of `R_i` or it might combine
+ * them in some way. If all the `R_i` are the same, or at least compatible, a
+ * fold expression might be computed. And there's also the question about how
+ * many to compute. Boolean folds with `||` and `&&` have short-circuit
+ * behavior.
+ */
+
+/**
+ * `TT` is a product type and `F` is object-invocable on each element of `TT`,
+ * returning `R`.
+ *
+ * Object-invocable means that `operator()` is parametric on the member
+ * function, meaning that `operator()` is a function template. The type of the
+ * argument of `operator()` comes from the function template argument.
+ *
+ * @tparam R
+ * @tparam F
+ * @tparam TT
+ */
+template <class F, class TT>
+concept invocable_over_product = product_type<TT> && requires(TT xx) {
+  std::apply([]<class... T>(T...) { (std::is_invocable_v<F, T> && ...); }, xx);
+};
+
+/**
+ * `TT` is a product type and `F` is object-invocable on each element of `TT`,
+ * returning `R`.
+ *
+ * Object-invocable means that `operator()` is parametric on the member
+ * function, meaning that `operator()` is a function template. The type of the
+ * argument of `operator()` comes from the function template argument.
+ *
+ * @tparam R
+ * @tparam F
+ * @tparam TT
+ */
+template <class R, class F, class TT>
+concept invocable_over_product_r = product_type<TT> && requires(TT xx) {
+  std::apply(
+      []<class... T>(T...) { (std::is_invocable_r_v<R, F, T> && ...); }, xx);
+};
+
+/**
+ * `TT` is a product type and `F` is invocable on each element of `TT`,
+ * returning `bool`.
+ *
+ * @tparam F
+ * @tparam TT
+ */
+template <class F, class TT>
+concept predicate_over_product = invocable_over_product_r<bool, F, TT>;
+
+/*
+ * Note that we do not have a single "invoke" function in parallel with the
+ * "invocable" concept `invocable_over_product_r`. Defining a single function
+ * would require a way to specify the fold expression that combines the results
+ * of individual invocations with each other.
+ * ```
+ * template <class R, template <class> typename F, class TT, ??? Fold>
+ * constexpr R invoke_over_product_r
+ * ```
+ * Instead of a single invocation function, we define the most common ones.
+ */
+
+template <class F, product_type TT>
+  requires predicate_over_product<F, TT>
+constexpr bool invoke_over_product_and(F&& f, const TT& xx) {
+  return std::apply(
+      [&f]<class... T>(T&&... x) -> bool {
+        return (
+            (std::invoke(std::forward<F&&>(f), std::forward<T&&>(x))) && ...);
+      },
+      std::forward<const TT&>(xx));
+};
+
+template <class F, product_type TT>
+  requires predicate_over_product<F, TT>
+constexpr bool invoke_over_product_or(F&& f, const TT& xx) {
+  return std::apply(
+      [&f]<class... T>(T&&... x) -> bool {
+        return (
+            (std::invoke(std::forward<F&&>(f), std::forward<T&&>(x))) || ...);
+      },
+      std::forward<const TT&>(xx));
+};
+
+//-------------------------------------------------------
+// reference equality
+//-------------------------------------------------------
+/**
+ * Heterogeneous equality operation
+ *
+ * Two elements are always unequal if they are of different types. If they're
+ * of the same type, we defer to the equality operator on that type. If
+ * there's no equality operator for that type, we return false.
+ *
+ * @tparam T type of left-hand operand
+ * @tparam U type of right-hand operand
+ * @param x value of left-hand operand
+ * @param y value of right-hand operand
+ */
+template <class T, class U>
+constexpr bool is_equal_reference(const T& x, const U& y) {
+  if constexpr (!(std::is_same_v<std::remove_cv_t<T>, std::remove_cv_t<U>>)) {
+    return false;
+  } else {
+    return std::addressof(x) == std::addressof(y);
+  }
+}
+
+/**
+ * Bound version of `is_equal_reference`; one argument is bound at construction.
+ *
+ * @tparam T type of left-hand operand
+ */
+template <class T>
+class is_equal_as_reference_to {
+  /**
+   * Left-hand operand
+   */
+  const T& x_;
+
+ public:
+  /**
+   * Ordinary constructor takes one operand of the equality operator.
+   *
+   * @param x value of left-hand operand
+   */
+  constexpr explicit is_equal_as_reference_to(const T& x)
+      : x_{x} {};
+
+  /**
+   * Call operator takes the other operand of the equality operator.
+   *
+   * @tparam U type of right-hand operand
+   * @param y value of right-hand operand
+   * @return whether constructor argument `x` and this argument `y` are equal
+   *   as references
+   */
+  template <class U>
+  constexpr bool operator()(const U& y) {
+    return is_equal_reference(x_, std::forward<const U&>(y));
+  }
+};
+
+/**
+ * List membership for a reference within a list of references
+ *
+ * @tparam T Base type of the reference argument `x`
+ * @tparam UU A tuple-like type holding references
+ * @param x Reference to an object
+ * @param yy A list of references
+ * @return `true` if and only if the reference `x` is equal to some element in
+ *   the list `yy`
+ */
+template <class T, product_type UU>
+constexpr bool is_reference_element_of(const T& x, const UU& yy) {
+  return invoke_over_product_or(
+      is_equal_as_reference_to{std::forward<const T&>(x)},
+      std::forward<const UU&>(yy));
+}
+
+//-------------------------------------------------------
+// `count_until_satisfied`
+//-------------------------------------------------------
+
+/**
+ * Evaluates a predicate on each argument until the predicate is satisfied.
+ * Returns the number of times the predicate was evaluated and not satisfied.
+ *
+ * The two extremal cases are worth noting. If first argument in the parameter
+ * pack satisfies the predicate, this function returns zero. If no argument in
+ * the pack satisfies the predicate, this function returns the number of
+ * arguments in the pack.
+ *
+ * @tparam F The underlying type of a predicate object
+ * @tparam T A pack of types for the arguments
+ * @param f A predicate object
+ * @param x A pack of arguments
+ * @return an integer in the range [0, factor_sizeof(xx)]
+ */
+template <class F, class... T>
+constexpr size_t count_until_satisfied(F&& f, T&&... x) {
+  if constexpr (sizeof...(T) == 0) {
+    /*
+     * End recursion when parameter pack is empty.
+     */
+    return 0;
+  } else {
+    return [&f]<class U, class... V>(U&& y, V&&... z) -> size_t {
+      if (std::invoke(std::forward<F&&>(f), std::forward<U&&>(y))) {
+        /*
+         * Short-circuit when the invocation is true.
+         */
+        return 0;
+      } else {
+        /*
+         * Invoke recursively when the invocation is false.
+         */
+        return 1 + count_until_satisfied(
+                       std::forward<F&&>(f), std::forward<V&&>(z)...);
+      }
+    }(std::forward<T&&>(x)...);
+  }
+};
+
+/**
+ * `count_until_satisfied` applied to a product type.
+ *
+ * @tparam F A predicate that may be evaluated over a product type.
+ * @tparam TT A product type
+ * @param f A predicate object
+ * @param xx A product object
+ * @return an integer in the range [0, factor_sizeof(xx)]
+ */
+template <class F, product_type TT>
+constexpr size_t count_until_satisfied_p(F&& f, const TT& xx)
+  requires predicate_over_product<F, TT>
+{
+  return std::apply(
+      [&f]<class... T>(T... x) {
+        return count_until_satisfied(std::forward<F&&>(f), x...);
+      },
+      std::forward<const TT&>(xx));
+};
+
+//-------------------------------------------------------
+// reference_tuple
+//-------------------------------------------------------
+/*
+ * Directly declaring a node list of reference types is verbose and redundant:
+ * ```
+ * constexpr static std::tuple<
+ *     const DummyOutputNodeSpecification<T>&,
+ *     const DummyInputNodeSpecification<T>&>
+ *     nodes{a, b};
+ * ```
+ * The reason for this verbosity is that if nodes are declared `constexpr`, the
+ * expression `tuple{a,b}` is taken as a tuple of values, not of references. We
+ * would prefer to specify node lists with simple declaration lists where the
+ * reference type is inferred rather than declared.
+ */
+
+/**
+ * Product type containing a tuple of references
+ *
+ * @tparam T Pack parameter for the type of each tuple element.
+ */
+template <typename... T>
+class reference_tuple : public std::tuple<T...> {
+ public:
+  /*
+   * The constructor forward is arguments to the base-class tuple.
+   */
+  template <typename... U>
+  explicit constexpr reference_tuple(const U&... u)
+      : std::tuple<T...>{std::forward<const U&>(u)...} {
+  }
+  using type_tuple = std::tuple<T...>;
+};
+/**
+ * Deduction guide ensures that reference_tuple is instantiated as a tuple of
+ * references, that is, that each element of pack `T` is a `const U&`.
+ */
+template <typename... U>
+reference_tuple(const U&...) -> reference_tuple<const U&...>;
+
+/*
+template <class... X>
+struct type_tuple<reference_tuple<X...>> {
+  using types = std::tuple<X...>;
+};
+*/
+
+}  // namespace tiledb::flow_graph
+namespace std {
+
+/**
+ * Specialization of `std::tuple_size` for `reference_tuple`.
+ *
+ * This is required for `std::apply` to work with `reference_tuple`. Without it,
+ * `apply` does not treat it as a "tuple-like" type and does not unpack it as
+ * a parameter pack but instead leaves it unchanged as a single argument.
+ */
+template <class... T>
+struct tuple_size<  // NOLINT(cert-dcl58-cpp)
+    tiledb::flow_graph::reference_tuple<T...>>
+    : integral_constant<std::size_t, sizeof...(T)> {};
+/*
+ * "cert-dcl58-cpp" says not to modify anything in the namespace `std`. The
+ * existing way this check is implemented is overly strict. It does not exempt
+ * definitions such as `tuple_size` that are explicitly permitted to be
+ * specialized with user-defined types.
+ *
+ * See: https://clang.llvm.org/extra/clang-tidy/checks/cert/dcl58-cpp.html
+ */
+
+}  // namespace std
+
+#endif  // TILEDB_FLOW_GRAPH_GRAPH_TYPE_H

--- a/tiledb/flow_graph/system/node_body.h
+++ b/tiledb/flow_graph/system/node_body.h
@@ -1,0 +1,112 @@
+/**
+ * @file flow_graph/node_body.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_SYSTEM_NODE_BODY_H
+#define TILEDB_FLOW_GRAPH_SYSTEM_NODE_BODY_H
+
+#include <type_traits>
+
+#include "discrete_coroutine.h"
+#include "node_services.h"
+
+namespace tiledb::flow_graph::execution {
+
+// Anonymous namespace hides the alias to the minimal node services class
+namespace {
+using MNS = MinimalNodeServices;
+}  // namespace
+
+//-------------------------------------------------------
+// Node Body
+//-------------------------------------------------------
+/**
+ * Node bodies must declare themselves as such. By design we do not admit
+ * outside traits classes that might declare node properties. Self-declaration
+ * is the first and simplest requirement.
+ *
+ * @tparam N a potential node body class
+ */
+template <template <class> class T>
+concept self_declared_as_node_body =
+    requires(T<MNS> x) { x.invariants.i_am_node_body; };
+
+/**
+ * A node body has a discrete coroutine when instantiated with node services.
+ *
+ * @tparam T a potential node body class
+ */
+template <template <class> class T>
+concept node_body_base =
+    self_declared_as_node_body<T> && discrete_coroutine<T<MNS>>;
+
+/**
+ * A node body with a virtual destructor.
+ *
+ * @tparam T a potential node body class
+ */
+template <template <class> class T>
+concept node_body_with_virtual_destructor =
+    node_body_base<T> && std::has_virtual_destructor_v<T<MNS>>;
+
+/**
+ * A node body with a trivial destructor
+ *
+ * @tparam T
+ */
+template <template <class> class T>
+concept node_body_trivially_destructible =
+    node_body_base<T> && std::is_trivially_destructible_v<T<MNS>>;
+
+/**
+ * A node body is a discrete coroutine with destruction that can be type-erased.
+ *
+ * @tparam T
+ */
+template <template <class> class T>
+concept node_body_impl =
+    node_body_trivially_destructible<T> || node_body_with_virtual_destructor<T>;
+
+}  // namespace tiledb::flow_graph::execution
+
+namespace tiledb::flow_graph {
+
+/**
+ * A node body is essential part of an execution node. It's supported from below
+ * by node services class and from about by node class, both provided by an
+ * execution platform.
+ *
+ * @tparam T a potential node body class
+ */
+template <template <class> class T>
+concept node_body = execution::node_body_impl<T>;
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_NODE_BODY_H

--- a/tiledb/flow_graph/system/node_dynamic_specification.h
+++ b/tiledb/flow_graph/system/node_dynamic_specification.h
@@ -1,0 +1,98 @@
+/**
+ * @file flow_graph/system/node_dynamic_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_NODE_DYNAMIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_NODE_DYNAMIC_SPECIFICATION_H
+
+#include "tiledb/flow_graph/system/port_dynamic_specification.h"
+
+namespace tiledb::flow_graph::dynamic_specification {
+/**
+ * Specification nodes must declare themselves as such.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept self_declared_as_node_dynamic_specification =
+    requires(T x) { x.invariants.i_am_node_dynamic_specification; };
+
+/**
+ * A dynamic node specification has a type-erased factory for its node body.
+ *
+ * @tparam T a potential node dynamic specification class
+ */
+template <class T>
+concept declares_node_size = requires(T x) { x.size_of_node(); };
+
+/**
+ * Class has a factory function with placement signature.
+ *
+ * @tparam T a potential node dynamic specification class
+ */
+template <class T>
+concept has_factory_function = requires { [](T xx, void* p) { xx.make(p); }; };
+
+/**
+ * A type-erased factory requires both a size function to determine allocation
+ * size and a factory function with a placement argument to accept the address
+ * of the allocation.
+ *
+ * @tparam T a potential node dynamic specification class
+ */
+template <class T>
+concept has_node_body_factory =
+    declares_node_size<T> && has_factory_function<T>;
+
+/**
+ * A node dynamic specification has a factory for its node body.
+ *
+ * At present there's no requirement for self-declaration. The only dynamic
+ * specification is the class transformer `ToDynamic`. Should there be many
+ * other dynamic specifications, it might be prudent to add an analogous
+ * requirement.
+ *
+ * @tparam T a potential node dynamic specification class
+ */
+template <class T>
+concept node = has_node_body_factory<T>;
+}  // namespace tiledb::flow_graph::dynamic_specification
+
+namespace tiledb::flow_graph {
+/**
+ * A node specification to be used as part of a larger dynamic graph
+ * specification.
+ *
+ * @tparam T a potential node dynamic specification class
+ */
+template <class T>
+concept node_dynamic_specification = dynamic_specification::node<T>;
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_NODE_DYNAMIC_SPECIFICATION_H

--- a/tiledb/flow_graph/system/node_services.h
+++ b/tiledb/flow_graph/system/node_services.h
@@ -1,0 +1,92 @@
+/**
+ * @file flow_graph/system/node_services.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Node services concept
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_NODE_SERVICES_H
+#define TILEDB_FLOW_GRAPH_NODE_SERVICES_H
+
+namespace tiledb::flow_graph::execution {
+
+/**
+ * Node services are self-declared as such.
+ *
+ * @tparam T a potential node services class
+ */
+template <class T>
+concept self_declared_as_node_services =
+    requires(T x) { x.invariants.i_am_node_services; };
+
+/**
+ * Node services are self-declared.
+ *
+ * Maturity Note: This concept is not yet implemented. It needs an I/O
+ * implementation.
+ *
+ * @tparam T a potential node services class
+ */
+template <class T>
+concept node_services_impl = self_declared_as_node_services<T>;
+
+//-------------------------------------------------------
+// MinimalNodeServices
+//-------------------------------------------------------
+/**
+ * A minimal node services class, acting as a stub to instantiate node body
+ * templates so the resulting class can have concepts evaluated against it.
+ * This technique substitutes for some way of evaluating universal quantifiers
+ * on concepts. In this case we want a quantifier "for all node services class
+ * arguments NS ...".
+ */
+class MinimalNodeServices {
+ public:
+  static constexpr struct invariant_type {
+    static constexpr bool i_am_node_services{true};
+  } invariants;
+};
+static_assert(node_services_impl<MinimalNodeServices>);
+
+}  // namespace tiledb::flow_graph::execution
+
+namespace tiledb::flow_graph {
+
+/**
+ * Node services are the means by which a node body accesses services from an
+ * execution platform.
+ *
+ * The most basic service is I/O along edges, the service that puts the "flow"
+ * in "flow graph".
+ *
+ * @tparam T a potential node services class
+ */
+template <class T>
+concept node_services = execution::node_services_impl<T>;
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_NODE_SERVICES_H

--- a/tiledb/flow_graph/system/node_static_specification.h
+++ b/tiledb/flow_graph/system/node_static_specification.h
@@ -1,0 +1,209 @@
+/**
+ * @file flow_graph/system/node_static_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_NODE_STATIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_NODE_STATIC_SPECIFICATION_H
+
+#include "graph_type.h"
+#include "node_body.h"
+#include "port_static_specification.h"
+#include "tiledb/stdx/type_traits.h"
+
+namespace tiledb::flow_graph::static_specification {
+namespace {
+using MNS = tiledb::flow_graph::execution::MinimalNodeServices;
+}  // namespace
+
+//-------------------------------------------------------
+// Node
+//-------------------------------------------------------
+/**
+ * Specification nodes must declare themselves as such.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept self_declared_as_node_static_specification =
+    requires(T x) { x.invariants.i_am_node_static_specification; };
+
+/**
+ * 'T' has a member class template `node_body_template`
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept declares_node_body_template =
+    requires(T) { typename T::template node_body_template<MNS>; };
+
+template <class T>
+concept node_body_template_satisfies_node_body =
+    node_body<T::template node_body_template>;
+
+template <class T>
+concept has_nody_body =
+    declares_node_body_template<T> && node_body_template_satisfies_node_body<T>;
+
+/**
+ * Class declares a member variable `input_ports`.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept declares_input_port_list = requires(T x) {
+  { T::input_ports };
+};
+
+/**
+ * Member variable `input_ports` is tuple-like for `std::apply`.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept input_port_list_is_tuplelike =
+    declares_input_port_list<T> &&
+    requires(T x) { applicable<decltype(x.input_ports)>; };
+
+/**
+ * Member variable `input_ports` contains only lvalue references.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept input_port_list_contains_lvalue_references =
+    input_port_list_is_tuplelike<T> &&
+    requires(T x) { contains_lvalue_references_v(x.input_ports); };
+
+/**
+ * Member variable `input_ports` is a tuple-like list of lvalue references to
+ * input port objects.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept has_input_port_list =
+    input_port_list_contains_lvalue_references<T> && requires(T x) {
+      std::apply(
+          []<class... U>(U...) {
+            return (input_port<std::remove_reference<U>> && ...);
+          },
+          x.input_ports);
+    };
+
+/**
+ * Class declares a member variable `output_ports`.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept declares_output_port_list = requires(T x) {
+  { T::output_ports };
+};
+
+/**
+ * Member variable `output_ports` is tuple-like for `std::apply`.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept output_port_list_is_tuplelike =
+    declares_output_port_list<T> &&
+    requires(T x) { applicable<decltype(x.output_ports)>; };
+
+/**
+ * Member variable `output_ports` contains only lvalue references.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept output_port_list_contains_lvalue_references =
+    output_port_list_is_tuplelike<T> &&
+    requires(T x) { contains_lvalue_references_v(x.output_ports); };
+
+/**
+ * Member variable `output_ports` is a tuple-like list of lvalue references to
+ * output port objects.
+ *
+ * @tparam T a potential node specification class
+ */
+template <class T>
+concept has_output_port_list =
+    output_port_list_contains_lvalue_references<T> && requires(T x) {
+      std::apply(
+          []<class... U>(U...) {
+            return (output_port<std::remove_reference<U>> && ...);
+          },
+          x.output_ports);
+    };
+
+/**
+ * A node static specification is self-declared as such. It declares a node body
+ * and annotates its input and output ports.
+ *
+ * @tparam T a potential node static specification class
+ */
+template <class T>
+concept node =
+    self_declared_as_node_static_specification<T> && has_input_port_list<T> &&
+    has_output_port_list<T> && has_nody_body<T>;
+
+}  // namespace tiledb::flow_graph::static_specification
+
+namespace tiledb::flow_graph {
+/**
+ * A node specification to be used as part of a larger graph static
+ * specification.
+ *
+ * @tparam T a potential node static specification class
+ */
+template <class T>
+concept node_static_specification = static_specification::node<T>;
+
+/**
+ * Class function on a node static specification for the number of its input
+ * ports.
+ *
+ * @tparam T a potential node static specification class
+ */
+template <node_static_specification T>
+constexpr size_t number_of_input_ports{
+    std::tuple_size_v<decltype(T::input_ports)>};
+
+/**
+ * Class function on a node static specification for the number of its output
+ * ports.
+ *
+ * @tparam T a potential node static specification class
+ */
+template <node_static_specification T>
+constexpr size_t number_of_output_ports{
+    std::tuple_size_v<decltype(T::output_ports)>};
+
+}  // namespace tiledb::flow_graph
+#endif  // TILEDB_FLOW_GRAPH_NODE_STATIC_SPECIFICATION_H

--- a/tiledb/flow_graph/system/port_dynamic_specification.h
+++ b/tiledb/flow_graph/system/port_dynamic_specification.h
@@ -1,0 +1,74 @@
+/**
+ * @file flow_graph/system/port_dynamic_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_PORT_DYNAMIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_PORT_DYNAMIC_SPECIFICATION_H
+
+namespace tiledb::flow_graph::dynamic_specification {
+/**
+ * Stub concept for an output port dynamic specification.
+ *
+ * @tparam T a potential output port dynamic specification
+ */
+template <class T>
+concept output_port = true;
+
+/**
+ * Stub concept for an input port dynamic specification.
+ *
+ * @tparam T a potential input port dynamic specification
+ */
+template <class T>
+concept input_port = true;
+
+}  // namespace tiledb::flow_graph::dynamic_specification
+
+namespace tiledb::flow_graph {
+
+/**
+ * Stub concept for an output port dynamic specification.
+ *
+ * @tparam T a potential output port dynamic specification
+ */
+template <class T>
+concept output_port_dynamic_specification =
+    dynamic_specification::output_port<T>;
+
+/**
+ * Stub concept for an input port dynamic specification.
+ *
+ * @tparam T a potential input port dynamic specification
+ */
+template <class T>
+concept input_port_dynamic_specification = dynamic_specification::input_port<T>;
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_PORT_DYNAMIC_SPECIFICATION_H

--- a/tiledb/flow_graph/system/port_static_specification.h
+++ b/tiledb/flow_graph/system/port_static_specification.h
@@ -1,0 +1,137 @@
+/**
+ * @file flow_graph/system/port_static_specification.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_FLOW_GRAPH_PORT_STATIC_SPECIFICATION_H
+#define TILEDB_FLOW_GRAPH_PORT_STATIC_SPECIFICATION_H
+
+/*
+ * TODO: split into static and dynamic headers
+ */
+
+namespace tiledb::flow_graph::static_specification {
+/**
+ * The class declares itself as an output port static specification.
+ *
+ * @tparam T a potential output port static specification
+ */
+template <class T>
+concept self_declared_as_output_port =
+    requires(T x) { x.invariants.i_am_output_port_static_specification; };
+
+/**
+ * The class declares itself as an input port static specification.
+ *
+ * @tparam T a potential input port static specification
+ */
+template <class T>
+concept self_declared_as_input_port =
+    requires(T x) { x.invariants.i_am_input_port_static_specification; };
+
+/**
+ * The class declares a flow type.
+ *
+ * @tparam T a potential port static specification
+ */
+template <class T>
+concept port_has_typed_flow = requires(T) { typename T::flow_type; };
+
+/**
+ * An output port is self-declared and has a flow type.
+ *
+ * @tparam T a potential output port static specification
+ */
+template <class T>
+concept output_port = self_declared_as_output_port<T> && port_has_typed_flow<T>;
+
+/**
+ * An input port is self-declared and has a flow type.
+ *
+ * @tparam T a potential input port static specification
+ */
+template <class T>
+concept input_port = self_declared_as_input_port<T> && port_has_typed_flow<T>;
+
+}  // namespace tiledb::flow_graph::static_specification
+
+namespace tiledb::flow_graph {
+
+/**
+ * An output port static specification is part of a node static specification.
+ * Its primary purpose is to specify a flow type that matches an edge.
+ *
+ * @tparam T a potential output port static specification
+ */
+template <class T>
+concept output_port_static_specification = static_specification::output_port<T>;
+
+/**
+ * An input port static specification is part of a node static specification.
+ * Its primary purpose is to specify a flow type that matches an edge.
+ *
+ * @tparam T a potential input port static specification
+ */
+template <class T>
+concept input_port_static_specification = static_specification::input_port<T>;
+
+/**
+ * Extended sizeof. Operates on types. Extension returns 0 for void instead of
+ * a syntax error.
+ *
+ * @tparam T
+ */
+template <class T>
+constexpr size_t sizeof_type{sizeof(T)};
+/**
+ * Specialization that yields zero for void.
+ */
+template <>
+constexpr size_t sizeof_type<void>{0};
+
+/**
+ * The size of the flow type of `T`.
+ *
+ * @tparam T either an input or an output port specification
+ */
+template <static_specification::port_has_typed_flow T>
+constexpr size_t flow_size_type{sizeof_type<typename T::flow_type>};
+
+/**
+ * The size of the flow type of an object of type `T`.
+ *
+ * @tparam T either an input or an output port specification
+ */
+template <class T>
+constexpr size_t flow_size(const T&) {
+  return flow_size_type<T>;
+};
+
+}  // namespace tiledb::flow_graph
+
+#endif  // TILEDB_FLOW_GRAPH_PORT_STATIC_SPECIFICATION_H

--- a/tiledb/flow_graph/test/CMakeLists.txt
+++ b/tiledb/flow_graph/test/CMakeLists.txt
@@ -1,0 +1,44 @@
+#
+# flow_graph/test/CMakeLists.txt
+#
+# The MIT License
+#
+# Copyright (c) 2023 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+include(unit_test)
+
+set(SOLO_SOURCES solo/solo_graph_static_specification.cc
+    solo/solo_graph_dynamic_specification.cc
+    solo/solo_node_services.cc
+    solo/solo_node_body.cc
+    )
+
+commence(unit_test flow_graph)
+  this_target_sources(
+      main.cc
+      test_general_factory.cc
+      test_graph_type.cc
+      test_graph_specification.cc
+      test_execution_graph.cc
+      ${SOLO_SOURCES}
+      )
+conclude(unit_test)

--- a/tiledb/flow_graph/test/TESTING.md
+++ b/tiledb/flow_graph/test/TESTING.md
@@ -1,0 +1,16 @@
+# Flow Graph Testing
+
+## `flow_graph/test`
+
+* `test_graph_type.cc`: Classes that support static graph
+  specifications
+* `test_graph_specification.cc`:
+  * Static graph specifications. Compile as `constexpr`. Have referential
+    integrity.
+  * Conversion of static graph specifications to dynamic ones. Topology of
+    converted specification matches original.
+* `test_execution_graph.cc`:
+
+## `flow_graph/<subdirectory>/test`
+
+Tests for individual modules. 

--- a/tiledb/flow_graph/test/compile_flow_graph_main.cc
+++ b/tiledb/flow_graph/test/compile_flow_graph_main.cc
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/tiledb/flow_graph/test/main.cc
+++ b/tiledb/flow_graph/test/main.cc
@@ -1,0 +1,32 @@
+/**
+ * @file flow_graph/test/main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#define CATCH_CONFIG_MAIN
+#include "tdb_catch.h"

--- a/tiledb/flow_graph/test/solo/solo_graph_dynamic_specification.cc
+++ b/tiledb/flow_graph/test/solo/solo_graph_dynamic_specification.cc
@@ -1,0 +1,30 @@
+/**
+ * @file flow_graph/test/solo/solo_graph_dynamic_specification.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+#include "../../system/graph_dynamic_specification.h"

--- a/tiledb/flow_graph/test/solo/solo_graph_static_specification.cc
+++ b/tiledb/flow_graph/test/solo/solo_graph_static_specification.cc
@@ -1,0 +1,30 @@
+/**
+ * @file flow_graph/test/solo/solo_graph_static_specification.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+#include "../../system/graph_static_specification.h"

--- a/tiledb/flow_graph/test/solo/solo_node_body.cc
+++ b/tiledb/flow_graph/test/solo/solo_node_body.cc
@@ -1,0 +1,30 @@
+/**
+ * @file flow_graph/test/solo/solo_node_body.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+#include "../../system/node_body.h"

--- a/tiledb/flow_graph/test/solo/solo_node_services.cc
+++ b/tiledb/flow_graph/test/solo/solo_node_services.cc
@@ -1,0 +1,30 @@
+/**
+ * @file flow_graph/test/solo/solo_node_services.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+#include "../../system/node_services.h"

--- a/tiledb/flow_graph/test/test_execution_graph.cc
+++ b/tiledb/flow_graph/test/test_execution_graph.cc
@@ -1,0 +1,80 @@
+/**
+ * @file flow_graph/test/test_execution_graph.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include "tdb_catch.h"
+
+/*
+ * This file performs whole-system instantiation tests. As such it requires all
+ * the stages:
+ *   1. Static graph specifications. These are in `test_graphs.h`.
+ *   2. Converter from static to dynamic specification. This is in
+ *      "graph_specification.h"
+ *   3. An execution platform. The basic one is used here.
+ *   4. An execution graph class. This is in "flow_graph.h".
+ */
+
+#include "../library/static/static_zero_graph.h"
+#include "test_graphs.h"
+
+// the system definition
+#include "../system.h"
+// for the test
+#include "../system/execution_graph.h"    // for `concept execution_graph`
+#include "../system/flow_graph_system.h"  // for `concept flow_graph_system`
+
+using namespace tiledb::flow_graph;
+using namespace tiledb::flow_graph::test;
+
+using S = tiledb::flow_graph::ReferenceSystem;
+
+template <>
+struct TestGraphTraits<static_specification::ZeroGraph> {
+  static constexpr std::string_view name{"ZeroGraph"};
+};
+
+using AllTheTestGraphs = std::tuple<
+    static_specification::ZeroGraph,
+    DummyTestGraph<void>,
+    DummyTestGraphActualTupleOfNodes<void>>;
+
+TEST_CASE("ReferenceSystem soundness", "[flow_graph][ReferenceSystem]") {
+  STATIC_CHECK(flow_graph_system<S>);
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy graph, execution ", "[flow_graph]", AllTheTestGraphs) {
+  DYNAMIC_SECTION(TestGraphTraits<TestType>::name) {
+    using GDS =
+        S::static_to_dynamic_transformer<TestType, S::execution_platform>;
+    STATIC_CHECK(graph_dynamic_specification<GDS>);
+    S::dynamic_to_execution_transformer<GDS> x{GDS{}};
+    STATIC_CHECK(execution_graph<decltype(x)>);
+  }
+}

--- a/tiledb/flow_graph/test/test_general_factory.cc
+++ b/tiledb/flow_graph/test/test_general_factory.cc
@@ -1,0 +1,103 @@
+/**
+ * @file flow_graph/test/test_general_factory.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Tests for `graph_type.h`. These eventually might be
+ * moved into their own directory.
+ */
+
+#include "tdb_catch.h"
+#include "tiledb/flow_graph/general_factory.h"
+
+using namespace tiledb;
+
+class ProducedBase {
+  int x_;
+
+ public:
+  ProducedBase(int x)
+      : x_{x} {};
+  int x() const {
+    return x_;
+  }
+};
+
+class Produced_0 : public ProducedBase {
+ public:
+  Produced_0()
+      : ProducedBase{5} {};
+  Produced_0(int x)
+      : ProducedBase{x} {};
+};
+
+void prototype_0(){};
+void prototype_1(int){};
+
+template <class T>
+class Produced_1 : public ProducedBase {
+ public:
+  Produced_1()
+      : ProducedBase{T::x} {};
+  Produced_1(int x)
+      : ProducedBase{x} {};
+};
+
+struct ProducedInitializer {
+  static constexpr int x{7};
+};
+
+TEST_CASE("ClassFactory, simple 0", "[general_factory]") {
+  Produced_0 destination{0};
+  CHECK(destination.x() == 0);
+  ClassFactory<prototype_0> factory{ForClass<Produced_0>};
+  factory.make(&destination);
+  CHECK(destination.x() == 5);
+}
+
+TEST_CASE("ClassFactory, simple 1", "[general_factory]") {
+  Produced_0 destination;
+  ClassFactory<prototype_1> factory{ForClass<Produced_0>};
+  factory.make(&destination, 3);
+  CHECK(destination.x() == 3);
+}
+
+TEST_CASE("ClassTemplateFactory, simple 0", "[general_factory]") {
+  Produced_1<ProducedInitializer> destination{0};
+  CHECK(destination.x() == 0);
+  ClassTemplateFactory<prototype_0, ProducedInitializer> factory{
+      ForClassTemplate<Produced_1>};
+  factory.make(&destination);
+  CHECK(destination.x() == 7);
+}
+
+TEST_CASE("ClassTemplateFactory, simple 1", "[general_factory]") {
+  Produced_1<ProducedInitializer> destination{0};
+  CHECK(destination.x() == 0);
+  ClassTemplateFactory<prototype_1, ProducedInitializer> factory{
+      ForClassTemplate<Produced_1>};
+  factory.make(&destination, 2);
+  CHECK(destination.x() == 2);
+}

--- a/tiledb/flow_graph/test/test_graph_specification.cc
+++ b/tiledb/flow_graph/test/test_graph_specification.cc
@@ -1,0 +1,125 @@
+/**
+ * @file flow_graph/test/test_graph_specification.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include "tdb_catch.h"
+
+#include "../library/dynamic/to_dynamic_reference.h"
+#include "../library/platform/basic_execution_platform.h"
+#include "test_graphs.h"
+
+using namespace tiledb::flow_graph;
+using namespace tiledb::flow_graph::test;
+
+template <class>
+class TrivialClassTemplate {};
+
+TEST_CASE("node_body concept is not trivial") {
+  /*
+   * The trivial class template should not satisfy the `node_body` concept.
+   */
+  STATIC_CHECK(!node_body<TrivialClassTemplate>);
+}
+
+//----------------------------------
+// Graph
+//----------------------------------
+
+using Gr = DummyTestGraph<void>;
+using Gr2 = DummyTestGraphActualTupleOfNodes<void>;
+
+TEST_CASE("dummy graph instance, void", "[fgl][dummy]") {
+  static_assert(
+      graph_static_specification<DummyTestGraph<void>>,
+      "It's supposed to be a specification graph");
+  static_assert(
+      graph_static_specification<DummyTestGraphActualTupleOfNodes<void>>,
+      "It's supposed to be a specification graph");
+  constexpr DummyTestGraph<void> g{};
+
+  static_assert(is_reference_element_of(Gr::a, Gr::nodes));
+  static_assert(is_reference_element_of(Gr2::a, Gr2::nodes));
+  static_assert(is_reference_element_of(Gr::b, Gr::nodes));
+  static_assert(is_reference_element_of(Gr2::b, Gr2::nodes));
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy graph instance", "[fgl][dummy]", AllTheDummyTestGraphs) {
+  DYNAMIC_SECTION(TestGraphTraits<TestType>::name) {
+    STATIC_CHECK(graph_static_specification<TestType>);
+    constexpr TestType g{};
+
+    STATIC_CHECK(std::tuple_size_v<decltype(TestType::nodes)> == 2);
+    STATIC_CHECK(std::tuple_size_v<decltype(TestType::edges)> == 1);
+
+    STATIC_CHECK(is_reference_element_of(TestType::a, TestType::nodes));
+    STATIC_CHECK(is_reference_element_of(TestType::b, TestType::nodes));
+  }
+}
+
+TEMPLATE_LIST_TEST_CASE(
+    "dummy graph, static specification to dynamic",
+    "[fgl][dummy]",
+    AllTheDummyTestGraphs) {
+  DYNAMIC_SECTION(TestGraphTraits<TestType>::name) {
+    // graph in bulk
+    using dynamic_specification_type =
+        ToDynamicReference<TestType, BasicExecutionPlatform>;
+    STATIC_CHECK(graph_dynamic_specification<dynamic_specification_type>);
+    dynamic_specification_type g{};
+    CHECK(g.nodes_size() == 2);
+    REQUIRE(g.nodes_size() >= 2);
+    auto edges{g.edges()};
+    CHECK(g.edges_size() == 1);
+    REQUIRE(g.edges_size() >= 1);
+
+    // graph elements
+    auto nodes{g.nodes()};
+    auto initial{nodes[0]};
+    STATIC_CHECK(dynamic_specification::node<decltype(initial)>);
+    CHECK(initial.inputs_size() == 0);
+    CHECK(initial.outputs_size() == 1);
+    REQUIRE(initial.outputs_size() >= 1);
+    auto initial_port{initial.outputs()[0]};
+
+    auto final{nodes[1]};
+    STATIC_CHECK(dynamic_specification::node<decltype(final)>);
+    CHECK(final.inputs_size() == 1);
+    CHECK(final.outputs_size() == 0);
+    REQUIRE(final.inputs_size() >= 1);
+    auto final_port{final.inputs()[0]};
+
+    auto edge{edges[0]};
+    /* No checks for edges at this time */
+  }
+}
+
+//---------------------
+//----------------------------------
+//-------------------------------------------------------

--- a/tiledb/flow_graph/test/test_graph_type.cc
+++ b/tiledb/flow_graph/test/test_graph_type.cc
@@ -1,0 +1,193 @@
+/**
+ * @file flow_graph/test/test_graph_type.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION Tests for `graph_type.h`. These eventually might be
+ * moved into their own directory.
+ */
+
+#include "tdb_catch.h"
+#include "tiledb/flow_graph/system/graph_type.h"
+
+using namespace tiledb::flow_graph;
+
+//-------------------------------------------------------
+// test data
+//-------------------------------------------------------
+constexpr std::tuple t0{};
+constexpr std::tuple t1{0};
+constexpr std::tuple t2{0, 1};
+constexpr std::tuple t3{0, 1, 2};
+
+// tuples of member references
+struct T1 {
+  // elements of list; values 0,1
+  static constexpr int a{0};
+  static constexpr int b{0};
+  static constexpr int c{1};
+  // absent from list; values 1,2
+  static constexpr int d{1};
+  static constexpr int e{1};
+  static constexpr int f{2};
+  // reference list to test against
+  constexpr static std::tuple<const int&, const int&, const int&> x{a, b, c};
+  constexpr static reference_tuple x2{a, b, c};
+};
+// also absent from list; values 1,2
+constexpr int g1{1};
+constexpr int g2{2};
+
+//-------------------------------------------------------
+// product_type
+//-------------------------------------------------------
+
+TEST_CASE("product_type vs. std::tuple", "[fgl][product_type]") {
+  static_assert(product_type<std::tuple<>>);
+  static_assert(product_type<std::tuple<int>>);
+  static_assert(product_type<std::tuple<int, int>>);
+  static_assert(product_type<decltype(t0)>);
+  static_assert(product_type<decltype(t1)>);
+  static_assert(product_type<decltype(t2)>);
+  static_assert(product_type<decltype(t3)>);
+  static_assert(product_type<decltype(T1::x)>);
+  static_assert(product_type<decltype(T1::x2)>);
+}
+
+TEST_CASE("factor_sizeof vs. std::tuple", "[fgl][factor_sizeof]") {
+  static_assert(factor_sizeof(std::tuple<>{}) == 0);
+  static_assert(factor_sizeof(std::tuple<int>{}) == 1);
+  static_assert(factor_sizeof(std::tuple<int, int>{}) == 2);
+  static_assert(factor_sizeof(t0) == 0);
+  static_assert(factor_sizeof(t1) == 1);
+  static_assert(factor_sizeof(t2) == 2);
+  static_assert(factor_sizeof(t3) == 3);
+  static_assert(factor_sizeof(T1::x) == 3);
+  static_assert(factor_sizeof(T1::x2) == 3);
+}
+
+TEST_CASE(
+    "product_type vs. reference_tuple",
+    "[fgl][product_type][reference_tuple]") {
+  static_assert(product_type<reference_tuple<>>);
+  static_assert(product_type<reference_tuple<int>>);
+  static_assert(product_type<reference_tuple<int, int>>);
+  static_assert(product_type<decltype(T1::x2)>);
+}
+
+TEST_CASE(
+    "factor_sizeof vs. reference_tuple",
+    "[fgl][factor_sizeof][reference_tuple]") {
+  static_assert(factor_sizeof(reference_tuple<>{}) == 0);
+  static_assert(factor_sizeof(reference_tuple<int>{}) == 1);
+  static_assert(factor_sizeof(reference_tuple<int, int>{}) == 2);
+  static_assert(factor_sizeof(T1::x2) == 3);
+}
+
+//-------------------------------------------------------
+// `is_reference_element_of` and `contains_lvalue_references`
+//-------------------------------------------------------
+TEST_CASE(
+    "is_reference_element_of_old vs. std::tuple",
+    "[fgl][is_reference_element_of]") {
+  static_assert(is_reference_element_of(T1::a, T1::x));
+  static_assert(is_reference_element_of(T1::b, T1::x));
+  static_assert(is_reference_element_of(T1::c, T1::x));
+  static_assert(!is_reference_element_of(T1::d, T1::x));
+  static_assert(!is_reference_element_of(T1::e, T1::x));
+  static_assert(!is_reference_element_of(T1::f, T1::x));
+  static_assert(!is_reference_element_of(g1, T1::x));
+  static_assert(!is_reference_element_of(g2, T1::x));
+}
+
+TEST_CASE(
+    "is_reference_element_of_old vs. reference_tuple",
+    "[fgl][is_reference_element_of_old][reference_tuple]") {
+  static_assert(is_reference_element_of(T1::a, T1::x2));
+  static_assert(is_reference_element_of(T1::b, T1::x2));
+  static_assert(is_reference_element_of(T1::c, T1::x2));
+  static_assert(!is_reference_element_of(T1::d, T1::x2));
+  static_assert(!is_reference_element_of(T1::e, T1::x2));
+  static_assert(!is_reference_element_of(T1::f, T1::x2));
+  static_assert(!is_reference_element_of(g1, T1::x2));
+  static_assert(!is_reference_element_of(g2, T1::x2));
+}
+
+TEST_CASE(
+    "contains_lvalue_references vs. std::tuple",
+    "[fgl][contains_lvalue_references]") {
+  static_assert(contains_lvalue_references_v(T1::x));
+}
+
+TEST_CASE(
+    "contains_lvalue_references vs. reference_tuple",
+    "[fgl][contains_lvalue_references][reference_tuple]") {
+  static_assert(contains_lvalue_references_v(T1::x2));
+}
+
+//-------------------------------------------------------
+// predicate_class_over_product
+//-------------------------------------------------------
+
+struct false_funobject {
+  template <class T>
+  constexpr bool operator()(T&&) {
+    return false;
+  }
+  constexpr false_funobject() = default;
+};
+
+struct true_funobject {
+  template <class T>
+  constexpr bool operator()(T&&) {
+    return true;
+  }
+  constexpr true_funobject() = default;
+};
+
+TEST_CASE(
+    "predicate_class_over_product vs. std::tuple",
+    "[fgl][predicate_class_over_product][reference_tuple]") {
+  static_assert(predicate_over_product<true_funobject, decltype(T1::x)>);
+  static_assert(predicate_over_product<false_funobject, decltype(T1::x)>);
+}
+
+TEST_CASE(
+    "predicate_class_over_product vs. reference_tuple",
+    "[fgl][predicate_class_over_product][reference_tuple]") {
+  static_assert(predicate_over_product<true_funobject, decltype(T1::x2)>);
+  static_assert(predicate_over_product<false_funobject, decltype(T1::x2)>);
+}
+
+TEST_CASE("count_until_satisfied_p", "[fgl][predicate_class_over_product]") {
+  static_assert(count_until_satisfied_p(true_funobject{}, T1::x) == 0);
+  static_assert(count_until_satisfied_p(true_funobject{}, T1::x2) == 0);
+  static_assert(
+      count_until_satisfied_p(false_funobject{}, T1::x) ==
+      factor_sizeof(T1::x));
+  static_assert(
+      count_until_satisfied_p(false_funobject{}, T1::x2) ==
+      factor_sizeof(T1::x2));
+}

--- a/tiledb/flow_graph/test/test_graphs.h
+++ b/tiledb/flow_graph/test/test_graphs.h
@@ -1,0 +1,123 @@
+/**
+ * @file flow_graph/test/test_graphs.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <string_view>
+
+#include "../graph.h"
+#include "../library/static/dummy.h"
+
+namespace tiledb::flow_graph::test {
+
+/**
+ * Trait class for annotating DYNAMIC_SECTION
+ *
+ * @tparam T a class that appears in a list for TEMPLATE_LIST_TEST_CASE
+ */
+template <class T>
+struct TestGraphTraits;
+
+/*
+ * The dummy graph is here for construction tests. It's the simplest non-
+ * trivial graph, with two nodes with one port each and a single edge.
+ *
+ * There are multiple versions of the dummy graph with the same topology. They
+ * are present in order to ensure that implementation-dependent details don't
+ * leak through the concept. Node and edge lists must be tuple-like, but they
+ * don't need to be `std::tuple` itself.
+ *
+ * The class `reference_tuple` is available for compact specification of node
+ * lists. Use of this class avoids repeating the node definition type in a node
+ * list.
+ *
+ * At present an analogous class for specifying edges is not available, such as
+ * `edge_tuple`. Its benefit would be to avoid an edge type altogether for the
+ * ordinary case when the graph specification only uses default edge parameters
+ * and does not override any edge type.
+ */
+
+/**
+ * The test graph has a dummy output node, a dummy input node, and a dummy edge.
+ * It will instantiate, but it all starts out in a terminal state, so it won't
+ * do anything.
+ */
+template <class T>
+class DummyTestGraph {
+ public:
+  constexpr static struct invariant_type {
+    constexpr static bool i_am_graph_static_specification{true};
+  } invariants;
+  constexpr static DummyOutputNodeSpecification<T> a{};
+  constexpr static DummyInputNodeSpecification<T> b{};
+  constexpr static reference_tuple nodes{a, b};
+  constexpr static std::tuple edges{
+      DummyEdgeSpecification{a, a.output, b, b.input}};
+};
+
+template <>
+struct TestGraphTraits<DummyTestGraph<void>> {
+  static constexpr std::string_view name{"DummyTestGraph<void>"};
+};
+
+/**
+ * An alternate and more verbose way to specify a node list. This uses
+ * `std::tuple` for its node list rather than `reference_tuple`.
+ *
+ * @tparam T
+ */
+template <class T>
+class DummyTestGraphActualTupleOfNodes {
+ public:
+  constexpr static struct invariant_type {
+    constexpr static bool i_am_graph_static_specification{true};
+  } invariants;
+  constexpr static DummyOutputNodeSpecification<T> a{};
+  constexpr static DummyInputNodeSpecification<T> b{};
+  constexpr static std::tuple<
+      const DummyOutputNodeSpecification<T>&,
+      const DummyInputNodeSpecification<T>&>
+      nodes{a, b};
+  constexpr static std::tuple edges{
+      DummyEdgeSpecification{a, a.output, b, b.input}};
+};
+
+template <>
+struct TestGraphTraits<DummyTestGraphActualTupleOfNodes<void>> {
+  static constexpr std::string_view name{
+      "DummyTestGraphActualTupleOfNodes<void>"};
+};
+
+/**
+ * Tuple type containing all the variations of the dummy test graph for use with
+ * `TEMPLATE_LIST_TEST_CASE`
+ */
+using AllTheDummyTestGraphs =
+    std::tuple<DummyTestGraph<void>, DummyTestGraphActualTupleOfNodes<void>>;
+
+}  // namespace tiledb::flow_graph::test

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -1143,7 +1143,7 @@ uint64_t Dimension::map_to_uint64_2<char>(
   // "cat\0\0\0\0\0" inside the 8-byte uint64 value `ret`.
   uint64_t ret = 0;
   for (uint64_t i = 0; i < 8; ++i) {
-    ret <<= 8;  // Shift by one byte
+    ret <<= 8;                    // Shift by one byte
     if (i < v_str_size)
       ret |= (uint64_t)v_str[i];  // Add next character (if exists)
   }
@@ -1197,7 +1197,7 @@ ByteVecValue Dimension::map_from_uint64<char>(
     const Dimension* dim, uint64_t value, int bits, uint64_t max_bucket_val) {
   assert(dim != nullptr);
   (void)dim;
-  (void)max_bucket_val;  // Not needed here
+  (void)max_bucket_val;                        // Not needed here
 
   std::vector<uint8_t> ret(sizeof(uint64_t));  // 8 bytes
 

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -614,7 +614,7 @@ uint64_t compute_tile_extent_based_on_file_size(uint64_t file_size) {
   } else if (file_size > 1024ULL * 1024ULL) {           // 1MB
     return 1024ULL * 256ULL;                            // 256KB
   } else {
-    return 1024ULL;  // 1KB
+    return 1024ULL;                                     // 1KB
   }
 }
 

--- a/tiledb/sm/compressors/rle_compressor.cc
+++ b/tiledb/sm/compressors/rle_compressor.cc
@@ -69,7 +69,7 @@ Status RLE::compress(
     if (std::memcmp(input_cur, input_prev, value_size) == 0 &&
         cur_run_len < max_run_len) {  // Expand the run
       ++cur_run_len;
-    } else {  // Save the run
+    } else {                          // Save the run
       // Copy to output buffer
       RETURN_NOT_OK(output_buffer->write(input_prev, value_size));
       byte = (unsigned char)(cur_run_len >> 8);

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -106,15 +106,15 @@ Status FragmentMetaConsolidator::consolidate(
   RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, &meta_version));
 
   // Calculate offset of first fragment footer
-  uint64_t offset = sizeof(uint32_t);  // Fragment num
+  uint64_t offset = sizeof(uint32_t);                       // Fragment num
   for (auto m : meta) {
-    offset += sizeof(uint64_t);  // Name size
+    offset += sizeof(uint64_t);                             // Name size
     if (meta_version >= 9) {
       offset += m->fragment_uri().last_path_part().size();  // Name
     } else {
-      offset += m->fragment_uri().to_string().size();  // Name
+      offset += m->fragment_uri().to_string().size();       // Name
     }
-    offset += sizeof(uint64_t);  // Offset
+    offset += sizeof(uint64_t);                             // Offset
   }
 
   // Serialize all fragment metadata footers in parallel

--- a/tiledb/sm/filter/test/compile_all_filters_main.cc
+++ b/tiledb/sm/filter/test/compile_all_filters_main.cc
@@ -33,7 +33,7 @@ int main() {
 
   (void)sizeof(tiledb::sm::FilterCreate);
   (void)static_cast<shared_ptr<Filter> (*)(
-      Deserializer & deserializer, const uint32_t version)>(
+      Deserializer& deserializer, const uint32_t version)>(
       tiledb::sm::FilterCreate::deserialize);
   return 0;
 }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -477,7 +477,7 @@ uint64_t FragmentMetadata::cell_num() const {
   assert(tile_num != 0);
   if (dense_) {  // Dense fragment
     return tile_num * array_schema_->domain().cell_num_per_tile();
-  } else {  // Sparse fragment
+  } else {       // Sparse fragment
     return (tile_num - 1) * array_schema_->capacity() + last_tile_cell_num();
   }
 }
@@ -3973,7 +3973,7 @@ void FragmentMetadata::write_non_empty_domain(Serializer& serializer) const {
       const auto& r = non_empty_domain_[d];
       if (!dim->var_size()) {  // Fixed-sized
         serializer.write(r.data(), r.size());
-      } else {  // Var-sized
+      } else {                 // Var-sized
         auto r_size = r.size();
         auto r_start_size = r.start_size();
         serializer.write<uint64_t>(r_size);

--- a/tiledb/sm/misc/hilbert.h
+++ b/tiledb/sm/misc/hilbert.h
@@ -270,7 +270,7 @@ class Hilbert {
       for (i = 1; i < n; i++)
         if (X[i] & Q)  // invert
           X[0] ^= P;
-        else {  // exchange
+        else {         // exchange
           t = (X[0] ^ X[i]) & P;
           X[0] ^= t;
           X[i] ^= t;
@@ -334,7 +334,7 @@ class Hilbert {
       for (i = n - 1; i; i--)
         if (X[i] & Q)  // invert
           X[0] ^= P;
-        else {  // exchange
+        else {         // exchange
           t = (X[0] ^ X[i]) & P;
           X[0] ^= t;
           X[i] ^= t;

--- a/tiledb/sm/misc/tdb_math.cc
+++ b/tiledb/sm/misc/tdb_math.cc
@@ -66,7 +66,7 @@ uint64_t left_p2_m1(uint64_t value) {
   if (value == UINT64_MAX)
     return value;
 
-  uint64_t ret = 0;  // Min power of 2 minus 1
+  uint64_t ret = 0;        // Min power of 2 minus 1
   while (ret <= value) {
     ret = (ret << 1) | 1;  // Next larger power of 2 minus 1
   }
@@ -81,7 +81,7 @@ uint64_t right_p2_m1(uint64_t value) {
 
   uint64_t ret = UINT64_MAX;  // Max power of 2 minus 1
   while (ret >= value) {
-    ret >>= 1;  // Next smaller power of 2 minus 1
+    ret >>= 1;                // Next smaller power of 2 minus 1
   }
 
   return (ret << 1) | 1;

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -182,7 +182,7 @@ void Stats::add_counter(const std::string& stat, uint64_t count) {
   auto it = counters_.find(new_stat);
   if (it == counters_.end()) {  // Counter not found
     counters_[new_stat] = count;
-  } else {  // Counter found
+  } else {                      // Counter found
     it->second += count;
   }
 }
@@ -204,7 +204,7 @@ void Stats::report_duration(
   auto it2 = timers_.find(new_stat + ".sum");
   if (it2 == timers_.end()) {  // Timer not found
     timers_[new_stat + ".sum"] = duration.count();
-  } else {  // Timer found
+  } else {                     // Timer found
     it2->second += duration.count();
   }
 
@@ -212,7 +212,7 @@ void Stats::report_duration(
   auto it3 = timers_.find(new_stat + ".max");
   if (it3 == timers_.end()) {  // Timer not found
     timers_[new_stat + ".max"] = duration.count();
-  } else {  // Timer found
+  } else {                     // Timer found
     if (duration.count() > it3->second)
       it3->second = duration.count();
   }
@@ -221,7 +221,7 @@ void Stats::report_duration(
   auto it4 = counters_.find(new_stat + ".timer_count");
   if (it4 == counters_.end()) {  // Timer not found
     counters_[new_stat + ".timer_count"] = 1;
-  } else {  // Timer found
+  } else {                       // Timer found
     it4->second += 1;
   }
 }

--- a/tiledb/sm/stats/test/unit_stats.cc
+++ b/tiledb/sm/stats/test/unit_stats.cc
@@ -35,7 +35,7 @@
 #include <test/support/tdb_catch.h>
 #include <tiledb/common/common.h>
 #include <tiledb/common/dynamic_memory/dynamic_memory.h>
-//#include <tiledb/sm/cpp_api/tiledb>
+// #include <tiledb/sm/cpp_api/tiledb>
 #include <tiledb/sm/stats/global_stats.h>
 
 #include <string>

--- a/tiledb/stdx/type_traits.h
+++ b/tiledb/stdx/type_traits.h
@@ -1,0 +1,51 @@
+/**
+ * @file stdx/type_traits.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+#ifndef TILEDB_STDX_TYPE_TRAITS_H
+#define TILEDB_STDX_TYPE_TRAITS_H
+
+namespace stdx {
+
+template <class T>
+struct remove_member_pointer {
+  using type = T;
+  using class_type = void;
+};
+template <class C, class T>
+struct remove_member_pointer<T C::*> {
+  using type = T;
+  using class_type = C;
+};
+template <class T>
+using remove_member_pointer_t = remove_member_pointer<T>::type;
+template <class T>
+using remove_member_pointer_c = remove_member_pointer<T>::class_type;
+
+}  // namespace stdx
+#endif  // TILEDB_STDX_TYPE_TRAITS_H


### PR DESCRIPTION
Initial skeleton for `flow_graph`. Focus is on (1) overall structure with decomposition into stages mediated by concepts, and (2) passage through the stages from a static graph specification to an executable graph.

Adds new directives to `.clang-format` to account for concept. This requires an upgrade to version 16.

---
TYPE: NO_HISTORY
DESC: Initial skeleton for `flow_graph`
