### PR TITLE
Allow null cfg in group consolidate_metadata and vacuum_metadata

### DIFF
--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -227,6 +227,10 @@ TEST_CASE_METHOD(
   // Write a correct item
   group.put_metadata("key", TILEDB_INT32, 1, &v);
 
+  // Consolidate and vacuum metadata with default config
+  group.consolidate_metadata(ctx_, group1_uri);
+  group.vacuum_metadata(ctx_, group1_uri);
+
   // Close group
   group.close();
 

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -523,7 +523,6 @@ capi_return_t tiledb_deserialize_group_metadata(
 capi_return_t tiledb_group_consolidate_metadata(
     tiledb_ctx_handle_t* ctx, const char* group_uri, tiledb_config_t* config) {
   ensure_group_uri_argument_is_valid(group_uri);
-  ensure_config_is_valid(config);
 
   auto cfg =
       (config == nullptr) ? ctx->storage_manager()->config() : config->config();
@@ -536,7 +535,6 @@ capi_return_t tiledb_group_consolidate_metadata(
 capi_return_t tiledb_group_vacuum_metadata(
     tiledb_ctx_handle_t* ctx, const char* group_uri, tiledb_config_t* config) {
   ensure_group_uri_argument_is_valid(group_uri);
-  ensure_config_is_valid(config);
 
   auto cfg =
       (config == nullptr) ? ctx->storage_manager()->config() : config->config();


### PR DESCRIPTION
---
TYPE: BUG
DESC: Allow null cfg in group consolidate_metadata and vacuum_metadata