### PR TITLE
Sorted reads tests: faster tests.

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -960,15 +960,15 @@ void DenseArrayFx::write_dense_subarray_2D_with_cancel(
 
 void DenseArrayFx::check_sorted_reads(const std::string& path) {
   // Parameters used in this test
-  int64_t domain_size_0 = 5000;
-  int64_t domain_size_1 = 10000;
-  int64_t tile_extent_0 = 1000;
-  int64_t tile_extent_1 = 1000;
+  int64_t domain_size_0 = 2500;
+  int64_t domain_size_1 = 5000;
+  int64_t tile_extent_0 = 500;
+  int64_t tile_extent_1 = 500;
   int64_t domain_0_lo = 0;
   int64_t domain_0_hi = domain_size_0 - 1;
   int64_t domain_1_lo = 0;
   int64_t domain_1_hi = domain_size_1 - 1;
-  uint64_t capacity = 1000000;
+  uint64_t capacity = 250000;
   tiledb_layout_t cell_order = TILEDB_ROW_MAJOR;
   tiledb_layout_t tile_order = TILEDB_ROW_MAJOR;
   std::string array_name = path + "sorted_reads_array";

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -764,15 +764,15 @@ void SparseArrayFx::check_sorted_reads(
     tiledb_layout_t tile_order,
     tiledb_layout_t cell_order) {
   // Parameters used in this test
-  int64_t domain_size_0 = 5000;
-  int64_t domain_size_1 = 1000;
-  int64_t tile_extent_0 = 100;
-  int64_t tile_extent_1 = 100;
+  int64_t domain_size_0 = 2500;
+  int64_t domain_size_1 = 500;
+  int64_t tile_extent_0 = 50;
+  int64_t tile_extent_1 = 50;
   int64_t domain_0_lo = 0;
   int64_t domain_0_hi = domain_size_0 - 1;
   int64_t domain_1_lo = 0;
   int64_t domain_1_hi = domain_size_1 - 1;
-  int64_t capacity = 100000;
+  int64_t capacity = 25000;
   int iter_num = (compressor != TILEDB_FILTER_BZIP2) ? ITER_NUM : 1;
 
   create_sparse_array_2D(


### PR DESCRIPTION
This reduces the size of the arrays for the sorted reads tests by a factor of 2 for each dimensions. It takes my local debug runs of tiledb unit from ~586 seconds to ~305 seconds.

---
TYPE: IMPROVEMENT
DESC: Sorted reads tests: faster tests.