### PR TITLE
Add a `make_unique` helper function to create unique pointers.

### DIFF
--- a/test/support/src/ast_helpers.cc
+++ b/test/support/src/ast_helpers.cc
@@ -67,7 +67,7 @@ std::string bbv_to_hex_str(const tiledb::sm::ByteVecValue& b) {
   return ss.str();
 }
 
-std::string ast_node_to_str(const tdb_unique_ptr<tiledb::sm::ASTNode>& node) {
+std::string ast_node_to_str(const tiledb::sm::ASTNode* node) {
   if (node == nullptr)
     return "";
   std::string result_str;
@@ -86,7 +86,7 @@ std::string ast_node_to_str(const tdb_unique_ptr<tiledb::sm::ASTNode>& node) {
     result_str = "(";
     const auto& nodes = node->get_children();
     for (size_t i = 0; i < nodes.size(); i++) {
-      result_str += ast_node_to_str(nodes[i]);
+      result_str += ast_node_to_str(nodes[i].get());
       if (i != nodes.size() - 1) {
         result_str += " ";
         result_str +=
@@ -99,9 +99,7 @@ std::string ast_node_to_str(const tdb_unique_ptr<tiledb::sm::ASTNode>& node) {
   }
 }
 
-bool ast_equal(
-    const tdb_unique_ptr<sm::ASTNode>& lhs,
-    const tdb_unique_ptr<sm::ASTNode>& rhs) {
+bool ast_equal(const sm::ASTNode* lhs, const sm::ASTNode* rhs) {
   if (!lhs->is_expr() && !rhs->is_expr()) {
     if (lhs->get_field_name() != rhs->get_field_name())
       return false;
@@ -131,7 +129,7 @@ bool ast_equal(
       return false;
 
     for (size_t i = 0; i < lhs_children.size(); ++i) {
-      if (!ast_equal(lhs_children[i], rhs_children[i]))
+      if (!ast_equal(lhs_children[i].get(), rhs_children[i].get()))
         return false;
     }
     return true;

--- a/test/support/src/ast_helpers.h
+++ b/test/support/src/ast_helpers.h
@@ -51,14 +51,25 @@ std::string bbv_to_hex_str(const tiledb::sm::ByteVecValue& b);
 /**
  * Returns the string representation of a Query AST node.
  */
-std::string ast_node_to_str(const tdb_unique_ptr<tiledb::sm::ASTNode>& node);
+std::string ast_node_to_str(const tiledb::sm::ASTNode* node);
+
+template <class T>
+inline std::string ast_node_to_str(const tdb_unique_ptr<T>& node) {
+  return ast_node_to_str(static_cast<tiledb::sm::ASTNode*>(node.get()));
+}
 
 /**
  * Returns whether two ASTs are syntactically equal.
  */
-bool ast_equal(
-    const tdb_unique_ptr<tiledb::sm::ASTNode>& lhs,
-    const tdb_unique_ptr<tiledb::sm::ASTNode>& rhs);
+bool ast_equal(const tiledb::sm::ASTNode* lhs, const tiledb::sm::ASTNode* rhs);
+
+template <class T1, class T2>
+inline bool ast_equal(
+    const tdb_unique_ptr<T1>& lhs, const tdb_unique_ptr<T2>& rhs) {
+  return ast_equal(
+      static_cast<tiledb::sm::ASTNode*>(lhs.get()),
+      static_cast<tiledb::sm::ASTNode*>(rhs.get()));
+}
 
 }  // namespace tiledb::test
 #endif  //  TILEDB_AST_HELPERS_H

--- a/tiledb/common/common.h
+++ b/tiledb/common/common.h
@@ -56,6 +56,12 @@ using tiledb::common::allocator;
 using tiledb::common::make_shared;
 
 /*
+ * Heap memory
+ */
+#include "heap_memory.h"
+using tiledb::common::make_unique;
+
+/*
  * Exception
  *
  * The exception header also put `class Status` in scope.

--- a/tiledb/common/heap_memory.h
+++ b/tiledb/common/heap_memory.h
@@ -136,6 +136,16 @@ struct TileDBUniquePtrDeleter {
 template <class T>
 using tiledb_unique_ptr = std::unique_ptr<T, TileDBUniquePtrDeleter<T>>;
 
+template <class T, class... Args>
+tiledb_unique_ptr<T> make_unique(const std::string& label, Args&&... args) {
+  return {tiledb_new<T>(label, std::forward<Args>(args)...), {}};
+}
+
+template <class T, int n, class... Args>
+tiledb_unique_ptr<T> make_unique(const char (&label)[n], Args&&... args) {
+  return {tiledb_new<T>(label, std::forward<Args>(args)...), {}};
+}
+
 }  // namespace common
 }  // namespace tiledb
 

--- a/tiledb/common/heap_memory.h
+++ b/tiledb/common/heap_memory.h
@@ -129,6 +129,10 @@ void tiledb_delete_array(T* const p) {
 /** TileDB variant of `std::unique_ptr`. */
 template <class T>
 struct TileDBUniquePtrDeleter {
+  TileDBUniquePtrDeleter() = default;
+  template <class U>
+  TileDBUniquePtrDeleter(const TileDBUniquePtrDeleter<U>&) noexcept {
+  }
   void operator()(T* const p) {
     tiledb_delete<T>(p);
   }

--- a/tiledb/sm/array/test/unit_consistency.h
+++ b/tiledb/sm/array/test/unit_consistency.h
@@ -121,9 +121,8 @@ class WhiteboxConsistencyController : public ConsistencyController {
       throw std::runtime_error(
           "[WhiteboxConsistencyController] Could not create array.");
     }
-    tdb_unique_ptr<Array> array(new Array{uri, sm, *this});
 
-    return array;
+    return make_unique<Array>(HERE(), uri, sm, *this);
   }
 
   tdb_unique_ptr<Array> open_array(const URI uri, StorageManager* sm) {

--- a/tiledb/sm/array_schema/array_schema_evolution.cc
+++ b/tiledb/sm/array_schema/array_schema_evolution.cc
@@ -165,8 +165,7 @@ void ArraySchemaEvolution::add_attribute(shared_ptr<const Attribute> attr) {
    * container type, but until then, we copy the attribute into a new
    * allocation.
    */
-  attributes_to_add_map_[attr->name()] =
-      tdb_unique_ptr<Attribute>(tdb_new(Attribute, *attr));
+  attributes_to_add_map_[attr->name()] = make_unique<Attribute>(HERE(), *attr);
   if (attributes_to_drop_.find(attr->name()) != attributes_to_drop_.end()) {
     attributes_to_drop_.erase(attr->name());
   }

--- a/tiledb/sm/crypto/crypto_win32.cc
+++ b/tiledb/sm/crypto/crypto_win32.cc
@@ -333,7 +333,7 @@ Status Win32CNG::hash_bytes(
   }
 
   // allocate the hash object on the heap
-  tdb_unique_ptr<Buffer> hash_obj = tdb_unique_ptr<Buffer>(tdb_new(Buffer));
+  tdb_unique_ptr<Buffer> hash_obj = make_unique<Buffer>(HERE());
   throw_if_not_ok(hash_obj->realloc(hash_size));
 
   // create a hash

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -183,19 +183,15 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
   // Construct the Azure SDK blob service client.
   // We pass a shared key if it was specified.
   if (!account_key.empty()) {
-    client_ =
-        tdb_unique_ptr<::Azure::Storage::Blobs::BlobServiceClient>(tdb_new(
-            ::Azure::Storage::Blobs::BlobServiceClient,
-            blob_endpoint,
-            make_shared<::Azure::Storage::StorageSharedKeyCredential>(
-                HERE(), account_name, account_key),
-            options));
+    client_ = make_unique<::Azure::Storage::Blobs::BlobServiceClient>(
+        HERE(),
+        blob_endpoint,
+        make_shared<::Azure::Storage::StorageSharedKeyCredential>(
+            HERE(), account_name, account_key),
+        options);
   } else {
-    client_ =
-        tdb_unique_ptr<::Azure::Storage::Blobs::BlobServiceClient>(tdb_new(
-            ::Azure::Storage::Blobs::BlobServiceClient,
-            blob_endpoint,
-            options));
+    client_ = make_unique<::Azure::Storage::Blobs::BlobServiceClient>(
+        HERE(), blob_endpoint, options);
   }
 
   return Status::Ok();

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -341,7 +341,7 @@ class MemFilesystem::Directory : public MemFilesystem::FSNode {
 };
 
 MemFilesystem::MemFilesystem()
-    : root_(tdb_unique_ptr<FSNode>(tdb_new(Directory))) {
+    : root_(make_unique<Directory>(HERE())) {
   assert(root_);
 }
 
@@ -569,7 +569,7 @@ Status MemFilesystem::create_dir_internal(
     assert(cur_lock.mutex() == &cur->mutex_);
 
     if (!cur->has_child(token)) {
-      cur->children_[token] = tdb_unique_ptr<FSNode>(tdb_new(Directory));
+      cur->children_[token] = make_unique<Directory>(HERE());
     } else if (!cur->is_dir()) {
       return LOG_STATUS(Status_MemFSError(std::string(
           "Cannot create directory, a file with that name exists already: " +
@@ -623,7 +623,7 @@ Status MemFilesystem::touch_internal(
   }
 
   const std::string& filename = tokens[tokens.size() - 1];
-  cur->children_[filename] = tdb_unique_ptr<FSNode>(tdb_new(File));
+  cur->children_[filename] = make_unique<File>(HERE());
 
   // Save the output argument, `node`, if requested.
   if (node != nullptr) {

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1458,8 +1458,7 @@ Status S3::init_client() const {
   // check for client configuration on create, which can be slow if aws is not
   // configured on a users systems due to ec2 metadata check
 
-  client_config_ = tdb_unique_ptr<Aws::Client::ClientConfiguration>(
-      tdb_new(Aws::Client::ClientConfiguration));
+  client_config_ = make_unique<Aws::Client::ClientConfiguration>(HERE());
 
   s3_tp_executor_ = make_shared<S3ThreadPoolExecutor>(HERE(), vfs_thread_pool_);
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -72,12 +72,12 @@ VFS::VFS(
   assert(io_tp);
 
   // Construct the read-ahead cache.
-  read_ahead_cache_ = tdb_unique_ptr<ReadAheadCache>(
-      tdb_new(ReadAheadCache, vfs_params_.read_ahead_cache_size_));
+  read_ahead_cache_ =
+      make_unique<ReadAheadCache>(HERE(), vfs_params_.read_ahead_cache_size_);
 
 #ifdef HAVE_HDFS
   supported_fs_.insert(Filesystem::HDFS);
-  hdfs_ = tdb_unique_ptr<hdfs::HDFS>(tdb_new(hdfs::HDFS));
+  hdfs_ = make_unique<hdfs::HDFS>(HERE());
   st = hdfs_->init(config_);
   if (!st.ok()) {
     throw std::runtime_error("[VFS::VFS] Failed to initialize HDFS backend.");

--- a/tiledb/sm/filter/checksum_md5_filter.cc
+++ b/tiledb/sm/filter/checksum_md5_filter.cc
@@ -197,8 +197,7 @@ Status ChecksumMD5Filter::run_reverse(
 Status ChecksumMD5Filter::checksum_part(
     ConstBuffer* part, FilterBuffer* output_metadata) const {
   // Allocate an initial output buffer.
-  tdb_unique_ptr<Buffer> computed_hash =
-      tdb_unique_ptr<Buffer>(tdb_new(Buffer));
+  auto computed_hash = make_unique<Buffer>(HERE());
   throw_if_not_ok(computed_hash->realloc(Crypto::MD5_DIGEST_BYTES));
   RETURN_NOT_OK(Crypto::md5(part, computed_hash.get()));
 
@@ -213,10 +212,9 @@ Status ChecksumMD5Filter::checksum_part(
 
 Status ChecksumMD5Filter::compare_checksum_part(
     FilterBuffer* part, uint64_t bytes_to_compare, void* checksum) const {
-  tdb_unique_ptr<Buffer> byte_buffer_to_compare =
-      tdb_unique_ptr<Buffer>(tdb_new(Buffer));
-  tdb_unique_ptr<ConstBuffer> buffer_to_compare = tdb_unique_ptr<ConstBuffer>(
-      tdb_new(ConstBuffer, byte_buffer_to_compare.get()));
+  auto byte_buffer_to_compare = make_unique<Buffer>(HERE());
+  auto buffer_to_compare =
+      make_unique<ConstBuffer>(HERE(), byte_buffer_to_compare.get());
 
   // First we try to get a view on the bytes we need without copying
   // This might fail if the bytes we need to compare are contained in multiple
@@ -227,8 +225,8 @@ Status ChecksumMD5Filter::compare_checksum_part(
     throw_if_not_ok(byte_buffer_to_compare->realloc(bytes_to_compare));
     RETURN_NOT_OK(part->read(byte_buffer_to_compare->data(), bytes_to_compare));
     // Set the buffer back
-    buffer_to_compare = tdb_unique_ptr<ConstBuffer>(
-        tdb_new(ConstBuffer, byte_buffer_to_compare.get()));
+    buffer_to_compare =
+        make_unique<ConstBuffer>(HERE(), byte_buffer_to_compare.get());
   } else {
     // Move offset location if we used a view so next checksum will read
     // subsequent bytes
@@ -236,8 +234,7 @@ Status ChecksumMD5Filter::compare_checksum_part(
   }
 
   // Buffer to store the newly computed hash value for comparison
-  tdb_unique_ptr<Buffer> computed_hash =
-      tdb_unique_ptr<Buffer>(tdb_new(Buffer));
+  tdb_unique_ptr<Buffer> computed_hash = make_unique<Buffer>(HERE());
   throw_if_not_ok(computed_hash->realloc(Crypto::MD5_DIGEST_BYTES));
 
   RETURN_NOT_OK(Crypto::md5(

--- a/tiledb/sm/filter/filter_buffer.cc
+++ b/tiledb/sm/filter/filter_buffer.cc
@@ -52,8 +52,7 @@ FilterBuffer::BufferOrView::BufferOrView(
     const shared_ptr<Buffer>& buffer, uint64_t offset, uint64_t nbytes) {
   is_view_ = true;
   underlying_buffer_ = buffer;
-  view_ = tdb_unique_ptr<Buffer>(
-      tdb_new(Buffer, (char*)buffer->data() + offset, nbytes));
+  view_ = make_unique<Buffer>(HERE(), (char*)buffer->data() + offset, nbytes);
 }
 
 FilterBuffer::BufferOrView::BufferOrView(BufferOrView&& other) {
@@ -79,8 +78,8 @@ FilterBuffer::BufferOrView FilterBuffer::BufferOrView::get_view(
   if (is_view_) {
     BufferOrView new_view(underlying_buffer_);
     new_view.is_view_ = true;
-    new_view.view_ = tdb_unique_ptr<Buffer>(
-        tdb_new(Buffer, (char*)view_->data() + offset, nbytes));
+    new_view.view_ =
+        make_unique<Buffer>(HERE(), (char*)view_->data() + offset, nbytes);
     return new_view;
   } else {
     return BufferOrView(underlying_buffer_, offset, nbytes);

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -531,8 +531,7 @@ void FilterPipeline::serialize(Serializer& serializer) const {
     // as a no-op filter instead.
     auto as_compression = dynamic_cast<CompressionFilter*>(f.get());
     if (as_compression != nullptr && f->type() == FilterType::FILTER_NONE) {
-      auto noop =
-          tdb_unique_ptr<NoopFilter>(tdb_new(NoopFilter, Datatype::ANY));
+      auto noop = make_unique<NoopFilter>(HERE(), Datatype::ANY);
       noop->serialize(serializer);
     } else {
       f->serialize(serializer);

--- a/tiledb/sm/query/ast/query_ast.cc
+++ b/tiledb/sm/query/ast/query_ast.cc
@@ -50,11 +50,11 @@ bool ASTNodeVal::is_expr() const {
 }
 
 tdb_unique_ptr<ASTNode> ASTNodeVal::clone() const {
-  return tdb_unique_ptr<ASTNode>(tdb_new(ASTNodeVal, *this));
+  return make_unique<ASTNodeVal>(HERE(), *this);
 }
 
 tdb_unique_ptr<ASTNode> ASTNodeVal::get_negated_tree() const {
-  return tdb_unique_ptr<ASTNode>(tdb_new(ASTNodeVal, *this, ASTNegation));
+  return make_unique<ASTNodeVal>(HERE(), *this, ASTNegation);
 }
 
 void ASTNodeVal::get_field_names(
@@ -216,8 +216,7 @@ tdb_unique_ptr<ASTNode> ASTNodeVal::combine(
       ast_nodes.push_back(rhs->clone());
     }
   }
-  return tdb_unique_ptr<ASTNode>(
-      tdb_new(ASTNodeExpr, std::move(ast_nodes), combination_op));
+  return make_unique<ASTNodeExpr>(HERE(), std::move(ast_nodes), combination_op);
 }
 
 const std::string& ASTNodeVal::get_field_name() const {
@@ -256,11 +255,11 @@ bool ASTNodeExpr::is_expr() const {
 }
 
 tdb_unique_ptr<ASTNode> ASTNodeExpr::clone() const {
-  return tdb_unique_ptr<ASTNode>(tdb_new(ASTNodeExpr, *this));
+  return make_unique<ASTNodeExpr>(HERE(), *this);
 }
 
 tdb_unique_ptr<ASTNode> ASTNodeExpr::get_negated_tree() const {
-  return tdb_unique_ptr<ASTNode>(tdb_new(ASTNodeExpr, *this, ASTNegation));
+  return make_unique<ASTNodeExpr>(HERE(), *this, ASTNegation);
 }
 
 void ASTNodeExpr::get_field_names(
@@ -330,8 +329,7 @@ tdb_unique_ptr<ASTNode> ASTNodeExpr::combine(
     ast_nodes.push_back(rhs->clone());
   }
 
-  return tdb_unique_ptr<ASTNode>(
-      tdb_new(ASTNodeExpr, std::move(ast_nodes), combination_op));
+  return make_unique<ASTNodeExpr>(HERE(), std::move(ast_nodes), combination_op);
 }
 
 const std::string& ASTNodeExpr::get_field_name() const {

--- a/tiledb/sm/query/ast/test/unit-query-ast.cc
+++ b/tiledb/sm/query/ast/test/unit-query-ast.cc
@@ -51,8 +51,8 @@ tdb_unique_ptr<ASTNode> test_value_node(
     const std::string& expected_result,
     bool negate = false) {
   // Test validity of construction of value node.
-  auto node_val = tdb_unique_ptr<ASTNode>(
-      tdb_new(ASTNodeVal, field_name, val, sizeof(T), op));
+  auto node_val =
+      make_unique<ASTNodeVal>(HERE(), field_name, val, sizeof(T), op);
 
   if (!negate) {
     CHECK(ast_node_to_str(node_val) == expected_result);
@@ -80,8 +80,8 @@ tdb_unique_ptr<ASTNode> test_string_value_node(
     throw std::runtime_error("test_string_value_node: val cannot be null.");
   }
   // Test validity of construction of value node.
-  auto node_val = tdb_unique_ptr<ASTNode>(
-      tdb_new(ASTNodeVal, field_name, val, strlen(val), op));
+  auto node_val =
+      make_unique<ASTNodeVal>(HERE(), field_name, val, strlen(val), op);
   if (!negate) {
     CHECK(ast_node_to_str(node_val) == expected_result);
   }

--- a/tiledb/sm/query/deletes_and_updates/serialization.cc
+++ b/tiledb/sm/query/deletes_and_updates/serialization.cc
@@ -120,8 +120,8 @@ tdb_unique_ptr<ASTNode> deserialize_condition_impl(Deserializer& deserializer) {
     auto value_size = deserializer.read<storage_size_t>();
     auto value_data = deserializer.get_ptr<void>(value_size);
 
-    return tdb_unique_ptr<ASTNode>(
-        tdb_new(ASTNodeVal, field_name, value_data, value_size, op));
+    return make_unique<ASTNodeVal>(
+        HERE(), field_name, value_data, value_size, op);
   } else if (node_type == NodeType::EXPRESSION) {
     // Deserialize combination op.
     auto combination_op = deserializer.read<QueryConditionCombinationOp>();
@@ -135,8 +135,8 @@ tdb_unique_ptr<ASTNode> deserialize_condition_impl(Deserializer& deserializer) {
       ast_nodes.push_back(deserialize_condition_impl(deserializer));
     }
 
-    return tdb_unique_ptr<ASTNode>(
-        tdb_new(ASTNodeExpr, std::move(ast_nodes), combination_op));
+    return make_unique<ASTNodeExpr>(
+        HERE(), std::move(ast_nodes), combination_op);
   } else {
     throw std::logic_error("Cannot deserialize, unknown node type.");
   }

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -117,8 +117,8 @@ Status QueryCondition::init(
   }
 
   // AST Construction.
-  tree_ = tdb_unique_ptr<ASTNode>(tdb_new(
-      ASTNodeVal, field_name, condition_value, condition_value_size, op));
+  tree_ = make_unique<ASTNodeVal>(
+      HERE(), field_name, condition_value, condition_value_size, op);
 
   return Status::Ok();
 }

--- a/tiledb/sm/serialization/array_schema_evolution.cc
+++ b/tiledb/sm/serialization/array_schema_evolution.cc
@@ -181,13 +181,13 @@ tdb_unique_ptr<ArraySchemaEvolution> array_schema_evolution_from_capnp(
     ts_range = std::make_pair(timestamp_range[0], timestamp_range[1]);
   }
 
-  return tdb_unique_ptr<ArraySchemaEvolution>(tdb_new(
-      ArraySchemaEvolution,
+  return make_unique<ArraySchemaEvolution>(
+      HERE(),
       attrs_to_add,
       attrs_to_drop,
       enmrs_to_add,
       enmrs_to_drop,
-      ts_range));
+      ts_range);
 }
 
 Status array_schema_evolution_serialize(

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1008,8 +1008,8 @@ tdb_unique_ptr<ASTNode> condition_ast_from_capnp(
 
     auto use_enumeration = ast_reader.getUseEnumeration();
 
-    return tdb_unique_ptr<ASTNode>(
-        tdb_new(ASTNodeVal, field_name, data, size, op, use_enumeration));
+    return make_unique<ASTNodeVal>(
+        HERE(), field_name, data, size, op, use_enumeration);
   }
 
   // Getting and validating the query condition combination operator.
@@ -1030,8 +1030,7 @@ tdb_unique_ptr<ASTNode> condition_ast_from_capnp(
   for (const auto child : ast_reader.getChildren()) {
     ast_nodes.push_back(condition_ast_from_capnp(child));
   }
-  return tdb_unique_ptr<ASTNode>(
-      tdb_new(ASTNodeExpr, std::move(ast_nodes), combination_op));
+  return make_unique<ASTNodeExpr>(HERE(), std::move(ast_nodes), combination_op);
 }
 
 Status condition_from_capnp(
@@ -1063,8 +1062,8 @@ Status condition_from_capnp(
 
       bool use_enumeration = clause.getUseEnumeration();
 
-      ast_nodes.push_back(tdb_unique_ptr<ASTNode>(
-          tdb_new(ASTNodeVal, field_name, data, size, op, use_enumeration)));
+      ast_nodes.push_back(make_unique<ASTNodeVal>(
+          HERE(), field_name, data, size, op, use_enumeration));
     }
 
     // Constructing the tree from the list of AST nodes.
@@ -1072,8 +1071,8 @@ Status condition_from_capnp(
     if (ast_nodes.size() == 1) {
       condition->set_ast(std::move(ast_nodes[0]));
     } else {
-      auto tree_ptr = tdb_unique_ptr<ASTNode>(tdb_new(
-          ASTNodeExpr, std::move(ast_nodes), QueryConditionCombinationOp::AND));
+      auto tree_ptr = make_unique<ASTNodeExpr>(
+          HERE(), std::move(ast_nodes), QueryConditionCombinationOp::AND);
       condition->set_ast(std::move(tree_ptr));
     }
   } else if (condition_reader.hasTree()) {
@@ -2501,8 +2500,7 @@ Status query_deserialize(
   // Similarly, we must create a copy of 'copy_state'.
   tdb_unique_ptr<CopyState> original_copy_state = nullptr;
   if (copy_state) {
-    original_copy_state =
-        tdb_unique_ptr<CopyState>(tdb_new(CopyState, *copy_state));
+    original_copy_state = make_unique<CopyState>(HERE(), *copy_state);
   }
 
   // Deserialize 'serialized_buffer'.


### PR DESCRIPTION
To record allocations to the heap profiler, all smart pointers must be allocated with custom allocators and deleters. While we can create a `shared_ptr` by writing `make_shared<T>(HERE(), args)`, creating a `tdb_unique_ptr` has been more convoluted and required you to write `tdb_unique_ptr<T>(tdb_new(T, args))`, necessitating adding one extra layer of parentheses and typing the type's name twice.

This PR introduces a helper function called `make_unique`, having identical semantics with the existing `make_shared` and reducing the boilerplate when creating unique pointers.

The first two commits add the function itself, and the last commit uses it throughout the codebase.

---
TYPE: IMPROVEMENT
DESC: Add a `make_unique` helper function to create unique pointers.