### PR TITLE
tiledb_vfs_open is not reporting error correctly

### DIFF
--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -290,7 +290,7 @@ void VFSFx::check_vfs(const std::string& path) {
   rc = tiledb_vfs_is_file(ctx_, vfs_, foo_file.c_str(), &is_file);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(!is_file);
-  tiledb_vfs_fh_t* fh;
+  tiledb_vfs_fh_t* fh = nullptr;
   rc = tiledb_vfs_open(ctx_, vfs_, foo_file.c_str(), TILEDB_VFS_READ, &fh);
   REQUIRE(rc == TILEDB_ERR);
   REQUIRE(fh == nullptr);

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -529,10 +529,6 @@ TEST_CASE("C API: tiledb_vfs_open argument validation", "[capi][vfs]") {
     CHECK(tiledb_status(rc) == TILEDB_OK);
     CHECK(vfs_fh != nullptr);
     tiledb_vfs_fh_free(&vfs_fh);
-
-    // An empty file is created by the destruction of the handle during closing
-    // of the file handle, it needs to be removed here
-    tiledb_vfs_remove_file(x.ctx, x.vfs, TEST_URI);
   }
   SECTION("null context") {
     auto rc{

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -666,8 +666,8 @@ TEST_CASE(
 
   tiledb_error_t* error = nullptr;
 
-  capi_return_t rc =
-      tiledb_vfs_open(x.ctx, x.vfs, TEST_URI, TILEDB_VFS_READ, &vfs_fh);
+  capi_return_t rc = tiledb_vfs_open(
+      x.ctx, x.vfs, "doesnotexistfile", TILEDB_VFS_READ, &vfs_fh);
   REQUIRE(tiledb_status(rc) == TILEDB_ERR);
 
   rc = tiledb_ctx_get_last_error(x.ctx, &error);

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -529,6 +529,10 @@ TEST_CASE("C API: tiledb_vfs_open argument validation", "[capi][vfs]") {
     CHECK(tiledb_status(rc) == TILEDB_OK);
     CHECK(vfs_fh != nullptr);
     tiledb_vfs_fh_free(&vfs_fh);
+
+    // An empty file is created by the destruction of the handle during closing
+    // of the file handle, it needs to be removed here
+    tiledb_vfs_remove_file(x.ctx, x.vfs, TEST_URI);
   }
   SECTION("null context") {
     auto rc{

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -658,3 +658,20 @@ TEST_CASE("C API: tiledb_vfs_fh_is_closed argument validation", "[capi][vfs]") {
 TEST_CASE("C API: tiledb_vfs_fh_free argument validation", "[capi][vfs]") {
   REQUIRE_NOTHROW(tiledb_vfs_fh_free(nullptr));
 }
+
+TEST_CASE(
+    "C API: tiledb_vfs_open reports error when open fails", "[capi][vfs]") {
+  ordinary_vfs x;
+  tiledb_vfs_fh_handle_t* vfs_fh;
+
+  tiledb_error_t* error = nullptr;
+
+  capi_return_t rc =
+      tiledb_vfs_open(x.ctx, x.vfs, TEST_URI, TILEDB_VFS_READ, &vfs_fh);
+  REQUIRE(tiledb_status(rc) == TILEDB_ERR);
+
+  rc = tiledb_ctx_get_last_error(x.ctx, &error);
+  REQUIRE(tiledb_status(rc) == TILEDB_OK);
+
+  CHECK(error != nullptr);
+}

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -216,6 +216,7 @@ capi_return_t tiledb_vfs_copy_dir(
 }
 
 capi_return_t tiledb_vfs_open(
+    tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
     tiledb_vfs_mode_t mode,
@@ -234,6 +235,7 @@ capi_return_t tiledb_vfs_open(
   // Open VFS file
   auto st{(*fh)->open()};
   if (!st.ok()) {
+    save_error(ctx, st);
     tiledb_vfs_fh_t::break_handle(*fh);
     return TILEDB_ERR;
   }
@@ -320,6 +322,7 @@ capi_return_t tiledb_vfs_touch(tiledb_vfs_t* vfs, const char* uri) {
 
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_plain;
+using tiledb::api::api_entry_with_context;
 
 capi_return_t tiledb_vfs_mode_to_str(
     tiledb_vfs_mode_t vfs_mode, const char** str) noexcept {
@@ -475,7 +478,7 @@ capi_return_t tiledb_vfs_open(
     const char* uri,
     tiledb_vfs_mode_t mode,
     tiledb_vfs_fh_t** fh) noexcept {
-  return api_entry_context<tiledb::api::tiledb_vfs_open>(
+  return api_entry_with_context<tiledb::api::tiledb_vfs_open>(
       ctx, vfs, uri, mode, fh);
 }
 

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -239,11 +239,7 @@ capi_return_t tiledb_vfs_open(
 capi_return_t tiledb_vfs_close(tiledb_vfs_fh_t* fh) {
   ensure_output_pointer_is_valid(fh);
   ensure_vfs_fh_is_valid(fh);
-
-  // There is no way ro re-open a tiledb_vfs_fh_t without recreating
-  // the handle, so there is no point to have a close API anymore,
-  // thus this is a noop, closing is handled by handle destructor,
-  // api should be deprecated in the future.
+  throw_if_not_ok(fh->close());
   return TILEDB_OK;
 }
 
@@ -305,9 +301,7 @@ void tiledb_vfs_fh_free(tiledb_vfs_fh_t** fh) {
 capi_return_t tiledb_vfs_fh_is_closed(tiledb_vfs_fh_t* fh, int32_t* is_closed) {
   ensure_vfs_fh_is_valid(fh);
   ensure_output_pointer_is_valid(is_closed);
-  // This should eventually be deprecated as there
-  // is no way to have a file handle which isn't open.
-  *is_closed = false;
+  *is_closed = !fh->is_open();
   return TILEDB_OK;
 }
 

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -165,14 +165,10 @@ struct tiledb_vfs_fh_handle_t
       tiledb::sm::VFS* vfs,
       tiledb::sm::VFSMode mode)
       : vfs_fh_{uri, vfs, mode} {
+    throw_if_not_ok(vfs_fh_.open());
   }
-
-  Status open() {
-    return vfs_fh_.open();
-  }
-
-  Status close() {
-    return vfs_fh_.close();
+  ~tiledb_vfs_fh_handle_t() {
+    throw_if_not_ok(vfs_fh_.close());
   }
 
   Status read(uint64_t offset, void* buffer, uint64_t nbytes) {
@@ -185,10 +181,6 @@ struct tiledb_vfs_fh_handle_t
 
   Status sync() {
     return vfs_fh_.sync();
-  }
-
-  bool is_open() const {
-    return vfs_fh_.is_open();
   }
 };
 

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -167,8 +167,13 @@ struct tiledb_vfs_fh_handle_t
       : vfs_fh_{uri, vfs, mode} {
     throw_if_not_ok(vfs_fh_.open());
   }
-  ~tiledb_vfs_fh_handle_t() {
-    throw_if_not_ok(vfs_fh_.close());
+
+  Status open() {
+    return vfs_fh_.open();
+  }
+
+  Status close() {
+    return vfs_fh_.close();
   }
 
   Status read(uint64_t offset, void* buffer, uint64_t nbytes) {
@@ -181,6 +186,10 @@ struct tiledb_vfs_fh_handle_t
 
   Status sync() {
     return vfs_fh_.sync();
+  }
+
+  bool is_open() const {
+    return vfs_fh_.is_open();
   }
 };
 


### PR DESCRIPTION
Save error on the context before returning error code.

---
TYPE: BUG
DESC: tiledb_vfs_open is not reporting error correcly
