### PR TITLE
Add HDFS to `as_built`.

### DIFF
--- a/test/src/unit-capi-as_built.cc
+++ b/test/src/unit-capi-as_built.cc
@@ -129,6 +129,12 @@ TEST_CASE(
   CHECK(x["gcs"]["enabled"] == false);
 #endif  // HAVE_GCS
 
+#ifdef HAVE_HDFS
+  CHECK(x["hdfs"]["enabled"] == true);
+#else
+  CHECK(x["hdfs"]["enabled"] == false);
+#endif  // HAVE_HDFS
+
 #ifdef HAVE_S3
   CHECK(x["s3"]["enabled"] == true);
 #else

--- a/tiledb/as_built/storage_backends.h
+++ b/tiledb/as_built/storage_backends.h
@@ -55,6 +55,12 @@ static constexpr bool gcs = true;
 static constexpr bool gcs = false;
 #endif  // HAVE_GCS
 
+#ifdef HAVE_HDFS
+static constexpr bool hdfs = true;
+#else
+static constexpr bool hdfs = false;
+#endif  // HAVE_HDFS
+
 #ifdef HAVE_S3
 static constexpr bool s3 = true;
 #else
@@ -70,6 +76,7 @@ void to_json(json& j, const storage_backends&) {
   j = {
       {"azure", {{"enabled", azure}}},
       {"gcs", {{"enabled", gcs}}},
+      {"hdfs", {{"enabled", hdfs}}},
       {"s3", {{"enabled", s3}}}};
 }
 

--- a/tiledb/as_built/test/unit_as_built.cc
+++ b/tiledb/as_built/test/unit_as_built.cc
@@ -118,6 +118,12 @@ TEST_CASE(
   CHECK(x["gcs"]["enabled"] == false);
 #endif  // HAVE_GCS
 
+#ifdef HAVE_HDFS
+  CHECK(x["hdfs"]["enabled"] == true);
+#else
+  CHECK(x["hdfs"]["enabled"] == false);
+#endif  // HAVE_HDFS
+
 #ifdef HAVE_S3
   CHECK(x["s3"]["enabled"] == true);
 #else


### PR DESCRIPTION
[SC-34351](https://app.shortcut.com/tiledb-inc/story/34351/hdfs-is-missing-from-as-built)

---
TYPE: BUG
DESC: Specify whether the HDFS backend is enabled in the string returned by `tiledb_as_built_dump`.