### PR TITLE
Find the OpenSSL dependency of the AWS SDK on non-Windows only.

### DIFF
--- a/ports/aws-sdk-cpp/003-fix-AWSSDKCONFIG.patch
+++ b/ports/aws-sdk-cpp/003-fix-AWSSDKCONFIG.patch
@@ -2,18 +2,20 @@ diff --git a/cmake/AWSSDKConfig.cmake b/cmake/AWSSDKConfig.cmake
 index c2f643e..4fb4a2f 100644
 --- a/cmake/AWSSDKConfig.cmake
 +++ b/cmake/AWSSDKConfig.cmake
-@@ -24,6 +24,10 @@ if(AWSSDK_FOUND)
+@@ -24,6 +24,12 @@ if(AWSSDK_FOUND)
      return()
  endif()
  
 +include(CMakeFindDependencyMacro)
++if (NOT WIN32)
 +find_dependency(OpenSSL)
++endif()
 +find_dependency(ZLIB)
 +
  include(${CMAKE_CURRENT_LIST_DIR}/AWSSDKConfigVersion.cmake)
  include(${CMAKE_CURRENT_LIST_DIR}/sdksCommon.cmake)
  include(${CMAKE_CURRENT_LIST_DIR}/platformDeps.cmake)
-@@ -43,7 +47,6 @@ endif()
+@@ -43,7 +49,6 @@ endif()
  
  # On Windows, dlls are treated as runtime target and installed in bindir
  if (WIN32 AND AWSSDK_INSTALL_AS_SHARED_LIBS)
@@ -21,7 +23,7 @@ index c2f643e..4fb4a2f 100644
      # If installed CMake scripts are associated with dll library, define USE_IMPORT_EXPORT for customers
      add_definitions(-DUSE_IMPORT_EXPORT)
  endif()
-@@ -54,7 +57,6 @@ endif()
+@@ -54,7 +59,6 @@ endif()
  get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
  get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${AWSSDK_DEFAULT_ROOT_DIR}" PATH)
  get_filename_component(AWSSDK_DEFAULT_ROOT_DIR "${AWSSDK_DEFAULT_ROOT_DIR}" PATH)


### PR DESCRIPTION
The vcpkg port of `aws-sdk-cpp` declares OpenSSL to be a Windows-only dependency, but a patch calls `find_dependency(OpenSSL)` on all platforms. This PR updates the patch to call it only on non-Windows platforms.

Tested locally by successfully running a configure.

---
TYPE: BUILD
DESC: Find the OpenSSL dependency of the AWS SDK on non-Windows only.