### PR TITLE
Fix nightly build issue creation failures.

### DIFF
--- a/.github/workflows/nightly-failure-issue-template.md
+++ b/.github/workflows/nightly-failure-issue-template.md
@@ -1,6 +1,6 @@
 ---
 title: Nightly GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: ihnorton, dhoke4tdb
+assignees: ihnorton
 labels: nightly
 ---
 

--- a/.github/workflows/nightly-failure-issue-template.md
+++ b/.github/workflows/nightly-failure-issue-template.md
@@ -1,6 +1,6 @@
 ---
 title: Nightly GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: ihnorton
+assignees: ihnorton, teo-tsirpanis, davisp
 labels: nightly
 ---
 


### PR DESCRIPTION
Nightly builds [are failing since July 6](https://github.com/TileDB-Inc/TileDB/actions/workflows/nightly-test.yml) but [creating an issue for them failed as well](https://github.com/TileDB-Inc/TileDB/actions/runs/5582850439/jobs/10203504347#step:3:20). This PR should fix creating the issue.

@ihnorton do you want me to assign nightly build failures to someone else besides yourself?

---
TYPE: NO_HISTORY