### PR TITLE
Bump default compiler to GCC 10 and macos images from 11 to 12.

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -3,7 +3,8 @@ on:
   workflow_call:
 
 env:
-  CXX: g++
+  CXX: g++-10
+  CC: gcc-10
 
 jobs:
   build:

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -147,7 +147,7 @@ jobs:
         shell: bash
         env:
           ASAN_OPTIONS: ${{ inputs.asan && 'detect_leaks=0' || '' }}
-          LD_PRELOAD: ${{ inputs.asan && '/usr/lib/x86_64-linux-gnu/libasan.so.5' || '' }}
+          LD_PRELOAD: ${{ inputs.asan && '/usr/lib/x86_64-linux-gnu/libasan.so.6' || '' }}
         run: |
           set -e pipefail
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -41,6 +41,8 @@ jobs:
     with:
       ci_backend: GCS
       matrix_image: ubuntu-20.04
+      matrix_compiler_cc: 'gcc-10'
+      matrix_compiler_cxx: 'g++-10'
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -64,7 +66,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: S3
-      matrix_image: macos-11
+      matrix_image: macos-12
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -72,7 +74,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: GCS
-      matrix_image: macos-11
+      matrix_image: macos-12
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -96,6 +98,8 @@ jobs:
     with:
       ci_option: ASAN
       matrix_image: ubuntu-20.04
+      matrix_compiler_cc: 'gcc-10'
+      matrix_compiler_cxx: 'g++-10'
       timeout: 120
       bootstrap_args: '--enable-serialization'
       asan: true
@@ -104,7 +108,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: AZURE
-      matrix_image: macos-11
+      matrix_image: macos-12
       timeout: 120
       bootstrap_args: '--enable-azure'
 


### PR DESCRIPTION
bump compilers to gnu 10 and macos images from 11 to 12 for better c++20 concepts support

TYPE: BUILD
DESC: Bump default compiler to GCC 10 and macos images from 11 to 12.
