### PR TITLE
Move `StorageManager::load_array_metadata` to `Array` et. al.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1490,7 +1490,8 @@ Status Array::compute_max_buffer_sizes(
 
 void Array::do_load_metadata() {
   if (!array_dir_.loaded()) {
-    throw ArrayException("Cannot load metadata; array directory is not loaded.");
+    throw ArrayException(
+        "Cannot load metadata; array directory is not loaded.");
   }
   auto timer_se = resources_.stats().start_timer("sm_load_array_metadata");
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1488,8 +1488,10 @@ Status Array::compute_max_buffer_sizes(
   return Status::Ok();
 }
 
-void Array::load_local_metadata() {
-  assert(array_dir_.loaded());
+void Array::do_load_metadata() {
+  if (!array_dir_.loaded()) {
+    throw ArrayException("Cannot load metadata; array directory is not loaded.");
+  }
   auto timer_se = resources_.stats().start_timer("sm_load_array_metadata");
 
   // Determine which array metadata to load
@@ -1530,7 +1532,7 @@ Status Array::load_metadata() {
     RETURN_NOT_OK(rest_client->get_array_metadata_from_rest(
         array_uri_, timestamp_start_, timestamp_end_opened_at_, this));
   } else {
-    load_local_metadata();
+    do_load_metadata();
   }
   metadata_loaded_ = true;
   return Status::Ok();

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -148,8 +148,7 @@ Status Array::open_without_fragments(
     EncryptionType encryption_type,
     const void* encryption_key,
     uint32_t key_length) {
-  auto timer =
-      storage_manager_->stats()->start_timer("array_open_without_fragments");
+  auto timer = resources_.stats().start_timer("array_open_without_fragments");
   Status st;
   // Checks
   if (is_open()) {
@@ -205,7 +204,7 @@ Status Array::open_without_fragments(
       }
     } else {
       {
-        auto timer_se = storage_manager_->stats()->start_timer(
+        auto timer_se = resources_.stats().start_timer(
             "array_open_without_fragments_load_directory");
         array_dir_ = ArrayDirectory(
             resources_, array_uri_, 0, UINT64_MAX, ArrayDirectoryMode::READ);
@@ -258,7 +257,7 @@ Status Array::open(
     EncryptionType encryption_type,
     const void* encryption_key,
     uint32_t key_length) {
-  auto timer = storage_manager_->stats()->start_timer(
+  auto timer = resources_.stats().start_timer(
       "array_open_" + query_type_str(query_type));
   Status st;
   // Checks
@@ -378,8 +377,8 @@ Status Array::open(
       }
     } else if (query_type == QueryType::READ) {
       {
-        auto timer_se = storage_manager_->stats()->start_timer(
-            "array_open_read_load_directory");
+        auto timer_se =
+            resources_.stats().start_timer("array_open_read_load_directory");
         array_dir_ = ArrayDirectory(
             resources_, array_uri_, timestamp_start_, timestamp_end_opened_at_);
       }
@@ -394,8 +393,8 @@ Status Array::open(
         query_type == QueryType::WRITE ||
         query_type == QueryType::MODIFY_EXCLUSIVE) {
       {
-        auto timer_se = storage_manager_->stats()->start_timer(
-            "array_open_write_load_directory");
+        auto timer_se =
+            resources_.stats().start_timer("array_open_write_load_directory");
         array_dir_ = ArrayDirectory(
             resources_,
             array_uri_,
@@ -414,7 +413,7 @@ Status Array::open(
     } else if (
         query_type == QueryType::DELETE || query_type == QueryType::UPDATE) {
       {
-        auto timer_se = storage_manager_->stats()->start_timer(
+        auto timer_se = resources_.stats().start_timer(
             "array_open_delete_or_update_load_directory");
         array_dir_ = ArrayDirectory(
             resources_,
@@ -798,7 +797,7 @@ Status Array::reopen() {
 }
 
 Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
-  auto timer = storage_manager_->stats()->start_timer("array_reopen");
+  auto timer = resources_.stats().start_timer("array_reopen");
   if (!is_open_) {
     return LOG_STATUS(
         Status_ArrayError("Cannot reopen array; Array is not open"));
@@ -842,8 +841,7 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
 
   try {
     {
-      auto timer_se =
-          storage_manager_->stats()->start_timer("array_reopen_directory");
+      auto timer_se = resources_.stats().start_timer("array_reopen_directory");
       array_dir_ = ArrayDirectory(
           resources_,
           array_uri_,

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -210,8 +210,6 @@ Status Array::open_without_fragments(
             resources_, array_uri_, 0, UINT64_MAX, ArrayDirectoryMode::READ);
       }
       auto&& [array_schema, array_schemas] = open_for_reads_without_fragments();
-      if (!st.ok())
-        throw StatusException(st);
 
       array_schema_latest_ = array_schema.value();
       array_schemas_all_ = array_schemas.value();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -770,7 +770,7 @@ class Array {
   /**
    * Load non-remote array metadata.
    */
-  void load_local_metadata();
+  void do_load_metadata();
 
   /**
    * Load array metadata, handles remote arrays vs non-remote arrays

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -768,6 +768,11 @@ class Array {
           max_buffer_sizes_) const;
 
   /**
+   * Load non-remote array metadata.
+   */
+  void load_local_metadata();
+
+  /**
    * Load array metadata, handles remote arrays vs non-remote arrays
    * @return  Status
    */

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -635,15 +635,6 @@ class StorageManagerCanonical {
   Status is_group(const URI& uri, bool* is_group) const;
 
   /**
-   * Loads the array metadata from persistent storage based on
-   * the input URI manager.
-   */
-  void load_array_metadata(
-      const ArrayDirectory& array_dir,
-      const EncryptionKey& encryption_key,
-      Metadata* metadata);
-
-  /**
    * Loads the delete and update conditions from storage.
    *
    * @param array The array.


### PR DESCRIPTION
[SC-23376](https://app.shortcut.com/tiledb-inc/story/23376/move-storagemanager-load-array-metadata-to-array)

---
TYPE: IMPROVEMENT
DESC: Move `StorageManager::load_array_metadata` to `Array` et. al.