### PR TITLE
[Backport release-2.16] Optimize capnp traversal size usage (#4287)

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -226,6 +226,7 @@ void check_save_to_file() {
   ss << "config.logging_level 0\n";
 #endif
   ss << "filestore.buffer_size 104857600\n";
+  ss << "rest.capnp_traversal_limit 536870912\n";
   ss << "rest.curl.buffer_size 524288\n";
   ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
@@ -592,6 +593,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.retry_delay_factor"] = "1.25";
   all_param_values["rest.retry_initial_delay_ms"] = "500";
   all_param_values["rest.retry_http_codes"] = "503";
+  all_param_values["rest.capnp_traversal_limit"] = "536870912";
   all_param_values["rest.curl.buffer_size"] = "524288";
   all_param_values["rest.curl.verbose"] = "false";
   all_param_values["rest.load_metadata_on_array_open"] = "false";

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -608,6 +608,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `rest.curl.buffer_size` <br>
  *    Set curl buffer size for REST requests <br>
  *    **Default**: 524288 (512KB)
+ * - `rest.capnp_traversal_limit` <br>
+ *    CAPNP traversal limit used in the deserialization of messages(bytes) <br>
+ *    **Default**: 536870912 (512MB)
  * - `filestore.buffer_size` <br>
  *    Specifies the size in bytes of the internal buffers used in the filestore
  *    API. The size should be bigger than the minimum tile size filestore

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -89,6 +89,7 @@ const std::string Config::REST_RETRY_COUNT = "25";
 const std::string Config::REST_RETRY_INITIAL_DELAY_MS = "500";
 const std::string Config::REST_RETRY_DELAY_FACTOR = "1.25";
 const std::string Config::REST_CURL_BUFFER_SIZE = "524288";
+const std::string Config::REST_CAPNP_TRAVERSAL_LIMIT = "536870912";
 const std::string Config::REST_CURL_VERBOSE = "false";
 const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
@@ -234,6 +235,8 @@ const std::map<std::string, std::string> default_config_values = {
         "rest.retry_initial_delay_ms", Config::REST_RETRY_INITIAL_DELAY_MS),
     std::make_pair("rest.retry_delay_factor", Config::REST_RETRY_DELAY_FACTOR),
     std::make_pair("rest.curl.buffer_size", Config::REST_CURL_BUFFER_SIZE),
+    std::make_pair(
+        "rest.capnp_traversal_limit", Config::REST_CAPNP_TRAVERSAL_LIMIT),
     std::make_pair("rest.curl.verbose", Config::REST_CURL_VERBOSE),
     std::make_pair(
         "rest.load_metadata_on_array_open",

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -96,6 +96,9 @@ class Config {
   /** The default buffer size for curl reads used by REST. */
   static const std::string REST_CURL_BUFFER_SIZE;
 
+  /** CAPNP traversal limit used in the deserialization of messages(MB). */
+  static const std::string REST_CAPNP_TRAVERSAL_LIMIT;
+
   /** The default for Curl's verbose mode used by REST. */
   static const std::string REST_CURL_VERBOSE;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -786,6 +786,10 @@ class Config {
    * - `rest.curl.buffer_size` <br>
    *    Set curl buffer size for REST requests <br>
    *    **Default**: 524288 (512KB)
+   * - `rest.capnp_traversal_limit` <br>
+   *    CAPNP traversal limit used in the deserialization of messages(bytes)
+   * <br>
+   *    **Default**: 536870912 (512MB)
    * - `filestore.buffer_size` <br>
    *    Specifies the size in bytes of the internal buffers used in the
    *    filestore API. The size should be bigger than the minimum tile size

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -4705,6 +4705,23 @@ Status FragmentMetadata::store_footer(const EncryptionKey& encryption_key) {
   return Status::Ok();
 }
 
+void FragmentMetadata::resize_tile_offsets_vectors(uint64_t size) {
+  tile_offsets_mtx().resize(size);
+  tile_offsets().resize(size);
+}
+
+void FragmentMetadata::resize_tile_var_offsets_vectors(uint64_t size) {
+  tile_var_offsets_mtx().resize(size);
+  tile_var_offsets().resize(size);
+}
+
+void FragmentMetadata::resize_tile_var_sizes_vectors(uint64_t size) {
+  tile_var_sizes().resize(size);
+}
+void FragmentMetadata::resize_tile_validity_offsets_vectors(uint64_t size) {
+  tile_validity_offsets().resize(size);
+}
+
 void FragmentMetadata::clean_up() {
   auto fragment_metadata_uri =
       fragment_uri_.join_path(constants::fragment_metadata_filename);

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1202,6 +1202,26 @@ class FragmentMetadata {
     loaded_metadata_ = loaded_metadata;
   }
 
+  /**
+   * Resize tile offsets related vectors.
+   */
+  void resize_tile_offsets_vectors(uint64_t size);
+
+  /**
+   * Resize tile var offsets related vectors.
+   */
+  void resize_tile_var_offsets_vectors(uint64_t size);
+
+  /**
+   * Resize tile var sizes related vectors.
+   */
+  void resize_tile_var_sizes_vectors(uint64_t size);
+
+  /**
+   * Resize tile validity offsets related vectors.
+   */
+  void resize_tile_validity_offsets_vectors(uint64_t size);
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -166,6 +166,14 @@ Status array_to_capnp(
                 fragment_metadata_all.size());
         for (size_t i = 0; i < fragment_metadata_all.size(); i++) {
           auto fragment_metadata_builder = fragment_metadata_all_builder[i];
+
+          // Old fragment with zipped coordinates didn't have a format that
+          // allow to dynamically load tile offsets and sizes and since they all
+          // get loaded at array open, we need to serialize them here.
+          if (fragment_metadata_all[i]->version() <= 2) {
+            fragment_meta_sizes_offsets_to_capnp(
+                *fragment_metadata_all[i], &fragment_metadata_builder);
+          }
           RETURN_NOT_OK(fragment_metadata_to_capnp(
               *fragment_metadata_all[i], &fragment_metadata_builder));
         }

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -131,24 +131,24 @@ Status fragment_metadata_from_capnp(
     frag_meta->set_memory_tracker(memory_tracker);
   }
   if (frag_meta_reader.hasFileSizes()) {
-    frag_meta->file_sizes().reserve(frag_meta_reader.getFileSizes().size());
-    for (const auto& file_size : frag_meta_reader.getFileSizes()) {
+    auto filesizes_reader = frag_meta_reader.getFileSizes();
+    frag_meta->file_sizes().reserve(filesizes_reader.size());
+    for (const auto& file_size : filesizes_reader) {
       frag_meta->file_sizes().emplace_back(file_size);
     }
   }
   if (frag_meta_reader.hasFileVarSizes()) {
-    frag_meta->file_var_sizes().reserve(
-        frag_meta_reader.getFileVarSizes().size());
-    for (const auto& file_var_size : frag_meta_reader.getFileVarSizes()) {
+    auto filevarsizes_reader = frag_meta_reader.getFileVarSizes();
+    frag_meta->file_var_sizes().reserve(filevarsizes_reader.size());
+    for (const auto& file_var_size : filevarsizes_reader) {
       frag_meta->file_var_sizes().emplace_back(file_var_size);
     }
   }
   if (frag_meta_reader.hasFileValiditySizes()) {
-    frag_meta->file_validity_sizes().reserve(
-        frag_meta_reader.getFileValiditySizes().size());
+    auto filevaliditysizes_reader = frag_meta_reader.getFileValiditySizes();
+    frag_meta->file_validity_sizes().reserve(filevaliditysizes_reader.size());
 
-    for (const auto& file_validity_size :
-         frag_meta_reader.getFileValiditySizes()) {
+    for (const auto& file_validity_size : filevaliditysizes_reader) {
       frag_meta->file_validity_sizes().emplace_back(file_validity_size);
     }
   }
@@ -165,70 +165,111 @@ Status fragment_metadata_from_capnp(
   frag_meta->tile_index_base() = frag_meta_reader.getTileIndexBase();
   frag_meta->version() = frag_meta_reader.getVersion();
 
+  // Set the array schema and most importantly retrigger the build
+  // of the internal idx_map. Also set array_schema_name which is used
+  // in some places in the global writer
+  frag_meta->set_array_schema(array_schema);
+  frag_meta->set_schema_name(array_schema->name());
+  frag_meta->set_dense(array_schema->dense());
+
   FragmentMetadata::LoadedMetadata loaded_metadata;
+
+  // num_dims_and_attrs() requires a set array schema, so it's important
+  // schema is set above on the fragment metadata object.
+  uint64_t num_dims_and_attrs = frag_meta->num_dims_and_attrs();
+
+  // The tile offsets field may not be present here in some usecases such as
+  // refactored query, but readers on the server side require these vectors to
+  // have the first dimension properly allocated when loading their data on
+  // demand.
+  frag_meta->resize_tile_offsets_vectors(num_dims_and_attrs);
+  loaded_metadata.tile_offsets_.resize(num_dims_and_attrs, false);
+
   // There is a difference in the metadata loaded for versions >= 2
   auto loaded = frag_meta->version() <= 2 ? true : false;
+
   if (frag_meta_reader.hasTileOffsets()) {
-    for (const auto& t : frag_meta_reader.getTileOffsets()) {
-      auto& last = frag_meta->tile_offsets().emplace_back();
+    auto tileoffsets_reader = frag_meta_reader.getTileOffsets();
+    uint64_t i = 0;
+    for (const auto& t : tileoffsets_reader) {
+      auto& last = frag_meta->tile_offsets()[i];
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
+      loaded_metadata.tile_offsets_[i++] = loaded;
     }
-    frag_meta->tile_offsets_mtx().resize(
-        frag_meta_reader.getTileOffsets().size());
-    loaded_metadata.tile_offsets_.resize(
-        frag_meta_reader.getTileOffsets().size(), loaded);
   }
+
+  // The tile var offsets field may not be present here in some usecases such as
+  // refactored query, but readers on the server side require these vectors to
+  // have the first dimension properly allocated when loading its data on
+  // demand.
+  frag_meta->resize_tile_var_offsets_vectors(num_dims_and_attrs);
+  loaded_metadata.tile_var_offsets_.resize(num_dims_and_attrs, false);
   if (frag_meta_reader.hasTileVarOffsets()) {
-    for (const auto& t : frag_meta_reader.getTileVarOffsets()) {
-      auto& last = frag_meta->tile_var_offsets().emplace_back();
+    auto tilevaroffsets_reader = frag_meta_reader.getTileVarOffsets();
+    uint64_t i = 0;
+    for (const auto& t : tilevaroffsets_reader) {
+      auto& last = frag_meta->tile_var_offsets()[i];
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
+      loaded_metadata.tile_var_offsets_[i++] = loaded;
     }
-    frag_meta->tile_var_offsets_mtx().resize(
-        frag_meta_reader.getTileVarOffsets().size());
-    loaded_metadata.tile_var_offsets_.resize(
-        frag_meta_reader.getTileVarOffsets().size(), loaded);
   }
+
+  // The tile var sizes field may not be present here in some usecases such as
+  // refactored query, but readers on the server side require these vectors to
+  // have the first dimension properly allocated when loading its data on
+  // demand.
+  frag_meta->resize_tile_var_sizes_vectors(num_dims_and_attrs);
+  loaded_metadata.tile_var_sizes_.resize(num_dims_and_attrs, false);
   if (frag_meta_reader.hasTileVarSizes()) {
-    for (const auto& t : frag_meta_reader.getTileVarSizes()) {
-      auto& last = frag_meta->tile_var_sizes().emplace_back();
+    auto tilevarsizes_reader = frag_meta_reader.getTileVarSizes();
+    uint64_t i = 0;
+    for (const auto& t : tilevarsizes_reader) {
+      auto& last = frag_meta->tile_var_sizes()[i];
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
+      loaded_metadata.tile_var_sizes_[i++] = loaded;
     }
-    loaded_metadata.tile_var_sizes_.resize(
-        frag_meta_reader.getTileVarSizes().size(), loaded);
   }
+
+  // This field may not be present here in some usecases such as refactored
+  // query, but readers on the server side require this vector to have the first
+  // dimension properly allocated when loading its data on demand.
+  frag_meta->resize_tile_validity_offsets_vectors(num_dims_and_attrs);
+  loaded_metadata.tile_validity_offsets_.resize(num_dims_and_attrs, false);
   if (frag_meta_reader.hasTileValidityOffsets()) {
-    for (const auto& t : frag_meta_reader.getTileValidityOffsets()) {
-      auto& last = frag_meta->tile_validity_offsets().emplace_back();
+    auto tilevalidityoffsets_reader = frag_meta_reader.getTileValidityOffsets();
+    uint64_t i = 0;
+    for (const auto& t : tilevalidityoffsets_reader) {
+      auto& last = frag_meta->tile_validity_offsets()[i];
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
+      loaded_metadata.tile_validity_offsets_[i++] = false;
     }
-    loaded_metadata.tile_validity_offsets_.resize(
-        frag_meta_reader.getTileValidityOffsets().size(), false);
   }
   if (frag_meta_reader.hasTileMinBuffer()) {
-    for (const auto& t : frag_meta_reader.getTileMinBuffer()) {
+    auto tileminbuffer_reader = frag_meta_reader.getTileMinBuffer();
+    for (const auto& t : tileminbuffer_reader) {
       auto& last = frag_meta->tile_min_buffer().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
     }
-    loaded_metadata.tile_min_.resize(
-        frag_meta_reader.getTileMinBuffer().size(), false);
+    loaded_metadata.tile_min_.resize(tileminbuffer_reader.size(), false);
   }
   if (frag_meta_reader.hasTileMinVarBuffer()) {
-    for (const auto& t : frag_meta_reader.getTileMinVarBuffer()) {
+    auto tileminvarbuffer_reader = frag_meta_reader.getTileMinVarBuffer();
+    for (const auto& t : tileminvarbuffer_reader) {
       auto& last = frag_meta->tile_min_var_buffer().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
@@ -237,18 +278,19 @@ Status fragment_metadata_from_capnp(
     }
   }
   if (frag_meta_reader.hasTileMaxBuffer()) {
-    for (const auto& t : frag_meta_reader.getTileMaxBuffer()) {
+    auto tilemaxbuffer_reader = frag_meta_reader.getTileMaxBuffer();
+    for (const auto& t : tilemaxbuffer_reader) {
       auto& last = frag_meta->tile_max_buffer().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
     }
-    loaded_metadata.tile_max_.resize(
-        frag_meta_reader.getTileMaxBuffer().size(), false);
+    loaded_metadata.tile_max_.resize(tilemaxbuffer_reader.size(), false);
   }
   if (frag_meta_reader.hasTileMaxVarBuffer()) {
-    for (const auto& t : frag_meta_reader.getTileMaxVarBuffer()) {
+    auto tilemaxvarbuffer_reader = frag_meta_reader.getTileMaxVarBuffer();
+    for (const auto& t : tilemaxvarbuffer_reader) {
       auto& last = frag_meta->tile_max_var_buffer().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
@@ -257,18 +299,19 @@ Status fragment_metadata_from_capnp(
     }
   }
   if (frag_meta_reader.hasTileSums()) {
-    for (const auto& t : frag_meta_reader.getTileSums()) {
+    auto tilesums_reader = frag_meta_reader.getTileSums();
+    for (const auto& t : tilesums_reader) {
       auto& last = frag_meta->tile_sums().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
         last.emplace_back(v);
       }
     }
-    loaded_metadata.tile_sum_.resize(
-        frag_meta_reader.getTileSums().size(), false);
+    loaded_metadata.tile_sum_.resize(tilesums_reader.size(), false);
   }
   if (frag_meta_reader.hasTileNullCounts()) {
-    for (const auto& t : frag_meta_reader.getTileNullCounts()) {
+    auto tilenullcounts_reader = frag_meta_reader.getTileNullCounts();
+    for (const auto& t : tilenullcounts_reader) {
       auto& last = frag_meta->tile_null_counts().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
@@ -276,10 +319,11 @@ Status fragment_metadata_from_capnp(
       }
     }
     loaded_metadata.tile_null_count_.resize(
-        frag_meta_reader.getTileNullCounts().size(), false);
+        tilenullcounts_reader.size(), false);
   }
   if (frag_meta_reader.hasFragmentMins()) {
-    for (const auto& t : frag_meta_reader.getFragmentMins()) {
+    auto fragmentmins_reader = frag_meta_reader.getFragmentMins();
+    for (const auto& t : fragmentmins_reader) {
       auto& last = frag_meta->fragment_mins().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
@@ -288,7 +332,8 @@ Status fragment_metadata_from_capnp(
     }
   }
   if (frag_meta_reader.hasFragmentMaxs()) {
-    for (const auto& t : frag_meta_reader.getFragmentMaxs()) {
+    auto fragmentmaxs_reader = frag_meta_reader.getFragmentMaxs();
+    for (const auto& t : fragmentmaxs_reader) {
       auto& last = frag_meta->fragment_maxs().emplace_back();
       last.reserve(t.size());
       for (const auto& v : t) {
@@ -297,17 +342,16 @@ Status fragment_metadata_from_capnp(
     }
   }
   if (frag_meta_reader.hasFragmentSums()) {
-    frag_meta->fragment_sums().reserve(
-        frag_meta_reader.getFragmentSums().size());
-    for (const auto& fragment_sum : frag_meta_reader.getFragmentSums()) {
+    auto fragmentsums_reader = frag_meta_reader.getFragmentSums();
+    frag_meta->fragment_sums().reserve(fragmentsums_reader.size());
+    for (const auto& fragment_sum : fragmentsums_reader) {
       frag_meta->fragment_sums().emplace_back(fragment_sum);
     }
   }
   if (frag_meta_reader.hasFragmentNullCounts()) {
-    frag_meta->fragment_null_counts().reserve(
-        frag_meta_reader.getFragmentNullCounts().size());
-    for (const auto& fragment_null_count :
-         frag_meta_reader.getFragmentNullCounts()) {
+    auto fragmentnullcounts_reader = frag_meta_reader.getFragmentNullCounts();
+    frag_meta->fragment_null_counts().reserve(fragmentnullcounts_reader.size());
+    for (const auto& fragment_null_count : fragmentnullcounts_reader) {
       frag_meta->fragment_null_counts().emplace_back(fragment_null_count);
     }
   }
@@ -336,13 +380,6 @@ Status fragment_metadata_from_capnp(
     frag_meta->rtree().deserialize(
         deserializer, &domain, constants::format_version);
   }
-
-  // Set the array schema and most importantly retrigger the build
-  // of the internal idx_map. Also set array_schema_name which is used
-  // in some places in the global writer
-  frag_meta->set_array_schema(array_schema);
-  frag_meta->set_schema_name(array_schema->name());
-  frag_meta->set_dense(array_schema->dense());
 
   // It's important to do this here as init_domain depends on some fields
   // above to be properly initialized
@@ -444,42 +481,9 @@ void generic_tile_offsets_to_capnp(
       gt_offsets.processed_conditions_offsets_);
 }
 
-Status fragment_metadata_to_capnp(
+void fragment_meta_sizes_offsets_to_capnp(
     const FragmentMetadata& frag_meta,
     capnp::FragmentMetadata::Builder* frag_meta_builder) {
-  auto& file_sizes = frag_meta.file_sizes();
-  if (!file_sizes.empty()) {
-    auto builder = frag_meta_builder->initFileSizes(file_sizes.size());
-    for (uint64_t i = 0; i < file_sizes.size(); ++i) {
-      builder.set(i, file_sizes[i]);
-    }
-  }
-  auto& file_var_sizes = frag_meta.file_var_sizes();
-  if (!file_var_sizes.empty()) {
-    auto builder = frag_meta_builder->initFileVarSizes(file_var_sizes.size());
-    for (uint64_t i = 0; i < file_var_sizes.size(); ++i) {
-      builder.set(i, file_var_sizes[i]);
-    }
-  }
-  auto& file_validity_sizes = frag_meta.file_validity_sizes();
-  if (!file_validity_sizes.empty()) {
-    auto builder =
-        frag_meta_builder->initFileValiditySizes(file_validity_sizes.size());
-    for (uint64_t i = 0; i < file_validity_sizes.size(); ++i) {
-      builder.set(i, file_validity_sizes[i]);
-    }
-  }
-
-  const auto& relative_fragment_uri =
-      serialize_array_uri_to_relative(frag_meta.fragment_uri());
-  frag_meta_builder->setFragmentUri(relative_fragment_uri);
-  frag_meta_builder->setHasTimestamps(frag_meta.has_timestamps());
-  frag_meta_builder->setHasDeleteMeta(frag_meta.has_delete_meta());
-  frag_meta_builder->setHasConsolidatedFooter(
-      frag_meta.has_consolidated_footer());
-  frag_meta_builder->setSparseTileNum(frag_meta.sparse_tile_num());
-  frag_meta_builder->setTileIndexBase(frag_meta.tile_index_base());
-
   auto& tile_offsets = frag_meta.tile_offsets();
   if (!tile_offsets.empty()) {
     auto builder = frag_meta_builder->initTileOffsets(tile_offsets.size());
@@ -522,6 +526,44 @@ Status fragment_metadata_to_capnp(
       }
     }
   }
+}
+
+Status fragment_metadata_to_capnp(
+    const FragmentMetadata& frag_meta,
+    capnp::FragmentMetadata::Builder* frag_meta_builder) {
+  const auto& relative_fragment_uri =
+      serialize_array_uri_to_relative(frag_meta.fragment_uri());
+  frag_meta_builder->setFragmentUri(relative_fragment_uri);
+  frag_meta_builder->setHasTimestamps(frag_meta.has_timestamps());
+  frag_meta_builder->setHasDeleteMeta(frag_meta.has_delete_meta());
+  frag_meta_builder->setHasConsolidatedFooter(
+      frag_meta.has_consolidated_footer());
+  frag_meta_builder->setSparseTileNum(frag_meta.sparse_tile_num());
+  frag_meta_builder->setTileIndexBase(frag_meta.tile_index_base());
+
+  auto& file_sizes = frag_meta.file_sizes();
+  if (!file_sizes.empty()) {
+    auto builder = frag_meta_builder->initFileSizes(file_sizes.size());
+    for (uint64_t i = 0; i < file_sizes.size(); ++i) {
+      builder.set(i, file_sizes[i]);
+    }
+  }
+  auto& file_var_sizes = frag_meta.file_var_sizes();
+  if (!file_var_sizes.empty()) {
+    auto builder = frag_meta_builder->initFileVarSizes(file_var_sizes.size());
+    for (uint64_t i = 0; i < file_var_sizes.size(); ++i) {
+      builder.set(i, file_var_sizes[i]);
+    }
+  }
+  auto& file_validity_sizes = frag_meta.file_validity_sizes();
+  if (!file_validity_sizes.empty()) {
+    auto builder =
+        frag_meta_builder->initFileValiditySizes(file_validity_sizes.size());
+    for (uint64_t i = 0; i < file_validity_sizes.size(); ++i) {
+      builder.set(i, file_validity_sizes[i]);
+    }
+  }
+
   auto& tile_min_buffer = frag_meta.tile_min_buffer();
   if (!tile_min_buffer.empty()) {
     auto builder = frag_meta_builder->initTileMinBuffer(tile_min_buffer.size());

--- a/tiledb/sm/serialization/fragment_metadata.h
+++ b/tiledb/sm/serialization/fragment_metadata.h
@@ -69,6 +69,24 @@ Status fragment_metadata_from_capnp(
     MemoryTracker* memory_tracker = nullptr);
 
 /**
+ * Serialize Fragment Metadata sizes and offsets
+ * (fileSizes, fileVarSizes, fileValiditySizes, tileOffsets, tileVarOffsets,
+ * tileVarSizes, tileValidityOffsets)
+ *
+ * This function was split from fragment_metadata_to_capnp so that these
+ * potentially very large items are sent over the wire only for use cases
+ * such as global order writes, partial attribute writes
+ * where their existence is a strict requirement.
+ * Please only call this function if your use case meets the criteria above.
+ *
+ * @param frag_meta fragment metadata to serialize
+ * @param frag_meta_builder cap'n proto class
+ */
+void fragment_meta_sizes_offsets_to_capnp(
+    const FragmentMetadata& frag_meta,
+    capnp::FragmentMetadata::Builder* frag_meta_builder);
+
+/**
  * Convert Fragment Metadata to Cap'n Proto message
  *
  * @param frag_meta fragment metadata to serialize


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/946e2ce24c0666b639976e6042136be08659087d from https://github.com/TileDB-Inc/TileDB/pull/4287.

---
TYPE: BUG
DESC: Optimize capnp traversal size usage