### PR TITLE
Remove default constructor argument for FieldInfo.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -1987,13 +1987,9 @@ TEST_CASE_METHOD(
         // second attribute.
         query.ptr()->query_->add_aggregator_to_default_channel(
             "NullCount2",
-            std::make_shared<tiledb::sm::NullCountAggregator>(
-                tiledb::sm::FieldInfo(
-                    "a2",
-                    true,
-                    nullable_,
-                    TILEDB_VAR_NUM,
-                    tdb_type<std::string>())));
+            std::make_shared<
+                tiledb::sm::NullCountAggregator>(tiledb::sm::FieldInfo(
+                "a2", true, nullable_, TILEDB_VAR_NUM, tdb_type<std::string>)));
 
         set_ranges_and_condition_if_needed(array, query, true);
 
@@ -2129,13 +2125,9 @@ TEST_CASE_METHOD(
         // the first one hence throw an exception.
         query.ptr()->query_->add_aggregator_to_default_channel(
             "NullCount2",
-            std::make_shared<tiledb::sm::NullCountAggregator>(
-                tiledb::sm::FieldInfo(
-                    "a2",
-                    true,
-                    nullable_,
-                    TILEDB_VAR_NUM,
-                    tdb_type<std::string>())));
+            std::make_shared<
+                tiledb::sm::NullCountAggregator>(tiledb::sm::FieldInfo(
+                "a2", true, nullable_, TILEDB_VAR_NUM, tdb_type<std::string>)));
 
         set_ranges_and_condition_if_needed(array, query, true);
 

--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -38,6 +38,7 @@
 #include "tiledb/sm/query/readers/aggregators/min_max_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/sum_aggregator.h"
 
+#include <test/support/src/helper_type.h>
 #include <test/support/tdb_catch.h>
 
 using namespace tiledb;
@@ -1987,7 +1988,12 @@ TEST_CASE_METHOD(
         query.ptr()->query_->add_aggregator_to_default_channel(
             "NullCount2",
             std::make_shared<tiledb::sm::NullCountAggregator>(
-                tiledb::sm::FieldInfo("a2", true, nullable_, TILEDB_VAR_NUM)));
+                tiledb::sm::FieldInfo(
+                    "a2",
+                    true,
+                    nullable_,
+                    TILEDB_VAR_NUM,
+                    tdb_type<std::string>())));
 
         set_ranges_and_condition_if_needed(array, query, true);
 
@@ -2124,7 +2130,12 @@ TEST_CASE_METHOD(
         query.ptr()->query_->add_aggregator_to_default_channel(
             "NullCount2",
             std::make_shared<tiledb::sm::NullCountAggregator>(
-                tiledb::sm::FieldInfo("a2", true, nullable_, TILEDB_VAR_NUM)));
+                tiledb::sm::FieldInfo(
+                    "a2",
+                    true,
+                    nullable_,
+                    TILEDB_VAR_NUM,
+                    tdb_type<std::string>())));
 
         set_ranges_and_condition_if_needed(array, query, true);
 
