### PR TITLE
Do not install static libraries when `TILEDB_INSTALL_STATIC_DEPS` is not enabled.

### DIFF
--- a/cmake/Modules/TileDBCommon.cmake
+++ b/cmake/Modules/TileDBCommon.cmake
@@ -86,6 +86,9 @@ endfunction()
 # manifest.
 #
 function(install_target_libs LIB_TARGET)
+  if (NOT TILEDB_INSTALL_STATIC_DEPS)
+    return()
+  endif()
   get_imported_location(TARGET_LIBRARIES ${LIB_TARGET})
   if (TARGET_LIBRARIES MATCHES "NOTFOUND")
     message(FATAL_ERROR "Could not determine library location for ${LIB_TARGET}")


### PR DESCRIPTION
[SC-32593](https://app.shortcut.com/tiledb-inc/story/32593/incorrectly-installing-static-libraries-when-only-building-shared-with-vcpkg)

Installation log after this change on Windows:

```
-- Install configuration: "Debug"
-- Installing: C:/Users/teo/code/TileDB/dist/lib/tiledb.lib
-- Installing: C:/Users/teo/code/TileDB/dist/bin/tiledb.dll
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb_version.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb_dimension_label_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb_experimental
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/array_deprecated.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/array.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/array_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/array_schema.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/array_schema_evolution.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/array_schema_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/attribute.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/attribute_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/config.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/consolidation_plan_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/context.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/core_interface.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/deleter.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/dimension.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/dimension_label_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/domain.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/enumeration_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/error.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/exception.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/filter.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/filter_list.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/fragment_info.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/group.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/group_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/log.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/object.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/object_iter.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/query.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/query_condition_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/query_condition.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/query_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/schema_base.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/stats.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/subarray.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/subarray_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/type.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/utils.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/version.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/vfs.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/arrowio
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/arrow_io_impl.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/tiledb_export.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/api_external_common.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/attribute/attribute_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/attribute/attribute_api_external_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/buffer/buffer_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/buffer_list/buffer_list_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/config/config_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/context/context_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/data_order/data_order_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/data_order/data_order_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/datatype/datatype_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/datatype/datatype_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/dimension/dimension_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/dimension_label/dimension_label_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/domain/domain_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/enumeration/enumeration_api_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/error/error_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/filesystem/filesystem_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/filesystem/filesystem_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/filter/filter_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/filter/filter_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/filter_list/filter_list_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/group/group_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/group/group_api_external_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/object/object_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/object/object_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/query/query_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/query/query_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/query_plan/query_plan_api_external_experimental.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/string/string_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/vfs/vfs_api_enum.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb/api/c_api/vfs/vfs_api_external.h
-- Installing: C:/Users/teo/code/TileDB/dist/include/tiledb_export.h
-- Installing: C:/Users/teo/code/TileDB/dist/lib/cmake/TileDB/TileDBConfig.cmake
-- Installing: C:/Users/teo/code/TileDB/dist/lib/cmake/TileDB/TileDBConfigVersion.cmake
-- Installing: C:/Users/teo/code/TileDB/dist/lib/cmake/TileDB/TileDBTargets.cmake
-- Installing: C:/Users/teo/code/TileDB/dist/lib/cmake/TileDB/TileDBTargets-debug.cmake
-- Installing: C:/Users/teo/code/TileDB/dist/lib/pkgconfig/tiledb.pc
```

---
TYPE: BUILD
DESC: Do not install static libraries when `TILEDB_INSTALL_STATIC_DEPS` is not enabled.