### PR TITLE
MEAN and NULL_COUNT capi/cppapi wraps

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -1389,12 +1389,12 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
           CppAggregatesFx<T>::layout_ = layout;
           Query query(CppAggregatesFx<T>::ctx_, array, TILEDB_READ);
 
-          // TODO: Change to real CPPAPI. Add a mean aggregator to the query.
-          query.ptr()->query_->add_aggregator_to_default_channel(
-              "Mean",
-              std::make_shared<tiledb::sm::MeanAggregator<T>>(
-                  tiledb::sm::FieldInfo(
-                      "a1", false, CppAggregatesFx<T>::nullable_, 1)));
+          QueryChannel default_channel =
+              QueryExperimental::get_default_channel(query);
+          ChannelOperation operation =
+              QueryExperimental::create_unary_aggregate<MeanOperator>(
+                  query, "a1");
+          default_channel.apply_aggregate("Mean", operation);
 
           CppAggregatesFx<T>::set_ranges_and_condition_if_needed(
               array, query, false);
@@ -1785,19 +1785,12 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
           CppAggregatesFx<T>::layout_ = layout;
           Query query(CppAggregatesFx<T>::ctx_, array, TILEDB_READ);
 
-          // TODO: Change to real CPPAPI. Add a null count aggregator to the
-          // query.
-          uint64_t cell_val_num = std::is_same<T, std::string>::value ?
-                                      CppAggregatesFx<T>::STRING_CELL_VAL_NUM :
-                                      1;
-          query.ptr()->query_->add_aggregator_to_default_channel(
-              "NullCount",
-              std::make_shared<tiledb::sm::NullCountAggregator>(
-                  tiledb::sm::FieldInfo(
-                      "a1",
-                      false,
-                      CppAggregatesFx<T>::nullable_,
-                      cell_val_num)));
+          QueryChannel default_channel =
+              QueryExperimental::get_default_channel(query);
+          ChannelOperation operation =
+              QueryExperimental::create_unary_aggregate<NullCountOperator>(
+                  query, "a1");
+          default_channel.apply_aggregate("NullCount", operation);
 
           CppAggregatesFx<T>::set_ranges_and_condition_if_needed(
               array, query, false);
