### PR TITLE
Update libwebp to version 1.3.2.

### DIFF
--- a/cmake/Modules/FindWebp_EP.cmake
+++ b/cmake/Modules/FindWebp_EP.cmake
@@ -51,7 +51,7 @@ if(NOT TILEDB_WEBP_EP_BUILT)
     ExternalProject_Add(ep_webp
       PREFIX "externals"
       GIT_REPOSITORY "https://chromium.googlesource.com/webm/libwebp"
-      GIT_TAG "v1.3.1"
+      GIT_TAG "v1.3.2"
       GIT_SUBMODULES_RECURSE TRUE
       UPDATE_COMMAND ""
       CMAKE_ARGS

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -92,7 +92,7 @@
             "dependencies": [
                 {
                     "name": "libwebp",
-                    "version>=": "1.3.1"
+                    "version>=": "1.3.2"
                 }
             ]
         }


### PR DESCRIPTION
[SC-34761](https://app.shortcut.com/tiledb-inc/story/34761/update-libwebp-to-fix-cve-2023-5129)

Fixes CVE-2023-5129.

---
TYPE: IMPROVEMENT
DESC: Update libwebp to version 1.3.2 to fix CVE-2023-5129.