### PR TITLE
Implement read logging modes

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -200,6 +200,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-SubarrayPartitioner-dense.cc
   src/unit-SubarrayPartitioner-error.cc
   src/unit-SubarrayPartitioner-sparse.cc
+  src/unit-vfs-read-log-modes.cc
   src/unit-vfs.cc
   src/unit-win-filesystem.cc
   )

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -685,6 +685,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.min_parallel_size"] = "10485760";
   all_param_values["vfs.read_ahead_size"] = "102400";
   all_param_values["vfs.read_ahead_cache_size"] = "10485760";
+  all_param_values["vfs.read_logging_mode"] = "";
   all_param_values["vfs.gcs.endpoint"] = "";
   all_param_values["vfs.gcs.project_id"] = "";
   all_param_values["vfs.gcs.max_parallel_ops"] =
@@ -752,6 +753,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["min_parallel_size"] = "10485760";
   vfs_param_values["read_ahead_size"] = "102400";
   vfs_param_values["read_ahead_cache_size"] = "10485760";
+  vfs_param_values["read_logging_mode"] = "";
   vfs_param_values["gcs.endpoint"] = "";
   vfs_param_values["gcs.project_id"] = "";
   vfs_param_values["gcs.max_parallel_ops"] =

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -67,7 +67,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 62);
+  CHECK(names.size() == 63);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/test/src/unit-vfs-read-log-modes.cc
+++ b/test/src/unit-vfs-read-log-modes.cc
@@ -1,0 +1,79 @@
+/**
+ * @file unit-vfs-read-log-modes.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for VFS read log modes.
+ */
+
+#include <test/support/tdb_catch.h>
+#include "tiledb/common/logger_public.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/storage_manager/context.h"
+
+using namespace tiledb::sm;
+
+TEST_CASE("VFS Read Log Modes", "[vfs][read-logging-modes]") {
+  std::string mode = GENERATE(
+      "",
+      "Don't set config",
+      "fragments",
+      "fragment_files",
+      "all_files",
+      "all_reads",
+      "all_reads_always",
+      "bad_value");
+
+  LOG_WARN("Checking vfs.read_logging_mode '" + mode + "'");
+
+  Config cfg;
+  throw_if_not_ok(cfg.set("config.logging_level", "3"));
+  if (mode != std::string("Don't set config")) {
+    throw_if_not_ok(cfg.set("vfs.read_logging_mode", mode));
+  }
+
+  Context ctx(cfg);
+  VFS vfs(&ctx.resources().stats(), ctx.compute_tp(), ctx.io_tp(), cfg);
+
+  std::vector<std::string> uris_to_read = {
+      "foo",
+      "foo__fragments",
+      "foo/__fragments/fragment_name",
+      "foo/__fragments/fragment_name/baz.tdb",
+      "foo/__meta/thing.tdb"};
+
+  // This outer loop exists to show that we're only logging once when not
+  // in all_reads mode.
+  for (int i = 0; i < 2; i++) {
+    char buffer[123];
+    for (auto& uri : uris_to_read) {
+      auto st = vfs.read(URI(uri), 123, buffer, 456);
+      // None of these files exist, so we expect every read to fail.
+      REQUIRE(!st.ok());
+    }
+  }
+}

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -322,6 +322,23 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `vfs.min_batch_gap` <br>
  *    The minimum number of bytes between two VFS read batches.<br>
  *    **Default**: 500KB
+ * - `vfs.read_logging_mode` <br>
+ *    Log read operations at varying levels of verbosity.<br>
+ *   **Default: ""**
+ *    Possible values:<br>
+ *    <ul>
+ *     <li><pre>""</pre> An empty string disables read logging.</li>
+ *     <li><pre>"fragments"</pre> Log each fragment read.</li>
+ *     <li><pre>"fragment_files"</pre> Log each individual fragment file
+ *         read.</li>
+ *     <li><pre>"all_files"</pre> Log all files read.</li>
+ *     <li><pre>"all_reads"</pre> Log all files with offset and length
+ *         parameters.</li>
+ *     <li><pre>"all_reads_always"</pre> Log all files with offset and length
+ *         parameters on every read, not just the first read. On large arrays
+ *         the read cache may get large so this trades of RAM usage vs
+ *         increased log verbosity.</li>
+ *   </ul>
  * - `vfs.file.posix_file_permissions` <br>
  *    Permissions to use for posix file system with file creation.<br>
  *    **Default**: 644

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -171,6 +171,7 @@ const std::string Config::VFS_FILE_POSIX_FILE_PERMISSIONS = "644";
 const std::string Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS = "755";
 const std::string Config::VFS_READ_AHEAD_SIZE = "102400";          // 100KiB
 const std::string Config::VFS_READ_AHEAD_CACHE_SIZE = "10485760";  // 10MiB;
+const std::string Config::VFS_READ_LOGGING_MODE = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_KEY = "";
 const std::string Config::VFS_AZURE_STORAGE_SAS_TOKEN = "";
@@ -393,6 +394,7 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "vfs.file.posix_directory_permissions",
         Config::VFS_FILE_POSIX_DIRECTORY_PERMISSIONS),
