### PR TITLE
Add an aspect template argument to `class CAPIFunction`.

### DIFF
--- a/tiledb/api/c_api/config/config_api.cc
+++ b/tiledb/api/c_api/config/config_api.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -172,122 +172,77 @@ capi_return_t tiledb_config_iter_done(
 
 }  // namespace tiledb::api
 
-using tiledb::api::api_entry_error;
-
-capi_return_t tiledb_config_alloc(
-    tiledb_config_t** config, tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_alloc>(error, config);
-}
+CAPI_ERROR_BEGIN(config_alloc, tiledb_config_t** config)
+CAPI_ERROR_END(config_alloc, config)
 
 /*
  * API Audit: Void return means no possible signal for an error. No channel that
  * can return an error.
  * Possible errors: `config` may be null or an invalid handle.
  */
-void tiledb_config_free(tiledb_config_t** config) noexcept {
-  return tiledb::api::api_entry_void<tiledb::api::tiledb_config_free>(config);
-}
+CAPI_VOID_BEGIN(config_free, tiledb_config_t** config)
+CAPI_VOID_END(config_free, config)
 
-capi_return_t tiledb_config_set(
-    tiledb_config_t* config,
-    const char* param,
-    const char* value,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_set>(
-      error, config, param, value);
-}
+CAPI_ERROR_BEGIN(
+    config_set, tiledb_config_t* config, const char* param, const char* value)
+CAPI_ERROR_END(config_set, config, param, value)
 
-capi_return_t tiledb_config_get(
-    tiledb_config_t* config,
-    const char* param,
-    const char** value,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_get>(
-      error, config, param, value);
-}
+CAPI_ERROR_BEGIN(
+    config_get, tiledb_config_t* config, const char* param, const char** value)
+CAPI_ERROR_END(config_get, config, param, value)
 
-capi_return_t tiledb_config_unset(
-    tiledb_config_t* config,
-    const char* param,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_unset>(
-      error, config, param);
-}
+CAPI_ERROR_BEGIN(config_unset, tiledb_config_t* config, const char* param)
+CAPI_ERROR_END(config_unset, config, param)
 
-capi_return_t tiledb_config_load_from_file(
-    tiledb_config_t* config,
-    const char* filename,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_load_from_file>(
-      error, config, filename);
-}
+CAPI_ERROR_BEGIN(
+    config_load_from_file, tiledb_config_t* config, const char* filename)
+CAPI_ERROR_END(config_load_from_file, config, filename)
 
-capi_return_t tiledb_config_save_to_file(
-    tiledb_config_t* config,
-    const char* filename,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_save_to_file>(
-      error, config, filename);
-}
+CAPI_ERROR_BEGIN(
+    config_save_to_file, tiledb_config_t* config, const char* filename)
+CAPI_ERROR_END(config_save_to_file, config, filename)
 
 /*
  * API Audit: No channel that can return an error.
  * Possible errors: Both `lhs` and `rhs` may be null or an invalid handle.
  * `equal` may be a null pointer
  */
-capi_return_t tiledb_config_compare(
-    tiledb_config_t* lhs, tiledb_config_t* rhs, uint8_t* equal) noexcept {
-  return tiledb::api::api_entry_plain<tiledb::api::tiledb_config_compare>(
-      lhs, rhs, equal);
-}
+CAPI_PLAIN_BEGIN(
+    config_compare, tiledb_config_t* lhs, tiledb_config_t* rhs, uint8_t* equal)
+CAPI_PLAIN_END(config_compare, lhs, rhs, equal)
 
-capi_return_t tiledb_config_iter_alloc(
+CAPI_ERROR_BEGIN(
+    config_iter_alloc,
     tiledb_config_t* config,
     const char* prefix,
-    tiledb_config_iter_t** config_iter,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_iter_alloc>(
-      error, config, prefix, config_iter);
-}
+    tiledb_config_iter_t** config_iter)
+CAPI_ERROR_END(config_iter_alloc, config, prefix, config_iter)
 
-capi_return_t tiledb_config_iter_reset(
+CAPI_ERROR_BEGIN(
+    config_iter_reset,
     tiledb_config_t* config,
     tiledb_config_iter_t* config_iter,
-    const char* prefix,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_iter_reset>(
-      error, config, config_iter, prefix);
-}
+    const char* prefix)
+CAPI_ERROR_END(config_iter_reset, config, config_iter, prefix)
 
 /*
  * API Audit: Void return means no possible signal for an error. No channel that
  * can return an error.
  * Possible errors: `config` may be null or an invalid handle.
  */
-void tiledb_config_iter_free(tiledb_config_iter_t** config_iter) noexcept {
-  tiledb::api::api_entry_void<tiledb::api::tiledb_config_iter_free>(
-      config_iter);
-}
+CAPI_VOID_BEGIN(config_iter_free, tiledb_config_iter_t** config_iter)
+CAPI_VOID_END(config_iter_free, config_iter)
 
-capi_return_t tiledb_config_iter_here(
+CAPI_ERROR_BEGIN(
+    config_iter_here,
     tiledb_config_iter_t* config_iter,
     const char** param,
-    const char** value,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_iter_here>(
-      error, config_iter, param, value);
-}
+    const char** value)
+CAPI_ERROR_END(config_iter_here, config_iter, param, value)
 
-capi_return_t tiledb_config_iter_next(
-    tiledb_config_iter_t* config_iter, tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_iter_next>(
-      error, config_iter);
-}
+CAPI_ERROR_BEGIN(config_iter_next, tiledb_config_iter_t* config_iter)
+CAPI_ERROR_END(config_iter_next, config_iter)
 
-capi_return_t tiledb_config_iter_done(
-    tiledb_config_iter_t* config_iter,
-    int32_t* done,
-    tiledb_error_t** error) noexcept {
-  return api_entry_error<tiledb::api::tiledb_config_iter_done>(
-      error, config_iter, done);
-}
+CAPI_ERROR_BEGIN(
+    config_iter_done, tiledb_config_iter_t* config_iter, int32_t* done)
+CAPI_ERROR_END(config_iter_done, config_iter, done)

--- a/tiledb/api/c_api/config/config_api.cc
+++ b/tiledb/api/c_api/config/config_api.cc
@@ -172,77 +172,135 @@ capi_return_t tiledb_config_iter_done(
 
 }  // namespace tiledb::api
 
-CAPI_ERROR_BEGIN(config_alloc, tiledb_config_t** config)
-CAPI_ERROR_END(config_alloc, config)
+using tiledb::api::api_entry_error;
+
+CAPI_INTERFACE(config_alloc, tiledb_config_t** config, tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_alloc>(error, config);
+}
 
 /*
  * API Audit: Void return means no possible signal for an error. No channel that
  * can return an error.
  * Possible errors: `config` may be null or an invalid handle.
  */
-CAPI_VOID_BEGIN(config_free, tiledb_config_t** config)
-CAPI_VOID_END(config_free, config)
+CAPI_INTERFACE_VOID(config_free, tiledb_config_t** config) {
+  tiledb::api::api_entry_void<tiledb::api::tiledb_config_free>(config);
+}
 
-CAPI_ERROR_BEGIN(
-    config_set, tiledb_config_t* config, const char* param, const char* value)
-CAPI_ERROR_END(config_set, config, param, value)
+CAPI_INTERFACE(
+    config_set,
+    tiledb_config_t* config,
+    const char* param,
+    const char* value,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_set>(
+      error, config, param, value);
+}
 
-CAPI_ERROR_BEGIN(
-    config_get, tiledb_config_t* config, const char* param, const char** value)
-CAPI_ERROR_END(config_get, config, param, value)
+CAPI_INTERFACE(
+    config_get,
+    tiledb_config_t* config,
+    const char* param,
+    const char** value,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_get>(
+      error, config, param, value);
+}
 
-CAPI_ERROR_BEGIN(config_unset, tiledb_config_t* config, const char* param)
-CAPI_ERROR_END(config_unset, config, param)
+CAPI_INTERFACE(
+    config_unset,
+    tiledb_config_t* config,
+    const char* param,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_unset>(
+      error, config, param);
+}
 
-CAPI_ERROR_BEGIN(
-    config_load_from_file, tiledb_config_t* config, const char* filename)
-CAPI_ERROR_END(config_load_from_file, config, filename)
+CAPI_INTERFACE(
+    config_load_from_file,
+    tiledb_config_t* config,
+    const char* filename,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_load_from_file>(
+      error, config, filename);
+}
 
