### PR TITLE
Align comments with `clang-format-16`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,10 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
 AlignOperands:   true
-AlignTrailingComments: true
+#AlignTrailingComments: true
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,6 @@ AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
 AlignOperands:   true
-#AlignTrailingComments: true
 AlignTrailingComments:
   Kind: Always
   OverEmptyLines: 0


### PR DESCRIPTION
Running `clang-format-16` locally aligns trailing comments differently than what's already in `dev`. Furthermore, the directive `AlignTrailingComments` changed from its old value (boolean) to one with more parameters. This PR updates `.clang-format` for that directive. Hopefully this reduces any variation between local and CI installations.

---
TYPE: NO_HISTORY
DESC: clang-format-16
