### PR TITLE
Move VFS read log modes tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -201,7 +201,6 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-SubarrayPartitioner-dense.cc
   src/unit-SubarrayPartitioner-error.cc
   src/unit-SubarrayPartitioner-sparse.cc
-  src/unit-vfs-read-log-modes.cc
   src/unit-vfs.cc
   src/unit-win-filesystem.cc
   )

--- a/tiledb/sm/filesystem/test/CMakeLists.txt
+++ b/tiledb/sm/filesystem/test/CMakeLists.txt
@@ -29,3 +29,8 @@ commence(unit_test vfs)
     this_target_object_libraries(vfs)
     this_target_sources(main.cc unit_uri.cc)
 conclude(unit_test)
+
+commence(unit_test vfs_read_log_modes)
+    this_target_object_libraries(context_resources)
+    this_target_sources(main.cc unit_vfs_read_log_modes.cc)
+conclude(unit_test)


### PR DESCRIPTION
Move the VFS read log tests to a real unit test.

---
TYPE: NO_HISTORY
DESC: No history because its just moving a test.