-CAPI_ERROR_BEGIN(
-    config_save_to_file, tiledb_config_t* config, const char* filename)
-CAPI_ERROR_END(config_save_to_file, config, filename)
+CAPI_INTERFACE(
+    config_save_to_file,
+    tiledb_config_t* config,
+    const char* filename,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_save_to_file>(
+      error, config, filename);
+}
 
 /*
  * API Audit: No channel that can return an error.
  * Possible errors: Both `lhs` and `rhs` may be null or an invalid handle.
  * `equal` may be a null pointer
  */
-CAPI_PLAIN_BEGIN(
-    config_compare, tiledb_config_t* lhs, tiledb_config_t* rhs, uint8_t* equal)
-CAPI_PLAIN_END(config_compare, lhs, rhs, equal)
+CAPI_INTERFACE(
+    config_compare,
+    tiledb_config_t* lhs,
+    tiledb_config_t* rhs,
+    uint8_t* equal) {
+  return tiledb::api::api_entry_plain<tiledb::api::tiledb_config_compare>(
+      lhs, rhs, equal);
+}
 
-CAPI_ERROR_BEGIN(
+CAPI_INTERFACE(
     config_iter_alloc,
     tiledb_config_t* config,
     const char* prefix,
-    tiledb_config_iter_t** config_iter)
-CAPI_ERROR_END(config_iter_alloc, config, prefix, config_iter)
+    tiledb_config_iter_t** config_iter,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_iter_alloc>(
+      error, config, prefix, config_iter);
+}
 
-CAPI_ERROR_BEGIN(
+CAPI_INTERFACE(
     config_iter_reset,
     tiledb_config_t* config,
     tiledb_config_iter_t* config_iter,
-    const char* prefix)
-CAPI_ERROR_END(config_iter_reset, config, config_iter, prefix)
+    const char* prefix,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_iter_reset>(
+      error, config, config_iter, prefix);
+}
 
 /*
  * API Audit: Void return means no possible signal for an error. No channel that
  * can return an error.
  * Possible errors: `config` may be null or an invalid handle.
  */
-CAPI_VOID_BEGIN(config_iter_free, tiledb_config_iter_t** config_iter)
-CAPI_VOID_END(config_iter_free, config_iter)
+CAPI_INTERFACE_VOID(config_iter_free, tiledb_config_iter_t** config_iter) {
+  tiledb::api::api_entry_void<tiledb::api::tiledb_config_iter_free>(
+      config_iter);
+}
 
-CAPI_ERROR_BEGIN(
+CAPI_INTERFACE(
     config_iter_here,
     tiledb_config_iter_t* config_iter,
     const char** param,
-    const char** value)
-CAPI_ERROR_END(config_iter_here, config_iter, param, value)
+    const char** value,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_iter_here>(
+      error, config_iter, param, value);
+}
 
-CAPI_ERROR_BEGIN(config_iter_next, tiledb_config_iter_t* config_iter)
-CAPI_ERROR_END(config_iter_next, config_iter)
+CAPI_INTERFACE(
+    config_iter_next,
+    tiledb_config_iter_t* config_iter,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_iter_next>(
+      error, config_iter);
+}
 
-CAPI_ERROR_BEGIN(
-    config_iter_done, tiledb_config_iter_t* config_iter, int32_t* done)
-CAPI_ERROR_END(config_iter_done, config_iter, done)
+CAPI_INTERFACE(
+    config_iter_done,
+    tiledb_config_iter_t* config_iter,
+    int32_t* done,
+    tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_config_iter_done>(
+      error, config_iter, done);
+}

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -138,75 +138,67 @@ using tiledb::api::api_entry_with_context;
 /*
  * API Audit: No channel to return error message (failure code only)
  */
-capi_return_t tiledb_ctx_alloc(
-    tiledb_config_handle_t* config, tiledb_ctx_handle_t** ctx) noexcept {
-  return tiledb::api::api_entry_plain<tiledb::api::tiledb_ctx_alloc>(
-      config, ctx);
-}
+CAPI_PLAIN_BEGIN(
+    ctx_alloc, tiledb_config_handle_t* config, tiledb_ctx_handle_t** ctx)
+CAPI_PLAIN_END(ctx_alloc,config, ctx)
 
 /*
  * We have a special case with tiledb_ctx_alloc_with_error. It's declared in
  * tiledb_experimental.h. Rather than all the apparatus needed to split up that
- * header (as tiledb.h is), we declare its linkage separately at the point of
- * definition.
+ * header (as tiledb.h is), we declare it separately here, at the point of
+ * definition, with its correct link specification.
  *
  * Not including the experimental header means that we're not using the compiler
  * to check the definition against the declaration. This won't scale
  * particularly well, but it doesn't need to for the time being.
  */
 extern "C" {
-
 capi_return_t tiledb_ctx_alloc_with_error(
     tiledb_config_handle_t* config,
     tiledb_ctx_handle_t** ctx,
-    tiledb_error_handle_t** error) noexcept {
-  /*
-   * Wrapped with the `api_entry_error` variation. Note that the same function
-   * is wrapped with `api_entry_plain` above.
-   */
-  return tiledb::api::api_entry_error<tiledb::api::tiledb_ctx_alloc>(
-      error, config, ctx);
-}
-
+    tiledb_error_t** error) noexcept;
 }  // extern "C"
+
+/*
+ * This is a special case. The API function does not match the name of the
+ * implementation function. See`capi_definition.h` for more information.
+ */
+/* clang-format off */
+capi_return_t tiledb_ctx_alloc_with_error(
+    tiledb_config_handle_t* config,
+    tiledb_ctx_handle_t** ctx,
+    tiledb_error_t** error)
+CAPI_MIDDLE(ctx_alloc, error)
+CAPI_ERROR_END(ctx_alloc_with_error, config, ctx)
+/* clang-format on */
 
 /*
  * API Audit: void return
  */
-void tiledb_ctx_free(tiledb_ctx_handle_t** ctx) noexcept {
-  return tiledb::api::api_entry_void<tiledb::api::tiledb_ctx_free>(ctx);
-}
+CAPI_VOID_BEGIN(ctx_free, tiledb_ctx_handle_t** ctx)
+CAPI_VOID_END(ctx_free,ctx)
 
-capi_return_t tiledb_ctx_get_stats(
-    tiledb_ctx_t* ctx, char** stats_json) noexcept {
-  return api_entry_with_context<tiledb::api::tiledb_ctx_get_stats>(
-      ctx, stats_json);
-}
+CAPI_WITH_CONTEXT_BEGIN(ctx_get_stats, tiledb_ctx_t* ctx, char** stats_json)
+CAPI_WITH_CONTEXT_END(ctx_get_stats,ctx, stats_json)
 
-capi_return_t tiledb_ctx_get_config(
-    tiledb_ctx_t* ctx, tiledb_config_handle_t** config) noexcept {
-  return api_entry_with_context<tiledb::api::tiledb_ctx_get_config>(
-      ctx, config);
-}
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_get_config, tiledb_ctx_t* ctx, tiledb_config_handle_t** config)
+CAPI_WITH_CONTEXT_END(ctx_get_config, ctx, config)
 
-capi_return_t tiledb_ctx_get_last_error(
-    tiledb_ctx_t* ctx, tiledb_error_handle_t** err) noexcept {
-  return api_entry_with_context<tiledb::api::tiledb_ctx_get_last_error>(
-      ctx, err);
-}
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_get_last_error, tiledb_ctx_t* ctx, tiledb_error_handle_t** err)
+CAPI_WITH_CONTEXT_END(ctx_get_last_error,ctx, err)
 
-capi_return_t tiledb_ctx_is_supported_fs(
-    tiledb_ctx_t* ctx, tiledb_filesystem_t fs, int32_t* is_supported) noexcept {
-  return api_entry_with_context<tiledb::api::tiledb_ctx_is_supported_fs>(
-      ctx, fs, is_supported);
-}
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_is_supported_fs,
+    tiledb_ctx_t* ctx,
+    tiledb_filesystem_t fs,
+    int32_t* is_supported)
+CAPI_WITH_CONTEXT_END(ctx_is_supported_fs,ctx, fs, is_supported)
 
