### PR TITLE
Compilation fix for GCC 9.4 of Ubuntu 20.04

### DIFF
--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -48,7 +48,7 @@
 #include <vector>
 
 // Workaround for GCC < 5.0
-#if not defined(__clang__) && __GNUG__ && __GNUC__ < 5
+#if !defined(__clang__) && __GNUC__ && __GNUC__ < 5
 #define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
 #else
 #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -47,7 +47,6 @@
 #include <type_traits>
 #include <vector>
 
-
 #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
 
 namespace tiledb {

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -47,12 +47,8 @@
 #include <type_traits>
 #include <vector>
 
-// Workaround for GCC < 5.0
-#if !defined(__clang__) && __GNUC__ && __GNUC__ < 5
-#define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
-#else
+
 #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
-#endif
 
 namespace tiledb {
 


### PR DESCRIPTION
gcc 9.4 doesn't like "not defined"
And there was a typo __GNUG__ --> __GNUC__

This should be backported to the 2.17 branch

---
TYPE: CPP_API
DESC: Compilation fix for GCC 9.4 of Ubuntu 20.04
