### PR TITLE
Fix regression test exit status; fix unhandled throw (expected)

### DIFF
--- a/test/regression/regression.cc
+++ b/test/regression/regression.cc
@@ -8,5 +8,5 @@ int main(const int argc, char** const argv) {
   if (rc != 0)
     return rc;
 
-  session.run();
+  return session.run();
 }

--- a/test/regression/targets/sc-19240_cppapi-vfs-exception.cc
+++ b/test/regression/targets/sc-19240_cppapi-vfs-exception.cc
@@ -13,7 +13,9 @@ TEST_CASE(
 
   const std::string uri{"/dir/not/exists/hello.txt"};
 
-  /* currently segfaults (11/July/2022) */
-  REQUIRE(fb.open(uri, std::ios::out));
-  fb.close();
+  fb.open(uri, std::ios::out);
+  // Previously segfaulted, before fix in PR 3360,
+  // now expected to throw. The throw happens here
+  // because VFS::filebuf is a streambuf API.
+  REQUIRE_THROWS(fb.close());
 }


### PR DESCRIPTION
tiledb_regression was not returning the session 2 status, so section failures did not lead to overall failure status of the runner executable.

This masked an unhandled throw in one test, which is otherwise expected to throw (rather than segfault) because the corresponding fix was already committed.

---
TYPE: BUG
DESC: Fix regression test exit status; fix unhandled throw (expected)