### PR TITLE
Update `tiledb_group_remove_member` to remove members by name first.

### DIFF
--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -893,12 +893,18 @@ TEST_CASE_METHOD(
   rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
+  // The member has a name; removing it by URI should fail.
   rc = tiledb_group_remove_member(ctx_, group1, group2_uri.c_str());
+  REQUIRE(rc != TILEDB_OK);
+  rc = tiledb_group_remove_member(ctx_, group1, "four");
   REQUIRE(rc == TILEDB_OK);
   // Group is the latest element
   group1_expected.resize(group1_expected.size() - 1);
 
+  // The member has a name; removing it by URI should fail.
   rc = tiledb_group_remove_member(ctx_, group2, array3_uri.c_str());
+  REQUIRE(rc != TILEDB_OK);
+  rc = tiledb_group_remove_member(ctx_, group2, "three");
   REQUIRE(rc == TILEDB_OK);
   // There should be nothing left in group2
   group2_expected.clear();
@@ -1321,12 +1327,18 @@ TEST_CASE_METHOD(
   rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
+  // The member has a name; removing it by URI should fail.
   rc = tiledb_group_remove_member(ctx_, group1, group2_uri.c_str());
+  REQUIRE(rc != TILEDB_OK);
+  rc = tiledb_group_remove_member(ctx_, group1, "eight");
   REQUIRE(rc == TILEDB_OK);
   // Group is the latest element
   group1_expected.resize(group1_expected.size() - 1);
 
+  // The member has a name; removing it by URI should fail.
   rc = tiledb_group_remove_member(ctx_, group2, array3_relative_uri.c_str());
+  REQUIRE(rc != TILEDB_OK);
+  rc = tiledb_group_remove_member(ctx_, group2, "seven");
   REQUIRE(rc == TILEDB_OK);
   // There should be nothing left in group2
   group2_expected.clear();

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -944,6 +944,78 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     GroupFx,
+    "C API: Group, write duplicate members",
+    "[capi][group][write][duplicate]") {
+  // Create and open group in write mode
+  // TODO: refactor for each supported FS.
+  std::string temp_dir = fs_vec_[0]->temp_dir();
+  create_temp_dir(temp_dir);
+
+  const tiledb::sm::URI group1_uri(temp_dir + "group1");
+  const tiledb::sm::URI group2_uri(temp_dir + "group1/group2");
+  const tiledb::sm::URI group3_uri(temp_dir + "group1/group3");
+
+  REQUIRE(tiledb_group_create(ctx_, group1_uri.c_str()) == TILEDB_OK);
+  REQUIRE(tiledb_group_create(ctx_, group2_uri.c_str()) == TILEDB_OK);
+  REQUIRE(tiledb_group_create(ctx_, group3_uri.c_str()) == TILEDB_OK);
+
+  tiledb_group_t* group1;
+  int rc = tiledb_group_alloc(ctx_, group1_uri.c_str(), &group1);
+  REQUIRE(rc == TILEDB_OK);
+  set_group_timestamp(group1, 1);
+  rc = tiledb_group_open(ctx_, group1, TILEDB_WRITE);
+  REQUIRE(rc == TILEDB_OK);
+
+  SECTION("Name-name collision") {
+    rc =
+        tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, "one");
+    REQUIRE(rc == TILEDB_OK);
+    rc =
+        tiledb_group_add_member(ctx_, group1, group3_uri.c_str(), false, "one");
+    REQUIRE(rc == TILEDB_ERR);
+    rc = tiledb_group_remove_member(ctx_, group1, "one");
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("Name-URI collision") {
+    rc = tiledb_group_add_member(
+        ctx_, group1, group2_uri.c_str(), false, "group2");
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(ctx_, group1, "group2", true, nullptr);
+    REQUIRE(rc == TILEDB_ERR);
+    rc = tiledb_group_remove_member(ctx_, group1, "group2");
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("URI-name collision") {
+    rc = tiledb_group_add_member(ctx_, group1, "group2", true, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, group3_uri.c_str(), false, "group2");
+    REQUIRE(rc == TILEDB_ERR);
+    rc = tiledb_group_remove_member(ctx_, group1, "group2");
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  SECTION("URI-URI collision") {
+    rc = tiledb_group_add_member(
+        ctx_, group1, group2_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, group2_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_ERR);
+    rc = tiledb_group_remove_member(ctx_, group1, group2_uri.c_str());
+    REQUIRE(rc == TILEDB_ERR);
+  }
+
+  // Close group
+  rc = tiledb_group_close(ctx_, group1);
+  tiledb_group_free(&group1);
+  remove_temp_dir(temp_dir);
+}
+
+TEST_CASE_METHOD(
+    GroupFx,
     "C API: Group, consolidation",
     "[capi][group][metadata][consolidation]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -784,11 +784,13 @@ TEST_CASE_METHOD(
   set_group_timestamp(&group2, 2);
   group2.open(TILEDB_WRITE);
 
-  group1.remove_member(group2_uri.to_string());
+  REQUIRE_THROWS(group1.remove_member(group2_uri.to_string()));
+  group1.remove_member("three");
   // Group is the latest element
   group1_expected.resize(group1_expected.size() - 1);
 
-  group2.remove_member(array3_relative_uri);
+  REQUIRE_THROWS(group2.remove_member(array3_relative_uri));
+  group2.remove_member("four");
   // There should be nothing left in group2
   group2_expected.clear();
 

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -52,13 +52,6 @@ inline void ensure_group_uri_argument_is_valid(const char* group_uri) {
   }
 }
 
-inline void ensure_group_name_or_uri_argument_is_valid(
-    const char* name_or_uri) {
-  if (name_or_uri == nullptr) {
-    throw CAPIStatusException("argument `name_or_uri` may not be nullptr");
-  }
-}
-
 inline void ensure_key_argument_is_valid(const char* key) {
   if (key == nullptr) {
     throw CAPIStatusException("argument `key` may not be nullptr");
@@ -286,11 +279,11 @@ capi_return_t tiledb_group_add_member(
 }
 
 capi_return_t tiledb_group_remove_member(
-    tiledb_group_handle_t* group, const char* name_or_uri) {
+    tiledb_group_handle_t* group, const char* name) {
   ensure_group_is_valid(group);
-  ensure_group_name_or_uri_argument_is_valid(name_or_uri);
+  ensure_name_argument_is_valid(name);
 
-  throw_if_not_ok(group->group().mark_member_for_removal(name_or_uri));
+  throw_if_not_ok(group->group().mark_member_for_removal(name));
 
   return TILEDB_OK;
 }
@@ -683,11 +676,9 @@ capi_return_t tiledb_group_add_member(
 }
 
 capi_return_t tiledb_group_remove_member(
-    tiledb_ctx_t* ctx,
-    tiledb_group_t* group,
-    const char* name_or_uri) noexcept {
+    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* name) noexcept {
   return api_entry_context<tiledb::api::tiledb_group_remove_member>(
-      ctx, group, name_or_uri);
+      ctx, group, name);
 }
 
 capi_return_t tiledb_group_get_member_count(

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -52,6 +52,13 @@ inline void ensure_group_uri_argument_is_valid(const char* group_uri) {
   }
 }
 
+inline void ensure_group_name_or_uri_argument_is_valid(
+    const char* name_or_uri) {
+  if (name_or_uri == nullptr) {
+    throw CAPIStatusException("argument `name_or_uri` may not be nullptr");
+  }
+}
+
 inline void ensure_key_argument_is_valid(const char* key) {
   if (key == nullptr) {
     throw CAPIStatusException("argument `key` may not be nullptr");
@@ -279,11 +286,11 @@ capi_return_t tiledb_group_add_member(
 }
 
 capi_return_t tiledb_group_remove_member(
-    tiledb_group_handle_t* group, const char* group_uri) {
+    tiledb_group_handle_t* group, const char* name_or_uri) {
   ensure_group_is_valid(group);
-  ensure_group_uri_argument_is_valid(group_uri);
+  ensure_group_name_or_uri_argument_is_valid(name_or_uri);
 
-  throw_if_not_ok(group->group().mark_member_for_removal(group_uri));
+  throw_if_not_ok(group->group().mark_member_for_removal(name_or_uri));
 
   return TILEDB_OK;
 }
@@ -676,9 +683,11 @@ capi_return_t tiledb_group_add_member(
 }
 
 capi_return_t tiledb_group_remove_member(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* uri) noexcept {
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* name_or_uri) noexcept {
   return api_entry_context<tiledb::api::tiledb_group_remove_member>(
-      ctx, group, uri);
+      ctx, group, name_or_uri);
 }
 
 capi_return_t tiledb_group_get_member_count(

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -366,15 +366,13 @@ TILEDB_EXPORT capi_return_t tiledb_group_add_member(
  *
  * @param ctx The TileDB context.
  * @param group An group opened in WRITE mode.
- * @param name_or_uri Name of member to remove. If the member has no name, this
+ * @param name Name of member to remove. If the member has no name, this
  * parameter should be set to the URI of the member. In that case, only the
  * unnamed member with the given URI will be removed.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_group_remove_member(
-    tiledb_ctx_t* ctx,
-    tiledb_group_t* group,
-    const char* name_or_uri) TILEDB_NOEXCEPT;
+    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* name) TILEDB_NOEXCEPT;
 
 /**
  * Get the count of members in a group

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -367,7 +367,7 @@ TILEDB_EXPORT capi_return_t tiledb_group_add_member(
  * @param ctx The TileDB context.
  * @param group An group opened in WRITE mode.
  * @param name_or_uri Name of member to remove. If the member has no name, this
- * parameter should be set of the URI of the member. In that case, only the
+ * parameter should be set to the URI of the member. In that case, only the
  * unnamed member with the given URI will be removed.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -343,8 +343,8 @@ TILEDB_EXPORT capi_return_t tiledb_group_has_metadata_key(
  * @param group An group opened in WRITE mode.
  * @param uri URI of member to add
  * @param relative is the URI relative to the group
- * @param name optional name group member can be given to be looked up by. Set
- * to NULL if wishing to remain unset.
+ * @param name optional name group member can be given to be looked up by.
+ * Can be set to NULL.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_group_add_member(
@@ -479,8 +479,6 @@ TILEDB_EXPORT capi_return_t tiledb_group_get_member_by_name(
     char** uri,
     tiledb_object_t* type) TILEDB_NOEXCEPT;
 
-/* (clang format was butchering the tiledb_group_add_member() calls) */
-/* clang-format off */
 /**
  * Get a member of a group by name and relative characteristic of that name
  *

--- a/tiledb/api/c_api/group/group_api_external_experimental.h
+++ b/tiledb/api/c_api/group/group_api_external_experimental.h
@@ -366,12 +366,15 @@ TILEDB_EXPORT capi_return_t tiledb_group_add_member(
  *
  * @param ctx The TileDB context.
  * @param group An group opened in WRITE mode.
- * @param uri URI of member to remove. Passing a name is also supported if the
- * group member was assigned a name.
+ * @param name_or_uri Name of member to remove. If the member has no name, this
+ * parameter should be set of the URI of the member. In that case, only the
+ * unnamed member with the given URI will be removed.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_group_remove_member(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* uri) TILEDB_NOEXCEPT;
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* name_or_uri) TILEDB_NOEXCEPT;
 
 /**
  * Get the count of members in a group

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -400,14 +400,15 @@ class Group {
   /**
    * Remove a member from a group
    *
-   * @param uri of member to remove. Passing a name is also supported if the
-   * group member was assigned a name.
+   * @param name_or_uri Name of member to remove. If the member has no name,
+   * this parameter should be set of the URI of the member. In that case, only
+   * the unnamed member with the given URI will be removed.
    */
-  void remove_member(const std::string& uri) {
+  void remove_member(const std::string& name_or_uri) {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(
-        tiledb_group_remove_member(c_ctx, group_.get(), uri.c_str()));
+        tiledb_group_remove_member(c_ctx, group_.get(), name_or_uri.c_str()));
   }
 
   uint64_t member_count() const {

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -400,15 +400,15 @@ class Group {
   /**
    * Remove a member from a group
    *
-   * @param name_or_uri Name of member to remove. If the member has no name,
+   * @param name Name of member to remove. If the member has no name,
    * this parameter should be set to the URI of the member. In that case, only
    * the unnamed member with the given URI will be removed.
    */
-  void remove_member(const std::string& name_or_uri) {
+  void remove_member(const std::string& name) {
     auto& ctx = ctx_.get();
     tiledb_ctx_t* c_ctx = ctx.ptr().get();
     ctx.handle_error(
-        tiledb_group_remove_member(c_ctx, group_.get(), name_or_uri.c_str()));
+        tiledb_group_remove_member(c_ctx, group_.get(), name.c_str()));
   }
 
   uint64_t member_count() const {

--- a/tiledb/sm/cpp_api/group_experimental.h
+++ b/tiledb/sm/cpp_api/group_experimental.h
@@ -401,7 +401,7 @@ class Group {
    * Remove a member from a group
    *
    * @param name_or_uri Name of member to remove. If the member has no name,
-   * this parameter should be set of the URI of the member. In that case, only
+   * this parameter should be set to the URI of the member. In that case, only
    * the unnamed member with the given URI will be removed.
    */
   void remove_member(const std::string& name_or_uri) {

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -579,11 +579,7 @@ Status Group::mark_member_for_addition(
       group_member_uri, relative, name, storage_manager_);
 }
 
-Status Group::mark_member_for_removal(const URI& uri) {
-  return mark_member_for_removal(uri.to_string());
-}
-
-Status Group::mark_member_for_removal(const std::string& uri) {
+Status Group::mark_member_for_removal(const std::string& name_or_uri) {
   std::lock_guard<std::mutex> lck(mtx_);
   // Check if group is open
   if (!is_open_) {
@@ -599,7 +595,7 @@ Status Group::mark_member_for_removal(const std::string& uri) {
         "mode");
   }
 
-  return group_details_->mark_member_for_removal(uri);
+  return group_details_->mark_member_for_removal(name_or_uri);
 }
 
 const std::vector<shared_ptr<GroupMember>>& Group::members_to_modify() const {

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -204,7 +204,6 @@ Status Group::open(
   query_type_ = query_type;
   is_open_ = true;
   changes_applied_ = false;
-  group_details_->finish_populating();
 
   return Status::Ok();
 }

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -579,7 +579,7 @@ Status Group::mark_member_for_addition(
       group_member_uri, relative, name, storage_manager_);
 }
 
-Status Group::mark_member_for_removal(const std::string& name_or_uri) {
+Status Group::mark_member_for_removal(const std::string& name) {
   std::lock_guard<std::mutex> lck(mtx_);
   // Check if group is open
   if (!is_open_) {
@@ -595,7 +595,7 @@ Status Group::mark_member_for_removal(const std::string& name_or_uri) {
         "mode");
   }
 
-  return group_details_->mark_member_for_removal(name_or_uri);
+  return group_details_->mark_member_for_removal(name);
 }
 
 const std::vector<shared_ptr<GroupMember>>& Group::members_to_modify() const {

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -204,6 +204,7 @@ Status Group::open(
   query_type_ = query_type;
   is_open_ = true;
   changes_applied_ = false;
+  group_details_->finish_populating();
 
   return Status::Ok();
 }

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -254,11 +254,12 @@ class Group {
   /**
    * Remove a member from a group, this will be flushed to disk on close
    *
-   * @param name_or_uri name of member to remove, or URI if the member is
-   * unnamed.
+   * @param name Name of member to remove. If the member has no name,
+   * this parameter should be set to the URI of the member. In that case, only
+   * the unnamed member with the given URI will be removed.
    * @return Status
    */
-  Status mark_member_for_removal(const std::string& name_or_uri);
+  Status mark_member_for_removal(const std::string& name);
 
   /**
    * Get the vector of members to modify, used in serialization only

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -254,18 +254,11 @@ class Group {
   /**
    * Remove a member from a group, this will be flushed to disk on close
    *
-   * @param uri of member to remove
+   * @param name_or_uri name of member to remove, or URI if the member is
+   * unnamed.
    * @return Status
    */
-  Status mark_member_for_removal(const URI& uri);
-
-  /**
-   * Remove a member from a group, this will be flushed to disk on close
-   *
-   * @param uri of member to remove
-   * @return Status
-   */
-  Status mark_member_for_removal(const std::string& uri);
+  Status mark_member_for_removal(const std::string& name_or_uri);
 
   /**
    * Get the vector of members to modify, used in serialization only

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -115,14 +115,6 @@ class GroupDetails {
   void delete_member(const shared_ptr<GroupMember> group_member);
 
   /**
-   * Finish populating the group after creating it.
-   * Sets is_populated_ to true.
-   * Subsequent calls to add_member, delete_member and finish_populating will
-   * assert.
-   */
-  void finish_populating();
-
-  /**
    * Serializes the object members into a binary buffer.
    *
    * @param buff The buffer to serialize the data into.
@@ -170,7 +162,7 @@ class GroupDetails {
   uint64_t member_count() const;
 
   /**
-   * Get a member by index. Must be called after finish_populating.
+   * Get a member by index.
    *
    * @param index of member
    * @return Tuple of URI string, ObjectType, optional GroupMember name
@@ -179,7 +171,7 @@ class GroupDetails {
       uint64_t index);
 
   /**
-   * Get a member by name. Must be called after finish_populating.
+   * Get a member by name.
    *
    * @param name of member
    * @return Tuple of URI string, ObjectType, optional GroupMember name,
@@ -233,9 +225,6 @@ class GroupDetails {
 
   /** Were changes applied and is a write is required */
   bool changes_applied_;
-
-  /** Has the group finished being populated with members. */
-  bool is_populated_;
 };
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -189,7 +189,7 @@ class GroupDetails {
   /**
    * Apply any pending member additions or removals
    *
-   * mutates members_ and clears members_to_add_ and members_to_remove_
+   * mutates members_ and clears members_to_modify_
    *
    * @return Status
    */
@@ -203,13 +203,14 @@ class GroupDetails {
   /** The group URI. */
   URI group_uri_;
 
-  /** The mapping of all members of this group. */
+  /** The mapping of all members of this group. This is the canonical store of
+   * the group's members. The key is the member's name_or_uri. */
   std::unordered_map<std::string, shared_ptr<GroupMember>> members_;
 
   /** Vector for index based lookup. */
   std::vector<shared_ptr<GroupMember>> members_vec_;
 
-  /** Unordered map of members by their name, if the member doesn't have a name,
+  /** Unordered map for name based lookup. If the member doesn't have a name,
    * it will not be in the map. */
   std::unordered_map<std::string, shared_ptr<GroupMember>> members_by_name_;
 
@@ -219,10 +220,10 @@ class GroupDetails {
   /** Mutex for thread safety. */
   mutable std::mutex mtx_;
 
-  /* Format version. */
+  /** Format version. */
   const uint32_t version_;
 
-  /* Were changes applied and is a write is required */
+  /** Were changes applied and is a write is required */
   bool changes_applied_;
 };
 }  // namespace sm

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -217,8 +217,11 @@ class GroupDetails {
   /** Mapping of members slated for adding. */
   std::vector<shared_ptr<GroupMember>> members_to_modify_;
 
-  /** Set of member keys that have been marked for addition or removal. */
-  std::unordered_set<std::string> member_keys_to_modify_;
+  /** Set of member keys that have been marked for addition. */
+  std::unordered_set<std::string> member_keys_to_add_;
+
+  /** Set of member keys that have been marked for removal. */
+  std::unordered_set<std::string> member_keys_to_delete_;
 
   /** Mutex for thread safety. */
   mutable std::mutex mtx_;

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -115,6 +115,14 @@ class GroupDetails {
   void delete_member(const shared_ptr<GroupMember> group_member);
 
   /**
+   * Finish populating the group after creating it.
+   * Sets is_populated_ to true.
+   * Subsequent calls to add_member, delete_member and finish_populating will
+   * assert.
+   */
+  void finish_populating();
+
+  /**
    * Serializes the object members into a binary buffer.
    *
    * @param buff The buffer to serialize the data into.
@@ -162,7 +170,7 @@ class GroupDetails {
   uint64_t member_count() const;
 
   /**
-   * Get a member by index
+   * Get a member by index. Must be called after finish_populating.
    *
    * @param index of member
    * @return Tuple of URI string, ObjectType, optional GroupMember name
@@ -171,7 +179,7 @@ class GroupDetails {
       uint64_t index);
 
   /**
-   * Get a member by name
+   * Get a member by name. Must be called after finish_populating.
    *
    * @param name of member
    * @return Tuple of URI string, ObjectType, optional GroupMember name,
@@ -225,6 +233,9 @@ class GroupDetails {
 
   /** Were changes applied and is a write is required */
   bool changes_applied_;
+
+  /** Has the group finished being populated with members. */
+  bool is_populated_;
 };
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -80,11 +80,12 @@ class GroupDetails {
   /**
    * Remove a member from a group, this will be flushed to disk on close
    *
-   * @param name_or_uri name of member to remove, or URI if the member is
-   * unnamed.
+   * @param name Name of member to remove. If the member has no name,
+   * this parameter should be set to the URI of the member. In that case, only
+   * the unnamed member with the given URI will be removed.
    * @return Status
    */
-  Status mark_member_for_removal(const std::string& name_or_uri);
+  Status mark_member_for_removal(const std::string& name);
 
   /**
    * Get the vector of members to modify, used in serialization only
@@ -204,7 +205,7 @@ class GroupDetails {
   URI group_uri_;
 
   /** The mapping of all members of this group. This is the canonical store of
-   * the group's members. The key is the member's name_or_uri. */
+   * the group's members. The key is the member's key(). */
   std::unordered_map<std::string, shared_ptr<GroupMember>> members_;
 
   /** Vector for index based lookup. */

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -217,6 +217,9 @@ class GroupDetails {
   /** Mapping of members slated for adding. */
   std::vector<shared_ptr<GroupMember>> members_to_modify_;
 
+  /** Set of member keys that have been marked for addition or removal. */
+  std::unordered_set<std::string> member_keys_to_modify_;
+
   /** Mutex for thread safety. */
   mutable std::mutex mtx_;
 

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -80,18 +80,11 @@ class GroupDetails {
   /**
    * Remove a member from a group, this will be flushed to disk on close
    *
-   * @param uri of member to remove
+   * @param name_or_uri name of member to remove, or URI if the member is
+   * unnamed.
    * @return Status
    */
-  Status mark_member_for_removal(const URI& uri);
-
-  /**
-   * Remove a member from a group, this will be flushed to disk on close
-   *
-   * @param uri of member to remove
-   * @return Status
-   */
-  Status mark_member_for_removal(const std::string& uri);
+  Status mark_member_for_removal(const std::string& name_or_uri);
 
   /**
    * Get the vector of members to modify, used in serialization only

--- a/tiledb/sm/group/group_details_v1.cc
+++ b/tiledb/sm/group/group_details_v1.cc
@@ -75,21 +75,20 @@ Status GroupDetailsV1::apply_pending_changes() {
 
   // Remove members first
   for (const auto& member : members_to_modify_) {
-    auto& uri = member->uri();
+    auto key = member->name_or_uri();
     if (member->deleted()) {
-      members_.erase(uri.to_string());
+      members_.erase(key);
 
       // Check to remove relative URIs
-      auto uri_str = uri.to_string();
-      if (uri_str.find(group_uri_.add_trailing_slash().to_string()) !=
+      if (key.find(group_uri_.add_trailing_slash().to_string()) !=
           std::string::npos) {
         // Get the substring relative path
-        auto relative_uri = uri_str.substr(
-            group_uri_.add_trailing_slash().to_string().size(), uri_str.size());
+        auto relative_uri = key.substr(
+            group_uri_.add_trailing_slash().to_string().size(), key.size());
         members_.erase(relative_uri);
       }
     } else {
-      members_.emplace(member->uri().to_string(), member);
+      members_.emplace(member->name_or_uri(), member);
     }
   }
   changes_applied_ = !members_to_modify_.empty();

--- a/tiledb/sm/group/group_details_v1.cc
+++ b/tiledb/sm/group/group_details_v1.cc
@@ -96,14 +96,6 @@ Status GroupDetailsV1::apply_pending_changes() {
 
   members_vec_.clear();
   members_by_name_.clear();
-  members_vec_.reserve(members_.size());
-  for (auto& it : members_) {
-    members_vec_.emplace_back(it.second);
-    if (it.second->name().has_value()) {
-      members_by_name_.emplace(it.second->name().value(), it.second);
-    }
-  }
-
   return Status::Ok();
 }
 

--- a/tiledb/sm/group/group_details_v1.cc
+++ b/tiledb/sm/group/group_details_v1.cc
@@ -75,7 +75,7 @@ Status GroupDetailsV1::apply_pending_changes() {
 
   // Remove members first
   for (const auto& member : members_to_modify_) {
-    auto key = member->name_or_uri();
+    auto key = member->key();
     if (member->deleted()) {
       members_.erase(key);
 
@@ -88,7 +88,7 @@ Status GroupDetailsV1::apply_pending_changes() {
         members_.erase(relative_uri);
       }
     } else {
-      members_.emplace(member->name_or_uri(), member);
+      members_.emplace(member->key(), member);
     }
   }
   changes_applied_ = !members_to_modify_.empty();

--- a/tiledb/sm/group/group_details_v2.cc
+++ b/tiledb/sm/group/group_details_v2.cc
@@ -114,7 +114,7 @@ Status GroupDetailsV2::apply_pending_changes() {
   // First add each member to unordered map, overriding if the user adds/removes
   // it multiple times
   for (auto& it : members_to_modify_) {
-    members_[it->uri().to_string()] = it;
+    members_[it->name_or_uri()] = it;
   }
 
   for (auto& it : members_) {

--- a/tiledb/sm/group/group_details_v2.cc
+++ b/tiledb/sm/group/group_details_v2.cc
@@ -109,7 +109,6 @@ Status GroupDetailsV2::apply_pending_changes() {
   members_.clear();
   members_vec_.clear();
   members_by_name_.clear();
-  members_vec_.reserve(members_to_modify_.size());
 
   // First add each member to unordered map, overriding if the user adds/removes
   // it multiple times
@@ -117,12 +116,6 @@ Status GroupDetailsV2::apply_pending_changes() {
     members_[it->name_or_uri()] = it;
   }
 
-  for (auto& it : members_) {
-    members_vec_.emplace_back(it.second);
-    if (it.second->name().has_value()) {
-      members_by_name_.emplace(it.second->name().value(), it.second);
-    }
-  }
   changes_applied_ = !members_to_modify_.empty();
   members_to_modify_.clear();
 

--- a/tiledb/sm/group/group_details_v2.cc
+++ b/tiledb/sm/group/group_details_v2.cc
@@ -113,7 +113,7 @@ Status GroupDetailsV2::apply_pending_changes() {
   // First add each member to unordered map, overriding if the user adds/removes
   // it multiple times
   for (auto& it : members_to_modify_) {
-    members_[it->name_or_uri()] = it;
+    members_[it->key()] = it;
   }
 
   changes_applied_ = !members_to_modify_.empty();

--- a/tiledb/sm/group/group_member.h
+++ b/tiledb/sm/group/group_member.h
@@ -82,6 +82,11 @@ class GroupMember {
   /** Return the Name. */
   const std::optional<std::string> name() const;
 
+  /** Return the name or the URI if it does not exist. */
+  const std::string name_or_uri() const {
+    return name_ ? *name_ : uri_.to_string();
+  }
+
   /** Return if object is relative. */
   bool relative() const;
 

--- a/tiledb/sm/group/group_member.h
+++ b/tiledb/sm/group/group_member.h
@@ -82,8 +82,13 @@ class GroupMember {
   /** Return the Name. */
   const std::optional<std::string> name() const;
 
-  /** Return the name or the URI if it does not exist. */
-  const std::string name_or_uri() const {
+  /**
+   * Return the discriminating key of the member within a group. No
+   * multiple members with the same key may exist in a group.
+   *
+   * This method returns the member's name, or its URI if it does not exist.
+   */
+  const std::string key() const {
     return name_ ? *name_ : uri_.to_string();
   }
 


### PR DESCRIPTION
[SC-34787](https://app.shortcut.com/tiledb-inc/story/34787/convert-apis-to-use-name-instead-of-uri-for-group-item-reference)

This PR changes the behavior of the `tiledb_group_remove_member` function to make its semantics around named members more predictable. If you want to remove a named member, call the function and pass its name. If the member does not have a name, pass its URI.

There is a behavioral breaking change, where named members cannot be removed by their URI anymore. This is the behavior that was originally specified. 

The tests were updated to account for that. I found the existing tests pretty comprehensive and did not add another test case. For example removing unnamed group members [is already tested](https://github.com/TileDB-Inc/TileDB/blob/553979ce4b4f1a6d90ec89f992607363f2387d3a/test/src/unit-capi-group.cc#L645).

---
TYPE: C_API
DESC: Behavior breaking change: `tiledb_group_remove_member` cannot remove named members by URI.