### PR TITLE
Legacy reader: reading non written region causes segfault.

### DIFF
--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1016,8 +1016,8 @@ Status Reader::copy_partitioned_fixed_cells(
     // for this tile.
     const bool split_buffer_for_zipped_coords =
         is_dim && cs.tile_->stores_zipped_coords();
-    const bool field_not_present =
-        (is_dim || is_attr) && cs.tile_->tile_tuple(*name) == nullptr;
+    const bool field_not_present = (is_dim || is_attr) && cs.tile_ != nullptr &&
+                                   cs.tile_->tile_tuple(*name) == nullptr;
     if ((cs.tile_ == nullptr || field_not_present) &&
         !split_buffer_for_zipped_coords) {  // Empty range or attributed added
                                             // in schema evolution


### PR DESCRIPTION
This fixes an issue with legacy dense reads where reading a region that is not written causes segfault. In this case, the reader generates a cell slab with a nullptr tile, which signals the copy function to return the fill value for those cells. The nullptr value was causing an issue when trying to determine if a field is present or not.

---
TYPE: IMPROVEMENT
DESC: Legacy reader: reading non written region causes segfault.
