### PR TITLE
Tweak vcpkg installs on GHA CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,6 +52,7 @@ jobs:
       TILEDB_WEBP: ${{ matrix.TILEDB_WEBP }}
       TILEDB_CMAKE_BUILD_TYPE: 'Release'
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      VCPKG_DOWNLOADS: ${{ github.workspace }}\vcpkg-downloads
     steps:
       - name: 'tiledb env prep'
         run: |
@@ -212,6 +213,8 @@ jobs:
             Write-Host "Bootstrap failed."
             exit $LastExitCode
           }
+
+          dir $env:VCPKG_DOWNLOADS
 
           cmake --build $env:BUILD_BUILDDIRECTORY --config $CMakeBuildType -j $env:NUMBER_OF_PROCESSORS 2>&1
 

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -42,6 +42,7 @@ env:
   CC: ${{ inputs.matrix_compiler_cc }}
   bootstrap_args: "--enable-vcpkg --enable-ccache ${{ inputs.bootstrap_args }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_DOWNLOADS: ${{ github.workspace }}/vcpkg-downloads
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
@@ -68,6 +69,9 @@ jobs:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Create VCPKG_DOWNLOADS directory
+        run: mkdir "${{ github.workspace }}/vcpkg-downloads"
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11
@@ -125,6 +129,7 @@ jobs:
           # cache vcpkg deps across runs if the libtiledb build fails.
 
           source $GITHUB_WORKSPACE/scripts/ci/bootstrap_libtiledb.sh
+          ls $GITHUB_WORKSPACE/vcpkg-downloads
 
       - name: 'Build libtiledb'
         id: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ cmake_minimum_required(VERSION 3.21)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Options")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/vcpkg")
 
 include(CIConfig)
 include(BuildOptions)

--- a/cmake/Options/TileDBToolchain.cmake
+++ b/cmake/Options/TileDBToolchain.cmake
@@ -11,6 +11,8 @@ if (NOT TILEDB_SUPERBUILD)
     return()
 endif()
 
+include(tiledb-vcpkg-on-github-actions)
+
 if(DEFINED ENV{VCPKG_ROOT})
     set(CMAKE_TOOLCHAIN_FILE
         "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"

--- a/cmake/vcpkg/tiledb-vcpkg-download-utils.cmake
+++ b/cmake/vcpkg/tiledb-vcpkg-download-utils.cmake
@@ -1,0 +1,17 @@
+############################################################
+# TileDB Vcpkg Download Helpers
+############################################################
+
+function(tiledb_vcpkg_download tag_name file_name)
+  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/vcpkg/downloads/${file_name}")
+    file(
+      DOWNLOAD
+        "https://github.com/TileDB-Inc/tiledb-deps-mirror/releases/download/${tag_name}/${file_name}"
+        "$ENV{VCPKG_DOWNLOADS}/${file_name}"
+      LOG result
+    )
+    message("Downloaded: ${file_name}")
+  else()
+    message("Previously downloaded: ${file_name}")
+  endif()
+endfunction()

--- a/cmake/vcpkg/tiledb-vcpkg-on-github-actions.cmake
+++ b/cmake/vcpkg/tiledb-vcpkg-on-github-actions.cmake
@@ -1,0 +1,34 @@
+############################################################
+# TileDB Vcpkg Customization
+############################################################
+
+# A set of TileDB specific tweaks for vcpkg due to various weirdness like
+# flaky download mirrors that kill CI. As these are all targeted at CI, we
+# only apply them when running in the context of GitHub Actions.
+
+if (NOT DEFINED ENV{GITHUB_ACTIONS})
+  message("Skipping GitHub Actions vpckg Tweaks")
+  return()
+endif()
+
+if (NOT DEFINED ENV{VCPKG_DOWNLOADS})
+  message(WARNING "The VCPKG_DOWNLAODS environment variable is not set.")
+  message(WARNING "Flaky download mirrors may be an issue for this build.")
+  return()
+else()
+  file(MAKE_DIRECTORY $ENV{VCPKG_DOWNLOADS})
+endif()
+
+include(tiledb-vcpkg-download-utils)
+
+tiledb_vcpkg_download("2.17-deps" "nasm-2.16.01.zip")
+tiledb_vcpkg_download("2.17-deps" "xz-5.4.1.tar.xz")
+
+# TMP: Debugging
+file(GLOB_RECURSE TILEDB_VCPKG_DOWNLOADS $ENV{VCPKG_DOWNLOADS}/*)
+
+message("Show downloade files.")
+foreach(path ${TILEDB_VCPKG_DOWNLOADS})
+  message("Downloaded: ${path}")
+endforeach()
+message("Done showing downloads.")


### PR DESCRIPTION
DON'T MERGE ME, BRO!

We've had a number of flaky mirror downloads lately that cause CI to
fail on GitHub Actions. These CMake tweaks are applied only on GitHub
Actions to use alternative mirrors for a number of dependencies that
have been observed to have flakiness issues.

---
TYPE: NO_HISTORY
DESC: Add vcpkg customization for things like flaky mirrors
