### PR TITLE
Fix bug with get_footer_size

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -537,10 +537,9 @@ URI ArrayDirectory::get_commits_dir(uint32_t write_version) const {
 
 URI ArrayDirectory::get_commit_uri(const URI& fragment_uri) const {
   auto name = fragment_uri.remove_trailing_slash().last_path_part();
-  uint32_t version;
-  throw_if_not_ok(utils::parse::get_fragment_version(name, &version));
+  auto fragment_version = utils::parse::get_fragment_version(name);
 
-  if (version == UINT32_MAX || version < 12) {
+  if (fragment_version < 12) {
     return URI(fragment_uri.to_string() + constants::ok_file_suffix);
   }
 
@@ -551,10 +550,9 @@ URI ArrayDirectory::get_commit_uri(const URI& fragment_uri) const {
 
 URI ArrayDirectory::get_vacuum_uri(const URI& fragment_uri) const {
   auto name = fragment_uri.remove_trailing_slash().last_path_part();
-  uint32_t version;
-  throw_if_not_ok(utils::parse::get_fragment_version(name, &version));
+  auto fragment_version = utils::parse::get_fragment_version(name);
 
-  if (version == UINT32_MAX || version < 12) {
+  if (fragment_version < 12) {
     return URI(fragment_uri.to_string() + constants::vacuum_file_suffix);
   }
 
@@ -1281,9 +1279,8 @@ Status ArrayDirectory::is_fragment(
 
   // If the format version is >= 5, then the above suffices to check if
   // the URI is indeed a fragment
-  uint32_t version;
-  RETURN_NOT_OK(utils::parse::get_fragment_version(name, &version));
-  if (version != UINT32_MAX && version >= 5) {
+  auto fragment_version = utils::parse::get_fragment_version(name);
+  if (fragment_version >= 5) {
     *is_fragment = false;
     return Status::Ok();
   }
@@ -1299,16 +1296,15 @@ Status ArrayDirectory::is_fragment(
 bool ArrayDirectory::consolidation_with_timestamps_supported(
     const URI& uri) const {
   // Get the fragment version from the uri
-  uint32_t version;
   auto name = uri.remove_trailing_slash().last_path_part();
-  throw_if_not_ok(utils::parse::get_fragment_version(name, &version));
+  auto fragment_version = utils::parse::get_fragment_version(name);
 
   // get_fragment_version returns UINT32_MAX for versions <= 2 so we should
   // explicitly exclude this case when checking if consolidation with timestamps
   // is supported on a fragment
   return mode_ == ArrayDirectoryMode::READ &&
-         version >= constants::consolidation_with_timestamps_min_version &&
-         version != UINT32_MAX;
+         fragment_version >=
+             constants::consolidation_with_timestamps_min_version;
 }
 
 shared_ptr<const Enumeration> ArrayDirectory::load_enumeration(

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -102,8 +102,7 @@ Status FragmentMetaConsolidator::consolidate(
   auto meta_name = uri.remove_trailing_slash().last_path_part();
   auto pos = meta_name.find_last_of('.');
   meta_name = (pos == std::string::npos) ? meta_name : meta_name.substr(0, pos);
-  uint32_t meta_version = 0;
-  RETURN_NOT_OK(utils::parse::get_fragment_version(meta_name, &meta_version));
+  auto meta_version = utils::parse::get_fragment_version(meta_name);
 
   // Calculate offset of first fragment footer
   uint64_t offset = sizeof(uint32_t);  // Fragment num

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -1041,14 +1041,12 @@ tuple<Status, optional<SingleFragmentInfo>> FragmentInfo::load(
   RETURN_NOT_OK_TUPLE(
       utils::parse::get_timestamp_range(new_fragment_uri, &timestamp_range),
       nullopt);
-  uint32_t version;
   auto name = new_fragment_uri.remove_trailing_slash().last_path_part();
-  RETURN_NOT_OK_TUPLE(
-      utils::parse::get_fragment_name_version(name, &version), nullopt);
+  auto fragment_version = utils::parse::get_fragment_version(name);
 
   // Check if fragment is sparse
   bool sparse = false;
-  if (version == 1) {  // This corresponds to format version <=2
+  if (fragment_version <= 2) {
     URI coords_uri =
         new_fragment_uri.join_path(constants::coords + constants::file_suffix);
     RETURN_NOT_OK_TUPLE(vfs->is_file(coords_uri, &sparse), nullopt);

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2132,7 +2132,7 @@ Status FragmentMetadata::get_footer_offset_and_size(
     *size = footer_size_v5_v6();
     *offset = meta_file_size_ - *size;
   } else if (all_fixed && fragment_format_version < 10) {
-    *size = footer_size_v7_v10();
+    *size = footer_size_v7_v9();
     *offset = meta_file_size_ - *size;
   } else {
     URI fragment_metadata_uri = fragment_uri_.join_path(
@@ -2213,7 +2213,7 @@ uint64_t FragmentMetadata::footer_size_v5_v6() const {
   return size;
 }
 
-uint64_t FragmentMetadata::footer_size_v7_v10() const {
+uint64_t FragmentMetadata::footer_size_v7_v9() const {
   auto dim_num = array_schema_->dim_num();
   auto num = num_dims_and_attrs();
   uint64_t domain_size = 0;

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1443,9 +1443,9 @@ class FragmentMetadata {
    * Returns the size of the fragment metadata footer
    * (which contains the generic tile offsets) along with its size.
    *
-   * Applicable to format version 7 to 10.
+   * Applicable to format version 7 to 9.
    */
-  uint64_t footer_size_v7_v10() const;
+  uint64_t footer_size_v7_v9() const;
 
   /**
    * Returns the ids (positions) of the tiles overlapping `subarray`.

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -727,12 +727,6 @@ class FragmentMetadata {
   uint64_t file_validity_offset(
       const std::string& name, uint64_t tile_idx) const;
 
-  /**
-   * Retrieves the size of the fragment metadata footer
-   * (which contains the generic tile offsets) along with its size.
-   */
-  Status get_footer_size(uint32_t version, uint64_t* size) const;
-
   uint64_t footer_size() const;
 
   /** Returns the MBR of the input tile. */

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1448,14 +1448,6 @@ class FragmentMetadata {
   uint64_t footer_size_v7_v10() const;
 
   /**
-   * Returns the size of the fragment metadata footer
-   * (which contains the generic tile offsets) along with its size.
-   *
-   * Applicable to format version 11 or higher.
-   */
-  uint64_t footer_size_v11_or_higher() const;
-
-  /**
    * Returns the ids (positions) of the tiles overlapping `subarray`.
    * Applicable only to dense arrays.
    */

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -145,10 +145,9 @@ Status DeletesAndUpdates::dowork() {
   // consolidated without timestamps.
   auto& frag_uris = array_->array_directory().unfiltered_fragment_uris();
   for (auto& uri : frag_uris) {
-    uint32_t version;
     auto name = uri.remove_trailing_slash().last_path_part();
-    RETURN_NOT_OK(utils::parse::get_fragment_version(name, &version));
-    if (version < constants::consolidation_with_timestamps_min_version) {
+    auto format_version = utils::parse::get_fragment_version(name);
+    if (format_version < constants::consolidation_with_timestamps_min_version) {
       std::pair<uint64_t, uint64_t> fragment_timestamp_range;
       RETURN_NOT_OK(
           utils::parse::get_timestamp_range(uri, &fragment_timestamp_range));

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1945,14 +1945,13 @@ StorageManagerCanonical::load_fragment_metadata(
         sf.uri_.join_path(constants::coords + constants::file_suffix);
 
     auto name = sf.uri_.remove_trailing_slash().last_path_part();
-    uint32_t f_version;
-    RETURN_NOT_OK(utils::parse::get_fragment_name_version(name, &f_version));
+    auto format_version = utils::parse::get_fragment_version(name);
 
     // Note that the fragment metadata version is >= the array schema
     // version. Therefore, the check below is defensive and will always
     // ensure backwards compatibility.
     shared_ptr<FragmentMetadata> metadata;
-    if (f_version == 1) {  // This is equivalent to format version <=2
+    if (format_version <= 2) {
       bool sparse;
       RETURN_NOT_OK(vfs()->is_file(coords_uri, &sparse));
       metadata = make_shared<FragmentMetadata>(
@@ -1963,7 +1962,8 @@ StorageManagerCanonical::load_fragment_metadata(
           sf.uri_,
           sf.timestamp_range_,
           !sparse);
-    } else {  // Format version > 2
+    } else {
+      // Fragment format version > 2
       metadata = make_shared<FragmentMetadata>(
           HERE(),
           this,

--- a/tiledb/storage_format/uri/parse_uri.h
+++ b/tiledb/storage_format/uri/parse_uri.h
@@ -47,22 +47,11 @@ Status get_timestamp_range(
     const URI& uri, std::pair<uint64_t, uint64_t>* timestamp_range);
 
 /**
- * Retrieves the fragment name version.
- *  - Version 1 corresponds to format versions 1 and 2
- *      * __uuid_<t1>{_t2}
- *  - Version 2 corresponds to version 3 and 4
- *      * __t1_t2_uuid
- *  - Version 3 corresponds to version 5 or higher
- *      * __t1_t2_uuid_version
- */
-Status get_fragment_name_version(const std::string& name, uint32_t* version);
-
-/**
  * Retrieves the fragment version. This will work only for
  * name versions > 2, otherwise the function sets `version`
  * to UINT32_MAX.
  */
-Status get_fragment_version(const std::string& name, uint32_t* version);
+format_version_t get_fragment_version(const std::string& name);
 
 /**
  * Returns true if the given URIs have the same "prefix" and could


### PR DESCRIPTION
My original understanding of this bug was super wrong. I'll also call this not a bug per se, just a badly named function with a few different definitions of "version" in a small space.

https://github.com/TileDB-Inc/TileDB/blob/038dfad4dbdd841a05e111e6f05922f957ed2d66/tiledb/storage_format/uri/parse_uri.h#L49-L58

https://github.com/TileDB-Inc/TileDB/blob/038dfad4dbdd841a05e111e6f05922f957ed2d66/tiledb/storage_format/uri/parse_uri.cc#L81-L107

The key bit that helped me figure out what's going on is the comment inside parse_uri which mentions footer size out of nowhere. Once I realized we had a third definition of version going on it was easy to pull apart what was really going on.

The last question for @KiterLuc is around the `footer_size_v7_v10` function naming. I can't decide if format version 10 should actually go through that function, or if the function is named incorrectly. The code as written before this PR it is very clearly not using `footer_size_v7_v10` since `>= 10` gets a version of 5 which is the "read footer size from file" logic.

~~This is an old bug that's been around for ages with no one noticing. It was only found during code inspection for a separate change to the versioning system.~~

~~The initial part of this bug is the use of get_fragment_name_version instead of get_fragment_version. The former function returns the version of the fragment URI (a value in the inclusive range 1 to 5) where get_footer_version was expecting a format version in the range 1 to 20.~~

~~This fixes things by removing get_footer_size entirely and fixing the body of get_footer_offset_and_size to call footer_size_v3_v4 directly and removing all other versions of footer_size_vX_vY as they are dead code.~~

---
TYPE: BUG
DESC: Fix bug in FragmentMetadata::get_footer_size.
