### PR TITLE
Remove an extraneous constructor for `class ArraySchema`

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -127,43 +127,6 @@ ArraySchema::ArraySchema(
     uint64_t capacity,
     std::vector<shared_ptr<const Attribute>> attributes,
     std::vector<shared_ptr<const DimensionLabel>> dim_label_refs,
-    std::unordered_map<std::string, std::string> enumeration_path_map,
-    FilterPipeline cell_var_offsets_filters,
-    FilterPipeline cell_validity_filters,
-    FilterPipeline coords_filters)
-    : ArraySchema(
-          uri,
-          version,
-          timestamp_range,
-          name,
-          array_type,
-          allows_dups,
-          domain,
-          cell_order,
-          tile_order,
-          capacity,
-          attributes,
-          dim_label_refs,
-          {},
-          enumeration_path_map,
-          cell_var_offsets_filters,
-          cell_validity_filters,
-          coords_filters) {
-}
-
-ArraySchema::ArraySchema(
-    URI uri,
-    uint32_t version,
-    std::pair<uint64_t, uint64_t> timestamp_range,
-    std::string name,
-    ArrayType array_type,
-    bool allows_dups,
-    shared_ptr<Domain> domain,
-    Layout cell_order,
-    Layout tile_order,
-    uint64_t capacity,
-    std::vector<shared_ptr<const Attribute>> attributes,
-    std::vector<shared_ptr<const DimensionLabel>> dim_label_refs,
     std::vector<shared_ptr<const Enumeration>> enumerations,
     std::unordered_map<std::string, std::string> enumeration_path_map,
     FilterPipeline cell_var_offsets_filters,
@@ -1357,8 +1320,6 @@ ArraySchema ArraySchema::deserialize(
   // Set schema name
   std::string name = uri.last_path_part();
 
-  // TODO: This is the only use of an extraneous constructor that only omits a
-  // single argument. Use the full one instead.
   return ArraySchema(
       uri,
       version,
@@ -1372,6 +1333,7 @@ ArraySchema ArraySchema::deserialize(
       capacity,
       attributes,
       dimension_labels,
+      {},
       enumeration_path_map,
       cell_var_filters,
       cell_validity_filters,

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -98,45 +98,7 @@ class ArraySchema {
   /** Constructor. */
   ArraySchema(ArrayType array_type);
 
-  /** Constructor.
-   * @param uri The URI of the array schema file.
-   * @param version The format version of this array schema.
-   * @param timestamp_range The timestamp the array schema was written.
-   * @param name The file name of the schema in timestamp_timestamp_uuid format.
-   * @param array_type The array type.
-   * @param allows_dups True if the (sparse) array allows coordinate duplicates.
-   * @param domain The array domain.
-   * @param cell_order The cell order.
-   * @param tile_order The tile order.
-   * @param capacity The tile capacity for the case of sparse fragments.
-   * @param attributes The array attributes.
-   * @param dimension_labels The array dimension labels.
-   * @param enumeration_path_map The array enumeration path map
-   * @param cell_var_offsets_filters
-   *    The filter pipeline run on offset tiles for var-length attributes.
-   * @param cell_validity_filters
-   *    The filter pipeline run on validity tiles for nullable attributes.
-   * @param coords_filters The filter pipeline run on coordinate tiles.
-   **/
-  ArraySchema(
-      URI uri,
-      uint32_t version,
-      std::pair<uint64_t, uint64_t> timestamp_range,
-      std::string name,
-      ArrayType array_type,
-      bool allows_dups,
-      shared_ptr<Domain> domain,
-      Layout cell_order,
-      Layout tile_order,
-      uint64_t capacity,
-      std::vector<shared_ptr<const Attribute>> attributes,
-      std::vector<shared_ptr<const DimensionLabel>> dimension_labels,
-      std::unordered_map<std::string, std::string> enumeration_path_map,
-      FilterPipeline cell_var_offsets_filters,
-      FilterPipeline cell_validity_filters,
-      FilterPipeline coords_filters);
-
-  /** Constructor.
+   /** Constructor.
    * @param uri The URI of the array schema file.
    * @param version The format version of this array schema.
    * @param timestamp_range The timestamp the array schema was written.

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -98,7 +98,7 @@ class ArraySchema {
   /** Constructor. */
   ArraySchema(ArrayType array_type);
 
-   /** Constructor.
+  /** Constructor.
    * @param uri The URI of the array schema file.
    * @param version The format version of this array schema.
    * @param timestamp_range The timestamp the array schema was written.

--- a/tiledb/sm/array_schema/test/array_schema_test_support.h
+++ b/tiledb/sm/array_schema/test/array_schema_test_support.h
@@ -309,7 +309,8 @@ class TestArraySchema {
             10000,  // capacity
             make_attributes(attributes),
             {},  // dimension labels
-            {},  // enumeration path map
+            {},  // the first enumeration thing
+            {},  // the second enumeration thing
             FilterPipeline(),
             FilterPipeline(),
             FilterPipeline()) {


### PR DESCRIPTION
Remove an extraneous constructor for `class ArraySchema`. It only differed from the full constructor by one argument that was default-constructed.

---
TYPE: NO_HISTORY
DESC: Remove an extraneous constructor for `class ArraySchema`
