### PR TITLE
fix compile error on macos 13.4.1 with c++20 enabled

### DIFF
--- a/tiledb/api/c_api/buffer_list/buffer_list_api_internal.h
+++ b/tiledb/api/c_api/buffer_list/buffer_list_api_internal.h
@@ -34,8 +34,8 @@
 #define TILEDB_CAPI_BUFFER_LIST_API_INTERNAL_H
 
 #include "../../c_api_support/handle/handle.h"
+#include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/buffer_list.h"
-
 struct tiledb_buffer_list_handle_t
     : public tiledb::api::CAPIHandle<tiledb_buffer_list_handle_t> {
   /**


### PR DESCRIPTION
simple header reordering fixes the issue, the failure appears on my mac after #4034 because 13.4.1 has newer compiler versions than what we have in CI. Error here https://gist.github.com/robertbindar/a25afceaf32483c42e076ca82657a778

---
TYPE: BUG
DESC: fix compile error on macos 13.4.1 with c++20 enabled
