### PR TITLE
Allow forward slashes in enumeration names

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -495,11 +495,12 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
-    "Enumeration Creation Error - Invalid name with slash",
+    "Enumeration Creation Error - Invalid path_name with slash",
     "[enumeration][error][invalid-name]") {
   std::vector<int> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   REQUIRE_THROWS(Enumeration::create(
-      "an/enumeration",
+      default_enmr_name,
+      "an/bad/path",
       Datatype::INT32,
       2,
       false,

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -77,9 +77,9 @@ Enumeration::Enumeration(
         "__" + tmp_uuid + "_" + std::to_string(constants::enumerations_version);
   }
 
-  if (name.find("/") != std::string::npos) {
+  if (path_name.find("/") != std::string::npos) {
     throw EnumerationException(
-        "Enumeration name must not contain path separators");
+        "Enumeration path name must not contain path separators");
   }
 
   if (cell_val_num == 0) {


### PR DESCRIPTION
Originally I was going to use the enumeration name in the URI and so disallowed names from containing `/` characters. Given that we don't put names in URIs this is no longer a valid requirement.

---
TYPE: IMPROVEMENT
DESC: Allow forward slashes in enumeration names
