### PR TITLE
Fix build with Clang 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,8 +233,8 @@ else()
     add_link_options("$<$<CONFIG:Coverage>:--coverage;-fprofile-instr-generate;-fcoverage-mapping>")
   endif()
 
-  # Disable newer Apple Clang warnings about unqualified calls to std::move
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  # Disable newer Clang warnings about unqualified calls to std::move
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if (${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "14.0.3")
       add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-unqualified-std-cast-call>)
     endif()

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -48,7 +48,7 @@
 #include <vector>
 
 // Workaround for GCC < 5.0
-#if __GNUG__ && __GNUC__ < 5
+#if not defined(__clang__) && __GNUG__ && __GNUC__ < 5
 #define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
 #else
 #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value


### PR DESCRIPTION
- unqualified std::move error needs to be generic for Clang or AppleClang
- one of the old GCC compat checks needs to account for the fact that clang defines GCC variables

---
TYPE: BUILD
DESC: Fix build with Clang 16
