### PR TITLE
Prepend a question mark to the Azure Storage SAS token if it does not begin with one.

### DIFF
--- a/test/src/unit-azure.cc
+++ b/test/src/unit-azure.cc
@@ -481,7 +481,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE(
     "Test constructing Azure Blob Storage endpoint URIs", "[azure][uri]") {
-  std::string sas_token, expected_endpoint;
+  std::string sas_token, custom_endpoint, expected_endpoint;
   SECTION("No SAS token") {
     sas_token = "";
     expected_endpoint = "https://devstoreaccount1.blob.core.windows.net";
@@ -496,9 +496,21 @@ TEST_CASE(
     expected_endpoint =
         "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
   }
+  SECTION("SAS token in both endpoint and config option") {
+    sas_token = "baz=qux&foo=bar";
+    custom_endpoint =
+        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+    expected_endpoint =
+        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+  }
+  SECTION("No SAS token") {
+    sas_token = "";
+    expected_endpoint = "https://devstoreaccount1.blob.core.windows.net";
+  }
   Config config;
   REQUIRE(
       config.set("vfs.azure.storage_account_name", "devstoreaccount1").ok());
+  REQUIRE(config.set("vfs.azure.blob_endpoint", custom_endpoint).ok());
   REQUIRE(config.set("vfs.azure.storage_sas_token", sas_token).ok());
   tiledb::sm::Azure azure;
   ThreadPool thread_pool(1);

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -128,6 +128,13 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
         "or HTTPS).");
   }
   if (!blob_endpoint.empty()) {
+    // The question mark is not strictly part of the SAS token
+    // (https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#sas-token),
+    // but in the Azure Portal the SAS token starts with one. If it does not, we
+    // add the question mark ourselves.
+    if (!utils::parse::starts_with(sas_token, "?")) {
+      blob_endpoint += '?';
+    }
     blob_endpoint += sas_token;
   }
 

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -127,7 +127,7 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
         "The 'vfs.azure.blob_endpoint' option should include the scheme (HTTP "
         "or HTTPS).");
   }
-  if (!blob_endpoint.empty()) {
+  if (!blob_endpoint.empty() && !sas_token.empty()) {
     // The question mark is not strictly part of the SAS token
     // (https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#sas-token),
     // but in the Azure Portal the SAS token starts with one. If it does not, we

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -309,6 +309,16 @@ class Azure {
    */
   Status write(const URI& uri, const void* buffer, uint64_t length);
 
+  /**
+   * Returns a reference to the Azure blob service client.
+   *
+   * Used for testing. Calling code should include the Azure SDK headers to make
+   * use of the BlobServiceClient.
+   */
+  const ::Azure::Storage::Blobs::BlobServiceClient& client() const {
+    return *client_;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE DATATYPES         */


### PR DESCRIPTION
[SC-35417](https://app.shortcut.com/tiledb-inc/story/35417/azure-bug-in-path-separator-and-query-string-prefix-usage-w-sas-tokens-with-azure-blob-storage)

Fixes TileDB-Inc/TileDB-Py#1844.

When the user specifies an Azure Storage SAS token, we pass it to the Azure SDK by appending it to the service endpoint URI. As shown in the Azure Portal, the SAS token starts with a `?`, but this is not always the case. This PR puts a `?` between the service endpoint and the SAS token if the SAS token does not start with a `?`.

In the linked GitHub issue, its reporter worked around it by prepending the SAS token with a `/?`, instead of `?`. Both [seem to be handled just fine in the Azure SDK](https://github.com/Azure/azure-sdk-for-cpp/blob/436c0905e20ec2892b5ff85fe9ada988ae24ebd7/sdk/core/azure-core/src/http/url.cpp#L73-L88).

Let me know how to test this.

---
TYPE: BUG
DESC: Support Azure Storage SAS tokens that don't start with a question mark.