### PR TITLE
Sparse unordered w/ dups reader: adding ignored tiles.

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -83,7 +83,7 @@ struct CSparseUnorderedWithDupsFx {
       uint64_t* a2_validity_size);
   int32_t read(
       bool set_subarray,
-      bool set_qc,
+      int qc_idx,
       int* coords,
       uint64_t* coords_size,
       int* data,
@@ -387,7 +387,7 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
 
 int32_t CSparseUnorderedWithDupsFx::read(
     bool set_subarray,
-    bool set_qc,
+    int qc_idx,
     int* coords,
     uint64_t* coords_size,
     int* data,
@@ -413,27 +413,24 @@ int32_t CSparseUnorderedWithDupsFx::read(
     CHECK(rc == TILEDB_OK);
   }
 
-  if (set_qc) {
+  if (qc_idx != 0) {
     tiledb_query_condition_t* query_condition = nullptr;
     rc = tiledb_query_condition_alloc(ctx_, &query_condition);
     CHECK(rc == TILEDB_OK);
-    int32_t val = 11;
-    rc = tiledb_query_condition_init(
-        ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
-    CHECK(rc == TILEDB_OK);
 
-    // Negated query condition should produce the same results.
-    SECTION("- Test TILEDB_NOT") {
+    if (qc_idx == 1) {
+      int32_t val = 11;
+      rc = tiledb_query_condition_init(
+          ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
+      CHECK(rc == TILEDB_OK);
+    } else if (qc_idx == 2) {
+      // Negated query condition should produce the same results.
+      int32_t val = 11;
       tiledb_query_condition_t* qc;
       rc = tiledb_query_condition_alloc(ctx_, &qc);
       CHECK(rc == TILEDB_OK);
       rc = tiledb_query_condition_init(
           ctx_, qc, "a", &val, sizeof(int32_t), TILEDB_GE);
-      CHECK(rc == TILEDB_OK);
-
-      tiledb_query_condition_free(&query_condition);
-      query_condition = nullptr;
-      rc = tiledb_query_condition_alloc(ctx_, &query_condition);
       CHECK(rc == TILEDB_OK);
       rc = tiledb_query_condition_negate(ctx_, qc, &query_condition);
       CHECK(rc == TILEDB_OK);
@@ -810,7 +807,7 @@ TEST_CASE_METHOD(
   int data_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(true, false, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(true, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -864,7 +861,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc =
-      read(set_subarray, false, coords_r, &coords_r_size, data_r, &data_r_size);
+      read(set_subarray, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -937,7 +934,7 @@ TEST_CASE_METHOD(
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
       set_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -1025,7 +1022,7 @@ TEST_CASE_METHOD(
 
   auto rc = read(
       use_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -1100,7 +1097,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc =
-      read(use_subarray, false, coords_r, &coords_r_size, data_r, &data_r_size);
+      read(use_subarray, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -1140,14 +1137,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
-      false,
-      false,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
+      false, 0, coords_r, &coords_r_size, data_r, &data_r_size, &query, &array);
   CHECK(rc == TILEDB_OK);
 
   // Check incomplete query status.
@@ -1215,6 +1205,8 @@ TEST_CASE_METHOD(
 
   bool use_subarray = false;
   int tile_idx = 0;
+  int qc_index = GENERATE(1, 2);
+  bool use_budget = GENERATE(true, false);
   SECTION("- No subarray") {
     use_subarray = false;
     SECTION("- First tile") {
@@ -1238,6 +1230,13 @@ TEST_CASE_METHOD(
     SECTION("- Last tile") {
       tile_idx = 2;
     }
+  }
+
+  if (use_budget) {
+    // Two result tile (2 * ~1208) will be bigger than the budget (1500).
+    total_budget_ = "100000";
+    ratio_coords_ = "0.015";
+    update_config();
   }
 
   int coords_1[] = {1, 2, 3};
@@ -1279,8 +1278,8 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(
+      use_subarray, qc_index, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Should read two tile (6 values).
@@ -1326,7 +1325,7 @@ TEST_CASE_METHOD(
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
       use_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -388,6 +388,10 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
     const uint64_t last_t,
     const FragmentMetadata& frag_md,
     ResultTilesList& result_tiles) {
+  if (tmp_read_state_.is_ignored_tile(f, t)) {
+    return false;
+  }
+
   // Use either the coordinate portion of the total budget or the tile upper
   // memory limit as the upper memory limit, whichever is smaller.
   const uint64_t upper_memory_limit = std::min<uint64_t>(
@@ -545,6 +549,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::clean_tile_list(
   while (it != result_tiles.end()) {
     auto f = it->frag_idx();
     if (it->result_num() == 0) {
+      tmp_read_state_.add_ignored_tile(*it);
       remove_result_tile(f, result_tiles, it++);
     } else {
       it++;


### PR DESCRIPTION
This fixes reads where all tiles in a loop end up with 0 results because of query condition.

---
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: adding ignored tiles.