### PR TITLE
[cppapi] Fix sc-34380: don't error out if DELETE symbol is defined

### DIFF
--- a/tiledb/api/c_api/query/query_api_enum.h
+++ b/tiledb/api/c_api/query/query_api_enum.h
@@ -35,18 +35,7 @@
   /** Write query */
   TILEDB_QUERY_TYPE_ENUM(WRITE) = 1,
   /** Delete query */
-  #if (defined(DELETE))
-  // note: 'DELETE' is #define'd somewhere within windows headers as
-  // something resolving to '(0x00010000L)', which causes problems with
-  // query_type.h which does not qualify the 'id' like tiledb.h does.
-  // #undef DELETE
-  #error "'DELETE' should not be defined before now in tiledb_enum.h.\nHas it seeped out from include of windows.h somewhere that needs changing?\n(Catch2 includes have been a past culprit.)\nFind error message in tiledb_enum.h for more information."
-  // If this is encountered 'too often', further consideration might be given to
-  // simply qualifying the currently unqualified definition of TILEDB_QUERY_TYPE_ENUM in
-  // query_type.h so 'DELETE' and any other enum items here would not collide with this
-  // windows definition known to be in conflict.
-  #endif
-  TILEDB_QUERY_TYPE_ENUM(DELETE) = 2,
+  TILEDB_QUERY_TYPE_ENUM_CONCAT_ID(DEL,ETE) = 2,
   /** Update query */
   TILEDB_QUERY_TYPE_ENUM(UPDATE) = 3,
   /** Exclusive Modification query */

--- a/tiledb/api/c_api/query/query_api_external.h
+++ b/tiledb/api/c_api/query/query_api_external.h
@@ -45,8 +45,12 @@ typedef struct tiledb_query_t tiledb_query_t;
 typedef enum {
 /** Helper macro for defining query type enums. */
 #define TILEDB_QUERY_TYPE_ENUM(id) TILEDB_##id
+// Use token-pasting _CONCAT_ID version for precarious symbols
+// (such as DELETE, see `query_api_enum.h`)
+#define TILEDB_QUERY_TYPE_ENUM_CONCAT_ID(id, id2) TILEDB_##id##id2
 #include "tiledb/api/c_api/query/query_api_enum.h"
 #undef TILEDB_QUERY_TYPE_ENUM
+#undef TILEDB_QUERY_TYPE_ENUM_CONCAT_ID
 } tiledb_query_type_t;
 
 /**

--- a/tiledb/sm/enums/query_type.h
+++ b/tiledb/sm/enums/query_type.h
@@ -44,8 +44,12 @@ namespace sm {
 /** Defines the query type. */
 enum class QueryType : uint8_t {
 #define TILEDB_QUERY_TYPE_ENUM(id) id
+// Use token-pasting _CONCAT_ID version for precarious symbols
+// (such as DELETE, see `query_api_enum.h`)
+#define TILEDB_QUERY_TYPE_ENUM_CONCAT_ID(id, id2) id##id2
 #include "tiledb/api/c_api/query/query_api_enum.h"
 #undef TILEDB_QUERY_TYPE_ENUM
+#undef TILEDB_QUERY_TYPE_ENUM_CONCAT_ID
 };
 
 /** Returns the string representation of the input query type. */


### PR DESCRIPTION
We can avoid conflicting with the DELETE symbol by creating it, using token-pasting.

---
TYPE: CPP_API
DESC: Don't error out if DELETE symbol is defined.
