### PR TITLE
Revert change to S3 existence checks

### DIFF
--- a/test/src/unit-ssl-config.cc
+++ b/test/src/unit-ssl-config.cc
@@ -266,10 +266,10 @@ void check_failure(Filesystem fs, Config& cfg) {
   URI bucket_uri = URI(scheme + "://" + bucket_name);
 
   Status st;
-  bool is_bucket;
+  std::vector<URI> uris;
 
   try {
-    st = vfs.is_bucket(bucket_uri, &is_bucket);
+    st = vfs.ls(bucket_uri, &uris);
   } catch (...) {
     // Some backends throw exceptions to signal SSL error conditions
     // so we pass the test by returning early here.

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -784,23 +784,9 @@ Status S3::is_bucket(const URI& uri, bool* const exists) const {
   Aws::S3::Model::HeadBucketRequest head_bucket_request;
   head_bucket_request.SetBucket(aws_uri.GetAuthority());
   auto head_bucket_outcome = client_->HeadBucket(head_bucket_request);
+  *exists = head_bucket_outcome.IsSuccess();
 
-  if (head_bucket_outcome.IsSuccess()) {
-    *exists = true;
-    return Status::Ok();
-  }
-
-  auto err = head_bucket_outcome.GetError();
-
-  if (err.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_BUCKET ||
-      err.GetErrorType() == Aws::S3::S3Errors::RESOURCE_NOT_FOUND) {
-    *exists = false;
-    return Status::Ok();
-  }
-
-  return LOG_STATUS(Status_S3Error(
-      "Failed to check if S3 bucket '" + uri.to_string() +
-      "' exists: " + outcome_error_message(head_bucket_outcome)));
+  return Status::Ok();
 }
 
 Status S3::is_object(const URI& uri, bool* const exists) const {
@@ -828,23 +814,9 @@ Status S3::is_object(
   if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
     head_object_request.SetRequestPayer(request_payer_);
   auto head_object_outcome = client_->HeadObject(head_object_request);
+  *exists = head_object_outcome.IsSuccess();
 
-  if (head_object_outcome.IsSuccess()) {
-    *exists = true;
-    return Status::Ok();
-  }
-
-  auto err = head_object_outcome.GetError();
-
-  if (err.GetErrorType() == Aws::S3::S3Errors::NO_SUCH_KEY ||
-      err.GetErrorType() == Aws::S3::S3Errors::RESOURCE_NOT_FOUND) {
-    *exists = false;
-    return Status::Ok();
-  }
-
-  return LOG_STATUS(Status_S3Error(
-      "Failed to check if S3 object 's3://" + bucket_name + "/" + object_key +
-      "' exists: " + outcome_error_message(head_object_outcome)));
+  return Status::Ok();
 }
 
 Status S3::is_dir(const URI& uri, bool* exists) const {


### PR DESCRIPTION
The is_bucket and is_object methods are now behaving different in 2.17 and returning errors when they wouldn't previously. For now we're reverting to the previous 2.16 behavior.

---
TYPE: BUG
DESC: Revert changes in s3.cc that exposed more error causese
