### PR TITLE
Remove tiledb_array_schema_load_with_enumerations

### DIFF
--- a/ports/libxml2/portfile.cmake
+++ b/ports/libxml2/portfile.cmake
@@ -1,5 +1,4 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.gnome.org/
+vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO GNOME/libxml2
     REF f507d167f1755b7eaea09fb1a44d29aab828b6d1

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -137,25 +137,6 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CPPEnumerationFx,
-    "CPP: Load Schema from URI",
-    "[enumeration][add-attribute]") {
-  create_array();
-  auto schema = ArraySchemaExperimental::load_with_enumerations(ctx_, uri_);
-  auto enmr_names =
-      schema.ptr().get()->array_schema_->get_loaded_enumeration_names();
-  REQUIRE(enmr_names.size() > 0);
-}
-
-TEST_CASE_METHOD(
-    CPPEnumerationFx,
-    "CPP: Load Schema from URI - REMOTE NOT SUPPORTED YET",
-    "[enumeration][add-attribute][fixme]") {
-  std::string uri = "tiledb://namespace/array_name";
-  REQUIRE_THROWS(ArraySchemaExperimental::load_with_enumerations(ctx_, uri));
-}
-
-TEST_CASE_METHOD(
-    CPPEnumerationFx,
     "CPP: Schema Dump With Enumeration",
     "[enumeration][array-schema][dump]") {
   ArraySchema schema(ctx_, TILEDB_DENSE);

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -317,28 +317,6 @@ TILEDB_EXPORT int32_t tiledb_array_schema_add_enumeration(
     tiledb_array_schema_t* array_schema,
     tiledb_enumeration_t* enumeration) TILEDB_NOEXCEPT;
 
-/**
- * Retrieves the schema of an array from the disk with all enumerations loaded,
- * creating an array schema struct.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_array_schema_t* array_schema;
- * tiledb_array_schema_load(ctx, "s3://tiledb_bucket/my_array", &array_schema);
- * // Make sure to free the array schema in the end
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param array_uri The array whose schema will be retrieved.
- * @param array_schema The array schema to be retrieved, or `NULL` upon error.
- * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT int32_t tiledb_array_schema_load_with_enumerations(
-    tiledb_ctx_t* ctx,
-    const char* array_uri,
-    tiledb_array_schema_t** array_schema) TILEDB_NOEXCEPT;
-
 /* ********************************* */
 /*               ARRAY               */
 /* ********************************* */

--- a/tiledb/sm/cpp_api/array_schema_experimental.h
+++ b/tiledb/sm/cpp_api/array_schema_experimental.h
@@ -45,22 +45,6 @@ namespace tiledb {
 class ArraySchemaExperimental {
  public:
   /**
-   * Load an ArraySchema from the given URI with all of its enumerations.
-   *
-   * @param ctx The TileDB context.
-   * @param uri The URI to load from.
-   * @return ArraySchema The loaded array schema.
-   */
-  static ArraySchema load_with_enumerations(
-      const Context& ctx, const std::string& uri) {
-    tiledb_ctx_t* c_ctx = ctx.ptr().get();
-    tiledb_array_schema_t* schema;
-    ctx.handle_error(tiledb_array_schema_load_with_enumerations(
-        c_ctx, uri.c_str(), &schema));
-    return ArraySchema(ctx, schema);
-  }
-
-  /**
    * Adds a DimensionLabel to the array.
    *
    * @param ctx TileDB context.


### PR DESCRIPTION
Removing the relatively obscure feature for loading array schema with all enumerations. This will be re-implemented using a completely new TileDB Cloud REST HTTP endpoint in the future.

---
TYPE: NO_HISTORY
DESC: Remove tiledb_array_schema_load_with_enumerations