### PR TITLE
[release-2.16] Fix importing Win32 static dependencies for S3 and Azure.

### DIFF
--- a/cmake/Modules/FindAWSSDK_EP.cmake
+++ b/cmake/Modules/FindAWSSDK_EP.cmake
@@ -238,9 +238,4 @@ if (AWSSDK_FOUND)
 
   endforeach ()
 
-  # the AWSSDK does not include links to some transitive dependencies
-  # ref: github<dot>com/aws<slash>aws-sdk-cpp/issues/1074#issuecomment-466252911
-  if (WIN32)
-    list(APPEND AWS_EXTRA_LIBS userenv ws2_32 wininet winhttp bcrypt version)
-  endif()
 endif ()

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -571,18 +571,13 @@ if (TILEDB_AZURE)
         find_package(LibXml2 REQUIRED)
         install_target_libs(LibXml2::LibXml2)
       endif()
+      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE LibXml2::LibXml2)
     endif()
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
             INTERFACE
             Azure::azure-storage-blobs
             Azure::azure-storage-common
             Azure::azure-core)
-    if(WIN32)
-      # WebServices and crypt32 needed by Azure storage on windows
-      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE WebServices crypt32)
-    else()
-      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE LibXml2::LibXml2)
-    endif()
   endif()
 endif()
 
@@ -720,19 +715,22 @@ endif()
 
 # Win32 specific libraries
 if (WIN32)
-  set(WIN32_LIBS shlwapi rpcrt4 bcrypt)
+  target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE shlwapi rpcrt4 bcrypt)
   if(TILEDB_SERIALIZATION)
     #ws2_32.lib, crypt32.lib needed to satisfy curl dependencies
-    set(WIN32_LIBS ${WIN32_LIBS} ws2_32 crypt32)
+    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE ws2_32 crypt32)
   endif()
 
   if (TILEDB_S3)
-    list(APPEND WIN32_LIBS "${AWS_EXTRA_LIBS}")
+    # the AWSSDK does not include links to some transitive dependencies
+    # ref: github<dot>com/aws<slash>aws-sdk-cpp/issues/1074#issuecomment-466252911
+    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE userenv ws2_32 wininet winhttp bcrypt version secur32)
   endif()
 
-  foreach (LIB ${WIN32_LIBS})
-    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE ${LIB})
-  endforeach()
+  if (TILEDB_AZURE)
+    # WebServices and crypt32 needed by Azure storage on windows
+    target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE WebServices crypt32)
+  endif()
 endif()
 
 # macOS specific libraries


### PR DESCRIPTION
Backports #4263 to 2.16.

---
TYPE: BUILD
DESC: Fix static linking from the GitHub Releases package on Windows.