### PR TITLE
Add tests for TILEDB_NOT

### DIFF
--- a/test/src/unit-cppapi-dense-qc-coords-mode.cc
+++ b/test/src/unit-cppapi-dense-qc-coords-mode.cc
@@ -105,9 +105,10 @@ TEST_CASE_METHOD(
   std::vector<int> c_d1_go;
   std::vector<int> c_d2_go;
   QueryCondition qc(ctx_);
+  tiledb_layout_t read_layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_GLOBAL_ORDER);
 
   // Set condition and expected results.
-  SECTION("Test 1") {
+  SECTION("Test TILEDB_LE") {
     int val = 20;
     qc.init("a1", &val, sizeof(int), TILEDB_LE);
     c_d1_rm = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
@@ -117,7 +118,7 @@ TEST_CASE_METHOD(
     c_result_num = 20;
   }
 
-  SECTION("Test 2") {
+  SECTION("Test TILEDB_AND") {
     int val = 60;
     qc.init("a1", &val, sizeof(int), TILEDB_GT);
     QueryCondition qc2(ctx_);
@@ -131,8 +132,38 @@ TEST_CASE_METHOD(
     c_result_num = 15;
   }
 
+  SECTION("Test TILEDB_OR") {
+    int val = 90;
+    qc.init("a1", &val, sizeof(int), TILEDB_GT);
+    QueryCondition qc2(ctx_);
+    val = 5;
+    qc2.init("a1", &val, sizeof(int), TILEDB_LE);
+    qc = qc.combine(qc2, TILEDB_OR);
+    c_d1_rm = {1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10};
+    c_d2_rm = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    c_d1_go = {1, 1, 1, 1, 1, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10};
+    c_d2_go = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    c_result_num = 15;
+  }
+
+  SECTION("Test TILEDB_NOT") {
+    int val = 90;
+    qc.init("a1", &val, sizeof(int), TILEDB_LT);
+    QueryCondition qc2(ctx_);
+    val = 10;
+    qc2.init("a1", &val, sizeof(int), TILEDB_GE);
+    qc = qc.combine(qc2, TILEDB_AND);
+    qc = qc.negate();
+    c_d1_rm = {1,  1,  1,  1,  1,  1,  1,  1,  1,  9,
+               10, 10, 10, 10, 10, 10, 10, 10, 10, 10};
+    c_d2_rm = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    c_d1_go = {1,  1,  1,  1,  1,  1,  1,  1, 1,  10,
+               10, 10, 10, 10, 10, 10, 10, 9, 10, 10};
+    c_d2_go = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 10, 9, 10};
+    c_result_num = 20;
+  }
+
   // Set and run the query.
-  tiledb_layout_t read_layout = GENERATE(TILEDB_ROW_MAJOR, TILEDB_GLOBAL_ORDER);
   std::vector<int> subarray = {1, 10, 1, 10};
   std::vector<int> d1(100);
   std::vector<int> d2(100);

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -377,6 +377,25 @@ int32_t CSparseGlobalOrderFx::read(
         ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
     CHECK(rc == TILEDB_OK);
 
+    // Negated query condition should produce the same results.
+    SECTION("- Test TILEDB_NOT") {
+      tiledb_query_condition_t* qc;
+      rc = tiledb_query_condition_alloc(ctx_, &qc);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_init(
+          ctx_, qc, "a", &val, sizeof(int32_t), TILEDB_GE);
+      CHECK(rc == TILEDB_OK);
+
+      tiledb_query_condition_free(&query_condition);
+      query_condition = nullptr;
+      rc = tiledb_query_condition_alloc(ctx_, &query_condition);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_negate(ctx_, qc, &query_condition);
+      CHECK(rc == TILEDB_OK);
+
+      tiledb_query_condition_free(&qc);
+    }
+
     rc = tiledb_query_set_condition(ctx_, query, query_condition);
     CHECK(rc == TILEDB_OK);
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -422,6 +422,25 @@ int32_t CSparseUnorderedWithDupsFx::read(
         ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
     CHECK(rc == TILEDB_OK);
 
+    // Negated query condition should produce the same results.
+    SECTION("- Test TILEDB_NOT") {
+      tiledb_query_condition_t* qc;
+      rc = tiledb_query_condition_alloc(ctx_, &qc);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_init(
+          ctx_, qc, "a", &val, sizeof(int32_t), TILEDB_GE);
+      CHECK(rc == TILEDB_OK);
+
+      tiledb_query_condition_free(&query_condition);
+      query_condition = nullptr;
+      rc = tiledb_query_condition_alloc(ctx_, &query_condition);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_negate(ctx_, qc, &query_condition);
+      CHECK(rc == TILEDB_OK);
+
+      tiledb_query_condition_free(&qc);
+    }
+
     rc = tiledb_query_set_condition(ctx_, query, query_condition);
     CHECK(rc == TILEDB_OK);
 


### PR DESCRIPTION
Adds tests for TILEDB_NOT via `QueryCondition::negate` APIs in C / C++.

---
TYPE: IMPROVEMENT
DESC: Add tests for TILEDB_NOT
