### PR TITLE
Update `clang-format` to version 16.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -59,6 +59,7 @@ IncludeCategories:
     Priority:        3
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
@@ -76,6 +77,8 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments:  true
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
 SortIncludes:    true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true

--- a/cmake/Modules/FindClangTools.cmake
+++ b/cmake/Modules/FindClangTools.cmake
@@ -53,22 +53,6 @@ endif()
 find_program(CLANG_FORMAT_BIN
   NAMES
   clang-format-16
-  clang-format-15
-  clang-format-14
-  clang-format-13
-  clang-format-12
-  clang-format-11
-  clang-format-10
-  clang-format-9
-  clang-format-8
-  clang-format-7
-  clang-format-6
-  clang-format-5.0
-  clang-format-4.0
-  clang-format-3.9
-  clang-format-3.8
-  clang-format-3.7
-  clang-format-3.6
   clang-format
   PATHS ${ClangTools_PATH} $ENV{CLANG_TOOLS_PATH} /usr/local/bin /usr/bin
         NO_DEFAULT_PATH

--- a/cmake/Modules/FindClangTools.cmake
+++ b/cmake/Modules/FindClangTools.cmake
@@ -52,6 +52,8 @@ endif()
 
 find_program(CLANG_FORMAT_BIN
   NAMES
+  clang-format-16
+  clang-format-15
   clang-format-14
   clang-format-13
   clang-format-12

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -208,7 +208,7 @@ set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 
 find_package(ClangTools)
 if (NOT ${CLANG_FORMAT_FOUND})
-  find_program(CLANG_FORMAT_BIN NAMES clang-format-16 clang-format-15 clang-format-14 clang-format-13 clang-format-12 clang-format-11 clang-format-10 clang-format-9 clang-format-8 clang-format-7 clang-format-6.0 clang-format-5.0 clang-format-4.0)
+  find_program(CLANG_FORMAT_BIN NAMES clang-format-16)
   if(CLANG_FORMAT_BIN)
     set(CLANG_FORMAT_FOUND TRUE)
   endif()

--- a/cmake/TileDB-Superbuild.cmake
+++ b/cmake/TileDB-Superbuild.cmake
@@ -208,7 +208,7 @@ set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 
 find_package(ClangTools)
 if (NOT ${CLANG_FORMAT_FOUND})
-  find_program(CLANG_FORMAT_BIN NAMES clang-format-14 clang-format-13 clang-format-12 clang-format-11 clang-format-10 clang-format-9 clang-format-8 clang-format-7 clang-format-6.0 clang-format-5.0 clang-format-4.0)
+  find_program(CLANG_FORMAT_BIN NAMES clang-format-16 clang-format-15 clang-format-14 clang-format-13 clang-format-12 clang-format-11 clang-format-10 clang-format-9 clang-format-8 clang-format-7 clang-format-6.0 clang-format-5.0 clang-format-4.0)
   if(CLANG_FORMAT_BIN)
     set(CLANG_FORMAT_FOUND TRUE)
   endif()

--- a/examples/png_ingestion/src/main.cc
+++ b/examples/png_ingestion/src/main.cc
@@ -36,7 +36,7 @@
 
 #include <png.h>
 // Note: on some macOS platforms with a brew-installed libpng, use this instead:
-//#include <libpng16/png.h>
+// #include <libpng16/png.h>
 
 // Include the TileDB C++ API headers
 #include <tiledb/tiledb>

--- a/experimental/tiledb/common/dag/execution/test/unit_frugal.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_frugal.cc
@@ -587,9 +587,9 @@ TEMPLATE_TEST_CASE(
  * Some deduction guides
  */
 namespace tiledb::common {
-Task(node&)->Task<node>;
+Task(node&) -> Task<node>;
 
-Task(const node&)->Task<node>;
+Task(const node&) -> Task<node>;
 
 template <template <class> class M, class T>
 Task(producer_node<M, T>) -> Task<node>;

--- a/experimental/tiledb/common/dag/execution/test/unit_tasks.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_tasks.cc
@@ -326,9 +326,9 @@ TEMPLATE_TEST_CASE(
  * Some deduction guides
  */
 namespace tiledb::common {
-Task(node&)->Task<node>;
+Task(node&) -> Task<node>;
 
-Task(const node&)->Task<node>;
+Task(const node&) -> Task<node>;
 
 template <template <class> class M, class T>
 Task(producer_node<M, T>) -> Task<node>;

--- a/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
+++ b/experimental/tiledb/common/dag/nodes/detail/segmented/function.h
@@ -208,8 +208,8 @@ class function_node_impl : public node_base,
   BlockOut out_thing{};
 
  public:
-  //#pragma clang diagnostic push
-  //#pragma ide diagnostic ignored "UnreachableCode"
+  // #pragma clang diagnostic push
+  // #pragma ide diagnostic ignored "UnreachableCode"
   /**
    * Resume the node.  This will call the function that produces items.
    * Main entry point of the node.
@@ -335,7 +335,7 @@ auto post_state = sink_mover->state();
     }
     return scheduler_event_type::error;
   }
-  //#pragma clang diagnostic pop
+  // #pragma clang diagnostic pop
 
   /** Run the node until it is done. */
   void run() override {

--- a/scripts/ci/check_formatting_linux.sh
+++ b/scripts/ci/check_formatting_linux.sh
@@ -28,11 +28,11 @@
 
 set -e pipefail
 
-# Install clang-format (v9)
+# Install clang-format
 ls -la
 sudo ./scripts/install-clangformat.sh
 
 src=$GITHUB_WORKSPACE
 cd $src
 
-$src/scripts/run-clang-format.sh $src clang-format-14 0
+$src/scripts/run-clang-format.sh $src clang-format-16 0

--- a/scripts/install-clangformat.sh
+++ b/scripts/install-clangformat.sh
@@ -30,8 +30,8 @@ die() {
 
 install_apt_pkg() {
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main' &&
-  apt-get update -qq && apt-get install -qq -y clang-format-14
+  add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main' &&
+  apt-get update -qq && apt-get install -qq -y clang-format-16
 }
 
 install_brew_pkg() {

--- a/test/src/unit-capi-query_2.cc
+++ b/test/src/unit-capi-query_2.cc
@@ -1093,8 +1093,8 @@ TEST_CASE_METHOD(
       CHECK(
           size_off == (uint64_t)((2.0 / 3 + 2.0 / 6) * (2 * sizeof(uint64_t))));
       CHECK(
-          size_val ==
-          (uint64_t)((2.0 / 3) * (3 * sizeof(int)) + (2.0 / 6) * (6 * sizeof(int))));
+          size_val == (uint64_t)((2.0 / 3) * (3 * sizeof(int)) +
+                                 (2.0 / 6) * (6 * sizeof(int))));
     }
 
     SECTION("-- Partial overlap, 2 ranges") {
@@ -1223,8 +1223,8 @@ TEST_CASE_METHOD(
       CHECK(
           size_off == (uint64_t)((2.0 / 3 + 2.0 / 6) * (2 * sizeof(uint64_t))));
       CHECK(
-          size_val ==
-          (uint64_t)((2.0 / 3) * (3 * sizeof(int)) + (2.0 / 6) * (6 * sizeof(int))));
+          size_val == (uint64_t)((2.0 / 3) * (3 * sizeof(int)) +
+                                 (2.0 / 6) * (6 * sizeof(int))));
     }
 
     SECTION("-- Partial overlap, 2 ranges") {

--- a/tiledb/sm/filter/test/compile_all_filters_main.cc
+++ b/tiledb/sm/filter/test/compile_all_filters_main.cc
@@ -33,7 +33,7 @@ int main() {
 
   (void)sizeof(tiledb::sm::FilterCreate);
   (void)static_cast<shared_ptr<Filter> (*)(
-      Deserializer & deserializer, const uint32_t version, Datatype datatype)>(
+      Deserializer& deserializer, const uint32_t version, Datatype datatype)>(
       tiledb::sm::FilterCreate::deserialize);
   return 0;
 }

--- a/tiledb/sm/stats/test/unit_stats.cc
+++ b/tiledb/sm/stats/test/unit_stats.cc
@@ -35,7 +35,7 @@
 #include <test/support/tdb_catch.h>
 #include <tiledb/common/common.h>
 #include <tiledb/common/dynamic_memory/dynamic_memory.h>
-//#include <tiledb/sm/cpp_api/tiledb>
+// #include <tiledb/sm/cpp_api/tiledb>
 #include <tiledb/sm/stats/global_stats.h>
 
 #include <string>

--- a/tiledb/sm/stats/test/unit_stats.cc
+++ b/tiledb/sm/stats/test/unit_stats.cc
@@ -35,7 +35,6 @@
 #include <test/support/tdb_catch.h>
 #include <tiledb/common/common.h>
 #include <tiledb/common/dynamic_memory/dynamic_memory.h>
-// #include <tiledb/sm/cpp_api/tiledb>
 #include <tiledb/sm/stats/global_stats.h>
 
 #include <string>


### PR DESCRIPTION
[SC-28596](https://app.shortcut.com/tiledb-inc/story/28596/core-update-to-clang-format-16)

The process is identical to 14706065bc9812e89b1cea1890226f391c8de77f (updating the tool) and c2451645b19e0ca0bec944e21d5beee1b22a2c91 (reformatting the code).

---
TYPE: IMPROVEMENT
DESC: Update `clang-format` to version 16.