### PR TITLE
Remove `RETURN_NOT_OK_ELSE_TUPLE`

### DIFF
--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -88,15 +88,6 @@ namespace common {
     }                               \
   } while (false)
 
-#define RETURN_NOT_OK_ELSE_TUPLE(s, else_, ...) \
-  do {                                          \
-    Status _s = (s);                            \
-    if (!_s.ok()) {                             \
-      else_;                                    \
-      return {_s, __VA_ARGS__};                 \
-    }                                           \
-  } while (false)
-
 /**
  * The original `Status` class, used as a ubiquitous return value to avoid
  * throwing exceptions.


### PR DESCRIPTION
Remove `RETURN_NOT_OK_ELSE_TUPLE`. It's no longer used.

---
TYPE: NO_HISTORY
DESC: Remove `RETURN_NOT_OK_ELSE_TUPLE`
