### PR TITLE
Patch the AWS SDK external project to disable -Werror

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -145,10 +145,12 @@ if (NOT AWSSDK_FOUND)
     if (WIN32)
       find_package(Git REQUIRED)
       set(CONDITIONAL_PATCH cd ${CMAKE_SOURCE_DIR} && ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch &&
-                                                      ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch)
+                                                      ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch &&
+                                                      ${GIT_EXECUTABLE} apply --ignore-whitespace -p1 --unsafe-paths --verbose --directory=${TILEDB_EP_SOURCE_DIR}/ep_awssdk < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/disable-werror.patch)
     else()
       set(CONDITIONAL_PATCH patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsccommon.patch &&
-                            patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch)
+                            patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/awsconfig_cmake_3.22.patch &&
+                            patch -N -p1 < ${TILEDB_CMAKE_INPUTS_DIR}/patches/ep_awssdk/disable-werror.patch)
     endif()
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR NOT WIN32)
       set(CONDITIONAL_CXX_FLAGS "-DCMAKE_CXX_FLAGS=-Wno-nonnull -Wno-error=deprecated-declarations")

--- a/cmake/inputs/patches/ep_awssdk/disable-werror.patch
+++ b/cmake/inputs/patches/ep_awssdk/disable-werror.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/compiler_settings.cmake b/cmake/compiler_settings.cmake
+index c92652cc5..e2fa5e27a 100644
+--- a/cmake/compiler_settings.cmake
++++ b/cmake/compiler_settings.cmake
+@@ -53,7 +53,7 @@ macro(set_gcc_flags)
+ endmacro()
+ 
+ macro(set_gcc_warnings)
+-    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-Werror" "-pedantic" "-Wextra")
++    list(APPEND AWS_COMPILER_WARNINGS "-Wall" "-pedantic" "-Wextra")
+     if(COMPILER_CLANG)
+         if(PLATFORM_ANDROID)
+             # when using clang with libc and API lower than 21 we need to include Android support headers and ignore the gnu-include-next warning.
+ 


### PR DESCRIPTION
[SC-32594](https://app.shortcut.com/tiledb-inc/story/32594/building-awssdk-with-g-12-yield-compilation-warnings-as-errors)

This PR applies the patch of #4144 the AWS SDK external project. Should fix compile errors in g++12 when not using vcpkg.

I verified that the patch is applied. Building fails on my WSL Ubuntu 22.04 machine after installing g++12; can someone else validate it?

---
TYPE: NO_HISTORY