### PR TITLE
LibXML2 needs to be linked after Azure libraries

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -582,13 +582,16 @@ if (TILEDB_AZURE)
         find_package(LibXml2 REQUIRED)
         install_target_libs(LibXml2::LibXml2)
       endif()
-      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE LibXml2::LibXml2)
     endif()
     target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
             INTERFACE
             Azure::azure-storage-blobs
             Azure::azure-storage-common
             Azure::azure-core)
+    # Link xml after Azure to allow symbol resolution on all platforms
+    if (NOT WIN32)
+      target_link_libraries(TILEDB_CORE_OBJECTS_ILIB INTERFACE LibXml2::LibXml2)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
This solves a symbol error on Linux with cross-compilation were symbol resolution doesn't happen because the linking of libxml2 happens before Azure is linked in.


---
TYPE: BUILD
DESC: Libxml2 needs to be linked after Azure libraries
