### PR TITLE
Suppress clang warning in tests

### DIFF
--- a/test/src/unit-cppapi-query-condition-sets.cc
+++ b/test/src/unit-cppapi-query-condition-sets.cc
@@ -1017,5 +1017,5 @@ T CPPQueryConditionFx::choose_value(std::vector<T>& values) {
 }
 
 float CPPQueryConditionFx::random() {
-  return static_cast<float>(std::rand()) / RAND_MAX;
+  return static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
 }


### PR DESCRIPTION
Suppress clang warning causing build failure with warnings-as-errors on (default).

---
TYPE: NO_HISTORY
