### PR TITLE
Implement v1 serialization for Enumerations

### DIFF
--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -200,7 +200,7 @@ TEST_CASE_METHOD(
     CPPEnumerationFx,
     "C API: Array load_all_enumerations - Check nullptr",
     "[enumeration][array-load-all-enumerations]") {
-  auto rc = tiledb_array_load_all_enumerations(ctx_.ptr().get(), nullptr, 0);
+  auto rc = tiledb_array_load_all_enumerations(ctx_.ptr().get(), nullptr);
   REQUIRE(rc != TILEDB_OK);
 }
 

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -598,7 +598,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     EnumerationFx,
     "Array - Get Enumeration Repeated",
-    "[enumeration][array][get-enumeration]") {
+    "[enumeration][array][get-enumeration][repeated]") {
   create_array();
   auto array = get_array(QueryType::READ);
   auto enmr1 = array->get_enumeration("test_enmr");
@@ -608,20 +608,11 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
-    "Array - Get Enumeration Error - REMOTE NOT YET SUPPORTED",
-    "[enumeration][array][error][get-remote]") {
-  std::string uri_str = "tiledb://namespace/array_name";
-  auto array = make_shared<Array>(HERE(), URI(uri_str), ctx_.storage_manager());
-  auto matcher = Catch::Matchers::ContainsSubstring("Array is remote");
-  REQUIRE_THROWS_WITH(array->get_enumeration("something_here"), matcher);
-}
-
-TEST_CASE_METHOD(
-    EnumerationFx,
     "Array - Get Enumeration Error - Not Open",
     "[enumeration][array][error][not-open]") {
   auto array = make_shared<Array>(HERE(), uri_, ctx_.storage_manager());
-  REQUIRE_THROWS(array->get_enumeration("foo"));
+  auto matcher = Catch::Matchers::ContainsSubstring("Array is not open");
+  REQUIRE_THROWS(array->get_enumeration("foo"), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -664,19 +655,10 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
-    "Array - Load All Enumerations Error - REMOTE NOT YET SUPPORTED",
-    "[enumeration][array][error][get-remote]") {
-  std::string uri_str = "tiledb://namespace/array_name";
-  auto array = make_shared<Array>(HERE(), URI(uri_str), ctx_.storage_manager());
-  auto matcher = Catch::Matchers::ContainsSubstring("Array is remote");
-  REQUIRE_THROWS_WITH(array->load_all_enumerations(), matcher);
-}
-
-TEST_CASE_METHOD(
-    EnumerationFx,
     "Array - Load All Enumerations Error - Not Open",
     "[enumeration][array][error][not-open]") {
   auto array = make_shared<Array>(HERE(), uri_, ctx_.storage_manager());
+  auto matcher = Catch::Matchers::ContainsSubstring("Array is not open");
   REQUIRE_THROWS(array->load_all_enumerations());
 }
 
@@ -687,7 +669,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     EnumerationFx,
     "ArrayDirectory - Load Enumerations From Paths",
-    "[enumeration][array-directory][load-enumeration]") {
+    "[enumeration][array-directory][load-enumerations-from-paths]") {
   create_array();
 
   auto schema = get_array_schema_latest();

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -89,7 +89,7 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/array_schema.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/array_schema_evolution.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/array_schema_experimental.h
-    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/as_built_experimental.h 
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/as_built_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/attribute.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/attribute_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/config.h
@@ -278,6 +278,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema_evolution.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/config.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/enumeration.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/fragment_info.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/fragment_metadata.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/group.cc
@@ -328,6 +329,7 @@ if (TILEDB_SERIALIZATION)
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema_evolution.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/config.cc
+      ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/enumeration.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/fragment_info.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/fragment_metadata.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/group.cc
@@ -347,6 +349,7 @@ if (TILEDB_SERIALIZATION)
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/array_schema_evolution.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/config.cc
+      ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/enumeration.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/fragment_info.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/fragment_metadata.cc
       ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/group.cc

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -271,14 +271,14 @@ class Array {
       const std::string& enumeration_name);
 
   /**
-   * Get the enumerations for the given names.
+   * Get the enumerations with the given names.
    *
-   * This function retrieves the enumerations for the given names. If any of the
+   * This function retrieves the enumerations with the given names. If the
    * corresponding enumerations have not been loaded from storage they are
    * loaded before this function returns.
    *
-   * @param enumeration_names The name of the enumeration.
-   * @return std::vector<shared_ptr<const Enumeration>> The enumerations.
+   * @param enumeration_names The names of the enumerations.
+   * @return std::vector<shared_ptr<const Enumeration>> The loaded enumerations.
    */
   std::vector<shared_ptr<const Enumeration>> get_enumerations(
       const std::vector<std::string>& enumeration_names);

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -271,16 +271,20 @@ class Array {
       const std::string& enumeration_name);
 
   /**
-   * Load all enumerations for the array.
+   * Get the enumerations for the given names.
    *
-   * Ensure that all enumerations have been loaded. If latest_only is true
-   * (the default) then only enumerations for the latest schema are loaded.
-   * When latest_only is false, all schemas have their enumerations loaded.
+   * This function retrieves the enumerations for the given names. If any of the
+   * corresponding enumerations have not been loaded from storage they are
+   * loaded before this function returns.
    *
-   * @param latest_only Whether to load enumerations for just the latest
-   * schema or all schemas.
+   * @param enumeration_names The name of the enumeration.
+   * @return std::vector<shared_ptr<const Enumeration>> The enumerations.
    */
-  void load_all_enumerations(bool latest_only = true);
+  std::vector<shared_ptr<const Enumeration>> get_enumerations(
+      const std::vector<std::string>& enumeration_names);
+
+  /** Load all enumerations for the array. */
+  void load_all_enumerations();
 
   /**
    * Returns `true` if the array is empty at the time it is opened.

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -386,7 +386,7 @@ class ArrayDirectory {
   load_all_array_schemas(const EncryptionKey& encryption_key) const;
 
   /**
-   * Load all enumerations for the given schema.
+   * Load the enumerations from the provided list of paths.
    *
    * @param enumeration_paths The list of enumeration paths to load.
    * @param encryption_key The encryption key to use.
@@ -818,9 +818,8 @@ class ArrayDirectory {
   bool consolidation_with_timestamps_supported(const URI& uri) const;
 
   /**
-   * Load an enumeration from schema with the given name.
+   * Load an enumeration from the given path.
    *
-   * @param schema The ArraySchema that references the enumeration name.
    * @param enumeration_path The enumeration path to load.
    * @param encryption_key The encryption key to use.
    * @return shared_ptr<Enumeration> The loaded enumeration.

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -386,26 +386,14 @@ class ArrayDirectory {
   load_all_array_schemas(const EncryptionKey& encryption_key) const;
 
   /**
-   * Load an enumeration from schema with the given name.
-   *
-   * @param schema The ArraySchema that references the enumeration name.
-   * @param enumeration_name The name of the enumeration to load.
-   * @param encryption_key The encryption key to use.
-   * @return shared_ptr<Enumeration> The loaded enumeration.
-   */
-  shared_ptr<const Enumeration> load_enumeration(
-      shared_ptr<ArraySchema> schema,
-      const std::string& enumeration_name,
-      const EncryptionKey& encryption_key) const;
-
-  /**
    * Load all enumerations for the given schema.
    *
-   * @param schema The ArraySchema to load Enumerations for
+   * @param enumeration_paths The list of enumeration paths to load.
    * @param encryption_key The encryption key to use.
+   * @return The loaded enumerations.
    */
-  void load_all_enumerations(
-      shared_ptr<ArraySchema> schema,
+  std::vector<shared_ptr<const Enumeration>> load_enumerations_from_paths(
+      const std::vector<std::string>& enumeration_paths,
       const EncryptionKey& encryption_key) const;
 
   /** Returns the array URI. */
@@ -828,6 +816,18 @@ class ArrayDirectory {
    * @return True if supported, false otherwise
    */
   bool consolidation_with_timestamps_supported(const URI& uri) const;
+
+  /**
+   * Load an enumeration from schema with the given name.
+   *
+   * @param schema The ArraySchema that references the enumeration name.
+   * @param enumeration_path The enumeration path to load.
+   * @param encryption_key The encryption key to use.
+   * @return shared_ptr<Enumeration> The loaded enumeration.
+   */
+  shared_ptr<const Enumeration> load_enumeration(
+      const std::string& enumeration_path,
+      const EncryptionKey& encryption_key) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -423,7 +423,7 @@ class ArraySchema {
   bool is_enumeration_loaded(const std::string& enumeration_name) const;
 
   /**
-   * Get an Enumeration by name. Throws if the attribute is unknown.
+   * Get an Enumeration by name. Throws if the enumeration is unknown.
    *
    * @param enmr_name The name of the Enumeration.
    * @return shared_ptr<Enumeration>
@@ -432,7 +432,7 @@ class ArraySchema {
       const std::string& enmr_name) const;
 
   /**
-   * Get an Enumeration's object name. Throws if the attribute is unknown.
+   * Get an Enumeration's object name. Throws if the enumeration is unknown.
    *
    * @param enmr_name The name of the Enumeration.
    * @return The path name of the enumeration on disk

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3108,12 +3108,12 @@ capi_return_t tiledb_array_get_enumeration(
 }
 
 capi_return_t tiledb_array_load_all_enumerations(
-    tiledb_ctx_t* ctx, const tiledb_array_t* array, int latest_only) {
+    tiledb_ctx_t* ctx, const tiledb_array_t* array) {
   if (sanity_check(ctx, array) == TILEDB_ERR) {
     return TILEDB_ERR;
   }
 
-  array->array_->load_all_enumerations(latest_only ? true : false);
+  array->array_->load_all_enumerations();
 
   return TILEDB_OK;
 }
@@ -6537,9 +6537,8 @@ capi_return_t tiledb_array_get_enumeration(
 }
 
 capi_return_t tiledb_array_load_all_enumerations(
-    tiledb_ctx_t* ctx, const tiledb_array_t* array, int latest_only) noexcept {
-  return api_entry<tiledb::api::tiledb_array_load_all_enumerations>(
-      ctx, array, latest_only);
+    tiledb_ctx_t* ctx, const tiledb_array_t* array) noexcept {
+  return api_entry<tiledb::api::tiledb_array_load_all_enumerations>(ctx, array);
 }
 
 int32_t tiledb_array_upgrade_version(

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -418,9 +418,7 @@ TILEDB_EXPORT capi_return_t tiledb_array_get_enumeration(
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_array_load_all_enumerations(
-    tiledb_ctx_t* ctx,
-    const tiledb_array_t* array,
-    int latest_only) TILEDB_NOEXCEPT;
+    tiledb_ctx_t* ctx, const tiledb_array_t* array) TILEDB_NOEXCEPT;
 
 /**
  * Upgrades an array to the latest format version.

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -716,6 +716,24 @@ TILEDB_EXPORT int32_t tiledb_deserialize_group_metadata(
     tiledb_group_t* group,
     tiledb_serialization_type_t serialization_type,
     const tiledb_buffer_t* buffer) TILEDB_NOEXCEPT;
+
+/**
+ * Process a load enumerations request.
+ *
+ * @param ctx The TileDB context.
+ * @param array The TileDB Array.
+ * @param request A buffer containing the LoadEnumerationsRequest Capnp message.
+ * @param response An allocated buffer that will contain the
+ *        LoadEnumerationsResponse Capnp message.
+ * @return capi_return_t TILEDB_OK on success, TILEDB_ERR on error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_handle_load_enumerations_request(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    tiledb_serialization_type_t serialization_type,
+    const tiledb_buffer_t* request,
+    tiledb_buffer_t* response) TILEDB_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/sm/cpp_api/array_experimental.h
+++ b/tiledb/sm/cpp_api/array_experimental.h
@@ -63,12 +63,10 @@ class ArrayExperimental {
    *
    * @param ctx The context to use.
    * @param array The array to load enumerations for.
-   * @param latest_only Whether to only load enumerations for the latest schema.
    */
-  static void load_all_enumerations(
-      const Context& ctx, const Array& array, bool latest_only = true) {
-    ctx.handle_error(tiledb_array_load_all_enumerations(
-        ctx.ptr().get(), array.ptr().get(), latest_only ? 1 : 0));
+  static void load_all_enumerations(const Context& ctx, const Array& array) {
+    ctx.handle_error(
+        tiledb_array_load_all_enumerations(ctx.ptr().get(), array.ptr().get()));
   }
 };
 

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -194,6 +194,22 @@ class RestClient {
       Array* array);
 
   /**
+   * Get the requested enumerations from the REST server via POST request.
+   *
+   * @param uri Array URI.
+   * @param timestamp_start Inclusive starting timestamp at which to open array.
+   * @param timestamp_end Inclusive ending timestamp at which to open array.
+   * @param array Array to fetch metadata for.
+   * @param enumeration_names The names of the enumerations to get.
+   */
+  std::vector<shared_ptr<const Enumeration>> post_enumerations_from_rest(
+      const URI& uri,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
+      Array* array,
+      const std::vector<std::string>& enumeration_names);
+
+  /**
    * Post a data query to rest server
    *
    * @param uri of array being queried

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -120,25 +120,6 @@ void dimension_label_to_capnp(
 shared_ptr<DimensionLabel> dimension_label_from_capnp(
     const capnp::DimensionLabel::Reader& reader);
 
-/**
- * Serialize an Enumeration do cap'n proto object
- *
- * @param enumeration Enumeration to serialize.
- * @param enmr_builder Cap'n proto class.
- */
-void enumeration_to_capnp(
-    shared_ptr<const Enumeration> enumeration,
-    capnp::Enumeration::Builder& enmr_builder);
-
-/**
- * Deserialize a dimension label from a cap'n proto object
- *
- * @param reader Cap'n proto reader object
- * @return A new Enumeration
- */
-shared_ptr<const Enumeration> enumeration_from_capnp(
-    const capnp::Enumeration::Reader& reader);
-
 #endif  // TILEDB_SERIALIZATION
 
 /**

--- a/tiledb/sm/serialization/array_schema_evolution.cc
+++ b/tiledb/sm/serialization/array_schema_evolution.cc
@@ -53,6 +53,7 @@
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/serialization/array_schema.h"
+#include "tiledb/sm/serialization/enumeration.h"
 
 #include <set>
 

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -1,0 +1,375 @@
+/**
+ * @file enumeration.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements serialization for the Enumeration class
+ */
+
+// clang-format off
+#ifdef TILEDB_SERIALIZATION
+#include <capnp/compat/json.h>
+#include <capnp/message.h>
+#include <capnp/serialize.h>
+#include "tiledb/sm/serialization/capnp_utils.h"
+#endif
+// clang-format on
+
+#include "tiledb/sm/array_schema/enumeration.h"
+#include "tiledb/sm/enums/serialization_type.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm::serialization {
+
+#ifdef TILEDB_SERIALIZATION
+
+void enumeration_to_capnp(
+    shared_ptr<const Enumeration> enumeration,
+    capnp::Enumeration::Builder& enmr_builder) {
+  enmr_builder.setName(enumeration->name());
+  enmr_builder.setPathName(enumeration->path_name());
+  enmr_builder.setType(datatype_str(enumeration->type()));
+  enmr_builder.setCellValNum(enumeration->cell_val_num());
+  enmr_builder.setOrdered(enumeration->ordered());
+
+  auto dspan = enumeration->data();
+  enmr_builder.setData(::kj::arrayPtr(dspan.data(), dspan.size()));
+
+  if (enumeration->var_size()) {
+    auto ospan = enumeration->offsets();
+    enmr_builder.setOffsets(::kj::arrayPtr(ospan.data(), ospan.size()));
+  }
+}
+
+shared_ptr<const Enumeration> enumeration_from_capnp(
+    const capnp::Enumeration::Reader& reader) {
+  auto name = reader.getName();
+  auto path_name = reader.getPathName();
+  Datatype datatype = Datatype::ANY;
+  throw_if_not_ok(datatype_enum(reader.getType(), &datatype));
+
+  if (!reader.hasData()) {
+    throw SerializationStatusException(
+        "[Deserialization::enumeration_from_capnp] Deserialization of "
+        "Enumeration is missing its data buffer.");
+  }
+
+  auto data_reader = reader.getData().asBytes();
+  auto data = data_reader.begin();
+  auto data_size = data_reader.size();
+
+  const void* offsets = nullptr;
+  uint64_t offsets_size = 0;
+
+  if (reader.hasOffsets()) {
+    auto offsets_reader = reader.getOffsets().asBytes();
+    offsets = offsets_reader.begin();
+    offsets_size = offsets_reader.size();
+  }
+
+  return Enumeration::create(
+      name,
+      path_name,
+      datatype,
+      reader.getCellValNum(),
+      reader.getOrdered(),
+      data,
+      data_size,
+      offsets,
+      offsets_size);
+}
+
+void load_enumerations_request_to_capnp(
+    capnp::LoadEnumerationsRequest::Builder& builder,
+    const Config& config,
+    const std::vector<std::string>& enumeration_names) {
+  auto config_builder = builder.initConfig();
+  throw_if_not_ok(config_to_capnp(config, &config_builder));
+
+  auto num_names = enumeration_names.size();
+  if (num_names > 0) {
+    auto names_builder = builder.initEnumerations(num_names);
+    for (size_t i = 0; i < num_names; i++) {
+      names_builder.set(i, enumeration_names[i]);
+    }
+  }
+}
+
+std::vector<std::string> load_enumerations_request_from_capnp(
+    capnp::LoadEnumerationsRequest::Reader& reader) {
+  std::vector<std::string> ret;
+  if (reader.hasEnumerations()) {
+    for (auto name_reader : reader.getEnumerations()) {
+      ret.push_back(name_reader.cStr());
+    }
+  }
+
+  return ret;
+}
+
+void load_enumerations_response_to_capnp(
+    capnp::LoadEnumerationsResponse::Builder& builder,
+    const std::vector<shared_ptr<const Enumeration>>& enumerations) {
+  auto num_enmrs = enumerations.size();
+  if (num_enmrs > 0) {
+    auto enmr_builders = builder.initEnumerations(num_enmrs);
+    for (size_t i = 0; i < num_enmrs; i++) {
+      auto enmr_builder = enmr_builders[i];
+      enumeration_to_capnp(enumerations[i], enmr_builder);
+    }
+  }
+}
+
+std::vector<shared_ptr<const Enumeration>>
+load_enumerations_response_from_capnp(
+    capnp::LoadEnumerationsResponse::Reader& reader) {
+  std::vector<shared_ptr<const Enumeration>> ret;
+  if (reader.hasEnumerations()) {
+    auto enmr_readers = reader.getEnumerations();
+    for (auto enmr_reader : enmr_readers) {
+      ret.push_back(enumeration_from_capnp(enmr_reader));
+    }
+  }
+  return ret;
+}
+
+void serialize_load_enumerations_request(
+    const Config& config,
+    const std::vector<std::string>& enumeration_names,
+    SerializationType serialize_type,
+    Buffer& request) {
+  try {
+    ::capnp::MallocMessageBuilder message;
+    capnp::LoadEnumerationsRequest::Builder builder =
+        message.initRoot<capnp::LoadEnumerationsRequest>();
+    load_enumerations_request_to_capnp(builder, config, enumeration_names);
+
+    request.reset_size();
+    request.reset_offset();
+
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        kj::String capnp_json = json.encode(builder);
+        const auto json_len = capnp_json.size();
+        const char nul = '\0';
+        // size does not include needed null terminator, so add +1
+        throw_if_not_ok(request.realloc(json_len + 1));
+        throw_if_not_ok(request.write(capnp_json.cStr(), json_len));
+        throw_if_not_ok(request.write(&nul, 1));
+        break;
+      }
+      case SerializationType::CAPNP: {
+        kj::Array<::capnp::word> protomessage = messageToFlatArray(message);
+        kj::ArrayPtr<const char> message_chars = protomessage.asChars();
+        const auto nbytes = message_chars.size();
+        throw_if_not_ok(request.realloc(nbytes));
+        throw_if_not_ok(request.write(message_chars.begin(), nbytes));
+        break;
+      }
+      default: {
+        throw Status_SerializationError(
+            "Error serializing load enumerations request; "
+            "Unknown serialization type passed");
+      }
+    }
+
+  } catch (kj::Exception& e) {
+    throw Status_SerializationError(
+        "Error serializing load enumerations request; kj::Exception: " +
+        std::string(e.getDescription().cStr()));
+  } catch (std::exception& e) {
+    throw Status_SerializationError(
+        "Error serializing load enumerations request; exception " +
+        std::string(e.what()));
+  }
+}
+
+std::vector<std::string> deserialize_load_enumerations_request(
+    SerializationType serialize_type, const Buffer& request) {
+  try {
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        ::capnp::MallocMessageBuilder message_builder;
+        capnp::LoadEnumerationsRequest::Builder builder =
+            message_builder.initRoot<capnp::LoadEnumerationsRequest>();
+        json.decode(
+            kj::StringPtr(static_cast<const char*>(request.data())), builder);
+        capnp::LoadEnumerationsRequest::Reader reader = builder.asReader();
+        return load_enumerations_request_from_capnp(reader);
+      }
+      case SerializationType::CAPNP: {
+        const auto mBytes = reinterpret_cast<const kj::byte*>(request.data());
+        ::capnp::FlatArrayMessageReader array_reader(kj::arrayPtr(
+            reinterpret_cast<const ::capnp::word*>(mBytes),
+            request.size() / sizeof(::capnp::word)));
+        capnp::LoadEnumerationsRequest::Reader reader =
+            array_reader.getRoot<capnp::LoadEnumerationsRequest>();
+        return load_enumerations_request_from_capnp(reader);
+      }
+      default: {
+        throw Status_SerializationError(
+            "Error deserializing load enumerations request; "
+            "Unknown serialization type passed");
+      }
+    }
+  } catch (kj::Exception& e) {
+    throw Status_SerializationError(
+        "Error deserializing load enumerations request; kj::Exception: " +
+        std::string(e.getDescription().cStr()));
+  } catch (std::exception& e) {
+    throw Status_SerializationError(
+        "Error deserializing load enumerations request; exception " +
+        std::string(e.what()));
+  }
+}
+
+void serialize_load_enumerations_response(
+    const std::vector<shared_ptr<const Enumeration>> enumerations,
+    SerializationType serialize_type,
+    Buffer& response) {
+  try {
+    ::capnp::MallocMessageBuilder message;
+    capnp::LoadEnumerationsResponse::Builder builder =
+        message.initRoot<capnp::LoadEnumerationsResponse>();
+    load_enumerations_response_to_capnp(builder, enumerations);
+
+    response.reset_size();
+    response.reset_offset();
+
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        kj::String capnp_json = json.encode(builder);
+        const auto json_len = capnp_json.size();
+        const char nul = '\0';
+        // size does not include needed null terminator, so add +1
+        throw_if_not_ok(response.realloc(json_len + 1));
+        throw_if_not_ok(response.write(capnp_json.cStr(), json_len));
+        throw_if_not_ok(response.write(&nul, 1));
+        break;
+      }
+      case SerializationType::CAPNP: {
+        kj::Array<::capnp::word> protomessage = messageToFlatArray(message);
+        kj::ArrayPtr<const char> message_chars = protomessage.asChars();
+        const auto nbytes = message_chars.size();
+        throw_if_not_ok(response.realloc(nbytes));
+        throw_if_not_ok(response.write(message_chars.begin(), nbytes));
+        break;
+      }
+      default: {
+        throw Status_SerializationError(
+            "Error serializing load enumerations response; "
+            "Unknown serialization type passed");
+      }
+    }
+
+  } catch (kj::Exception& e) {
+    throw Status_SerializationError(
+        "Error serializing load enumerations response; kj::Exception: " +
+        std::string(e.getDescription().cStr()));
+  } catch (std::exception& e) {
+    throw Status_SerializationError(
+        "Error serializing load enumerations response; exception " +
+        std::string(e.what()));
+  }
+}
+
+std::vector<shared_ptr<const Enumeration>>
+deserialize_load_enumerations_response(
+    SerializationType serialize_type, const Buffer& response) {
+  try {
+    switch (serialize_type) {
+      case SerializationType::JSON: {
+        ::capnp::JsonCodec json;
+        ::capnp::MallocMessageBuilder message_builder;
+        capnp::LoadEnumerationsResponse::Builder builder =
+            message_builder.initRoot<capnp::LoadEnumerationsResponse>();
+        json.decode(
+            kj::StringPtr(static_cast<const char*>(response.data())), builder);
+        capnp::LoadEnumerationsResponse::Reader reader = builder.asReader();
+        return load_enumerations_response_from_capnp(reader);
+      }
+      case SerializationType::CAPNP: {
+        const auto mBytes = reinterpret_cast<const kj::byte*>(response.data());
+        ::capnp::FlatArrayMessageReader array_reader(kj::arrayPtr(
+            reinterpret_cast<const ::capnp::word*>(mBytes),
+            response.size() / sizeof(::capnp::word)));
+        capnp::LoadEnumerationsResponse::Reader reader =
+            array_reader.getRoot<capnp::LoadEnumerationsResponse>();
+        return load_enumerations_response_from_capnp(reader);
+      }
+      default: {
+        throw Status_SerializationError(
+            "Error deserializing load enumerations response; "
+            "Unknown serialization type passed");
+      }
+    }
+  } catch (kj::Exception& e) {
+    throw Status_SerializationError(
+        "Error deserializing load enumerations response; kj::Exception: " +
+        std::string(e.getDescription().cStr()));
+  } catch (std::exception& e) {
+    throw Status_SerializationError(
+        "Error deserializing load enumerations response; exception " +
+        std::string(e.what()));
+  }
+}
+
+#else
+
+void serialize_load_enumerations_request(
+    const std::vector<std::string>&, SerializationType, Buffer&) {
+  throw Status_SerializationError(
+      "Cannot serialize; serialization not enabled.");
+}
+
+std::vector<std::string> deserialize_load_enumerations_request(
+    SerializationType, const Buffer&) {
+  throw Status_SerializationError(
+      "Cannot serialize; serialization not enabled.");
+}
+
+void serialize_load_enumerations_response(
+    const std::vector<shared_ptr<const Enumeration>>,
+    SerializationType,
+    Buffer&) {
+  throw Status_SerializationError(
+      "Cannot serialize; serialization not enabled.");
+}
+
+std::vector<shared_ptr<const Enumeration>>
+deserialize_load_enumerations_response(SerializationType, const Buffer&) {
+  throw Status_SerializationError(
+      "Cannot serialize; serialization not enabled.");
+}
+
+#endif  // TILEDB_SERIALIZATION
+
+}  // namespace tiledb::sm::serialization

