### PR TITLE
Make generic tile decompression single threaded.

### DIFF
--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -410,28 +410,14 @@ Status FilterPipeline::run_forward(
   return Status::Ok();
 }
 
-void FilterPipeline::run_reverse(
-    stats::Stats* stats,
-    Tile& tile,
-    ThreadPool& compute_tp,
-    const Config& config) const {
+void FilterPipeline::run_reverse_generic_tile(
+    stats::Stats* stats, Tile& tile, const Config& config) const {
   ChunkData chunk_data;
   tile.load_chunk_data(chunk_data);
-  throw_if_not_ok(parallel_for(
-      &compute_tp,
-      0,
-      chunk_data.filtered_chunks_.size(),
-      [&](const unsigned c) {
-        return run_reverse(
-            stats,
-            &tile,
-            nullptr,
-            chunk_data,
-            c,
-            c + 1,
-            compute_tp.concurrency_level(),
-            config);
-      }));
+  for (unsigned c = 0; c < chunk_data.filtered_chunks_.size(); c++) {
+    throw_if_not_ok(
+        run_reverse(stats, &tile, nullptr, chunk_data, c, c + 1, 1, config));
+  }
   tile.clear_filtered_buffer();
 }
 

--- a/tiledb/sm/filter/filter_pipeline.h
+++ b/tiledb/sm/filter/filter_pipeline.h
@@ -221,18 +221,14 @@ class FilterPipeline {
       bool chunking = true) const;
 
   /**
-   * Runs the pipeline in reverse on the given tile.
+   * Runs the pipeline in reverse on the given generic tile.
    *
    * @param reader_stats Stats to record in the function.
    * @param tile Current tile on which the filter pipeline is being run.
-   * @param compute_tp Compute theread pool.
    * @param config Global config.
    */
-  void run_reverse(
-      stats::Stats* stats,
-      Tile& tile,
-      ThreadPool& compute_tp,
-      const Config& config) const;
+  void run_reverse_generic_tile(
+      stats::Stats* stats, Tile& tile, const Config& config) const;
 
   /**
    * Run the given chunk range in reverse through the pipeline.

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -127,8 +127,7 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
 
   // Unfilter
   assert(tile.filtered());
-  header.filters.run_reverse(
-      &resources_.stats(), tile, resources_.compute_tp(), config);
+  header.filters.run_reverse_generic_tile(&resources_.stats(), tile, config);
   assert(!tile.filtered());
 
   return {Status::Ok(), std::move(tile)};


### PR DESCRIPTION
When loading fragment metadata structures like rtrees, tile offsets, fragments are processed in parallel. Then each generic tile would get unfiltered in parallel, causing nested parallel_for's. While loading the data for a fragment, a lock was held to make sure no other threads can load the data at the same time. This could cause a deadlock when the nested parallel for would call wait_all, trying to acquire the lock already held by other threads. This change fixes the issue by making the generic tile unfiltering single threaded, which shouldn't cause performance issues in most cases since we already parallelize for each fragments. More, this might improve performance in some cases where we might have been using too many threads.

---
TYPE: IMPROVEMENT
DESC: Make generic tile decompression single threaded.