-capi_return_t tiledb_ctx_cancel_tasks(tiledb_ctx_t* ctx) noexcept {
-  return api_entry_with_context<tiledb::api::tiledb_ctx_cancel_tasks>(ctx);
-}
+CAPI_WITH_CONTEXT_BEGIN(ctx_cancel_tasks, tiledb_ctx_t* ctx)
+CAPI_WITH_CONTEXT_END(ctx_cancel_tasks,ctx)
 
-capi_return_t tiledb_ctx_set_tag(
-    tiledb_ctx_t* ctx, const char* key, const char* value) noexcept {
-  return api_entry_with_context<tiledb::api::tiledb_ctx_set_tag>(
-      ctx, key, value);
-}
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_set_tag, tiledb_ctx_t* ctx, const char* key, const char* value)
+CAPI_WITH_CONTEXT_END(ctx_set_tag,ctx, key, value)

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -138,72 +138,77 @@ using tiledb::api::api_entry_with_context;
 /*
  * API Audit: No channel to return error message (failure code only)
  */
-CAPI_PLAIN_BEGIN(
-    ctx_alloc, tiledb_config_handle_t* config, tiledb_ctx_handle_t** ctx)
-CAPI_PLAIN_END(ctx_alloc, config, ctx)
-
-/*
- * API Audit: void return
- */
-CAPI_VOID_BEGIN(ctx_free, tiledb_ctx_handle_t** ctx)
-CAPI_VOID_END(ctx_free, ctx)
-
-CAPI_WITH_CONTEXT_BEGIN(ctx_get_stats, tiledb_ctx_t* ctx, char** stats_json)
-CAPI_WITH_CONTEXT_END(ctx_get_stats, ctx, stats_json)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_get_config, tiledb_ctx_t* ctx, tiledb_config_handle_t** config)
-CAPI_WITH_CONTEXT_END(ctx_get_config, ctx, config)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_get_last_error, tiledb_ctx_t* ctx, tiledb_error_handle_t** err)
-CAPI_WITH_CONTEXT_END(ctx_get_last_error, ctx, err)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_is_supported_fs,
-    tiledb_ctx_t* ctx,
-    tiledb_filesystem_t fs,
-    int32_t* is_supported)
-CAPI_WITH_CONTEXT_END(ctx_is_supported_fs, ctx, fs, is_supported)
-
-CAPI_WITH_CONTEXT_BEGIN(ctx_cancel_tasks, tiledb_ctx_t* ctx)
-CAPI_WITH_CONTEXT_END(ctx_cancel_tasks, ctx)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_set_tag, tiledb_ctx_t* ctx, const char* key, const char* value)
-CAPI_WITH_CONTEXT_END(ctx_set_tag, ctx, key, value)
+CAPI_INTERFACE(
+    ctx_alloc, tiledb_config_handle_t* config, tiledb_ctx_handle_t** ctx) {
+  return tiledb::api::api_entry_plain<tiledb::api::tiledb_ctx_alloc>(
+      config, ctx);
+}
 
 /*
  * We have a special case with tiledb_ctx_alloc_with_error. It's declared in
  * tiledb_experimental.h. Rather than all the apparatus needed to split up that
- * header (as tiledb.h is), we declare it separately here, at the point of
- * definition, with its correct link specification.
+ * header (as tiledb.h is), we declare its linkage separately at the point of
+ * definition.
  *
  * Not including the experimental header means that we're not using the compiler
  * to check the definition against the declaration. This won't scale
  * particularly well, but it doesn't need to for the time being.
  */
 extern "C" {
+
 capi_return_t tiledb_ctx_alloc_with_error(
     tiledb_config_handle_t* config,
     tiledb_ctx_handle_t** ctx,
-    tiledb_error_t** error) noexcept;
+    tiledb_error_handle_t** error) noexcept {
+  /*
+   * Wrapped with the `api_entry_error` variation. Note that the same function
+   * is wrapped with `api_entry_plain` above.
+   */
+  return tiledb::api::api_entry_error<tiledb::api::tiledb_ctx_alloc>(
+      error, config, ctx);
+}
+
 }  // extern "C"
 
 /*
- * This is a special case. The API function does not match the name of the
- * implementation function, which the macros assume. See`capi_definition.h` for
- * more information.
+ * API Audit: void return
  */
-/* clang-format off */
-capi_return_t tiledb_ctx_alloc_with_error(
-    tiledb_config_handle_t* config,
-    tiledb_ctx_handle_t** ctx,
-    tiledb_error_t** error)
-CAPI_MIDDLE(ctx_alloc, error)
-CAPI_ERROR_END(ctx_alloc_with_error, config, ctx)
-    /* clang-format on */
-    /*
-     * WARNING: Don't include any code past this point lest you incur the wrath
-     * of a mistreated `clang-format`.
-     */
+CAPI_INTERFACE_VOID(ctx_free, tiledb_ctx_handle_t** ctx) {
+  return tiledb::api::api_entry_void<tiledb::api::tiledb_ctx_free>(ctx);
+}
+
+CAPI_INTERFACE(ctx_get_stats, tiledb_ctx_t* ctx, char** stats_json) {
+  return api_entry_with_context<tiledb::api::tiledb_ctx_get_stats>(
+      ctx, stats_json);
+}
+
+CAPI_INTERFACE(
+    ctx_get_config, tiledb_ctx_t* ctx, tiledb_config_handle_t** config) {
+  return api_entry_with_context<tiledb::api::tiledb_ctx_get_config>(
+      ctx, config);
+}
+
+CAPI_INTERFACE(
+    ctx_get_last_error, tiledb_ctx_t* ctx, tiledb_error_handle_t** err) {
+  return api_entry_with_context<tiledb::api::tiledb_ctx_get_last_error>(
+      ctx, err);
+}
+
+CAPI_INTERFACE(
+    ctx_is_supported_fs,
+    tiledb_ctx_t* ctx,
+    tiledb_filesystem_t fs,
+    int32_t* is_supported) {
+  return api_entry_with_context<tiledb::api::tiledb_ctx_is_supported_fs>(
+      ctx, fs, is_supported);
+}
+
+CAPI_INTERFACE(ctx_cancel_tasks, tiledb_ctx_t* ctx) {
+  return api_entry_with_context<tiledb::api::tiledb_ctx_cancel_tasks>(ctx);
+}
+
+CAPI_INTERFACE(
+    ctx_set_tag, tiledb_ctx_t* ctx, const char* key, const char* value) {
+  return api_entry_with_context<tiledb::api::tiledb_ctx_set_tag>(
+      ctx, key, value);
+}

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -140,7 +140,38 @@ using tiledb::api::api_entry_with_context;
  */
 CAPI_PLAIN_BEGIN(
     ctx_alloc, tiledb_config_handle_t* config, tiledb_ctx_handle_t** ctx)
