### PR TITLE
Update docs for set data buffer APIs

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1100,8 +1100,8 @@ TILEDB_EXPORT int32_t tiledb_query_set_subarray_t(
  * The caller owns the `buffer` provided and is responsible for freeing the
  * memory associated with it. For writes, the buffer holds values to be written
  * which can be freed at any time after query completion. For reads, the buffer
- * is allocated by the client and will contain data read by the query after
- * completion. The freeing of this memory is up to the user once they are done
+ * is allocated by the caller and will contain data read by the query after
+ * completion. The freeing of this memory is up to the caller once they are done
  * referencing the read data.
  *
  * **Example:**
@@ -1137,9 +1137,9 @@ TILEDB_EXPORT int32_t tiledb_query_set_data_buffer(
  * The caller owns the `buffer` provided and is responsible for freeing the
  * memory associated with it. For writes, the buffer holds offsets to be written
  * which can be freed at any time after query completion. For reads, the buffer
- * is allocated by the client and will contain offset data read by the query
- * after completion. The freeing of this memory is up to the user once they are
- * done referencing the read data.
+ * is allocated by the caller and will contain offset data read by the query
+ * after completion. The freeing of this memory is up to the caller once they
+ * are done referencing the read data.
  *
  * **Example:**
  *
@@ -1176,9 +1176,9 @@ TILEDB_EXPORT int32_t tiledb_query_set_offsets_buffer(
  * The caller owns the `buffer` provided and is responsible for freeing the
  * memory associated with it. For writes, the buffer holds validity values to be
  * written which can be freed at any time after query completion. For reads, the
- * buffer is allocated by the client and will contain the validity map read by
- * the query after completion. The freeing of this memory is up to the user once
- * they are done referencing the read data.
+ * buffer is allocated by the caller and will contain the validity map read by
+ * the query after completion. The freeing of this memory is up to the caller
+ * once they are done referencing the read data.
  *
  * **Example:**
  *

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -1097,6 +1097,13 @@ TILEDB_EXPORT int32_t tiledb_query_set_subarray_t(
  * either hold the values to be written (if it is a write query), or will hold
  * the results from a read query.
  *
+ * The caller owns the `buffer` provided and is responsible for freeing the
+ * memory associated with it. For writes, the buffer holds values to be written
+ * which can be freed at any time after query completion. For reads, the buffer
+ * is allocated by the client and will contain data read by the query after
+ * completion. The freeing of this memory is up to the user once they are done
+ * referencing the read data.
+ *
  * **Example:**
  *
  * @code{.c}
@@ -1126,6 +1133,13 @@ TILEDB_EXPORT int32_t tiledb_query_set_data_buffer(
 
 /**
  * Sets the starting offsets of each cell value in the data buffer.
+ *
+ * The caller owns the `buffer` provided and is responsible for freeing the
+ * memory associated with it. For writes, the buffer holds offsets to be written
+ * which can be freed at any time after query completion. For reads, the buffer
+ * is allocated by the client and will contain offset data read by the query
+ * after completion. The freeing of this memory is up to the user once they are
+ * done referencing the read data.
  *
  * **Example:**
  *
@@ -1158,6 +1172,13 @@ TILEDB_EXPORT int32_t tiledb_query_set_offsets_buffer(
 /**
  * Sets the validity byte map that has exactly one value for each value in the
  * data buffer.
+ *
+ * The caller owns the `buffer` provided and is responsible for freeing the
+ * memory associated with it. For writes, the buffer holds validity values to be
+ * written which can be freed at any time after query completion. For reads, the
+ * buffer is allocated by the client and will contain the validity map read by
+ * the query after completion. The freeing of this memory is up to the user once
+ * they are done referencing the read data.
  *
  * **Example:**
  *

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1525,6 +1525,13 @@ class Query {
   /**
    * Sets the data for a fixed/var-sized attribute/dimension.
    *
+   * The caller owns the buffer provided and is responsible for freeing the
+   * memory associated with it. For writes, the buffer holds values to be
+   * written which can be freed at any time after query completion. For reads,
+   * the buffer is allocated by the client and will contain data read by the
+   * query after completion. The freeing of this memory is up to the user once
+   * they are done referencing the read data.
+   *
    * **Example:**
    * @code{.cpp}
    * tiledb::Context ctx;
@@ -1587,6 +1594,13 @@ class Query {
   /**
    * Sets the data for a fixed/var-sized attribute/dimension.
    *
+   * The caller owns the buffer provided and is responsible for freeing the
+   * memory associated with it. For writes, the buffer holds values to be
+   * written which can be freed at any time after query completion. For reads,
+   * the buffer is allocated by the client and will contain data read by the
+   * query after completion. The freeing of this memory is up to the user once
+   * they are done referencing the read data.
+   *
    * @note This unsafe version does not perform type checking; the given buffer
    * is assumed to be the correct type, and the size of an element in the given
    * buffer is assumed to be the size of the datatype of the attribute.
@@ -1642,6 +1656,13 @@ class Query {
 
   /**
    * Sets the offset buffer for a var-sized attribute/dimension.
+   *
+   * The caller owns the buffer provided and is responsible for freeing the
+   * memory associated with it. For writes, the buffer holds offsets to be
+   * written which can be freed at any time after query completion. For reads,
+   * the buffer is allocated by the client and will contain offset data read by
+   * the query after completion. The freeing of this memory is up to the user
+   * once they are done referencing the read data.
    *
    * **Example:**
    *
@@ -1706,6 +1727,13 @@ class Query {
 
   /**
    * Sets the validity buffer for nullable attribute/dimension.
+   *
+   * The caller owns the buffer provided and is responsible for freeing the
+   * memory associated with it. For writes, the buffer holds validity values to
+   * be written which can be freed at any time after query completion. For
+   * reads, the buffer is allocated by the client and will contain the validity
+   * map read by the query after completion. The freeing of this memory is up to
+   * the user once they are done referencing the read data.
    *
    * @tparam T Attribute value type
    * @param attr Attribute name

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -1528,8 +1528,8 @@ class Query {
    * The caller owns the buffer provided and is responsible for freeing the
    * memory associated with it. For writes, the buffer holds values to be
    * written which can be freed at any time after query completion. For reads,
-   * the buffer is allocated by the client and will contain data read by the
-   * query after completion. The freeing of this memory is up to the user once
+   * the buffer is allocated by the caller and will contain data read by the
+   * query after completion. The freeing of this memory is up to the caller once
    * they are done referencing the read data.
    *
    * **Example:**
@@ -1597,8 +1597,8 @@ class Query {
    * The caller owns the buffer provided and is responsible for freeing the
    * memory associated with it. For writes, the buffer holds values to be
    * written which can be freed at any time after query completion. For reads,
-   * the buffer is allocated by the client and will contain data read by the
-   * query after completion. The freeing of this memory is up to the user once
+   * the buffer is allocated by the caller and will contain data read by the
+   * query after completion. The freeing of this memory is up to the caller once
    * they are done referencing the read data.
    *
    * @note This unsafe version does not perform type checking; the given buffer
@@ -1660,8 +1660,8 @@ class Query {
    * The caller owns the buffer provided and is responsible for freeing the
    * memory associated with it. For writes, the buffer holds offsets to be
    * written which can be freed at any time after query completion. For reads,
-   * the buffer is allocated by the client and will contain offset data read by
-   * the query after completion. The freeing of this memory is up to the user
+   * the buffer is allocated by the caller and will contain offset data read by
+   * the query after completion. The freeing of this memory is up to the caller
    * once they are done referencing the read data.
    *
    * **Example:**
@@ -1731,9 +1731,9 @@ class Query {
    * The caller owns the buffer provided and is responsible for freeing the
    * memory associated with it. For writes, the buffer holds validity values to
    * be written which can be freed at any time after query completion. For
-   * reads, the buffer is allocated by the client and will contain the validity
+   * reads, the buffer is allocated by the caller and will contain the validity
    * map read by the query after completion. The freeing of this memory is up to
-   * the user once they are done referencing the read data.
+   * the caller once they are done referencing the read data.
    *
    * @tparam T Attribute value type
    * @param attr Attribute name


### PR DESCRIPTION
Updates documentation for `tiledb_query_set_data_buffer` to mention the client is responsible for freeing once the data is no longer needed. Also adds this section for offset and validity buffer APIs.

---
TYPE: IMPROVEMENT
DESC: Update docs for set data buffer APIs