--- a/tiledb/sm/serialization/enumeration.h
+++ b/tiledb/sm/serialization/enumeration.h
@@ -1,0 +1,95 @@
+/**
+ * @file enumeration.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares serialization functions for Enumeration.
+ */
+
+#ifndef TILEDB_SERIALIZATION_ENUMERATION_H
+#define TILEDB_SERIALIZATION_ENUMERATION_H
+
+#ifdef TILEDB_SERIALIZATION
+#include "tiledb/sm/serialization/capnp_utils.h"
+#endif
+
+#include "tiledb/sm/array_schema/enumeration.h"
+#include "tiledb/sm/buffer/buffer.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+enum class SerializationType : uint8_t;
+
+namespace serialization {
+
+#ifdef TILEDB_SERIALIZATION
+
+/**
+ * Serialize an Enumeration to cap'n proto object
+ *
+ * @param enumeration Enumeration to serialize.
+ * @param enmr_builder Cap'n proto class.
+ */
+void enumeration_to_capnp(
+    shared_ptr<const Enumeration> enumeration,
+    capnp::Enumeration::Builder& enmr_builder);
+
+/**
+ * Deserialize an enumeration from a cap'n proto object
+ *
+ * @param reader Cap'n proto reader object
+ * @return A new Enumeration
+ */
+shared_ptr<const Enumeration> enumeration_from_capnp(
+    const capnp::Enumeration::Reader& reader);
+
+#endif
+
+void serialize_load_enumerations_request(
+    const Config& config,
+    const std::vector<std::string>& enumeration_names,
+    SerializationType serialization_type,
+    Buffer& request);
+
+std::vector<std::string> deserialize_load_enumerations_request(
+    SerializationType serialization_type, const Buffer& request);
+
+void serialize_load_enumerations_response(
+    const std::vector<shared_ptr<const Enumeration>> enumerations,
+    SerializationType serialization_type,
+    Buffer& response);
+
+std::vector<shared_ptr<const Enumeration>>
+deserialize_load_enumerations_response(
+    SerializationType serialization_type, const Buffer& response);
+
+}  // namespace serialization
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_SERIALIZATION_ENUMERATION_H

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
@@ -9344,6 +9344,129 @@ const ::capnp::_::RawSchema s_e68edfc0939e63df = {
   1, 1, i_e68edfc0939e63df, nullptr, nullptr, { &s_e68edfc0939e63df, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<55> b_891a70a671f15cf6 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    246,  92, 241, 113, 166, 112,  26, 137,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  82,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  69, 110,
+    117, 109, 101, 114,  97, 116, 105, 111,
+    110, 115,  82, 101, 113, 117, 101, 115,
+    116,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0, 106,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     72,   0,   0,   0,   2,   0,   1,   0,
+     99, 111, 110, 102, 105, 103,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    101, 110, 117, 109, 101, 114,  97, 116,
+    105, 111, 110, 115,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_891a70a671f15cf6 = b_891a70a671f15cf6.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_891a70a671f15cf6[] = {
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_891a70a671f15cf6[] = {0, 1};
+static const uint16_t i_891a70a671f15cf6[] = {0, 1};
+const ::capnp::_::RawSchema s_891a70a671f15cf6 = {
+  0x891a70a671f15cf6, b_891a70a671f15cf6.words, 55, d_891a70a671f15cf6, m_891a70a671f15cf6,
+  1, 2, i_891a70a671f15cf6, nullptr, nullptr, { &s_891a70a671f15cf6, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<40> b_805c080c10c1e959 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     89, 233, 193,  16,  12,   8,  92, 128,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  90,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  69, 110,
+    117, 109, 101, 114,  97, 116, 105, 111,
+    110, 115,  82, 101, 115, 112, 111, 110,
+    115, 101,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0, 106,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   3,   0,   1,   0,
+     40,   0,   0,   0,   2,   0,   1,   0,
+    101, 110, 117, 109, 101, 114,  97, 116,
+    105, 111, 110, 115,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    180, 185,  33, 204,  25,  47,  11, 208,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_805c080c10c1e959 = b_805c080c10c1e959.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_805c080c10c1e959[] = {
+  &s_d00b2f19cc21b9b4,
+};
+static const uint16_t m_805c080c10c1e959[] = {0};
+static const uint16_t i_805c080c10c1e959[] = {0};
+const ::capnp::_::RawSchema s_805c080c10c1e959 = {
+  0x805c080c10c1e959, b_805c080c10c1e959.words, 40, d_805c080c10c1e959, m_805c080c10c1e959,
+  1, 1, i_805c080c10c1e959, nullptr, nullptr, { &s_805c080c10c1e959, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp
 
@@ -10000,6 +10123,22 @@ constexpr uint16_t ArrayVacuumRequest::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind ArrayVacuumRequest::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* ArrayVacuumRequest::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadEnumerationsRequest
+constexpr uint16_t LoadEnumerationsRequest::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadEnumerationsRequest::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadEnumerationsRequest::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadEnumerationsRequest::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadEnumerationsResponse
+constexpr uint16_t LoadEnumerationsResponse::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadEnumerationsResponse::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadEnumerationsResponse::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadEnumerationsResponse::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
@@ -97,6 +97,8 @@ CAPNP_DECLARE_SCHEMA(a736c51d292ca752);
 CAPNP_DECLARE_SCHEMA(cd8abc9dabc4b03f);
 CAPNP_DECLARE_SCHEMA(f5a35661031194d2);
 CAPNP_DECLARE_SCHEMA(e68edfc0939e63df);
+CAPNP_DECLARE_SCHEMA(891a70a671f15cf6);
+CAPNP_DECLARE_SCHEMA(805c080c10c1e959);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -1564,6 +1566,40 @@ struct ArrayVacuumRequest {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(e68edfc0939e63df, 0, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadEnumerationsRequest {
+  LoadEnumerationsRequest() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(891a70a671f15cf6, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadEnumerationsResponse {
+  LoadEnumerationsResponse() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(805c080c10c1e959, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -14044,6 +14080,241 @@ class ArrayVacuumRequest::Pipeline {
   }
 
   inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadEnumerationsRequest::Reader {
+ public:
+  typedef LoadEnumerationsRequest Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig() const;
+  inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
+
+  inline bool hasEnumerations() const;
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+  getEnumerations() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadEnumerationsRequest::Builder {
+ public:
+  typedef LoadEnumerationsRequest Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig();
+  inline ::tiledb::sm::serialization::capnp::Config::Builder getConfig();
+  inline void setConfig(
+      ::tiledb::sm::serialization::capnp::Config::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Config::Builder initConfig();
+  inline void adoptConfig(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+  disownConfig();
+
+  inline bool hasEnumerations();
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+  getEnumerations();
+  inline void setEnumerations(
+      ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader value);
+  inline void setEnumerations(
+      ::kj::ArrayPtr<const ::capnp::Text::Reader> value);
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+  initEnumerations(unsigned int size);
+  inline void adoptEnumerations(
+      ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>&&
+          value);
+  inline ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>
+  disownEnumerations();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadEnumerationsRequest::Pipeline {
+ public:
+  typedef LoadEnumerationsRequest Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadEnumerationsResponse::Reader {
+ public:
+  typedef LoadEnumerationsResponse Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEnumerations() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Reader
+  getEnumerations() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadEnumerationsResponse::Builder {
+ public:
+  typedef LoadEnumerationsResponse Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEnumerations();
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Builder
+  getEnumerations();
+  inline void setEnumerations(::capnp::List<
+                              ::tiledb::sm::serialization::capnp::Enumeration,
+                              ::capnp::Kind::STRUCT>::Reader value);
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Builder
+  initEnumerations(unsigned int size);
+  inline void adoptEnumerations(
+      ::capnp::Orphan<::capnp::List<
+          ::tiledb::sm::serialization::capnp::Enumeration,
+          ::capnp::Kind::STRUCT>>&& value);
+  inline ::capnp::Orphan<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>
+  disownEnumerations();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadEnumerationsResponse::Pipeline {
+ public:
+  typedef LoadEnumerationsResponse Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -30294,6 +30565,188 @@ ArrayVacuumRequest::Builder::disownConfig() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsRequest::Reader::hasConfig() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsRequest::Builder::hasConfig() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Config::Reader
+LoadEnumerationsRequest::Reader::getConfig() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadEnumerationsRequest::Builder::getConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Config::Pipeline
+LoadEnumerationsRequest::Pipeline::getConfig() {
+  return ::tiledb::sm::serialization::capnp::Config::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void LoadEnumerationsRequest::Builder::setConfig(
+    ::tiledb::sm::serialization::capnp::Config::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadEnumerationsRequest::Builder::initConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void LoadEnumerationsRequest::Builder::adoptConfig(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+LoadEnumerationsRequest::Builder::disownConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsRequest::Reader::hasEnumerations() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsRequest::Builder::hasEnumerations() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+LoadEnumerationsRequest::Reader::getEnumerations() const {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+LoadEnumerationsRequest::Builder::getEnumerations() {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void LoadEnumerationsRequest::Builder::setEnumerations(
+    ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader value) {
+  ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline void LoadEnumerationsRequest::Builder::setEnumerations(
+    ::kj::ArrayPtr<const ::capnp::Text::Reader> value) {
+  ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+LoadEnumerationsRequest::Builder::initEnumerations(unsigned int size) {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::init(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          size);
+}
+inline void LoadEnumerationsRequest::Builder::adoptEnumerations(
+    ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>&&
+        value) {
+  ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>
+LoadEnumerationsRequest::Builder::disownEnumerations() {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsResponse::Reader::hasEnumerations() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsResponse::Builder::hasEnumerations() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Reader
+LoadEnumerationsResponse::Reader::getEnumerations() const {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::get(_reader
+                                       .getPointerField(
+                                           ::capnp::bounded<0>() *
+                                           ::capnp::POINTERS));
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Builder
+LoadEnumerationsResponse::Builder::getEnumerations() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::get(_builder
+                                       .getPointerField(
+                                           ::capnp::bounded<0>() *
+                                           ::capnp::POINTERS));
+}
+inline void LoadEnumerationsResponse::Builder::setEnumerations(
+    ::capnp::List<
+        ::tiledb::sm::serialization::capnp::Enumeration,
+        ::capnp::Kind::STRUCT>::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Builder
+LoadEnumerationsResponse::Builder::initEnumerations(unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          size);
+}
+inline void LoadEnumerationsResponse::Builder::adoptEnumerations(
+    ::capnp::Orphan<::capnp::List<
+        ::tiledb::sm::serialization::capnp::Enumeration,
+        ::capnp::Kind::STRUCT>>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>>
+LoadEnumerationsResponse::Builder::disownEnumerations() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::disown(_builder
+                                          .getPointerField(
+                                              ::capnp::bounded<0>() *
+                                              ::capnp::POINTERS));
 }
 
 }  // namespace capnp

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -1208,3 +1208,16 @@ struct ArrayVacuumRequest {
   config @0 :Config;
   # Config
 }
+
+struct LoadEnumerationsRequest {
+  config @0 :Config;
+  # Config
+
+  enumerations @1 :List(Text);
+  # Enumeration names to load
+}
+
+struct LoadEnumerationsResponse {
+  enumerations @0 :List(Enumeration);
+  # The loaded enumerations
+}

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
@@ -9344,6 +9344,129 @@ const ::capnp::_::RawSchema s_e68edfc0939e63df = {
   1, 1, i_e68edfc0939e63df, nullptr, nullptr, { &s_e68edfc0939e63df, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<55> b_891a70a671f15cf6 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    246,  92, 241, 113, 166, 112,  26, 137,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  82,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  69, 110,
+    117, 109, 101, 114,  97, 116, 105, 111,
+    110, 115,  82, 101, 113, 117, 101, 115,
+    116,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0, 106,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     44,   0,   0,   0,   3,   0,   1,   0,
+     72,   0,   0,   0,   2,   0,   1,   0,
+     99, 111, 110, 102, 105, 103,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    101, 110, 117, 109, 101, 114,  97, 116,
+    105, 111, 110, 115,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_891a70a671f15cf6 = b_891a70a671f15cf6.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_891a70a671f15cf6[] = {
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_891a70a671f15cf6[] = {0, 1};
+static const uint16_t i_891a70a671f15cf6[] = {0, 1};
+const ::capnp::_::RawSchema s_891a70a671f15cf6 = {
+  0x891a70a671f15cf6, b_891a70a671f15cf6.words, 55, d_891a70a671f15cf6, m_891a70a671f15cf6,
+  1, 2, i_891a70a671f15cf6, nullptr, nullptr, { &s_891a70a671f15cf6, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<40> b_805c080c10c1e959 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     89, 233, 193,  16,  12,   8,  92, 128,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  90,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  69, 110,
+    117, 109, 101, 114,  97, 116, 105, 111,
+    110, 115,  82, 101, 115, 112, 111, 110,
+    115, 101,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0, 106,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   3,   0,   1,   0,
+     40,   0,   0,   0,   2,   0,   1,   0,
+    101, 110, 117, 109, 101, 114,  97, 116,
+    105, 111, 110, 115,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    180, 185,  33, 204,  25,  47,  11, 208,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_805c080c10c1e959 = b_805c080c10c1e959.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_805c080c10c1e959[] = {
+  &s_d00b2f19cc21b9b4,
+};
+static const uint16_t m_805c080c10c1e959[] = {0};
+static const uint16_t i_805c080c10c1e959[] = {0};
+const ::capnp::_::RawSchema s_805c080c10c1e959 = {
+  0x805c080c10c1e959, b_805c080c10c1e959.words, 40, d_805c080c10c1e959, m_805c080c10c1e959,
+  1, 1, i_805c080c10c1e959, nullptr, nullptr, { &s_805c080c10c1e959, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp
 
@@ -10000,6 +10123,22 @@ constexpr uint16_t ArrayVacuumRequest::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind ArrayVacuumRequest::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* ArrayVacuumRequest::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadEnumerationsRequest
+constexpr uint16_t LoadEnumerationsRequest::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadEnumerationsRequest::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadEnumerationsRequest::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadEnumerationsRequest::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadEnumerationsResponse
+constexpr uint16_t LoadEnumerationsResponse::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadEnumerationsResponse::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadEnumerationsResponse::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadEnumerationsResponse::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
@@ -97,6 +97,8 @@ CAPNP_DECLARE_SCHEMA(a736c51d292ca752);
 CAPNP_DECLARE_SCHEMA(cd8abc9dabc4b03f);
 CAPNP_DECLARE_SCHEMA(f5a35661031194d2);
 CAPNP_DECLARE_SCHEMA(e68edfc0939e63df);
+CAPNP_DECLARE_SCHEMA(891a70a671f15cf6);
+CAPNP_DECLARE_SCHEMA(805c080c10c1e959);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -1564,6 +1566,40 @@ struct ArrayVacuumRequest {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(e68edfc0939e63df, 0, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadEnumerationsRequest {
+  LoadEnumerationsRequest() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(891a70a671f15cf6, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadEnumerationsResponse {
+  LoadEnumerationsResponse() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(805c080c10c1e959, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -14044,6 +14080,241 @@ class ArrayVacuumRequest::Pipeline {
   }
 
   inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadEnumerationsRequest::Reader {
+ public:
+  typedef LoadEnumerationsRequest Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig() const;
+  inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
+
+  inline bool hasEnumerations() const;
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+  getEnumerations() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadEnumerationsRequest::Builder {
+ public:
+  typedef LoadEnumerationsRequest Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig();
+  inline ::tiledb::sm::serialization::capnp::Config::Builder getConfig();
+  inline void setConfig(
+      ::tiledb::sm::serialization::capnp::Config::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Config::Builder initConfig();
+  inline void adoptConfig(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+  disownConfig();
+
+  inline bool hasEnumerations();
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+  getEnumerations();
+  inline void setEnumerations(
+      ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader value);
+  inline void setEnumerations(
+      ::kj::ArrayPtr<const ::capnp::Text::Reader> value);
+  inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+  initEnumerations(unsigned int size);
+  inline void adoptEnumerations(
+      ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>&&
+          value);
+  inline ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>
+  disownEnumerations();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadEnumerationsRequest::Pipeline {
+ public:
+  typedef LoadEnumerationsRequest Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadEnumerationsResponse::Reader {
+ public:
+  typedef LoadEnumerationsResponse Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEnumerations() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Reader
+  getEnumerations() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadEnumerationsResponse::Builder {
+ public:
+  typedef LoadEnumerationsResponse Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEnumerations();
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Builder
+  getEnumerations();
+  inline void setEnumerations(::capnp::List<
+                              ::tiledb::sm::serialization::capnp::Enumeration,
+                              ::capnp::Kind::STRUCT>::Reader value);
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Builder
+  initEnumerations(unsigned int size);
+  inline void adoptEnumerations(
+      ::capnp::Orphan<::capnp::List<
+          ::tiledb::sm::serialization::capnp::Enumeration,
+          ::capnp::Kind::STRUCT>>&& value);
+  inline ::capnp::Orphan<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>
+  disownEnumerations();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadEnumerationsResponse::Pipeline {
+ public:
+  typedef LoadEnumerationsResponse Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -30294,6 +30565,188 @@ ArrayVacuumRequest::Builder::disownConfig() {
   return ::capnp::_::
       PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
           _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsRequest::Reader::hasConfig() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsRequest::Builder::hasConfig() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Config::Reader
+LoadEnumerationsRequest::Reader::getConfig() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadEnumerationsRequest::Builder::getConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Config::Pipeline
+LoadEnumerationsRequest::Pipeline::getConfig() {
+  return ::tiledb::sm::serialization::capnp::Config::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void LoadEnumerationsRequest::Builder::setConfig(
+    ::tiledb::sm::serialization::capnp::Config::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadEnumerationsRequest::Builder::initConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void LoadEnumerationsRequest::Builder::adoptConfig(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+LoadEnumerationsRequest::Builder::disownConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsRequest::Reader::hasEnumerations() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsRequest::Builder::hasEnumerations() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader
+LoadEnumerationsRequest::Reader::getEnumerations() const {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+LoadEnumerationsRequest::Builder::getEnumerations() {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::get(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void LoadEnumerationsRequest::Builder::setEnumerations(
+    ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Reader value) {
+  ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline void LoadEnumerationsRequest::Builder::setEnumerations(
+    ::kj::ArrayPtr<const ::capnp::Text::Reader> value) {
+  ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>::Builder
+LoadEnumerationsRequest::Builder::initEnumerations(unsigned int size) {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::init(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          size);
+}
+inline void LoadEnumerationsRequest::Builder::adoptEnumerations(
+    ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>&&
+        value) {
+  ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>
+LoadEnumerationsRequest::Builder::disownEnumerations() {
+  return ::capnp::_::
+      PointerHelpers<::capnp::List<::capnp::Text, ::capnp::Kind::BLOB>>::disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsResponse::Reader::hasEnumerations() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsResponse::Builder::hasEnumerations() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Reader
+LoadEnumerationsResponse::Reader::getEnumerations() const {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::get(_reader
+                                       .getPointerField(
+                                           ::capnp::bounded<0>() *
+                                           ::capnp::POINTERS));
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Builder
+LoadEnumerationsResponse::Builder::getEnumerations() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::get(_builder
+                                       .getPointerField(
+                                           ::capnp::bounded<0>() *
+                                           ::capnp::POINTERS));
+}
+inline void LoadEnumerationsResponse::Builder::setEnumerations(
+    ::capnp::List<
+        ::tiledb::sm::serialization::capnp::Enumeration,
+        ::capnp::Kind::STRUCT>::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Builder
+LoadEnumerationsResponse::Builder::initEnumerations(unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          size);
+}
+inline void LoadEnumerationsResponse::Builder::adoptEnumerations(
+    ::capnp::Orphan<::capnp::List<
+        ::tiledb::sm::serialization::capnp::Enumeration,
+        ::capnp::Kind::STRUCT>>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>>
+LoadEnumerationsResponse::Builder::disownEnumerations() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::disown(_builder
+                                          .getPointerField(
+                                              ::capnp::bounded<0>() *
+                                              ::capnp::POINTERS));
 }
 
 }  // namespace capnp


### PR DESCRIPTION
This change adds support for the new
tiledb_handle_load_enumerations_request and adds the corresponding REST
client APIs to make use of it. The changes in this PR cannot be tested
directly until after TileDB-Cloud-REST has merged support for the new
HTTP endpoint that will connect these two new functions. Although I have
tested these locally using REST-CI tests and the basic tests all pass
just fine.

---
TYPE: IMPROVEMENT
DESC: Add tiledb_handle_load_enumerations_request
