### PR TITLE
Unordered writes: fix deserialization for older clients.

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2193,7 +2193,8 @@ Status query_from_capnp(
     }
   } else if (
       query_type == QueryType::WRITE &&
-      query_status == QueryStatus::COMPLETED) {
+      query_status == QueryStatus::COMPLETED &&
+      context == SerializationContext::SERVER) {
     // Handle pre 2.16 clients...
     // For pre-2.16 clients writes always had to write all attributes +
     // dimensions at once so we just list all fields here.

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2194,10 +2194,10 @@ Status query_from_capnp(
   } else if (
       query_type == QueryType::WRITE &&
       query_status == QueryStatus::COMPLETED &&
-      context == SerializationContext::SERVER) {
+      context == SerializationContext::SERVER && layout == Layout::UNORDERED) {
     // Handle pre 2.16 clients...
-    // For pre-2.16 clients writes always had to write all attributes +
-    // dimensions at once so we just list all fields here.
+    // For pre-2.16 clients, unordered writes always had to write all attributes
+    // + dimensions at once so we just list all fields here.
     auto& written_buffers = query->get_written_buffers();
     written_buffers.clear();
     for (const auto& it : schema.attributes()) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2191,6 +2191,20 @@ Status query_from_capnp(
     for (auto written_buffer : written_buffer_list) {
       written_buffers.emplace(written_buffer.cStr());
     }
+  } else if (
+      query_type == QueryType::WRITE &&
+      query_status == QueryStatus::COMPLETED) {
+    // Handle pre 2.16 clients...
+    // For pre-2.16 clients writes always had to write all attributes +
+    // dimensions at once so we just list all fields here.
+    auto& written_buffers = query->get_written_buffers();
+    written_buffers.clear();
+    for (const auto& it : schema.attributes()) {
+      written_buffers.emplace(it->name());
+    }
+    for (const auto& it : schema.dim_names()) {
+      written_buffers.emplace(it);
+    }
   }
 
   return Status::Ok();


### PR DESCRIPTION
This fixes de-serialization for older clients that do unordered writes to a 2.16 server from an older client that don't support partial attribute writes. If the written buffers are not written, the write will not be able to be finalized.

---
TYPE: BUG
DESC: Unordered writes: fix deserialization for older clients.
