### PR TITLE
Avoid empty HTTP requests to load Enumerations

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -192,6 +192,13 @@ std::vector<shared_ptr<const Enumeration>>
 ArrayDirectory::load_enumerations_from_paths(
     const std::vector<std::string>& enumeration_paths,
     const EncryptionKey& encryption_key) const {
+  // This should never be called with an empty list of enumeration paths, but
+  // there's no reason to not check an early return case here given that code
+  // changes.
+  if (enumeration_paths.size() == 0) {
+    return {};
+  }
+
   std::vector<shared_ptr<const Enumeration>> ret(enumeration_paths.size());
   auto& tp = resources_.get().io_tp();
   throw_if_not_ok(parallel_for(&tp, 0, enumeration_paths.size(), [&](size_t i) {

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -524,6 +524,13 @@ RestClient::post_enumerations_from_rest(
         "Error getting enumerations from REST; array is null.");
   }
 
+  // This should never be called with an empty list of enumeration names, but
+  // there's no reason to not check an early return case here given that code
+  // changes.
+  if (enumeration_names.size() == 0) {
+    return {};
+  }
+
   Buffer buf;
   serialization::serialize_load_enumerations_request(
       array->config(), enumeration_names, serialization_type_, buf);


### PR DESCRIPTION
Previously, we weren't checking if we actually had any enumerations to load which resulted in REST requests for an empty list of enumerations. That just wastes time and resources for no reason so this change avoids the request whn there's no work to do.

---
TYPE: IMPROVEMENT
DESC: Avoid empty Enumeration REST requests.
