### PR TITLE
bump curl version to 7.88.1

### DIFF
--- a/cmake/Modules/FindCurl_EP.cmake
+++ b/cmake/Modules/FindCurl_EP.cmake
@@ -80,10 +80,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_curl.tar.gz
-      URL
-        "https://github.com/TileDB-Inc/tiledb-deps-mirror/releases/download/2.11-deps/curl-7.74.0.tar.gz"
-        "https://curl.se/download/curl-7.74.0.tar.gz"
-      URL_HASH SHA1=cd7239cf9223b39ade86a14eb37fe68f5656eae9
+      URL "https://curl.se/download/curl-7.88.1.tar.gz"
+      URL_HASH SHA1=6ae5229c36badb822641bb14958e7d227c57611d
       CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}
         -DCMAKE_BUILD_TYPE=Release
@@ -163,8 +161,8 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
 
     ExternalProject_Add(ep_curl
       PREFIX "externals"
-      URL "https://curl.se/download/curl-7.74.0.tar.gz"
-      URL_HASH SHA1=cd7239cf9223b39ade86a14eb37fe68f5656eae9
+      URL "https://curl.se/download/curl-7.88.1.tar.gz"
+      URL_HASH SHA1=6ae5229c36badb822641bb14958e7d227c57611d
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E env PKG_CONFIG_PATH=${SSL_PKG_CONFIG_PATH} ${TILEDB_EP_BASE}/src/ep_curl/configure
           --prefix=${TILEDB_EP_INSTALL_PREFIX}
@@ -181,7 +179,6 @@ if (NOT CURL_FOUND AND TILEDB_SUPERBUILD)
           --without-gnutls
           --without-gssapi
           --without-idn2
-          --without-libmetalink
           --without-libssh2
           --without-librtmp
           --without-nghttp2


### PR DESCRIPTION
The older curl version is causing the MyTile linux superbuild to fail: https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=33324&view=logs&j=c621a6e4-69cf-593b-9b4a-5a8ad299b082&s=ae4f8708-9994-57d3-c2d7-b892156e7812&t=bbf63cee-da08-5225-17b6-f91b86847a91&l=2331

The issue comes from missing the ```CURLOPT_CAINFO_BLOB``` which was introduced in curl 7.77.0 https://curl.se/libcurl/c/CURLOPT_CAINFO_BLOB.html

---
TYPE: IMPROVEMENT
DESC: curl version bump to resolve MyTile superbuild failure
