### PR TITLE
Throw if incorrect type is passed to set_data_type

### DIFF
--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -344,3 +344,55 @@ TEST_CASE(
   if (vfs.is_dir(array_name))
     vfs.remove_dir(array_name);
 }
+
+TEST_CASE(
+    "C++ API: Test query set_data_buffer typecheck",
+    "[cppapi][query][set_data_buffer]") {
+  const std::string array_name = "bool_buffer_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+
+  // Create the array
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<uint32_t>(ctx, "d1", {{0, 3}}, 4));
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.add_attribute(Attribute::create<float>(ctx, "a1"));
+  Array::create(array_name, schema);
+  Array array(ctx, array_name, TILEDB_WRITE);
+  Query query(ctx, array);
+
+  SECTION("- Test setting buffers with invalid datatype") {
+    std::vector<uint16_t> d1_data = {0, 1, 2, 3};
+    std::vector<uint64_t> a1_data = {0, 1, 2, 3};
+    CHECK_THROWS_WITH(
+        query.set_data_buffer("d1", d1_data),
+        Catch::Matchers::ContainsSubstring("does not match expected type"));
+    CHECK_THROWS_WITH(
+        query.set_data_buffer("a1", a1_data),
+        Catch::Matchers::ContainsSubstring("does not match expected type"));
+    CHECK_THROWS_WITH(
+        query.set_data_buffer("d1", d1_data.data(), d1_data.size()),
+        Catch::Matchers::ContainsSubstring("does not match expected type"));
+    CHECK_THROWS_WITH(
+        query.set_data_buffer("a1", a1_data.data(), a1_data.size()),
+        Catch::Matchers::ContainsSubstring("does not match expected type"));
+  }
+
+  std::vector<uint32_t> d1_data = {0, 1, 2, 3};
+  std::vector<float> a1_data = {0.0, 1.1, 2.2, 3.3};
+  SECTION("- Test setting buffers with valid datatype") {
+    CHECK_NOTHROW(query.set_data_buffer("d1", d1_data));
+    CHECK_NOTHROW(query.set_data_buffer("a1", a1_data));
+    CHECK_NOTHROW(query.submit());
+  }
+
+  array.close();
+  if (vfs.is_dir(array_name)) {
+    vfs.remove_dir(array_name);
+  }
+}

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1548,16 +1548,17 @@ class Query {
     // Checks
     auto is_attr = schema_.has_attribute(name);
     auto is_dim = schema_.domain().has_dimension(name);
-    if (name != "__coords" && !is_attr && !is_dim)
+    if (name != "__coords" && !is_attr && !is_dim) {
       throw TileDBError(
           std::string("Cannot set buffer; Attribute/Dimension '") + name +
           "' does not exist");
-    else if (is_attr)
+    } else if (is_attr) {
       impl::type_check<T>(schema_.attribute(name).type());
-    else if (is_dim)
+    } else if (is_dim) {
       impl::type_check<T>(schema_.domain().dimension(name).type());
-    else if (name == "__coords")
+    } else if (name == "__coords") {
       impl::type_check<T>(schema_.domain().type());
+    }
 
     return set_data_buffer(name, buff, nelements, sizeof(T));
   }
@@ -1580,6 +1581,21 @@ class Query {
    **/
   template <typename T>
   Query& set_data_buffer(const std::string& name, std::vector<T>& buf) {
+    // Checks
+    auto is_attr = schema_.has_attribute(name);
+    auto is_dim = schema_.domain().has_dimension(name);
+    if (name != "__coords" && !is_attr && !is_dim) {
+      throw TileDBError(
+          std::string("Cannot set buffer; Attribute/Dimension '") + name +
+          "' does not exist");
+    } else if (is_attr) {
+      impl::type_check<T>(schema_.attribute(name).type());
+    } else if (is_dim) {
+      impl::type_check<T>(schema_.domain().dimension(name).type());
+    } else if (name == "__coords") {
+      impl::type_check<T>(schema_.domain().type());
+    }
+
     return set_data_buffer(name, buf.data(), buf.size(), sizeof(T));
   }
 


### PR DESCRIPTION
Adds checks to ensure the datatype matches the expected schema type when the vector variant of `Query::set_data_type` is called.

---
TYPE: BUG
DESC: Throw if incorrect type is passed to set_data_type.
