### PR TITLE
Use generator expressions when setting compile options for the benchmarks.

### DIFF
--- a/test/benchmarking/src/CMakeLists.txt
+++ b/test/benchmarking/src/CMakeLists.txt
@@ -34,18 +34,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
-if (WIN32)
-  if (CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(/DDEBUG /Od /Zi)
-  elseif (CMAKE_BUILD_TYPE MATCHES "Release")
-    add_compile_options(/DNDEBUG /Ox)
-  endif()
+if (MSVC)
+  add_compile_options("$<$<CONFIG:Debug>:/DDEBUG;/Od;/Zi>")
+  add_compile_options("$<$<CONFIG:Release>:/DNDEBUG;/Ox>")
 else()
-  if (CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(-DDEBUG -O0 -g3 -ggdb3 -gdwarf-3)
-  elseif (CMAKE_BUILD_TYPE MATCHES "Release")
-    add_compile_options(-DNDEBUG -O3)
-  endif()
+  add_compile_options("$<$<CONFIG:Debug>:-DDEBUG;-O0;-g3;-ggdb3;-gdwarf-3>")
+  add_compile_options("$<$<CONFIG:Release>:-DNDEBUG;-O3>")
 endif()
 
 # Find TileDB


### PR DESCRIPTION
Contributes to SC-32877.

---
TYPE: BUILD
DESC: Use generator expressions when setting compile options for the benchmarks.