### PR TITLE
Fix the format specification for group members.

### DIFF
--- a/format_spec/group.md
+++ b/format_spec/group.md
@@ -35,6 +35,9 @@ The current group member format version is `2`.
 | Version | `uint32_t` | Format version number of the group member |
 | Object type | `uint8_t` | Object type of the member |
 | Relative | `uint8_t` | Is the URI relative to the group |
-| URI length | `uint32_t` | Number of characters in URI |
+| URI length | `uint64_t` | Number of characters in URI |
 | URI | `uint8_t[]` | URI character array |
+| Name set | `uint8_t` | Is the name set |
+| Name length | `uint64_t` | Number of characters in name |
+| Name | `uint8_t[]` | Name character array |
 | Deleted | `uint8_t` | Is the member deleted |

--- a/tiledb/sm/group/group_member_v2.cc
+++ b/tiledb/sm/group/group_member_v2.cc
@@ -52,6 +52,10 @@ GroupMemberV2::GroupMemberV2(
 // relative (uint8_t)
 // uri_size (uint64_t)
 // uri (string)
+// name_set (uint8_t)
+// name_size (uint64_t)
+// name (string)
+// deleted (uint8_t)
 void GroupMemberV2::serialize(Serializer& serializer) {
   serializer.write<uint32_t>(GroupMemberV2::format_version_);
 


### PR DESCRIPTION
[SC-34693](https://app.shortcut.com/tiledb-inc/story/34693/group-member-specification-is-incomplete)

---
TYPE: FORMAT
DESC: Fix the format specification for group members.