### PR TITLE
Fix debug mode nightly build timeouts.

### DIFF
--- a/test/ci/CMakeLists.txt
+++ b/test/ci/CMakeLists.txt
@@ -23,19 +23,11 @@ if (TILEDB_ASSERTIONS)
   )
 endif()
 
-if (MSVC)
-  target_compile_definitions(
-    test_assert
-    PRIVATE
-    -DTILEDB_PATH_TO_TRY_ASSERT="${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}"
-  )
-else()
-  target_compile_definitions(
-    test_assert
-    PRIVATE
-    -DTILEDB_PATH_TO_TRY_ASSERT="${CMAKE_CURRENT_BINARY_DIR}"
-  )
-endif()
+target_compile_definitions(
+  test_assert
+  PRIVATE
+  -DTILEDB_PATH_TO_TRY_ASSERT="$<TARGET_FILE:try_assert>"
+)
 
 add_executable(
   try_assert

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -49,12 +49,11 @@ std::vector<int> assert_exit_codes{
 #endif
 
 TEST_CASE("CI: Test assertions configuration", "[ci][assertions]") {
-  int retval = system(TILEDB_PATH_TO_TRY_ASSERT "/try_assert");
+  int retval = system(TILEDB_PATH_TO_TRY_ASSERT);
 
   // in case value is one not currently accepted, report what was returned.
   std::cout << "retval is " << retval << " (0x" << std::hex << retval
-            << ") from " << TILEDB_PATH_TO_TRY_ASSERT "/try_assert"
-            << std::endl;
+            << ") from " << TILEDB_PATH_TO_TRY_ASSERT << std::endl;
 
 #ifdef TILEDB_ASSERTIONS
   REQUIRE(

--- a/test/ci/try_assert.cc
+++ b/test/ci/try_assert.cc
@@ -3,7 +3,11 @@
 
 int main(int, char**) {
 #if defined(_MSC_VER)
-  // Do not display message box on abort.
+  // We disable the following events on abort:
+  // _WRITE_ABORT_MSG: Display message box with Abort, Retry, Ignore
+  // _CALL_REPORTFAULT: Send an error report to Microsoft
+  // The second parameter specifies which flags to change, and the first
+  // the value of these flags.
   _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
 #endif
   assert(false);

--- a/test/ci/try_assert.cc
+++ b/test/ci/try_assert.cc
@@ -2,6 +2,10 @@
 #include <iostream>
 
 int main(int, char**) {
+#if defined(_MSC_VER)
+  // Do not display message box on abort.
+  _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+#endif
   assert(false);
 
   std::cout << "Assert did not exit!" << std::endl;


### PR DESCRIPTION
This PR uses [`_set_abort_behavior`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/set-abort-behavior) to cause `assert` failures to exit without displaying a message box. Closing that message box required user interaction which is not available in CI and causes debug mode nightly builds to timeout after six hours. With this change, [the builds no longer timeout](https://github.com/teo-tsirpanis/TileDB/actions/runs/5807926610/job/15743691237) (but still fail like the Release Windows builds).

Also this PR switches to using `$<TARGET_FILE:try_assert>` to pass the precise path returned by CMake to `test_assert`, instead of using an approximation.

---
TYPE: NO_HISTORY