### PR TITLE
Build curl with ZStandard support on vcpkg when serialization is enabled.

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         winidn      USE_WIN32_IDN
         winldap     USE_WIN32_LDAP
         websockets  ENABLE_WEBSOCKETS
+        zstd        CURL_ZSTD
     INVERTED_FEATURES
         non-http    HTTP_ONLY
         winldap     CURL_DISABLE_LDAP # Only WinLDAP support ATM

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -200,6 +200,12 @@
       "dependencies": [
         "wolfssl"
       ]
+    },
+    "zstd": {
+      "description": "ZStandard support (zstd)",
+      "dependencies": [
+        "zstd"
+      ]
     }
   }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -52,7 +52,10 @@
         "serialization": {
             "description": "Enable TileDB Cloud Support",
             "dependencies": [
-                "curl",
+                {
+                    "name": "curl",
+                    "features": [ "zstd" ]
+                },
                 {
                     "name": "capnproto",
                     "version>=": "0.8.0"


### PR DESCRIPTION
[SC-31595](https://app.shortcut.com/tiledb-inc/story/31595/enable-zstd-in-vcpkg-curl-build)

The vcpkg port for curl does not have a feature to enable zstd. I created one and opened microsoft/vcpkg#32533 to add it upstream.

---
TYPE: IMPROVEMENT
DESC: Build curl with ZStandard support on vcpkg when serialization is enabled.