+    std::make_pair("vfs.read_logging_mode", Config::VFS_READ_LOGGING_MODE),
     std::make_pair(
         "vfs.azure.storage_account_name",
         Config::VFS_AZURE_STORAGE_ACCOUNT_NAME),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -418,6 +418,9 @@ class Config {
   /** The maximum size (in bytes) of the VFS read-ahead cache . */
   static const std::string VFS_READ_AHEAD_CACHE_SIZE;
 
+  /** The type of read logging to perform in the VFS. */
+  static const std::string VFS_READ_LOGGING_MODE;
+
   /** Azure storage account name. */
   static const std::string VFS_AZURE_STORAGE_ACCOUNT_NAME;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -500,6 +500,23 @@ class Config {
    * - `vfs.min_batch_gap` <br>
    *    The minimum number of bytes between two VFS read batches.<br>
    *    **Default**: 500KB
+   * - `vfs.read_logging_mode` <br>
+   *    Log read operations at varying levels of verbosity.<br>
+   *   **Default: ""**
+   *    Possible values:<br>
+   *    <ul>
+   *     <li><pre>""</pre> An empty string disables read logging.</li>
+   *     <li><pre>"fragments"</pre> Log each fragment read.</li>
+   *     <li><pre>"fragment_files"</pre> Log each individual fragment file
+   *         read.</li>
+   *     <li><pre>"all_files"</pre> Log all files read.</li>
+   *     <li><pre>"all_reads"</pre> Log all files with offset and length
+   *         parameters.</li>
+   *     <li><pre>"all_reads_always"</pre> Log all files with offset and length
+   *         parameters on every read, not just the first read. On large arrays
+   *         the read cache may get large so this trades of RAM usage vs
+   *         increased log verbosity.</li>
+   *   </ul>
    * - `vfs.file.posix_file_permissions` <br>
    *    permissions to use for posix file system with file or dir creation.<br>
    *    **Default**: 644

--- a/tiledb/sm/filesystem/test/unit_uri.cc
+++ b/tiledb/sm/filesystem/test/unit_uri.cc
@@ -224,6 +224,29 @@ TEST_CASE("URI: Test REST components", "[uri]") {
   CHECK(!URI("tiledb:///").get_rest_components(&ns, &array).ok());
 }
 
+TEST_CASE("URI: Test get_fragment_name", "[uri][get_fragment_name]") {
+  std::vector<std::pair<URI, std::optional<URI>>> cases = {
+      {URI("a randomish string"), std::nullopt},
+      {URI("file:///array_name"), std::nullopt},
+      {URI("file:///array_name/__schema/__t1_t2_uuid_version"), std::nullopt},
+      {URI("file:///array_name/__fragment_metadata/something_here"),
+       std::nullopt},
+      {URI("file:///array_name/__fragments/"), std::nullopt},
+      {URI("/__fragments//"), std::nullopt},
+      {URI("file:///array_name/__fragments//"), std::nullopt},
+      {URI("file:///array_name/__fragments/a"),
+       URI("file:///array_name/__fragments/a")},
+      {URI("file:///array_name/__fragments/a/b"),
+       URI("file:///array_name/__fragments/a")},
+      {URI("green /__fragments/ and ham"), URI("green /__fragments/ and ham")},
+      {URI("green /__fragments/ and ham/but no eggs"),
+       URI("green /__fragments/ and ham")}};
+
+  for (auto& test : cases) {
+    REQUIRE(test.first.get_fragment_name() == test.second);
+  }
+}
+
 #ifdef _WIN32
 
 TEST_CASE("URI: Test Windows paths", "[uri]") {

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -239,6 +239,32 @@ Status URI::get_rest_components(
   return Status::Ok();
 }
 
+std::optional<URI> URI::get_fragment_name() const {
+  auto to_find = "/" + sm::constants::array_fragments_dir_name + "/";
+  auto pos = uri_.find(to_find);
+  if (pos == std::string::npos) {
+    // Unable to find '/__fragments/' anywhere.
+    return std::nullopt;
+  }
+
+  if (pos + to_find.size() == uri_.size()) {
+    // URI is to the '/__fragments/' directory, no name present.
+    return std::nullopt;
+  }
+
+  auto slash_pos = uri_.find("/", pos + to_find.size());
+  if (slash_pos == pos + to_find.size()) {
+    // URI has an empty fragment name with '/__fragments//'
+    return std::nullopt;
+  }
+
+  if (slash_pos != std::string::npos) {
+    return URI(uri_.substr(0, slash_pos));
+  }
+
+  return URI(uri_);
+}
+
 URI URI::join_path(const std::string& path) const {
   // Check for empty strings.
   if (path.empty()) {

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -243,6 +243,17 @@ class URI {
       std::string* array_namespace, std::string* array_uri) const;
 
   /**
+   * Return the fragment name from the URI if one can be found.
+   *
+   * The logic for this parsing is that first we locate a '/__fragments/' path
+   * component in the string and then take everything up to the next possibly
+   * non-existent '/' separator.
+   *
+   * @return The fragment name URI if one is found, else std::nullopt.
+   */
+  std::optional<URI> get_fragment_name() const;
+
+  /**
    * Joins the URI with the input path.
    *
    * @param path The path to append.


### PR DESCRIPTION
This change implements a new set of read logging modes that control whether the VFS will log read information. This is useful for folks wanting to know how much of an array their queries are touching at various granularities. This feature is controlled by the new `vfs.read_logging_mode` setting. Valid values are:

* fragments - Log which fragments are read.
* fragment_files - Log which fragment files are read.
* all_files - Log any file that is read.
* all_reads - Log every read with the read offset and length.
* all_reads_always - Logs every read with the read offset and length.
         Using all_reads on large arrays could conceivably cause the read
         log cache to grow quite large. This setting exists to disable the
         caching to trade off RAM usage vs increase log sizes.

Leaving it unset (the default) disables any new read logging. Note that for every mode except 'all_reads_always', each relevant read is only logged once.

---
TYPE: IMPROVEMENT
DESC: Implement read logging modes
