### PR TITLE
Reduce rtools40 matrix down to the ucrt build used by R since 4.2

### DIFF
--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -8,8 +8,6 @@ jobs:
     strategy:
       matrix:
         include: [
-          #{ msystem: MINGW64, toolchain: x86_64 },
-          #{ msystem: MINGW32, toolchain: i686 },
           { msystem: ucrt64, toolchain: "ucrt-x86_64" }
         ]
       fail-fast: false

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         include: [
-          { msystem: MINGW64, toolchain: x86_64 },
-          { msystem: MINGW32, toolchain: i686 },
+          #{ msystem: MINGW64, toolchain: x86_64 },
+          #{ msystem: MINGW32, toolchain: i686 },
           { msystem: ucrt64, toolchain: "ucrt-x86_64" }
         ]
       fail-fast: false


### PR DESCRIPTION
The other two variants are for 32 and 64 bit builds under the preceding setup and no longer needed.

---
TYPE: IMPROVEMENT
DESC: Require only ucrt build from Rtools
