### PR TITLE
Channel operation needs virtual destructor.

### DIFF
--- a/tiledb/sm/cpp_api/channel_operation.h
+++ b/tiledb/sm/cpp_api/channel_operation.h
@@ -68,7 +68,7 @@ class ChannelOperation {
   ChannelOperation& operator=(ChannelOperation&&) = default;
 
   /** Destructor. */
-  ~ChannelOperation() = default;
+  virtual ~ChannelOperation() = default;
 
   /* ********************************* */
   /*                API                */


### PR DESCRIPTION
This came out of the maria DB nightlies returning the following error: /usr/local/include/tiledb/channel_operation.h:71:3: error: 'tiledb::ChannelOperation' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]

The fix is trivial.

---
TYPE: NO_HISTORY
DESC: Channel operation needs virtual destructor.
