### PR TITLE
Add space in aws-sdk-cpp 0008 patch to support Windows

### DIFF
--- a/ports/aws-sdk-cpp/008-disable-werror.patch
+++ b/ports/aws-sdk-cpp/008-disable-werror.patch
@@ -4,11 +4,11 @@ index c92652cc5..e2fa5e27a 100644
 +++ b/cmake/compiler_settings.cmake
 @@ -53,7 +53,7 @@ macro(set_gcc_flags)
  endmacro()
-
+ 
  macro(set_gcc_warnings)
 -    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-Werror" "-pedantic" "-Wextra")
 +    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-pedantic" "-Wextra")
      if(COMPILER_CLANG)
          if(PLATFORM_ANDROID)
              # when using clang with libc and API lower than 21 we need to include Android support headers and ignore the gnu-include-next warning.
-
+ 


### PR DESCRIPTION
Windows patch command complains if there is an empty line in the patch. This adds a single space character to work around this.

Related to: #4144 

---
TYPE: NO_HISTORY
DESC: NO_HISTORY