### PR TITLE
Remove `class Status` from exception handler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,15 +569,13 @@ if (TILEDB_TESTS)
   # C API support
   add_dependencies(tests unit_capi_handle unit_capi_exception_wrapper)
   # C API basics
-  add_dependencies(tests unit_capi_error unit_capi_config unit_capi_context)
+  add_dependencies(tests unit_capi_config unit_capi_context)
   add_dependencies(tests unit_capi_array)
   add_dependencies(tests unit_capi_buffer)
   add_dependencies(tests unit_capi_buffer_list)
   add_dependencies(tests unit_capi_data_order)
   add_dependencies(tests unit_capi_datatype)
   add_dependencies(tests unit_capi_filesystem)
-  add_dependencies(tests unit_capi_object_type)
-  add_dependencies(tests unit_capi_object_walk_order)
   add_dependencies(tests unit_capi_query_type)
   add_dependencies(tests unit_capi_vfs)
   # C API array schema

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -1,5 +1,5 @@
 /**
- * @file tiledb/api/c_api/error/context_api.cc
+ * @file tiledb/api/c_api/context/context_api.cc
  *
  * @section LICENSE
  *

--- a/tiledb/api/c_api/context/context_api_internal.h
+++ b/tiledb/api/c_api/context/context_api_internal.h
@@ -88,7 +88,7 @@ bool save_error(tiledb_ctx_handle_t* ctx, const tiledb::common::Status& st);
  * @tparam E Exception type to throw if context is not valid
  * @param ctx A context of unknown validity
  */
-template <class E = CAPIStatusException>
+template <class E = CAPIException>
 inline void ensure_context_is_valid(const tiledb_ctx_handle_t* ctx) {
   ensure_handle_is_valid<tiledb_ctx_handle_t, E>(ctx);
 }

--- a/tiledb/api/c_api/data_order/CMakeLists.txt
+++ b/tiledb/api/c_api/data_order/CMakeLists.txt
@@ -25,26 +25,17 @@
 #
 
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 list(APPEND SOURCES
   data_order_api.cc
 )
 gather_sources(${SOURCES})
 
-#
-# Object library for other units to depend upon
-#
-add_library(capi_data_order OBJECT ${SOURCES})
-target_link_libraries(capi_data_order PUBLIC export)
-target_link_libraries(capi_data_order PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-target_link_libraries(capi_data_order PUBLIC constants $<TARGET_OBJECTS:constants>)
-
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_capi_data_order EXCLUDE_FROM_ALL)
-target_sources(compile_capi_data_order PRIVATE test/compile_capi_data_order_main.cc)
-target_link_libraries(compile_capi_data_order PRIVATE capi_data_order)
-add_dependencies(all_link_complete compile_capi_data_order)
+commence(object_library capi_data_order)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline constants exception_wrapper)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api/datatype/CMakeLists.txt
+++ b/tiledb/api/c_api/datatype/CMakeLists.txt
@@ -23,28 +23,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 list(APPEND SOURCES
-  datatype_api.cc
+    datatype_api.cc
 )
 gather_sources(${SOURCES})
 
-#
-# Object library for other units to depend upon
-#
-add_library(capi_datatype OBJECT ${SOURCES})
-target_link_libraries(capi_datatype PUBLIC export)
-target_link_libraries(capi_datatype PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-target_link_libraries(capi_datatype PUBLIC constants $<TARGET_OBJECTS:constants>)
-
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_capi_datatype EXCLUDE_FROM_ALL)
-target_sources(compile_capi_datatype PRIVATE test/compile_capi_datatype_main.cc)
-target_link_libraries(compile_capi_datatype PRIVATE capi_datatype)
-add_dependencies(all_link_complete compile_capi_datatype)
+commence(object_library capi_datatype)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline constants capi_enumeration_stub)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api/error/CMakeLists.txt
+++ b/tiledb/api/c_api/error/CMakeLists.txt
@@ -25,25 +25,17 @@
 #
 
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 list(APPEND SOURCES
     error_api.cc
 )
 gather_sources(${SOURCES})
 