@@ -2189,6 +2200,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
       for (tiledb_layout_t layout : CppAggregatesFx<T>::layout_values_) {
         CppAggregatesFx<T>::layout_ = layout;
         Query query(CppAggregatesFx<T>::ctx_, array, TILEDB_READ);
+
         // Add a count aggregator to the query. We add both sum and count as
         // they are processed separately in the dense case.
         QueryChannel default_channel =

--- a/test/support/src/helper_type.h
+++ b/test/support/src/helper_type.h
@@ -1,0 +1,129 @@
+/**
+ * @file   type.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This defines TileDB datatypes.
+ */
+
+#ifndef TILEDB_TEST_TYPE_H
+#define TILEDB_TEST_TYPE_H
+
+namespace tiledb::test {
+
+using Datatype = tiledb::sm::Datatype;
+
+/**
+ * Convert a type into a tiledb::sm::Datatype. The default for all copyable
+ * types is char.
+ */
+template <typename T>
+struct type_to_tiledb {
+  using type = char;
+  static const Datatype tiledb_type = Datatype::STRING_ASCII;
+};
+
+template <>
+struct type_to_tiledb<std::byte> {
+  using type = std::byte;
+  static const Datatype tiledb_type = Datatype::BLOB;
+};
+
+template <>
+struct type_to_tiledb<bool> {
+  using type = bool;
+  static const Datatype tiledb_type = Datatype::BOOL;
+};
+
+template <>
+struct type_to_tiledb<int8_t> {
+  using type = int8_t;
+  static const Datatype tiledb_type = Datatype::INT8;
+};
+
+template <>
+struct type_to_tiledb<uint8_t> {
+  using type = uint8_t;
+  static const Datatype tiledb_type = Datatype::UINT8;
+};
+
+template <>
+struct type_to_tiledb<int16_t> {
+  using type = int16_t;
+  static const Datatype tiledb_type = Datatype::INT16;
+};
+
+template <>
+struct type_to_tiledb<uint16_t> {
+  using type = uint16_t;
+  static const Datatype tiledb_type = Datatype::UINT16;
+};
+
+template <>
+struct type_to_tiledb<int32_t> {
+  using type = int32_t;
+  static const Datatype tiledb_type = Datatype::INT32;
+};
+
+template <>
+struct type_to_tiledb<uint32_t> {
+  using type = uint32_t;
+  static const Datatype tiledb_type = Datatype::UINT32;
+};
+
+template <>
+struct type_to_tiledb<int64_t> {
+  using type = int64_t;
+  static const Datatype tiledb_type = Datatype::INT64;
+};
+
+template <>
+struct type_to_tiledb<uint64_t> {
+  using type = uint64_t;
+  static const Datatype tiledb_type = Datatype::UINT64;
+};
+
+template <>
+struct type_to_tiledb<float> {
+  using type = float;
+  static const Datatype tiledb_type = Datatype::FLOAT32;
+};
+
+template <>
+struct type_to_tiledb<double> {
+  using type = double;
+  static const Datatype tiledb_type = Datatype::FLOAT64;
+};
+
+template <typename T>
+Datatype tdb_type() {
+  return type_to_tiledb<T>::tiledb_type;
+}
+
+}  // namespace tiledb::test
+
+#endif  // TILEDB_TEST_TYPE_H

--- a/test/support/src/helper_type.h
+++ b/test/support/src/helper_type.h
@@ -1,5 +1,5 @@
 /**
- * @file   type.h
+ * @file   helper_type.h
  *
  * @section LICENSE
  *
@@ -42,87 +42,88 @@ using Datatype = tiledb::sm::Datatype;
  * types is char.
  */
 template <typename T>
-struct type_to_tiledb {
-  using type = char;
-  static const Datatype tiledb_type = Datatype::STRING_ASCII;
-};
+struct type_to_tiledb {};
 
 template <>
 struct type_to_tiledb<std::byte> {
   using type = std::byte;
-  static const Datatype tiledb_type = Datatype::BLOB;
+  static constexpr Datatype tiledb_type = Datatype::BLOB;
 };
 
 template <>
 struct type_to_tiledb<bool> {
   using type = bool;
-  static const Datatype tiledb_type = Datatype::BOOL;
+  static constexpr Datatype tiledb_type = Datatype::BOOL;
 };
 
 template <>
 struct type_to_tiledb<int8_t> {
   using type = int8_t;
-  static const Datatype tiledb_type = Datatype::INT8;
+  static constexpr Datatype tiledb_type = Datatype::INT8;
 };
 
 template <>
 struct type_to_tiledb<uint8_t> {
   using type = uint8_t;
-  static const Datatype tiledb_type = Datatype::UINT8;
+  static constexpr Datatype tiledb_type = Datatype::UINT8;
 };
 
 template <>
 struct type_to_tiledb<int16_t> {
   using type = int16_t;
-  static const Datatype tiledb_type = Datatype::INT16;
+  static constexpr Datatype tiledb_type = Datatype::INT16;
 };
 
 template <>
 struct type_to_tiledb<uint16_t> {
   using type = uint16_t;
-  static const Datatype tiledb_type = Datatype::UINT16;
+  static constexpr Datatype tiledb_type = Datatype::UINT16;
 };
 
 template <>
 struct type_to_tiledb<int32_t> {
   using type = int32_t;
-  static const Datatype tiledb_type = Datatype::INT32;
+  static constexpr Datatype tiledb_type = Datatype::INT32;
 };
 
 template <>
 struct type_to_tiledb<uint32_t> {
   using type = uint32_t;
-  static const Datatype tiledb_type = Datatype::UINT32;
+  static constexpr Datatype tiledb_type = Datatype::UINT32;
 };
 
 template <>
 struct type_to_tiledb<int64_t> {
   using type = int64_t;
-  static const Datatype tiledb_type = Datatype::INT64;
+  static constexpr Datatype tiledb_type = Datatype::INT64;
 };
 
 template <>
 struct type_to_tiledb<uint64_t> {
   using type = uint64_t;
-  static const Datatype tiledb_type = Datatype::UINT64;
+  static constexpr Datatype tiledb_type = Datatype::UINT64;
 };
 
 template <>
 struct type_to_tiledb<float> {
   using type = float;
-  static const Datatype tiledb_type = Datatype::FLOAT32;
+  static constexpr Datatype tiledb_type = Datatype::FLOAT32;
 };
 
 template <>
 struct type_to_tiledb<double> {
   using type = double;
-  static const Datatype tiledb_type = Datatype::FLOAT64;
+  static constexpr Datatype tiledb_type = Datatype::FLOAT64;
+};
+
+template <>
+struct type_to_tiledb<std::string> {
+  using type = char;
+  static const Datatype tiledb_type = Datatype::STRING_ASCII;
 };
 
 template <typename T>
-Datatype tdb_type() {
-  return type_to_tiledb<T>::tiledb_type;
-}
+constexpr Datatype tdb_type = type_to_tiledb<T>::tiledb_type;
 
 }  // namespace tiledb::test
 