-CAPI_PLAIN_END(ctx_alloc,config, ctx)
+CAPI_PLAIN_END(ctx_alloc, config, ctx)
+
+/*
+ * API Audit: void return
+ */
+CAPI_VOID_BEGIN(ctx_free, tiledb_ctx_handle_t** ctx)
+CAPI_VOID_END(ctx_free, ctx)
+
+CAPI_WITH_CONTEXT_BEGIN(ctx_get_stats, tiledb_ctx_t* ctx, char** stats_json)
+CAPI_WITH_CONTEXT_END(ctx_get_stats, ctx, stats_json)
+
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_get_config, tiledb_ctx_t* ctx, tiledb_config_handle_t** config)
+CAPI_WITH_CONTEXT_END(ctx_get_config, ctx, config)
+
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_get_last_error, tiledb_ctx_t* ctx, tiledb_error_handle_t** err)
+CAPI_WITH_CONTEXT_END(ctx_get_last_error, ctx, err)
+
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_is_supported_fs,
+    tiledb_ctx_t* ctx,
+    tiledb_filesystem_t fs,
+    int32_t* is_supported)
+CAPI_WITH_CONTEXT_END(ctx_is_supported_fs, ctx, fs, is_supported)
+
+CAPI_WITH_CONTEXT_BEGIN(ctx_cancel_tasks, tiledb_ctx_t* ctx)
+CAPI_WITH_CONTEXT_END(ctx_cancel_tasks, ctx)
+
+CAPI_WITH_CONTEXT_BEGIN(
+    ctx_set_tag, tiledb_ctx_t* ctx, const char* key, const char* value)
+CAPI_WITH_CONTEXT_END(ctx_set_tag, ctx, key, value)
 
 /*
  * We have a special case with tiledb_ctx_alloc_with_error. It's declared in
@@ -161,7 +192,8 @@ capi_return_t tiledb_ctx_alloc_with_error(
 
 /*
  * This is a special case. The API function does not match the name of the
- * implementation function. See`capi_definition.h` for more information.
+ * implementation function, which the macros assume. See`capi_definition.h` for
+ * more information.
  */
 /* clang-format off */
 capi_return_t tiledb_ctx_alloc_with_error(
@@ -170,35 +202,8 @@ capi_return_t tiledb_ctx_alloc_with_error(
     tiledb_error_t** error)
 CAPI_MIDDLE(ctx_alloc, error)
 CAPI_ERROR_END(ctx_alloc_with_error, config, ctx)
-/* clang-format on */
-
-/*
- * API Audit: void return
- */
-CAPI_VOID_BEGIN(ctx_free, tiledb_ctx_handle_t** ctx)
-CAPI_VOID_END(ctx_free,ctx)
-
-CAPI_WITH_CONTEXT_BEGIN(ctx_get_stats, tiledb_ctx_t* ctx, char** stats_json)
-CAPI_WITH_CONTEXT_END(ctx_get_stats,ctx, stats_json)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_get_config, tiledb_ctx_t* ctx, tiledb_config_handle_t** config)
-CAPI_WITH_CONTEXT_END(ctx_get_config, ctx, config)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_get_last_error, tiledb_ctx_t* ctx, tiledb_error_handle_t** err)
-CAPI_WITH_CONTEXT_END(ctx_get_last_error,ctx, err)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_is_supported_fs,
-    tiledb_ctx_t* ctx,
-    tiledb_filesystem_t fs,
-    int32_t* is_supported)
-CAPI_WITH_CONTEXT_END(ctx_is_supported_fs,ctx, fs, is_supported)
-
-CAPI_WITH_CONTEXT_BEGIN(ctx_cancel_tasks, tiledb_ctx_t* ctx)
-CAPI_WITH_CONTEXT_END(ctx_cancel_tasks,ctx)
-
-CAPI_WITH_CONTEXT_BEGIN(
-    ctx_set_tag, tiledb_ctx_t* ctx, const char* key, const char* value)
-CAPI_WITH_CONTEXT_END(ctx_set_tag,ctx, key, value)
+    /* clang-format on */
+    /*
+     * WARNING: Don't include any code past this point lest you incur the wrath
+     * of a mistreated `clang-format`.
+     */

--- a/tiledb/api/c_api/error/error_api.cc
+++ b/tiledb/api/c_api/error/error_api.cc
@@ -62,12 +62,8 @@ void tiledb_error_free(tiledb_error_handle_t** err) {
 
 }  // namespace tiledb::api
 
-capi_return_t tiledb_error_message(
-    tiledb_error_handle_t* err, const char** errmsg) noexcept {
-  return tiledb::api::api_entry_plain<tiledb::api::tiledb_error_message>(
-      err, errmsg);
-}
+CAPI_PLAIN_BEGIN(error_message, tiledb_error_handle_t* err, const char** errmsg)
+CAPI_PLAIN_END(error_message, err, errmsg)
 
-void tiledb_error_free(tiledb_error_handle_t** err) noexcept {
-  return tiledb::api::api_entry_void<tiledb::api::tiledb_error_free>(err);
-}
+CAPI_VOID_BEGIN(error_free, tiledb_error_handle_t** err)
+CAPI_VOID_END(error_free, err)

--- a/tiledb/api/c_api/error/error_api.cc
+++ b/tiledb/api/c_api/error/error_api.cc
@@ -62,8 +62,11 @@ void tiledb_error_free(tiledb_error_handle_t** err) {
 
 }  // namespace tiledb::api
 
-CAPI_PLAIN_BEGIN(error_message, tiledb_error_handle_t* err, const char** errmsg)
-CAPI_PLAIN_END(error_message, err, errmsg)
+CAPI_INTERFACE(error_message, tiledb_error_handle_t* err, const char** errmsg) {
+  return tiledb::api::api_entry_plain<tiledb::api::tiledb_error_message>(
+      err, errmsg);
+}
 
-CAPI_VOID_BEGIN(error_free, tiledb_error_handle_t** err)
-CAPI_VOID_END(error_free, err)
+CAPI_INTERFACE_VOID(error_free, tiledb_error_handle_t** err) {
+  return tiledb::api::api_entry_void<tiledb::api::tiledb_error_free>(err);
+}

--- a/tiledb/api/c_api_support/exception_wrapper/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/CMakeLists.txt
@@ -33,7 +33,6 @@ include(object_library)
 # only. `exception_wrapper.cc` is an empty source file needed to allow the
 # OBJECT syntax.
 
-# No actual source files at present.
 list(APPEND SOURCES
     exception_wrapper.cc
 )

--- a/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
+++ b/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
@@ -1,0 +1,114 @@
+/**
+ * @file tiledb/api/c_api_support/exception_wrapper/hook.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines macros to define C API functions.
+ */
+
+#ifndef TILEDB_CAPI_DEFINITION_H
+#define TILEDB_CAPI_DEFINITION_H
+
+/*
+ * The macro wrappers all have the same form
+ * ```
+ *   CAPI_XXX_BEGIN(name, ...)
+ *   CAPI_XXX_END(...)
+ * ```
+ * - The name argument is for the base name, that is, the name without the
+ *   `tiledb_` prefix.
+ * - The `__VA_ARGS__` argument in `*_BEGIN` is the full argument part of the
+ *   function signature. By "full", that means it requires that parameter names
+ *   be present.
+ * - The `__VA_ARGS__` argument in `*_END` are the call arguments, that is, it's
+ *   the function signature arguments without their type declarations.
+ */
+
+/* clang-format off */
+
+#define CAPI_DEFN(name) tiledb_##name
+#define CAPI_IMPL(name) tiledb::api::tiledb_##name
+#define CAPI_XFMR(name) tiledb::api::api_entry_##name
+#define CAPI_PREFIX(name)
+#define CAPI_SUFFIX(name)
+
+#define CAPI_BEGIN(root, ret) \
+  CAPI_PREFIX(root)           \
+  ret CAPI_DEFN(root)
+
+#define CAPI_MIDDLE(root, xfmr) \
+  noexcept {                    \
+    return CAPI_XFMR(xfmr)<CAPI_IMPL(root)>
+
+#define CAPI_END(root, ...) \
+  (__VA_ARGS__);            \
+  }                         \
+  CAPI_SUFFIX(root)
+
+#define CAPI_PLAIN_BEGIN(root, ...)             \
+  CAPI_BEGIN(root, capi_return_t )(__VA_ARGS__) \
+  CAPI_MIDDLE(root, plain)
+#define CAPI_PLAIN_END(root, ...) \
+  CAPI_END(root, __VA_ARGS__)
+
+#define CAPI_VOID_BEGIN(root, ...)     \
+  CAPI_BEGIN(root, void )(__VA_ARGS__) \
+  CAPI_MIDDLE(root, void)
+#define CAPI_VOID_END(root, ...) \
+  CAPI_END(root, __VA_ARGS__)
+
+#define CAPI_WITH_CONTEXT_BEGIN(root, ...)     \
+  CAPI_BEGIN(root, capi_return_t)(__VA_ARGS__) \
+  CAPI_MIDDLE(root, with_context)
+#define CAPI_WITH_CONTEXT_END(root, ...) \
+  CAPI_END(root, __VA_ARGS__)
+
+#define CAPI_CONTEXT_BEGIN(root, ...)          \
+  CAPI_BEGIN(root, capi_return_t)(__VA_ARGS__) \
+  CAPI_MIDDLE(root, context)
+#define CAPI_CONTEXT_END(root ,...) \
+  CAPI_END(root, __VA_ARGS__)
+
+/*
+ * The argument lists for the ERROR macros omit the `error` argument.
+ *
+ * The ERROR wrapper is different from the others because it makes a special
+ * case of the `error` argument. Its definition is at the end of the argument
+ * list of the signature but at the beginning of the argument list of the call.
+ *
+ * Note that these macros, as written, do not handle zero-length variable
+ * arguments. There are no cases where this is needed.
+ */
+#define CAPI_ERROR_BEGIN(root, ...)                                     \
+  CAPI_BEGIN(root, capi_return_t)(__VA_ARGS__, tiledb_error_t * *error) \
+  CAPI_MIDDLE(root, error)
+#define CAPI_ERROR_END(root, ...) \
+  CAPI_END(root, error, __VA_ARGS__)
+
+/* clang-format on */
+
+#endif  // TILEDB_CAPI_DEFINITION_H

