### PR TITLE
Dense reader: fix nullable string values when reading with qc.

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -120,10 +120,7 @@ void create_array(
   if (add_utf8_attr) {
     Attribute attr_c = Attribute::create(ctx, "c", TILEDB_STRING_UTF8);
     attr_c.set_cell_val_num(TILEDB_VAR_NUM);
-    if (array_type == TILEDB_DENSE) {
-      std::string ohai("ohai");
-      attr_c.set_fill_value(ohai.data(), ohai.size());
-    }
+    attr_c.set_nullable(true);
     schema.add_attribute(attr_c);
   }
   Array::create(array_name, schema);
@@ -135,6 +132,7 @@ void create_array(
   std::vector<float> b_data;
   std::vector<uint8_t> c_data;
   std::vector<uint64_t> c_offsets;
+  std::vector<uint8_t> c_validity;
 
   std::vector<std::string> c_choices = {
       std::string("bird"),
@@ -176,6 +174,8 @@ void create_array(
     for (size_t c_idx = 0; c_idx < c_str.size(); c_idx++) {
       c_data.push_back(c_str.at(c_idx));
     }
+
+    c_validity.push_back(1);
   }
 
   if (array_type == TILEDB_SPARSE) {
@@ -188,7 +188,9 @@ void create_array(
         .set_data_buffer("b", b_data);
 
     if (add_utf8_attr) {
-      query_w.set_data_buffer("c", c_data).set_offsets_buffer("c", c_offsets);
+      query_w.set_data_buffer("c", c_data)
+          .set_offsets_buffer("c", c_offsets)
+          .set_validity_buffer("c", c_validity);
     }
 
     query_w.submit();
@@ -202,7 +204,9 @@ void create_array(
         .set_data_buffer("b", b_data);
 
     if (add_utf8_attr) {
-      query_w.set_data_buffer("c", c_data).set_offsets_buffer("c", c_offsets);
+      query_w.set_data_buffer("c", c_data)
+          .set_offsets_buffer("c", c_offsets)
+          .set_validity_buffer("c", c_validity);
     }
 
     query_w.submit();
@@ -275,6 +279,7 @@ static void perform_query(
     std::vector<float>& b_data,
     std::string& c_data,
     std::vector<uint64_t>& c_offsets,
+    std::vector<uint8_t>& c_validity,
     const QueryCondition& qc,
     tiledb_layout_t layout_type,
     Query& query) {
@@ -283,6 +288,7 @@ static void perform_query(
       .set_data_buffer("b", b_data)
       .set_data_buffer("c", c_data)
       .set_offsets_buffer("c", c_offsets)
+      .set_validity_buffer("c", c_validity)
       .set_condition(qc);
   query.submit();
 }
@@ -1383,6 +1389,7 @@ TEST_CASE(
   std::string c_data_read_2;
   c_data_read_2.resize(64 * 5);
   std::vector<uint64_t> c_data_offsets_2(64);
+  std::vector<uint8_t> c_data_validity_2(64);
 
   // Generate test parameters.
   TestParams params = GENERATE(
@@ -1421,6 +1428,7 @@ TEST_CASE(
       b_data_read_2,
       c_data_read_2,
       c_data_offsets_2,
+      c_data_validity_2,
       qc,
       params.layout_,
       query);
@@ -1491,12 +1499,14 @@ TEST_CASE(
           REQUIRE(
               fabs(b_data_read_2[i] - b_data_read[original_arr_i]) <
               std::numeric_limits<float>::epsilon());
+          REQUIRE(c_data_validity_2[i] == 1);
         } else {
           // Checking for fill value.
           REQUIRE(a_data_read_2[i] == a_fill_value);
           REQUIRE(
               fabs(b_data_read_2[i] - b_fill_value) <
               std::numeric_limits<float>::epsilon());
+          REQUIRE(c_data_validity_2[i] == 0);
         }
       }
     }

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -1591,10 +1591,10 @@ Status DenseReader::copy_offset_tiles(
       for (uint64_t c = 0; c < iter.cell_slab_length(); c++) {
         if (!(qc_result[c + cell_offset] & 0x1)) {
           memset(dest_ptr + c * sizeof(OffType), 0xFF, sizeof(OffType));
-        }
 
-        if (nullable) {
-          std::memset(dest_validity_ptr + c, fill_value_nullable, 1);
+          if (nullable) {
+            std::memset(dest_validity_ptr + c, fill_value_nullable, 1);
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes dense reads for nullable string attributes when reading with query condition. The fix sets the validity value to the fill value only if the cell doesn't match the query condition whereas before it would always set the validity value to the fill value for all cells.

---
TYPE: IMPROVEMENT
DESC: Dense reader: fix nullable string values when reading with qc.
