### PR TITLE
Implement tiledb_handle_load_array_schema_request

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -188,6 +188,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-tile-metadata-generator.cc
   src/unit-ReadCellSlabIter.cc
   src/unit-Reader.cc
+  src/unit-request-handlers.cc
   src/unit-resource-pool.cc
   src/unit-result-coords.cc
   src/unit-result-tile.cc

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -1,0 +1,266 @@
+/**
+ * @file unit-request-handlers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the C API request handlers.
+ */
+
+#ifdef TILEDB_SERIALIZATION
+
+#include "test/support/tdb_catch.h"
+#include "tiledb/api/c_api/buffer/buffer_api_internal.h"
+#include "tiledb/sm/array_schema/enumeration.h"
+#include "tiledb/sm/c_api/tiledb_serialization.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/crypto/encryption_key.h"
+#include "tiledb/sm/enums/array_type.h"
+#include "tiledb/sm/enums/encryption_type.h"
+#include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/serialization/array_schema.h"
+#include "tiledb/sm/storage_manager/context.h"
+
+using namespace tiledb::sm;
+
+struct RequestHandlerFx {
+  RequestHandlerFx(const std::string array_uri);
+  virtual ~RequestHandlerFx();
+
+  virtual shared_ptr<ArraySchema> create_schema() = 0;
+
+  void create_array();
+  void delete_array();
+
+  shared_ptr<Array> get_array(QueryType type);
+
+  shared_ptr<const Enumeration> create_string_enumeration(
+      std::string name, std::vector<std::string>& values);
+
+  URI uri_;
+  Config cfg_;
+  Context ctx_;
+  EncryptionKey enc_key_;
+};
+
+struct HandleLoadArraySchemaRequestFx : RequestHandlerFx {
+  HandleLoadArraySchemaRequestFx()
+      : RequestHandlerFx("load_array_schema_handler") {
+  }
+
+  virtual shared_ptr<ArraySchema> create_schema() override;
+  ArraySchema call_handler(
+      serialization::LoadArraySchemaRequest req, SerializationType stype);
+};
+
+/* ********************************* */
+/*   Testing Array Schema Loading    */
+/* ********************************* */
+
+TEST_CASE_METHOD(
+    HandleLoadArraySchemaRequestFx,
+    "tiledb_handle_load_array_schema_request - default request",
+    "[request_handler][load_array_schema][default]") {
+  auto stype = GENERATE(SerializationType::JSON, SerializationType::CAPNP);
+
+  create_array();
+  auto schema =
+      call_handler(serialization::LoadArraySchemaRequest(false), stype);
+  REQUIRE(schema.has_enumeration("enmr"));
+  REQUIRE(schema.get_loaded_enumeration_names().size() == 0);
+}
+
+TEST_CASE_METHOD(
+    HandleLoadArraySchemaRequestFx,
+    "tiledb_handle_load_array_schema_request - load enumerations",
+    "[request_handler][load_array_schema][with-enumerations]") {
+  auto stype = GENERATE(SerializationType::JSON, SerializationType::CAPNP);
+
+  create_array();
+  auto schema =
+      call_handler(serialization::LoadArraySchemaRequest(true), stype);
+  REQUIRE(schema.has_enumeration("enmr"));
+  REQUIRE(schema.get_loaded_enumeration_names().size() == 1);
+  REQUIRE(schema.get_loaded_enumeration_names()[0] == "enmr");
+  REQUIRE(schema.get_enumeration("enmr") != nullptr);
+}
+
+TEST_CASE_METHOD(
+    HandleLoadArraySchemaRequestFx,
+    "Error Checks: tiledb_handle_load_array_schema_request",
+    "[request_handler][load_array_schema][errors]") {
+  create_array();
+
+  auto ctx = tiledb::Context();
+  auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
+  auto stype = TILEDB_CAPNP;
+  auto req_buf = tiledb_buffer_handle_t::make_handle();
+  auto resp_buf = tiledb_buffer_handle_t::make_handle();
+
+  auto rval = tiledb_handle_load_array_schema_request(
+      nullptr,
+      array.ptr().get(),
+      static_cast<tiledb_serialization_type_t>(stype),
+      req_buf,
+      resp_buf);
+  REQUIRE(rval != TILEDB_OK);
+
+  rval = tiledb_handle_load_array_schema_request(
+      ctx.ptr().get(),
+      nullptr,
+      static_cast<tiledb_serialization_type_t>(stype),
+      req_buf,
+      resp_buf);
+  REQUIRE(rval != TILEDB_OK);
+
+  rval = tiledb_handle_load_array_schema_request(
+      ctx.ptr().get(),
+      array.ptr().get(),
+      static_cast<tiledb_serialization_type_t>(stype),
+      nullptr,
+      resp_buf);
+  REQUIRE(rval != TILEDB_OK);
+
+  rval = tiledb_handle_load_array_schema_request(
+      ctx.ptr().get(),
+      array.ptr().get(),
+      static_cast<tiledb_serialization_type_t>(stype),
+      req_buf,
+      nullptr);
+  REQUIRE(rval != TILEDB_OK);
+}
+
+/* ********************************* */
+/*       Testing Support Code        */
+/* ********************************* */
+
+RequestHandlerFx::RequestHandlerFx(const std::string uri)
+    : uri_(uri)
+    , ctx_(cfg_) {
+  delete_array();
+  throw_if_not_ok(enc_key_.set_key(EncryptionType::NO_ENCRYPTION, nullptr, 0));
+}
+
+RequestHandlerFx::~RequestHandlerFx() {
+  delete_array();
+}
+
+void RequestHandlerFx::create_array() {
+  auto schema = create_schema();
+  throw_if_not_ok(ctx_.storage_manager()->array_create(uri_, schema, enc_key_));
+}
+
+void RequestHandlerFx::delete_array() {
+  bool is_dir;
+  throw_if_not_ok(ctx_.resources().vfs().is_dir(uri_, &is_dir));
+  if (is_dir) {
+    throw_if_not_ok(ctx_.resources().vfs().remove_dir(uri_));
+  }
+}
+
+shared_ptr<Array> RequestHandlerFx::get_array(QueryType type) {
+  auto array = make_shared<Array>(HERE(), uri_, ctx_.storage_manager());
+  throw_if_not_ok(array->open(type, EncryptionType::NO_ENCRYPTION, nullptr, 0));
+  return array;
+}
+
+shared_ptr<const Enumeration> RequestHandlerFx::create_string_enumeration(
+    std::string name, std::vector<std::string>& values) {
+  uint64_t total_size = 0;
+  for (auto v : values) {
+    total_size += v.size();
+  }
+
+  std::vector<uint8_t> data(total_size, 0);
+  std::vector<uint64_t> offsets;
+  offsets.reserve(values.size());
+  uint64_t curr_offset = 0;
+
+  for (auto v : values) {
+    std::memcpy(data.data() + curr_offset, v.data(), v.size());
+    offsets.push_back(curr_offset);
+    curr_offset += v.size();
+  }
+
+  return Enumeration::create(
+      name,
+      Datatype::STRING_ASCII,
+      constants::var_num,
+      false,
+      data.data(),
+      total_size,
+      offsets.data(),
+      offsets.size() * sizeof(uint64_t));
+}
+
+shared_ptr<ArraySchema> HandleLoadArraySchemaRequestFx::create_schema() {
+  // Create a schema to serialize
+  auto schema = make_shared<ArraySchema>(HERE(), ArrayType::SPARSE);
+  auto dim = make_shared<Dimension>(HERE(), "dim1", Datatype::INT32);
+  int range[2] = {0, 1000};
+  throw_if_not_ok(dim->set_domain(range));
+
+  auto dom = make_shared<Domain>(HERE());
+  throw_if_not_ok(dom->add_dimension(dim));
+  throw_if_not_ok(schema->set_domain(dom));
+
+  std::vector<std::string> values = {"pig", "cow", "chicken", "dog", "cat"};
+  auto enmr = create_string_enumeration("enmr", values);
+  schema->add_enumeration(enmr);
+
+  auto attr = make_shared<Attribute>(HERE(), "attr", Datatype::INT32);
+  attr->set_enumeration_name("enmr");
+  throw_if_not_ok(schema->add_attribute(attr));
+
+  return schema;
+}
+
+ArraySchema HandleLoadArraySchemaRequestFx::call_handler(
+    serialization::LoadArraySchemaRequest req, SerializationType stype) {
+  // If this looks weird, its because we're using the public C++ API to create
+  // these objets instead of the internal APIs elsewhere in this test suite.
+  // This is because the handlers are C API so accept API handles, not internal
+  // objects.
+  auto ctx = tiledb::Context();
+  auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
+  auto req_buf = tiledb_buffer_handle_t::make_handle();
+  auto resp_buf = tiledb_buffer_handle_t::make_handle();
+
+  serialization::serialize_load_array_schema_request(
+      cfg_, req, stype, req_buf->buffer());
+  auto rval = tiledb_handle_load_array_schema_request(
+      ctx.ptr().get(),
+      array.ptr().get(),
+      static_cast<tiledb_serialization_type_t>(stype),
+      req_buf,
+      resp_buf);
+  REQUIRE(rval == TILEDB_OK);
+
+  return serialization::deserialize_load_array_schema_response(
+      stype, resp_buf->buffer());
+}
+
+#endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -746,6 +746,25 @@ TILEDB_EXPORT int32_t tiledb_deserialize_group_metadata(
     const tiledb_buffer_t* buffer) TILEDB_NOEXCEPT;
 
 /**
+ * Process a load array schema request.
+ *
+ * @param ctx The TileDB context.
+ * @param array The TileDB Array.
+ * @param serialization_type The type of Cap'n Proto serialization used.
+ * @param request A buffer containing the LoadArraySchemaRequest Cap'n Proto
+ *        message.
+ * @param response An allocated buffer that will contain the
+ *        LoadArraySchemaResponse Cap'n Proto message.
+ * @return capi_return_t TILEDB_OK on success, TILEDB_ERR on error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_handle_load_array_schema_request(
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    tiledb_serialization_type_t serialization_type,
+    const tiledb_buffer_t* request,
+    tiledb_buffer_t* response) TILEDB_NOEXCEPT;
+
+/**
  * Process a load enumerations request.
  *
  * @param ctx The TileDB context.

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -246,6 +246,56 @@ RestClient::get_array_schema_from_rest(const URI& uri) {
               serialization_type_, returned_data))};
 }
 
+shared_ptr<ArraySchema> RestClient::post_array_schema_from_rest(
+    const Config& config,
+    const URI& uri,
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    bool include_enumerations) {
+  serialization::LoadArraySchemaRequest req(include_enumerations);
+
+  Buffer buf;
+  serialization::serialize_load_array_schema_request(
+      config, req, serialization_type_, buf);
+
+  // Wrap in a list
+  BufferList serialized;
+  throw_if_not_ok(serialized.add_buffer(std::move(buf)));
+
+  // Init curl and form the URL
+  Curl curlc(logger_);
+  std::string array_ns, array_uri;
+  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  const std::string cache_key = array_ns + ":" + array_uri;
+  throw_if_not_ok(
+      curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
+                          "/" + curlc.url_escape(array_uri) + "/schema?" +
+                          "start_timestamp=" + std::to_string(timestamp_start) +
+                          "&end_timestamp=" + std::to_string(timestamp_end);
+
+  // Get the data
+  Buffer returned_data;
+  throw_if_not_ok(curlc.post_data(
+      stats_,
+      url,
+      serialization_type_,
+      &serialized,
+      &returned_data,
+      cache_key));
+  if (returned_data.data() == nullptr || returned_data.size() == 0) {
+    throw Status_RestError(
+        "Error getting array schema from REST; server returned no data.");
+  }
+
+  // Ensure data has a null delimiter for cap'n proto if using JSON
+  throw_if_not_ok(ensure_json_null_delimited_string(&returned_data));
+  return make_shared<ArraySchema>(
+      HERE(),
+      serialization::deserialize_load_array_schema_response(
+          serialization_type_, returned_data));
+}
+
 Status RestClient::post_array_schema_to_rest(
     const URI& uri, const ArraySchema& array_schema) {
   Buffer buff;

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -101,6 +101,21 @@ class RestClient {
       const URI& uri);
 
   /**
+   * Get an array schema from the rest server. This will eventually replace the
+   * get_array_schema_from_rest after TileDB-Cloud-REST merges support for the
+   * POST endpoint.
+   *
+   * @param uri The Array URI to load the schema from.
+   * @return shared_ptr<ArraySchema> The loaded array schema.
+   */
+  shared_ptr<ArraySchema> post_array_schema_from_rest(
+      const Config& config,
+      const URI& uri,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end,
+      bool include_enumerations = false);
+
+  /**
    * Post the array config and get an array from rest server
    *
    * @param uri of array being loaded

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -36,6 +36,7 @@
 #include <unordered_map>
 
 #include "tiledb/common/status.h"
+#include "tiledb/sm/config/config.h"
 
 #ifdef TILEDB_SERIALIZATION
 #include "tiledb/sm/serialization/capnp_utils.h"
@@ -53,6 +54,20 @@ class Dimension;
 enum class SerializationType : uint8_t;
 
 namespace serialization {
+
+class LoadArraySchemaRequest {
+ public:
+  LoadArraySchemaRequest(bool include_enumerations = false)
+      : include_enumerations_(include_enumerations) {
+  }
+
+  inline bool include_enumerations() const {
+    return include_enumerations_;
+  }
+
+ private:
+  bool include_enumerations_;
+};
 
 #ifdef TILEDB_SERIALIZATION
 /**
@@ -174,6 +189,23 @@ Status max_buffer_sizes_deserialize(
     SerializationType serialize_type,
     std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>*
         buffer_sizes);
+
+void serialize_load_array_schema_request(
+    const Config& config,
+    const LoadArraySchemaRequest& req,
+    SerializationType serialization_type,
+    Buffer& data);
+
+LoadArraySchemaRequest deserialize_load_array_schema_request(
+    SerializationType serialization_type, const Buffer& data);
+
+void serialize_load_array_schema_response(
+    const ArraySchema& schema,
+    SerializationType serialization_type,
+    Buffer& data);
+
+ArraySchema deserialize_load_array_schema_response(
+    SerializationType serialization_type, const Buffer& data);
 
 }  // namespace serialization
 }  // namespace sm

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.c++
@@ -9612,6 +9612,121 @@ const ::capnp::_::RawSchema s_805c080c10c1e959 = {
   1, 1, i_805c080c10c1e959, nullptr, nullptr, { &s_805c080c10c1e959, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<52> b_83f094010132ff21 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     33, 255,  50,   1,   1, 148, 240, 131,
+     18,   0,   0,   0,   1,   0,   1,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  74,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  65, 114,
+    114,  97, 121,  83,  99, 104, 101, 109,
+     97,  82, 101, 113, 117, 101, 115, 116,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0, 162,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     48,   0,   0,   0,   3,   0,   1,   0,
+     60,   0,   0,   0,   2,   0,   1,   0,
+     99, 111, 110, 102, 105, 103,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    105, 110,  99, 108, 117, 100, 101,  69,
+    110, 117, 109, 101, 114,  97, 116, 105,
+    111, 110, 115,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_83f094010132ff21 = b_83f094010132ff21.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_83f094010132ff21[] = {
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_83f094010132ff21[] = {0, 1};
+static const uint16_t i_83f094010132ff21[] = {0, 1};
+const ::capnp::_::RawSchema s_83f094010132ff21 = {
+  0x83f094010132ff21, b_83f094010132ff21.words, 52, d_83f094010132ff21, m_83f094010132ff21,
+  1, 2, i_83f094010132ff21, nullptr, nullptr, { &s_83f094010132ff21, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<35> b_ebe17f59ac9a1df1 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    241,  29, 154, 172,  89, 127, 225, 235,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  82,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  65, 114,
+    114,  97, 121,  83,  99, 104, 101, 109,
+     97,  82, 101, 115, 112, 111, 110, 115,
+    101,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+     20,   0,   0,   0,   2,   0,   1,   0,
+    115,  99, 104, 101, 109,  97,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    254, 150, 226, 152,  47, 227,  29, 215,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_ebe17f59ac9a1df1 = b_ebe17f59ac9a1df1.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_ebe17f59ac9a1df1[] = {
+  &s_d71de32f98e296fe,
+};
+static const uint16_t m_ebe17f59ac9a1df1[] = {0};
+static const uint16_t i_ebe17f59ac9a1df1[] = {0};
+const ::capnp::_::RawSchema s_ebe17f59ac9a1df1 = {
+  0xebe17f59ac9a1df1, b_ebe17f59ac9a1df1.words, 35, d_ebe17f59ac9a1df1, m_ebe17f59ac9a1df1,
+  1, 1, i_ebe17f59ac9a1df1, nullptr, nullptr, { &s_ebe17f59ac9a1df1, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp
 
@@ -10300,6 +10415,22 @@ constexpr uint16_t LoadEnumerationsResponse::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind LoadEnumerationsResponse::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* LoadEnumerationsResponse::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadArraySchemaRequest
+constexpr uint16_t LoadArraySchemaRequest::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadArraySchemaRequest::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadArraySchemaRequest::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadArraySchemaRequest::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadArraySchemaResponse
+constexpr uint16_t LoadArraySchemaResponse::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadArraySchemaResponse::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadArraySchemaResponse::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadArraySchemaResponse::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/posix/tiledb-rest.capnp.h
@@ -101,6 +101,8 @@ CAPNP_DECLARE_SCHEMA(f5a35661031194d2);
 CAPNP_DECLARE_SCHEMA(e68edfc0939e63df);
 CAPNP_DECLARE_SCHEMA(891a70a671f15cf6);
 CAPNP_DECLARE_SCHEMA(805c080c10c1e959);
+CAPNP_DECLARE_SCHEMA(83f094010132ff21);
+CAPNP_DECLARE_SCHEMA(ebe17f59ac9a1df1);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -1636,6 +1638,40 @@ struct LoadEnumerationsResponse {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(805c080c10c1e959, 0, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadArraySchemaRequest {
+  LoadArraySchemaRequest() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(83f094010132ff21, 1, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadArraySchemaResponse {
+  LoadArraySchemaResponse() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(ebe17f59ac9a1df1, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -14573,6 +14609,216 @@ class LoadEnumerationsResponse::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadArraySchemaRequest::Reader {
+ public:
+  typedef LoadArraySchemaRequest Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig() const;
+  inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
+
+  inline bool getIncludeEnumerations() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadArraySchemaRequest::Builder {
+ public:
+  typedef LoadArraySchemaRequest Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig();
+  inline ::tiledb::sm::serialization::capnp::Config::Builder getConfig();
+  inline void setConfig(
+      ::tiledb::sm::serialization::capnp::Config::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Config::Builder initConfig();
+  inline void adoptConfig(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+  disownConfig();
+
+  inline bool getIncludeEnumerations();
+  inline void setIncludeEnumerations(bool value);
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadArraySchemaRequest::Pipeline {
+ public:
+  typedef LoadArraySchemaRequest Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadArraySchemaResponse::Reader {
+ public:
+  typedef LoadArraySchemaResponse Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasSchema() const;
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Reader getSchema()
+      const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadArraySchemaResponse::Builder {
+ public:
+  typedef LoadArraySchemaResponse Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasSchema();
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder getSchema();
+  inline void setSchema(
+      ::tiledb::sm::serialization::capnp::ArraySchema::Reader value);
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder initSchema();
+  inline void adoptSchema(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>
+  disownSchema();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadArraySchemaResponse::Pipeline {
+ public:
+  typedef LoadArraySchemaResponse Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Pipeline getSchema();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -31179,6 +31425,123 @@ LoadEnumerationsResponse::Builder::disownEnumerations() {
                                           .getPointerField(
                                               ::capnp::bounded<0>() *
                                               ::capnp::POINTERS));
+}
+
+inline bool LoadArraySchemaRequest::Reader::hasConfig() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadArraySchemaRequest::Builder::hasConfig() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Config::Reader
+LoadArraySchemaRequest::Reader::getConfig() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadArraySchemaRequest::Builder::getConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Config::Pipeline
+LoadArraySchemaRequest::Pipeline::getConfig() {
+  return ::tiledb::sm::serialization::capnp::Config::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void LoadArraySchemaRequest::Builder::setConfig(
+    ::tiledb::sm::serialization::capnp::Config::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadArraySchemaRequest::Builder::initConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void LoadArraySchemaRequest::Builder::adoptConfig(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+LoadArraySchemaRequest::Builder::disownConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool LoadArraySchemaRequest::Reader::getIncludeEnumerations() const {
+  return _reader.getDataField<bool>(::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline bool LoadArraySchemaRequest::Builder::getIncludeEnumerations() {
+  return _builder.getDataField<bool>(::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline void LoadArraySchemaRequest::Builder::setIncludeEnumerations(
+    bool value) {
+  _builder.setDataField<bool>(::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
+}
+
+inline bool LoadArraySchemaResponse::Reader::hasSchema() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadArraySchemaResponse::Builder::hasSchema() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Reader
+LoadArraySchemaResponse::Reader::getSchema() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder
+LoadArraySchemaResponse::Builder::getSchema() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Pipeline
+LoadArraySchemaResponse::Pipeline::getSchema() {
+  return ::tiledb::sm::serialization::capnp::ArraySchema::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void LoadArraySchemaResponse::Builder::setSchema(
+    ::tiledb::sm::serialization::capnp::ArraySchema::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder
+LoadArraySchemaResponse::Builder::initSchema() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void LoadArraySchemaResponse::Builder::adoptSchema(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>
+LoadArraySchemaResponse::Builder::disownSchema() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace capnp

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -1232,3 +1232,16 @@ struct LoadEnumerationsResponse {
   enumerations @0 :List(Enumeration);
   # The loaded enumerations
 }
+
+struct LoadArraySchemaRequest {
+  config @0 :Config;
+  # Config
+
+  includeEnumerations @1 :Bool;
+  # When true, include all enumeration data in the returned ArraySchema
+}
+
+struct LoadArraySchemaResponse {
+  schema @0 :ArraySchema;
+  # The loaded ArraySchema
+}

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.c++
@@ -9612,6 +9612,121 @@ const ::capnp::_::RawSchema s_805c080c10c1e959 = {
   1, 1, i_805c080c10c1e959, nullptr, nullptr, { &s_805c080c10c1e959, nullptr, nullptr, 0, 0, nullptr }
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<52> b_83f094010132ff21 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+     33, 255,  50,   1,   1, 148, 240, 131,
+     18,   0,   0,   0,   1,   0,   1,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  74,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  65, 114,
+    114,  97, 121,  83,  99, 104, 101, 109,
+     97,  82, 101, 113, 117, 101, 115, 116,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0, 162,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     48,   0,   0,   0,   3,   0,   1,   0,
+     60,   0,   0,   0,   2,   0,   1,   0,
+     99, 111, 110, 102, 105, 103,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+     54, 173,  17, 129,  75,  91, 201, 182,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    105, 110,  99, 108, 117, 100, 101,  69,
+    110, 117, 109, 101, 114,  97, 116, 105,
+    111, 110, 115,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      1,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_83f094010132ff21 = b_83f094010132ff21.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_83f094010132ff21[] = {
+  &s_b6c95b4b8111ad36,
+};
+static const uint16_t m_83f094010132ff21[] = {0, 1};
+static const uint16_t i_83f094010132ff21[] = {0, 1};
+const ::capnp::_::RawSchema s_83f094010132ff21 = {
+  0x83f094010132ff21, b_83f094010132ff21.words, 52, d_83f094010132ff21, m_83f094010132ff21,
+  1, 2, i_83f094010132ff21, nullptr, nullptr, { &s_83f094010132ff21, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<35> b_ebe17f59ac9a1df1 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    241,  29, 154, 172,  89, 127, 225, 235,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  82,   1,   0,   0,
+     41,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     37,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  76, 111,  97, 100,  65, 114,
+    114,  97, 121,  83,  99, 104, 101, 109,
+     97,  82, 101, 115, 112, 111, 110, 115,
+    101,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0,  58,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+     20,   0,   0,   0,   2,   0,   1,   0,
+    115,  99, 104, 101, 109,  97,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    254, 150, 226, 152,  47, 227,  29, 215,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_ebe17f59ac9a1df1 = b_ebe17f59ac9a1df1.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_ebe17f59ac9a1df1[] = {
+  &s_d71de32f98e296fe,
+};
+static const uint16_t m_ebe17f59ac9a1df1[] = {0};
+static const uint16_t i_ebe17f59ac9a1df1[] = {0};
+const ::capnp::_::RawSchema s_ebe17f59ac9a1df1 = {
+  0xebe17f59ac9a1df1, b_ebe17f59ac9a1df1.words, 35, d_ebe17f59ac9a1df1, m_ebe17f59ac9a1df1,
+  1, 1, i_ebe17f59ac9a1df1, nullptr, nullptr, { &s_ebe17f59ac9a1df1, nullptr, nullptr, 0, 0, nullptr }
+};
+#endif  // !CAPNP_LITE
 }  // namespace schemas
 }  // namespace capnp
 
@@ -10300,6 +10415,22 @@ constexpr uint16_t LoadEnumerationsResponse::_capnpPrivate::pointerCount;
 #if !CAPNP_LITE
 constexpr ::capnp::Kind LoadEnumerationsResponse::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* LoadEnumerationsResponse::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadArraySchemaRequest
+constexpr uint16_t LoadArraySchemaRequest::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadArraySchemaRequest::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadArraySchemaRequest::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadArraySchemaRequest::_capnpPrivate::schema;
+#endif  // !CAPNP_LITE
+
+// LoadArraySchemaResponse
+constexpr uint16_t LoadArraySchemaResponse::_capnpPrivate::dataWordSize;
+constexpr uint16_t LoadArraySchemaResponse::_capnpPrivate::pointerCount;
+#if !CAPNP_LITE
+constexpr ::capnp::Kind LoadArraySchemaResponse::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* LoadArraySchemaResponse::_capnpPrivate::schema;
 #endif  // !CAPNP_LITE
 
 

--- a/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/win32/tiledb-rest.capnp.h
@@ -101,6 +101,8 @@ CAPNP_DECLARE_SCHEMA(f5a35661031194d2);
 CAPNP_DECLARE_SCHEMA(e68edfc0939e63df);
 CAPNP_DECLARE_SCHEMA(891a70a671f15cf6);
 CAPNP_DECLARE_SCHEMA(805c080c10c1e959);
+CAPNP_DECLARE_SCHEMA(83f094010132ff21);
+CAPNP_DECLARE_SCHEMA(ebe17f59ac9a1df1);
 
 }  // namespace schemas
 }  // namespace capnp
@@ -1636,6 +1638,40 @@ struct LoadEnumerationsResponse {
 
   struct _capnpPrivate {
     CAPNP_DECLARE_STRUCT_HEADER(805c080c10c1e959, 0, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadArraySchemaRequest {
+  LoadArraySchemaRequest() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(83f094010132ff21, 1, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct LoadArraySchemaResponse {
+  LoadArraySchemaResponse() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(ebe17f59ac9a1df1, 0, 1)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -14573,6 +14609,216 @@ class LoadEnumerationsResponse::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadArraySchemaRequest::Reader {
+ public:
+  typedef LoadArraySchemaRequest Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig() const;
+  inline ::tiledb::sm::serialization::capnp::Config::Reader getConfig() const;
+
+  inline bool getIncludeEnumerations() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadArraySchemaRequest::Builder {
+ public:
+  typedef LoadArraySchemaRequest Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasConfig();
+  inline ::tiledb::sm::serialization::capnp::Config::Builder getConfig();
+  inline void setConfig(
+      ::tiledb::sm::serialization::capnp::Config::Reader value);
+  inline ::tiledb::sm::serialization::capnp::Config::Builder initConfig();
+  inline void adoptConfig(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+  disownConfig();
+
+  inline bool getIncludeEnumerations();
+  inline void setIncludeEnumerations(bool value);
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadArraySchemaRequest::Pipeline {
+ public:
+  typedef LoadArraySchemaRequest Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::Config::Pipeline getConfig();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class LoadArraySchemaResponse::Reader {
+ public:
+  typedef LoadArraySchemaResponse Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasSchema() const;
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Reader getSchema()
+      const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class LoadArraySchemaResponse::Builder {
+ public:
+  typedef LoadArraySchemaResponse Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasSchema();
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder getSchema();
+  inline void setSchema(
+      ::tiledb::sm::serialization::capnp::ArraySchema::Reader value);
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder initSchema();
+  inline void adoptSchema(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>&& value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>
+  disownSchema();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class LoadArraySchemaResponse::Pipeline {
+ public:
+  typedef LoadArraySchemaResponse Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+  inline ::tiledb::sm::serialization::capnp::ArraySchema::Pipeline getSchema();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -31179,6 +31425,123 @@ LoadEnumerationsResponse::Builder::disownEnumerations() {
                                           .getPointerField(
                                               ::capnp::bounded<0>() *
                                               ::capnp::POINTERS));
+}
+
+inline bool LoadArraySchemaRequest::Reader::hasConfig() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadArraySchemaRequest::Builder::hasConfig() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::Config::Reader
+LoadArraySchemaRequest::Reader::getConfig() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadArraySchemaRequest::Builder::getConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::Config::Pipeline
+LoadArraySchemaRequest::Pipeline::getConfig() {
+  return ::tiledb::sm::serialization::capnp::Config::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void LoadArraySchemaRequest::Builder::setConfig(
+    ::tiledb::sm::serialization::capnp::Config::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::tiledb::sm::serialization::capnp::Config::Builder
+LoadArraySchemaRequest::Builder::initConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void LoadArraySchemaRequest::Builder::adoptConfig(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::Config>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::Config>
+LoadArraySchemaRequest::Builder::disownConfig() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::Config>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool LoadArraySchemaRequest::Reader::getIncludeEnumerations() const {
+  return _reader.getDataField<bool>(::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+
+inline bool LoadArraySchemaRequest::Builder::getIncludeEnumerations() {
+  return _builder.getDataField<bool>(::capnp::bounded<0>() * ::capnp::ELEMENTS);
+}
+inline void LoadArraySchemaRequest::Builder::setIncludeEnumerations(
+    bool value) {
+  _builder.setDataField<bool>(::capnp::bounded<0>() * ::capnp::ELEMENTS, value);
+}
+
+inline bool LoadArraySchemaResponse::Reader::hasSchema() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadArraySchemaResponse::Builder::hasSchema() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Reader
+LoadArraySchemaResponse::Reader::getSchema() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::get(
+          _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder
+LoadArraySchemaResponse::Builder::getSchema() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::get(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Pipeline
+LoadArraySchemaResponse::Pipeline::getSchema() {
+  return ::tiledb::sm::serialization::capnp::ArraySchema::Pipeline(
+      _typeless.getPointerField(0));
+}
+#endif  // !CAPNP_LITE
+inline void LoadArraySchemaResponse::Builder::setSchema(
+    ::tiledb::sm::serialization::capnp::ArraySchema::Reader value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::ArraySchema::Builder
+LoadArraySchemaResponse::Builder::initSchema() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void LoadArraySchemaResponse::Builder::adoptSchema(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>&& value) {
+  ::capnp::_::PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::ArraySchema>
+LoadArraySchemaResponse::Builder::disownSchema() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::ArraySchema>::disown(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
 }
 
 }  // namespace capnp


### PR DESCRIPTION
This adds all of the Capnp messages, serialization code, rest client functions, and server side request processing for handling the new load array schema handler.

Notably, this does not update `tiledb_array_schema_load` to use these new functions because that cannot happen until after TileDb-Cloud-REST is deployed with a libtiledb that contains this commit.

---
TYPE: C_API
DESC: Implement tiledb_handle_load_array_schema_request