### PR TITLE
C.41 compliance: S3 factory constructor

### DIFF
--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,34 +48,20 @@ using namespace tiledb::common;
 using namespace tiledb::sm;
 
 struct S3DirectFx {
+  S3DirectFx();
+  ~S3DirectFx();
+  static Config set_config_params();
+  static std::string random_name(const std::string& prefix);
+
   const std::string S3_PREFIX = "s3://";
   const tiledb::sm::URI S3_BUCKET =
       tiledb::sm::URI(S3_PREFIX + random_name("tiledb") + "/");
   const std::string TEST_DIR = S3_BUCKET.to_string() + "tiledb_test_dir/";
-  tiledb::sm::S3 s3_;
   ThreadPool thread_pool_{2};
-
-  S3DirectFx();
-  ~S3DirectFx();
-
-  static std::string random_name(const std::string& prefix);
+  tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, set_config_params()};
 };
 
 S3DirectFx::S3DirectFx() {
-  // Connect
-  Config config;
-#ifndef TILEDB_TESTS_AWS_S3_CONFIG
-  REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
-  REQUIRE(config.set("vfs.s3.scheme", "https").ok());
-  REQUIRE(config.set("vfs.s3.use_virtual_addressing", "false").ok());
-  REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
-#endif
-  REQUIRE(config.set("vfs.s3.max_parallel_ops", "1").ok());
-  // set max buffer size to 10 MB
-  REQUIRE(config.set("vfs.s3.multipart_part_size", "10000000").ok());
-  REQUIRE(config.set("vfs.s3.use_multipart_upload", "false").ok());
-  REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
-
   // Create bucket
   bool exists;
   REQUIRE(s3_.is_bucket(S3_BUCKET, &exists).ok());
@@ -105,6 +91,29 @@ S3DirectFx::~S3DirectFx() {
   // Delete bucket
   CHECK(s3_.remove_bucket(S3_BUCKET).ok());
   CHECK(s3_.disconnect().ok());
+}
+
+Config S3DirectFx::set_config_params() {
+  // Connect
+  Config config;
+#ifndef TILEDB_TESTS_AWS_S3_CONFIG
+  REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
+  REQUIRE(config.set("vfs.s3.scheme", "https").ok());
+  REQUIRE(config.set("vfs.s3.use_virtual_addressing", "false").ok());
+  REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
+#endif
+  REQUIRE(config.set("vfs.s3.max_parallel_ops", "1").ok());
+  // set max buffer size to 10 MB
+  REQUIRE(config.set("vfs.s3.multipart_part_size", "10000000").ok());
+  REQUIRE(config.set("vfs.s3.use_multipart_upload", "false").ok());
+  return config;
+}
+
+std::string S3DirectFx::random_name(const std::string& prefix) {
+  std::stringstream ss;
+  ss << prefix << "-" << std::this_thread::get_id() << "-"
+     << tiledb::sm::utils::time::timestamp_now_ms();
+  return ss.str();
 }
 
 TEST_CASE_METHOD(
@@ -182,12 +191,5 @@ TEST_CASE_METHOD(
   auto badfile = TEST_DIR + "badfile";
   auto badbuffer = (char*)malloc(11000000);
   CHECK(!(s3_.write(URI(badfile), badbuffer, 11000000).ok()));
-}
-
-std::string S3DirectFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << tiledb::sm::utils::time::timestamp_now_ms();
-  return ss.str();
 }
 #endif

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,30 +48,20 @@ using namespace tiledb::sm;
 using namespace tiledb::test;
 
 struct S3Fx {
+  S3Fx();
+  ~S3Fx();
+  static Config set_config_params();
+  static std::string random_name(const std::string& prefix);
+
   const std::string S3_PREFIX = "s3://";
   const tiledb::sm::URI S3_BUCKET =
       tiledb::sm::URI(S3_PREFIX + random_name("tiledb") + "/");
   const std::string TEST_DIR = S3_BUCKET.to_string() + "tiledb_test_dir/";
-  tiledb::sm::S3 s3_;
   ThreadPool thread_pool_{2};
-
-  S3Fx();
-  ~S3Fx();
-
-  static std::string random_name(const std::string& prefix);
+  tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, set_config_params()};
 };
 
 S3Fx::S3Fx() {
-  // Connect
-  Config config;
-#ifndef TILEDB_TESTS_AWS_S3_CONFIG
-  REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
-  REQUIRE(config.set("vfs.s3.scheme", "https").ok());
-  REQUIRE(config.set("vfs.s3.use_virtual_addressing", "false").ok());
-  REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
-#endif
-  REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
-
   // Create bucket
   bool exists;
   REQUIRE(s3_.is_bucket(S3_BUCKET, &exists).ok());
@@ -101,6 +91,18 @@ S3Fx::~S3Fx() {
   // Delete bucket
   CHECK(s3_.remove_bucket(S3_BUCKET).ok());
   CHECK(s3_.disconnect().ok());
+}
+
+Config S3Fx::set_config_params() {
+  // Connect
+  Config config;
+#ifndef TILEDB_TESTS_AWS_S3_CONFIG
+  REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
+  REQUIRE(config.set("vfs.s3.scheme", "https").ok());
+  REQUIRE(config.set("vfs.s3.use_virtual_addressing", "false").ok());
+  REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
+#endif
+  return config;
 }
 
 std::string S3Fx::random_name(const std::string& prefix) {
@@ -369,8 +371,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 use BucketCannedACL", "[s3]") {
   // by string parameter.
   auto try_with_bucket_canned_acl = [&](const char* bucket_acl_to_try) {
     REQUIRE(config.set("vfs.s3.bucket_canned_acl", bucket_acl_to_try).ok());
-    tiledb::sm::S3 s3_;
-    REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
+    tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, config};
 
     // Create bucket
     bool exists;
@@ -524,8 +525,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 use Bucket/Object CannedACL", "[s3]") {
     REQUIRE(config.set("vfs.s3.bucket_canned_acl", bucket_acl_to_try).ok());
     REQUIRE(config.set("vfs.s3.object_canned_acl", object_acl_to_try).ok());
 
-    tiledb::sm::S3 s3_;
-    REQUIRE(s3_.init(&g_helper_stats, config, &thread_pool_).ok());
+    tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, config};
 
     // Create bucket
     bool exists;

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -500,6 +500,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    The server-side encryption algorithm to use. Supported non-empty
  *    values are "aes256" and "kms" (AWS key management service). <br>
  *    **Default**: ""
+ * - `vfs.s3.sse_kms_key_id` <br>
+ *    The server-side encryption key to use if
+ *    vfs.s3.sse == "kms" (AWS key management service). <br>
+ *    **Default**: ""
  * - `vfs.s3.bucket_canned_acl` <br>
  *    Names of values found in Aws::S3::Model::BucketCannedACL enumeration.
  *    "NOT_SET"

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -644,7 +644,7 @@ class Config {
    *    The AWS SDK logging level. This is a process-global setting. The
    *    configuration of the most recently constructed context will set
    *    process state. Log files are written to the process working directory.
-   *    **Default**: off""
+   *    **Default**: "off"
    * - `vfs.s3.request_timeout_ms` <br>
    *    The request timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
@@ -677,6 +677,10 @@ class Config {
    * - `vfs.s3.sse` <br>
    *    The server-side encryption algorithm to use. Supported non-empty
    *    values are "aes256" and "kms" (AWS key management service). <br>
+   *    **Default**: ""
+   * - `vfs.s3.sse_kms_key_id` <br>
+   *    The server-side encryption key to use if
+   *    vfs.s3.sse == "kms" (AWS key management service). <br>
    *    **Default**: ""
    * - `vfs.s3.bucket_canned_acl` <br>
    *    Names of values found in Aws::S3::Model::BucketCannedACL enumeration.

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -274,7 +274,7 @@ S3::S3(
             "TileDB", Aws::Utils::Logging::LogLevel::Trace, "tiledb_s3_"));
   }
 
-  auto sse = s3_params_.sse_str_;
+  auto sse = s3_params_.sse_algorithm_;
   if (!sse.empty()) {
     if (sse == "aes256") {
       sse_ = Aws::S3::Model::ServerSideEncryption::AES256;
@@ -1367,7 +1367,7 @@ Status S3::init_client() const {
           credentials_provider_->GetAWSCredentials();
       if (credentials.IsExpired()) {
         throw S3Exception("AWS credentials are expired.");
-      } else if (!s3_params_.aws_no_sign_request_ && credentials.IsEmpty()) {
+      } else if (!s3_params_.no_sign_request_ && credentials.IsEmpty()) {
         throw S3Exception(
             "AWS credentials were not provided. For public S3 data, consider "
             "setting the vfs.s3.no_sign_request config option.");
@@ -1425,7 +1425,7 @@ Status S3::init_client() const {
   // If the user says not to sign a request, use the
   // AnonymousAWSCredentialsProvider This is equivalent to --no-sign-request on
   // the aws cli
-  if (s3_params_.aws_no_sign_request_) {
+  if (s3_params_.no_sign_request_) {
     credentials_provider_ =
         make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>(HERE());
   } else {  // Check other authentication methods

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -58,7 +58,6 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/common/unique_rwlock.h"
 #include "tiledb/platform/platform.h"
-#include "tiledb/sm/filesystem/ssl_config.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/utils.h"
@@ -160,8 +159,7 @@ Aws::S3::Model::BucketCannedACL S3_BucketCannedACL_from_str(
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 namespace {
 
@@ -237,27 +235,25 @@ static std::once_flag aws_lib_initialized;
 
 S3::S3(
     stats::Stats* parent_stats, ThreadPool* thread_pool, const Config& config)
-    : stats_(parent_stats->create_child("S3"))
+    : s3_params_(S3Parameters(config))
+    , stats_(parent_stats->create_child("S3"))
     , state_(State::UNINITIALIZED)
     , credentials_provider_(nullptr)
-    , file_buffer_size_(0)
-    , max_parallel_ops_(1)
-    , multipart_part_size_(0)
+    , file_buffer_size_(
+          s3_params_.multipart_part_size_ * s3_params_.max_parallel_ops_)
     , vfs_thread_pool_(thread_pool)
-    , use_virtual_addressing_(false)
-    , use_multipart_upload_(true)
-    , config_(config)
-    , request_payer_(Aws::S3::Model::RequestPayer::NOT_SET)
+    , request_payer_(
+          s3_params_.requester_pays_ ? Aws::S3::Model::RequestPayer::requester :
+                                       Aws::S3::Model::RequestPayer::NOT_SET)
     , sse_(Aws::S3::Model::ServerSideEncryption::NOT_SET)
-    , object_canned_acl_(Aws::S3::Model::ObjectCannedACL::NOT_SET)
-    , bucket_canned_acl_(Aws::S3::Model::BucketCannedACL::NOT_SET) {
+    , object_canned_acl_(
+          S3_ObjectCannedACL_from_str(s3_params_.object_acl_str_))
+    , bucket_canned_acl_(
+          S3_BucketCannedACL_from_str(s3_params_.bucket_acl_str_))
+    , ssl_config_(S3SSLConfig(config)) {
   assert(thread_pool);
-
-  // #TODO use S3Parameters here, update initializer list if applicable
-  bool found = false;
-  auto logging_level = config.get("vfs.s3.logging_level", &found);
-  assert(found);
-  options_.loggingOptions.logLevel = aws_log_name_to_level(logging_level);
+  options_.loggingOptions.logLevel =
+      aws_log_name_to_level(s3_params_.logging_level_);
 
   // By default, curl sets the signal handler for SIGPIPE to SIG_IGN while
   // executing. When curl is done executing, it restores the previous signal
@@ -269,74 +265,22 @@ S3::S3(
   // unexpectedly.
   options_.httpOptions.installSigPipeHandler = true;
 
-  // #TODO use S3Parameters here, update initializer list if applicable
-  bool skip_init;
-  throw_if_not_ok(config.get<bool>("vfs.s3.skip_init", &skip_init, &found));
-  assert(found);
-
-  // #TODO use S3Parameters here, update initializer list if applicable
   // Initialize the library once per process.
-  if (!skip_init)
+  if (!s3_params_.skip_init_)
     std::call_once(aws_lib_initialized, [this]() { Aws::InitAPI(options_); });
-
-  // #TODO use S3Parameters here, update initializer list if applicable
   if (options_.loggingOptions.logLevel != Aws::Utils::Logging::LogLevel::Off) {
     Aws::Utils::Logging::InitializeAWSLogging(
         Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>(
             "TileDB", Aws::Utils::Logging::LogLevel::Trace, "tiledb_s3_"));
   }
 
-  // #TODO use S3Parameters here, update initializer list if applicable
-  throw_if_not_ok(config.get<uint64_t>(
-      "vfs.s3.max_parallel_ops", &max_parallel_ops_, &found));
-  assert(found);
-  throw_if_not_ok(config.get<uint64_t>(
-      "vfs.s3.multipart_part_size", &multipart_part_size_, &found));
-  assert(found);
-  file_buffer_size_ = multipart_part_size_ * max_parallel_ops_;
-  region_ = config.get<std::string>("vfs.s3.region").value_or("");
-  assert(found);
-  throw_if_not_ok(config.get<bool>(
-      "vfs.s3.use_virtual_addressing", &use_virtual_addressing_, &found));
-  assert(found);
-  throw_if_not_ok(config.get<bool>(
-      "vfs.s3.use_multipart_upload", &use_multipart_upload_, &found));
-  assert(found);
-
-  // #TODO use S3Parameters here, update initializer list if applicable
-  bool request_payer;
-  throw_if_not_ok(
-      config.get<bool>("vfs.s3.requester_pays", &request_payer, &found));
-  assert(found);
-  if (request_payer)
-    request_payer_ = Aws::S3::Model::RequestPayer::requester;
-
-  // #TODO use S3Parameters here, update initializer list if applicable
-  auto object_acl_str = config.get("vfs.s3.object_canned_acl", &found);
-  assert(found);
-  if (found) {
-    object_canned_acl_ = S3_ObjectCannedACL_from_str(object_acl_str);
-  }
-
-  // #TODO use S3Parameters here, update initializer list if applicable
-  auto bucket_acl_str = config.get("vfs.s3.bucket_canned_acl", &found);
-  assert(found);
-  if (found) {
-    bucket_canned_acl_ = S3_BucketCannedACL_from_str(bucket_acl_str);
-  }
-
-  // #TODO use S3Parameters here, update initializer list if applicable
-  auto sse = config.get("vfs.s3.sse", &found);
-  assert(found);
-  auto sse_kms_key_id = config.get("vfs.s3.sse_kms_key_id", &found);
-  assert(found);
+  auto sse = s3_params_.sse_str_;
   if (!sse.empty()) {
     if (sse == "aes256") {
       sse_ = Aws::S3::Model::ServerSideEncryption::AES256;
     } else if (sse == "kms") {
       sse_ = Aws::S3::Model::ServerSideEncryption::aws_kms;
-      sse_kms_key_id_ = sse_kms_key_id;
-      if (sse_kms_key_id_.empty()) {
+      if (s3_params_.sse_kms_key_id_.empty()) {
         throw S3Exception(
             "Config parameter 'vfs.s3.sse_kms_key_id' must be set "
             "for kms server-side encryption.");
@@ -348,9 +292,8 @@ S3::S3(
     }
   }
 
-  // #TODO use S3Parameters here, update initializer list if applicable
   // Ensure `sse_kms_key_id` was only set for kms encryption.
-  if (!sse_kms_key_id.empty() &&
+  if (!s3_params_.sse_kms_key_id_.empty() &&
       sse_ != Aws::S3::Model::ServerSideEncryption::aws_kms) {
     throw S3Exception(
         "Config parameter 'vfs.s3.sse_kms_key_id' may only be "
@@ -396,9 +339,9 @@ Status S3::create_bucket(const URI& bucket) const {
 
   // Set the bucket location constraint equal to the S3 region.
   // Note: empty string and 'us-east-1' are parsing errors in the SDK.
-  if (!region_.empty() && region_ != "us-east-1") {
+  if (!s3_params_.region_.empty() && s3_params_.region_ != "us-east-1") {
     Aws::S3::Model::CreateBucketConfiguration cfg;
-    Aws::String region_str(region_.c_str());
+    Aws::String region_str(s3_params_.region_.c_str());
     auto location_constraint = Aws::S3::Model::BucketLocationConstraintMapper::
         GetBucketLocationConstraintForName(region_str);
     cfg.SetLocationConstraint(location_constraint);
@@ -518,7 +461,7 @@ Status S3::empty_bucket(const URI& bucket) const {
 
 Status S3::flush_object(const URI& uri) {
   RETURN_NOT_OK(init_client());
-  if (!use_multipart_upload_) {
+  if (!s3_params_.use_multipart_upload_) {
     return flush_direct(uri);
   }
   if (!uri.is_s3()) {
@@ -583,10 +526,10 @@ Status S3::flush_object(const URI& uri) {
 
 void S3::finalize_and_flush_object(const URI& uri) {
   throw_if_not_ok(init_client());
-  if (!use_multipart_upload_) {
-    throw S3Exception{
-        "Global order write failed! S3 multipart upload is"
-        " disabled from config"};
+  if (!s3_params_.use_multipart_upload_) {
+    throw S3Exception(
+        "Global order write failed! S3 multipart upload is disabled from "
+        "config");
   }
 
   Aws::Http::URI aws_uri{uri.c_str()};
@@ -597,10 +540,10 @@ void S3::finalize_and_flush_object(const URI& uri) {
 
   auto state_iter = multipart_upload_states_.find(uri_path);
   if (state_iter == multipart_upload_states_.end()) {
-    throw S3Exception{
+    throw S3Exception(
         "Global order write failed! Couldn't find a multipart upload state "
         "associated with buffer: " +
-        uri.last_path_part()};
+        uri.last_path_part());
   }
 
   auto& state = state_iter->second;
@@ -1148,8 +1091,9 @@ Status S3::touch(const URI& uri) const {
     put_object_request.SetRequestPayer(request_payer_);
   if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
     put_object_request.SetServerSideEncryption(sse_);
-  if (!sse_kms_key_id_.empty())
-    put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
+  if (!s3_params_.sse_kms_key_id_.empty())
+    put_object_request.SetSSEKMSKeyId(
+        Aws::String(s3_params_.sse_kms_key_id_.c_str()));
   if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     put_object_request.SetACL(object_canned_acl_);
   }
@@ -1187,7 +1131,7 @@ Status S3::write(const URI& uri, const void* buffer, uint64_t length) {
   uint64_t nbytes_filled;
   RETURN_NOT_OK(fill_file_buffer(buff, buffer, length, &nbytes_filled));
 
-  if ((!use_multipart_upload_) && (nbytes_filled != length)) {
+  if ((!s3_params_.use_multipart_upload_) && (nbytes_filled != length)) {
     std::stringstream errmsg;
     errmsg << "Direct write failed! " << nbytes_filled
            << " bytes written to buffer, " << length << " bytes requested.";
@@ -1197,7 +1141,7 @@ Status S3::write(const URI& uri, const void* buffer, uint64_t length) {
   // Flush file buffer
   // multipart objects will flush whenever the writes exceed file_buffer_size_
   // write_direct should just append to buffer and upload later
-  if (use_multipart_upload_) {
+  if (s3_params_.use_multipart_upload_) {
     if (buff->size() == file_buffer_size_)
       RETURN_NOT_OK(flush_file_buffer(uri, buff, is_last_part));
 
@@ -1227,10 +1171,10 @@ void S3::global_order_write_buffered(
     const URI& uri, const void* buffer, uint64_t length) {
   throw_if_not_ok(init_client());
 
-  if (!use_multipart_upload_) {
+  if (!s3_params_.use_multipart_upload_) {
     throw S3Exception(
-        "Global order write failed! S3 multipart upload is "
-        "disabled from config");
+        "Global order write failed! S3 multipart upload is disabled from "
+        "config");
   }
 
   // Get file buffer
@@ -1345,9 +1289,10 @@ void S3::global_order_write(
   uint64_t num_ops = utils::math::ceil(
       merged.size(),
       std::max(
-          multipart_part_size_,
+          s3_params_.multipart_part_size_,
           tiledb::sm::constants::s3_min_multipart_part_size));
-  num_ops = std::min(std::max(num_ops, uint64_t(1)), max_parallel_ops_);
+  num_ops =
+      std::min(std::max(num_ops, uint64_t(1)), s3_params_.max_parallel_ops_);
 
   auto upload_id = state.upload_id;
 
@@ -1360,7 +1305,7 @@ void S3::global_order_write(
   } else {
     std::vector<MakeUploadPartCtx> ctx_vec;
     ctx_vec.resize(num_ops);
-    const uint64_t bytes_per_op = multipart_part_size_;
+    const uint64_t bytes_per_op = s3_params_.multipart_part_size_;
     const int part_num_base = state.part_number;
     throw_if_not_ok(
         parallel_for(vfs_thread_pool_, 0, num_ops, [&](uint64_t op_idx) {
@@ -1406,8 +1351,7 @@ Status S3::init_client() const {
 
   std::lock_guard<std::mutex> lck(client_init_mtx_);
 
-  auto s3_config_source = config_.get<std::string>(
-      "vfs.s3.config_source", Config::MustFindMarker());
+  auto s3_config_source = s3_params_.config_source_;
   if (s3_config_source != "auto" && s3_config_source != "config_files" &&
       s3_config_source != "sts_profile_with_web_identity") {
     throw S3Exception(
@@ -1416,28 +1360,21 @@ Status S3::init_client() const {
         "'sts_profile_with_web_identity'");
   }
 
-  auto aws_no_sign_request =
-      config_.get<bool>("vfs.s3.no_sign_request", Config::MustFindMarker());
-
   if (client_ != nullptr) {
     // Check credentials. If expired, refresh it
     if (credentials_provider_) {
       Aws::Auth::AWSCredentials credentials =
           credentials_provider_->GetAWSCredentials();
       if (credentials.IsExpired()) {
-        return LOG_STATUS(
-            Status_S3Error(std::string("AWS credentials are expired.")));
-      } else if (!aws_no_sign_request && credentials.IsEmpty()) {
-        return LOG_STATUS(Status_S3Error(std::string(
+        throw S3Exception("AWS credentials are expired.");
+      } else if (!s3_params_.aws_no_sign_request_ && credentials.IsEmpty()) {
+        throw S3Exception(
             "AWS credentials were not provided. For public S3 data, consider "
-            "setting the vfs.s3.no_sign_request config option.")));
+            "setting the vfs.s3.no_sign_request config option.");
       }
     }
     return Status::Ok();
   }
-
-  auto s3_endpoint_override = config_.get<std::string>(
-      "vfs.s3.endpoint_override", Config::MustFindMarker());
 
   // ClientConfiguration should be lazily init'ed here in init_client to avoid
   // potential slowdowns for non s3 users as the ClientConfig now attempts to
@@ -1453,114 +1390,65 @@ Status S3::init_client() const {
 
   auto& client_config = *client_config_.get();
 
-  if (!region_.empty())
-    client_config.region = region_.c_str();
+  if (!s3_params_.region_.empty())
+    client_config.region = s3_params_.region_.c_str();
 
-  if (!s3_endpoint_override.empty()) {
-    client_config.endpointOverride = s3_endpoint_override;
+  if (!s3_params_.endpoint_override_.empty()) {
+    client_config.endpointOverride = s3_params_.endpoint_override_;
   }
 
-  auto proxy_host =
-      config_.get<std::string>("vfs.s3.proxy_host", Config::MustFindMarker());
-
-  auto proxy_port =
-      config_.get<uint32_t>("vfs.s3.proxy_port", Config::MustFindMarker());
-
-  auto proxy_username = config_.get<std::string>(
-      "vfs.s3.proxy_username", Config::MustFindMarker());
-
-  auto proxy_password = config_.get<std::string>(
-      "vfs.s3.proxy_password", Config::MustFindMarker());
-
-  auto proxy_scheme =
-      config_.get<std::string>("vfs.s3.proxy_scheme", Config::MustFindMarker());
-
-  if (!proxy_host.empty()) {
-    client_config.proxyHost = proxy_host;
-    client_config.proxyPort = proxy_port;
-    client_config.proxyScheme = proxy_scheme == "https" ?
+  if (!s3_params_.proxy_host_.empty()) {
+    client_config.proxyHost = s3_params_.proxy_host_;
+    client_config.proxyPort = s3_params_.proxy_port_;
+    client_config.proxyScheme = s3_params_.proxy_scheme_ == "https" ?
                                     Aws::Http::Scheme::HTTPS :
                                     Aws::Http::Scheme::HTTP;
-    client_config.proxyUserName = proxy_username;
-    client_config.proxyPassword = proxy_password;
+    client_config.proxyUserName = s3_params_.proxy_username_;
+    client_config.proxyPassword = s3_params_.proxy_password_;
   }
 
-  auto s3_scheme =
-      config_.get<std::string>("vfs.s3.scheme", Config::MustFindMarker());
-
-  auto connect_timeout_ms = config_.get<int64_t>(
-      "vfs.s3.connect_timeout_ms", Config::MustFindMarker());
-
-  auto request_timeout_ms = config_.get<int64_t>(
-      "vfs.s3.request_timeout_ms", Config::MustFindMarker());
-
-  auto aws_access_key_id = config_.get<std::string>(
-      "vfs.s3.aws_access_key_id", Config::MustFindMarker());
-
-  auto aws_secret_access_key = config_.get<std::string>(
-      "vfs.s3.aws_secret_access_key", Config::MustFindMarker());
-
-  auto aws_session_token = config_.get<std::string>(
-      "vfs.s3.aws_session_token", Config::MustFindMarker());
-
-  auto aws_role_arn =
-      config_.get<std::string>("vfs.s3.aws_role_arn", Config::MustFindMarker());
-
-  auto aws_external_id = config_.get<std::string>(
-      "vfs.s3.aws_external_id", Config::MustFindMarker());
-
-  auto aws_load_frequency = config_.get<std::string>(
-      "vfs.s3.aws_load_frequency", Config::MustFindMarker());
-
-  auto aws_session_name = config_.get<std::string>(
-      "vfs.s3.aws_session_name", Config::MustFindMarker());
-
-  auto connect_max_tries = config_.get<int64_t>(
-      "vfs.s3.connect_max_tries", Config::MustFindMarker());
-
-  auto connect_scale_factor = config_.get<int64_t>(
-      "vfs.s3.connect_scale_factor", Config::MustFindMarker());
-
-  SSLConfig ssl_cfg = S3SSLConfig(config_);
-
-  client_config.scheme = (s3_scheme == "http") ? Aws::Http::Scheme::HTTP :
-                                                 Aws::Http::Scheme::HTTPS;
-  client_config.connectTimeoutMs = (long)connect_timeout_ms;
-  client_config.requestTimeoutMs = (long)request_timeout_ms;
-  client_config.caFile = ssl_cfg.ca_file();
-  client_config.caPath = ssl_cfg.ca_path();
-  client_config.verifySSL = ssl_cfg.verify();
+  client_config.scheme = (s3_params_.scheme_ == "http") ?
+                             Aws::Http::Scheme::HTTP :
+                             Aws::Http::Scheme::HTTPS;
+  client_config.connectTimeoutMs = (long)s3_params_.connect_timeout_ms_;
+  client_config.requestTimeoutMs = (long)s3_params_.request_timeout_ms_;
+  client_config.caFile = ssl_config_.ca_file();
+  client_config.caPath = ssl_config_.ca_path();
+  client_config.verifySSL = ssl_config_.verify();
 
   client_config.retryStrategy = Aws::MakeShared<S3RetryStrategy>(
       constants::s3_allocation_tag.c_str(),
       stats_,
-      connect_max_tries,
-      connect_scale_factor);
+      s3_params_.connect_max_tries_,
+      s3_params_.connect_scale_factor_);
 
   // If the user says not to sign a request, use the
   // AnonymousAWSCredentialsProvider This is equivalent to --no-sign-request on
   // the aws cli
-  if (aws_no_sign_request) {
+  if (s3_params_.aws_no_sign_request_) {
     credentials_provider_ =
         make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>(HERE());
   } else {  // Check other authentication methods
-    switch ((!aws_access_key_id.empty() ? 1 : 0) +
-            (!aws_secret_access_key.empty() ? 2 : 0) +
-            (!aws_role_arn.empty() ? 4 : 0) +
+    switch ((!s3_params_.aws_access_key_id_.empty() ? 1 : 0) +
+            (!s3_params_.aws_secret_access_key_.empty() ? 2 : 0) +
+            (!s3_params_.aws_role_arn_.empty() ? 4 : 0) +
             (s3_config_source == "config_files" ? 8 : 0) +
             (s3_config_source == "sts_profile_with_web_identity" ? 16 : 0)) {
       case 0:
         break;
       case 1:
       case 2:
-        return Status_S3Error(
+        throw S3Exception(
             "Insufficient authentication credentials; "
             "Both access key id and secret key are needed");
       case 3: {
-        Aws::String access_key_id(aws_access_key_id.c_str());
-        Aws::String secret_access_key(aws_secret_access_key.c_str());
+        Aws::String access_key_id(s3_params_.aws_access_key_id_.c_str());
+        Aws::String secret_access_key(
+            s3_params_.aws_secret_access_key_.c_str());
         Aws::String session_token(
-            !aws_session_token.empty() ? aws_session_token.c_str() : "");
+            !s3_params_.aws_session_token_.empty() ?
+                s3_params_.aws_session_token_.c_str() :
+                "");
         credentials_provider_ =
             make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(
                 HERE(), access_key_id, secret_access_key, session_token);
@@ -1569,15 +1457,19 @@ Status S3::init_client() const {
       case 4: {
         // If AWS Role ARN provided instead of access_key and secret_key,
         // temporary credentials will be fetched by assuming this role.
-        Aws::String role_arn(aws_role_arn.c_str());
+        Aws::String role_arn(s3_params_.aws_role_arn_.c_str());
         Aws::String external_id(
-            !aws_external_id.empty() ? aws_external_id.c_str() : "");
+            !s3_params_.aws_external_id_.empty() ?
+                s3_params_.aws_external_id_.c_str() :
+                "");
         int load_frequency(
-            !aws_load_frequency.empty() ?
-                std::stoi(aws_load_frequency) :
+            !s3_params_.aws_load_frequency_.empty() ?
+                std::stoi(s3_params_.aws_load_frequency_) :
                 Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS);
         Aws::String session_name(
-            !aws_session_name.empty() ? aws_session_name.c_str() : "");
+            !s3_params_.aws_session_name_.empty() ?
+                s3_params_.aws_session_name_.c_str() :
+                "");
         credentials_provider_ =
             make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(
                 HERE(),
@@ -1591,10 +1483,9 @@ Status S3::init_client() const {
       case 7: {
         s3_tp_executor_->Stop();
 
-        throw S3Exception{
+        throw S3Exception(
             "Ambiguous authentication credentials; both permanent and "
-            "temporary "
-            "authentication credentials are configured"};
+            "temporary authentication credentials are configured");
       }
       case 8: {
         credentials_provider_ =
@@ -1610,10 +1501,11 @@ Status S3::init_client() const {
       default: {
         s3_tp_executor_->Stop();
 
-        throw S3Exception{
-            "Ambiguous authentification options; Setting "
-            "vfs.s3.config_source is mutually exclusive with providing "
-            "either permanent or temporary credentials"};
+        throw S3Exception(
+            "Ambiguous authentification options; Setting vfs.s3.config_source "
+            "is "
+            "mutually exclusive with providing either permanent or temporary "
+            "credentials");
       }
     }
   }
@@ -1632,14 +1524,14 @@ Status S3::init_client() const {
           HERE(),
           *client_config_,
           Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-          use_virtual_addressing_);
+          s3_params_.use_virtual_addressing_);
     } else {
       client_ = make_shared<Aws::S3::S3Client>(
           HERE(),
           credentials_provider_,
           *client_config_,
           Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
-          use_virtual_addressing_);
+          s3_params_.use_virtual_addressing_);
     }
   }
 
@@ -1662,8 +1554,9 @@ Status S3::copy_object(const URI& old_uri, const URI& new_uri) {
     copy_object_request.SetRequestPayer(request_payer_);
   if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
     copy_object_request.SetServerSideEncryption(sse_);
-  if (!sse_kms_key_id_.empty())
-    copy_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
+  if (!s3_params_.sse_kms_key_id_.empty())
+    copy_object_request.SetSSEKMSKeyId(
+        Aws::String(s3_params_.sse_kms_key_id_.c_str()));
   if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     copy_object_request.SetACL(object_canned_acl_);
   }
@@ -1754,9 +1647,9 @@ Status S3::initiate_multipart_request(
     multipart_upload_request.SetRequestPayer(request_payer_);
   if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
     multipart_upload_request.SetServerSideEncryption(sse_);
-  if (!sse_kms_key_id_.empty())
+  if (!s3_params_.sse_kms_key_id_.empty())
     multipart_upload_request.SetSSEKMSKeyId(
-        Aws::String(sse_kms_key_id_.c_str()));
+        Aws::String(s3_params_.sse_kms_key_id_.c_str()));
   if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     multipart_upload_request.SetACL(object_canned_acl_);
   }
@@ -1891,8 +1784,9 @@ void S3::write_direct(const URI& uri, const void* buffer, uint64_t length) {
     put_object_request.SetRequestPayer(request_payer_);
   if (sse_ != Aws::S3::Model::ServerSideEncryption::NOT_SET)
     put_object_request.SetServerSideEncryption(sse_);
-  if (!sse_kms_key_id_.empty())
-    put_object_request.SetSSEKMSKeyId(Aws::String(sse_kms_key_id_.c_str()));
+  if (!s3_params_.sse_kms_key_id_.empty())
+    put_object_request.SetSSEKMSKeyId(
+        Aws::String(s3_params_.sse_kms_key_id_.c_str()));
   if (object_canned_acl_ != Aws::S3::Model::ObjectCannedACL::NOT_SET) {
     put_object_request.SetACL(object_canned_acl_);
   }
@@ -1927,12 +1821,13 @@ Status S3::write_multipart(
   // thread should write less), and cap the number of parallel operations at the
   // configured max number. Length must be evenly divisible by
   // multipart_part_size_ unless this is the last part.
-  uint64_t num_ops = last_part ?
-                         utils::math::ceil(length, multipart_part_size_) :
-                         (length / multipart_part_size_);
-  num_ops = std::min(std::max(num_ops, uint64_t(1)), max_parallel_ops_);
+  uint64_t num_ops =
+      last_part ? utils::math::ceil(length, s3_params_.multipart_part_size_) :
+                  (length / s3_params_.multipart_part_size_);
+  num_ops =
+      std::min(std::max(num_ops, uint64_t(1)), s3_params_.max_parallel_ops_);
 
-  if (!last_part && length % multipart_part_size_ != 0) {
+  if (!last_part && length % s3_params_.multipart_part_size_ != 0) {
     return LOG_STATUS(
         Status_S3Error("Length not evenly divisible by part length"));
   }
@@ -2014,7 +1909,7 @@ Status S3::write_multipart(
   } else {
     std::vector<MakeUploadPartCtx> ctx_vec;
     ctx_vec.resize(num_ops);
-    const uint64_t bytes_per_op = multipart_part_size_;
+    const uint64_t bytes_per_op = s3_params_.multipart_part_size_;
     const int part_num_base = state->part_number;
     auto status = parallel_for(vfs_thread_pool_, 0, num_ops, [&](uint64_t i) {
       uint64_t begin = i * bytes_per_op,
@@ -2172,7 +2067,6 @@ URI S3::generate_chunk_uri(
   return buffering_dir.join_path(chunk_name);
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -103,8 +103,14 @@ class S3 {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Constructor. */
-  S3();
+  /**
+   * Constructor.
+   *
+   * @param parent_stats The parent stats to inherit from.
+   * @param thread_pool The parent VFS thread pool.
+   * @param config Configuration parameters.
+   */
+  S3(stats::Stats* parent_stats, ThreadPool* thread_pool, const Config& config);
 
   /** Destructor. */
   ~S3();
@@ -115,19 +121,6 @@ class S3 {
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
-
-  /**
-   * Initializes and connects an S3 client.
-   *
-   * @param parent_stats The parent stats.
-   * @param config Configuration parameters.
-   * @param thread_pool The parent VFS thread pool.
-   * @return Status
-   */
-  Status init(
-      stats::Stats* parent_stats,
-      const Config& config,
-      ThreadPool* thread_pool);
 
   /**
    * Creates a bucket.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -161,205 +161,100 @@ struct S3Parameters {
 
   ~S3Parameters() = default;
 
-  /**
-   * The AWS region.
-   * Default: us-east-1
-   */
+  /** The AWS region. */
   std::string region_;
 
-  /**
-   * Set the AWS_ACCESS_KEY_ID.
-   * Default: ""
-   */
+  /** Set the AWS_ACCESS_KEY_ID. */
   std::string aws_access_key_id_;
 
-  /**
-   * Set the AWS_SECRET_ACCESS_KEY.
-   * Default: ""
-   */
+  /** Set the AWS_SECRET_ACCESS_KEY. */
   std::string aws_secret_access_key_;
 
-  /**
-   * Set the AWS_SESSION_TOKEN.
-   * Default: ""
-   */
+  /** Set the AWS_SESSION_TOKEN. */
   std::string aws_session_token_;
 
-  /**
-   * Set the AWS_ROLE_ARN. Determines the role that we want to assume.
-   * Default: ""
-   */
+  /** Set the AWS_ROLE_ARN. Determines the role that we want to assume. */
   std::string aws_role_arn_;
 
-  /**
-   * Set the AWS_EXTERNAL_ID.
-   * Third party access ID to your resources when assuming a role.
-   * Default: ""
-   */
+  /** Set the AWS_EXTERNAL_ID. Third party access ID when assuming a role. */
   std::string aws_external_id_;
 
-  /**
-   * Set the AWS_LOAD_FREQUENCY. Session time limit when assuming a role.
-   * Default: ""
-   */
+  /** Set the AWS_LOAD_FREQUENCY. Session time limit when assuming a role. */
   std::string aws_load_frequency_;
 
-  /**
-   * Optional.
-   * Set the AWS_SESSION_NAME. Session name when assuming a role.
-   * Can be used for tracing and bookkeeping.
-   * Default: ""
-   */
+  /** Optional. Set the AWS_SESSION_NAME. Session name when assuming a role. */
   std::string aws_session_name_;
 
-  /**
-   * The S3 scheme (`http` or `https`), if S3 is enabled.
-   * Default: https
-   */
+  /** The S3 scheme (`http` or `https`), if S3 is enabled. */
   std::string scheme_;
 
-  /**
-   * The S3 endpoint, if S3 is enabled.
-   * Default: ""
-   */
+  /** The S3 endpoint, if S3 is enabled. */
   std::string endpoint_override_;
 
-  /**
-   * Whether or not to use virtual addressing.
-   * Default: true
-   */
+  /** Whether or not to use virtual addressing. */
   bool use_virtual_addressing_;
 
-  /**
-   * Skip Aws::InitAPI for the S3 layer.
-   * Default: false
-   */
+  /** Skip Aws::InitAPI for the S3 layer. */
   bool skip_init_;
 
-  /**
-   * Whether or not to use multipart upload.
-   * Default: true
-   */
+  /** Whether or not to use multipart upload. */
   bool use_multipart_upload_;
 
-  /**
-   * The maximum number of parallel operations issued.
-   * Default: sm.io_concurrency_level
-   */
+  /** The maximum number of parallel operations issued. */
   uint64_t max_parallel_ops_;
 
-  /**
-   * The part size (in bytes) used in S3 multipart writes.
-   * Note: s3.multipart_part_size * s3.max_parallel_ops bytes will be buffered
-   * before issuing multipart uploads in parallel.
-   * Default: 5MB
-   */
+  /** The part size (in bytes) used in S3 multipart writes. */
   uint64_t multipart_part_size_;
 
-  /**
-   * The connection timeout in ms. Any `long` value is acceptable.
-   * Default: 3000
-   */
+  /** The connection timeout in ms. Any `long` value is acceptable. */
   int64_t connect_timeout_ms_;
 
-  /**
-   * The maximum tries for a connection. Any `long` value is acceptable.
-   * Default: 5
-   */
+  /** The maximum tries for a connection. Any `long` value is acceptable. */
   int64_t connect_max_tries_;
 
-  /**
-   * The scale factor for exponential backoff when connecting to S3.
-   * Any `long` value is acceptable.
-   * Default: 25
-   */
+  /** The scale factor for exponential backoff when connecting to S3. */
   int64_t connect_scale_factor_;
 
-  /**
-   * Process-global AWS SDK logging level. Log files are written to the process
-   * working directory.
-   * Default: "off"
-   */
+  /** Process-global AWS SDK logging level. */
   std::string logging_level_;
 
-  /**
-   * The request timeout in ms. Any `long` value is acceptable.
-   * Default: 3000
-   */
+  /** The request timeout in ms. */
   int64_t request_timeout_ms_;
 
-  /**
-   * If true, the requester pays for S3 access charges.
-   * Default: false
-   */
+  /** If true, the requester pays for S3 access charges. */
   bool requester_pays_;
 
-  /**
-   * The S3 proxy host.
-   * Default: ""
-   */
+  /** The S3 proxy host. */
   std::string proxy_host_;
 
-  /**
-   * The S3 proxy port.
-   * Default: 0
-   */
+  /** The S3 proxy port. */
   uint32_t proxy_port_;
 
-  /**
-   * The S3 proxy scheme.
-   * Default: "http"
-   */
+  /** The S3 proxy scheme. */
   std::string proxy_scheme_;
 
-  /**
-   * The S3 proxy username. Note: not serialized by tiledb_config_save_to_file
-   * Default: ""
-   */
+  /** The S3 proxy username. Not serialized by tiledb_config_save_to_file. */
   std::string proxy_username_;
 
-  /**
-   * The S3 proxy password.
-   * Default: ""
-   */
+  /** The S3 proxy password. */
   std::string proxy_password_;
 
-  /**
-   * Make unauthenticated requests to s3.
-   * Default: false
-   */
+  /** Make unauthenticated requests to s3. */
   bool no_sign_request_;
 
-  /**
-   * The server-side encryption algorithm to use.
-   * Supported non-empty values are "aes256" and "kms"
-   * Default: ""
-   */
+  /** The server-side encryption algorithm to use. "aes256" or "kms". */
   std::string sse_algorithm_;
 
-  /**
-   * The server-side encryption kms key to use if
-   * vfs.s3.sse == "kms" (AWS key management service).
-   * Default: ""
-   */
+  /** The server-side encryption key to use with the kms algorithm. */
   std::string sse_kms_key_id_;
 
-  /**
-   * Names of values found in Aws::S3::Model::BucketCannedACL enumeration.
-   * Default: "NOT_SET"
-   */
+  /** Names of values found in Aws::S3::Model::BucketCannedACL enumeration. */
   std::string bucket_acl_str_;
 
-  /**
-   * Names of values found in Aws::S3::Model::ObjectCannedACL enumeration.
-   * Default: "NOT_SET"
-   */
+  /** Names of values found in Aws::S3::Model::ObjectCannedACL enumeration. */
   std::string object_acl_str_;
 
-  /**
-   * Force S3 SDK to only load config options from a set source.
-   * Default: auto
-   */
+  /** Force S3 SDK to only load config options from a set source. */
   std::string config_source_;
 };
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -62,7 +62,8 @@ VFS::VFS(
     ThreadPool* const compute_tp,
     ThreadPool* const io_tp,
     const Config& config)
-    : stats_(parent_stats->create_child("VFS"))
+    : VFSBase(parent_stats)
+    , S3_within_VFS(stats_, io_tp, config)
     , config_(config)
     , compute_tp_(compute_tp)
     , io_tp_(io_tp)
@@ -86,10 +87,6 @@ VFS::VFS(
 
 #ifdef HAVE_S3
   supported_fs_.insert(Filesystem::S3);
-  st = s3_.init(stats_, config_, io_tp_);
-  if (!st.ok()) {
-    throw std::runtime_error("[VFS::VFS] Failed to initialize S3 backend.");
-  }
 #endif
 
 #ifdef HAVE_AZURE


### PR DESCRIPTION
Remove `S3::init` in favor of a C.41 compliant factory constructor. Use struct `S3Parameters` to store s3-specific configuration parameters and remove the `Config` member variable. 

---
TYPE: IMPROVEMENT
DESC: C.41 constructor: S3
