### PR TITLE
Add Enumeration max size configuration

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -262,6 +262,8 @@ void check_save_to_file() {
   ss << "sm.dedup_coords false\n";
   ss << "sm.enable_signal_handlers true\n";
   ss << "sm.encryption_type NO_ENCRYPTION\n";
+  ss << "sm.enumerations_max_size 10485760\n";
+  ss << "sm.enumerations_max_total_size 52428800\n";
   ss << "sm.fragment_info.preload_mbrs false\n";
   ss << "sm.group.timestamp_end 18446744073709551615\n";
   ss << "sm.group.timestamp_start 0\n";
@@ -608,6 +610,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.encryption_type"] = "NO_ENCRYPTION";
   all_param_values["sm.dedup_coords"] = "false";
   all_param_values["sm.partial_tile_offsets_loading"] = "false";
+  all_param_values["sm.enumerations_max_size"] = "10485760";
+  all_param_values["sm.enumerations_max_total_size"] = "52428800";
   all_param_values["sm.check_coord_dups"] = "true";
   all_param_values["sm.check_coord_oob"] = "true";
   all_param_values["sm.check_global_order"] = "true";

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -917,13 +917,68 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
+    "ArraySchema - Large Single Enumeration",
+    "[enumeration][array-scehma][size-check]") {
+  auto schema = create_schema();
+  REQUIRE_NOTHROW(schema->check(cfg_));
+
+  std::vector<uint8_t> data(1024 * 1024 * 10 + 1);
+  std::vector<uint64_t> offsets = {0};
+  auto enmr = Enumeration::create(
+      "enmr_name",
+      Datatype::STRING_ASCII,
+      constants::var_num,
+      false,
+      data.data(),
+      data.size(),
+      offsets.data(),
+      offsets.size() * constants::cell_var_offset_size);
+
+  schema->add_enumeration(enmr);
+
+  // One single enumeration larger than 10MiB
+  auto matcher = Catch::Matchers::ContainsSubstring("has a size exceeding");
+  REQUIRE_THROWS_WITH(schema->check(cfg_), matcher);
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
+    "ArraySchema - Many Large Enumerations",
+    "[enumeration][array-scehma][size-check]") {
+  auto schema = create_schema();
+  REQUIRE_NOTHROW(schema->check(cfg_));
+
+  std::vector<uint8_t> data(1024 * 1024 * 5 + 1);
+  std::vector<uint64_t> offsets = {0};
+
+  // Create more than 50MiB of enumeration data
+  for (size_t i = 0; i < 10; i++) {
+    auto enmr = Enumeration::create(
+        "enmr_name_" + std::to_string(i),
+        Datatype::STRING_ASCII,
+        constants::var_num,
+        false,
+        data.data(),
+        data.size(),
+        offsets.data(),
+        offsets.size() * constants::cell_var_offset_size);
+    schema->add_enumeration(enmr);
+  }
+
+  // 10 enumerations each over 5MiB for more than 50MiB total.
+  auto matcher = Catch::Matchers::ContainsSubstring("Total enumeration size");
+  REQUIRE_THROWS_WITH(schema->check(cfg_), matcher);
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
     "ArraySchema - Schema Copy Constructor",
     "[enumeration][array-schema][copy-ctor]") {
   auto schema = create_schema();
 
   // Check that the schema is valid and that we can copy it using the
   // copy constructor.
-  CHECK_NOTHROW(schema->check());
+  CHECK_NOTHROW(schema->check(cfg_));
   CHECK_NOTHROW(make_shared<ArraySchema>(HERE(), *(schema.get())));
 }
 

--- a/tiledb/api/c_api/context/context_api_internal.h
+++ b/tiledb/api/c_api/context/context_api_internal.h
@@ -59,9 +59,14 @@ struct tiledb_ctx_handle_t
     return ctx_;
   }
 
+  inline tiledb::sm::ContextResources& resources() {
+    return ctx_.resources();
+  }
+
   inline tiledb::sm::StorageManager* storage_manager() {
     return ctx_.storage_manager();
   }
