### PR TITLE
Aggregators: adding null count aggregate.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/query/readers/aggregators/count_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/min_max_aggregator.h"
+#include "tiledb/sm/query/readers/aggregators/null_count_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/sum_aggregator.h"
 
 #include <test/support/tdb_catch.h>
@@ -1624,6 +1625,234 @@ TEMPLATE_LIST_TEST_CASE(
 
           if (request_data) {
             fx.validate_data_var(
+                query, dim1, dim2, a1_data, a1_offsets, a1_validity);
+          }
+        }
+      }
+    }
+  }
+
+  // Close array.
+  array.close();
+}
+
+typedef tuple<
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    float,
+    double,
+    std::string>
+    NullCountFixedTypesUnderTest;
+TEMPLATE_LIST_TEST_CASE_METHOD(
+    CppAggregatesFx,
+    "C++ API: Aggregates basic null count",
+    "[cppapi][aggregates][basic][null-count][fixed]",
+    NullCountFixedTypesUnderTest) {
+  typedef TestType T;
+  CppAggregatesFx<T>::generate_test_params();
+  if (!CppAggregatesFx<T>::nullable_) {
+    return;
+  }
+
+  CppAggregatesFx<T>::create_array_and_write_fragments();
+
+  Array array{
+      CppAggregatesFx<T>::ctx_, CppAggregatesFx<T>::ARRAY_NAME, TILEDB_READ};
+
+  for (bool set_ranges : {true, false}) {
+    CppAggregatesFx<T>::set_ranges_ = set_ranges;
+    for (bool request_data : {true, false}) {
+      CppAggregatesFx<T>::request_data_ = request_data;
+      for (bool set_qc : CppAggregatesFx<T>::set_qc_values_) {
+        CppAggregatesFx<T>::set_qc_ = set_qc;
+        for (tiledb_layout_t layout : CppAggregatesFx<T>::layout_values_) {
+          CppAggregatesFx<T>::layout_ = layout;
+          Query query(CppAggregatesFx<T>::ctx_, array, TILEDB_READ);
+
+          // TODO: Change to real CPPAPI. Add a count aggregator to the query.
+          uint64_t cell_val_num = std::is_same<T, std::string>::value ?
+                                      CppAggregatesFx<T>::STRING_CELL_VAL_NUM :
+                                      1;
+          query.ptr()->query_->add_aggregator_to_default_channel(
+              "NullCount",
+              std::make_shared<tiledb::sm::NullCountAggregator<T>>(
+                  tiledb::sm::FieldInfo(
+                      "a1",
+                      false,
+                      CppAggregatesFx<T>::nullable_,
+                      cell_val_num)));
+
+          CppAggregatesFx<T>::set_ranges_and_condition_if_needed(
+              array, query, false);
+
+          // Set the data buffer for the aggregator.
+          uint64_t cell_size = std::is_same<T, std::string>::value ?
+                                   CppAggregatesFx<T>::STRING_CELL_VAL_NUM :
+                                   sizeof(T);
+          uint64_t null_count = 0;
+          std::vector<uint64_t> dim1(100);
+          std::vector<uint64_t> dim2(100);
+          std::vector<uint8_t> a1(100 * cell_size);
+          std::vector<uint8_t> a1_validity(100);
+          query.set_layout(layout);
+
+          // TODO: Change to real CPPAPI. Use set_data_buffer from the internal
+          // query directly because the CPPAPI doesn't know what is an aggregate
+          // and what the size of an aggregate should be.
+          uint64_t returned_null_count_size = 8;
+          CHECK(query.ptr()
+                    ->query_
+                    ->set_data_buffer(
+                        "NullCount", &null_count, &returned_null_count_size)
+                    .ok());
+
+          if (request_data) {
+            query.set_data_buffer("d1", dim1);
+            query.set_data_buffer("d2", dim2);
+            query.set_data_buffer(
+                "a1", static_cast<void*>(a1.data()), a1.size() / cell_size);
+            query.set_validity_buffer("a1", a1_validity);
+          }
+
+          // Submit the query.
+          query.submit();
+
+          // Check the results.
+          uint64_t expected_null_count;
+          if (CppAggregatesFx<T>::dense_) {
+            if (set_qc) {
+              expected_null_count = 0;
+            } else {
+              if (set_ranges) {
+                expected_null_count = 12;
+              } else {
+                expected_null_count = 17;
+              }
+            }
+          } else {
+            if (set_ranges) {
+              expected_null_count = CppAggregatesFx<T>::allow_dups_ ? 4 : 3;
+            } else {
+              expected_null_count = CppAggregatesFx<T>::allow_dups_ ? 8 : 7;
+            }
+          }
+
+          // TODO: use 'std::get<1>(result_el["NullCount"]) == 1' once we use
+          // the set_data_buffer api.
+          CHECK(returned_null_count_size == 8);
+          CHECK(null_count == expected_null_count);
+
+          if (request_data) {
+            CppAggregatesFx<T>::validate_data(
+                query, dim1, dim2, a1, a1_validity);
+          }
+        }
+      }
+    }
+  }
+
+  // Close array.
+  array.close();
+}
+
+TEST_CASE_METHOD(
+    CppAggregatesFx<std::string>,
+    "C++ API: Aggregates basic null count var",
+    "[cppapi][aggregates][basic][null-count][var]") {
+  CppAggregatesFx<std::string> fx;
+  generate_test_params();
+  if (!nullable_) {
+    return;
+  }
+
+  create_var_array_and_write_fragments();
+
+  Array array{ctx_, ARRAY_NAME, TILEDB_READ};
+
+  for (bool set_ranges : {true, false}) {
+    set_ranges_ = set_ranges;
+    for (bool request_data : {true, false}) {
+      request_data_ = request_data;
+      for (bool set_qc : set_qc_values_) {
+        set_qc_ = set_qc;
+        for (tiledb_layout_t layout : layout_values_) {
+          layout_ = layout;
+          Query query(ctx_, array, TILEDB_READ);
+
+          // TODO: Change to real CPPAPI. Add a count aggregator to the query.
+          query.ptr()->query_->add_aggregator_to_default_channel(
+              "NullCount",
+              std::make_shared<tiledb::sm::NullCountAggregator<std::string>>(
+                  tiledb::sm::FieldInfo(
+                      "a1", true, nullable_, TILEDB_VAR_NUM)));
+
+          set_ranges_and_condition_if_needed(array, query, true);
+
+          // Set the data buffer for the aggregator.
+          uint64_t null_count = 0;
+          std::vector<uint64_t> dim1(100);
+          std::vector<uint64_t> dim2(100);
+          std::vector<uint64_t> a1_offsets(100);
+          std::string a1_data;
+          a1_data.resize(100);
+          std::vector<uint8_t> a1_validity(100);
+          query.set_layout(layout);
+
+          // TODO: Change to real CPPAPI. Use set_data_buffer and
+          // set_validity_buffer from the internal query directly because the
+          // CPPAPI doesn't know what is an aggregate and what the size of an
+          // aggregate should be.
+          uint64_t returned_null_count_size = 8;
+          CHECK(query.ptr()
+                    ->query_
+                    ->set_data_buffer(
+                        "NullCount", &null_count, &returned_null_count_size)
+                    .ok());
+
+          if (request_data) {
+            query.set_data_buffer("d1", dim1);
+            query.set_data_buffer("d2", dim2);
+            query.set_data_buffer("a1", a1_data);
+            query.set_offsets_buffer("a1", a1_offsets);
+            query.set_validity_buffer("a1", a1_validity);
+          }
+
+          // Submit the query.
+          query.submit();
+
+          // Check the results.
+          uint64_t expected_null_count;
+          if (dense_) {
+            if (set_qc) {
+              expected_null_count = 0;
+            } else {
+              if (set_ranges) {
+                expected_null_count = 12;
+              } else {
+                expected_null_count = 17;
+              }
+            }
+          } else {
+            if (set_ranges) {
+              expected_null_count = allow_dups_ ? 4 : 3;
+            } else {
+              expected_null_count = allow_dups_ ? 8 : 7;
+            }
+          }
+
+          // TODO: use 'std::get<1>(result_el["NullCount"]) == 1' once we use
+          // the set_data_buffer api.
+          CHECK(returned_null_count_size == 8);
+          CHECK(null_count == expected_null_count);
+
+          if (request_data) {
+            validate_data_var(
                 query, dim1, dim2, a1_data, a1_offsets, a1_validity);
           }
         }

--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -1681,7 +1681,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
                                       1;
           query.ptr()->query_->add_aggregator_to_default_channel(
               "NullCount",
-              std::make_shared<tiledb::sm::NullCountAggregator<T>>(
+              std::make_shared<tiledb::sm::NullCountAggregator>(
                   tiledb::sm::FieldInfo(
                       "a1",
                       false,
@@ -1788,7 +1788,7 @@ TEST_CASE_METHOD(
           // TODO: Change to real CPPAPI. Add a count aggregator to the query.
           query.ptr()->query_->add_aggregator_to_default_channel(
               "NullCount",
-              std::make_shared<tiledb::sm::NullCountAggregator<std::string>>(
+              std::make_shared<tiledb::sm::NullCountAggregator>(
                   tiledb::sm::FieldInfo(
                       "a1", true, nullable_, TILEDB_VAR_NUM)));
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -254,6 +254,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_remote_buffer_storage.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/count_aggregator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/dense_reader.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/ordered_dim_label_reader.cc

--- a/tiledb/sm/query/readers/CMakeLists.txt
+++ b/tiledb/sm/query/readers/CMakeLists.txt
@@ -27,12 +27,4 @@
 include(common NO_POLICY_SCOPE)
 include(object_library)
 
-#
-# `result_tile` object library
-#
-commence(object_library result_tile)
-  this_target_sources(result_tile.cc)
-  this_target_object_libraries(array_schema baseline tile)
-conclude(object_library)
-
 add_subdirectory(aggregators)

--- a/tiledb/sm/query/readers/aggregators/CMakeLists.txt
+++ b/tiledb/sm/query/readers/aggregators/CMakeLists.txt
@@ -31,8 +31,8 @@ include(object_library)
 # `aggregators` object library
 #
 commence(object_library aggregators)
-    this_target_sources(count_aggregator.cc min_max_aggregator.cc sum_aggregator.cc)
-    this_target_object_libraries(baseline array_schema result_tile)
+    this_target_sources(count_aggregator.cc min_max_aggregator.cc null_count_aggregator.cc sum_aggregator.cc)
+    this_target_object_libraries(baseline array_schema)
 conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/sm/query/readers/aggregators/aggregate_buffer.h
+++ b/tiledb/sm/query/readers/aggregators/aggregate_buffer.h
@@ -33,10 +33,7 @@
 #ifndef TILEDB_AGGREGATE_BUFFER_H
 #define TILEDB_AGGREGATE_BUFFER_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
-
-using namespace tiledb::common;
+#include "tiledb/common/common.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.cc
@@ -35,8 +35,6 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 
-using namespace tiledb::common;
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.h
@@ -33,11 +33,7 @@
 #ifndef TILEDB_COUNT_AGGREGATOR_H
 #define TILEDB_COUNT_AGGREGATOR_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/query/readers/aggregators/iaggregator.h"
-
-using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/field_info.h
+++ b/tiledb/sm/query/readers/aggregators/field_info.h
@@ -33,10 +33,7 @@
 #ifndef TILEDB_FIELD_INFO_H
 #define TILEDB_FIELD_INFO_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
-
-using namespace tiledb::common;
+#include "tiledb/common/common.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/iaggregator.h
+++ b/tiledb/sm/query/readers/aggregators/iaggregator.h
@@ -33,10 +33,8 @@
 #ifndef TILEDB_IAGGREGATOR_H
 #define TILEDB_IAGGREGATOR_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
-
-using namespace tiledb::common;
+#include "tiledb/common/common.h"
+#include "tiledb/sm/misc/constants.h"
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
@@ -32,7 +32,6 @@
 
 #include "tiledb/sm/query/readers/aggregators/min_max_aggregator.h"
 
-#include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
@@ -35,8 +35,6 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 
-using namespace tiledb::common;
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
@@ -33,14 +33,10 @@
 #ifndef TILEDB_MIN_MAX_AGGREGATOR_H
 #define TILEDB_MIN_MAX_AGGREGATOR_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/query/readers/aggregators/field_info.h"
 #include "tiledb/sm/query/readers/aggregators/iaggregator.h"
 
 #include <functional>
-
-using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
@@ -35,8 +35,6 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 
-using namespace tiledb::common;
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
@@ -47,8 +47,7 @@ class NullCountAggregatorStatusException : public StatusException {
   }
 };
 
-template <typename T>
-NullCountAggregator<T>::NullCountAggregator(const FieldInfo field_info)
+NullCountAggregator::NullCountAggregator(const FieldInfo field_info)
     : field_info_(field_info)
     , null_count_(0) {
   if (!field_info_.is_nullable_) {
@@ -57,8 +56,7 @@ NullCountAggregator<T>::NullCountAggregator(const FieldInfo field_info)
   }
 }
 
-template <typename T>
-void NullCountAggregator<T>::validate_output_buffer(
+void NullCountAggregator::validate_output_buffer(
     std::string output_field_name,
     std::unordered_map<std::string, QueryBuffer>& buffers) {
   if (buffers.count(output_field_name) == 0) {
@@ -89,8 +87,7 @@ void NullCountAggregator<T>::validate_output_buffer(
   }
 }
 
-template <typename T>
-void NullCountAggregator<T>::aggregate_data(AggregateBuffer& input_data) {
+void NullCountAggregator::aggregate_data(AggregateBuffer& input_data) {
   if (input_data.is_count_bitmap()) {
     null_count_ += null_count<uint64_t>(input_data);
   } else {
@@ -98,8 +95,7 @@ void NullCountAggregator<T>::aggregate_data(AggregateBuffer& input_data) {
   }
 }
 
-template <typename T>
-void NullCountAggregator<T>::copy_to_user_buffer(
+void NullCountAggregator::copy_to_user_buffer(
     std::string output_field_name,
     std::unordered_map<std::string, QueryBuffer>& buffers) {
   auto& result_buffer = buffers[output_field_name];
@@ -110,9 +106,8 @@ void NullCountAggregator<T>::copy_to_user_buffer(
   }
 }
 
-template <typename T>
 template <typename BITMAP_T>
-uint64_t NullCountAggregator<T>::null_count(AggregateBuffer& input_data) {
+uint64_t NullCountAggregator::null_count(AggregateBuffer& input_data) {
   uint64_t null_count{0};
 
   // Run different loops for bitmap versus no bitmap. The bitmap tells us which
@@ -140,19 +135,6 @@ uint64_t NullCountAggregator<T>::null_count(AggregateBuffer& input_data) {
 
   return null_count;
 }
-
-// Explicit template instantiations
-template NullCountAggregator<int8_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<int16_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<int32_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<int64_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<uint8_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<uint16_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<uint32_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<uint64_t>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<float>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<double>::NullCountAggregator(const FieldInfo);
-template NullCountAggregator<std::string>::NullCountAggregator(const FieldInfo);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/null_count_aggregator.cc
@@ -1,0 +1,158 @@
+/**
+ * @file null_count_aggregator.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements class NullCountAggregator.
+ */
+
+#include "tiledb/sm/query/readers/aggregators/null_count_aggregator.h"
+
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class NullCountAggregatorStatusException : public StatusException {
+ public:
+  explicit NullCountAggregatorStatusException(const std::string& message)
+      : StatusException("NullCountAggregator", message) {
+  }
+};
+
+template <typename T>
+NullCountAggregator<T>::NullCountAggregator(const FieldInfo field_info)
+    : field_info_(field_info)
+    , null_count_(0) {
+  if (!field_info_.is_nullable_) {
+    throw NullCountAggregatorStatusException(
+        "NullCount aggregates must only be requested for nullable attributes.");
+  }
+}
+
+template <typename T>
+void NullCountAggregator<T>::validate_output_buffer(
+    std::string output_field_name,
+    std::unordered_map<std::string, QueryBuffer>& buffers) {
+  if (buffers.count(output_field_name) == 0) {
+    throw NullCountAggregatorStatusException("Result buffer doesn't exist.");
+  }
+
+  auto& result_buffer = buffers[output_field_name];
+  if (result_buffer.buffer_ == nullptr) {
+    throw NullCountAggregatorStatusException(
+        "NullCount aggregates must have a fixed size buffer.");
+  }
+
+  if (result_buffer.buffer_var_ != nullptr) {
+    throw NullCountAggregatorStatusException(
+        "NullCount aggregates must not have a var buffer.");
+  }
+
+  if (result_buffer.original_buffer_size_ != 8) {
+    throw NullCountAggregatorStatusException(
+        "NullCount aggregates fixed size buffer should be for one element "
+        "only.");
+  }
+
+  bool exists_validity = result_buffer.validity_vector_.buffer();
+  if (exists_validity) {
+    throw NullCountAggregatorStatusException(
+        "NullCount aggregates must not have a validity buffer.");
+  }
+}
+
+template <typename T>
+void NullCountAggregator<T>::aggregate_data(AggregateBuffer& input_data) {
+  if (input_data.is_count_bitmap()) {
+    null_count_ += null_count<uint64_t>(input_data);
+  } else {
+    null_count_ += null_count<uint8_t>(input_data);
+  }
+}
+
+template <typename T>
+void NullCountAggregator<T>::copy_to_user_buffer(
+    std::string output_field_name,
+    std::unordered_map<std::string, QueryBuffer>& buffers) {
+  auto& result_buffer = buffers[output_field_name];
+  *static_cast<uint64_t*>(result_buffer.buffer_) = null_count_;
+
+  if (result_buffer.buffer_size_) {
+    *result_buffer.buffer_size_ = sizeof(uint64_t);
+  }
+}
+
+template <typename T>
+template <typename BITMAP_T>
+uint64_t NullCountAggregator<T>::null_count(AggregateBuffer& input_data) {
+  uint64_t null_count{0};
+
+  // Run different loops for bitmap versus no bitmap. The bitmap tells us which
+  // cells was already filtered out by ranges or query conditions.
+  if (input_data.has_bitmap()) {
+    auto bitmap_values = input_data.bitmap_data_as<BITMAP_T>();
+    auto validity_values = input_data.validity_data();
+
+    // Process with bitmap.
+    for (uint64_t c = input_data.min_cell(); c < input_data.max_cell(); c++) {
+      if (validity_values[c] == 0) {
+        null_count += bitmap_values[c];
+      }
+    }
+  } else {
+    auto validity_values = input_data.validity_data();
+
+    // Process with no bitmap.
+    for (uint64_t c = input_data.min_cell(); c < input_data.max_cell(); c++) {
+      if (validity_values[c] == 0) {
+        null_count++;
+      }
+    }
+  }
+
+  return null_count;
+}
+
+// Explicit template instantiations
+template NullCountAggregator<int8_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<int16_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<int32_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<int64_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<uint8_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<uint16_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<uint32_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<uint64_t>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<float>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<double>::NullCountAggregator(const FieldInfo);
+template NullCountAggregator<std::string>::NullCountAggregator(const FieldInfo);
+
+}  // namespace sm
+}  // namespace tiledb

--- a/tiledb/sm/query/readers/aggregators/null_count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/null_count_aggregator.h
@@ -1,0 +1,143 @@
+/**
+ * @file   null_count_aggregator.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class NullCountAggregator.
+ */
+
+#ifndef TILEDB_NULL_COUNT_AGGREGATOR_H
+#define TILEDB_NULL_COUNT_AGGREGATOR_H
+
+#include "tiledb/common/status.h"
+#include "tiledb/sm/enums/layout.h"
+#include "tiledb/sm/query/readers/aggregators/field_info.h"
+#include "tiledb/sm/query/readers/aggregators/iaggregator.h"
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+class QueryBuffer;
+
+template <typename T>
+class NullCountAggregator : public IAggregator {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  NullCountAggregator() = delete;
+
+  /**
+   * Constructor.
+   *
+   * @param field_info Field info.
+   */
+  NullCountAggregator(FieldInfo field_info);
+
+  DISABLE_COPY_AND_COPY_ASSIGN(NullCountAggregator);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(NullCountAggregator);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the field name for the aggregator. */
+  std::string field_name() override {
+    return field_info_.name_;
+  }
+
+  /** Returns if the aggregation is var sized or not. */
+  bool var_sized() override {
+    return false;
+  };
+
+  /** Returns if the aggregate needs to be recomputed on overflow. */
+  bool need_recompute_on_overflow() override {
+    return true;
+  }
+
+  /**
+   * Validate the result buffer.
+   *
+   * @param output_field_name Name for the output buffer.
+   * @param buffers Query buffers.
+   */
+  void validate_output_buffer(
+      std::string output_field_name,
+      std::unordered_map<std::string, QueryBuffer>& buffers) override;
+
+  /**
+   * Aggregate data using the aggregator.
+   *
+   * @param input_data Input data for aggregation.
+   */
+  void aggregate_data(AggregateBuffer& input_data) override;
+
+  /**
+   * Copy final data to the user buffer.
+   *
+   * @param output_field_name Name for the output buffer.
+   * @param buffers Query buffers.
+   */
+  void copy_to_user_buffer(
+      std::string output_field_name,
+      std::unordered_map<std::string, QueryBuffer>& buffers) override;
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Field information. */
+  const FieldInfo field_info_;
+
+  /** Computed null count. */
+  std::atomic<uint64_t> null_count_;
+
+  /* ********************************* */
+  /*           PRIVATE METHODS         */
+  /* ********************************* */
+
+  /**
+   * Add the null count of cells for the input data.
+   *
+   * @tparam BITMAP_T Bitmap type.
+   * @param input_data Input data for the null count.
+   *
+   * @return {Computed null count for the cells}.
+   */
+  template <typename BITMAP_T>
+  uint64_t null_count(AggregateBuffer& input_data);
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // TILEDB_NULL_COUNT_AGGREGATOR_H

--- a/tiledb/sm/query/readers/aggregators/null_count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/null_count_aggregator.h
@@ -33,12 +33,8 @@
 #ifndef TILEDB_NULL_COUNT_AGGREGATOR_H
 #define TILEDB_NULL_COUNT_AGGREGATOR_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/query/readers/aggregators/field_info.h"
 #include "tiledb/sm/query/readers/aggregators/iaggregator.h"
-
-using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/null_count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/null_count_aggregator.h
@@ -45,7 +45,6 @@ namespace sm {
 
 class QueryBuffer;
 
-template <typename T>
 class NullCountAggregator : public IAggregator {
  public:
   /* ********************************* */

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
@@ -32,7 +32,6 @@
 
 #include "tiledb/sm/query/readers/aggregators/sum_aggregator.h"
 
-#include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
@@ -35,8 +35,6 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 
-using namespace tiledb::common;
-
 namespace tiledb {
 namespace sm {
 

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.h
@@ -33,12 +33,8 @@
 #ifndef TILEDB_SUM_AGGREGATOR_H
 #define TILEDB_SUM_AGGREGATOR_H
 
-#include "tiledb/common/status.h"
-#include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/query/readers/aggregators/field_info.h"
 #include "tiledb/sm/query/readers/aggregators/iaggregator.h"
-
-using namespace tiledb::common;
 
 namespace tiledb {
 namespace sm {

--- a/tiledb/sm/query/readers/aggregators/test/CMakeLists.txt
+++ b/tiledb/sm/query/readers/aggregators/test/CMakeLists.txt
@@ -27,6 +27,6 @@
 include(unit_test)
 
 commence(unit_test aggregators)
-    this_target_sources(main.cc unit_count.cc unit_min_max.cc unit_sum.cc)
+    this_target_sources(main.cc unit_count.cc unit_min_max.cc unit_null_count.cc unit_sum.cc)
     this_target_object_libraries(aggregators)
 conclude(unit_test)

--- a/tiledb/sm/query/readers/aggregators/test/compile_aggregators_main.cc
+++ b/tiledb/sm/query/readers/aggregators/test/compile_aggregators_main.cc
@@ -29,55 +29,79 @@
 #include "../count_aggregator.h"
 #include "../field_info.h"
 #include "../min_max_aggregator.h"
+#include "../null_count_aggregator.h"
 #include "../sum_aggregator.h"
 
 int main() {
   tiledb::sm::CountAggregator();
 
   tiledb::sm::MinAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<int8_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<int16_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<int32_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<int64_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<float>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<double>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MinAggregator<std::string>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<int8_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<int16_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<int32_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<int64_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<float>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<double>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
   tiledb::sm::MaxAggregator<std::string>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+      tiledb::sm::FieldInfo("MinMax", false, false, 1));
+
+  tiledb::sm::NullCountAggregator<uint8_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<uint16_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<uint32_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<uint64_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<int8_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<int16_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<int32_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<int64_t>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<float>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<double>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator<std::string>(
+      tiledb::sm::FieldInfo("NullCount", false, false, 1));
 
   tiledb::sm::SumAggregator<uint8_t>(
       tiledb::sm::FieldInfo("Sum", false, false, 1));

--- a/tiledb/sm/query/readers/aggregators/test/compile_aggregators_main.cc
+++ b/tiledb/sm/query/readers/aggregators/test/compile_aggregators_main.cc
@@ -80,27 +80,7 @@ int main() {
   tiledb::sm::MaxAggregator<std::string>(
       tiledb::sm::FieldInfo("MinMax", false, false, 1));
 
-  tiledb::sm::NullCountAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<int8_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<int16_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<int32_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<int64_t>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<float>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<double>(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
-  tiledb::sm::NullCountAggregator<std::string>(
+  tiledb::sm::NullCountAggregator(
       tiledb::sm::FieldInfo("NullCount", false, false, 1));
 
   tiledb::sm::SumAggregator<uint8_t>(

--- a/tiledb/sm/query/readers/aggregators/test/unit_null_count.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_null_count.cc
@@ -44,7 +44,7 @@ TEST_CASE(
     "[null-count-aggregator][constructor]") {
   SECTION("Non nullable") {
     CHECK_THROWS_WITH(
-        NullCountAggregator<uint8_t>(FieldInfo("a1", false, false, 1)),
+        NullCountAggregator(FieldInfo("a1", false, false, 1)),
         "NullCountAggregator: NullCount aggregates must only be requested for "
         "nullable attributes.");
   }
@@ -53,27 +53,27 @@ TEST_CASE(
 TEST_CASE(
     "NullCount aggregator: var sized", "[null-count-aggregator][var-sized]") {
   bool var_sized = GENERATE(true, false);
-  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", var_sized, true, 1));
+  NullCountAggregator aggregator(FieldInfo("a1", var_sized, true, 1));
   CHECK(aggregator.var_sized() == false);
 }
 
 TEST_CASE(
     "NullCount aggregator: need recompute",
     "[null-count-aggregator][need-recompute]") {
-  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", false, true, 1));
+  NullCountAggregator aggregator(FieldInfo("a1", false, true, 1));
   CHECK(aggregator.need_recompute_on_overflow() == true);
 }
 
 TEST_CASE(
     "NullCount aggregator: field name", "[null-count-aggregator][field-name]") {
-  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", false, true, 1));
+  NullCountAggregator aggregator(FieldInfo("a1", false, true, 1));
   CHECK(aggregator.field_name() == "a1");
 }
 
 TEST_CASE(
     "NullCount aggregator: Validate buffer",
     "[null-count-aggregator][validate-buffer]") {
-  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", false, true, 1));
+  NullCountAggregator aggregator(FieldInfo("a1", false, true, 1));
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 
@@ -176,7 +176,7 @@ TEMPLATE_LIST_TEST_CASE(
     "[null-count-aggregator][basic-aggregation]",
     FixedTypesUnderTest) {
   typedef TestType T;
-  NullCountAggregator<T> aggregator(FieldInfo("a1", false, true, 1));
+  NullCountAggregator aggregator(FieldInfo("a1", false, true, 1));
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 
@@ -270,7 +270,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEST_CASE(
     "NullCount aggregator: Basic string aggregation",
     "[null-count-aggregator][basic-string-aggregation]") {
-  NullCountAggregator<std::string> aggregator(
+  NullCountAggregator aggregator(
       FieldInfo("a1", true, true, constants::var_num));
 
   std::unordered_map<std::string, QueryBuffer> buffers;

--- a/tiledb/sm/query/readers/aggregators/test/unit_null_count.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_null_count.cc
@@ -1,0 +1,363 @@
+/**
+ * @file unit_null_count.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests the `NullCountAggregator` class.
+ */
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/query/query_buffer.h"
+#include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
+#include "tiledb/sm/query/readers/aggregators/null_count_aggregator.h"
+
+#include <test/support/tdb_catch.h>
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "NullCount aggregator: constructor",
+    "[null-count-aggregator][constructor]") {
+  SECTION("Non nullable") {
+    CHECK_THROWS_WITH(
+        NullCountAggregator<uint8_t>(FieldInfo("a1", false, false, 1)),
+        "NullCountAggregator: NullCount aggregates must only be requested for "
+        "nullable attributes.");
+  }
+}
+
+TEST_CASE(
+    "NullCount aggregator: var sized", "[null-count-aggregator][var-sized]") {
+  bool var_sized = GENERATE(true, false);
+  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", var_sized, true, 1));
+  CHECK(aggregator.var_sized() == false);
+}
+
+TEST_CASE(
+    "NullCount aggregator: need recompute",
+    "[null-count-aggregator][need-recompute]") {
+  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", false, true, 1));
+  CHECK(aggregator.need_recompute_on_overflow() == true);
+}
+
+TEST_CASE(
+    "NullCount aggregator: field name", "[null-count-aggregator][field-name]") {
+  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", false, true, 1));
+  CHECK(aggregator.field_name() == "a1");
+}
+
+TEST_CASE(
+    "NullCount aggregator: Validate buffer",
+    "[null-count-aggregator][validate-buffer]") {
+  NullCountAggregator<uint8_t> aggregator(FieldInfo("a1", false, true, 1));
+
+  std::unordered_map<std::string, QueryBuffer> buffers;
+
+  SECTION("Doesn't exist") {
+    CHECK_THROWS_WITH(
+        aggregator.validate_output_buffer("NullCount", buffers),
+        "NullCountAggregator: Result buffer doesn't exist.");
+  }
+
+  SECTION("Null data buffer") {
+    buffers["NullCount"].buffer_ = nullptr;
+    CHECK_THROWS_WITH(
+        aggregator.validate_output_buffer("NullCount", buffers),
+        "NullCountAggregator: NullCount aggregates must have a fixed size "
+        "buffer.");
+  }
+
+  SECTION("Wrong size") {
+    uint64_t count = 0;
+    buffers["NullCount"].buffer_ = &count;
+    buffers["NullCount"].original_buffer_size_ = 1;
+    CHECK_THROWS_WITH(
+        aggregator.validate_output_buffer("NullCount", buffers),
+        "NullCountAggregator: NullCount aggregates fixed size buffer should be "
+        "for one element only.");
+  }
+
+  SECTION("With var buffer") {
+    uint64_t null_count = 0;
+    buffers["NullCount"].buffer_ = &null_count;
+    buffers["NullCount"].original_buffer_size_ = 8;
+    buffers["NullCount"].buffer_var_ = &null_count;
+
+    CHECK_THROWS_WITH(
+        aggregator.validate_output_buffer("NullCount", buffers),
+        "NullCountAggregator: NullCount aggregates must not have a var "
+        "buffer.");
+  }
+
+  SECTION("With validity") {
+    uint64_t null_count = 0;
+    buffers["NullCount"].buffer_ = &null_count;
+    buffers["NullCount"].original_buffer_size_ = 8;
+
+    uint8_t validity = 0;
+    uint64_t validity_size = 1;
+    buffers["NullCount"].validity_vector_ =
+        ValidityVector(&validity, &validity_size);
+    CHECK_THROWS_WITH(
+        aggregator.validate_output_buffer("NullCount", buffers),
+        "NullCountAggregator: NullCount aggregates must not have a validity "
+        "buffer.");
+  }
+
+  SECTION("Success") {
+    uint64_t null_count = 0;
+    buffers["NullCount"].buffer_ = &null_count;
+    buffers["NullCount"].original_buffer_size_ = 8;
+    aggregator.validate_output_buffer("NullCount", buffers);
+  }
+}
+
+template <class T, class RetT>
+std::vector<RetT> make_fixed_data_nc(T) {
+  return {1, 2, 3, 4, 5, 5, 4, 3, 2, 1};
+}
+
+template <>
+std::vector<char> make_fixed_data_nc(std::string) {
+  return {'1', '2', '3', '4', '5', '5', '4', '3', '2', '1'};
+}
+
+template <typename T>
+struct fixed_data_type {
+  using type = T;
+  typedef T value_type;
+};
+
+template <>
+struct fixed_data_type<std::string> {
+  using type = std::string;
+  typedef char value_type;
+};
+
+typedef tuple<
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    float,
+    double,
+    std::string>
+    FixedTypesUnderTest;
+TEMPLATE_LIST_TEST_CASE(
+    "NullCount aggregator: Basic aggregation",
+    "[null-count-aggregator][basic-aggregation]",
+    FixedTypesUnderTest) {
+  typedef TestType T;
+  NullCountAggregator<T> aggregator(FieldInfo("a1", false, true, 1));
+
+  std::unordered_map<std::string, QueryBuffer> buffers;
+
+  uint64_t null_count = 0;
+  buffers["NullCount"].buffer_ = &null_count;
+  buffers["NullCount"].original_buffer_size_ = 8;
+
+  auto fixed_data =
+      make_fixed_data_nc<T, typename fixed_data_type<T>::value_type>(T());
+  std::vector<uint8_t> validity_data = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+
+  SECTION("No bitmap") {
+    AggregateBuffer input_data{
+        2,
+        10,
+        10,
+        fixed_data.data(),
+        nullopt,
+        0,
+        validity_data.data(),
+        false,
+        nullopt};
+    aggregator.aggregate_data(input_data);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 4);
+  }
+
+  SECTION("Regular bitmap") {
+    std::vector<uint8_t> bitmap = {1, 1, 0, 0, 0, 1, 1, 0, 1, 0};
+    AggregateBuffer input_data{
+        2,
+        10,
+        10,
+        fixed_data.data(),
+        nullopt,
+        0,
+        validity_data.data(),
+        false,
+        bitmap.data()};
+    aggregator.aggregate_data(input_data);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 1);
+
+    AggregateBuffer input_data2{
+        0,
+        2,
+        10,
+        fixed_data.data(),
+        nullopt,
+        0,
+        validity_data.data(),
+        false,
+        bitmap.data()};
+    aggregator.aggregate_data(input_data2);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 3);
+  }
+
+  SECTION("Count bitmap") {
+    std::vector<uint64_t> bitmap_count = {1, 2, 4, 0, 0, 1, 2, 0, 1, 2};
+    AggregateBuffer input_data{
+        2,
+        10,
+        10,
+        fixed_data.data(),
+        nullopt,
+        0,
+        validity_data.data(),
+        true,
+        bitmap_count.data()};
+    aggregator.aggregate_data(input_data);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 3);
+
+    AggregateBuffer input_data2{
+        0,
+        2,
+        10,
+        fixed_data.data(),
+        nullopt,
+        0,
+        validity_data.data(),
+        true,
+        bitmap_count.data()};
+    aggregator.aggregate_data(input_data2);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 6);
+  }
+}
+
+TEST_CASE(
+    "NullCount aggregator: Basic string aggregation",
+    "[null-count-aggregator][basic-string-aggregation]") {
+  NullCountAggregator<std::string> aggregator(
+      FieldInfo("a1", true, true, constants::var_num));
+
+  std::unordered_map<std::string, QueryBuffer> buffers;
+
+  uint64_t null_count = 0;
+  buffers["NullCount"].buffer_ = &null_count;
+  buffers["NullCount"].original_buffer_size_ = 8;
+
+  std::vector<uint64_t> offsets = {0, 2, 3, 6, 8, 11, 15, 16, 18, 22};
+  std::string var_data = "11233344555555543322221";
+  std::vector<uint8_t> validity_data = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0};
+
+  SECTION("No bitmap") {
+    AggregateBuffer input_data{
+        2,
+        10,
+        10,
+        offsets.data(),
+        var_data.data(),
+        var_data.size(),
+        validity_data.data(),
+        false,
+        nullopt};
+    aggregator.aggregate_data(input_data);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 4);
+  }
+
+  SECTION("Regular bitmap") {
+    std::vector<uint8_t> bitmap = {1, 1, 0, 0, 0, 1, 1, 0, 1, 0};
+    AggregateBuffer input_data{
+        2,
+        10,
+        10,
+        offsets.data(),
+        var_data.data(),
+        var_data.size(),
+        validity_data.data(),
+        false,
+        bitmap.data()};
+    aggregator.aggregate_data(input_data);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 1);
+
+    AggregateBuffer input_data2{
+        0,
+        2,
+        10,
+        offsets.data(),
+        var_data.data(),
+        var_data.size(),
+        validity_data.data(),
+        false,
+        bitmap.data()};
+    aggregator.aggregate_data(input_data2);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 3);
+  }
+
+  SECTION("Count bitmap") {
+    std::vector<uint64_t> bitmap_count = {1, 2, 4, 0, 0, 1, 2, 0, 1, 2};
+    AggregateBuffer input_data{
+        2,
+        10,
+        10,
+        offsets.data(),
+        var_data.data(),
+        var_data.size(),
+        validity_data.data(),
+        true,
+        bitmap_count.data()};
+    aggregator.aggregate_data(input_data);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 3);
+
+    AggregateBuffer input_data2{
+        0,
+        2,
+        10,
+        offsets.data(),
+        var_data.data(),
+        var_data.size(),
+        validity_data.data(),
+        true,
+        bitmap_count.data()};
+    aggregator.aggregate_data(input_data2);
+    aggregator.copy_to_user_buffer("NullCount", buffers);
+    CHECK(null_count == 6);
+  }
+}


### PR DESCRIPTION
This adds a null count aggregator, which is very simple and can be improved upon. For now, it will load all tiles for an attribute whilst only the validity tile could be required.

---
TYPE: IMPROVEMENT
DESC: Aggregators: adding null count aggregate.
