### PR TITLE
Fix macOS "experimental-features" build; CMake and CI QOL improvements

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -42,6 +42,9 @@ jobs:
             TILEDB_ARROW_TESTS: OFF
             TILEDB_SERIALIZATION: ON
             TILEDB_WEBP: ON
+
+    name: ${{ matrix.os }} - ${{ matrix.environ }}
+
     env:
       TILEDB_HOME: ${{ github.workspace }}
       TILEDB_GA_IMAGE_NAME: ${{ matrix.os }}

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -27,7 +27,7 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-## NOTE: the job names below must be unique!
+## NOTE: the job ids below must be unique!
 jobs:
   ci1:
     uses: ./.github/workflows/ci-linux_mac.yml

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -24,6 +24,8 @@ jobs:
             config: "Debug"
       fail-fast: false
 
+    name: ${{ matrix.os }} - Sanitizer: ${{ matrix.sanitizer }} | Experimental: ${{ matrix.experimental }} | ${{ matrix.debug }}
+
     permissions:
       issues: write
     env:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -15,7 +15,7 @@ jobs:
           - os: ubuntu-latest
           - os: macos-latest
           - os: macos-latest # ASAN build
-            asan: true
+            sanitizer: "address"
           - os: macos-latest
             experimental: ON
           - os: windows-latest
@@ -37,15 +37,15 @@ jobs:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v3
 
-      - name: Configure TileDB CMake
+      - name: Configure TileDB CMake (not-Windows)
         if: ${{ ! contains(matrix.os, 'windows') }}
         env:
-          SANITIZER_ARG: ${{ matrix.asan && 'address' || 'OFF' }}
+          SANITIZER_ARG: ${{ matrix.sanitizer || 'OFF' }}
           EXPERIMENTAL: ${{ matrix.experimental || 'OFF' }}
         run: |
           cmake -B build -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DTILEDB_EXPERIMENTAL_FEATURES=$EXPERIMENTAL -DCMAKE_BUILD_TYPE=${{ matrix.config || 'Release' }} -DSANITIZER=$SANITIZER_ARG
 
-      - name: Configure TileDB CMake
+      - name: Configure TileDB CMake (Windows)
         if: contains(matrix.os, 'windows')
         run: |
           cmake -B build -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=${{ matrix.config || 'Release' }}

--- a/experimental/tiledb/common/dag/nodes/generators.h
+++ b/experimental/tiledb/common/dag/nodes/generators.h
@@ -33,6 +33,8 @@
 #ifndef TILEDB_DAG_GENERATOR_H
 #define TILEDB_DAG_GENERATOR_H
 
+#include <tiledb/stdx/stop_token>
+
 #include "experimental/tiledb/common/dag/ports/ports.h"
 
 namespace tiledb::common {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -393,6 +393,7 @@ endif()
 add_custom_target(check
   COMMAND ${CMAKE_CTEST_COMMAND} -V -C $<CONFIG>
   DEPENDS tests
+  USES_TERMINAL
 )
 
 # CI tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -390,9 +390,9 @@ if(TILEDB_HDFS)
 endif()
 
 # Add custom target 'check'
-add_custom_target(
-  check COMMAND ${CMAKE_CTEST_COMMAND} -V -C $<CONFIG>
-  DEPENDS tiledb_unit
+add_custom_target(check
+  COMMAND ${CMAKE_CTEST_COMMAND} -V -C $<CONFIG>
+  DEPENDS tests
 )
 
 # CI tests


### PR DESCRIPTION
This PR fixes the macOS unit test build with the `experimental-features` flag enabled (AppleClang 14.0.3). To avoid future regressions, the `check` target defined in `test/CMakeLists.txt` is modified to depend on the implicit `tests` target, which includes _everything_ created by `add_tests`. Previously it only depended on `tiledb_unit`, which meant that `cmake --target check`/`make check` did not build all unit tests. This PR does not change which tests are actually run in the matrix jobs, but the dependency change should ensure that the unit tests always build successfully in every build configuration (those are still run in separate jobs for now).

Several small, unrelated QoL improvements are included:
- pass `USES_TERMINAL` flag to `add_custom_target(check...`, which causes ctest output to be forwarded through `cmake --build . --target check`. This should improve monitoring of CI jobs because test progress will be visible before the job concludes.
- Add constructed names to several build jobs, in order to improve legibility of the CI matrix.

---
TYPE: CI
DESC: Fix macOS "experimental-features" build; CMake and CI QOL improvements