--- a/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
+++ b/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
@@ -33,81 +33,28 @@
 #ifndef TILEDB_CAPI_DEFINITION_H
 #define TILEDB_CAPI_DEFINITION_H
 
-/*
- * The macro wrappers all have the same form
- * ```
- *   CAPI_XXX_BEGIN(name, ...)
- *   CAPI_XXX_END(...)
- * ```
- * - The name argument is for the base name, that is, the name without the
- *   `tiledb_` prefix.
- * - The `__VA_ARGS__` argument in `*_BEGIN` is the full argument part of the
- *   function signature. By "full", that means it requires that parameter names
- *   be present.
- * - The `__VA_ARGS__` argument in `*_END` are the call arguments, that is, it's
- *   the function signature arguments without their type declarations.
- */
-
 /* clang-format off */
 
-#define CAPI_DEFN(name) tiledb_##name
-#define CAPI_IMPL(name) tiledb::api::tiledb_##name
-#define CAPI_XFMR(name) tiledb::api::api_entry_##name
+/*
+ * Hook for additional code to be generated before each C API interface
+ * function.
+ */
 #define CAPI_PREFIX(name)
-#define CAPI_SUFFIX(name)
-
-#define CAPI_BEGIN(root, ret) \
-  CAPI_PREFIX(root)           \
-  ret CAPI_DEFN(root)
-
-#define CAPI_MIDDLE(root, xfmr) \
-  noexcept {                    \
-    return CAPI_XFMR(xfmr)<CAPI_IMPL(root)>
-
-#define CAPI_END(root, ...) \
-  (__VA_ARGS__);            \
-  }                         \
-  CAPI_SUFFIX(root)
-
-#define CAPI_PLAIN_BEGIN(root, ...)             \
-  CAPI_BEGIN(root, capi_return_t )(__VA_ARGS__) \
-  CAPI_MIDDLE(root, plain)
-#define CAPI_PLAIN_END(root, ...) \
-  CAPI_END(root, __VA_ARGS__)
-
-#define CAPI_VOID_BEGIN(root, ...)     \
-  CAPI_BEGIN(root, void )(__VA_ARGS__) \
-  CAPI_MIDDLE(root, void)
-#define CAPI_VOID_END(root, ...) \
-  CAPI_END(root, __VA_ARGS__)
-
-#define CAPI_WITH_CONTEXT_BEGIN(root, ...)     \
-  CAPI_BEGIN(root, capi_return_t)(__VA_ARGS__) \
-  CAPI_MIDDLE(root, with_context)
-#define CAPI_WITH_CONTEXT_END(root, ...) \
-  CAPI_END(root, __VA_ARGS__)
-
-#define CAPI_CONTEXT_BEGIN(root, ...)          \
-  CAPI_BEGIN(root, capi_return_t)(__VA_ARGS__) \
-  CAPI_MIDDLE(root, context)
-#define CAPI_CONTEXT_END(root ,...) \
-  CAPI_END(root, __VA_ARGS__)
 
 /*
- * The argument lists for the ERROR macros omit the `error` argument.
- *
- * The ERROR wrapper is different from the others because it makes a special
- * case of the `error` argument. Its definition is at the end of the argument
- * list of the signature but at the beginning of the argument list of the call.
- *
- * Note that these macros, as written, do not handle zero-length variable
- * arguments. There are no cases where this is needed.
+ * Declaration clause for a C API interface function. Follow with a `{ ... }`
+ * block defining the body.
  */
-#define CAPI_ERROR_BEGIN(root, ...)                                     \
-  CAPI_BEGIN(root, capi_return_t)(__VA_ARGS__, tiledb_error_t * *error) \
-  CAPI_MIDDLE(root, error)
-#define CAPI_ERROR_END(root, ...) \
-  CAPI_END(root, error, __VA_ARGS__)
+#define CAPI_INTERFACE(root, ...) \
+CAPI_PREFIX(root)                 \
+capi_return_t tiledb_##root(__VA_ARGS__) noexcept
+
+/*
+ * A variant of CAPI_INTERFACE for the handful of `void` returns.
+ */
+#define CAPI_INTERFACE_VOID(root, ...) \
+CAPI_PREFIX(root)                      \
+void tiledb_##root(__VA_ARGS__) noexcept
 
 /* clang-format on */
 

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -514,18 +514,39 @@ using ExceptionActionCtxErr = detail::ExceptionActionDetailCtxErr;
 //-------------------------------------------------------
 // Exception wrapper
 //-------------------------------------------------------
+template <auto f>
+class CAPIFunctionNullAspect {
+ public:
+  template <typename... Args>
+  static void call(Args...) {
+  }
+};
+
+/**
+ * Selection struct defines the default aspect type for CAPIFunction. This class
+ * is always used with second template argument as `void`. This definition is
+ * for the general case; a specialization can override it.
+ */
+template <auto f, typename>
+struct CAPIFunctionSelector {
+  using aspect_type = CAPIFunctionNullAspect<f>;
+};
+
 /**
  * Non-specialized wrapper for implementations functions for the C API. May
  * only be used as a specialization.
  */
-template <auto f, class H>
+template <
+    auto f,
+    class H,
+    class A = typename CAPIFunctionSelector<f, void>::aspect_type>
 class CAPIFunction;
 
 /**
  * Wrapper for implementations functions for the C API
  */
-template <class... Args, capi_return_t (*f)(Args...), class H>
-class CAPIFunction<f, H> {
+template <class R, class... Args, R (*f)(Args...), class H, class A>
+class CAPIFunction<f, H, A> {
  public:
   /**
    * Forwarded alias to template parameter H.
@@ -539,7 +560,7 @@ class CAPIFunction<f, H> {
    * @param args Arguments to an API implementation function
    * @return
    */
-  static capi_return_t function(H& h, Args... args) {
+  static R function(H& h, Args... args) {
     /*
      * The order of the catch blocks is not arbitrary:
      * - `std::bad_alloc` comes first because it overrides other problems
@@ -561,27 +582,46 @@ class CAPIFunction<f, H> {
        * Note that we don't need std::forward here because all the arguments
        * must have "C" linkage.
        */
-      auto x{f(args...)};
-      h.action_on_success();
-      return x;
+      //-------------------------------------------------------
+      A::call(args...);
+      if constexpr (std::same_as<R, void>) {
+        f(args...);
+        h.action_on_success();
+      } else {
+        auto x{f(args...)};
+        h.action_on_success();
+        return x;
+      }
     } catch (const std::bad_alloc& e) {
       h.action(e);
-      return TILEDB_OOM;
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_OOM;
+      }
     } catch (const detail::InvalidContextException& e) {
       h.action(e);
-      return TILEDB_INVALID_CONTEXT;
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_INVALID_CONTEXT;
+      }
     } catch (const detail::InvalidErrorException& e) {
       h.action(e);
-      return TILEDB_INVALID_ERROR;
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_INVALID_ERROR;
+      }
     } catch (const StatusException& e) {
       h.action(e);
-      return TILEDB_ERR;
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_ERR;
+      }
     } catch (const std::exception& e) {
       h.action(e);
-      return TILEDB_ERR;
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_ERR;
+      }
     } catch (...) {
       h.action(CAPIException("unknown exception type; no further information"));
-      return TILEDB_ERR;
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_ERR;
+      }
     }
   };
 
