### PR TITLE
[backport release-2.17] Prepend a question mark to the Azure Storage SAS token if it does not…

### DIFF
--- a/test/src/unit-azure.cc
+++ b/test/src/unit-azure.cc
@@ -33,6 +33,7 @@
 #ifdef HAVE_AZURE
 
 #include <test/support/tdb_catch.h>
+#include <azure/storage/blobs.hpp>
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/thread_pool.h"
 #include "tiledb/sm/config/config.h"
@@ -476,6 +477,45 @@ TEST_CASE_METHOD(
     }
   }
   REQUIRE(allok);
+}
+
+TEST_CASE(
+    "Test constructing Azure Blob Storage endpoint URIs", "[azure][uri]") {
+  std::string sas_token, custom_endpoint, expected_endpoint;
+  SECTION("No SAS token") {
+    sas_token = "";
+    expected_endpoint = "https://devstoreaccount1.blob.core.windows.net";
+  }
+  SECTION("SAS token without leading question mark") {
+    sas_token = "baz=qux&foo=bar";
+    expected_endpoint =
+        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+  }
+  SECTION("SAS token with leading question mark") {
+    sas_token = "?baz=qux&foo=bar";
+    expected_endpoint =
+        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+  }
+  SECTION("SAS token in both endpoint and config option") {
+    sas_token = "baz=qux&foo=bar";
+    custom_endpoint =
+        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+    expected_endpoint =
+        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+  }
+  SECTION("No SAS token") {
+    sas_token = "";
+    expected_endpoint = "https://devstoreaccount1.blob.core.windows.net";
+  }
+  Config config;
+  REQUIRE(
+      config.set("vfs.azure.storage_account_name", "devstoreaccount1").ok());
+  REQUIRE(config.set("vfs.azure.blob_endpoint", custom_endpoint).ok());
+  REQUIRE(config.set("vfs.azure.storage_sas_token", sas_token).ok());
+  tiledb::sm::Azure azure;
+  ThreadPool thread_pool(1);
+  REQUIRE(azure.init(config, &thread_pool).ok());
+  REQUIRE(azure.client().GetUrl() == expected_endpoint);
 }
 
 #endif

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -127,7 +127,14 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
         "The 'vfs.azure.blob_endpoint' option should include the scheme (HTTP "
         "or HTTPS).");
   }
-  if (!blob_endpoint.empty()) {
+  if (!blob_endpoint.empty() && !sas_token.empty()) {
+    // The question mark is not strictly part of the SAS token
+    // (https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#sas-token),
+    // but in the Azure Portal the SAS token starts with one. If it does not, we
+    // add the question mark ourselves.
+    if (!utils::parse::starts_with(sas_token, "?")) {
+      blob_endpoint += '?';
+    }
     blob_endpoint += sas_token;
   }
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -309,6 +309,16 @@ class Azure {
    */
   Status write(const URI& uri, const void* buffer, uint64_t length);
 
+  /**
+   * Returns a reference to the Azure blob service client.
+   *
+   * Used for testing. Calling code should include the Azure SDK headers to make
+   * use of the BlobServiceClient.
+   */
+  const ::Azure::Storage::Blobs::BlobServiceClient& client() const {
+    return *client_;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE DATATYPES         */


### PR DESCRIPTION
… begin with one. (#4418)

* Prepend a question mark to the Azure Storage SAS token if it does not begin with one.

* Add a test.

* Don't add the question mark if the SAS token option is not specified.

The Azure SDK will absorb the trailing question mark and `BlobServiceClient.GetUri()` will not contain it. But nevertheless it's a good thing to not modify the user-provided endpoint if we don't have to.

* Add two more test cases, with no SAS token and with SAS token in both the URI and the config option.

(cherry picked from commit 8543188e04b6d5e84c7040c19ab8745d15c88c0c)

<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
