### PR TITLE
Run the backport workflow on the `pull_request_target` event.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,7 +24,7 @@ jobs:
       )
     steps:
       - name: Backport
-        uses: zephyrproject-rtos/action-backport@v2.0.3-3
+        uses: zephyrproject-rtos/action-backport@7e74f601d11eaca577742445e87775b5651a965f #tag=v2.0.3-3
         with:
           issue_labels: Backport
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled


### PR DESCRIPTION
It matches what the repository with the backport action does.

Hopefully fixes [SC-35571].

https://github.com/zephyrproject-rtos/action-backport/blob/b7bc23473310e9982167a8a295fe91e59fd4bf0a/.github/workflows/backport.yml#L3

---
TYPE: NO_HISTORY