### PR TITLE
Update filter checks for accepted datatypes

### DIFF
--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -116,7 +116,11 @@ Status BitWidthReductionFilter::run_forward(
   auto data_type_size = static_cast<uint8_t>(datatype_size(filter_data_type_));
 
   // If bit width compression can't work, just return the input unmodified.
-  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1) {
+  const bool backwards_compat =
+      tile.format_version() < 20 &&
+      (!datatype_is_integer(filter_data_type_) || data_type_size == 1);
+  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1 ||
+      backwards_compat) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();
@@ -298,7 +302,11 @@ Status BitWidthReductionFilter::run_reverse(
   auto data_type_size = static_cast<uint8_t>(datatype_size(filter_data_type_));
 
   // If bit width compression wasn't applied, just return the input unmodified.
-  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1) {
+  const bool backwards_compat =
+      tile.format_version() < 20 &&
+      (!datatype_is_integer(filter_data_type_) || data_type_size == 1);
+  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1 ||
+      backwards_compat) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -113,31 +113,14 @@ Status BitWidthReductionFilter::run_forward(
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  auto data_type_size = static_cast<uint8_t>(datatype_size(filter_data_type_));
-
-  // If bit width compression can't work, just return the input unmodified.
-  const bool backwards_compat =
-      tile.format_version() < 20 &&
-      (!datatype_is_integer(filter_data_type_) || data_type_size == 1);
-  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1 ||
-      backwards_compat) {
+  // For backwards compatibility, skip filtering non-integral types.
+  if (tile.format_version() < 20 && !datatype_is_integer(filter_data_type_)) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();
   }
 
