### PR TITLE
Pass `/EHsc` on MSVC to fix Ninja builds on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,10 @@ set(TILEDB_EP_INSTALL_PREFIX "${TILEDB_EP_BASE}/install")
 if (MSVC)
   # Turn on standards-conformance mode
   add_compile_options("/permissive-")
+  # /EH: Enables standard C++ stack unwinding.
+  # s: Catches only standard C++ exceptions when you use catch(...) syntax.
+  # c: The compiler assumes that functions declared as extern "C" never throw a C++ exception
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
   # We disable some warnings that are not present in gcc/clang -Wall:
   #   C4101: unreferenced local variable
   #   C4146: unary minus operator applied to unsigned type


### PR DESCRIPTION
I tried building with the Ninja CMake generator on Windows but failed with this warning that turned into an error:

```
C:\Users\teo\code\TileDB\tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h(431): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
```

This PR explicitly specifies `/EHsc` to the compile options if we are on MSVC. Builds with both Ninja and MSBuild work with it.

---
TYPE: BUG
DESC: Fix Ninja builds on Windows