### PR TITLE
[Backport release-2.16] update to Catch2 3.3.2

### DIFF
--- a/cmake/Modules/FindCatch_EP.cmake
+++ b/cmake/Modules/FindCatch_EP.cmake
@@ -49,7 +49,7 @@ if (NOT TILEDB_FORCE_ALL_DEPS OR TILEDB_CATCH_EP_BUILT)
   )
 endif()
 
-find_package(Catch2 3.1
+find_package(Catch2 3.3
   HINTS
     ${CATCH_PATHS}
     ${TILEDB_DEPS_NO_DEFAULT_PATH}
@@ -73,8 +73,8 @@ if (NOT Catch2_FOUND AND TILEDB_SUPERBUILD)
     PREFIX "externals"
     # Set download name to avoid collisions with only the version number in the filename
     DOWNLOAD_NAME ep_catch.zip
-    URL "https://github.com/catchorg/Catch2/archive/v3.1.0.zip"
-    URL_HASH SHA1=b23753594a743feabd4e30f83b31ebb31081092a
+    URL "https://github.com/catchorg/Catch2/archive/v3.3.2.zip"
+    URL_HASH SHA1=ab23bef93b3c5ddf696d8855f34a3e882e71c64b
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_INSTALL_PREFIX=${TILEDB_EP_INSTALL_PREFIX}

--- a/ports/catch2/fix-install-path.patch
+++ b/ports/catch2/fix-install-path.patch
@@ -1,7 +1,7 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -170,7 +170,7 @@
+@@ -164,7 +164,7 @@
  
      ## Provide some pkg-config integration
      set(PKGCONFIG_INSTALL_DIR
@@ -13,20 +13,19 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -356,12 +356,28 @@
+@@ -401,16 +401,28 @@
      install(
        TARGETS
          Catch2
 -        Catch2WithMain
        EXPORT
          Catch2Targets
--      DESTINATION
-+      LIBRARY DESTINATION
+       LIBRARY DESTINATION
          ${CMAKE_INSTALL_LIBDIR}
-+      ARCHIVE DESTINATION
-+        ${CMAKE_INSTALL_LIBDIR}
-+      RUNTIME DESTINATION
-+        ${CMAKE_INSTALL_BINDIR}
+       ARCHIVE DESTINATION
+         ${CMAKE_INSTALL_LIBDIR}
+       RUNTIME DESTINATION
+         ${CMAKE_INSTALL_BINDIR}
      )
 +
 +     install(

--- a/ports/catch2/portfile.cmake
+++ b/ports/catch2/portfile.cmake
@@ -6,12 +6,11 @@ endif()
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO catchorg/Catch2
-    REF v3.1.0
-    SHA512 49e5339263190a6ef15284ef2dcc9e727ce0659cb750d4078024ccf6c6f339740a3a662273718ea73adfbc5928c3ef7268175ebda5ee9ec97ca58fed98747b44
+    REF v3.3.2
+    SHA512 3d0c5666509a19be54ea0c48a3c8e1c4a951a2d991a7c9f7fe6d326661464538f1ab9dc573b1b2647f49fb6bef45bbd866142a4ce0fba38545ad182b8d55f61f
     HEAD_REF devel
     PATCHES
         fix-install-path.patch
-        fix-uwp-build.patch
 )
 
 vcpkg_cmake_configure(

--- a/ports/catch2/vcpkg.json
+++ b/ports/catch2/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "catch2",
-  "version-semver": "3.1.0",
+  "version-semver": "3.3.2",
   "port-version": 1,
   "description": "A modern, header-only test framework for unit testing.",
   "homepage": "https://github.com/catchorg/Catch2",

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -44,10 +44,6 @@
 #include "test/support/src/serialization_wrappers.h"
 #include "test/support/src/vfs_helpers.h"
 #ifdef _WIN32
-#if !defined(NOMINMAX)
-#define NOMINMAX
-#endif
-#include <Windows.h>
 #include "tiledb/sm/filesystem/win.h"
 #else
 #include "tiledb/sm/filesystem/posix.h"
@@ -70,6 +66,16 @@
 #include <iostream>
 #include <sstream>
 #include <thread>
+
+#ifdef _WIN32
+#if !defined(NOMINMAX)
+#define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+#endif
 
 using namespace tiledb::test;
 using namespace tiledb::common;

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1081,6 +1081,30 @@ Status Azure::parse_azure_uri(
   return Status::Ok();
 }
 
+/* Generates the next base64-encoded block id. */
+std::string Azure::BlockListUploadState::next_block_id() {
+  const uint64_t block_id = next_block_id_++;
+  const std::string block_id_str = std::to_string(block_id);
+
+  // Pad the block id string with enough leading zeros to support
+  // the maximum number of blocks (50,000). All block ids must be
+  // of equal length among a single blob.
+  const int block_id_chars = 5;
+  std::vector<uint8_t> padded_block_id(
+      block_id_chars - block_id_str.length(), '0');
+  std::copy(
+      block_id_str.begin(),
+      block_id_str.end(),
+      std::back_inserter(padded_block_id));
+
+  const std::string b64_block_id_str =
+      ::Azure::Core::Convert::Base64Encode(padded_block_id);
+
+  block_ids_.emplace_back(b64_block_id_str);
+
+  return b64_block_id_str;
+}
+
 }  // namespace sm
 }  // namespace tiledb
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -34,8 +34,6 @@
 #define TILEDB_AZURE_H
 
 #ifdef HAVE_AZURE
-#include <azure/core/base64.hpp>
-
 #include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
 #include "tiledb/common/thread_pool.h"
@@ -325,28 +323,7 @@ class Azure {
     }
 
     /* Generates the next base64-encoded block id. */
-    std::string next_block_id() {
-      const uint64_t block_id = next_block_id_++;
-      const std::string block_id_str = std::to_string(block_id);
-
-      // Pad the block id string with enough leading zeros to support
-      // the maximum number of blocks (50,000). All block ids must be
-      // of equal length among a single blob.
-      const int block_id_chars = 5;
-      std::vector<uint8_t> padded_block_id(
-          block_id_chars - block_id_str.length(), '0');
-      std::copy(
-          block_id_str.begin(),
-          block_id_str.end(),
-          std::back_inserter(padded_block_id));
-
-      const std::string b64_block_id_str =
-          ::Azure::Core::Convert::Base64Encode(padded_block_id);
-
-      block_ids_.emplace_back(b64_block_id_str);
-
-      return b64_block_id_str;
-    }
+    std::string next_block_id();
 
     /* Returns all generated block ids. */
     std::list<std::string> get_block_ids() const {


### PR DESCRIPTION
Backport 8e89e1d59 from https://github.com/TileDB-Inc/TileDB/pull/4150


This was missed in #4151 due to the backport bot just grabbing the first commit sha.

---
TYPE: BUILD
DESC: update to Catch2 3.3.2
