### PR TITLE
Run Windows nightly debug build on C:/ drive to avoid out of space er…

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -22,6 +22,8 @@ jobs:
           - os: windows-2019
           - os: windows-latest
             config: "Debug"
+            # Insufficient space on default D:/ for debug build
+            working_directory: "C:/"
       fail-fast: false
 
     name: |
@@ -43,19 +45,23 @@ jobs:
         env:
           SANITIZER_ARG: ${{ matrix.sanitizer || 'OFF' }}
           EXPERIMENTAL: ${{ matrix.experimental || 'OFF' }}
+        working-directory: ${{ matrix.working_directory || github.workspace }}
         run: |
-          cmake -B build -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DTILEDB_EXPERIMENTAL_FEATURES=$EXPERIMENTAL -DCMAKE_BUILD_TYPE=${{ matrix.config || 'Release' }} -DSANITIZER=$SANITIZER_ARG
+          cmake -B build -DTILEDB_VCPKG=ON -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DTILEDB_EXPERIMENTAL_FEATURES=$EXPERIMENTAL -DCMAKE_BUILD_TYPE=${{ matrix.config || 'Release' }} -DSANITIZER=$SANITIZER_ARG
 
       - name: Configure TileDB CMake (Windows)
         if: contains(matrix.os, 'windows')
+        working-directory: ${{ matrix.working_directory || github.workspace }}
         run: |
-          cmake -B build -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=${{ matrix.config || 'Release' }}
+          cmake -B build -S $env:GITHUB_WORKSPACE -DTILEDB_VCPKG=ON -DTILEDB_WERROR=ON -DTILEDB_SERIALIZATION=ON -DCMAKE_BUILD_TYPE=${{ matrix.config || 'Release' }}
 
       - name: Build TileDB
+        working-directory: ${{ matrix.working_directory || github.workspace }}
         run: |
           cmake --build build -j2 --config ${{ matrix.config || 'Release' }}
 
       - name: Test TileDB
+        working-directory: ${{ matrix.working_directory || github.workspace }}
         run: |
           cmake --build build --target check --config ${{ matrix.config || 'Release' }}
 


### PR DESCRIPTION
…rors

---
TYPE: BUILD
DESC: Run Windows nightly debug build on C:/ drive to avoid out of space errors.