### PR TITLE
bump default compiler to gnu 10 and macos images from 11 to 12

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -3,7 +3,8 @@ on:
   workflow_call:
 
 env:
-  CXX: g++
+  CXX: g++-10
+  CC: gcc-10
 
 jobs:
   build:

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -21,11 +21,11 @@ on:
         required: true
         type: string
       matrix_compiler_cc:
-        default: 'gcc'
+        default: 'gcc-10'
         required: false
         type: string
       matrix_compiler_cxx:
-        default: 'g++'
+        default: 'g++-10'
         required: false
         type: string
       timeout:

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -64,7 +64,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: S3
-      matrix_image: macos-11
+      matrix_image: macos-12
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -72,7 +72,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: GCS
-      matrix_image: macos-11
+      matrix_image: macos-12
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -104,7 +104,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: AZURE
-      matrix_image: macos-11
+      matrix_image: macos-12
       timeout: 120
       bootstrap_args: '--enable-azure'
 


### PR DESCRIPTION
bump default compiler to gnu 10 and macos images from 11 to 12 for better c++20 concepts support

TYPE: NO_HISTORY | IMPROVEMENT
DESC: bump default compiler to gnu 10 and macos images from 11 to 12
