### PR TITLE
Adding extra in memory offset for var tiles on read path.

### DIFF
--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -173,7 +173,7 @@ void DenseTilerFx::close_array() {
 template <class T>
 bool DenseTilerFx::check_tile(WriterTile& tile, const std::vector<T>& data) {
   std::vector<T> tile_data(data.size());
-  CHECK(tile.size() == data.size() * sizeof(T));
+  CHECK(tile.size_as<T>() == data.size());
   CHECK(tile.read(&tile_data[0], 0, data.size() * sizeof(T)).ok());
   CHECK(tile_data == data);
   return tile_data == data;

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -510,9 +510,9 @@ TEST_CASE_METHOD(
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
-  ResultTile result_tile_2_0(1, 0, array_schema);
-  ResultTile result_tile_3_0(2, 0, array_schema);
-  ResultTile result_tile_3_1(2, 1, array_schema);
+  ResultTile result_tile_2_0(1, 0, *fragments[0]);
+  ResultTile result_tile_3_0(2, 0, *fragments[0]);
+  ResultTile result_tile_3_1(2, 1, *fragments[1]);
 
   set_result_tile_dim(
       array_schema, result_tile_2_0, "d", 0, {{1000, 3, 1000, 5}});
@@ -1361,8 +1361,8 @@ TEST_CASE_METHOD(
 
   // Create result coordinates
   std::vector<ResultCoords> result_coords;
-  ResultTile result_tile_3_0(2, 0, array_schema);
-  ResultTile result_tile_3_1(2, 1, array_schema);
+  ResultTile result_tile_3_0(2, 0, *fragments[0]);
+  ResultTile result_tile_3_1(2, 1, *fragments[1]);
 
   set_result_tile_dim(
       array_schema, result_tile_3_0, "d1", 0, {{1000, 3, 1000, 1000}});

--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -271,15 +271,15 @@ TEST_CASE_METHOD(
   CHECK(result_space_tiles.size() == 6);
 
   // Result tiles for fragment #1
-  ResultTile result_tile_1_0_1(1, 0, *(schema.get()));
-  ResultTile result_tile_1_2_1(1, 2, *(schema.get()));
+  ResultTile result_tile_1_0_1(1, 0, *fragments[0]);
+  ResultTile result_tile_1_2_1(1, 2, *fragments[0]);
 
   // Result tiles for fragment #2
-  ResultTile result_tile_1_0_2(2, 0, *(schema.get()));
+  ResultTile result_tile_1_0_2(2, 0, *fragments[1]);
 
   // Result tiles for fragment #3
-  ResultTile result_tile_2_0_3(3, 0, *(schema.get()));
-  ResultTile result_tile_3_0_3(3, 2, *(schema.get()));
+  ResultTile result_tile_2_0_3(3, 0, *fragments[2]);
+  ResultTile result_tile_3_0_3(3, 2, *fragments[2]);
 
   // Initialize result_space_tiles
   ResultSpaceTile<int32_t> rst_1_0;

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1296,9 +1296,9 @@ TEST_CASE_METHOD(
       a2_offsets.data(),
       &a2_offsets_size);
 
-  // First var tiles is 91 and subequent are 100 bytes, this will only allow to
+  // First var tiles is 99 and subequent are 108 bytes, this will only allow to
   // load two tiles the first loop and one on the subsequents.
-  tile_upper_memory_limit_ = "384";
+  tile_upper_memory_limit_ = "416";
   update_config();
 
   // Try to read.

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -54,15 +54,13 @@ struct CResultCoordsFx {
   std::string array_name_;
   const char* ARRAY_NAME = "test_result_coords";
   tiledb_array_t* array_;
-  std::unique_ptr<FragmentMetadata> frag_md;
+  std::unique_ptr<FragmentMetadata> frag_md_;
 
-  CResultCoordsFx();
+  CResultCoordsFx(uint64_t num_cells);
   ~CResultCoordsFx();
-
-  GlobalOrderResultTile<uint8_t> make_tile_with_num_cells(uint64_t num_cells);
 };
 
-CResultCoordsFx::CResultCoordsFx() {
+CResultCoordsFx::CResultCoordsFx(uint64_t num_cells) {
   tiledb_config_t* config;
   tiledb_error_t* error = nullptr;
   REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
@@ -81,8 +79,8 @@ CResultCoordsFx::CResultCoordsFx() {
   create_dir(temp_dir_, ctx_, vfs_);
   array_name_ = temp_dir_ + ARRAY_NAME;
 
-  int64_t domain[] = {1, 10};
-  int64_t tile_extent = 5;
+  int64_t domain[] = {1, 2 * static_cast<int64_t>(num_cells)};
+  int64_t tile_extent = num_cells;
   // Create array
   create_array(
       ctx_,
@@ -98,7 +96,7 @@ CResultCoordsFx::CResultCoordsFx() {
       {tiledb::test::Compressor(TILEDB_FILTER_NONE, -1)},
       TILEDB_ROW_MAJOR,
       TILEDB_ROW_MAJOR,
-      5);
+      num_cells);
 
   // Open array for reading.
   auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array_);
@@ -106,7 +104,7 @@ CResultCoordsFx::CResultCoordsFx() {
   rc = tiledb_array_open(ctx_, array_, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
 
-  frag_md.reset(new FragmentMetadata(
+  frag_md_.reset(new FragmentMetadata(
       nullptr,
       nullptr,
       array_->array_->array_schema_latest_ptr(),
@@ -125,26 +123,21 @@ CResultCoordsFx::~CResultCoordsFx() {
   tiledb_vfs_free(&vfs_);
 }
 
-GlobalOrderResultTile<uint8_t> CResultCoordsFx::make_tile_with_num_cells(
-    uint64_t num_cells) {
-  GlobalOrderResultTile<uint8_t> result_tile(0, 0, false, false, *frag_md);
-  ResultTile::TileSizes tile_sizes(
-      num_cells * sizeof(int64_t),
-      0,
-      std::nullopt,
-      std::nullopt,
-      std::nullopt,
-      std::nullopt);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
-  result_tile.init_attr_tile(
-      constants::format_version,
-      array_->array_->array_schema_latest(),
-      constants::coords,
-      tile_sizes,
-      tile_data);
+struct CResultCoordsFxSmall {
+  CResultCoordsFxSmall()
+      : fx_(5) {
+  }
 
-  return result_tile;
-}
+  CResultCoordsFx fx_;
+};
+
+struct CResultCoordsFxLarge {
+  CResultCoordsFxLarge()
+      : fx_(100) {
+  }
+
+  CResultCoordsFx fx_;
+};
 
 /* ********************************* */
 /*                TESTS              */
@@ -168,10 +161,10 @@ class Cmp {
 };
 
 TEST_CASE_METHOD(
-    CResultCoordsFx,
+    CResultCoordsFxSmall,
     "GlobalOrderResultCoords: test max_slab_length",
     "[globalorderresultcoords][max_slab_length]") {
-  auto tile = make_tile_with_num_cells(5);
+  GlobalOrderResultTile<uint8_t> tile(0, 0, false, false, *fx_.frag_md_);
 
   // Test max_slab_length with no bitmap.
   GlobalOrderResultCoords rc1(&tile, 1);
@@ -195,10 +188,10 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
-    CResultCoordsFx,
+    CResultCoordsFxSmall,
     "GlobalOrderResultCoords: test max_slab_length with comparator",
     "[globalorderresultcoords][max_slab_length_with_comp]") {
-  auto tile = make_tile_with_num_cells(5);
+  GlobalOrderResultTile<uint8_t> tile(0, 0, false, false, *fx_.frag_md_);
   Cmp cmp;
 
   // Test max_slab_length with no bitmap and comparator.
@@ -222,24 +215,30 @@ TEST_CASE_METHOD(
   tile.count_cells();
   rc1.pos_ = 0;
   REQUIRE(rc1.max_slab_length(GlobalOrderResultCoords(&tile, 3), cmp) == 0);
+}
 
-  auto tile2 = make_tile_with_num_cells(100);
-  rc1.tile_ = &tile2;
+TEST_CASE_METHOD(
+    CResultCoordsFxLarge,
+    "GlobalOrderResultCoords: test max_slab_length with comparator, large tile",
+    "[globalorderresultcoords][max_slab_length_with_comp]") {
+  GlobalOrderResultTile<uint8_t> tile(0, 0, false, false, *fx_.frag_md_);
+  Cmp cmp;
+
+  GlobalOrderResultCoords rc1(&tile, 1);
   for (uint64_t i = 0; i < 100; i++) {
     for (uint64_t j = i + 1; j < 100; j++) {
       rc1.pos_ = i;
       REQUIRE(
-          rc1.max_slab_length(GlobalOrderResultCoords(&tile2, j), cmp) ==
-          j - i);
+          rc1.max_slab_length(GlobalOrderResultCoords(&tile, j), cmp) == j - i);
     }
   }
 }
 
 TEST_CASE_METHOD(
-    CResultCoordsFx,
+    CResultCoordsFxSmall,
     "GlobalOrderResultCoords: advance_to_next_cell",
     "[globalorderresultcoords][advance_to_next_cell]") {
-  auto tile = make_tile_with_num_cells(5);
+  GlobalOrderResultTile<uint8_t> tile(0, 0, false, false, *fx_.frag_md_);
   Cmp cmp;
 
   GlobalOrderResultCoords rc1(&tile, 0);

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -234,13 +234,13 @@ TEST_CASE_METHOD(
   Tile* const t_var = &tile_tuple->var_tile();
 
   // Initialize offsets, use 1 character strings.
-  uint64_t* offsets = (uint64_t*)t->data();
+  offsets_t* offsets = t->data_as<offsets_t>();
   for (uint64_t i = 0; i < num_cells + 1; i++) {
     offsets[i] = i;
   }
 
   // Initialize data, use incrementing single string values starting with 'a'.
-  char* var = (char*)t_var->data();
+  char* var = t_var->data_as<char>();
   for (uint64_t i = 0; i < num_cells; i++) {
     var[i] = 'a' + i;
   }
@@ -344,13 +344,13 @@ TEST_CASE_METHOD(
   Tile* const t_var = &tile_tuple->var_tile();
 
   // Initialize offsets, use 1 character strings.
-  uint64_t* offsets = (uint64_t*)t->data();
+  offsets_t* offsets = t->data_as<offsets_t>();
   for (uint64_t i = 0; i < num_cells + 1; i++) {
     offsets[i] = i;
   }
 
   // Initialize data, use incrementing single string values starting with 'a'.
-  char* var = (char*)t_var->data();
+  char* var = t_var->data_as<char>();
   for (uint64_t i = 0; i < num_cells; i++) {
     var[i] = 'a' + i;
   }

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -186,12 +186,19 @@ TEST_CASE_METHOD(
   uint64_t num_cells = 8;
 
   auto& array_schema = array_->array_->array_schema_latest();
-  ResultTile rt(0, 0, array_schema);
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_->array_->array_schema_latest_ptr(),
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+  ResultTile rt(0, 0, frag_md);
 
   // Make sure cell_num() will return the correct value.
   if (!first_dim) {
     ResultTile::TileSizes tile_sizes(
-        num_cells * constants::cell_var_offset_size,
+        (num_cells + 1) * constants::cell_var_offset_size,
         0,
         0,
         0,
@@ -208,7 +215,7 @@ TEST_CASE_METHOD(
   }
 
   ResultTile::TileSizes tile_sizes(
-      num_cells * constants::cell_var_offset_size,
+      (num_cells + 1) * constants::cell_var_offset_size,
       0,
       num_cells,
       0,
@@ -228,7 +235,7 @@ TEST_CASE_METHOD(
 
   // Initialize offsets, use 1 character strings.
   uint64_t* offsets = (uint64_t*)t->data();
-  for (uint64_t i = 0; i < num_cells; i++) {
+  for (uint64_t i = 0; i < num_cells + 1; i++) {
     offsets[i] = i;
   }
 
@@ -289,12 +296,19 @@ TEST_CASE_METHOD(
   uint64_t num_cells = 8;
 
   auto& array_schema = array_->array_->array_schema_latest();
-  ResultTile rt(0, 0, array_schema);
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_->array_->array_schema_latest_ptr(),
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+  ResultTile rt(0, 0, frag_md);
 
   // Make sure cell_num() will return the correct value.
   if (!first_dim) {
     ResultTile::TileSizes tile_sizes(
-        num_cells * constants::cell_var_offset_size,
+        (num_cells + 1) * constants::cell_var_offset_size,
         0,
         0,
         0,
@@ -311,7 +325,7 @@ TEST_CASE_METHOD(
   }
 
   ResultTile::TileSizes tile_sizes(
-      num_cells * constants::cell_var_offset_size,
+      (num_cells + 1) * constants::cell_var_offset_size,
       0,
       num_cells,
       0,
@@ -331,7 +345,7 @@ TEST_CASE_METHOD(
 
   // Initialize offsets, use 1 character strings.
   uint64_t* offsets = (uint64_t*)t->data();
-  for (uint64_t i = 0; i < num_cells; i++) {
+  for (uint64_t i = 0; i < num_cells + 1; i++) {
     offsets[i] = i;
   }
 

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -102,10 +102,10 @@ TEMPLATE_LIST_TEST_CASE(
       nullable,
       cell_val_num * sizeof(T),
       tiledb_type);
-  auto tile_buff = (T*)writer_tile.fixed_tile().data();
+  auto tile_buff = writer_tile.fixed_tile().data_as<T>();
   uint8_t* nullable_buff = nullptr;
   if (nullable) {
-    nullable_buff = (uint8_t*)writer_tile.validity_tile().data();
+    nullable_buff = writer_tile.validity_tile().data_as<uint8_t>();
   }
 
   // Compute correct values as the tile is filled with data.
@@ -264,7 +264,7 @@ TEMPLATE_LIST_TEST_CASE(
   // Initialize a new tile.
   auto tiledb_type = static_cast<Datatype>(type.tiledb_type);
   WriterTileTuple writer_tile(schema, 4, false, false, sizeof(T), tiledb_type);
-  auto tile_buff = (T*)writer_tile.fixed_tile().data();
+  auto tile_buff = writer_tile.fixed_tile().data_as<T>();
 
   // Once an overflow happens, the computation should abort, try to add a few
   // min values after the overflow to confirm.
@@ -290,7 +290,7 @@ TEMPLATE_LIST_TEST_CASE(
     // Initialize a new tile.
     WriterTileTuple writer_tile(
         schema, 4, false, false, sizeof(T), tiledb_type);
-    auto tile_buff = (T*)writer_tile.fixed_tile().data();
+    auto tile_buff = writer_tile.fixed_tile().data_as<T>();
 
     // Once an overflow happens, the computation should abort, try to add a few
     // max values after the overflow to confirm.
@@ -357,12 +357,12 @@ TEST_CASE(
   // Initialize tile.
   WriterTileTuple writer_tile(
       schema, num_cells, true, nullable, 1, Datatype::CHAR);
-  auto offsets_tile_buff = (uint64_t*)writer_tile.offset_tile().data();
+  auto offsets_tile_buff = writer_tile.offset_tile().data_as<offsets_t>();
 
   // Initialize a new nullable tile.
   uint8_t* nullable_buff = nullptr;
   if (nullable) {
-    nullable_buff = (uint8_t*)writer_tile.validity_tile().data();
+    nullable_buff = writer_tile.validity_tile().data_as<uint8_t>();
   }
 
   // Compute correct values as the tile is filled with data.
@@ -440,7 +440,7 @@ TEST_CASE(
   // Store '123' and '12'
   // Initialize offsets tile.
   WriterTileTuple writer_tile(schema, 2, true, false, 1, Datatype::CHAR);
-  auto offsets_tile_buff = (uint64_t*)writer_tile.offset_tile().data();
+  auto offsets_tile_buff = writer_tile.offset_tile().data_as<offsets_t>();
   offsets_tile_buff[0] = 0;
   offsets_tile_buff[1] = 3;
 

--- a/tiledb/common/common-std.h
+++ b/tiledb/common/common-std.h
@@ -52,6 +52,11 @@ using storage_size_t = uint64_t;
  */
 using format_version_t = uint32_t;
 
+/**
+ * Type for anything offsets related.
+ */
+using offsets_t = uint64_t;
+
 /*
  * Value manipulation
  */

--- a/tiledb/sm/array_schema/dimension.cc
+++ b/tiledb/sm/array_schema/dimension.cc
@@ -323,14 +323,11 @@ Range Dimension::compute_mbr_var<char>(
   auto cell_num = tile_off.cell_num();
   assert(cell_num > 0);
 
-  void* tile_buffer_off = tile_off.data();
-  assert(tile_buffer_off != nullptr);
+  offsets_t* d_off = tile_off.data_as<offsets_t>();
+  assert(d_off != nullptr);
 
-  void* tile_buffer_val = tile_val.data();
-  assert(tile_buffer_val != nullptr);
-
-  uint64_t* const d_off = static_cast<uint64_t*>(tile_buffer_off);
-  char* const d_val = static_cast<char*>(tile_buffer_val);
+  char* d_val = tile_val.data_as<char>();
+  assert(d_val != nullptr);
 
   // Initialize MBR with the first tile values
   auto size_0 = (cell_num == 1) ? d_val_size : d_off[1];

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -139,6 +139,10 @@ Status Domain::add_dimension(shared_ptr<Dimension> dim) {
   dimensions_.emplace_back(dim);
   dimension_ptrs_.emplace_back(p);
   ++dim_num_;
+
+  // Compute number of cells per tile
+  compute_cell_num_per_tile();
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -562,7 +562,8 @@ Status CompressionFilter::compress_var_string_coords(
     max_strlen_bytesize = compute_bytesize(max_string_len);
     // Allocate for worst case dict_size when all strings unique, in format:
     // [num_of_strings|size_str1|str1|...|size_strN|strN]
-    dict_size = max_strlen_bytesize * num_strings + input.size();
+    dict_size =
+        max_strlen_bytesize * static_cast<uint32_t>(num_strings) + input.size();
     // Extra metadata bytes to store the dictionary and string length datasize,
     // id size, and dict size
     metadata_size += 2 * sizeof(uint8_t) + sizeof(uint32_t) + dict_size;

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -142,9 +142,8 @@ FilterPipeline::get_var_chunk_sizes(
     WriterTile* const offsets_tile) const {
   std::vector<uint64_t> chunk_offsets;
   if (offsets_tile != nullptr) {
-    uint64_t num_offsets =
-        offsets_tile->size() / constants::cell_var_offset_size;
-    auto offsets = (uint64_t*)offsets_tile->data();
+    uint64_t num_offsets = offsets_tile->size_as<offsets_t>();
+    auto offsets = offsets_tile->data_as<offsets_t>();
 
     uint64_t current_size = 0;
     uint64_t min_size = chunk_size / 2;
@@ -232,7 +231,7 @@ Status FilterPipeline::filter_chunks_forward(
 
     // First filter's input is the original chunk.
     uint64_t offset = var_sizes ? chunk_offsets[i] : i * chunk_size;
-    void* chunk_buffer = static_cast<char*>(tile.data()) + offset;
+    void* chunk_buffer = tile.data_as<char>() + offset;
     uint32_t chunk_buffer_size =
         i == nchunks - 1 ? last_buffer_size :
         var_sizes        ? chunk_offsets[i + 1] - chunk_offsets[i] :
@@ -446,7 +445,7 @@ Status FilterPipeline::run_reverse(
     // If the pipeline is empty, just copy input to output.
     if (filters_.empty()) {
       void* output_chunk_buffer =
-          static_cast<char*>(tile->data()) + chunk_data.chunk_offsets_[i];
+          tile->data_as<char>() + chunk_data.chunk_offsets_[i];
       RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
       continue;
     }
@@ -469,7 +468,7 @@ Status FilterPipeline::run_reverse(
       bool last_filter = filter_idx == 0;
       if (last_filter) {
         void* output_chunk_buffer =
-            static_cast<char*>(tile->data()) + chunk_data.chunk_offsets_[i];
+            tile->data_as<char>() + chunk_data.chunk_offsets_[i];
         RETURN_NOT_OK(output_data.set_fixed_allocation(
             output_chunk_buffer, chunk.unfiltered_data_size_));
         reader_stats->add_counter(

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1636,7 +1636,7 @@ uint64_t FragmentMetadata::tile_size(
     const std::string& name, uint64_t tile_idx) const {
   auto var_size = array_schema_->var_size(name);
   auto cell_num = this->cell_num(tile_idx);
-  return (var_size) ? cell_num * constants::cell_var_offset_size :
+  return (var_size) ? (cell_num + 1) * constants::cell_var_offset_size :
                       cell_num * array_schema_->cell_size(name);
 }
 

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1215,13 +1215,13 @@ Status Reader::compute_var_cell_destinations(
     auto cs_length = cs.length_;
 
     // Get tile information, if the range is nonempty.
-    uint64_t* tile_offsets = nullptr;
+    offsets_t* tile_offsets = nullptr;
     if (cs.tile_ != nullptr && cs.tile_->tile_tuple(name) != nullptr) {
       const auto tile_tuple = cs.tile_->tile_tuple(name);
       const auto& tile = tile_tuple->fixed_tile();
 
       // Get the internal buffer to the offset values.
-      tile_offsets = (uint64_t*)tile.data();
+      tile_offsets = tile.data_as<offsets_t>();
     }
 
     // Compute the destinations for each cell in the range.
@@ -1314,7 +1314,7 @@ Status Reader::copy_partitioned_var_cells(
     auto cs_length = cs.length_;
 
     // Get tile information, if the range is nonempty.
-    uint64_t* tile_offsets = nullptr;
+    offsets_t* tile_offsets = nullptr;
     Tile* tile_var = nullptr;
     Tile* tile_validity = nullptr;
     if (cs.tile_ != nullptr && cs.tile_->tile_tuple(*name) != nullptr) {
@@ -1324,7 +1324,7 @@ Status Reader::copy_partitioned_var_cells(
       tile_validity = nullable ? &tile_tuple->validity_tile() : nullptr;
 
       // Get the internal buffer to the offset values.
-      tile_offsets = (uint64_t*)tile->data();
+      tile_offsets = tile->data_as<offsets_t>();
     }
 
     // Copy each cell in the range

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -661,21 +661,16 @@ void QueryCondition::apply_ast_node(
       if (var_size) {
         const auto& tile = tile_tuple->var_tile();
         const char* buffer = static_cast<char*>(tile.data());
-        const uint64_t buffer_size = tile.size();
 
         const auto& tile_offsets = tile_tuple->fixed_tile();
         const uint64_t* buffer_offsets =
             static_cast<uint64_t*>(tile_offsets.data());
-        const uint64_t buffer_offsets_el =
-            tile_offsets.size() / constants::cell_var_offset_size;
 
         // Iterate through each cell in this slab.
         while (c < length) {
           const uint64_t buffer_offset = buffer_offsets[start + c * stride];
           const uint64_t next_cell_offset =
-              (start + c * stride + 1 < buffer_offsets_el) ?
-                  buffer_offsets[start + c * stride + 1] :
-                  buffer_size;
+              buffer_offsets[start + c * stride + 1];
           const uint64_t cell_size = next_cell_offset - buffer_offset;
 
           const bool null_cell =
@@ -1364,13 +1359,10 @@ void QueryCondition::apply_ast_node_dense(
     // Get var data buffer and tile offsets buffer.
     const auto& tile = tile_tuple->var_tile();
     const char* buffer = static_cast<char*>(tile.data());
-    const uint64_t buffer_size = tile.size();
 
     const auto& tile_offsets = tile_tuple->fixed_tile();
     const uint64_t* buffer_offsets =
         static_cast<uint64_t*>(tile_offsets.data());
-    const uint64_t buffer_offsets_el =
-        tile_offsets.size() / constants::cell_var_offset_size;
 
     // Iterate through each cell in this slab.
     for (uint64_t c = 0; c < result_buffer.size(); ++c) {
@@ -1379,9 +1371,7 @@ void QueryCondition::apply_ast_node_dense(
       // ok.
       const uint64_t offset_idx = src_cell + (start + c) * stride;
       const uint64_t buffer_offset = buffer_offsets[offset_idx];
-      const uint64_t next_cell_offset = (offset_idx + 1 < buffer_offsets_el) ?
-                                            buffer_offsets[offset_idx + 1] :
-                                            buffer_size;
+      const uint64_t next_cell_offset = buffer_offsets[offset_idx + 1];
       const uint64_t cell_size = next_cell_offset - buffer_offset;
 
       // Get the cell value.
@@ -2328,13 +2318,12 @@ void QueryCondition::apply_ast_node_sparse(
     // Get var data buffer and tile offsets buffer.
     const auto& tile = tile_tuple->var_tile();
     const char* buffer = static_cast<char*>(tile.data());
-    const uint64_t buffer_size = tile.size();
 
     const auto& tile_offsets = tile_tuple->fixed_tile();
     const uint64_t* buffer_offsets =
         static_cast<uint64_t*>(tile_offsets.data());
     const uint64_t buffer_offsets_el =
-        tile_offsets.size() / constants::cell_var_offset_size;
+        tile_offsets.size() / constants::cell_var_offset_size - 1;
 
     // Iterate through each cell.
     for (uint64_t c = 0; c < buffer_offsets_el; ++c) {
@@ -2342,8 +2331,7 @@ void QueryCondition::apply_ast_node_sparse(
       // is string data requiring a strcmp which cannot be vectorized, this is
       // ok.
       const uint64_t buffer_offset = buffer_offsets[c];
-      const uint64_t next_cell_offset =
-          (c + 1 < buffer_offsets_el) ? buffer_offsets[c + 1] : buffer_size;
+      const uint64_t next_cell_offset = buffer_offsets[c + 1];
       const uint64_t cell_size = next_cell_offset - buffer_offset;
 
       // Get the cell value.

--- a/tiledb/sm/query/readers/aggregators/aggregate_buffer.h
+++ b/tiledb/sm/query/readers/aggregators/aggregate_buffer.h
@@ -49,33 +49,24 @@ class AggregateBuffer {
    *
    * @param min_cell Min cell position to aggregate.
    * @param max_cell Max cell position to aggregate.
-   * @param cell_num Cell num for the tile.
    * @param fixed_data Fixed data buffer.
    * @param var_data Var data buffer.
    * @param validity_data Validity data buffer.
    * @param count_bitmap Is the bitmap a count bitmap?
-   * @param name Name of the field for the buffer.
-   * @param var_sized Is the field var sized?
-   * @param nullable Is the field nullable?
-   * @param rt Result tile containing the data.
    * @param bitmap_data Bitmap data.
    */
   AggregateBuffer(
       const uint64_t min_cell,
       const uint64_t max_cell,
-      const uint64_t cell_num,
       const void* fixed_data,
       const optional<char*> var_data,
-      const uint64_t var_data_size,
       const optional<uint8_t*> validity_data,
       const bool count_bitmap,
       const optional<void*> bitmap_data)
-      : includes_last_var_cell_(var_data.has_value() && max_cell == cell_num)
-      , min_cell_(min_cell)
+      : min_cell_(min_cell)
       , max_cell_(max_cell)
       , fixed_data_(fixed_data)
       , var_data_(var_data)
-      , var_data_size_(var_data_size)
       , validity_data_(validity_data)
       , count_bitmap_(count_bitmap)
       , bitmap_data_(bitmap_data) {
@@ -130,26 +121,10 @@ class AggregateBuffer {
     return max_cell_;
   }
 
-  /** Returns if this buffer includes the last cell of a tile. */
-  bool includes_last_var_cell() const {
-    return includes_last_var_cell_;
-  }
-
-  /**
-   * Returns the var data size. Will only be non 0 if the buffers include the
-   * last cell of a var data input.
-   */
-  uint64_t var_data_size() const {
-    return var_data_size_;
-  }
-
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
-
-  /** Does this buffer include the last var cell of the tile. */
-  const bool includes_last_var_cell_;
 
   /** Min cell to aggregate. */
   const uint64_t min_cell_;
@@ -162,9 +137,6 @@ class AggregateBuffer {
 
   /** Pointer to the var data. */
   const optional<char*> var_data_;
-
-  /** Var data size. */
-  uint64_t var_data_size_;
 
   /** Pointer to the validity data. */
   const optional<uint8_t*> validity_data_;

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
@@ -106,22 +106,6 @@ class ComparatorAggregatorBase {
       const uint64_t cell_idx) const;
 
   /**
-   * Get the last value for the input buffers.
-   *
-   * @tparam VALUE_T Value type.
-   * @param fixed_data Fixed data buffer.
-   * @param var_data Var data buffer.
-   * @param input_data Aggregate buffer.
-   *
-   * @return Value.
-   */
-  template <typename VALUE_T>
-  VALUE_T last_var_value(
-      const void* fixed_data,
-      const char* var_data,
-      const AggregateBuffer& input_data) const;
-
-  /**
    * Copy final data to the user buffer.
    *
    * @param output_field_name Name for the output buffer.
@@ -246,28 +230,6 @@ class ComparatorAggregator : public ComparatorAggregatorBase<T>,
       const uint64_t c) {
     auto cmp = ComparatorAggregatorBase<T>::template value_at<VALUE_T>(
         fixed_data, var_data, c);
-    if (!value.has_value()) {
-      value = cmp;
-    } else if (op_(cmp, value.value())) {
-      value = cmp;
-    }
-  }
-
-  /**
-   * Potentially update the min/max value with the last var value.
-   *
-   * @param value Value to possibly update.
-   * @param fixed_data Fixed data.
-   * @param var_data Var data.
-   * @param input_data Aggregate buffer.
-   */
-  inline void update_last_var_min_max(
-      optional<VALUE_T>& value,
-      const void* fixed_data,
-      const char* var_data,
-      const AggregateBuffer& input_data) {
-    auto cmp = ComparatorAggregatorBase<T>::template last_var_value<VALUE_T>(
-        fixed_data, var_data, input_data);
     if (!value.has_value()) {
       value = cmp;
     } else if (op_(cmp, value.value())) {

--- a/tiledb/sm/query/readers/aggregators/test/unit_count.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_count.cc
@@ -31,7 +31,6 @@
  */
 
 #include "tiledb/common/common.h"
-#include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/count_aggregator.h"
@@ -132,7 +131,7 @@ TEST_CASE(
 
   SECTION("No bitmap") {
     AggregateBuffer input_data{
-        2, 10, 10, nullptr, nullopt, 0, nullopt, false, nullopt};
+        2, 10, nullptr, nullopt, nullopt, false, nullopt};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Count", buffers);
     CHECK(count == 8);
@@ -141,13 +140,13 @@ TEST_CASE(
   SECTION("Regular bitmap") {
     std::vector<uint8_t> bitmap = {1, 1, 0, 0, 0, 1, 1, 0, 1, 0};
     AggregateBuffer input_data{
-        2, 10, 10, nullptr, nullopt, 0, nullopt, false, bitmap.data()};
+        2, 10, nullptr, nullopt, nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Count", buffers);
     CHECK(count == 3);
 
     AggregateBuffer input_data2{
-        0, 2, 10, nullptr, nullopt, 0, nullopt, false, bitmap.data()};
+        0, 2, nullptr, nullopt, nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("Count", buffers);
     CHECK(count == 5);
@@ -156,13 +155,13 @@ TEST_CASE(
   SECTION("Count bitmap") {
     std::vector<uint64_t> bitmap_count = {1, 2, 4, 0, 0, 1, 2, 0, 1, 2};
     AggregateBuffer input_data{
-        2, 10, 10, nullptr, nullopt, 0, nullopt, true, bitmap_count.data()};
+        2, 10, nullptr, nullopt, nullopt, true, bitmap_count.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Count", buffers);
     CHECK(count == 10);
 
     AggregateBuffer input_data2{
-        0, 2, 10, nullptr, nullopt, 0, nullopt, true, bitmap_count.data()};
+        0, 2, nullptr, nullopt, nullopt, true, bitmap_count.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("Count", buffers);
     CHECK(count == 13);

--- a/tiledb/sm/query/readers/aggregators/test/unit_min_max.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_min_max.cc
@@ -352,7 +352,7 @@ TEMPLATE_LIST_TEST_CASE(
   SECTION("No bitmap") {
     // Regular attribute.
     AggregateBuffer input_data{
-        2, 10, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+        2, 10, fixed_data.data(), nullopt, nullopt, false, nullopt};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value(T(), min_max, min, 1, 5);
@@ -361,10 +361,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data2{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         nullopt};
@@ -378,36 +376,20 @@ TEMPLATE_LIST_TEST_CASE(
     // Regular attribute.
     std::vector<uint8_t> bitmap = {1, 1, 0, 0, 0, 1, 1, 0, 1, 0};
     AggregateBuffer input_data{
-        2,
-        10,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        nullopt,
-        false,
-        bitmap.data()};
+        2, 10, fixed_data.data(), nullopt, nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value(T(), min_max, min, 2, 5);
 
     AggregateBuffer input_data2{
-        0, 2, 10, fixed_data.data(), nullopt, 0, nullopt, false, bitmap.data()};
+        0, 2, fixed_data.data(), nullopt, nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value(T(), min_max, min, 1, 5);
 
     // Nullable attribute.
     AggregateBuffer input_data3{
-        0,
-        2,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        validity_data.data(),
-        false,
-        nullopt};
+        0, 2, fixed_data.data(), nullopt, validity_data.data(), false, nullopt};
     aggregator_nullable.aggregate_data(input_data3);
     aggregator_nullable.copy_to_user_buffer("MinMax2", buffers);
 
@@ -423,10 +405,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data4{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         bitmap.data()};
@@ -440,29 +420,13 @@ TEMPLATE_LIST_TEST_CASE(
     // Regular attribute.
     std::vector<uint64_t> bitmap_count = {1, 2, 4, 0, 0, 1, 2, 0, 1, 2};
     AggregateBuffer input_data{
-        2,
-        10,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        nullopt,
-        true,
-        bitmap_count.data()};
+        2, 10, fixed_data.data(), nullopt, nullopt, true, bitmap_count.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value(T(), min_max, min, 1, 5);
 
     AggregateBuffer input_data2{
-        0,
-        2,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        nullopt,
-        true,
-        bitmap_count.data()};
+        0, 2, fixed_data.data(), nullopt, nullopt, true, bitmap_count.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value(T(), min_max, min, 1, 5);
@@ -471,10 +435,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data3{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -486,10 +448,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data4{
         0,
         2,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -553,22 +513,14 @@ TEMPLATE_LIST_TEST_CASE(
   buffers["MinMax2"].validity_vector_ =
       ValidityVector(&validity, &validity_size);
 
-  std::vector<uint64_t> offsets = {0, 2, 3, 6, 8, 11, 15, 16, 18, 22};
+  std::vector<uint64_t> offsets = {0, 2, 3, 6, 8, 11, 15, 16, 18, 22, 23};
   std::string var_data = "11233344555555543322221";
   std::vector<uint8_t> validity_data = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0};
 
   SECTION("No bitmap") {
     // Regular attribute.
     AggregateBuffer input_data{
-        2,
-        10,
-        10,
-        offsets.data(),
-        var_data.data(),
-        var_data.size(),
-        nullopt,
-        false,
-        nullopt};
+        2, 10, offsets.data(), var_data.data(), nullopt, false, nullopt};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value_var(offset, min_max_size, min_max, min, "1", "5555");
@@ -577,10 +529,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data2{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         false,
         nullopt};
@@ -594,29 +544,13 @@ TEMPLATE_LIST_TEST_CASE(
     // Regular attribute.
     std::vector<uint8_t> bitmap = {1, 1, 0, 0, 0, 1, 1, 0, 1, 0};
     AggregateBuffer input_data{
-        2,
-        10,
-        10,
-        offsets.data(),
-        var_data.data(),
-        var_data.size(),
-        nullopt,
-        false,
-        bitmap.data()};
+        2, 10, offsets.data(), var_data.data(), nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value_var(offset, min_max_size, min_max, min, "2222", "5555");
 
     AggregateBuffer input_data2{
-        0,
-        2,
-        10,
-        offsets.data(),
-        var_data.data(),
-        var_data.size(),
-        nullopt,
-        false,
-        bitmap.data()};
+        0, 2, offsets.data(), var_data.data(), nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("MinMax", buffers);
     check_value_var(offset, min_max_size, min_max, min, "11", "5555");
@@ -625,10 +559,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data3{
         0,
         2,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         false,
         nullopt};
@@ -640,10 +572,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data4{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         false,
         bitmap.data()};
@@ -659,10 +589,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         nullopt,
         true,
         bitmap_count.data()};
@@ -673,10 +601,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data2{
         0,
         2,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         nullopt,
         true,
         bitmap_count.data()};
@@ -688,10 +614,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data3{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -703,10 +627,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data4{
         0,
         2,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         true,
         bitmap_count.data()};

--- a/tiledb/sm/query/readers/aggregators/test/unit_null_count.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_null_count.cc
@@ -192,10 +192,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         nullopt};
@@ -209,10 +207,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         bitmap.data()};
@@ -223,10 +219,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data2{
         0,
         2,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         bitmap.data()};
@@ -240,10 +234,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -254,10 +246,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data2{
         0,
         2,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -287,10 +277,8 @@ TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         false,
         nullopt};
@@ -304,10 +292,8 @@ TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         false,
         bitmap.data()};
@@ -318,10 +304,8 @@ TEST_CASE(
     AggregateBuffer input_data2{
         0,
         2,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         false,
         bitmap.data()};
@@ -335,10 +319,8 @@ TEST_CASE(
     AggregateBuffer input_data{
         2,
         10,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -349,10 +331,8 @@ TEST_CASE(
     AggregateBuffer input_data2{
         0,
         2,
-        10,
         offsets.data(),
         var_data.data(),
-        var_data.size(),
         validity_data.data(),
         true,
         bitmap_count.data()};

--- a/tiledb/sm/query/readers/aggregators/test/unit_sum.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_sum.cc
@@ -210,7 +210,7 @@ TEMPLATE_LIST_TEST_CASE(
   SECTION("No bitmap") {
     // Regular attribute.
     AggregateBuffer input_data{
-        2, 10, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+        2, 10, fixed_data.data(), nullopt, nullopt, false, nullopt};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == 27);
@@ -219,10 +219,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data2{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         nullopt};
@@ -236,50 +234,30 @@ TEMPLATE_LIST_TEST_CASE(
     // Regular attribute.
     std::vector<uint8_t> bitmap = {1, 1, 0, 0, 0, 1, 1, 0, 1, 0};
     AggregateBuffer input_data{
-        2,
-        10,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        nullopt,
-        false,
-        bitmap.data()};
+        2, 10, fixed_data.data(), nullopt, nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == 11);
 
     AggregateBuffer input_data2{
-        0, 2, 10, fixed_data.data(), nullopt, 0, nullopt, false, bitmap.data()};
+        0, 2, fixed_data.data(), nullopt, nullopt, false, bitmap.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == 14);
 
     // Nullable attribute.
     AggregateBuffer input_data3{
-
-        0,
-        2,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        validity_data.data(),
-        false,
-        nullopt};
+        0, 2, fixed_data.data(), nullopt, validity_data.data(), false, nullopt};
     aggregator_nullable.aggregate_data(input_data3);
     aggregator_nullable.copy_to_user_buffer("Sum2", buffers);
     CHECK(sum2 == 0);
     CHECK(validity == 0);
 
     AggregateBuffer input_data4{
-
         2,
-        10,
         10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         false,
         bitmap.data()};
@@ -293,29 +271,13 @@ TEMPLATE_LIST_TEST_CASE(
     // Regular attribute.
     std::vector<uint64_t> bitmap_count = {1, 2, 4, 0, 0, 1, 2, 0, 1, 2};
     AggregateBuffer input_data{
-        2,
-        10,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        nullopt,
-        true,
-        bitmap_count.data()};
+        2, 10, fixed_data.data(), nullopt, nullopt, true, bitmap_count.data()};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == 29);
 
     AggregateBuffer input_data2{
-        0,
-        2,
-        10,
-        fixed_data.data(),
-        nullopt,
-        0,
-        nullopt,
-        true,
-        bitmap_count.data()};
+        0, 2, fixed_data.data(), nullopt, nullopt, true, bitmap_count.data()};
     aggregator.aggregate_data(input_data2);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == 34);
@@ -324,10 +286,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data3{
         2,
         10,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -339,10 +299,8 @@ TEMPLATE_LIST_TEST_CASE(
     AggregateBuffer input_data4{
         0,
         2,
-        10,
         fixed_data.data(),
         nullopt,
-        0,
         validity_data.data(),
         true,
         bitmap_count.data()};
@@ -370,15 +328,15 @@ TEST_CASE(
       std::numeric_limits<int64_t>::min() + 2};
 
   AggregateBuffer input_data_plus_one{
-      0, 1, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+      0, 1, fixed_data.data(), nullopt, nullopt, false, nullopt};
 
   AggregateBuffer input_data_minus_one{
-      2, 3, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+      2, 3, fixed_data.data(), nullopt, nullopt, false, nullopt};
 
   SECTION("Overflow") {
     // First sum doesn't overflow.
     AggregateBuffer input_data{
-        0, 2, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+        0, 2, fixed_data.data(), nullopt, nullopt, false, nullopt};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == std::numeric_limits<int64_t>::max() - 1);
@@ -408,7 +366,7 @@ TEST_CASE(
   SECTION("Underflow") {
     // First sum doesn't underflow.
     AggregateBuffer input_data{
-        2, 4, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+        2, 4, fixed_data.data(), nullopt, nullopt, false, nullopt};
     aggregator.aggregate_data(input_data);
     aggregator.copy_to_user_buffer("Sum", buffers);
     CHECK(sum == std::numeric_limits<int64_t>::min() + 1);
@@ -451,11 +409,11 @@ TEST_CASE(
       1, std::numeric_limits<uint64_t>::max() - 2};
 
   AggregateBuffer input_data_plus_one{
-      0, 1, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+      0, 1, fixed_data.data(), nullopt, nullopt, false, nullopt};
 
   // First sum doesn't overflow.
   AggregateBuffer input_data{
-      0, 2, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+      0, 2, fixed_data.data(), nullopt, nullopt, false, nullopt};
   aggregator.aggregate_data(input_data);
   aggregator.copy_to_user_buffer("Sum", buffers);
   CHECK(sum == std::numeric_limits<uint64_t>::max() - 1);
@@ -487,10 +445,10 @@ TEST_CASE(
       std::numeric_limits<double>::lowest()};
 
   AggregateBuffer input_data_max{
-      0, 1, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+      0, 1, fixed_data.data(), nullopt, nullopt, false, nullopt};
 
   AggregateBuffer input_data_lowest{
-      1, 2, 10, fixed_data.data(), nullopt, 0, nullopt, false, nullopt};
+      1, 2, fixed_data.data(), nullopt, nullopt, false, nullopt};
 
   SECTION("Overflow") {
     // First sum doesn't overflow.

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -252,12 +252,11 @@ class AttributeOrderValidator {
    */
   template <typename IndexType, typename AttributeType>
   void validate_without_loading_tiles(
-      const ArraySchema& schema,
       const Dimension* index_dim,
       bool increasing_data,
       uint64_t f,
       const std::vector<const void*>& non_empty_domains,
-      const std::vector<shared_ptr<FragmentMetadata>> fragment_metadata,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
       const std::vector<uint64_t>& frag_first_array_tile_idx) {
     // For easy reference.
     auto& val_data = per_fragment_validation_data_[f];
@@ -323,7 +322,7 @@ class AttributeOrderValidator {
         }
       } else {
         // Add the tile to the list of tiles to load.
-        add_tile_to_load(f, true, f2, f2_tile_idx, schema);
+        add_tile_to_load(f, true, f2, f2_tile_idx, fragment_metadata[f2]);
       }
     }
 
@@ -383,7 +382,7 @@ class AttributeOrderValidator {
 
       } else {
         // Add the tile to the list of tiles to load.
-        add_tile_to_load(f, false, f2, f2_tile_idx, schema);
+        add_tile_to_load(f, false, f2, f2_tile_idx, fragment_metadata[f2]);
       }
     }
   }
@@ -555,14 +554,15 @@ class AttributeOrderValidator {
       bool is_lower_bound,
       uint64_t f_to_compare,
       uint64_t t_to_compare,
-      const ArraySchema& schema) {
+      const shared_ptr<FragmentMetadata> fragment_metadata) {
     auto& val_data = per_fragment_validation_data_[f];
     auto it = result_tiles_to_load_[f].find(t_to_compare);
     if (it == result_tiles_to_load_[f].end()) {
       result_tiles_to_load_[f].emplace(
           std::piecewise_construct,
           std::forward_as_tuple(t_to_compare),
-          std::forward_as_tuple(f_to_compare, t_to_compare, schema));
+          std::forward_as_tuple(
+              f_to_compare, t_to_compare, *fragment_metadata.get()));
     }
 
     if (is_lower_bound) {

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -1664,9 +1664,8 @@ Status DenseReader::copy_offset_tiles(
         const auto& t_var = tile_tuples[fd]->var_tile();
 
         // Setup variables for the copy.
-        auto src_buff =
-            static_cast<uint64_t*>(tile_tuples[fd]->fixed_tile().data()) +
-            start * stride + src_cell;
+        auto src_buff = tile_tuples[fd]->fixed_tile().data_as<offsets_t>() +
+                        start * stride + src_cell;
         auto div = elements_mode_ ? data_type_size : 1;
         auto dest = (OffType*)dest_ptr + start;
 
@@ -1681,7 +1680,7 @@ Status DenseReader::copy_offset_tiles(
         // Process validity values.
         if (nullable) {
           auto src_buff_validity =
-              static_cast<uint8_t*>(tile_tuples[fd]->validity_tile().data()) +
+              tile_tuples[fd]->validity_tile().data_as<uint8_t>() +
               start * stride + src_cell;
 
           for (i = 0; i < end - start + 1; ++i) {

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -559,7 +559,6 @@ Status DenseReader::dense_read() {
           0,
           subarray_start_cell,
           subarray_end_cell,
-          0,
           nullptr,
           nullopt)};
       for (auto& aggregate : aggregates_[constants::count_of_rows]) {
@@ -1267,21 +1266,17 @@ AggregateBuffer DenseReader::make_aggregate_buffer(
     const uint64_t cell_size,
     const uint64_t min_cell,
     const uint64_t max_cell,
-    const uint64_t cell_num,
     ResultTile::TileTuple* tile_tuple,
     optional<void*> bitmap_data) {
   void* fixed_data = nullptr;
   optional<char*> var_data = nullopt;
   optional<uint8_t*> validity_data = nullopt;
-  uint64_t var_data_size = 0;
   if (tile_tuple != nullptr) {
     fixed_data =
         tile_tuple->fixed_tile().data_as<char>() + min_cell * cell_size;
     var_data = var_sized ?
                    std::make_optional(tile_tuple->var_tile().data_as<char>()) :
                    nullopt;
-    var_data_size =
-        var_sized && max_cell == cell_num ? tile_tuple->var_tile().size() : 0;
     validity_data =
         nullable ?
             std::make_optional(
@@ -1292,10 +1287,8 @@ AggregateBuffer DenseReader::make_aggregate_buffer(
   return AggregateBuffer(
       0,
       max_cell - min_cell,
-      cell_num - min_cell,
       fixed_data,
       var_data,
-      var_data_size,
       validity_data,
       false,
       bitmap_data);
@@ -1604,7 +1597,6 @@ Status DenseReader::copy_offset_tiles(
   // For easy reference
   const auto dim_num = array_schema_.dim_num();
   const auto cell_order = array_schema_.cell_order();
-  const auto cell_num_per_tile = array_schema_.domain().cell_num_per_tile();
   auto stride = array_schema_.domain().stride<DimType>(layout_);
   const auto& frag_domains = result_space_tile.frag_domains();
   auto dst_buf = static_cast<uint8_t*>(buffers_[name].buffer_);
@@ -1678,24 +1670,13 @@ Status DenseReader::copy_offset_tiles(
         auto div = elements_mode_ ? data_type_size : 1;
         auto dest = (OffType*)dest_ptr + start;
 
-        // Copy the data cell by cell, last copy was taken out to take
-        // advantage of vectorization.
+        // Copy the data cell by cell.
         uint64_t i = 0;
-        for (; i < end - start; ++i) {
+        for (; i <= end - start; ++i) {
           auto i_src = i * stride;
           dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
           var_data_buff[i + start] = t_var.data_as<char>() + src_buff[i_src];
         }
-
-        // Copy the last value.
-        if (start + src_cell + (end - start) * stride >=
-            cell_num_per_tile - 1) {
-          dest[i] = (t_var.size() - src_buff[i * stride]) / div;
-        } else {
-          auto i_src = i * stride;
-          dest[i] = (src_buff[i_src + 1] - src_buff[i_src]) / div;
-        }
-        var_data_buff[i + start] = t_var.data_as<char>() + src_buff[i * stride];
 
         // Process validity values.
         if (nullable) {
@@ -1874,7 +1855,6 @@ Status DenseReader::aggregate_tiles(
   // For easy reference
   const auto dim_num = array_schema_.dim_num();
   const auto cell_order = array_schema_.cell_order();
-  const auto cell_num_per_tile = array_schema_.domain().cell_num_per_tile();
   auto stride = array_schema_.domain().stride<DimType>(layout_);
   const auto& frag_domains = result_space_tile.frag_domains();
   const auto attribute = array_schema_.attribute(name);
@@ -1940,7 +1920,6 @@ Status DenseReader::aggregate_tiles(
               cell_size,
               iter.pos_in_tile() + start,
               iter.pos_in_tile() + end + 1,
-              cell_num_per_tile,
               tile_tuples[fd],
               &aggregate_bitmap[cell_offset + start])};
           for (auto& aggregate : aggregates) {
@@ -1957,7 +1936,6 @@ Status DenseReader::aggregate_tiles(
                 cell_size,
                 start_cell,
                 start_cell + 1,
-                cell_num_per_tile,
                 tile_tuples[fd],
                 &aggregate_bitmap[cell_offset + start + i])};
             for (auto& aggregate : aggregates) {

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -264,7 +264,6 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const uint64_t cell_size,
       const uint64_t min_cell,
       const uint64_t max_cell,
-      const uint64_t cell_num,
       ResultTile::TileTuple* tile_tuple,
       optional<void*> bitmap_data);
 

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -617,7 +617,8 @@ uint64_t OrderedDimLabelReader::create_result_tiles() {
               result_tiles_[f].emplace(
                   std::piecewise_construct,
                   std::forward_as_tuple(tile_idx),
-                  std::forward_as_tuple(f, frag_tile_idx, array_schema_));
+                  std::forward_as_tuple(
+                      f, frag_tile_idx, *fragment_metadata_[f].get()));
             } else {
               if (r == 0) {
                 throw OrderedDimLabelReaderStatusException(

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -718,7 +718,11 @@ ReaderBase::load_tile_chunk_data(
   const FilterPipeline& filters = array_schema_.filters(name);
   if (!var_size ||
       !filters.skip_offsets_filtering(t_var->type(), array_schema_.version())) {
-    unfiltered_tile_size = t->load_chunk_data(tile_chunk_data, var_size);
+    if (var_size) {
+      unfiltered_tile_size = t->load_offsets_chunk_data(tile_chunk_data);
+    } else {
+      unfiltered_tile_size = t->load_chunk_data(tile_chunk_data);
+    }
   }
 
   if (var_size) {

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -368,7 +368,8 @@ class ResultTile {
    * Constructor. The number of dimensions `dim_num` is used to allocate
    * the separate coordinate tiles.
    */
-  ResultTile(unsigned frag_idx, uint64_t tile_idx, const ArraySchema& schema);
+  ResultTile(
+      unsigned frag_idx, uint64_t tile_idx, const FragmentMetadata& frag_md);
 
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTile);
 
@@ -588,8 +589,6 @@ class ResultTile {
           cached_ranges,
       const char* buff_str,
       const uint64_t* buff_off,
-      const uint64_t cell_num,
-      const uint64_t buff_str_size,
       const uint64_t start,
       const uint64_t end,
       std::vector<BitmapType>& result_count);
@@ -670,9 +669,9 @@ class ResultTile {
       const uint64_t min_cell,
       const uint64_t max_cell) const;
 
- private:
+ protected:
   /* ********************************* */
-  /*         PRIVATE ATTRIBUTES        */
+  /*        PROTECTED ATTRIBUTES       */
   /* ********************************* */
 
   /** The array domain. */
@@ -683,6 +682,9 @@ class ResultTile {
 
   /** The id of the tile (which helps locating the physical attribute tiles). */
   uint64_t tile_idx_ = UINT64_MAX;
+
+  /** Number of cells. */
+  uint64_t cell_num_;
 
   /** Attribute names to tiles based on attribute ordering from array schema. */
   std::vector<std::pair<std::string, optional<TileTuple>>> attr_tiles_;
@@ -768,6 +770,7 @@ class ResultTile {
       const uint64_t)>>
       compute_results_count_sparse_uint8_t_func_;
 
+ private:
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
@@ -814,8 +817,7 @@ class ResultTileWithBitmap : public ResultTile {
 
   ResultTileWithBitmap(
       unsigned frag_idx, uint64_t tile_idx, const FragmentMetadata& frag_md)
-      : ResultTile(frag_idx, tile_idx, *frag_md.array_schema().get())
-      , cell_num_(frag_md.cell_num(tile_idx))
+      : ResultTile(frag_idx, tile_idx, frag_md)
       , result_num_(cell_num_) {
   }
 
@@ -946,7 +948,6 @@ class ResultTileWithBitmap : public ResultTile {
   void swap(ResultTileWithBitmap<BitmapType>& tile) {
     ResultTile::swap(tile);
     std::swap(bitmap_, tile.bitmap_);
-    std::swap(cell_num_, tile.cell_num_);
     std::swap(result_num_, tile.result_num_);
   }
 
@@ -956,9 +957,6 @@ class ResultTileWithBitmap : public ResultTile {
   /* ********************************* */
   /** Bitmap for this tile. */
   std::vector<BitmapType> bitmap_;
-
-  /** Cell number for this tile. */
-  uint64_t cell_num_;
 
   /** Number of cells in this bitmap. */
   uint64_t result_num_;
@@ -1043,13 +1041,12 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
       if (ResultTileWithBitmap<BitmapType>::has_bmp()) {
         post_dedup_bitmap_ = ResultTileWithBitmap<BitmapType>::bitmap_;
       } else {
-        post_dedup_bitmap_->resize(
-            ResultTileWithBitmap<BitmapType>::cell_num_, 1);
+        post_dedup_bitmap_->resize(ResultTile::cell_num_, 1);
       }
     } else {
       if (ResultTileWithBitmap<BitmapType>::bitmap_.size() == 0) {
         ResultTileWithBitmap<BitmapType>::bitmap_.resize(
-            ResultTileWithBitmap<BitmapType>::cell_num_, 1);
+            ResultTile::cell_num_, 1);
       }
     }
   }
@@ -1085,7 +1082,7 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
 
   /** Allocate space for the hilbert values vector. */
   inline void allocate_hilbert_vector() {
-    hilbert_values_.resize(ResultTileWithBitmap<BitmapType>::cell_num_);
+    hilbert_values_.resize(ResultTile::cell_num_);
   }
 
   /** Get the hilbert value at an index. */
@@ -1120,15 +1117,14 @@ class GlobalOrderResultTile : public ResultTileWithBitmap<BitmapType> {
 
   /** Allocate space for the delete condition index vector. */
   inline void allocate_per_cell_delete_condition_vector() {
-    per_cell_delete_condition_.resize(
-        ResultTileWithBitmap<BitmapType>::cell_num_, nullptr);
+    per_cell_delete_condition_.resize(ResultTile::cell_num_, nullptr);
   }
 
   /** Compute the delete condition index. */
   inline void compute_per_cell_delete_condition(QueryCondition* ptr) {
     // Go through all cells, if the delete condition cleared the cell, and the
     // index for this cell is still unset, set it to the current condition.
-    for (uint64_t c = 0; c < ResultTileWithBitmap<BitmapType>::cell_num_; c++) {
+    for (uint64_t c = 0; c < ResultTile::cell_num_; c++) {
       if (post_dedup_bitmap_->at(c) == 0 &&
           per_cell_delete_condition_[c] == nullptr) {
         per_cell_delete_condition_[c] = ptr;
@@ -1238,7 +1234,7 @@ class UnorderedWithDupsResultTile : public ResultTileWithBitmap<BitmapType> {
   void ensure_bitmap_for_query_condition() {
     if (ResultTileWithBitmap<BitmapType>::bitmap_.size() == 0) {
       ResultTileWithBitmap<BitmapType>::bitmap_.resize(
-          ResultTileWithBitmap<BitmapType>::cell_num_, 1);
+          ResultTile::cell_num_, 1);
     }
   }
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1214,8 +1214,6 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         }
 
         // Get source buffers.
-        const auto cell_num =
-            fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
         const auto tile_tuple = rt->tile_tuple(name);
 
         // If the tile_tuple is null, this is a field added in schema
@@ -1224,7 +1222,6 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         const uint8_t* src_var_buff = nullptr;
         bool use_fill_value = false;
         OffType fill_value_size = 0;
-        uint64_t t_var_size = 0;
         if (tile_tuple == nullptr) {
           use_fill_value = true;
           fill_value_size = static_cast<OffType>(
@@ -1233,7 +1230,6 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         } else {
           const auto& t = tile_tuple->fixed_tile();
           const auto& t_var = tile_tuple->var_tile();
-          t_var_size = t_var.size();
           src_buff = t.template data_as<uint64_t>();
           src_var_buff = t_var.template data_as<uint8_t>();
         }
@@ -1244,29 +1240,21 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
             query_buffer.validity_vector_.buffer() + dest_cell_offset;
         auto var_data_buffer = &var_data[dest_cell_offset - cell_offsets[0]];
 
-        // Copy full tile. Last cell might be taken out for vectorization.
-        uint64_t end =
-            (max_pos == cell_num && !use_fill_value) ? max_pos - 1 : max_pos;
+        // Copy full tile.
         if (!use_fill_value) {
-          for (uint64_t c = min_pos; c < end; c++) {
+          for (uint64_t c = min_pos; c < max_pos; c++) {
             *buffer = (OffType)(src_buff[c + 1] - src_buff[c]) / offset_div;
             buffer++;
             *var_data_buffer = src_var_buff + src_buff[c];
             var_data_buffer++;
           }
         } else {
-          for (uint64_t c = min_pos; c < end; c++) {
+          for (uint64_t c = min_pos; c < max_pos; c++) {
             *buffer = fill_value_size / offset_div;
             buffer++;
             *var_data_buffer = src_var_buff;
             var_data_buffer++;
           }
-        }
-
-        // Copy last cell.
-        if (max_pos == cell_num && !use_fill_value) {
-          *buffer = (OffType)(t_var_size - src_buff[max_pos - 1]) / offset_div;
-          *var_data_buffer = src_var_buff + src_buff[max_pos - 1];
         }
 
         // Copy nullable values.
@@ -2063,21 +2051,16 @@ AggregateBuffer SparseGlobalOrderReader<BitmapType>::make_aggregate_buffer(
     const bool nullable,
     const uint64_t min_cell,
     const uint64_t max_cell,
-    const uint64_t cell_num,
     ResultTile& rt) {
   return AggregateBuffer(
       min_cell,
       max_cell,
-      cell_num,
       name == constants::count_of_rows ?
           nullptr :
           rt.tile_tuple(name)->fixed_tile().data(),
       var_sized ?
           std::make_optional(rt.tile_tuple(name)->var_tile().data_as<char>()) :
           nullopt,
-      var_sized && max_cell == cell_num ?
-          rt.tile_tuple(name)->var_tile().size() :
-          0,
       nullable ? std::make_optional(
                      rt.tile_tuple(name)->validity_tile().data_as<uint8_t>()) :
                  nullopt,
@@ -2113,8 +2096,6 @@ void SparseGlobalOrderReader<BitmapType>::process_aggregates(
         auto& rcs = result_cell_slabs[i];
         auto rt = static_cast<GlobalOrderResultTile<BitmapType>*>(
             result_cell_slabs[i].tile_);
-        uint64_t cell_num =
-            fragment_metadata_[rt->frag_idx()]->cell_num(rt->tile_idx());
 
         // Compute parallelization parameters.
         auto&& [min_pos, max_pos, dest_cell_offset, skip_aggregate] =
@@ -2130,7 +2111,7 @@ void SparseGlobalOrderReader<BitmapType>::process_aggregates(
 
         // Compute aggregate.
         AggregateBuffer aggregate_buffer{make_aggregate_buffer(
-            name, var_sized, nullable, min_pos, max_pos, cell_num, *rt)};
+            name, var_sized, nullable, min_pos, max_pos, *rt)};
         for (auto& aggregate : aggregates) {
           aggregate->aggregate_data(aggregate_buffer);
         }

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1218,7 +1218,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
 
         // If the tile_tuple is null, this is a field added in schema
         // evolution. Use the fill value.
-        const uint64_t* src_buff = nullptr;
+        const offsets_t* src_buff = nullptr;
         const uint8_t* src_var_buff = nullptr;
         bool use_fill_value = false;
         OffType fill_value_size = 0;
@@ -1230,7 +1230,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
         } else {
           const auto& t = tile_tuple->fixed_tile();
           const auto& t_var = tile_tuple->var_tile();
-          src_buff = t.template data_as<uint64_t>();
+          src_buff = t.template data_as<offsets_t>();
           src_var_buff = t_var.template data_as<uint8_t>();
         }
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -555,7 +555,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
    * @param nullable Is the field nullable?
    * @param min_cell Min cell to aggregate.
    * @param min_cell Max cell to aggregate.
-   * @param cell_num Number of cells for the tile
    * @param rt Result tile.
    */
   AggregateBuffer make_aggregate_buffer(
@@ -564,7 +563,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       const bool nullable,
       const uint64_t min_cell,
       const uint64_t max_cell,
-      const uint64_t cell_num,
       ResultTile& rt);
 
   /**

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -610,7 +610,7 @@ void SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
 
   // If the tile_tuple is null, this is a field added in schema
   // evolution. Use the fill value.
-  const uint64_t* src_buff = nullptr;
+  const offsets_t* src_buff = nullptr;
   const uint8_t* src_var_buff = nullptr;
   bool use_fill_value = false;
   OffType fill_value_size = 0;
@@ -622,7 +622,7 @@ void SparseUnorderedWithDupsReader<uint64_t>::copy_offsets_tile(
   } else {
     const auto& t = tile_tuple->fixed_tile();
     const auto& t_var = tile_tuple->var_tile();
-    src_buff = t.template data_as<uint64_t>();
+    src_buff = t.template data_as<offsets_t>();
     src_var_buff = t_var.template data_as<uint8_t>();
   }
 
@@ -688,7 +688,7 @@ void SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
 
   // If the tile_tuple is null, this is a field added in schema
   // evolution. Use the fill value.
-  const uint64_t* src_buff = nullptr;
+  const offsets_t* src_buff = nullptr;
   const uint8_t* src_var_buff = nullptr;
   bool use_fill_value = false;
   OffType fill_value_size = 0;
@@ -701,7 +701,7 @@ void SparseUnorderedWithDupsReader<uint8_t>::copy_offsets_tile(
   } else {
     const auto& t = tile_tuple->fixed_tile();
     const auto& t_var = tile_tuple->var_tile();
-    src_buff = t.template data_as<uint64_t>();
+    src_buff = t.template data_as<offsets_t>();
     src_var_buff = t_var.template data_as<uint8_t>();
   }
 

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -499,7 +499,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
    * @param count_bitmap Is the bitmap a count bitmap?
    * @param min_cell Min cell to aggregate.
    * @param min_cell Max cell to aggregate.
-   * @param cell_num Number of cells for the tile
    * @param rt Result tile.
    */
   AggregateBuffer make_aggregate_buffer(
@@ -509,7 +508,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       const bool count_bitmap,
       const uint64_t min_cell,
       const uint64_t max_cell,
-      const uint64_t cell_num,
       UnorderedWithDupsResultTile<BitmapType>& rt);
 
   /**

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -2675,9 +2675,6 @@ void test_apply_cells_sparse<char*>(
   auto expected_iter = expected_cell_idx_vec.begin();
   for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
     if (result_bitmap[cell_idx]) {
-      if (*expected_iter != cell_idx) {
-        std::cout << "hello";
-      }
       REQUIRE(*expected_iter == cell_idx);
       ++expected_iter;
     }

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1462,14 +1462,15 @@ void test_apply_tile<char*>(
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
-    std::vector<uint64_t> offsets(cells);
+    std::vector<uint64_t> offsets(cells + 1);
     uint64_t offset = 0;
-    for (uint64_t i = 0; i < cells; ++i) {
+    for (uint64_t i = 0; i <= cells; ++i) {
       offsets[i] = offset;
       offset += 2;
     }
     REQUIRE(
-        tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+            .ok());
   }
 
   if (nullable) {
@@ -1555,13 +1556,23 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(array_schema->set_domain(make_shared<Domain>(HERE(), domain)).ok());
 
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+
   // Initialize the result tile.
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileSizes tile_sizes(
-      var_size ? cells * constants::cell_var_offset_size :
+      var_size ? (cells + 1) * constants::cell_var_offset_size :
                  2 * cells * sizeof(char),
       0,
       var_size ? std::optional(2 * cells * sizeof(char)) : std::nullopt,
@@ -1603,8 +1614,18 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(array_schema->set_domain(make_shared<Domain>(HERE(), domain)).ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
@@ -1614,7 +1635,7 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
       var_size ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -1701,14 +1722,26 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
 
+  std::vector<shared_ptr<FragmentMetadata>> frag_md(1);
+  frag_md[0] = make_shared<FragmentMetadata>(
+      HERE(),
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
-      var_size ? cells * constants::cell_var_offset_size :
+      var_size ? (cells + 1) * constants::cell_var_offset_size :
                  2 * (cells - 2) * sizeof(char),
       0,
       var_size ? std::optional(2 * (cells - 2) * sizeof(char)) : std::nullopt,
@@ -1716,7 +1749,7 @@ TEST_CASE(
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, *frag_md[0]);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -1743,7 +1776,7 @@ TEST_CASE(
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
-    std::vector<uint64_t> offsets(cells);
+    std::vector<uint64_t> offsets(cells + 1);
     uint64_t offset = 0;
     for (uint64_t i = 0; i < cells - 2; ++i) {
       offsets[i] = offset;
@@ -1751,8 +1784,10 @@ TEST_CASE(
     }
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
+    offsets[cells] = offset;
     REQUIRE(
-        tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+            .ok());
   }
 
   if (nullable) {
@@ -1810,15 +1845,6 @@ TEST_CASE(
   ResultCellSlab result_cell_slab(&result_tile, 0, cells);
   std::vector<ResultCellSlab> result_cell_slabs;
   result_cell_slabs.emplace_back(std::move(result_cell_slab));
-  std::vector<shared_ptr<FragmentMetadata>> frag_md(1);
-  frag_md[0] = make_shared<FragmentMetadata>(
-      HERE(),
-      nullptr,
-      nullptr,
-      array_schema,
-      URI(),
-      std::make_pair<uint64_t, uint64_t>(0, 0),
-      true);
   REQUIRE(
       query_condition.apply(*array_schema, frag_md, result_cell_slabs, 1).ok());
 
@@ -2150,14 +2176,15 @@ void test_apply_tile_dense<char*>(
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
-    std::vector<uint64_t> offsets(cells);
+    std::vector<uint64_t> offsets(cells + 1);
     uint64_t offset = 0;
-    for (uint64_t i = 0; i < cells; ++i) {
+    for (uint64_t i = 0; i <= cells; ++i) {
       offsets[i] = offset;
       offset += 2;
     }
     REQUIRE(
-        tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+            .ok());
   }
 
   if (nullable) {
@@ -2245,14 +2272,24 @@ void test_apply_dense<char*>(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
 
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
-      var_size ? cells * constants::cell_var_offset_size :
+      var_size ? (cells + 1) * constants::cell_var_offset_size :
                  2 * cells * sizeof(char),
       0,
       var_size ? std::optional(2 * cells * sizeof(char)) : std::nullopt,
@@ -2260,7 +2297,7 @@ void test_apply_dense<char*>(
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -2294,10 +2331,20 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
@@ -2307,7 +2354,7 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
       var_size ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -2395,14 +2442,24 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
 
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
-      var_size ? cells * constants::cell_var_offset_size :
+      var_size ? (cells + 1) * constants::cell_var_offset_size :
                  2 * (cells - 2) * sizeof(char),
       0,
       var_size ? std::optional(2 * (cells - 2) * sizeof(char)) : std::nullopt,
@@ -2410,7 +2467,7 @@ TEST_CASE(
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -2436,7 +2493,7 @@ TEST_CASE(
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
-    std::vector<uint64_t> offsets(cells);
+    std::vector<uint64_t> offsets(cells + 1);
     uint64_t offset = 0;
     for (uint64_t i = 0; i < cells - 2; ++i) {
       offsets[i] = offset;
@@ -2444,8 +2501,10 @@ TEST_CASE(
     }
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
+    offsets[cells] = offset;
     REQUIRE(
-        tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+            .ok());
   }
 
   if (nullable) {
@@ -2616,6 +2675,9 @@ void test_apply_cells_sparse<char*>(
   auto expected_iter = expected_cell_idx_vec.begin();
   for (uint64_t cell_idx = 0; cell_idx < cells; ++cell_idx) {
     if (result_bitmap[cell_idx]) {
+      if (*expected_iter != cell_idx) {
+        std::cout << "hello";
+      }
       REQUIRE(*expected_iter == cell_idx);
       ++expected_iter;
     }
@@ -2817,14 +2879,15 @@ void test_apply_tile_sparse<char*>(
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
-    std::vector<uint64_t> offsets(cells);
+    std::vector<uint64_t> offsets(cells + 1);
     uint64_t offset = 0;
-    for (uint64_t i = 0; i < cells; ++i) {
+    for (uint64_t i = 0; i <= cells; ++i) {
       offsets[i] = offset;
       offset += 2;
     }
     REQUIRE(
-        tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+            .ok());
   }
 
   if (nullable) {
@@ -2912,14 +2975,24 @@ void test_apply_sparse<char*>(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
 
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
-      var_size ? cells * constants::cell_var_offset_size :
+      var_size ? (cells + 1) * constants::cell_var_offset_size :
                  2 * cells * sizeof(char),
       0,
       var_size ? std::optional(2 * cells * sizeof(char)) : std::nullopt,
@@ -2927,7 +3000,7 @@ void test_apply_sparse<char*>(
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -2961,10 +3034,20 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
@@ -2974,7 +3057,7 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
       var_size ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -3721,10 +3804,20 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
@@ -3734,7 +3827,7 @@ TEST_CASE(
       std::nullopt,
       std::nullopt,
       std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -3999,19 +4092,29 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(array_schema->set_domain(make_shared<Domain>(HERE(), domain)).ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // Initialize the result tile.
   std::string data = "alicebobcraigdaveerinfrankgraceheidiivanjudy";
   ResultTile::TileSizes tile_sizes(
-      cells * constants::cell_var_offset_size,
+      (cells + 1) * constants::cell_var_offset_size,
       0,
       data.size(),
       0,
       std::nullopt,
       std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -4023,13 +4126,13 @@ TEST_CASE(
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
   Tile* const tile = &tile_tuple->var_tile();
 
-  std::vector<uint64_t> offsets = {0, 5, 8, 13, 17, 21, 26, 31, 36, 40};
+  std::vector<uint64_t> offsets = {0, 5, 8, 13, 17, 21, 26, 31, 36, 40, 44};
   REQUIRE(tile->write(data.c_str(), 0, data.size()).ok());
 
   // Write the tile offsets.
   Tile* const tile_offsets = &tile_tuple->fixed_tile();
-  REQUIRE(
-      tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+  REQUIRE(tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+              .ok());
 
   std::vector<TestParams> tp_vec;
   populate_string_test_params_vector(field_name, &result_tile, tp_vec);
@@ -4343,8 +4446,18 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(array_schema->set_domain(make_shared<Domain>(HERE(), domain)).ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // For pasting into a Python shell:
   //
@@ -4407,13 +4520,13 @@ TEST_CASE(
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
-      cells * constants::cell_var_offset_size,
+      (cells + 1) * constants::cell_var_offset_size,
       0,
       data.size(),
       0,
       std::nullopt,
       std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -4429,8 +4542,8 @@ TEST_CASE(
 
   // Write the tile offsets.
   Tile* const tile_offsets = &tile_tuple->fixed_tile();
-  REQUIRE(
-      tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+  REQUIRE(tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+              .ok());
 
   std::vector<TestParams> tp_vec;
   populate_utf8_string_test_params_vector(field_name, &result_tile, tp_vec);
@@ -4653,10 +4766,20 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(
       array_schema->set_domain(make_shared<tiledb::sm::Domain>(HERE(), domain))
           .ok());
+
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
@@ -4666,7 +4789,7 @@ TEST_CASE(
       std::nullopt,
       cells * constants::cell_validity_size,
       0);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -4744,12 +4867,22 @@ TEST_CASE(
   uint32_t bounds[2] = {1, cells};
   Range range(bounds, 2 * sizeof(uint32_t));
   REQUIRE(dim->set_domain(range).ok());
+  uint32_t tile_extent = 10;
+  REQUIRE(dim->set_tile_extent(&tile_extent).ok());
   REQUIRE(domain.add_dimension(dim).ok());
   REQUIRE(array_schema->set_domain(make_shared<Domain>(HERE(), domain)).ok());
 
+  FragmentMetadata frag_md(
+      nullptr,
+      nullptr,
+      array_schema,
+      URI(),
+      std::make_pair<uint64_t, uint64_t>(0, 0),
+      true);
+
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(
-      var_size ? cells * constants::cell_var_offset_size :
+      var_size ? (cells + 1) * constants::cell_var_offset_size :
                  2 * (cells - 2) * sizeof(char),
       0,
       var_size ? std::optional(2 * (cells - 2) * sizeof(char)) : std::nullopt,
@@ -4757,7 +4890,7 @@ TEST_CASE(
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile result_tile(0, 0, *array_schema);
+  ResultTile result_tile(0, 0, frag_md);
   ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
@@ -4783,7 +4916,7 @@ TEST_CASE(
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
-    std::vector<uint64_t> offsets(cells);
+    std::vector<uint64_t> offsets(cells + 1);
     uint64_t offset = 0;
     for (uint64_t i = 0; i < cells - 2; ++i) {
       offsets[i] = offset;
@@ -4791,8 +4924,10 @@ TEST_CASE(
     }
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
+    offsets[cells] = offset;
     REQUIRE(
-        tile_offsets->write(offsets.data(), 0, cells * sizeof(uint64_t)).ok());
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
+            .ok());
   }
 
   if (nullable) {

--- a/tiledb/sm/query/writers/dense_tiler.cc
+++ b/tiledb/sm/query/writers/dense_tiler.cc
@@ -226,8 +226,8 @@ Status DenseTiler<T>::get_tile(
         tile_off_size);
 
     // Fill entire tile with MAX_UINT64
-    std::vector<uint64_t> to_write(
-        cell_num_in_tile, std::numeric_limits<uint64_t>::max());
+    std::vector<offsets_t> to_write(
+        cell_num_in_tile, std::numeric_limits<offsets_t>::max());
     RETURN_NOT_OK(tile_pos.write(to_write.data(), 0, tile_off_size));
     to_write.clear();
     to_write.shrink_to_fit();
@@ -243,8 +243,7 @@ Status DenseTiler<T>::get_tile(
         id, constants::cell_var_offset_size, (uint8_t*)&cell_pos[0], tile_pos));
 
     // Copy real offsets and values to the corresponding tiles
-    void* tile_pos_buff_tmp = tile_pos.data();
-    auto tile_pos_buff = (uint64_t*)tile_pos_buff_tmp;
+    auto tile_pos_buff = tile_pos.data_as<offsets_t>();
     uint64_t tile_off_offset = 0, offset = 0, val_offset, val_size, pos;
     auto mul = (offsets_format_mode_ == "bytes") ? 1 : cell_size;
     auto& tile_off = tile.offset_tile();

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2003,6 +2003,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
               mem_vec[i].size_validity_ +=
                   tile_size / cell_size * constants::cell_validity_size;
           } else {
+            tile_size -= constants::cell_var_offset_size;
             auto tile_var_size = meta->tile_var_size(names[i], ft.second);
             mem_vec[i].size_fixed_ += tile_size;
             mem_vec[i].size_var_ += tile_var_size;
@@ -2312,6 +2313,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
                   tile_size / attr_datatype_size *
                   constants::cell_validity_size;
           } else {
+            tile_size -= constants::cell_var_offset_size;
             (*result_sizes)[n].size_fixed_ += tile_size;
             auto tile_var_size = meta->tile_var_size(names[n], tid);
             (*result_sizes)[n].size_var_ += tile_var_size;
@@ -2351,6 +2353,7 @@ Status Subarray::compute_relevant_fragment_est_result_sizes(
                 ratio;
 
         } else {
+          tile_size -= constants::cell_var_offset_size;
           (*result_sizes)[n].size_fixed_ += tile_size * ratio;
           auto tile_var_size = meta->tile_var_size(names[n], tid);
           (*result_sizes)[n].size_var_ += tile_var_size * ratio;

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -137,7 +137,6 @@ TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
 
   // Verify all public attributes are identical.
   CHECK(tile2.cell_size() == cell_size);
-  CHECK(tile2.cell_num() == buffer_len);
   CHECK(tile2.zipped_coords_dim_num() == dim_num);
   CHECK(tile2.filtered() == false);
   CHECK(tile2.format_version() == format_version);
@@ -178,7 +177,6 @@ TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
 
   // Verify all public attributes are identical.
   CHECK(tile2.cell_size() == cell_size);
-  CHECK(tile2.cell_num() == buffer_len);
   CHECK(tile2.zipped_coords_dim_num() == dim_num);
   CHECK(tile2.filtered() == false);
   CHECK(tile2.format_version() == format_version);

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -249,7 +249,7 @@ Status Tile::zip_coordinates() {
   return Status::Ok();
 }
 
-uint64_t Tile::load_chunk_data(ChunkData& unfiltered_tile) {
+uint64_t Tile::load_chunk_data(ChunkData& unfiltered_tile, bool is_offsets) {
   assert(filtered());
 
   Deserializer deserializer(filtered_data(), filtered_size());
@@ -276,7 +276,7 @@ uint64_t Tile::load_chunk_data(ChunkData& unfiltered_tile) {
     total_orig_size += chunk.unfiltered_data_size_;
   }
 
-  if (total_orig_size != size()) {
+  if (total_orig_size + (is_offsets ? sizeof(uint64_t) : 0) != size()) {
     throw TileStatusException("Incorrect unfiltered tile size allocated.");
   }
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -99,11 +99,6 @@ class TileBase {
     return size() / sizeof(T);
   }
 
-  /** Returns the number of cells stored in the tile. */
-  uint64_t cell_num() const {
-    return size() / cell_size_;
-  }
-
   /** Returns the internal buffer. */
   inline void* data() const {
     return data_.get();
@@ -133,6 +128,16 @@ class TileBase {
    *     properly allocated. It does not alter the tile offset and size.
    */
   Status write(const void* data, uint64_t offset, uint64_t nbytes);
+
+  /**
+   * Adds an extra offset at the end of this tile representing the size of the
+   * var tile.
+   *
+   * @param var_tile Var tile.
+   */
+  void add_extra_offset(TileBase& var_tile) {
+    data_as<uint64_t>()[size_ / cell_size_ - 1] = var_tile.size();
+  }
 
   /** Swaps the contents (all field values) of this tile with the given tile. */
   void swap(TileBase& tile);
@@ -286,9 +291,10 @@ class Tile : public TileBase {
    *   chunkN_data (uint8_t[])
    *
    * @param chunk_data Tile chunk info, buffers and offsets.
+   * @param is_offsets Does the tile contains offsets?
    * @return Original size.
    */
-  uint64_t load_chunk_data(ChunkData& chunk_data);
+  uint64_t load_chunk_data(ChunkData& chunk_data, bool is_offsets = false);
 
   /** Swaps the contents (all field values) of this tile with the given tile. */
   void swap(Tile& tile);
@@ -375,6 +381,11 @@ class WriterTile : public TileBase {
   /* ********************************* */
   /*                API                */
   /* ********************************* */
+
+  /** Returns the number of cells stored in the tile. */
+  uint64_t cell_num() const {
+    return size() / cell_size_;
+  }
 
   /** Clears the internal buffer. */
   void clear_data();

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -270,6 +270,31 @@ class Tile : public TileBase {
   /**
    * Reads the chunk data of a tile buffer and populates a chunk data structure.
    *
+   * @param chunk_data Tile chunk info, buffers and offsets.
+   * @return Original size.
+   */
+  uint64_t load_chunk_data(ChunkData& chunk_data);
+
+  /**
+   * Reads the chunk data of a tile offsets buffer and populates a chunk data
+   * structure.
+   *
+   * @param chunk_data Tile chunk info, buffers and offsets.
+   * @return Original size.
+   */
+  uint64_t load_offsets_chunk_data(ChunkData& chunk_data);
+
+  /** Swaps the contents (all field values) of this tile with the given tile. */
+  void swap(Tile& tile);
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE FUNCTIONS         */
+  /* ********************************* */
+
+  /**
+   * Reads the chunk data of a tile buffer and populates a chunk data structure.
+   *
    * This expects as input a Tile in the following byte format:
    *
    *   number_of_chunks (uint64_t)
@@ -291,15 +316,12 @@ class Tile : public TileBase {
    *   chunkN_data (uint8_t[])
    *
    * @param chunk_data Tile chunk info, buffers and offsets.
-   * @param is_offsets Does the tile contains offsets?
+   * @param expected_original_size Expected size for the tile.
    * @return Original size.
    */
-  uint64_t load_chunk_data(ChunkData& chunk_data, bool is_offsets = false);
+  uint64_t load_chunk_data(
+      ChunkData& chunk_data, uint64_t expected_original_size);
 
-  /** Swaps the contents (all field values) of this tile with the given tile. */
-  void swap(Tile& tile);
-
- private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -531,7 +531,7 @@ void TileMetadataGenerator::process_cell_range_var(
   }
 
   // Get pointers to the data and cell num.
-  auto offset_value = offset_tile.data_as<uint64_t>() + start;
+  auto offset_value = offset_tile.data_as<offsets_t>() + start;
   auto var_data = var_tile.data_as<char>();
   auto cell_num = tile.cell_num();
 


### PR DESCRIPTION
This change adds one extra in memory offset for the var fields on the read path. This way we don't have to process the last cell of a var tile in special cases anymore.

---
TYPE: IMPROVEMENT
DESC: Adding extra in memory offset for var tiles on read path.
