### PR TITLE
Add API to delete groups without a `tiledb_group_t*`.

### DIFF
--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -162,6 +162,18 @@ capi_return_t tiledb_group_put_metadata(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_group_delete(
+    tiledb_ctx_t* ctx, const char* uri, const uint8_t recursive) {
+  ensure_group_uri_argument_is_valid(uri);
+
+  tiledb::sm::URI tdb_uri(uri);
+  tiledb::sm::Group group{tdb_uri, ctx->storage_manager()};
+  throw_if_not_ok(group.open(tiledb::sm::QueryType::MODIFY_EXCLUSIVE));
+  group.delete_group(tdb_uri, recursive);
+
+  return TILEDB_OK;
+}
+
 capi_return_t tiledb_group_delete_group(
     tiledb_group_t* group, const char* uri, const uint8_t recursive) {
   ensure_group_is_valid(group);
@@ -608,6 +620,12 @@ capi_return_t tiledb_group_put_metadata(
     const void* value) noexcept {
   return api_entry_context<tiledb::api::tiledb_group_put_metadata>(
       ctx, group, key, value_type, value_num, value);
+}
+
+capi_return_t tiledb_group_delete(
+    tiledb_ctx_t* ctx, const char* uri, const uint8_t recursive) noexcept {
+  return api_entry_with_context<tiledb::api::tiledb_group_delete>(
+      ctx, uri, recursive);
 }
 
 capi_return_t tiledb_group_delete_group(

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -207,6 +207,27 @@ TILEDB_EXPORT capi_return_t tiledb_group_put_metadata(
     const void* value) TILEDB_NOEXCEPT;
 
 /**
+ * Deletes written data from a group.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_group_delete(ctx, "s3://tiledb_bucket/my_group", 0);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param uri The address of the group item to be deleted.
+ * @param recursive True if all data inside the group is to be deleted.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ *
+ * @note if recursive == false, data added to the group will be left as-is.
+ */
+TILEDB_EXPORT int32_t tiledb_group_delete(
+    tiledb_ctx_t* ctx,
+    const char* uri,
+    const uint8_t recursive) TILEDB_NOEXCEPT;
+
+/**
  * Deletes written data from an open group. The group must
  * be opened in MODIFY_EXCLSUIVE mode, otherwise the function will error out.
  *

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -239,7 +239,7 @@ TILEDB_EXPORT int32_t tiledb_group_delete(
  *
  * @note if recursive == false, data added to the group will be left as-is.
  */
-TILEDB_EXPORT int32_t tiledb_group_delete_group(
+TILEDB_DEPRECATED_EXPORT int32_t tiledb_group_delete_group(
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* uri,

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -272,9 +272,8 @@ class Group {
    * @note if recursive == false, data added to the group will be left as-is.
    * @post This is destructive; the group may not be reopened after delete.
    */
-  TILEDB_CPP_API_DEPRECATED(
-      "Use the static Group::delete_group method instead.")
-  void delete_group(const std::string& uri, bool recursive = false) {
+  TILEDB_DEPRECATED void delete_group(
+      const std::string& uri, bool recursive = false) {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -272,6 +272,8 @@ class Group {
    * @note if recursive == false, data added to the group will be left as-is.
    * @post This is destructive; the group may not be reopened after delete.
    */
+  TILEDB_CPP_API_DEPRECATED(
+      "Use the static Group::delete_group method instead.")
   void delete_group(const std::string& uri, bool recursive = false) {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -247,6 +247,22 @@ class Group {
   }
 
   /**
+   * Deletes all written data from a group.
+   *
+   * @param ctx TileDB context.
+   * @param uri The address of the group item to be deleted.
+   * @param recursive True if all data inside the group is to be deleted.
+   *
+   * @note if recursive == false, data added to the group will be left as-is.
+   * @post This is destructive; the group may not be reopened after delete.
+   */
+  static void delete_group(
+      const Context& ctx, const std::string& uri, bool recursive = false) {
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_group_delete(c_ctx, uri.c_str(), recursive));
+  }
+
+  /**
    * Deletes all written data from an open group. The group must
    * be opened in MODIFY_EXCLUSIVE mode, otherwise the function will error out.
    *

--- a/tiledb/sm/cpp_api/tiledb
+++ b/tiledb/sm/cpp_api/tiledb
@@ -44,6 +44,9 @@
 #ifndef TILEDB_DEPRECATED_EXPORT
 #define TILEDB_DEPRECATED_EXPORT
 #endif
+#define TILEDB_CPP_API_DEPRECATED(msg)
+#else
+#define TILEDB_CPP_API_DEPRECATED(msg) [[deprecated(msg)]]
 #endif
 
 #include "array.h"

--- a/tiledb/sm/cpp_api/tiledb
+++ b/tiledb/sm/cpp_api/tiledb
@@ -44,9 +44,6 @@
 #ifndef TILEDB_DEPRECATED_EXPORT
 #define TILEDB_DEPRECATED_EXPORT
 #endif
-#define TILEDB_CPP_API_DEPRECATED(msg)
-#else
-#define TILEDB_CPP_API_DEPRECATED(msg) [[deprecated(msg)]]
 #endif
 
 #include "array.h"


### PR DESCRIPTION
[SC-27339](https://app.shortcut.com/tiledb-inc/story/27339/add-api-to-delete-groups-without-a-tiledb-group-t)

This is very similar to #3744.

## TODO
- [x] Write tests. Deleting groups is currently entirely untested.
- [x] Decide how to deprecate the C++ API. I had the idea of using C++14's `[[deprecated("Use *** instead")]]` attribute and wrapping it in an `#ifndef TILEDB_NO_API_DEPRECATION_WARNINGS`.
  * Done, let me know what you think.

---
TYPE: C_API
DESC: Add `tiledb_group_delete` function that deletes a group without requiring the user to open it first.

---
TYPE: CPP_API
DESC: Add `Group::delete_group` static function that deletes a group without requiring the user to open it first.