### PR TITLE
Add Enumeration v2 Serialization Support

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -230,6 +230,7 @@ void check_save_to_file() {
   ss << "rest.curl.buffer_size 524288\n";
   ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
+  ss << "rest.load_enumerations_on_array_open true\n";
   ss << "rest.load_metadata_on_array_open true\n";
   ss << "rest.load_non_empty_domain_on_array_open true\n";
   ss << "rest.retry_count 25\n";
@@ -567,6 +568,10 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
   rc = tiledb_config_set(
+      config, "rest.load_enumerations_on_array_open", "false", &error);
+  CHECK(rc == TILEDB_OK);
+  CHECK(error == nullptr);
+  rc = tiledb_config_set(
       config, "rest.use_refactored_array_open", "true", &error);
   CHECK(rc == TILEDB_OK);
   CHECK(error == nullptr);
@@ -600,6 +605,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.curl.verbose"] = "false";
   all_param_values["rest.load_metadata_on_array_open"] = "false";
   all_param_values["rest.load_non_empty_domain_on_array_open"] = "false";
+  all_param_values["rest.load_enumerations_on_array_open"] = "false";
   all_param_values["rest.use_refactored_array_open"] = "true";
   all_param_values["rest.use_refactored_array_open_and_query_submit"] = "true";
   all_param_values["sm.allow_separate_attribute_writes"] = "false";

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -53,6 +53,7 @@
 
 #ifdef TILEDB_SERIALIZATION
 #include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/serialization/array.h"
 #include "tiledb/sm/serialization/array_schema.h"
 #include "tiledb/sm/serialization/array_schema_evolution.h"
 #include "tiledb/sm/serialization/query.h"
@@ -113,6 +114,13 @@ struct EnumerationFx {
 
   void ser_des_query(
       Query* q_in, Query* q_out, bool client_side, SerializationType stype);
+
+  void ser_des_array(
+      Context& ctx,
+      Array* in,
+      Array* out,
+      bool client_side,
+      SerializationType stype);
 
   template <typename T>
   bool vec_cmp(std::vector<T> v1, std::vector<T> v2);
@@ -1550,6 +1558,44 @@ TEST_CASE_METHOD(
   REQUIRE(node2->use_enumeration() == true);
 }
 
+TEST_CASE_METHOD(
+    EnumerationFx,
+    "Cap'N Proto - Basic Array v2 Serialization",
+    "[enumeration][capnp][serialization][v2][array]") {
+  auto client_side = GENERATE(true, false);
+  auto ser_type = GENERATE(SerializationType::CAPNP, SerializationType::JSON);
+  auto do_load = GENERATE(std::string("true"), std::string("false"));
+
+  create_array();
+
+  Config cfg;
+  throw_if_not_ok(cfg.set("rest.use_refactored_array_open", "true"));
+  throw_if_not_ok(cfg.set("rest.load_enumerations_on_array_open", do_load));
+  Context ctx(cfg);
+
+  auto a1 = make_shared<Array>(HERE(), uri_, ctx.storage_manager());
+  throw_if_not_ok(
+      a1->open(QueryType::READ, EncryptionType::NO_ENCRYPTION, nullptr, 0));
+  REQUIRE(a1->serialize_enumerations() == (do_load == "true"));
+  REQUIRE(
+      a1->array_schema_latest_ptr()->get_loaded_enumeration_names().size() ==
+      0);
+
+  auto a2 = make_shared<Array>(HERE(), uri_, ctx.storage_manager());
+
+  ser_des_array(ctx, a1.get(), a2.get(), client_side, ser_type);
+
+  auto schema = a2->array_schema_latest_ptr();
+  auto names = schema->get_enumeration_names();
+  auto loaded = schema->get_loaded_enumeration_names();
+
+  if (do_load == "true") {
+    REQUIRE(vec_cmp(loaded, names));
+  } else {
+    REQUIRE(loaded.size() == 0);
+  }
+}
+
 #endif  // ifdef TILEDB_SERIALIZATIONs
 
 /* ********************************* */
@@ -1839,9 +1885,9 @@ shared_ptr<ArraySchema> EnumerationFx::create_schema() {
   throw_if_not_ok(schema->set_domain(dom));
 
   std::vector<std::string> values = {"ant", "bat", "cat", "dog", "emu"};
-  auto enmr =
+  auto enmr1 =
       create_enumeration(values, false, Datatype::STRING_ASCII, "test_enmr");
-  schema->add_enumeration(enmr);
+  schema->add_enumeration(enmr1);
 
   auto attr1 = make_shared<Attribute>(HERE(), "attr1", Datatype::INT32);
   attr1->set_enumeration_name("test_enmr");
@@ -1849,6 +1895,15 @@ shared_ptr<ArraySchema> EnumerationFx::create_schema() {
 
   auto attr2 = make_shared<Attribute>(HERE(), "attr2", Datatype::STRING_ASCII);
   throw_if_not_ok(schema->add_attribute(attr2));
+
+  std::vector<std::string> names = {"fred", "wilma", "barney", "betty"};
+  auto enmr2 =
+      create_enumeration(names, false, Datatype::STRING_UTF8, "flintstones");
+  schema->add_enumeration(enmr2);
+
+  auto attr3 = make_shared<Attribute>(HERE(), "attr3", Datatype::UINT8);
+  attr3->set_enumeration_name("flintstones");
+  throw_if_not_ok(schema->add_attribute(attr3));
 
   return schema;
 }
@@ -1923,6 +1978,18 @@ void EnumerationFx::ser_des_query(
       &(ctx_.resources().compute_tp())));
 }
 
+void EnumerationFx::ser_des_array(
+    Context& ctx,
+    Array* in,
+    Array* out,
+    bool client_side,
+    SerializationType stype) {
+  Buffer buf;
+  throw_if_not_ok(serialization::array_serialize(in, stype, &buf, client_side));
+  throw_if_not_ok(
+      serialization::array_deserialize(out, stype, buf, ctx.storage_manager()));
+}
+
 #else  // No TILEDB_SERIALIZATION
 
 ArraySchema EnumerationFx::ser_des_array_schema(
@@ -1936,6 +2003,11 @@ shared_ptr<ArraySchemaEvolution> EnumerationFx::ser_des_array_schema_evolution(
 }
 
 void EnumerationFx::ser_des_query(Query*, Query*, bool, SerializationType) {
+  throw std::logic_error("Serialization not enabled.");
+}
+
+void EnumerationFx::ser_des_array(
+    Context&, Array*, Array*, bool, SerializationType) {
   throw std::logic_error("Serialization not enabled.");
 }
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1103,6 +1103,16 @@ bool Array::serialize_non_empty_domain() const {
   return serialize_ned_array_open;
 }
 
+bool Array::serialize_enumerations() const {
+  auto serialize = config_.get<bool>("rest.load_enumerations_on_array_open");
+  if (!serialize.has_value()) {
+    throw std::runtime_error(
+        "Cannot get rest.load_enumerations_on_array_open configuration option "
+        "from config");
+  }
+  return serialize.value();
+}
+
 bool Array::serialize_metadata() const {
   auto found = false;
   auto serialize_metadata_array_open = false;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -537,6 +537,11 @@ class Array {
   bool serialize_non_empty_domain() const;
 
   /**
+   * Checks the config to se if enumerations should be serialized on array open.
+   */
+  bool serialize_enumerations() const;
+
+  /**
    * Checks the config to see if metadata should be serialized on array open.
    */
   bool serialize_metadata() const;

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -91,6 +91,7 @@ const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::REST_CURL_BUFFER_SIZE = "524288";
 const std::string Config::REST_CAPNP_TRAVERSAL_LIMIT = "536870912";
 const std::string Config::REST_CURL_VERBOSE = "false";
+const std::string Config::REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_USE_REFACTORED_ARRAY_OPEN = "false";
@@ -243,6 +244,9 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "rest.capnp_traversal_limit", Config::REST_CAPNP_TRAVERSAL_LIMIT),
     std::make_pair("rest.curl.verbose", Config::REST_CURL_VERBOSE),
+    std::make_pair(
+        "rest.load_enumerations_on_array_open",
+        Config::REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN),
     std::make_pair(
         "rest.load_metadata_on_array_open",
         Config::REST_LOAD_METADATA_ON_ARRAY_OPEN),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -102,6 +102,9 @@ class Config {
   /** The default for Curl's verbose mode used by REST. */
   static const std::string REST_CURL_VERBOSE;
 
+  /** If the array enumerations should be loaded on array open */
+  static const std::string REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN;
+
   /** If the array metadata should be loaded on array open */
   static const std::string REST_LOAD_METADATA_ON_ARRAY_OPEN;
 

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -134,6 +134,10 @@ Status array_to_capnp(
 
   array_builder->setQueryType(query_type_str(array->get_query_type()));
 
+  if (array->use_refactored_array_open() && array->serialize_enumerations()) {
+    array->load_all_enumerations();
+  }
+
   const auto& array_schema_latest = array->array_schema_latest();
   auto array_schema_latest_builder = array_builder->initArraySchemaLatest();
   RETURN_NOT_OK(array_schema_to_capnp(

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -940,22 +940,28 @@ Status array_schema_to_capnp(
   // Loaded enumerations
   auto loaded_enmr_names = array_schema.get_loaded_enumeration_names();
   const unsigned num_loaded_enmrs = loaded_enmr_names.size();
-  auto enmr_builders = array_schema_builder->initEnumerations(num_loaded_enmrs);
-  for (size_t i = 0; i < num_loaded_enmrs; i++) {
-    auto enmr = array_schema.get_enumeration(loaded_enmr_names[i]);
-    auto builder = enmr_builders[i];
-    enumeration_to_capnp(enmr, builder);
+  if (num_loaded_enmrs > 0) {
+    auto enmr_builders =
+        array_schema_builder->initEnumerations(num_loaded_enmrs);
+    for (size_t i = 0; i < num_loaded_enmrs; i++) {
+      auto enmr = array_schema.get_enumeration(loaded_enmr_names[i]);
+      auto builder = enmr_builders[i];
+      enumeration_to_capnp(enmr, builder);
+    }
   }
 
   // Enumeration path map
   auto enmr_names = array_schema.get_enumeration_names();
   const unsigned num_enmr_names = enmr_names.size();
-  auto enmr_path_map_builders =
-      array_schema_builder->initEnumerationPathMap(num_enmr_names);
-  for (size_t i = 0; i < num_enmr_names; i++) {
-    auto enmr_path_name = array_schema.get_enumeration_path_name(enmr_names[i]);
-    enmr_path_map_builders[i].setKey(enmr_names[i]);
-    enmr_path_map_builders[i].setValue(enmr_path_name);
+  if (num_enmr_names > 0) {
+    auto enmr_path_map_builders =
+        array_schema_builder->initEnumerationPathMap(num_enmr_names);
+    for (size_t i = 0; i < num_enmr_names; i++) {
+      auto enmr_path_name =
+          array_schema.get_enumeration_path_name(enmr_names[i]);
+      enmr_path_map_builders[i].setKey(enmr_names[i]);
+      enmr_path_map_builders[i].setValue(enmr_path_name);
+    }
   }
 
   return Status::Ok();


### PR DESCRIPTION
Add Enumeration v2 Serialization Support

This adds a new `rest.load_enumerations_on_array_open` config value that flags whether or not Enumerations should be loaded before the array is serialized and returned to the client.

---
TYPE: IMPROVEMENT
DESC: Add Enumeration v2 Serialization Support