+
   inline optional<std::string> last_error() {
     return ctx_.last_error();
   }

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -228,7 +228,12 @@ class ArraySchema {
    *
    * Throws if validation fails
    */
-  void check() const;
+  void check(const Config& cfg) const;
+
+  /**
+   * Checks the correctness of the array schema without config access.
+   */
+  void check_without_config() const;
 
   /**
    * Throws an error if the provided schema does not match the definition given
@@ -701,8 +706,8 @@ class ArraySchema {
 
   void check_webp_filter() const;
 
-  // Check whether attributes referencing enumerations are valid.
-  void check_enumerations() const;
+  // Check enumeration sizes are below the configured maximums.
+  void check_enumerations(const Config& cfg) const;
 
   /** Clears all members. Use with caution! */
   void clear();

--- a/tiledb/sm/array_schema/dimension_label.cc
+++ b/tiledb/sm/array_schema/dimension_label.cc
@@ -182,7 +182,7 @@ DimensionLabel::DimensionLabel(
   throw_if_not_ok(schema_->add_attribute(label_attr));
 
   // Check the array schema is valid.
-  schema_->check();
+  schema_->check_without_config();
 }
 
 // FORMAT:

--- a/tiledb/sm/array_schema/test/unit_array_schema.cc
+++ b/tiledb/sm/array_schema/test/unit_array_schema.cc
@@ -91,7 +91,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
   auto schema{test_schema.second.schema()};
 
   DYNAMIC_SECTION("Base schema is valid - " + name) {
-    REQUIRE_NOTHROW(schema.check());
+    REQUIRE_NOTHROW(schema.check_without_config());
   }
 
   DYNAMIC_SECTION("Dimension names must be unique - " + name) {
@@ -108,7 +108,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
      * If this changes the following check will fail.
      */
     CHECK(st.ok());
-    REQUIRE_THROWS(schema.check());
+    REQUIRE_THROWS(schema.check_without_config());
   }
 
   DYNAMIC_SECTION("Attribute names must be unique - " + name) {
@@ -120,7 +120,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
      * If this changes the following check will fail.
      */
     CHECK(st.ok());
-    REQUIRE_THROWS(schema.check());
+    REQUIRE_THROWS(schema.check_without_config());
   }
 
   DYNAMIC_SECTION("Label names must be unique - " + name) {
@@ -139,7 +139,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
      * If this changes the following check will fail.
      */
     CHECK(st.ok());
-    REQUIRE_THROWS(schema.check());
+    REQUIRE_THROWS(schema.check_without_config());
   }
 
   DYNAMIC_SECTION("Label name may not be a dimension name - " + name) {
@@ -150,7 +150,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
   DYNAMIC_SECTION("Label name may not be a dimension name 2 - " + name) {
     schema.add_dimension_label(
         0, "x", DataOrder::INCREASING_DATA, Datatype::FLOAT64, false);
-    REQUIRE_THROWS(schema.check());
+    REQUIRE_THROWS(schema.check_without_config());
   }
 
   DYNAMIC_SECTION("Label name may really not be a dimension name - " + name) {
@@ -158,7 +158,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
         0, "x", DataOrder::INCREASING_DATA, Datatype::FLOAT64, false);
     schema.add_dimension_label(
         0, "x", DataOrder::INCREASING_DATA, Datatype::FLOAT64, false);
-    REQUIRE_THROWS(schema.check());
+    REQUIRE_THROWS(schema.check_without_config());
   }
 
   DYNAMIC_SECTION("Label name may not be an attribute name - " + name) {
@@ -171,7 +171,7 @@ TEST_CASE("Repeated names in schema columns", "[array_schema]") {
     // final 'false' argument suppresses verification of unique names
     schema.add_dimension_label(
         0, "a", DataOrder::INCREASING_DATA, Datatype::FLOAT64, false);
-    REQUIRE_THROWS(schema.check());
+    REQUIRE_THROWS(schema.check_without_config());
   }
 }
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -449,7 +449,7 @@ int32_t tiledb_array_schema_check(
     tiledb_ctx_t* ctx, tiledb_array_schema_t* array_schema) {
   if (sanity_check(ctx, array_schema) == TILEDB_ERR)
     return TILEDB_ERR;
-  array_schema->array_schema_->check();
+  array_schema->array_schema_->check(ctx->resources().config());
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -156,6 +156,8 @@ const std::string Config::SM_GROUP_TIMESTAMP_START = "0";
 const std::string Config::SM_GROUP_TIMESTAMP_END = std::to_string(UINT64_MAX);
 const std::string Config::SM_FRAGMENT_INFO_PRELOAD_MBRS = "false";
 const std::string Config::SM_PARTIAL_TILE_OFFSETS_LOADING = "false";
+const std::string Config::SM_ENUMERATIONS_MAX_SIZE = "10485760";        // 10MiB
+const std::string Config::SM_ENUMERATIONS_MAX_TOTAL_SIZE = "52428800";  // 50MiB
 const std::string Config::SSL_CA_FILE = "";
 const std::string Config::SSL_CA_PATH = "";
 const std::string Config::SSL_VERIFY = "true";
@@ -363,6 +365,11 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "sm.partial_tile_offsets_loading",
         Config::SM_PARTIAL_TILE_OFFSETS_LOADING),
+    std::make_pair(
+        "sm.enumerations_max_size", Config::SM_ENUMERATIONS_MAX_SIZE),
+    std::make_pair(
+        "sm.enumerations_max_total_size",
+        Config::SM_ENUMERATIONS_MAX_TOTAL_SIZE),
     std::make_pair("ssl.ca_file", Config::SSL_CA_FILE),
     std::make_pair("ssl.ca_path", Config::SSL_CA_PATH),
     std::make_pair("ssl.verify", Config::SSL_VERIFY),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -371,6 +371,12 @@ class Config {
   /** If `true` the readers might partially load/unload tile offsets. */
   static const std::string SM_PARTIAL_TILE_OFFSETS_LOADING;
 
+  /** The maximum size of a single enumeration. */
+  static const std::string SM_ENUMERATIONS_MAX_SIZE;
+
+  /** The maximum total size for all enumerations in a schema. */
+  static const std::string SM_ENUMERATIONS_MAX_TOTAL_SIZE;
+
   /** Certificate file path. */
   static const std::string SSL_CA_FILE;
 

--- a/tiledb/sm/serialization/test/unit_capnp_array_schema.cc
+++ b/tiledb/sm/serialization/test/unit_capnp_array_schema.cc
@@ -113,7 +113,7 @@ TEST_CASE(
     st = schema->add_attribute(
         make_shared<Attribute>(HERE(), "label", Datatype::FLOAT64));
     REQUIRE(st.ok());
-    schema->check();
+    schema->check_without_config();
 
     // Create dimension label.
     dim_label = make_shared<DimensionLabel>(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -635,7 +635,7 @@ Status StorageManagerCanonical::array_create(
   std::lock_guard<std::mutex> lock{object_create_mtx_};
   array_schema->set_array_uri(array_uri);
   RETURN_NOT_OK(array_schema->generate_uri());
-  array_schema->check();
+  array_schema->check(config_);
 
   // Create array directory
   RETURN_NOT_OK(vfs()->create_dir(array_uri));


### PR DESCRIPTION
By default, an Enumeration can only be 10MiB or less data, and the total combined sizes of all schemas must be less than 50MiB.

---
TYPE: IMPROVEMENT
DESC: Add Enumeration max size configuration
