### PR TITLE
[Backport release-2.16] Sparse unordered w/ dups reader: adding ignored tiles. (#4200)

### DIFF
--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -77,7 +77,7 @@ struct CSparseGlobalOrderFx {
   void write_delete_condition(char* value_to_delete, uint64_t value_size);
   int32_t read(
       bool set_subarray,
-      bool set_qc,
+      int qc_idx,
       int* coords,
       uint64_t* coords_size,
       int* data,
@@ -342,7 +342,7 @@ void CSparseGlobalOrderFx::write_delete_condition(
 
 int32_t CSparseGlobalOrderFx::read(
     bool set_subarray,
-    bool set_qc,
+    int qc_idx,
     int* coords,
     uint64_t* coords_size,
     int* data,
@@ -368,14 +368,30 @@ int32_t CSparseGlobalOrderFx::read(
     CHECK(rc == TILEDB_OK);
   }
 
-  if (set_qc) {
+  if (qc_idx != 0) {
     tiledb_query_condition_t* query_condition = nullptr;
     rc = tiledb_query_condition_alloc(ctx_, &query_condition);
     CHECK(rc == TILEDB_OK);
-    int32_t val = 11;
-    rc = tiledb_query_condition_init(
-        ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
-    CHECK(rc == TILEDB_OK);
+
+    if (qc_idx == 1) {
+      int32_t val = 11;
+      rc = tiledb_query_condition_init(
+          ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
+      CHECK(rc == TILEDB_OK);
+    } else if (qc_idx == 2) {
+      // Negated query condition should produce the same results.
+      int32_t val = 11;
+      tiledb_query_condition_t* qc;
+      rc = tiledb_query_condition_alloc(ctx_, &qc);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_init(
+          ctx_, qc, "a", &val, sizeof(int32_t), TILEDB_GE);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_negate(ctx_, qc, &query_condition);
+      CHECK(rc == TILEDB_OK);
+
+      tiledb_query_condition_free(&qc);
+    }
 
     rc = tiledb_query_set_condition(ctx_, query, query_condition);
     CHECK(rc == TILEDB_OK);
@@ -490,7 +506,7 @@ TEST_CASE_METHOD(
   int data_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(true, false, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(true, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -551,7 +567,7 @@ TEST_CASE_METHOD(
   tiledb_query_status_t status;
   rc = read(
       true,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -640,7 +656,7 @@ TEST_CASE_METHOD(
   tiledb_query_status_t status;
   rc = read(
       true,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -705,7 +721,7 @@ TEST_CASE_METHOD(
   int data_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(true, false, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(true, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -777,7 +793,7 @@ TEST_CASE_METHOD(
   uint64_t data_r_size = sizeof(data_r);
   rc = read(
       use_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -851,7 +867,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc =
-      read(use_subarray, false, coords_r, &coords_r_size, data_r, &data_r_size);
+      read(use_subarray, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -877,6 +893,7 @@ TEST_CASE_METHOD(
 
   bool use_subarray = false;
   int tile_idx = 0;
+  int qc_idx = GENERATE(1, 2);
   SECTION("- No subarray") {
     use_subarray = false;
     SECTION("- First tile") {
@@ -941,8 +958,8 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(
+      use_subarray, qc_idx, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Should read two tile (6 values).
@@ -966,6 +983,7 @@ TEST_CASE_METHOD(
   bool use_subarray = GENERATE(true, false);
   bool dups = GENERATE(false, true);
   bool extra_fragment = GENERATE(true, false);
+  int qc_idx = GENERATE(1, 2);
 
   create_default_array_1d(dups);
 
@@ -990,8 +1008,8 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(
+      use_subarray, qc_idx, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
   if (dups) {
@@ -1018,6 +1036,7 @@ TEST_CASE_METHOD(
   reset_config();
   create_default_array_1d();
 
+  int qc_idx = GENERATE(1, 2);
   bool use_subarray = false;
   SECTION("- No subarray") {
     use_subarray = false;
@@ -1043,8 +1062,8 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(
+      use_subarray, qc_idx, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
   // One value.
@@ -1066,6 +1085,7 @@ TEST_CASE_METHOD(
   create_default_array_1d(true);
 
   bool use_subarray = false;
+  int qc_idx = GENERATE(1, 2);
 
   int coords_1[] = {8, 9, 10, 11, 12, 13};
   int data_1[] = {8, 9, 10, 11, 12, 13};
@@ -1086,8 +1106,8 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(
+      use_subarray, qc_idx, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Should read (6 values).
@@ -1343,7 +1363,7 @@ TEST_CASE_METHOD(
   tiledb_query_status_t status;
   uint32_t rc = read(
       use_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -1412,14 +1432,7 @@ TEST_CASE_METHOD(
   int rc;
   tiledb_query_status_t status;
   rc = read(
-      true,
-      false,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
+      true, 0, coords_r, &coords_r_size, data_r, &data_r_size, &query, &array);
   CHECK(rc == TILEDB_OK);
 
   CHECK(coords_r[0] == 1);

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -83,7 +83,7 @@ struct CSparseUnorderedWithDupsFx {
       uint64_t* a2_validity_size);
   int32_t read(
       bool set_subarray,
-      bool set_qc,
+      int qc_idx,
       int* coords,
       uint64_t* coords_size,
       int* data,
@@ -387,7 +387,7 @@ void CSparseUnorderedWithDupsFx::write_1d_fragment_string(
 
 int32_t CSparseUnorderedWithDupsFx::read(
     bool set_subarray,
-    bool set_qc,
+    int qc_idx,
     int* coords,
     uint64_t* coords_size,
     int* data,
@@ -413,14 +413,30 @@ int32_t CSparseUnorderedWithDupsFx::read(
     CHECK(rc == TILEDB_OK);
   }
 
-  if (set_qc) {
+  if (qc_idx != 0) {
     tiledb_query_condition_t* query_condition = nullptr;
     rc = tiledb_query_condition_alloc(ctx_, &query_condition);
     CHECK(rc == TILEDB_OK);
-    int32_t val = 11;
-    rc = tiledb_query_condition_init(
-        ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
-    CHECK(rc == TILEDB_OK);
+
+    if (qc_idx == 1) {
+      int32_t val = 11;
+      rc = tiledb_query_condition_init(
+          ctx_, query_condition, "a", &val, sizeof(int32_t), TILEDB_LT);
+      CHECK(rc == TILEDB_OK);
+    } else if (qc_idx == 2) {
+      // Negated query condition should produce the same results.
+      int32_t val = 11;
+      tiledb_query_condition_t* qc;
+      rc = tiledb_query_condition_alloc(ctx_, &qc);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_init(
+          ctx_, qc, "a", &val, sizeof(int32_t), TILEDB_GE);
+      CHECK(rc == TILEDB_OK);
+      rc = tiledb_query_condition_negate(ctx_, qc, &query_condition);
+      CHECK(rc == TILEDB_OK);
+
+      tiledb_query_condition_free(&qc);
+    }
 
     rc = tiledb_query_set_condition(ctx_, query, query_condition);
     CHECK(rc == TILEDB_OK);
@@ -791,7 +807,7 @@ TEST_CASE_METHOD(
   int data_r[5];
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
-  auto rc = read(true, false, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(true, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -845,7 +861,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc =
-      read(set_subarray, false, coords_r, &coords_r_size, data_r, &data_r_size);
+      read(set_subarray, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -918,7 +934,7 @@ TEST_CASE_METHOD(
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
       set_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -1006,7 +1022,7 @@ TEST_CASE_METHOD(
 
   auto rc = read(
       use_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,
@@ -1081,7 +1097,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc =
-      read(use_subarray, false, coords_r, &coords_r_size, data_r, &data_r_size);
+      read(use_subarray, 0, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_ERR);
 
   // Check we hit the correct error.
@@ -1121,14 +1137,7 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
-      false,
-      false,
-      coords_r,
-      &coords_r_size,
-      data_r,
-      &data_r_size,
-      &query,
-      &array);
+      false, 0, coords_r, &coords_r_size, data_r, &data_r_size, &query, &array);
   CHECK(rc == TILEDB_OK);
 
   // Check incomplete query status.
@@ -1196,6 +1205,8 @@ TEST_CASE_METHOD(
 
   bool use_subarray = false;
   int tile_idx = 0;
+  int qc_index = GENERATE(1, 2);
+  bool use_budget = GENERATE(true, false);
   SECTION("- No subarray") {
     use_subarray = false;
     SECTION("- First tile") {
@@ -1219,6 +1230,13 @@ TEST_CASE_METHOD(
     SECTION("- Last tile") {
       tile_idx = 2;
     }
+  }
+
+  if (use_budget) {
+    // Two result tile (2 * ~1208) will be bigger than the budget (1500).
+    total_budget_ = "100000";
+    ratio_coords_ = "0.015";
+    update_config();
   }
 
   int coords_1[] = {1, 2, 3};
@@ -1260,8 +1278,8 @@ TEST_CASE_METHOD(
   uint64_t coords_r_size = sizeof(coords_r);
   uint64_t data_r_size = sizeof(data_r);
 
-  auto rc =
-      read(use_subarray, true, coords_r, &coords_r_size, data_r, &data_r_size);
+  auto rc = read(
+      use_subarray, qc_index, coords_r, &coords_r_size, data_r, &data_r_size);
   CHECK(rc == TILEDB_OK);
 
   // Should read two tile (6 values).
@@ -1307,7 +1325,7 @@ TEST_CASE_METHOD(
   uint64_t data_r_size = sizeof(data_r);
   auto rc = read(
       use_subarray,
-      false,
+      0,
       coords_r,
       &coords_r_size,
       data_r,

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -390,6 +390,10 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
     const uint64_t last_t,
     const FragmentMetadata& frag_md,
     ResultTilesList& result_tiles) {
+  if (tmp_read_state_.is_ignored_tile(f, t)) {
+    return false;
+  }
+
   // Use either the coordinate portion of the total budget or the tile upper
   // memory limit as the upper memory limit, whichever is smaller.
   const uint64_t upper_memory_limit = std::min<uint64_t>(
@@ -547,6 +551,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::clean_tile_list(
   while (it != result_tiles.end()) {
     auto f = it->frag_idx();
     if (it->result_num() == 0) {
+      tmp_read_state_.add_ignored_tile(*it);
       remove_result_tile(f, result_tiles, it++);
     } else {
       it++;


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/11e5d703c373c28fd15b0fee98ab3be49fcb8eef from https://github.com/TileDB-Inc/TileDB/pull/4200.

-------
TYPE: IMPROVEMENT
DESC: Sparse unordered w/ dups reader: adding ignored tiles.
