### PR TITLE
Switch to TileDB-Inc/github-actions/open-issue

### DIFF
--- a/.github/workflows/nightly-failure-issue-template.md
+++ b/.github/workflows/nightly-failure-issue-template.md
@@ -1,8 +1,0 @@
----
-title: Nightly GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: ihnorton, teo-tsirpanis, davisp
-labels: nightly
----
-
-See run for more details:
-https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -27,8 +27,6 @@ jobs:
     name: |
       ${{ matrix.os }} - Sanitizer: ${{ matrix.sanitizer || 'none' }} | Experimental: ${{ matrix.experimental || 'OFF' }} | ${{ matrix.config || 'Release' }}
 
-    permissions:
-      issues: write
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15
       TILEDB_NIGHTLY_BUILD: 1
@@ -62,6 +60,8 @@ jobs:
           cmake --build build --target check --config ${{ matrix.config || 'Release' }}
 
   create_issue_on_fail:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     needs: test
     if: failure() || cancelled()
@@ -69,8 +69,8 @@ jobs:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v3
       - name: Create Issue if Build Fails
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: TileDB-Inc/github-actions/open-issue@main
         with:
-          filename: .github/workflows/nightly-failure-issue-template.md
+          name: nightly GitHub Actions build
+          label: nightly
+          assignee: ihnorton,teo-tsirpanis,davisp


### PR DESCRIPTION
After a nightly build failure, report it using the new centralized GitHub Action [open-issue](https://github.com/TileDB-Inc/github-actions/tree/main/open-issue). It will comment on an open Issue with the provided label, eg #4333, instead of opening a new Issue every night

xref: #3081, https://github.com/TileDB-Inc/TileDB-Py/pull/1821
cc: @ihnorton 

---
TYPE: NO_HISTORY
DESC: Switch to TileDB-Inc/github-actions/open-issue
