### PR TITLE
Improve missing enumeration value error message

### DIFF
--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -372,6 +372,34 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CPPEnumerationFx,
+    "CPP: Enumeration Query - Invalid Enumeration Value",
+    "[enumeration][query][basic]") {
+  create_array();
+
+  // Attempt to query with an enumeration value that isn't in the Enumeration
+  QueryCondition qc(ctx_);
+  qc.init("attr1", "alf", 4, TILEDB_EQ);
+
+  // Execute the query condition against the array
+  std::vector<int> dim(5);
+  std::vector<int> attr1(5);
+
+  auto array = Array(ctx_, uri_, TILEDB_READ);
+  Query query(ctx_, array);
+  query.add_range("dim", 1, 5)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("dim", dim)
+      .set_data_buffer("attr1", attr1)
+      .set_condition(qc);
+
+  // Check that the error message is helpful to users.
+  auto matcher = Catch::Matchers::ContainsSubstring(
+      "Enumeration value not found for field 'attr1'");
+  REQUIRE_THROWS_WITH(query.submit(), matcher);
+}
+
+TEST_CASE_METHOD(
+    CPPEnumerationFx,
     "CPP: Enumeration Query - Set Use Enumeration",
     "[enumeration][query][set-use-enumeration]") {
   QueryCondition qc(ctx_);

--- a/tiledb/sm/query/ast/query_ast.cc
+++ b/tiledb/sm/query/ast/query_ast.cc
@@ -199,6 +199,10 @@ void ASTNodeVal::rewrite_enumeration_conditions(
 
   if (op_ != QueryConditionOp::IN && op_ != QueryConditionOp::NOT_IN) {
     auto idx = enumeration->index_of(get_value_ptr(), get_value_size());
+    if (idx == constants::enumeration_missing_value) {
+      throw std::invalid_argument(
+          "Enumeration value not found for field '" + attr->name() + "'");
+    }
 
     data_ = ByteVecValue(val_size);
     utils::safe_integral_cast_to_datatype(idx, attr->type(), data_);
@@ -215,6 +219,11 @@ void ASTNodeVal::rewrite_enumeration_conditions(
 
     for (auto& member : members_) {
       auto idx = enumeration->index_of(member.data(), member.size());
+      if (idx == constants::enumeration_missing_value) {
+        throw std::invalid_argument(
+            "Enumeration value not found for field '" + attr->name() + "'");
+      }
+
       utils::safe_integral_cast_to_datatype(idx, attr->type(), curr_data);
       data_writer.write(curr_data.data(), curr_data.size());
       offsets_writer.write(curr_offset);


### PR DESCRIPTION
Previously, the error message was a cryptic message about a failed integral cast which is terrible for user experience. This updates things to make the error message specifically state that the enumeration value wasn't found.

---
TYPE: IMPROVEMENT
DESC: Fix enumeration value not found error message