### PR TITLE
Fix order of azure static library linking

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -545,8 +545,8 @@ if (TILEDB_AZURE)
     endif()
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
             INTERFACE
-            Azure::azure-storage-blobs
             Azure::azure-storage-common
+            Azure::azure-storage-blobs
             Azure::azure-core
             LibXml2::LibXml2
             LibLZMA::LibLZMA
@@ -562,8 +562,8 @@ if (TILEDB_AZURE)
     endif()
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
             INTERFACE
-            Azure::azure-storage-common
             Azure::azure-storage-blobs
+            Azure::azure-storage-common
             Azure::azure-core
             LibXml2::LibXml2)
     if(WIN32)


### PR DESCRIPTION
This solves the missing symbol error by linking the azure-storage-common library before the azure-storage-blobs library.

Error solved:
```
libtiledb.so.2.16: undefined symbol: _ZN5Azure7Storage9_internal23UrlEncodeQueryParameterERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
```

---
TYPE: BUG
DESC: Fix azure static library linking order for superbuild
