### PR TITLE
Update VFS S3 to ListObjectsV2

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -50,7 +50,6 @@
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
-#include <aws/s3/model/ListObjectsV2Request.h>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <fstream>
 #include <iostream>
@@ -710,18 +709,20 @@ Status S3::is_empty_bucket(const URI& bucket, bool* is_empty) const {
 
   bool exists;
   RETURN_NOT_OK(is_bucket(bucket, &exists));
-  if (!exists)
+  if (!exists) {
     return LOG_STATUS(Status_S3Error(
         "Cannot check if bucket is empty; Bucket does not exist"));
+  }
 
   Aws::Http::URI aws_uri = bucket.c_str();
-  Aws::S3::Model::ListObjectsRequest list_objects_request;
+  Aws::S3::Model::ListObjectsV2Request list_objects_request;
   list_objects_request.SetBucket(aws_uri.GetAuthority());
   list_objects_request.SetPrefix("");
   list_objects_request.SetDelimiter("/");
-  if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
+  if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET) {
     list_objects_request.SetRequestPayer(request_payer_);
-  auto list_objects_outcome = client_->ListObjects(list_objects_request);
+  }
+  auto list_objects_outcome = client_->ListObjectsV2(list_objects_request);
 
   if (!list_objects_outcome.IsSuccess()) {
     return LOG_STATUS(Status_S3Error(

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -71,7 +71,7 @@
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadBucketRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
-#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
 #include <sys/types.h>

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -774,7 +774,7 @@ tuple<Status, optional<std::vector<directory_entry>>> VFS::ls_with_sizes(
   } else if (parent.is_s3()) {
 #ifdef HAVE_S3
     Status st;
-    std::tie(st, entries) = s3_.ls_with_sizes(parent);
+    std::tie(st, entries) = s3_.ls_with_sizes(parent, "");
 #else
     auto st =
         LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -774,7 +774,7 @@ tuple<Status, optional<std::vector<directory_entry>>> VFS::ls_with_sizes(
   } else if (parent.is_s3()) {
 #ifdef HAVE_S3
     Status st;
-    std::tie(st, entries) = s3_.ls_with_sizes(parent, "");
+    std::tie(st, entries) = s3_.ls_with_sizes(parent);
 #else
     auto st =
         LOG_STATUS(Status_VFSError("TileDB was built without S3 support"));


### PR DESCRIPTION
This updates `VFS::ls` to call ListObjectsV2 from the AWS SDK, which increases performance when listing a prefix with several objects.

This came up while working on SC-31529 after testing recursive ls performance with ~350k results. ListObjectsV1 completes in ~10 minutes while ListObjectsV2 completes in 1 minute.

---
TYPE: IMPROVEMENT
DESC: Update VFS to call ListObjectsV2 from the AWS SDK.