@@ -1885,13 +1878,12 @@ TEST_CASE_METHOD(
           layout_ = layout;
           Query query(ctx_, array, TILEDB_READ);
 
-          // TODO: Change to real CPPAPI. Add a null count aggregator to the
-          // query.
-          query.ptr()->query_->add_aggregator_to_default_channel(
-              "NullCount",
-              std::make_shared<tiledb::sm::NullCountAggregator>(
-                  tiledb::sm::FieldInfo(
-                      "a1", true, nullable_, TILEDB_VAR_NUM)));
+          QueryChannel default_channel =
+              QueryExperimental::get_default_channel(query);
+          ChannelOperation operation =
+              QueryExperimental::create_unary_aggregate<NullCountOperator>(
+                  query, "a1");
+          default_channel.apply_aggregate("NullCount", operation);
 
           set_ranges_and_condition_if_needed(array, query, true);
 
@@ -1981,12 +1973,12 @@ TEST_CASE_METHOD(
         layout_ = layout;
         Query query(ctx_, array, TILEDB_READ);
 
-        // TODO: Change to real CPPAPI. Add a null count aggregator to the
-        // query.
-        query.ptr()->query_->add_aggregator_to_default_channel(
-            "NullCount",
-            std::make_shared<tiledb::sm::NullCountAggregator>(
-                tiledb::sm::FieldInfo("a1", true, nullable_, TILEDB_VAR_NUM)));
+        QueryChannel default_channel =
+            QueryExperimental::get_default_channel(query);
+        ChannelOperation operation =
+            QueryExperimental::create_unary_aggregate<NullCountOperator>(
+                query, "a1");
+        default_channel.apply_aggregate("NullCount", operation);
 
         // Add another aggregator on the second attribute. We will make the
         // first attribute get a var size overflow, which should not impact the
@@ -2119,12 +2111,12 @@ TEST_CASE_METHOD(
         layout_ = layout;
         Query query(ctx_, array, TILEDB_READ);
 
-        // TODO: Change to real CPPAPI. Add a null count aggregator to the
-        // query.
-        query.ptr()->query_->add_aggregator_to_default_channel(
-            "NullCount",
-            std::make_shared<tiledb::sm::NullCountAggregator>(
-                tiledb::sm::FieldInfo("a1", true, nullable_, TILEDB_VAR_NUM)));
+        QueryChannel default_channel =
+            QueryExperimental::get_default_channel(query);
+        ChannelOperation operation =
+            QueryExperimental::create_unary_aggregate<NullCountOperator>(
+                query, "a1");
+        default_channel.apply_aggregate("NullCount", operation);
 
         // Add another aggregator on the second attribute. We will make this
         // attribute get a var size overflow, which should impact the result of

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -37,7 +37,6 @@
 #include "tiledb/api/c_api/query_field/query_field_api_external_experimental.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
 
-//
 const tiledb_channel_operator_handle_t* tiledb_channel_operator_sum =
     tiledb_channel_operator_handle_t::make_handle(
         tiledb::sm::constants::aggregate_sum_str);
@@ -47,6 +46,12 @@ const tiledb_channel_operator_handle_t* tiledb_channel_operator_min =
 const tiledb_channel_operator_handle_t* tiledb_channel_operator_max =
     tiledb_channel_operator_handle_t::make_handle(
         tiledb::sm::constants::aggregate_max_str);
+const tiledb_channel_operator_handle_t* tiledb_channel_operator_mean =
+    tiledb_channel_operator_handle_t::make_handle(
+        tiledb::sm::constants::aggregate_mean_str);
+const tiledb_channel_operator_handle_t* tiledb_channel_operator_null_count =
+    tiledb_channel_operator_handle_t::make_handle(
+        tiledb::sm::constants::aggregate_null_count_str);
 
 const tiledb_channel_operation_handle_t* tiledb_aggregate_count =
     tiledb_channel_operation_handle_t::make_handle(
@@ -124,6 +129,22 @@ capi_return_t tiledb_channel_operator_sum_get(
   ensure_aggregates_enabled_via_config(ctx);
   ensure_output_pointer_is_valid(op);
   *op = tiledb_channel_operator_sum;
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_channel_operator_mean_get(
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+  ensure_aggregates_enabled_via_config(ctx);
+  ensure_output_pointer_is_valid(op);
+  *op = tiledb_channel_operator_mean;
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_channel_operator_null_count_get(
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+  ensure_aggregates_enabled_via_config(ctx);
+  ensure_output_pointer_is_valid(op);
+  *op = tiledb_channel_operator_null_count;
   return TILEDB_OK;
 }
 
@@ -251,6 +272,12 @@ using tiledb::api::api_entry_with_context;
 capi_return_t tiledb_channel_operator_sum_get(
     tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_sum_get>(
+      ctx, op);
+}
+
+capi_return_t tiledb_channel_operator_mean_get(
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+  return api_entry_with_context<tiledb::api::tiledb_channel_operator_mean_get>(
       ctx, op);
 }
 

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -293,6 +293,12 @@ capi_return_t tiledb_channel_operator_max_get(
       ctx, op);
 }
 
+capi_return_t tiledb_channel_operator_null_count_get(
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+  return api_entry_with_context<
+      tiledb::api::tiledb_channel_operator_null_count_get>(ctx, op);
+}
+
 capi_return_t tiledb_aggregate_count_get(
     tiledb_ctx_t* ctx, const tiledb_channel_operation_t** operation) noexcept {
   return api_entry_with_context<tiledb::api::tiledb_aggregate_count_get>(

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api_external_experimental.h
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api_external_experimental.h
@@ -59,6 +59,12 @@ TILEDB_EXPORT extern const tiledb_channel_operator_t*
 TILEDB_EXPORT extern const tiledb_channel_operator_t*
     tiledb_channel_operator_max;
 
+TILEDB_EXPORT extern const tiledb_channel_operator_t*
+    tiledb_channel_operator_mean;
+
+TILEDB_EXPORT extern const tiledb_channel_operator_t*
+    tiledb_channel_operator_null_count;
+
 // Constant aggregate operation handles
 TILEDB_EXPORT extern const tiledb_channel_operation_t* tiledb_aggregate_count;
 
@@ -132,6 +138,43 @@ TILEDB_EXPORT int32_t tiledb_channel_operator_max_get(
 TILEDB_EXPORT int32_t tiledb_aggregate_count_get(
     tiledb_ctx_t* ctx,
     const tiledb_channel_operation_t** operation) TILEDB_NOEXCEPT;
+
+/**
+ * Helper function to access the constant MEAN channel operator handle
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_channel_operator_t *operator_mean;
+ * tiledb_channel_operator_mean_get(ctx, &operator_mean);
+ * tiledb_channel_operation_t* mean_A;
+ * tiledb_create_unary_aggregate(ctx, query, operator_mean, "A", mean_A);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param op The operator handle to be retrieved
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_channel_operator_mean_get(
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) TILEDB_NOEXCEPT;
+
+/**
+ * Helper function to access the constant NULL_COUNT channel operator handle
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_channel_operator_t *operator_nullcount;
+ * tiledb_channel_operator_null_count_get(ctx, &operator_nullcount);
+ * tiledb_channel_operation_t* nullcount_A;
+ * tiledb_create_unary_aggregate(ctx, query, operator_nullcount, "A",
+ * nullcount_A);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param op The operator handle to be retrieved
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT int32_t tiledb_channel_operator_null_count_get(
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) TILEDB_NOEXCEPT;
 
 /**
  * Gets the default channel of the query. The default channel consists of all

--- a/tiledb/api/c_api/query_aggregate/test/unit_capi_query_aggregate.cc
+++ b/tiledb/api/c_api/query_aggregate/test/unit_capi_query_aggregate.cc
@@ -657,9 +657,9 @@ TEST_CASE_METHOD(
     QueryAggregateFx,
     "C API: Query aggregates NULL_COUNT test",
     "[capi][query_aggregate][null_count]") {
-  // SECTION("- No serialization") {
-  //   serialize_ = false;
-  // }
+  SECTION("- No serialization") {
+    serialize_ = false;
+  }
 #ifdef TILEDB_SERIALIZATION
   SECTION("- Serialization") {
     serialize_ = true;

--- a/tiledb/sm/cpp_api/channel_operator.h
+++ b/tiledb/sm/cpp_api/channel_operator.h
@@ -72,6 +72,26 @@ class MaxOperator : public ChannelOperator {
   }
 };
 
+class MeanOperator : public ChannelOperator {
+ public:
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+  static const tiledb_channel_operator_t* ptr() {
+    return tiledb_channel_operator_mean;
+  }
+};
+
+class NullCountOperator : public ChannelOperator {
+ public:
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+  static const tiledb_channel_operator_t* ptr() {
+    return tiledb_channel_operator_null_count;
+  }
+};
+
 }  // namespace tiledb
 
 #endif  // TILEDB_CPP_API_CHANNEL_OPERATOR_H

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.h
@@ -101,11 +101,6 @@ class CountAggregatorBase : public OutputBufferValidator, public IAggregator {
       std::string output_field_name,
       std::unordered_map<std::string, QueryBuffer>& buffers) override;
 
-  /** Returns name of the aggregate. */
-  std::string aggregate_name() override {
-    return constants::aggregate_count_str;
-  }
-
   /** Returns the TileDB datatype of the output field for the aggregate. */
   Datatype output_datatype() override {
     return Datatype::UINT64;
@@ -142,6 +137,11 @@ class CountAggregator : public CountAggregatorBase<NonNull> {
   std::string field_name() override {
     return constants::count_of_rows;
   }
+
+  /** Returns name of the aggregate. */
+  std::string aggregate_name() override {
+    return constants::aggregate_count_str;
+  }
 };
 
 class NullCountAggregator : public CountAggregatorBase<Null>,
@@ -160,6 +160,11 @@ class NullCountAggregator : public CountAggregatorBase<Null>,
   /** Returns the field name for the aggregator. */
   std::string field_name() override {
     return field_info_.name_;
+  }
+
+  /** Returns name of the aggregate. */
+  std::string aggregate_name() override {
+    return constants::aggregate_null_count_str;
   }
 
  private:

--- a/tiledb/sm/query/readers/aggregators/operation.cc
+++ b/tiledb/sm/query/readers/aggregators/operation.cc
@@ -44,6 +44,10 @@ shared_ptr<Operation> Operation::make_operation(
     return common::make_shared<MaxOperation>(HERE(), fi.value());
   } else if (name == constants::aggregate_count_str) {
     return common::make_shared<CountOperation>(HERE());
+  } else if (name == constants::aggregate_mean_str) {
+    return common::make_shared<MeanOperation>(HERE(), fi.value());
+  } else if (name == constants::aggregate_null_count_str) {
+    return common::make_shared<NullCountOperation>(HERE(), fi.value());
   }
 
   throw std::logic_error(

--- a/tiledb/sm/query/readers/aggregators/operation.h
+++ b/tiledb/sm/query/readers/aggregators/operation.h
@@ -36,6 +36,7 @@
 #include "tiledb/common/common.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/query/readers/aggregators/count_aggregator.h"
+#include "tiledb/sm/query/readers/aggregators/mean_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/min_max_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/sum_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/sum_type.h"
@@ -201,6 +202,49 @@ class CountOperation : public Operation {
   [[nodiscard]] shared_ptr<tiledb::sm::IAggregator> aggregator()
       const override {
     return common::make_shared<tiledb::sm::CountAggregator>(HERE());
+  }
+};
+
+class MeanOperation : public Operation {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  MeanOperation() = delete;
+
+  /**
+   * Construct the operation where the internal aggregator object
+   * is instantiated to the correct type given the input field type.
+   * @param fi The FieldInfo for the input field
+   */
+  explicit MeanOperation(const tiledb::sm::FieldInfo& fi) {
+    auto g = [&](auto T) {
+      if constexpr (tiledb::type::TileDBNumeric<decltype(T)>) {
+        ensure_field_numeric(fi);
+        aggregator_ = tdb::make_shared<tiledb::sm::MeanAggregator<decltype(T)>>(
+            HERE(), fi);
+      } else {
+        throw std::logic_error(
+            "MEAN aggregates can only be requested on numeric types");
+      }
+    };
+    type::apply_with_type(g, fi.type_);
+  }
+};
+
+class NullCountOperation : public Operation {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+  NullCountOperation() = delete;
+
+  /**
+   * Construct the NULL_COUNT operation
+   * @param fi The FieldInfo for the input field
+   */
+  explicit NullCountOperation(const tiledb::sm::FieldInfo& fi) {
+    aggregator_ = tdb::make_shared<tiledb::sm::NullCountAggregator>(HERE(), fi);
   }
 };
 

--- a/tiledb/sm/query/readers/aggregators/operation.h
+++ b/tiledb/sm/query/readers/aggregators/operation.h
@@ -36,7 +36,6 @@
 #include "tiledb/common/common.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/query/readers/aggregators/count_aggregator.h"
-#include "tiledb/sm/query/readers/aggregators/mean_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/min_max_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/sum_aggregator.h"
 #include "tiledb/sm/query/readers/aggregators/sum_type.h"


### PR DESCRIPTION
Add CAPIs and CPPAPIs for mean and null  count aggregators.

---
TYPE: FEATURE | C_API | CPP_API
DESC: MEAN and NULL_COUNT capi/cppapi wraps
