### PR TITLE
Fix syntax errors in the nightly build script.

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
 
     name: |
-      ${{ matrix.os }} - Sanitizer: ${{ matrix.sanitizer }} | Experimental: ${{ matrix.experimental }} | ${{ matrix.config || 'Release' }}
+      ${{ matrix.os }} - Sanitizer: ${{ matrix.sanitizer || 'none' }} | Experimental: ${{ matrix.experimental || 'OFF' }} | ${{ matrix.config || 'Release' }}
 
     permissions:
       issues: write

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -24,7 +24,8 @@ jobs:
             config: "Debug"
       fail-fast: false
 
-    name: ${{ matrix.os }} - Sanitizer: ${{ matrix.sanitizer }} | Experimental: ${{ matrix.experimental }} | ${{ matrix.debug }}
+    name: |
+      ${{ matrix.os }} - Sanitizer: ${{ matrix.sanitizer }} | Experimental: ${{ matrix.experimental }} | ${{ matrix.config || 'Release' }}
 
     permissions:
       issues: write


### PR DESCRIPTION
#4297 introduced some typos in `nightly-test.yml`, [causing nightly builds to fail to start](https://github.com/TileDB-Inc/TileDB/actions/runs/5997906803). This PR fixes them.

Validated by the [GitHub Actions extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions) showing zero errors (it did show some before).

---
TYPE: NO_HISTORY