@@ -669,52 +709,14 @@ constexpr auto api_entry_plain =
     CAPIFunction<f, ExceptionAction>::function_plain;
 
 /**
- * Declaration only defined through a specialization.
- *
- * @tparam f An API implementation function
- */
-template <auto f>
-struct CAPIFunctionVoid;
-
-/**
- * Wrapper class for API implementation functions with `void` return.
- *
- * We require a separate wrapper class here so we can match the template
- * argument `f` to a function with void return, since `CAPIFunction` only
- * matches those that return `capi_return_t`.
- *
- * @tparam Args Argument types for the function
- * @tparam f An API implementation function
- */
-template <class... Args, void (*f)(Args...)>
-struct CAPIFunctionVoid<f> {
-  /**
-   * Function transformer changes an API implementation function with `void`
-   * return to one returning a (trivially constant) `capi_return_t` value.
-   *
-   * This function is used to match the function signature in `CAPIFunction`,
-   * which requires a return value. This allows us to reuse its wrapper function
-   * without duplicating code.
-   *
-   * @param args Arguments passed to the function
-   * @return TILEDB_OK
-   */
-  inline static capi_return_t function_from_void(Args... args) {
-    f(args...);
-    return TILEDB_OK;
-  }
-};
-
-/**
  * Function transformer changes an API implementation function with `void`
  * return to an API interface function, also with `void` return.
  *
  * @tparam f An implementation function.
  */
 template <auto f>