-  /* Note: Arithmetic operations cannot be performed on std::byte.
-    We will use uint8_t for the Datatype::BLOB case as it is the same size as
-    std::byte and can have arithmetic performed on it. */
   switch (filter_data_type_) {
-    case Datatype::INT8:
-      return run_forward<int8_t>(
-          tile, offsets_tile, input_metadata, input, output_metadata, output);
-    case Datatype::BLOB:
-    case Datatype::BOOL:
-    case Datatype::UINT8:
-      return run_forward<uint8_t>(
-          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT16:
       return run_forward<int16_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
@@ -180,9 +163,15 @@ Status BitWidthReductionFilter::run_forward(
     case Datatype::TIME_AS:
       return run_forward<int64_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
+    case Datatype::INT8:
+    case Datatype::BLOB:
+    case Datatype::BOOL:
+    case Datatype::UINT8:
     default:
-      return LOG_STATUS(
-          Status_FilterError("Cannot filter; Unsupported input type"));
+      // If bit width compression can't work, just return the input unmodified.
+      RETURN_NOT_OK(output->append_view(input));
+      RETURN_NOT_OK(output_metadata->append_view(input_metadata));
+      return Status::Ok();
   }
 }
 
@@ -297,33 +286,15 @@ Status BitWidthReductionFilter::run_reverse(
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output,
-    const Config& config) const {
-  (void)config;
-  auto data_type_size = static_cast<uint8_t>(datatype_size(filter_data_type_));
-
-  // If bit width compression wasn't applied, just return the input unmodified.
-  const bool backwards_compat =
-      tile.format_version() < 20 &&
-      (!datatype_is_integer(filter_data_type_) || data_type_size == 1);
-  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1 ||
-      backwards_compat) {
+    const Config&) const {
+  // For backwards compatibility, skip filtering non-integral types.
+  if (tile.format_version() < 20 && !datatype_is_integer(filter_data_type_)) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();
   }
 
-  /* Note: Arithmetic operations cannot be performed on std::byte.
-    We will use uint8_t for the Datatype::BLOB case as it is the same size as
-    std::byte and can have arithmetic perfomed on it. */
   switch (filter_data_type_) {
-    case Datatype::INT8:
-      return run_reverse<int8_t>(
-          tile, offsets_tile, input_metadata, input, output_metadata, output);
-    case Datatype::BLOB:
-    case Datatype::BOOL:
-    case Datatype::UINT8:
-      return run_reverse<uint8_t>(
-          tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT16:
       return run_reverse<int16_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
@@ -366,9 +337,15 @@ Status BitWidthReductionFilter::run_reverse(
     case Datatype::TIME_AS:
       return run_reverse<int64_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
+    case Datatype::INT8:
+    case Datatype::BLOB:
+    case Datatype::BOOL:
+    case Datatype::UINT8:
     default:
-      return LOG_STATUS(
-          Status_FilterError("Cannot filter; Unsupported input type"));
+      // If bit width compression wasn't applied, return the input unmodified.
+      RETURN_NOT_OK(output->append_view(input));
+      RETURN_NOT_OK(output_metadata->append_view(input_metadata));
+      return Status::Ok();
   }
 }
 

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -113,13 +113,6 @@ Status BitWidthReductionFilter::run_forward(
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  // For backwards compatibility, skip filtering non-integral types.
-  if (tile.format_version() < 20 && !datatype_is_integer(filter_data_type_)) {
-    RETURN_NOT_OK(output->append_view(input));
-    RETURN_NOT_OK(output_metadata->append_view(input_metadata));
-    return Status::Ok();
-  }
-
   switch (filter_data_type_) {
     case Datatype::INT16:
       return run_forward<int16_t>(
@@ -161,6 +154,12 @@ Status BitWidthReductionFilter::run_forward(
     case Datatype::TIME_PS:
     case Datatype::TIME_FS:
     case Datatype::TIME_AS:
+      if (tile.format_version() < 20) {
+        // Return data as-is for backwards compatibility
+        RETURN_NOT_OK(output->append_view(input));
+        RETURN_NOT_OK(output_metadata->append_view(input_metadata));
+        return Status::Ok();
+      }
       return run_forward<int64_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT8:
@@ -287,13 +286,6 @@ Status BitWidthReductionFilter::run_reverse(
     FilterBuffer* output_metadata,
     FilterBuffer* output,
     const Config&) const {
-  // For backwards compatibility, skip filtering non-integral types.
-  if (tile.format_version() < 20 && !datatype_is_integer(filter_data_type_)) {
-    RETURN_NOT_OK(output->append_view(input));
-    RETURN_NOT_OK(output_metadata->append_view(input_metadata));
-    return Status::Ok();
-  }
-
   switch (filter_data_type_) {
     case Datatype::INT16:
       return run_reverse<int16_t>(
@@ -335,6 +327,12 @@ Status BitWidthReductionFilter::run_reverse(
     case Datatype::TIME_PS:
     case Datatype::TIME_FS:
     case Datatype::TIME_AS:
+      if (tile.format_version() < 20) {
+        // Return data as-is for backwards compatibility.
+        RETURN_NOT_OK(output->append_view(input));
+        RETURN_NOT_OK(output_metadata->append_view(input_metadata));
+        return Status::Ok();
+      }
       return run_reverse<int64_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     case Datatype::INT8:

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -100,7 +100,7 @@ void BitWidthReductionFilter::dump(FILE* out) const {
 
 bool BitWidthReductionFilter::accepts_input_datatype(Datatype datatype) const {
   if (datatype_is_integer(datatype) || datatype_is_datetime(datatype) ||
-      datatype_is_time(datatype) || datatype_is_string(datatype)) {
+      datatype_is_time(datatype) || datatype == Datatype::BLOB) {
     return true;
   }
   return false;
@@ -116,9 +116,7 @@ Status BitWidthReductionFilter::run_forward(
   auto data_type_size = static_cast<uint8_t>(datatype_size(filter_data_type_));
 
   // If bit width compression can't work, just return the input unmodified.
-  if ((!datatype_is_integer(filter_data_type_) &&
-       filter_data_type_ != Datatype::BLOB) ||
-      data_type_size == 1) {
+  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();
@@ -300,9 +298,7 @@ Status BitWidthReductionFilter::run_reverse(
   auto data_type_size = static_cast<uint8_t>(datatype_size(filter_data_type_));
 
   // If bit width compression wasn't applied, just return the input unmodified.
-  if ((!datatype_is_integer(filter_data_type_) &&
-       filter_data_type_ != Datatype::BLOB) ||
-      data_type_size == 1) {
+  if (!accepts_input_datatype(filter_data_type_) || data_type_size == 1) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -77,7 +77,10 @@ Status PositiveDeltaFilter::run_forward(
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
   // If encoding can't work, just return the input unmodified.
-  if (!accepts_input_datatype(filter_data_type_)) {
+  const bool backwards_compat =
+      tile.format_version() < 20 && (!datatype_is_integer(filter_data_type_) &&
+                                     filter_data_type_ != Datatype::BLOB);
+  if (!accepts_input_datatype(filter_data_type_) || backwards_compat) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();
@@ -254,7 +257,10 @@ Status PositiveDeltaFilter::run_reverse(
     const Config& config) const {
   (void)config;
   // If encoding wasn't applied, just return the input unmodified.
-  if (!accepts_input_datatype(filter_data_type_)) {
+  const bool backwards_compat =
+      tile.format_version() < 20 && (!datatype_is_integer(filter_data_type_) &&
+                                     filter_data_type_ != Datatype::BLOB);
+  if (!accepts_input_datatype(filter_data_type_) || backwards_compat) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -62,7 +62,11 @@ void PositiveDeltaFilter::dump(FILE* out) const {
 }
 
 bool PositiveDeltaFilter::accepts_input_datatype(Datatype datatype) const {
-  return !datatype_is_real(datatype);
+  if (datatype_is_integer(datatype) || datatype_is_datetime(datatype) ||
+      datatype_is_time(datatype) || datatype == Datatype::BLOB) {
+    return true;
+  }
+  return false;
 }
 
 Status PositiveDeltaFilter::run_forward(
@@ -73,8 +77,7 @@ Status PositiveDeltaFilter::run_forward(
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
   // If encoding can't work, just return the input unmodified.
-  if (!datatype_is_integer(filter_data_type_) &&
-      filter_data_type_ != Datatype::BLOB) {
+  if (!accepts_input_datatype(filter_data_type_)) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();
@@ -251,8 +254,7 @@ Status PositiveDeltaFilter::run_reverse(
     const Config& config) const {
   (void)config;
   // If encoding wasn't applied, just return the input unmodified.
-  if (!datatype_is_integer(filter_data_type_) &&
-      filter_data_type_ != Datatype::BLOB) {
+  if (!accepts_input_datatype(filter_data_type_)) {
     RETURN_NOT_OK(output->append_view(input));
     RETURN_NOT_OK(output_metadata->append_view(input_metadata));
     return Status::Ok();

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -76,14 +76,6 @@ Status PositiveDeltaFilter::run_forward(
     FilterBuffer* input,
     FilterBuffer* output_metadata,
     FilterBuffer* output) const {
-  // For backwards compatibility, skip filtering non-integral types.
-  if (tile.format_version() < 20 && (!datatype_is_integer(filter_data_type_) &&
-                                     filter_data_type_ != Datatype::BLOB)) {
-    RETURN_NOT_OK(output->append_view(input));
-    RETURN_NOT_OK(output_metadata->append_view(input_metadata));
-    return Status::Ok();
-  }
-
   /* Note: Arithmetic operations cannot be performed on std::byte.
     We will use uint8_t for the Datatype::BLOB case as it is the same size as
     std::byte and can have arithmetic performed on it. */
@@ -136,6 +128,12 @@ Status PositiveDeltaFilter::run_forward(
     case Datatype::TIME_PS:
     case Datatype::TIME_FS:
     case Datatype::TIME_AS:
+      if (tile.format_version() < 20) {
+        // Return data as-is for backwards compatibility.
+        RETURN_NOT_OK(output->append_view(input));
+        RETURN_NOT_OK(output_metadata->append_view(input_metadata));
+        return Status::Ok();
+      }
       return run_forward<int64_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     default:
@@ -255,14 +253,6 @@ Status PositiveDeltaFilter::run_reverse(
     FilterBuffer* output_metadata,
     FilterBuffer* output,
     const Config&) const {
-  // For backwards compatibility, skip filtering non-integral types.
-  if (tile.format_version() < 20 && (!datatype_is_integer(filter_data_type_) &&
-                                     filter_data_type_ != Datatype::BLOB)) {
-    RETURN_NOT_OK(output->append_view(input));
-    RETURN_NOT_OK(output_metadata->append_view(input_metadata));
-    return Status::Ok();
-  }
-
   /* Note: Arithmetic operations cannot be performed on std::byte.
     We will use uint8_t for the Datatype::BLOB case as it is the same size as
     std::byte and can have arithmetic perfomed on it. */
@@ -315,6 +305,12 @@ Status PositiveDeltaFilter::run_reverse(
     case Datatype::TIME_PS:
     case Datatype::TIME_FS:
     case Datatype::TIME_AS:
+      if (tile.format_version() < 20) {
+        // Return data as-is for backwards compatibility.
+        RETURN_NOT_OK(output->append_view(input));
+        RETURN_NOT_OK(output_metadata->append_view(input_metadata));
+        return Status::Ok();
+      }
       return run_reverse<int64_t>(
           tile, offsets_tile, input_metadata, input, output_metadata, output);
     default:


### PR DESCRIPTION
There were some prechecks in place for positive delta and bit width reduction filters that early-out, resulting in no-op filtering for datatypes that are accepted for these filters.

The existing backwards compatibility arrays were impacted by this no-op. Now an exception is thrown when the incorrect type is used, so I opened TileDB-Inc/TileDB-Unit-Test-Arrays#40 to update the ingestion, skipping these filters for datatypes that are unsupported. From debugging I believe the issue first appears on arrays using format version 14. 

---
TYPE: BUG
DESC: Update filter checks for accepted datatypes.