--- a/tiledb/sm/query/readers/aggregators/field_info.h
+++ b/tiledb/sm/query/readers/aggregators/field_info.h
@@ -67,7 +67,7 @@ class FieldInfo {
       const bool var_sized,
       const bool is_nullable,
       const unsigned cell_val_num,
-      const Datatype type = Datatype::UINT8)
+      const Datatype type)
       : name_(name)
       , var_sized_(var_sized)
       , is_nullable_(is_nullable)

--- a/tiledb/sm/query/readers/aggregators/test/bench_aggregators.cc
+++ b/tiledb/sm/query/readers/aggregators/test/bench_aggregators.cc
@@ -158,7 +158,7 @@ void run_bench() {
                     << ", Segmented: " << (segmented ? "true" : "false")) {
     BENCHMARK("Bench") {
       AggregateWithCount<T, AggregateT, PolicyT, ValidityPolicyT> aggregator(
-          FieldInfo("a1", var_sized, nullable, 1, tdb_type<T>()));
+          FieldInfo("a1", var_sized, nullable, 1, tdb_type<T>));
       for (uint64_t s = 0; s < num_cells; s += increment) {
         AggregateBuffer input_data{
             s,

--- a/tiledb/sm/query/readers/aggregators/test/bench_aggregators.cc
+++ b/tiledb/sm/query/readers/aggregators/test/bench_aggregators.cc
@@ -38,9 +38,11 @@
 #include "tiledb/sm/query/readers/aggregators/sum_type.h"
 #include "tiledb/sm/query/readers/aggregators/validity_policies.h"
 
+#include <test/support/src/helper_type.h>
 #include <test/support/tdb_catch.h>
 
 using namespace tiledb::sm;
+using namespace tiledb::test;
 
 const uint64_t num_cells = 10 * 1024 * 1024;
 
@@ -156,7 +158,7 @@ void run_bench() {
                     << ", Segmented: " << (segmented ? "true" : "false")) {
     BENCHMARK("Bench") {
       AggregateWithCount<T, AggregateT, PolicyT, ValidityPolicyT> aggregator(
-          FieldInfo("a1", var_sized, nullable, 1));
+          FieldInfo("a1", var_sized, nullable, 1, tdb_type<T>()));
       for (uint64_t s = 0; s < num_cells; s += increment) {
         AggregateBuffer input_data{
             s,

--- a/tiledb/sm/query/readers/aggregators/test/compile_aggregators_main.cc
+++ b/tiledb/sm/query/readers/aggregators/test/compile_aggregators_main.cc
@@ -34,96 +34,96 @@
 int main() {
   tiledb::sm::CountAggregator();
 
-  tiledb::sm::MeanAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<int8_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<int16_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<int32_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<int64_t>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<float>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
-  tiledb::sm::MeanAggregator<double>(
-      tiledb::sm::FieldInfo("Mean", false, false, 1));
+  tiledb::sm::MeanAggregator<uint8_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<uint16_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<uint32_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<uint64_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<int8_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<int16_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<int32_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<int64_t>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<float>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MeanAggregator<double>(tiledb::sm::FieldInfo(
+      "Mean", false, false, 1, tiledb::sm::Datatype::UINT8));
 
-  tiledb::sm::MinAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<int8_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<int16_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<int32_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<int64_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<float>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<double>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MinAggregator<std::string>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
+  tiledb::sm::MinAggregator<uint8_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<uint16_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<uint32_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<uint64_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<int8_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<int16_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<int32_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<int64_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<float>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<double>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MinAggregator<std::string>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
 
-  tiledb::sm::MaxAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<int8_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<int16_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<int32_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<int64_t>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<float>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<double>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
-  tiledb::sm::MaxAggregator<std::string>(
-      tiledb::sm::FieldInfo("MinMax", false, false, 1));
+  tiledb::sm::MaxAggregator<uint8_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<uint16_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<uint32_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<uint64_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<int8_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<int16_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<int32_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<int64_t>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<float>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<double>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::MaxAggregator<std::string>(tiledb::sm::FieldInfo(
+      "MinMax", false, false, 1, tiledb::sm::Datatype::UINT8));
 
-  tiledb::sm::NullCountAggregator(
-      tiledb::sm::FieldInfo("NullCount", false, false, 1));
+  tiledb::sm::NullCountAggregator(tiledb::sm::FieldInfo(
+      "NullCount", false, false, 1, tiledb::sm::Datatype::UINT8));
 
-  tiledb::sm::SumAggregator<uint8_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<uint16_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<uint32_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<uint64_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<int8_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<int16_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<int32_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<int64_t>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<float>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
-  tiledb::sm::SumAggregator<double>(
-      tiledb::sm::FieldInfo("Sum", false, false, 1));
+  tiledb::sm::SumAggregator<uint8_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<uint16_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<uint32_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<uint64_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<int8_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<int16_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<int32_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<int64_t>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<float>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
+  tiledb::sm::SumAggregator<double>(tiledb::sm::FieldInfo(
+      "Sum", false, false, 1, tiledb::sm::Datatype::UINT8));
 
   return 0;
 }

--- a/tiledb/sm/query/readers/aggregators/test/unit_aggregate_with_count.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_aggregate_with_count.cc
@@ -61,9 +61,9 @@ TEMPLATE_LIST_TEST_CASE(
     FixedTypesUnderTest) {
   typedef TestType T;
   AggregateWithCount<T, typename sum_type_data<T>::sum_type, SafeSum, NonNull>
-      aggregator(FieldInfo("a1", false, false, 1, tdb_type<T>()));
+      aggregator(FieldInfo("a1", false, false, 1, tdb_type<T>));
   AggregateWithCount<T, typename sum_type_data<T>::sum_type, SafeSum, NonNull>
-      aggregator_nullable(FieldInfo("a2", false, true, 1, tdb_type<T>()));
+      aggregator_nullable(FieldInfo("a2", false, true, 1, tdb_type<T>));
 
   std::vector<T> fixed_data = {1, 2, 3, 4, 5, 5, 4, 3, 2, 1};
   std::vector<uint8_t> validity_data = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0};

--- a/tiledb/sm/query/readers/aggregators/test/unit_aggregate_with_count.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_aggregate_with_count.cc
@@ -37,9 +37,11 @@
 #include "tiledb/sm/query/readers/aggregators/sum_type.h"
 #include "tiledb/sm/query/readers/aggregators/validity_policies.h"
 
+#include <test/support/src/helper_type.h>
 #include <test/support/tdb_catch.h>
 
 using namespace tiledb::sm;
+using namespace tiledb::test;
 
 typedef tuple<
     uint8_t,
@@ -59,9 +61,9 @@ TEMPLATE_LIST_TEST_CASE(
     FixedTypesUnderTest) {
   typedef TestType T;
   AggregateWithCount<T, typename sum_type_data<T>::sum_type, SafeSum, NonNull>
-      aggregator(FieldInfo("a1", false, false, 1));
+      aggregator(FieldInfo("a1", false, false, 1, tdb_type<T>()));
   AggregateWithCount<T, typename sum_type_data<T>::sum_type, SafeSum, NonNull>
-      aggregator_nullable(FieldInfo("a2", false, true, 1));
+      aggregator_nullable(FieldInfo("a2", false, true, 1, tdb_type<T>()));
 
   std::vector<T> fixed_data = {1, 2, 3, 4, 5, 5, 4, 3, 2, 1};
   std::vector<uint8_t> validity_data = {0, 0, 1, 0, 1, 0, 1, 0, 1, 0};

--- a/tiledb/sm/query/readers/aggregators/test/unit_aggregators.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_aggregators.cc
@@ -444,12 +444,12 @@ void basic_aggregation_test(std::vector<double> expected_results) {
     if constexpr (std::is_same<AGGREGATOR, CountAggregator>::value) {
       aggregator.emplace();
     } else {
-      aggregator.emplace(FieldInfo("a1", false, false, 1, tdb_type<T>()));
+      aggregator.emplace(FieldInfo("a1", false, false, 1, tdb_type<T>));
     }
   }
 
   auto aggregator_nullable{make_aggregator<AGGREGATOR>(
-      FieldInfo("a1", false, true, 1, tdb_type<T>()))};
+      FieldInfo("a1", false, true, 1, tdb_type<T>))};
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 
@@ -710,7 +710,7 @@ TEMPLATE_LIST_TEST_CASE(
 TEST_CASE(
     "Sum aggregator: signed overflow", "[sum-aggregator][signed-overflow]") {
   SumAggregator<int64_t> aggregator(
-      FieldInfo("a1", false, false, 1, tdb_type<int64_t>()));
+      FieldInfo("a1", false, false, 1, tdb_type<int64_t>));
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 
@@ -795,7 +795,7 @@ TEST_CASE(
     "Sum aggregator: unsigned overflow",
     "[sum-aggregator][unsigned-overflow]") {
   SumAggregator<uint64_t> aggregator(
-      FieldInfo("a1", false, false, 1, tdb_type<int64_t>()));
+      FieldInfo("a1", false, false, 1, tdb_type<int64_t>));
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 
@@ -833,7 +833,7 @@ TEMPLATE_LIST_TEST_CASE(
     "Sum aggregator: double overflow",
     "[sum-aggregator][double-overflow]",
     DoubleAggUnderTest) {
-  TestType aggregator(FieldInfo("a1", false, false, 1, tdb_type<double>()));
+  TestType aggregator(FieldInfo("a1", false, false, 1, tdb_type<double>));
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 
@@ -910,11 +910,11 @@ void basic_string_aggregation_test(std::vector<RES> expected_results) {
   optional<AGGREGATOR> aggregator;
   if constexpr (!std::is_same<AGGREGATOR, NullCountAggregator>::value) {
     aggregator.emplace(FieldInfo(
-        "a1", true, false, constants::var_num, tdb_type<std::string>()));
+        "a1", true, false, constants::var_num, tdb_type<std::string>));
   }
 
   AGGREGATOR aggregator_nullable(
-      FieldInfo("a2", true, true, constants::var_num, tdb_type<std::string>()));
+      FieldInfo("a2", true, true, constants::var_num, tdb_type<std::string>));
 
   std::unordered_map<std::string, QueryBuffer> buffers;
 


### PR DESCRIPTION
This has caused misuse when refactoring tests and should be avoided.

---
TYPE: NO_HISTORY
DESC: Remove default constructor argument for FieldInfo.