-#
-# Object library uses `StorageManagerStub` to support API wrappers
-#
-add_library(capi_error OBJECT ${SOURCES})
-target_link_libraries(capi_error PUBLIC export)
-target_link_libraries(capi_error PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_capi_error EXCLUDE_FROM_ALL)
-target_link_libraries(compile_capi_error PRIVATE capi_error)
-target_sources(compile_capi_error PRIVATE test/compile_capi_error_main.cc)
-add_dependencies(all_link_complete compile_capi_error)
+commence(object_library capi_error)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline exception_wrapper)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api/error/error_api.cc
+++ b/tiledb/api/c_api/error/error_api.cc
@@ -36,14 +36,6 @@
 
 namespace tiledb::api {
 
-bool create_error(tiledb_error_handle_t** error, const Status& st) {
-  if (st.ok()) {
-    return false;
-  }
-  *error = tiledb_error_handle_t::make_handle(st.to_string());
-  return true;
-}
-
 void create_error(tiledb_error_handle_t** error, const std::string& message) {
   *error = tiledb_error_handle_t::make_handle(message);
 }

--- a/tiledb/api/c_api/error/error_api_internal.h
+++ b/tiledb/api/c_api/error/error_api_internal.h
@@ -72,28 +72,6 @@ struct tiledb_error_handle_t
 };
 
 namespace tiledb::api {
-/**
- * Conditionally create a C API error object based on a `Status`.
- *
- * The error object in the C API, unlike almost every other, is created outside
- * a `tiledb_*_alloc` function. This function is the one that creates such
- * objects for other functions that can return errors.
- *
- * Note that this function can throw, since it allocates to create an error
- * handle. In that case the argument error is ignored and superseded by an
- * out-of-memory exception, which the C API wrapper will process.
- *
- * @pre `error != nullptr`. Error arguments must always be validated, because
- * on error they're assigned an error handle and on success they're assigned
- * `nullptr`.
- *
- * @param error A non-null pointer to `tiledb_error_t *` object
- * @param st A status that might contain an error
- * @return true if `st` contained an error, false if it did not
- */
-bool create_error(
-    tiledb_error_handle_t** error, const tiledb::common::Status& st);
-
 /*
  * Create a C API error object with a given string.
  *

--- a/tiledb/api/c_api/error/test/CMakeLists.txt
+++ b/tiledb/api/c_api/error/test/CMakeLists.txt
@@ -23,21 +23,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+include(unit_test)
 
-add_executable(unit_capi_error EXCLUDE_FROM_ALL)
-find_package(Catch_EP REQUIRED)
-target_link_libraries(unit_capi_error PUBLIC Catch2::Catch2WithMain)
-
-# Sources for code under test
-target_link_libraries(unit_capi_error PUBLIC capi_error)
-
-# Sources for tests
-target_sources(unit_capi_error PUBLIC
-    unit_capi_error.cc
-    )
-
-add_test(
-    NAME "unit_capi_error"
-    COMMAND $<TARGET_FILE:unit_capi_error>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+commence(unit_test capi_error)
+  this_target_sources(unit_capi_error.cc)
+  this_target_object_libraries(capi_error)
+conclude(unit_test)

--- a/tiledb/api/c_api/filesystem/CMakeLists.txt
+++ b/tiledb/api/c_api/filesystem/CMakeLists.txt
@@ -25,26 +25,17 @@
 #
 
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 list(APPEND SOURCES
   filesystem_api.cc
 )
 gather_sources(${SOURCES})
 
-#
-# Object library for other units to depend upon
-#
-add_library(capi_filesystem OBJECT ${SOURCES})
-target_link_libraries(capi_filesystem PUBLIC export)
-target_link_libraries(capi_filesystem PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-target_link_libraries(capi_filesystem PUBLIC constants $<TARGET_OBJECTS:constants>)
-
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_capi_filesystem EXCLUDE_FROM_ALL)
-target_sources(compile_capi_filesystem PRIVATE test/compile_capi_filesystem_main.cc)
-target_link_libraries(compile_capi_filesystem PRIVATE capi_filesystem)
-add_dependencies(all_link_complete compile_capi_filesystem)
+commence(object_library capi_filesystem)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline constants exception_wrapper)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api/object/CMakeLists.txt
+++ b/tiledb/api/c_api/object/CMakeLists.txt
@@ -37,13 +37,16 @@ gather_sources(${SOURCES})
 # on StorageManager that would require us to link the entire library
 # for this to work.
 #
-# TODO: Remove StorageManager dependency from the object APIs and
-# make this a real object library for unit test use.
+# Maturity Warning: `capi_object` can't be a full object library unit the
+# `StorageManager` dependency is removed. Note that the test-compile is
+# commented out. This is the reason that it hasn't been converted to use the
+# `object_library` environment for CMake.
 #
 add_library(capi_object OBJECT ${SOURCES})
 target_link_libraries(capi_object PUBLIC export)
 target_link_libraries(capi_object PUBLIC baseline $<TARGET_OBJECTS:baseline>)
 target_link_libraries(capi_object PUBLIC constants $<TARGET_OBJECTS:constants>)
+target_link_libraries(capi_object PUBLIC exception_wrapper $<TARGET_OBJECTS:exception_wrapper>)
 
 #
 # Test-compile of object library ensures link-completeness

--- a/tiledb/api/c_api/object/test/CMakeLists.txt
+++ b/tiledb/api/c_api/object/test/CMakeLists.txt
@@ -24,26 +24,14 @@
 # THE SOFTWARE.
 #
 
-find_package(Catch_EP REQUIRED)
+include(unit_test)
 
-add_executable(unit_capi_object_type EXCLUDE_FROM_ALL)
-target_sources(unit_capi_object_type PUBLIC unit_capi_object_type.cc)
-target_link_libraries(unit_capi_object_type PUBLIC capi_object)
-target_link_libraries(unit_capi_object_type PUBLIC Catch2::Catch2WithMain)
+commence(unit_test capi_object_type)
+  this_target_sources(unit_capi_object_type.cc)
+  this_target_object_libraries(capi_object)
+conclude(unit_test)
 
-add_test(
-  NAME "unit_capi_object_type"
-  COMMAND $<TARGET_FILE:unit_capi_object_type>
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-add_executable(unit_capi_object_walk_order EXCLUDE_FROM_ALL)
-target_sources(unit_capi_object_walk_order PUBLIC unit_capi_object_walk_order.cc)
-target_link_libraries(unit_capi_object_walk_order PUBLIC capi_object)
-target_link_libraries(unit_capi_object_walk_order PUBLIC Catch2::Catch2WithMain)
-
-add_test(
-  NAME "unit_capi_object_walk_order"
-  COMMAND $<TARGET_FILE:unit_capi_object_walk_order>
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+commence(unit_test capi_object_walk_order)
+  this_target_sources(unit_capi_object_walk_order.cc)
+  this_target_object_libraries(capi_object)
+conclude(unit_test)

--- a/tiledb/api/c_api/query/CMakeLists.txt
+++ b/tiledb/api/c_api/query/CMakeLists.txt
@@ -25,26 +25,17 @@
 #
 
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 list(APPEND SOURCES
   query_api.cc
 )
 gather_sources(${SOURCES})
 
-#
-# Object library for other units to depend upon
-#
-add_library(capi_query OBJECT ${SOURCES})
-target_link_libraries(capi_query PUBLIC export)
-target_link_libraries(capi_query PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-target_link_libraries(capi_query PUBLIC constants $<TARGET_OBJECTS:constants>)
-
-#
-# Test-compile of object library ensures link-completeness
-#
-add_executable(compile_capi_query EXCLUDE_FROM_ALL)
-target_sources(compile_capi_query PRIVATE test/compile_capi_query_main.cc)
-target_link_libraries(compile_capi_query PRIVATE capi_query)
-add_dependencies(all_link_complete compile_capi_query)
+commence(object_library capi_query)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline constants exception_wrapper)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api/string/CMakeLists.txt
+++ b/tiledb/api/c_api/string/CMakeLists.txt
@@ -38,7 +38,7 @@ gather_sources(${SOURCES})
 commence(object_library capi_string)
   this_target_sources(${SOURCES})
   this_target_link_libraries(export)
-  this_target_object_libraries(baseline)
+  this_target_object_libraries(baseline capi_context_stub)
 conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api_support/argument_validation.h
+++ b/tiledb/api/c_api_support/argument_validation.h
@@ -38,12 +38,14 @@
 
 namespace tiledb::api {
 
-class CAPIStatusException : public common::StatusException {
+class CAPIException : public common::StatusException {
  public:
-  explicit CAPIStatusException(const std::string& message)
+  explicit CAPIException(const std::string& message)
       : StatusException("C API", message) {
   }
 };
+// Legacy alias to forestall massive sudden code change
+using CAPIStatusException = CAPIException;
 
 /*
  * Validation functions
@@ -67,7 +69,7 @@ class CAPIStatusException : public common::StatusException {
  */
 inline void ensure_output_pointer_is_valid(void* p) {
   if (p == nullptr) {
-    throw CAPIStatusException("Invalid output pointer for object");
+    throw CAPIException("Invalid output pointer for object");
   }
 }
 

--- a/tiledb/api/c_api_support/exception_wrapper/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/CMakeLists.txt
@@ -23,8 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-
 include(common NO_POLICY_SCOPE)
+include(object_library)
 
 #
 # `exception_wrapper` object library
@@ -39,10 +39,10 @@ list(APPEND SOURCES
 )
 gather_sources(${SOURCES})
 
-add_library(exception_wrapper OBJECT exception_wrapper.cc)
-target_link_libraries(exception_wrapper PUBLIC export)
-target_link_libraries(exception_wrapper PUBLIC baseline $<TARGET_OBJECTS:baseline>)
-target_link_libraries(exception_wrapper PUBLIC thread_pool $<TARGET_OBJECTS:thread_pool>)
-target_link_libraries(exception_wrapper PUBLIC config $<TARGET_OBJECTS:config>)
+commence(object_library exception_wrapper)
+  this_target_sources(${SOURCES})
+  this_target_link_libraries(export)
+  this_target_object_libraries(baseline thread_pool config)
+conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/api/c_api_support/exception_wrapper/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/CMakeLists.txt
@@ -34,9 +34,10 @@ include(common NO_POLICY_SCOPE)
 # OBJECT syntax.
 
 # No actual source files at present.
-#list(APPEND SOURCES
-#)
-#gather_sources(${SOURCES})
+list(APPEND SOURCES
+    exception_wrapper.cc
+)
+gather_sources(${SOURCES})
 
 add_library(exception_wrapper OBJECT exception_wrapper.cc)
 target_link_libraries(exception_wrapper PUBLIC export)

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.cc
@@ -1,1 +1,94 @@
-// Empty source file to allow exception_wrapper to be an OBJECT library
+/**
+ * @file tiledb/api/c_api_support/exception_wrapper/exception_wrapper.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines support functions for the exception wrappers.
+ */
+
+#include "exception_wrapper.h"
+
+namespace tiledb::api::detail {
+
+//----------------------------------
+// ETVisitorStdException
+//----------------------------------
+static_assert(ErrorTreeVisitor<ETVisitorStdException>);
+/**
+ * Quote a string appropriate for nested exceptions.
+ *
+ * Quoted characters:
+ * - ":" origin / message separator
+ * - "()" nesting indicator
+ * - "+" separator for multiples throw from parallel code
+ * - "\\" quoting character
+ *
+ * @section Maturity Notes
+ *
+ * Not implemented yet. We are not yet guaranteeing that error messages are
+ * recognizable by a formal grammar. The test coverage required for such
+ * a guarantee is not trivial; it has been deferred.
+ */
+std::string quoted(std::string s) {
+  return s;
+}
+
+void ETVisitorStdException::start_level() noexcept {
+  try {
+    s_ += " (";
+  } catch (...) {
+  }
+}
+void ETVisitorStdException::end_level() noexcept {
+  try {
+    s_ += ")";
+  } catch (...) {
+  }
+}
+void ETVisitorStdException::separator() noexcept {
+  try {
+    s_ += ", ";
+  } catch (...) {
+  }
+}
+void ETVisitorStdException::item(const std::exception& e) noexcept {
+  try {
+    try {
+      auto e2{dynamic_cast<const common::StatusException&>(e)};
+      // StatusException is already formatted with ": " inside
+      s_ += quoted(e.what());
+      return;
+    } catch (...) {
+      // If the cast fails, we'll revert to the base case.
+    }
+    s_ += "TileDB internal: ";
+    s_ += quoted(e.what());
+  } catch (...) {
+  }
+}
+
+}  // namespace tiledb::api::detail

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,49 +35,173 @@
 #define TILEDB_C_API_SUPPORT_EXCEPTION_WRAPPER_H
 
 #include <utility>                   // std::forward
-#include "../argument_validation.h"  // CAPIStatusException
+#include "../argument_validation.h"  // CAPIException
 #include "tiledb/api/c_api/api_external_common.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/api/c_api/error/error_api_internal.h"
 #include "tiledb/common/exception/exception.h"
-#include "tiledb/common/exception/status.h"
 
 namespace tiledb::api {
+namespace detail {
 
-/*
- * Top-level exception handling.
+//-------------------------------------------------------
+// Error message generation from exceptions
+//-------------------------------------------------------
+/**
+ * A visitor for an `ErrorTree`.
  *
+ * As a grammar, the visitation generates the following productions:
+ *   trees : list
+ *   list : full-item
+ *        | list "," full-item
+ *   full-item : Item [ "(" list ")" ]
+ *
+ * @tparam T the type representing items within the tree
+ */
+template <class T>
+concept ErrorTreeVisitor = requires(T t, const T::item_type& e) {
+  /*
+   * The action taken when starting a new level. This action is only ever
+   * immediately after an item.
+   */
+  t.start_level();
+
+  /*
+   * The action taken when ending a level, including the root. This action
+   * always immediately follows some item.
+   */
+  t.end_level();
+
+  /*
+   * The action taken after one item and before another. This action always
+   * immediately follows an item or an end-level.
+   */
+  t.separator();
+
+  /*
+   * The action taken for an item. This action always follows either a level
+   * start or a separator.
+   */
+  t.item(e);
+};
+
+/**
+ * A `std::exception`, possibly nested, treated as an error tree.
+ *
+ * An error tree is an interface for error messages. It takes as a template
+ * argument an error type taken as a primitive. It support two kinds of compound
+ * operations: sequence and nesting. Sequences support individual parallel
+ * operations that might generate more than one error message. Nesting supports
+ * rethrown exceptions and stack traces.
+ */
+class ErrorTreeStdException {
+  /**
+   * An exception to be visited.
+   */
+  const std::exception& e_;
+
+  /**
+   * Perform a complete visit of this exception as an error tree, calling the
+   * visitor at each event.
+   *
+   * The visit is a depth-first, left-to-right traversal of the error tree. The
+   * events are documented in more depth in `concept ErrorTreeVisitor`.
+   *
+   * @tparam V The type of the visitor
+   * @param v The visitor
+   * @param e The exception to be visited
+   */
+  template <ErrorTreeVisitor V>
+  void visit_nested_exception(V& v, const std::exception& e) const noexcept {
+    v.item(e);
+    try {
+      std::rethrow_if_nested(e);
+    } catch (const std::exception& e2) {
+      v.start_level();
+      visit_nested_exception(v, e2);
+      v.end_level();
+    } catch (...) {
+      v.item(std::logic_error("exception substituted for unknown type"));
+    }
+  }
+
+ public:
+  /**
+   * Default constructor is deleted.
+   */
+  ErrorTreeStdException() = delete;
+
+  /**
+   * Ordinary constructor
+   */
+  explicit ErrorTreeStdException(const std::exception& e)
+      : e_{e} {};
+
+  /**
+   * Perform a visitation with the specified visitor.
+   *
+   * This function is `const`. All results from the visitation are held within
+   * the visitor.
+   */
+  template <ErrorTreeVisitor V>
+  void visit(V& v) const {
+    visit_nested_exception(v, e_);
+  }
+};
+
+/**
+ * Visitor for `ErrorTreeStdException` generates text from a possibly-nested
+ * exception.
+ *
+ * All the visitation function have `try` blocks that suppress all exceptions.
+ * The only exception anticipated is `bad_alloc`, which would not allow a string
+ * lengthening to succeed regardless.
+ */
+class ETVisitorStdException {
+  std::string s_{};
+
+ public:
+  ETVisitorStdException() = default;
+  void start_level() noexcept;
+  void end_level() noexcept;
+  void separator() noexcept;
+  using item_type = std::exception;
+  void item(const item_type& e) noexcept;
+  [[nodiscard]] inline std::string value() const {
+    return s_;
+  }
+};
+
+/**
+ * Create a log message from an exception.
+ */
+inline std::string log_message(const std::exception& e) {
+  ETVisitorStdException v{};
+  ErrorTreeStdException x{e};
+  x.visit(v);
+  return v.value();
+}
+
+//-------------------------------------------------------
+// Handlers and actions
+//-------------------------------------------------------
+/*
  * Responsibilities of the exception wrappers:
  * - Ensure that no exception propagates out of the C API
  * - Provide uniform treatment of errors caught at the top level
  *
- * Actions taken for each exception:
- * - Generate a `Status` from an exception object
- *   - std::bad_alloc -> "Out of memory" + what()
- *   - std::exception -> "uncaught exception" + what()
- *   - StatusException -> extract_status()
- *   - other -> "uncaught unknown exception"
- * - Log the `Status`
+ * Actions taken for each (ordinary) exception:
+ * - Generate a log message from an exception object. The message generator
+ *   handles nested exceptions.
+ * - Log the generated message.
  * - (optional) Save the error to a context
  * - (optional) Pass the error back through an error argument
  *
- * We use `Status` here primarily out of convenience, even though it should be
- * considered a legacy class. It does, however, provide useful informtion, as it
- * separates the site (coarsely construed) where the error occurred from the
- * error message itself. Thus `StatusException` generated within the code have
- * their own sites. We designate standard library exceptions caught at the top
- * level with site "C API".
+ * @section Maturity Notes
  *
- * We'll have to stop using `Status` when we all support for nested exceptions.
- * At that point the simple strings of `Status` won't suffice to capture the
- * sequence-like nature of nested exceptions.
+ * Out of memory exceptions, notably `bad_alloc`, are not at present handled
+ * with an audited zero-allocation method.
  */
-
-inline Status CAPIStatusError(const std::string& msg) {
-  return {"C API", msg};
-};
-
-namespace detail {
 
 /**
  * Generic class for exception actions; only implemented as specializations.
@@ -112,13 +236,13 @@ class ExceptionActionImpl<Head, Tail...> : public Head,
       , ExceptionActionImpl<Tail...>{std::forward<Tail>(tail)...} {
   }
   /**
-   * Action to take upon catching an exception.
+   * Action to take upon catching `std::exception`
    *
-   * @param st A `Status` that captures the content of an exception.
+   * @param e An exception
    */
-  inline void action(const Status& st) {
-    Head::action(st);
-    ExceptionActionImpl<Tail...>::action(st);
+  inline void action(const std::exception& e) {
+    Head::action(e);
+    ExceptionActionImpl<Tail...>::action(e);
   }
   /**
    * Action to take when no exception was caught.
@@ -143,7 +267,7 @@ template <>
 class ExceptionActionImpl<> {
  public:
   ExceptionActionImpl() = default;
-  inline void action(const Status&) {
+  inline void action(const std::exception&) {
   }
   inline void action_on_success() {
   }
@@ -180,8 +304,8 @@ class ExceptionActionImpl<> {
 class LogAction {
  public:
   LogAction() = default;
-  inline void action(const Status& st) const {
-    (void)LOG_STATUS(st);
+  inline void action(const std::exception& e) {
+    (void)LOG_ERROR(log_message(e));
   }
   inline void action_on_success() {
   }
@@ -242,12 +366,12 @@ class ContextAction {
   /**
    * Action on exception
    */
-  inline void action(const Status& st) {
+  inline void action(const std::exception& e) {
     if (!valid_) {
       // Don't even try to report our own invalidity
       return;
     }
-    tiledb::api::save_error(ctx_, st);
+    ctx_->context().save_error(log_message(e));
   }
 
   /**
@@ -309,11 +433,11 @@ class ErrorAction {
   /**
    * Action to report an error
    */
-  inline void action(const Status& st) {
+  inline void action(const std::exception& e) {
     if (!valid_) {
       return;
     }
-    tiledb::api::create_error(err_, st);
+    tiledb::api::create_error(err_, log_message(e));
   }
 
   /**
@@ -387,6 +511,9 @@ using ExceptionActionCtx = detail::ExceptionActionDetailCtx;
 using ExceptionActionErr = detail::ExceptionActionDetailErr;
 using ExceptionActionCtxErr = detail::ExceptionActionDetailCtxErr;
 
+//-------------------------------------------------------
+// Exception wrapper
+//-------------------------------------------------------
 /**
  * Non-specialized wrapper for implementations functions for the C API. May
  * only be used as a specialization.
@@ -399,22 +526,6 @@ class CAPIFunction;
  */
 template <class... Args, capi_return_t (*f)(Args...), class H>
 class CAPIFunction<f, H> {
-  /**
-   * Convert `std:bad_alloc` to a C API `Status`.
-   */
-  static inline Status exception_to_status(const std::bad_alloc& e) {
-    return CAPIStatusError(
-        std::string{"Out of memory, caught std::bad_alloc; "} + e.what());
-  }
-
-  /**
-   * Convert `std:exception` to a C API `Status`.
-   */
-  static inline Status exception_to_status(const std::exception& e) {
-    return CAPIStatusError(
-        std::string{"TileDB Internal, std::exception; "} + e.what());
-  }
-
  public:
   /**
    * Forwarded alias to template parameter H.
@@ -454,23 +565,22 @@ class CAPIFunction<f, H> {
       h.action_on_success();
       return x;
     } catch (const std::bad_alloc& e) {
-      h.action(exception_to_status(e));
+      h.action(e);
       return TILEDB_OOM;
     } catch (const detail::InvalidContextException& e) {
-      h.action(exception_to_status(e));
+      h.action(e);
       return TILEDB_INVALID_CONTEXT;
     } catch (const detail::InvalidErrorException& e) {
-      h.action(exception_to_status(e));
+      h.action(e);
       return TILEDB_INVALID_ERROR;
     } catch (const StatusException& e) {
-      h.action(e.extract_status());
+      h.action(e);
       return TILEDB_ERR;
     } catch (const std::exception& e) {
-      h.action(exception_to_status(e));
+      h.action(e);
       return TILEDB_ERR;
     } catch (...) {
-      h.action(CAPIStatusError(
-          "TileDB Internal: unknown exception type; no further information"));
+      h.action(CAPIException("unknown exception type; no further information"));
       return TILEDB_ERR;
     }
   };
@@ -526,6 +636,9 @@ class CAPIFunction<f, H> {
   }
 };
 
+//-------------------------------------------------------
+// Exception-wrapping function transformers
+//-------------------------------------------------------
 /*
  * `class CAPIFunction` is the foundation for a set of function transformers
  * that convert API implementation functions into API interface functions. We

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -59,7 +59,7 @@ namespace detail {
  * @tparam T the type representing items within the tree
  */
 template <class T>
-concept ErrorTreeVisitor = requires(T t, const T::item_type& e) {
+concept ErrorTreeVisitor = requires(T t, const typename T::item_type& e) {
   /*
    * The action taken when starting a new level. This action is only ever
    * immediately after an item.

--- a/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
@@ -30,6 +30,7 @@ commence(unit_test capi_exception_wrapper)
       unit_capi_exception_wrapper.cc
       unit_capi_error_tree.cc)
   this_target_object_libraries(
-      capi_context_stub
-      exception_wrapper)
+      # The exception wrapper is wrapped up with the context, so that's the
+      # top-level dependency required for the test.
+      capi_context_stub)
 conclude(unit_test)

--- a/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
-# tiledb/api/c_api/exception_wrapper/test/CMakeLists.txt
+# tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
 #
 # The MIT License
 #
-# Copyright (c) 2022 TileDB, Inc.
+# Copyright (c) 2022-2023 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,22 +23,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+include(unit_test)
 
-add_executable(unit_capi_exception_wrapper EXCLUDE_FROM_ALL)
-find_package(Catch_EP REQUIRED)
-target_link_libraries(unit_capi_exception_wrapper PUBLIC Catch2::Catch2WithMain)
-
-# Sources for code under test
-target_link_libraries(unit_capi_exception_wrapper PUBLIC exception_wrapper)
-target_link_libraries(unit_capi_exception_wrapper PUBLIC capi_context_stub)
-
-# Sources for tests
-target_sources(unit_capi_exception_wrapper PUBLIC
-    unit_capi_exception_wrapper.cc
-    )
-
-add_test(
-    NAME "unit_capi_exception_wrapper"
-    COMMAND $<TARGET_FILE:unit_capi_exception_wrapper>
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+commence(unit_test capi_exception_wrapper)
+  this_target_sources(
+      unit_capi_exception_wrapper.cc
+      unit_capi_error_tree.cc)
+  this_target_object_libraries(
+      capi_context_stub
+      exception_wrapper)
+conclude(unit_test)

--- a/tiledb/api/c_api_support/exception_wrapper/test/compile_exception_wrapper_main.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/compile_exception_wrapper_main.cc
@@ -1,0 +1,36 @@
+/**
+ * @file c_api_support/exception_wrapper/test/compile_exception_wrapper_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../exception_wrapper.h"
+
+int main() {
+  tiledb::api::detail::ErrorTreeStdException x{std::runtime_error("")};
+  tiledb::api::detail::ETVisitorStdException v{};
+  x.visit(v);
+  return 1;
+}

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_error_tree.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_error_tree.cc
@@ -1,0 +1,459 @@
+/**
+ * @file c_api_support/exception_wrapper/test/unit_capi_error_tree.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <test/support/tdb_catch.h>
+
+#include <variant>
+
+#include "../exception_wrapper.h"
+#include "tiledb/common/tag.h"
+#include "tiledb/common/unreachable.h"
+
+using namespace tiledb::api;
+using namespace tiledb::api::detail;
+
+//----------------------------------
+// Error
+//----------------------------------
+/**
+ * An error instance, irrespective of ownership
+ *
+ * At base an error is two strings in a pair:
+ * 1. An origin
+ * 2. An error message
+ *
+ * The motivation for using more than `std::string` is to allow constant error
+ * object in support of allocation-free messages for `bad_alloc`. Another aspect
+ * of this goal is that this class is only data. It does not convert to string,
+ * not only to allow the details of formatting to be decided by a visitor, but
+ * also to avoid baking `std::string` operations, which would entail using
+ * the allocator, into this class.
+ *
+ * @section Maturity Notes
+ *
+ * This class has incubation status. It's currently only used in testing and
+ * validating the error tree model. This class can inform how to evolve `class
+ * StatusException`, which needs to unhook itself from `class Status` more.
+ */
+class Error {
+  using string_pair = std::pair<std::string, std::string>;
+  using string_view_pair = std::pair<std::string_view, std::string_view>;
+  /**
+   * A primitive error message (i.e. an item in an ErrorTree) is one of three
+   * things:
+   * index 0: Not actually an error (std::monostate)
+   * index 1: An ordinary error where this object holds the data (string pair)
+   * index 2: A view to an ordinary error in another object (string_view pair)
+   */
+  using storage_type =
+      std::variant<std::monostate, string_pair, string_view_pair>;
+
+  storage_type x_;
+
+ public:
+  [[nodiscard]] bool has_error() const {
+    return x_.index() != 0;
+  }
+
+  /**
+   * Retrieve the whole error.
+   */
+  [[nodiscard]] string_view_pair error() const noexcept {
+    switch (x_.index()) {
+      case 0:
+        /*
+         * Rather than throw when there's no actual stored error, we return a
+         * default object. This function is called as part of exception handling
+         * so we don't want it throwing.
+         */
+        return {};
+      case 1: {
+        /*
+         * The return expression calls the conversion constructor from
+         * `std::string` twice.
+         */
+        const auto& y{get<1>(x_)};
+        return {y.first, y.second};
+      }
+      case 2:
+        return get<2>(x_);
+      default:
+        stdx::unreachable();
+    }
+  }
+
+  /**
+   * Default constructor makes a "no error" instance.
+   */
+  Error()
+      : x_{std::monostate{}} {
+  }
+
+  /**
+   * Constructor from a pair of strings
+   */
+  Error(const std::string& origin, const std::string& message)
+      : x_{string_pair{origin, message}} {
+  }
+
+  /**
+   * Constructor from a pair of string views.
+   *
+   * The string_view constructor is tagged to prevent the compiler from
+   * inferring a string_view from what might be a transient object. Use this
+   * constructor only when life span assumptions are clearly documented.
+   */
+  Error(
+      Tag<std::string_view>, std::string_view origin, std::string_view message)
+      : x_{string_view_pair{origin, message}} {
+  }
+};
+
+TEST_CASE("Error - default constructor", "[error]") {
+  Error x{};
+  auto y{x.error()};
+  /*
+   * Default constructor makes an empty object, but constructs a pair of empty
+   * string views for `error()`.
+   */
+  CHECK(y.first.empty());
+  CHECK(y.second.empty());
+}
+
+TEST_CASE("Error - string constructor 0", "[error]") {
+  std::string origin{"origin"};
+  std::string message{"message"};
+  Error x{origin, message};
+  auto y{x.error()};
+  CHECK(y.first == "origin");
+  CHECK(y.second == "message");
+}
+
+TEST_CASE("Error - string constructor 1", "[error]") {
+  std::string ori{"ori"};
+  std::string gin{"gin"};
+  std::string message{"message"};
+  Error x{ori + gin, message};
+  auto y{x.error()};
+  CHECK(y.first == "origin");
+  CHECK(y.second == "message");
+}
+
+TEST_CASE("Error - string_view constructor", "[error]") {
+  std::string origin{"origin"};
+  std::string message{"message"};
+  Error x{
+      Tag<std::string_view>(),
+      std::string_view(origin),
+      std::string_view(message)};
+  auto y{x.error()};
+  CHECK(y.first == "origin");
+  CHECK(y.second == "message");
+}
+
+//----------------------------------
+// Skeleton Visitor
+//----------------------------------
+/**
+ * This visitor emits a skeleton of the parse structure, ignoring the content
+ * of the nodes.
+ *
+ * @tparam T The node type, which is ignored.
+ */
+template <class T>
+class SkeletonVisitor {
+  std::string s_{};
+
+ public:
+  SkeletonVisitor() = default;
+  void start_level() noexcept {
+    s_ += "(";
+  }
+  void end_level() noexcept {
+    s_ += ")";
+  }
+  void separator() noexcept {
+    s_ += ",";
+  }
+  using item_type = T;
+  void item(const T&) noexcept {
+    /*
+     * It's a skeleton because it ignores each actual item and just marks the
+     * presence of one.
+     */
+    s_ += "x";
+  }
+
+  [[nodiscard]] std::string value() const {
+    return s_;
+  }
+};
+static_assert(ErrorTreeVisitor<SkeletonVisitor<std::exception>>);
+
+//----------------------------------
+// ErrorTreeTest
+//----------------------------------
+/**
+ * An element within the tree of `ErrorTreeTest` along with all its children.
+ *
+ * @tparam E The type contained within each node.
+ */
+template <class E>
+class ETTElement {
+ public:
+  using self_type = E;
+  using vector_type = std::vector<ETTElement>;
+
+ private:
+  E e_;
+  vector_type x_;
+
+ public:
+  ETTElement() = delete;
+  ETTElement(const E& e, const vector_type& x)
+      : e_{e}
+      , x_{x} {
+  }
+  const self_type& self() const {
+    return e_;
+  }
+  const vector_type& children() const {
+    return x_;
+  }
+};
+
+/**
+ * An error graph for testing visitors.
+ *
+ * Each node in a tree is a pair (an Error and a vector of children) manifested
+ * as an instance of `class ETTElement`. The graph as a whole is multi-rooted
+ * for generality, although it's unlikely it will be used that way in practice.
+ */
+class ErrorTreeTest {
+  using vector_type = ETTElement<Error>::vector_type;
+  vector_type x_;
+
+  template <ErrorTreeVisitor V>
+  void visit_recursive(V& v, const vector_type nodes) const {
+    bool separating{false};
+    for (const auto& node : nodes) {
+      if (separating) {
+        v.separator();
+      } else {
+        separating = true;
+      }
+      v.item(node.self());
+      auto children{node.children()};
+      if (!children.empty()) {
+        v.start_level();
+        visit_recursive(v, node.children());
+        v.end_level();
+      }
+    }
+  }
+
+ public:
+  ErrorTreeTest()
+      : x_{vector_type{}} {
+  }
+  ErrorTreeTest(Error e)
+      : x_{ETTElement<Error>{e, {}}} {
+  }
+  ErrorTreeTest(vector_type x)
+      : x_(x) {
+  }
+
+  template <ErrorTreeVisitor V>
+  void visit(V& v) const {
+    visit_recursive(v, x_);
+  }
+};
+
+TEST_CASE("ErrorTreeTest - empty", "[error_tree_test]") {
+  ErrorTreeTest x{};
+  SkeletonVisitor<Error> v{};
+  x.visit(v);
+  CHECK(v.value() == "");
+}
+
+TEST_CASE("ErrorTreeTest - single node", "[error_tree_test]") {
+  ErrorTreeTest x{Error{"a", "b"}};
+  SkeletonVisitor<Error> v{};
+  x.visit(v);
+  CHECK(v.value() == "x");
+}
+
+TEST_CASE("ErrorTreeTest - two wide", "[error_tree_test]") {
+  ErrorTreeTest x{{{Error{"a", "b"}, {}}, {Error{"c", "d"}, {}}}};
+  SkeletonVisitor<Error> v{};
+  x.visit(v);
+  CHECK(v.value() == "x,x");
+}
+
+TEST_CASE("ErrorTreeTest - two deep", "[error_tree_test]") {
+  ErrorTreeTest x{{{Error{"a", "b"}, {{Error{"c", "d"}, {}}}}}};
+  SkeletonVisitor<Error> v{};
+  x.visit(v);
+  CHECK(v.value() == "x(x)");
+}
+
+//----------------------------------
+// ErrorTreeStdException
+//----------------------------------
+TEST_CASE("ErrorTreeStdException - direct throw std::exception") {
+  SkeletonVisitor<std::exception> v{};
+  try {
+    throw std::exception();
+  } catch (const std::exception& e) {
+    ErrorTreeStdException x{e};
+    x.visit(v);
+  }
+  CHECK(v.value() == "x");
+}
+
+/**
+ * Throws nested exceptions of different levels
+ *
+ * - level negative: does nothing
+ * - level zero: throw a non-nested exception
+ * - level N: throws an exception nested N times, all around a level-0 exception
+ *
+ * @param level The number of nesting levels
+ */
+void throw_nested_by_level(int level) {
+  /*
+   * Throw nothing if the level is negative
+   */
+  if (level < 0) {
+    return;
+  } else if (level == 0) {
+    throw std::runtime_error("level 0");
+  }
+  // Assert: level > 0
+  try {
+    throw_nested_by_level(level - 1);
+  } catch (...) {
+    std::throw_with_nested(
+        std::runtime_error("level " + std::to_string(level)));
+  }
+};
+
+std::exception_ptr nested_by_level(int level) {
+  if (level < 0) {
+    throw std::invalid_argument("level may not be negative");
+  }
+  try {
+    throw_nested_by_level(level);
+    throw std::logic_error("throw_nested_by_level did not throw");
+  } catch (...) {
+    return std::current_exception();
+  }
+};
+
+std::exception_ptr se0() {
+  try {
+    throw StatusException("here", "now");
+  } catch (...) {
+    return std::current_exception();
+  }
+}
+
+std::exception_ptr se1() {
+  try {
+    try {
+      throw StatusException("here", "now");
+    } catch (...) {
+      std::throw_with_nested(std::runtime_error("later"));
+    }
+  } catch (...) {
+    return std::current_exception();
+  }
+}
+
+std::exception_ptr se2() {
+  try {
+    try {
+      throw std::runtime_error("now");
+    } catch (...) {
+      std::throw_with_nested(StatusException("here", "later"));
+    }
+  } catch (...) {
+    return std::current_exception();
+  }
+}
+
+struct ETSETestVector {
+  std::string name_;
+  std::exception_ptr exception_;
+  std::string skeleton_;
+  std::string log_;
+};
+
+TEST_CASE("ErrorTreeStdException - skeleton & log") {
+  using TV = ETSETestVector;
+  std::array<TV, 6> vectors{
+      TV{"level 0", nested_by_level(0), "x", "TileDB internal: level 0"},
+      TV{"level 1",
+         nested_by_level(1),
+         "x(x)",
+         "TileDB internal: level 1 (TileDB internal: level 0)"},
+      TV{"level 2",
+         nested_by_level(2),
+         "x(x(x))",
+         "TileDB internal: level 2"
+         " (TileDB internal: level 1"
+         " (TileDB internal: level 0))"},
+      TV{"SE 0", se0(), "x", "here: now"},
+      TV{"SE 1", se1(), "x(x)", "TileDB internal: later (here: now)"},
+      TV{"SE 2", se2(), "x(x)", "here: later (TileDB internal: now)"},
+  };
+
+  for (const auto& vector : vectors) {
+    DYNAMIC_SECTION(vector.name_) {
+      SkeletonVisitor<std::exception> v{};
+      ETVisitorStdException v2{};
+      try {
+        std::rethrow_exception(vector.exception_);
+      } catch (const std::exception& e) {
+        ErrorTreeStdException x{e};
+        x.visit(v);
+        x.visit(v2);
+      } catch (...) {
+        throw std::logic_error("unexpected exception");
+      }
+      SECTION("skeleton") {
+        CHECK(v.value() == vector.skeleton_);
+      }
+      SECTION("log message") {
+        CHECK(v2.value() == vector.log_);
+      }
+    }
+  }
+}

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_exception_wrapper.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_exception_wrapper.cc
@@ -65,7 +65,7 @@ TEST_CASE("ExceptionAction - action") {
    * The action sends a message to the log. We're not going to check that, just
    * that it returns.
    */
-  CHECK_NOTHROW(h.action(Status_Error("an error message")));
+  CHECK_NOTHROW(h.action(std::runtime_error("an error message")));
 }
 
 TEST_CASE("ExceptionActionCtx - construct") {
@@ -84,10 +84,10 @@ TEST_CASE("ExceptionActionCtx - action") {
   tiledb::api::ExceptionActionCtx h{ctx};
   auto x{ctx->context().last_error()};
   CHECK(!x.has_value());
-  h.action(Status_Error("an error message"));
+  h.action(std::runtime_error("an error message"));
   auto y{ctx->context().last_error()};
   REQUIRE(y.has_value());
-  CHECK(y.value() == "Error: an error message");
+  CHECK(y.value() == "TileDB internal: an error message");
 }
 
 TEST_CASE("ExceptionActionErr - construct") {
@@ -117,10 +117,10 @@ TEST_CASE("ExceptionActionErr - action on success") {
 TEST_CASE("ExceptionActionErr - action") {
   tiledb_error_handle_t* error{nullptr};
   tiledb::api::ExceptionActionErr h{&error};
-  h.action(Status_Error("an error message"));
+  h.action(std::runtime_error("an error message"));
   REQUIRE(error != nullptr);
   REQUIRE_NOTHROW(tiledb::api::ensure_error_is_valid(error));
-  CHECK(error->message() == "Error: an error message");
+  CHECK(error->message() == "TileDB internal: an error message");
   tiledb_error_handle_t::break_handle(error);
 }
 
@@ -130,13 +130,13 @@ TEST_CASE("ExceptionActionCtxErr - action") {
   tiledb::api::ExceptionActionCtxErr h{ctx, &error};
   auto x{ctx->context().last_error()};
   CHECK(!x.has_value());
-  h.action(Status_Error("an error message"));
+  h.action(std::runtime_error("an error message"));
   auto y{ctx->context().last_error()};
   REQUIRE(y.has_value());
-  CHECK(y.value() == "Error: an error message");
+  CHECK(y.value() == "TileDB internal: an error message");
   REQUIRE(error != nullptr);
   REQUIRE_NOTHROW(tiledb::api::ensure_error_is_valid(error));
-  CHECK(error->message() == "Error: an error message");
+  CHECK(error->message() == "TileDB internal: an error message");
   tiledb_error_handle_t::break_handle(error);
 }
 
@@ -264,6 +264,7 @@ TEST_CASE("api_entry_context - throw") {
   CHECK(tiledb_status(rc) == TILEDB_ERR);
   auto e{x.context->last_error()};
   CHECK(e.has_value());
+  CHECK(e.value() == "Test: error");
 }
 
 TEST_CASE("api_entry_error - return") {
@@ -285,5 +286,6 @@ TEST_CASE("api_entry_error - throw") {
   auto rc{tiledb::api::api_entry_error<tf_always_throw>(&error)};
   CHECK(tiledb_status(rc) == TILEDB_ERR);
   REQUIRE(error != nullptr);
+  CHECK(error->message() == "Test: error");
   tiledb_error_free(&error);
 }

--- a/tiledb/api/c_api_support/handle/handle.h
+++ b/tiledb/api/c_api_support/handle/handle.h
@@ -216,7 +216,7 @@ class CAPIHandle {
  * @tparam E Exception type to throw if handle is not valid
  * @param p a possible pointer to an object of type T
  */
-template <class T, class E = CAPIStatusException>
+template <class T, class E = CAPIException>
 void ensure_handle_is_valid(const T* p) {
   if (p == nullptr) {
     throw E(std::string("Invalid TileDB ") + T::handle_name() + " object");

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -799,7 +799,7 @@ int32_t tiledb_array_schema_get_attribute_from_name(
   std::string name_string(name);
   auto found_attr = array_schema->array_schema_->shared_attribute(name_string);
   if (!found_attr) {
-    throw CAPIStatusError(
+    throw CAPIException(
         std::string("Attribute name: ") +
         (name_string.empty() ? "<anonymous>" : name) +
         " does not exist for array " +

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -84,6 +84,11 @@ void Context::save_error(const Status& st) {
   last_error_ = st.to_string();
 }
 
+void Context::save_error(const std::string& msg) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  last_error_ = msg;
+}
+
 void Context::save_error(const StatusException& st) {
   std::lock_guard<std::mutex> lock(mtx_);
   last_error_ = st.what();

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -81,6 +81,11 @@ class Context {
   void save_error(const Status& st);
 
   /**
+   * Saves a `std::string` as the last error.
+   */
+  void save_error(const std::string& msg);
+
+  /**
    * Saves a `StatusException` as the last error.
    */
   void save_error(const StatusException& st);


### PR DESCRIPTION
Stop converting exceptions to `class Status` in the exception handler. Replace it with direct handling of the exception. The new handler captures messages in `std::nested_exception`.

Rename `CAPIStatusException` to `CAPIException`. Remove no-longer-used code. Updated `CMakeLists.txt` for the exception wrapper tests.

[sc-33024]

---
TYPE: IMPROVEMENT
DESC: Logs for nested exceptions now incorporate all messages.
