### PR TITLE
Remove unnecessary transitive dependencies.

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -57,17 +57,6 @@ if(TILEDB_VCPKG)
   endif()
 
   install_all_target_libs("${AWSSDK_LINK_LIBRARIES}")
-  find_package(LibXml2 REQUIRED)
-  install_target_libs(LibXml2::LibXml2)
-
-  if (NOT TARGET LibLZMA::LibLZMA)
-      find_package(LibLZMA REQUIRED)
-      install_target_libs(LibLZMA::LibLZMA)
-  endif()
-
-  #find_package(Iconv REQUIRED)
-  #install_target_libs(Iconv::Iconv)
-
   return()
 endif()
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -545,39 +545,46 @@ if (TILEDB_AZURE)
 
   if (TILEDB_VCPKG)
     find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
-    if (NOT TARGET LibLZMA::LibLZMA)
-      find_package(LibLZMA REQUIRED)
-    endif()
-    if (NOT TARGET LibXml2::LibXml2)
-      find_package(LibXml2 REQUIRED)
-      install_target_libs(LibXml2::LibXml2)
+    if (NOT WIN32)
+      if (NOT TARGET LibLZMA::LibLZMA)
+        find_package(LibLZMA REQUIRED)
+      endif()
+      if (NOT TARGET LibXml2::LibXml2)
+        find_package(LibXml2 REQUIRED)
+        install_target_libs(LibXml2::LibXml2)
+      endif()
+      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
+              INTERFACE
+              LibXml2::LibXml2
+              LibLZMA::LibLZMA)
     endif()
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
             INTERFACE
             Azure::azure-storage-common
             Azure::azure-storage-blobs
             Azure::azure-core
-            LibXml2::LibXml2
-            LibLZMA::LibLZMA
             )
     install_all_target_libs("Azure::azure-storage-blobs;Azure::azure-storage-common;Azure::azure-core")
   else()
     find_package(AzureCore_EP REQUIRED)
     find_package(AzureStorageCommon_EP REQUIRED)
     find_package(AzureStorageBlobs_EP REQUIRED)
-    if (NOT TARGET LibXml2::LibXml2)
-      find_package(libxml2 REQUIRED)
-      install_target_libs(LibXml2::LibXml2)
+    if (NOT WIN32)
+      if (NOT TARGET LibXml2::LibXml2)
+        find_package(libxml2 REQUIRED)
+        install_target_libs(LibXml2::LibXml2)
+      endif()
     endif()
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
             INTERFACE
             Azure::azure-storage-blobs
             Azure::azure-storage-common
-            Azure::azure-core
-            LibXml2::LibXml2)
+            Azure::azure-core)
     if(WIN32)
-      # WebServices needed by Azure storage on windows
-      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE WebServices)
+      # WebServices and crypt32 needed by Azure storage on windows
+      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE WebServices crypt32)
+    else()
+      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE LibXml2::LibXml2)
     endif()
   endif()
 endif()


### PR DESCRIPTION
[SC-32037](https://app.shortcut.com/tiledb-inc/story/32037/fix-lzma-linkage-in-2-16-1)

We have been linking to liblzma when Azure or S3 are enabled, while actually it is only needed on Azure and on non-Windows. This PR removes this dependency.

Should fix [CI failures in TileDB-Java](https://github.com/TileDB-Inc/TileDB-Java/actions/runs/5589366233/job/15138136419#step:4:118). I have a branch ready to backport to 2.16, will need to run a test build with it in Java.

---
TYPE: BUG
DESC: Fix static linking to the on Windows.