### PR TITLE
[Backport release-2.16] Build curl with ZStandard support on vcpkg when serialization is enabled.

### DIFF
--- a/ports/curl/portfile.cmake
+++ b/ports/curl/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         winidn      USE_WIN32_IDN
         winldap     USE_WIN32_LDAP
         websockets  ENABLE_WEBSOCKETS
+        zstd        CURL_ZSTD
     INVERTED_FEATURES
         non-http    HTTP_ONLY
         winldap     CURL_DISABLE_LDAP # Only WinLDAP support ATM

--- a/ports/curl/vcpkg.json
+++ b/ports/curl/vcpkg.json
@@ -200,6 +200,12 @@
       "dependencies": [
         "wolfssl"
       ]
+    },
+    "zstd": {
+      "description": "ZStandard support (zstd)",
+      "dependencies": [
+        "zstd"
+      ]
     }
   }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -52,7 +52,10 @@
         "serialization": {
             "description": "Enable TileDB Cloud Support",
             "dependencies": [
-                "curl",
+                {
+                    "name": "curl",
+                    "features": [ "zstd" ]
+                },
                 {
                     "name": "capnproto",
                     "version>=": "0.8.0"


### PR DESCRIPTION
Backport 8be392f9084edfd4843c72bd9e95e11f08b86437 from #4166

---
TYPE: BUILD
DESC: Build curl with ZStandard support on vcpkg when serialization is enabled.
