### PR TITLE
Fix the aggregates CPP API install files.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -93,6 +93,7 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/attribute.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/attribute_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/channel_operation.h
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/channel_operator.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/config.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/consolidation_plan_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/context.h

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -92,6 +92,7 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/as_built_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/attribute.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/attribute_experimental.h
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/channel_operation.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/config.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/consolidation_plan_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/context.h
@@ -112,6 +113,7 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/object.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/object_iter.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query.h
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query_channel.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query_condition_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query_condition.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/query_experimental.h

--- a/tiledb/sm/cpp_api/channel_operation.h
+++ b/tiledb/sm/cpp_api/channel_operation.h
@@ -89,7 +89,9 @@ class ChannelOperation {
    * @param query The TileDB query
    * @param input_field The attribute name the aggregate operation will run on
    */
-  template <std::derived_from<ChannelOperator> Op>
+  template <
+      class Op,
+      std::enable_if_t<std::is_base_of_v<ChannelOperator, Op>, bool> = true>
   static ChannelOperation create(
       const Query& query, const std::string& input_field) {
     const Context& ctx = query.ctx();

--- a/tiledb/sm/cpp_api/query_experimental.h
+++ b/tiledb/sm/cpp_api/query_experimental.h
@@ -405,7 +405,9 @@ class QueryExperimental {
    * @param input_field The attribute name as input for the aggregate
    * @return The aggregate operation
    */
-  template <std::derived_from<ChannelOperator> Op>
+  template <
+      class Op,
+      std::enable_if_t<std::is_base_of_v<ChannelOperator, Op>, bool> = true>
   static ChannelOperation create_unary_aggregate(
       const Query& query, const std::string& input_field) {
     return ChannelOperation::create<Op>(query, input_field);


### PR DESCRIPTION
This also changes the use of concepts in std::derived_from to std::is_base_of_v to not require users of the CPP API to use c++ 20.

SC-35774

---
TYPE: IMPROVEMENT
DESC: Fix the aggregates CPP API install files.