-constexpr auto api_entry_void = CAPIFunction<
-    CAPIFunctionVoid<f>::function_from_void,
-    tiledb::api::ExceptionAction>::void_function;
+constexpr auto api_entry_void =
+    CAPIFunction<f, tiledb::api::ExceptionAction>::void_function;
 
 /**
  * Declaration only defined through a specialization.

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -551,8 +551,6 @@ class CAPIFunction;
  */
 template <class R, class... Args, R (*f)(Args...), class H, class A>
 class CAPIFunction<f, H, A> {
-
-  
  public:
   /**
    * Forwarded alias to template parameter H.

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -514,6 +514,10 @@ using ExceptionActionCtxErr = detail::ExceptionActionDetailCtxErr;
 //-------------------------------------------------------
 // Exception wrapper
 //-------------------------------------------------------
+/**
+ * Null aspect for `class CAPIFunction` has null operations for all aspects.
+ * @tparam f
+ */
 template <auto f>
 class CAPIFunctionNullAspect {
  public:
@@ -547,6 +551,8 @@ class CAPIFunction;
  */
 template <class R, class... Args, R (*f)(Args...), class H, class A>
 class CAPIFunction<f, H, A> {
+
+  
  public:
   /**
    * Forwarded alias to template parameter H.
@@ -582,7 +588,6 @@ class CAPIFunction<f, H, A> {
        * Note that we don't need std::forward here because all the arguments
        * must have "C" linkage.
        */
-      //-------------------------------------------------------
       A::call(args...);
       if constexpr (std::same_as<R, void>) {
         f(args...);

--- a/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
@@ -34,3 +34,53 @@ commence(unit_test capi_exception_wrapper)
       # top-level dependency required for the test.
       capi_context_stub)
 conclude(unit_test)
+
+#
+# Hook Tests
+#
+# These following two unit test runners are a pair, one compiled without an API
+# hook compiled in, one without. They run the same test, although with different
+# expectations about the results. The hook is specified in two different ways:
+# * In the ordinary way, with an additional include directory
+# * Specifically for testing, with a compile definition.
+# The two different ways are used to verify that the hook is activated or not
+# as appropriate.
+#
+# Changing the API hook changes the API object libraries. The API hook is
+# perforce a low-level mechanism. It changes the definition of C API calls. The
+# exception handler is intertwined with a few of the API classes, notably the
+# handles for context and error (and config gets pulled in as a dependency). As
+# a result, whereas the without-hook test runner can use an existing object
+# library, the with-hook ones needs to recompile an equivalent.
+#
+
+# Hook tests without the hook
+commence(unit_test capi_ew_without_hook)
+  this_target_sources(
+      unit_capi_hook.cc
+      unit_capi_hook_without.cc)
+  this_target_object_libraries(
+      capi_context_stub)
+conclude(unit_test)
+
+# Hook tests with the hook included.
+commence(unit_test capi_ew_with_hook)
+  this_target_sources(
+      unit_capi_hook.cc
+      unit_capi_hook_with.cc
+      ../../../c_api/config/config_api.cc
+      ../../../c_api/context/context_api.cc
+      ../../../c_api/error/error_api.cc
+      ../../../../sm/storage_manager/context.cc
+      ../../../../sm/storage_manager/context_resources.cc
+  )
+  this_target_link_libraries(export)
+  this_target_object_libraries(
+      exception_wrapper
+      storage_manager_stub
+      vfs
+  )
+  target_compile_definitions(unit_capi_ew_with_hook PUBLIC WITH_HOOK)
+  target_include_directories(
+      unit_capi_ew_with_hook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/hook)
+conclude(unit_test)

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook/DIRECTORY.md
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook/DIRECTORY.md
@@ -1,0 +1,5 @@
+# Directory for C API hook testing
+
+A user activates the C API hook by writing an override header and building the library with its directory as part of the include path. This is a compile-time mechanism, so in order to test it well, the same code should execute both with and without a test hook compiled in.
+
+This directory proivdes a place to put an override header that's not ordinarily included in the build.   

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
@@ -1,11 +1,12 @@
 /**
- * @file tiledb/api/c_api_support/c_api_support.h
+ * @file
+ * tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,20 +28,24 @@
  *
  * @section DESCRIPTION
  *
- * This file includes all the support functions that appear generally in C API
- * implementation functions:
- *   - Exception wrappers and error handling
- *   - Argument validation
+ * This file defines macros to define C API functions.
  */
 
-#ifndef TILEDB_CAPI_SUPPORT_H
-#define TILEDB_CAPI_SUPPORT_H
+#ifndef TILEDB_EXCEPTION_WRAPPER_TEST_CAPI_FUNCTION_OVERRIDE_H
+#define TILEDB_EXCEPTION_WRAPPER_TEST_CAPI_FUNCTION_OVERRIDE_H
 
-#include "argument_validation.h"
-#include "tiledb/api/c_api_support/exception_wrapper/capi_definition.h"
-#include "tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h"
-#if __has_include("capi_function_override.h")
-#include "capi_function_override.h"
-#endif
+#include "../logging_aspect.h"
 
-#endif  // TILEDB_CAPI_SUPPORT_H
+#undef CAPI_PREFIX
+#define CAPI_PREFIX(root)                                    \
+  template <>                                                \
+  struct CAPIFunctionMetadata<CAPI_IMPL(root)> {             \
+    static constexpr std::string_view name{"tiledb_" #root}; \
+  };
+
+template <auto f>
+struct tiledb::api::CAPIFunctionSelector<f, void> {
+  using aspect_type = LoggingAspect<f>;
+};
+
+#endif  // TILEDB_EXCEPTION_WRAPPER_TEST_CAPI_FUNCTION_OVERRIDE_H

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
@@ -36,13 +36,25 @@
 
 #include "../logging_aspect.h"
 
+/*
+ * CAPI_PREFIX is an extension point within the macros for defining C API
+ * interface functions. The override macro defines a trait class for each C API
+ * implementation function. The trait class is a specialization of an otherwise
+ * undefined class template. Each trait class contains the name of its
+ * implementation function; the name is subsequently picked up by `class
+ * LoggingAspect`.
+ */
 #undef CAPI_PREFIX
 #define CAPI_PREFIX(root)                                    \
   template <>                                                \
-  struct CAPIFunctionMetadata<CAPI_IMPL(root)> {             \
+  struct CAPIFunctionNameTrait<CAPI_IMPL(root)> {             \
     static constexpr std::string_view name{"tiledb_" #root}; \
   };
 
+/**
+ * Specialization of the aspect selector to `void` overrides the default (the
+ * null aspect) to compile with the logging aspect instead.
+ */
 template <auto f>
 struct tiledb::api::CAPIFunctionSelector<f, void> {
   using aspect_type = LoggingAspect<f>;

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
@@ -45,10 +45,10 @@
  * LoggingAspect`.
  */
 #undef CAPI_PREFIX
-#define CAPI_PREFIX(root)                                    \
-  template <>                                                \
-  struct CAPIFunctionNameTrait<CAPI_IMPL(root)> {            \
-    static constexpr std::string_view name{"tiledb_" #root}; \
+#define CAPI_PREFIX(root)                                     \
+  template <>                                                 \
+  struct CAPIFunctionNameTrait<tiledb::api::tiledb_##root> { \
+    static constexpr std::string_view name{"tiledb_" #root};  \
   };
 
 /**

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
@@ -45,10 +45,10 @@
  * LoggingAspect`.
  */
 #undef CAPI_PREFIX
-#define CAPI_PREFIX(root)                                     \
-  template <>                                                 \
+#define CAPI_PREFIX(root)                                    \
+  template <>                                                \
   struct CAPIFunctionNameTrait<tiledb::api::tiledb_##root> { \
-    static constexpr std::string_view name{"tiledb_" #root};  \
+    static constexpr std::string_view name{"tiledb_" #root}; \
   };
 
 /**

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook/capi_function_override.h
@@ -47,7 +47,7 @@
 #undef CAPI_PREFIX
 #define CAPI_PREFIX(root)                                    \
   template <>                                                \
-  struct CAPIFunctionNameTrait<CAPI_IMPL(root)> {             \
+  struct CAPIFunctionNameTrait<CAPI_IMPL(root)> {            \
     static constexpr std::string_view name{"tiledb_" #root}; \
   };
 

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook_common.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook_common.h
@@ -1,11 +1,11 @@
 /**
- * @file tiledb/api/c_api_support/c_api_support.h
+ * @file tiledb/api/c_api_support/exception_wrapper/test/hook_common.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,20 +27,19 @@
  *
  * @section DESCRIPTION
  *
- * This file includes all the support functions that appear generally in C API
- * implementation functions:
- *   - Exception wrappers and error handling
- *   - Argument validation
+ * This file defines macros to define C API functions.
  */
 
-#ifndef TILEDB_CAPI_SUPPORT_H
-#define TILEDB_CAPI_SUPPORT_H
+#ifndef TILEDB_EXCEPTION_WRAPPER_TEST_HOOK_COMMON_H
+#define TILEDB_EXCEPTION_WRAPPER_TEST_HOOK_COMMON_H
 
-#include "argument_validation.h"
-#include "tiledb/api/c_api_support/exception_wrapper/capi_definition.h"
-#include "tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h"
-#if __has_include("capi_function_override.h")
-#include "capi_function_override.h"
+/*
+ * Convert the possible command line argument WITH_HOOK into a C++ constant.
+ */
+#if defined(WITH_HOOK)
+constexpr bool compiled_with_hook{true};
+#else
+constexpr bool compiled_with_hook{false};
 #endif
 
-#endif  // TILEDB_CAPI_SUPPORT_H
+#endif  // TILEDB_EXCEPTION_WRAPPER_TEST_HOOK_COMMON_H

--- a/tiledb/api/c_api_support/exception_wrapper/test/logging_aspect.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/logging_aspect.h
@@ -27,7 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * This file defines macros to define C API functions.
+ * This file defines a logging aspect sufficient to verify that the C API
+ * aspect system in the exception wrapper is working.
  */
 
 #ifndef TILEDB_EXCEPTION_WRAPPER_TEST_LOGGING_ASPECT_H
@@ -35,44 +36,76 @@
 
 #include <string>
 
+/**
+ * Default trait class declaration has no members; it's only defined a
+ * specialization.
+ */
 template <auto f>
-struct CAPIFunctionMetadata;
-
-template <class R, class... Args, R (*f)(Args...)>
-struct CAPIFunctionMetadata<f>;
+struct CAPIFunctionNameTrait;
 
 /**
  * Base class for the logging aspect class template.
  *
  * This class mimics a global logger. It's rudimentary but suffices for testing.
- * Instead of a growing log, it has a single "log entry"
+ * Instead of a growing log, it has a single "log entry". It's not C.41, but it
+ * doesn't need to be, since it has an extremely limited purpose.
  */
 class LABase {
  protected:
+  /**
+   * The "log entry". There's only one.
+   */
   static std::string msg_;
+  /**
+   * Whether `call` has been called since the last reset.
+   */
   static bool touched_;
 
  public:
+  /**
+   * This isn't a C.41 class, as it's a wrapper around some static variables. In
+   * lieu of a real construct, we have a reset function.
+   */
   static void reset() {
     msg_ = "";
     touched_ = false;
   }
+  /** Accessor for the "log entry" */
   static inline std::string message() {
     return msg_;
   }
+  /** Accessor for the call history flag */
   static inline bool touched() {
     return touched_;
   }
 };
 
+/**
+ * Logging aspect for the exception wrapper from a C API function
+ *
+ * @tparam f C API implementation function
+ */
 template <auto f>
 class LoggingAspect;
 
+/**
+ * Specialization of the logging aspect that infers the return type and argument
+ * types of the template parameter.
+ *
+ * @tparam R The return type of `f`
+ * @tparam Args The argument types of `f`
+ * @tparam f C API implementation function
+ */
 template <class R, class... Args, R (*f)(Args...)>
 class LoggingAspect<f> : public LABase {
  public:
+  /**
+   * Record the name of the function is the "log entry"
+   *
+   * @param ... Arguments are ignored
+   */
   static void call(Args...) {
-    msg_ = CAPIFunctionMetadata<f>::name;
+    msg_ = CAPIFunctionNameTrait<f>::name;
     touched_ = true;
   }
 };

--- a/tiledb/api/c_api_support/exception_wrapper/test/logging_aspect.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/logging_aspect.h
@@ -1,0 +1,80 @@
+/**
+ * @file tiledb/api/c_api_support/exception_wrapper/test/logging_aspect.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines macros to define C API functions.
+ */
+
+#ifndef TILEDB_EXCEPTION_WRAPPER_TEST_LOGGING_ASPECT_H
+#define TILEDB_EXCEPTION_WRAPPER_TEST_LOGGING_ASPECT_H
+
+#include <string>
+
+template <auto f>
+struct CAPIFunctionMetadata;
+
+template <class R, class... Args, R (*f)(Args...)>
+struct CAPIFunctionMetadata<f>;
+
+/**
+ * Base class for the logging aspect class template.
+ *
+ * This class mimics a global logger. It's rudimentary but suffices for testing.
+ * Instead of a growing log, it has a single "log entry"
+ */
+class LABase {
+ protected:
+  static std::string msg_;
+  static bool touched_;
+
+ public:
+  static void reset() {
+    msg_ = "";
+    touched_ = false;
+  }
+  static inline std::string message() {
+    return msg_;
+  }
+  static inline bool touched() {
+    return touched_;
+  }
+};
+
+template <auto f>
+class LoggingAspect;
+
+template <class R, class... Args, R (*f)(Args...)>
+class LoggingAspect<f> : public LABase {
+ public:
+  static void call(Args...) {
+    msg_ = CAPIFunctionMetadata<f>::name;
+    touched_ = true;
+  }
+};
+
+#endif  // TILEDB_EXCEPTION_WRAPPER_TEST_LOGGING_ASPECT_H

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
@@ -69,8 +69,9 @@ capi_return_t tiledb_capi_nil(int) {
 /*
  * API definitions with macros.
  */
-CAPI_PLAIN_BEGIN(capi_nil, int x)
-CAPI_PLAIN_END(capi_nil, x)
+CAPI_INTERFACE(capi_nil, int x) {
+  return tiledb::api::api_entry_plain<tiledb::api::tiledb_capi_nil>(x);
+}
 
 /**
  * The wrapped function with an unconditional invocation of the logging

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
@@ -83,7 +83,7 @@ using null_always_wrapped_for_logging = tiledb::api::
  * logging aspect is compiled in or not. The aspect argument is omitted, the
  * default applies, and overriding is possible.
  */
-using null_naybe_wrapped_for_logging =
+using null_maybe_wrapped_for_logging =
     tiledb::api::CAPIFunction<tf_null, tiledb::api::ExceptionAction>;
 
 TEST_CASE("Compile consistency") {
@@ -123,7 +123,7 @@ TEST_CASE("Hook conditional for touch") {
   LABase::reset();
   CHECK(LABase::touched() == false);
   tiledb::api::ExceptionAction h;
-  null_naybe_wrapped_for_logging().function(h);
+  null_maybe_wrapped_for_logging().function(h);
   CHECK(LABase::touched() == compiled_with_hook);
 }
 
@@ -131,7 +131,7 @@ TEST_CASE("Hook conditional with text 1") {
   LABase::reset();
   CHECK(LABase::message() == "");
   tiledb::api::ExceptionAction h;
-  null_naybe_wrapped_for_logging().function(h);
+  null_maybe_wrapped_for_logging().function(h);
   if constexpr (compiled_with_hook) {
     CHECK(LABase::message() == "tf_null");
   } else {

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
@@ -1,5 +1,5 @@
 /**
- * @file c_api_support/exception_wrapper/test/unit_capi_hook.cc
+ * @file tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
  *
  * @section LICENSE
  *
@@ -54,7 +54,7 @@ capi_return_t tf_null() {
  * Metadata for null function.
  */
 template <>
-struct CAPIFunctionMetadata<tf_null> {
+struct CAPIFunctionNameTrait<tf_null> {
   static constexpr std::string_view name{"tf_null"};
 };
 

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook.cc
@@ -1,0 +1,152 @@
+/**
+ * @file c_api_support/exception_wrapper/test/unit_capi_hook.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <test/support/tdb_catch.h>
+
+#include "../../c_api_support.h"
+#include "hook_common.h"
+#include "logging_aspect.h"
+
+using namespace tiledb::api;
+using namespace tiledb::api::detail;
+
+// from `logging_aspect.h`
+std::string LABase::msg_{};
+bool LABase::touched_{false};
+
+template <auto f>
+using selector_type = CAPIFunctionSelector<f, void>;
+
+/**
+ * API function that does nothing.
+ */
+capi_return_t tf_null() {
+  return TILEDB_OK;
+}
+/**
+ * Metadata for null function.
+ */
+template <>
+struct CAPIFunctionMetadata<tf_null> {
+  static constexpr std::string_view name{"tf_null"};
+};
+
+namespace tiledb::api {
+/**
+ * API implementation function that does nothing.
+ */
+capi_return_t tiledb_capi_nil(int) {
+  return 0;
+}
+}  // namespace tiledb::api
+/*
+ * API definitions with macros.
+ */
+CAPI_PLAIN_BEGIN(capi_nil, int x)
+CAPI_PLAIN_END(capi_nil, x)
+
+/**
+ * The wrapped function with an unconditional invocation of the logging
+ * aspect as an explicit template argument.
+ */
+using null_always_wrapped_for_logging = tiledb::api::
+    CAPIFunction<tf_null, tiledb::api::ExceptionAction, LoggingAspect<tf_null>>;
+/**
+ * The wrapped function conditional upon an override as to whether the
+ * logging aspect is compiled in or not. The aspect argument is omitted, the
+ * default applies, and overriding is possible.
+ */
+using null_naybe_wrapped_for_logging =
+    tiledb::api::CAPIFunction<tf_null, tiledb::api::ExceptionAction>;
+
+TEST_CASE("Compile consistency") {
+  /*
+   * In all cases verify that the default aspect is being used if and only if
+   * the hook is not enabled.
+   */
+  CHECK(
+      compiled_with_hook != std::same_as<
+                                selector_type<tf_null>::aspect_type,
+                                CAPIFunctionNullAspect<tf_null>>);
+  if constexpr (compiled_with_hook) {
+    /*
+     * In the case "with hook", check that the aspect is what the test defines.
+     */
+    CHECK(std::same_as<
+          selector_type<tf_null>::aspect_type,
+          LoggingAspect<tf_null>>);
+  }
+}
+
+TEST_CASE("Hook unconditional") {
+  LABase::reset();
+  CHECK(LABase::touched() == false);
+  CHECK(LABase::message() == "");
+  tiledb::api::ExceptionAction h;
+  null_always_wrapped_for_logging().function(h);
+  CHECK(LABase::touched() == true);
+  CHECK(LABase::message() == "tf_null");
+}
+
+/*
+ * Test that the hook is invoked if and only if it's compiled in. This is the
+ * same as the previous test but for the last line.
+ */
+TEST_CASE("Hook conditional for touch") {
+  LABase::reset();
+  CHECK(LABase::touched() == false);
+  tiledb::api::ExceptionAction h;
+  null_naybe_wrapped_for_logging().function(h);
+  CHECK(LABase::touched() == compiled_with_hook);
+}
+
+TEST_CASE("Hook conditional with text 1") {
+  LABase::reset();
+  CHECK(LABase::message() == "");
+  tiledb::api::ExceptionAction h;
+  null_naybe_wrapped_for_logging().function(h);
+  if constexpr (compiled_with_hook) {
+    CHECK(LABase::message() == "tf_null");
+  } else {
+    CHECK(LABase::message() == "");
+  }
+}
+
+TEST_CASE("Hook conditional with text 2") {
+  LABase::reset();
+  CHECK(LABase::message() == "");
+  tiledb::api::ExceptionAction h;
+  ::tiledb_capi_nil(0);
+  if constexpr (compiled_with_hook) {
+    CHECK(LABase::message() == "tiledb_capi_nil");
+  } else {
+    CHECK(LABase::message() == "");
+  }
+}

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
@@ -1,5 +1,5 @@
 /**
- * @file c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
+ * @file tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
  *
  * @section LICENSE
  *

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
@@ -1,11 +1,11 @@
 /**
- * @file tiledb/api/c_api_support/c_api_support.h
+ * @file c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,21 +26,12 @@
  * THE SOFTWARE.
  *
  * @section DESCRIPTION
- *
- * This file includes all the support functions that appear generally in C API
- * implementation functions:
- *   - Exception wrappers and error handling
- *   - Argument validation
  */
 
-#ifndef TILEDB_CAPI_SUPPORT_H
-#define TILEDB_CAPI_SUPPORT_H
+#include <test/support/tdb_catch.h>
 
-#include "argument_validation.h"
-#include "tiledb/api/c_api_support/exception_wrapper/capi_definition.h"
-#include "tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h"
-#if __has_include("capi_function_override.h")
-#include "capi_function_override.h"
-#endif
+#include "hook_common.h"
 
-#endif  // TILEDB_CAPI_SUPPORT_H
+TEST_CASE("Compile definition - with hook") {
+  CHECK(compiled_with_hook == true);
+}

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
@@ -1,5 +1,5 @@
 /**
- * @file c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
+ * @file tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
  *
  * @section LICENSE
  *

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
@@ -1,5 +1,6 @@
 /**
- * @file tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
+ * @file
+ * tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
  *
  * @section LICENSE
  *

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
@@ -1,11 +1,11 @@
 /**
- * @file tiledb/api/c_api_support/c_api_support.h
+ * @file c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,21 +26,12 @@
  * THE SOFTWARE.
  *
  * @section DESCRIPTION
- *
- * This file includes all the support functions that appear generally in C API
- * implementation functions:
- *   - Exception wrappers and error handling
- *   - Argument validation
  */
 
-#ifndef TILEDB_CAPI_SUPPORT_H
-#define TILEDB_CAPI_SUPPORT_H
+#include <test/support/tdb_catch.h>
 
-#include "argument_validation.h"
-#include "tiledb/api/c_api_support/exception_wrapper/capi_definition.h"
-#include "tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h"
-#if __has_include("capi_function_override.h")
-#include "capi_function_override.h"
-#endif
+#include "hook_common.h"
 
-#endif  // TILEDB_CAPI_SUPPORT_H
+TEST_CASE("Compile definition - without hook") {
+  CHECK(compiled_with_hook == false);
+}


### PR DESCRIPTION
This PR makes two changes to the template signature of `class CAPIFunction`. The central one is to add an aspect argument that can provide hooks into `CAPIFunction::function`. In this initial version there's a single aspect point (the aspect member function `call`) that is only an observer. The `call` of the default aspect does nothing. The second change in template signature is to infer the return value of the wrapper function and to suppress return statements if that type is `void`. This allows the elimination of subsidiary wrapper for `void` functions to give them a (constant) return value.

Tests for the aspect implement `class LoggingAspect`, a primitive call-logger sufficient for testing, and provide an override header to activate it. The override header also generates a traits class for each C API implementation function that provides data for `LoggingAspect`. These elements are exercised by two new test runners that share a common set of tests; only the results differ depending on whether the hook is active or not.

In order to automatically generate metadata for API functions, the PR introduces a set of macros to define the C API interface functions. These functions are already essentially boilerplate, but they cannot be defined with function templates because they must have "C" linkage. The macros provide a pair of macro hooks for generating code either before or after the function definition.

---
TYPE: IMPROVEMENT
DESC: Add an aspect template argument to `class CAPIFunction`
