### PR TITLE
Increase Windows release builder timeout to 90 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,7 @@ stages:
        steps:
        - template: scripts/azure-linux_mac-release.yml
      - job: Windows
+       timeoutInMinutes: 90
        strategy:
          matrix:
            VS2019:


### PR DESCRIPTION
Jobs are timing out; linux and mac jobs already have this setting.

---
TYPE: NO_HISTORY
