### PR TITLE
Fix UBSAN error in the Enumeration CPP API

### DIFF
--- a/tiledb/sm/cpp_api/enumeration_experimental.h
+++ b/tiledb/sm/cpp_api/enumeration_experimental.h
@@ -239,17 +239,14 @@ class Enumeration {
       const std::string& name,
       std::vector<T>& values,
       bool ordered = false,
-      tiledb_datatype_t type = static_cast<tiledb_datatype_t>(255)) {
+      std::optional<tiledb_datatype_t> type = std::nullopt) {
     using DataT = impl::TypeHandler<T>;
-
-    if (type == static_cast<tiledb_datatype_t>(255)) {
-      type = DataT::tiledb_type;
-    }
+    tiledb_datatype_t dtype = type.value_or(DataT::tiledb_type);
 
     return create(
         ctx,
         name,
-        type,
+        dtype,
         DataT::tiledb_num,
         ordered,
         values.data(),
@@ -275,14 +272,11 @@ class Enumeration {
       const std::string& name,
       std::vector<std::basic_string<T>>& values,
       bool ordered = false,
-      tiledb_datatype_t type = static_cast<tiledb_datatype_t>(255)) {
+      std::optional<tiledb_datatype_t> type = std::nullopt) {
     using DataT = impl::TypeHandler<T>;
     static_assert(
         DataT::tiledb_num == 1, "Enumeration string values cannot be compound");
-
-    if (type == static_cast<tiledb_datatype_t>(255)) {
-      type = DataT::tiledb_type;
-    }
+    tiledb_datatype_t dtype = type.value_or(DataT::tiledb_type);
 
     uint64_t total_size = 0;
     for (auto v : values) {
@@ -303,7 +297,7 @@ class Enumeration {
     return create(
         ctx,
         name,
-        type,
+        dtype,
         TILEDB_VAR_NUM,
         ordered,
         data.data(),


### PR DESCRIPTION
Apparently one of our many build chains decided that faking a default parameter for a `tiledb_datatype_t` is undefined behavior, which, fair enough. The fix should be to just use a std::optional instead.

---
TYPE: BUG
DESC: Fix UBSAN error in the Enumeration CPP API
