### PR TITLE
Fix Enumeration API when passed std::vector<bool>

### DIFF
--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -60,6 +60,22 @@ const static std::string dump_name = "enumeration_dump_test.txt";
 
 TEST_CASE_METHOD(
     CPPEnumerationFx,
+    "CPP: Enumeration API - Create Boolean",
+    "[enumeration][create][bool]") {
+  std::vector<bool> values = {true, false};
+  auto enmr = Enumeration::create(ctx_, enmr_name, values);
+  REQUIRE(enmr.ptr() != nullptr);
+  REQUIRE(enmr.name() == enmr_name);
+  REQUIRE(enmr.type() == TILEDB_BOOL);
+  REQUIRE(enmr.cell_val_num() == 1);
+  REQUIRE(enmr.ordered() == false);
+
+  auto data = enmr.as_vector<bool>();
+  REQUIRE(data == values);
+}
+
+TEST_CASE_METHOD(
+    CPPEnumerationFx,
     "CPP: Enumeration API - Create Fixed Size",
     "[enumeration][create][fixed-size]") {
   std::vector<int> values = {1, 2, 3, 4, 5};


### PR DESCRIPTION
I forgot to account for the fact that `std::vector<bool>` is a specialized template which uses an internal bitmap instead of a standard backing array.

Also note that boolean enumerations can be created, they just have to use a `std::vector<uint8_t>` and manually specify the data type like such:

```c++
std::vector<uint8_t> values = {0, 1};
auto enmr = Enumeration::create(ctx, "my_enmr", values, false, TILEDB_BOOL);
```

---
TYPE: BUG
DESC: Fix creation of Enumerations with `std::vector<bool>`
