### PR TITLE
Allow for empty enumerations

### DIFF
--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -86,30 +86,86 @@ Enumeration::Enumeration(
     throw EnumerationException("Invalid cell_val_num in Enumeration");
   }
 
-  if (data == nullptr || data_size == 0) {
-    throw EnumerationException("No attribute value data supplied.");
-  }
-
-  if (var_size() && (offsets == nullptr || offsets_size == 0)) {
-    throw EnumerationException(
-        "Variable length datatype defined but offsets are not present");
-  } else if (!var_size() && (offsets != nullptr || offsets_size > 0)) {
-    throw EnumerationException(
-        "Fixed length datatype defined but offsets are present");
+  // Check if we're creating an empty enumeration and bail.
+  auto data_empty = (data == nullptr && data_size == 0);
+  auto offsets_empty = (offsets == nullptr && offsets_size == 0);
+  if (data_empty && offsets_empty) {
+    // This is an empty enumeration so we're done checking for argument
+    // validity.
+    return;
   }
 
   if (var_size()) {
-    if (offsets_size % sizeof(uint64_t) != 0) {
+    if (offsets == nullptr) {
+      throw EnumerationException(
+          "Var sized enumeration values require a non-null offsets pointer.");
+    }
+
+    if (offsets_size == 0) {
+      throw EnumerationException(
+          "Var sized enumeration values require a non-zero offsets size.");
+    }
+
+    if (offsets_size % constants::cell_var_offset_size != 0) {
       throw EnumerationException(
           "Invalid offsets size is not a multiple of sizeof(uint64_t)");
     }
+
+    // Setup some temporary aliases for quick reference
     auto offset_values = static_cast<const uint64_t*>(offsets);
-    uint64_t last_offset = (offsets_size / sizeof(uint64_t)) - 1;
-    if (offset_values[last_offset] > data_size) {
-      throw EnumerationException(
-          "Provided data buffer size is too small for the provided offsets.");
+    auto num_offsets = offsets_size / constants::cell_var_offset_size;
+
+    // Check for the edge case of a single value so we can handle the case of
+    // having a single empty value.
+    if (num_offsets == 1 && offset_values[0] == 0) {
+      // If data is nullptr and data_size > 0, then the user appears to have
+      // intended to provided us with a non-empty value.
+      if (data_size > 0 && data == nullptr) {
+        throw EnumerationException(
+            "Invalid data buffer; must not be nullptr when data_size "
+            "is non-zero.");
+      }
+      // Else, data_size is zero and we don't care what data is. We ignore the
+      // check for data_size == 0 && data != nullptr here because a common
+      // use case with our APIs is to use a std::string to contain all of the
+      // var data which AFAIK never returns nullptr.
+    } else {
+      // We have more than one string which requires a non-nullptr data and
+      // non-zero data size that is greater than or equal to the last
+      // offset provided.
+      if (data == nullptr) {
+        throw EnumerationException(
+            "Invalid data input, nullptr provided when the provided offsets "
+            "require data.");
+      }
+
+      if (data_size < offset_values[num_offsets - 1]) {
+        throw EnumerationException(
+            "Invalid data input, data_size is smaller than the last provided "
+            "offset.");
+      }
     }
-  } else {
+  } else {  // !var_sized()
+    if (offsets != nullptr) {
+      throw EnumerationException(
+          "Fixed length value type defined but offsets is not nullptr.");
+    }
+
+    if (offsets_size != 0) {
+      throw EnumerationException(
+          "Fixed length value type defined but offsets size is non-zero.");
+    }
+
+    if (data == nullptr) {
+      throw EnumerationException(
+          "Invalid data buffer must not be nullptr for fixed sized data.");
+    }
+
+    if (data_size == 0) {
+      throw EnumerationException(
+          "Invalid data size; must be non-zero for fixed size data.");
+    }
+
     if (data_size % cell_size() != 0) {
       throw EnumerationException(
           "Invalid data size is not a multiple of the cell size.");
@@ -117,11 +173,7 @@ Enumeration::Enumeration(
   }
 
   throw_if_not_ok(data_.write(data, 0, data_size));
-
-  if (offsets_size > 0) {
-    throw_if_not_ok(offsets_.write(offsets, 0, offsets_size));
-  }
-
+  throw_if_not_ok(offsets_.write(offsets, 0, offsets_size));
   generate_value_map();
 }
 
@@ -147,14 +199,20 @@ shared_ptr<const Enumeration> Enumeration::deserialize(
   auto ordered = deserializer.read<bool>();
 
   auto data_size = deserializer.read<uint64_t>();
-  const void* data = deserializer.get_ptr<void>(data_size);
+  const void* data = nullptr;
+
+  if (data_size > 0) {
+    data = deserializer.get_ptr<void>(data_size);
+  }
 
   uint64_t offsets_size = 0;
   const void* offsets = nullptr;
 
   if (cell_val_num == constants::var_num) {
     offsets_size = deserializer.read<uint64_t>();
-    offsets = deserializer.get_ptr<void>(offsets_size);
+    if (offsets_size > 0) {
+      offsets = deserializer.get_ptr<void>(offsets_size);
+    }
   }
 
   return create(
@@ -184,11 +242,15 @@ void Enumeration::serialize(Serializer& serializer) const {
   serializer.write<uint32_t>(cell_val_num_);
   serializer.write<bool>(ordered_);
   serializer.write<uint64_t>(data_.size());
-  serializer.write(data_.data(), data_.size());
+  if (data_.size() > 0) {
+    serializer.write(data_.data(), data_.size());
+  }
 
   if (var_size()) {
     serializer.write<uint64_t>(offsets_.size());
-    serializer.write(offsets_.data(), offsets_.size());
+    if (offsets_.size() > 0) {
+      serializer.write(offsets_.data(), offsets_.size());
+    }
   } else {
     assert(cell_val_num_ < constants::var_num);
     assert(offsets_.size() == 0);
@@ -221,6 +283,11 @@ void Enumeration::dump(FILE* out) const {
 }
 
 void Enumeration::generate_value_map() {
+  // If we've got no data, there are no values to generate.
+  if (data_.size() == 0) {
+    return;
+  }
+
   auto char_data = data_.data_as<char>();
   if (var_size()) {
     auto offsets = offsets_.data_as<uint64_t>();

--- a/tiledb/sm/cpp_api/enumeration_experimental.h
+++ b/tiledb/sm/cpp_api/enumeration_experimental.h
@@ -224,14 +224,36 @@ class Enumeration {
   /* ********************************* */
 
   /**
+   * Create an empty enumeration.
+   *
+   * @param ctx The context to use.
+   * @param name The name of the enumeration.
+   * @param type The datatype of the enumeration values. This is automatically
+   *        deduced if not provided.
+   * @param cell_val_num The number of values per cell.
+   * @param ordered Whether or not to consider this enumeration ordered.
+   * @return Enumeration The newly constructed enumeration.
+   */
+  static Enumeration create_empty(
+      const Context& ctx,
+      const std::string& name,
+      tiledb_datatype_t type,
+      uint32_t cell_val_num,
+      bool ordered = false) {
+    return create(
+        ctx, name, type, cell_val_num, ordered, nullptr, 0, nullptr, 0);
+  }
+
+  /**
    * Create an enumeration from a vector of trivial values (i.e., int's or other
    * integral or floating point values)
    *
    * @param ctx The context to use.
-   * @param values The list of values to use for this enumeration.
+   * @param name The name of the enumeration.
+   * @param values A vector of enumeration values
    * @param ordered Whether or not to consider this enumeration ordered.
-   * @param type The datatype of the enumeration values. This is automatically
-   *        deduced if not provided.
+   * @param type A specific type if you want to override the default.
+   * @return Enumeration The newly constructed enumeration.
    */
   template <typename T, impl::enable_trivial<T>* = nullptr>
   static Enumeration create(
@@ -279,13 +301,13 @@ class Enumeration {
    * Create an enumeration from a vector of strings
    *
    * @param ctx The context to use.
-   * @param values The vector of values for the enumeration.
-   * @param ordered Whether to consider the enumerationv alues as ordered.
-   * @param type The datatype of the enumeration values. This is automatically
-   *        deduced if not provided. However, this can be used to override the
-   *        deduced type if need be. For instance, TILEDB_STRING_ASCII is the
-   *        default type for strings but TILEDB_STRING_UTF8 can be specified.
+   * @param name The name of the enumeration.
+   * @param values A vector of enumeration values
+   * @param ordered Whether or not to consider this enumeration ordered.
+   * @param type A specific type if you want to override the default.
+   * @return Enumeration The newly constructed enumeration.
    */
+
   template <typename T, impl::enable_trivial<T>* = nullptr>
   static Enumeration create(
       const Context& ctx,
@@ -330,8 +352,9 @@ class Enumeration {
    * Create an enumeration
    *
    * @param ctx The context to use.
+   * @param name The name of the enumeration.
    * @param type The datatype of the enumeration values.
-   * @param cell_val_num The cell_val_num of the enumeration.
+   * @param cell_val_num The number of values per cell of the values.
    * @param ordered Whether this enumeration should be considered ordered.
    * @param data A pointer to a buffer of values for this enumeration.
    * @param data_size The size of the buffer pointed to by data.


### PR DESCRIPTION
This change allows users to create an empty enumeration when generating a schema which is then extended with schema evolution during the write phase.

---
TYPE: IMPROVEMENT
DESC: Allow for empty enumerations