### PR TITLE
Convert C API interface functions to CAPI_INTERFACE

### DIFF
--- a/tiledb/api/c_api/attribute/attribute_api.cc
+++ b/tiledb/api/c_api/attribute/attribute_api.cc
@@ -205,150 +205,150 @@ capi_return_t tiledb_attribute_get_enumeration_name(
 
 using tiledb::api::api_entry_context;
 
-int32_t tiledb_attribute_alloc(
+CAPI_INTERFACE(attribute_alloc,
     tiledb_ctx_t* ctx,
     const char* name,
     tiledb_datatype_t type,
-    tiledb_attribute_handle_t** attr) noexcept {
+    tiledb_attribute_handle_t** attr) {
   return api_entry_context<tiledb::api::tiledb_attribute_alloc>(
       ctx, name, type, attr);
 }
 
-void tiledb_attribute_free(tiledb_attribute_handle_t** attr) noexcept {
+CAPI_INTERFACE_VOID(attribute_free,tiledb_attribute_handle_t** attr) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_attribute_free>(attr);
 }
 
-int32_t tiledb_attribute_set_nullable(
+CAPI_INTERFACE(attribute_set_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
-    uint8_t nullable) noexcept {
+    uint8_t nullable) {
   return api_entry_context<tiledb::api::tiledb_attribute_set_nullable>(
       ctx, attr, nullable);
 }
 
-int32_t tiledb_attribute_set_filter_list(
+CAPI_INTERFACE(attribute_set_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
-    tiledb_filter_list_t* filter_list) noexcept {
+    tiledb_filter_list_t* filter_list) {
   return api_entry_context<tiledb::api::tiledb_attribute_set_filter_list>(
       ctx, attr, filter_list);
 }
 
-int32_t tiledb_attribute_set_cell_val_num(
+CAPI_INTERFACE(attribute_set_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
-    uint32_t cell_val_num) noexcept {
+    uint32_t cell_val_num) {
   return api_entry_context<tiledb::api::tiledb_attribute_set_cell_val_num>(
       ctx, attr, cell_val_num);
 }
 
-int32_t tiledb_attribute_get_name(
+CAPI_INTERFACE(attribute_get_name,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
-    const char** name) noexcept {
+    const char** name) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_name>(
       ctx, attr, name);
 }
 
-int32_t tiledb_attribute_get_type(
+CAPI_INTERFACE(attribute_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
-    tiledb_datatype_t* type) noexcept {
+    tiledb_datatype_t* type) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_type>(
       ctx, attr, type);
 }
 
-int32_t tiledb_attribute_get_nullable(
+CAPI_INTERFACE(attribute_get_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
-    uint8_t* nullable) noexcept {
+    uint8_t* nullable) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_nullable>(
       ctx, attr, nullable);
 }
 
-int32_t tiledb_attribute_get_filter_list(
+CAPI_INTERFACE(attribute_get_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
-    tiledb_filter_list_t** filter_list) noexcept {
+    tiledb_filter_list_t** filter_list) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_filter_list>(
       ctx, attr, filter_list);
 }
 
-int32_t tiledb_attribute_get_cell_val_num(
+CAPI_INTERFACE(attribute_get_cell_val_num,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
-    uint32_t* cell_val_num) noexcept {
+    uint32_t* cell_val_num) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_cell_val_num>(
       ctx, attr, cell_val_num);
 }
 
-int32_t tiledb_attribute_get_cell_size(
+CAPI_INTERFACE(attribute_get_cell_size,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
-    uint64_t* cell_size) noexcept {
+    uint64_t* cell_size) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_cell_size>(
       ctx, attr, cell_size);
 }
 
-int32_t tiledb_attribute_dump(
+CAPI_INTERFACE(attribute_dump,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
-    FILE* out) noexcept {
+    FILE* out) {
   return api_entry_context<tiledb::api::tiledb_attribute_dump>(ctx, attr, out);
 }
 
-int32_t tiledb_attribute_set_fill_value(
+CAPI_INTERFACE(attribute_set_fill_value,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void* value,
-    uint64_t size) noexcept {
+    uint64_t size) {
   return api_entry_context<tiledb::api::tiledb_attribute_set_fill_value>(
       ctx, attr, value, size);
 }
 
-int32_t tiledb_attribute_get_fill_value(
+CAPI_INTERFACE(attribute_get_fill_value,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void** value,
-    uint64_t* size) noexcept {
+    uint64_t* size) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_fill_value>(
       ctx, attr, value, size);
 }
 
-int32_t tiledb_attribute_set_fill_value_nullable(
+CAPI_INTERFACE(attribute_set_fill_value_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void* value,
     uint64_t size,
-    uint8_t valid) noexcept {
+    uint8_t valid) {
   return api_entry_context<
       tiledb::api::tiledb_attribute_set_fill_value_nullable>(
       ctx, attr, value, size, valid);
 }
 
-int32_t tiledb_attribute_get_fill_value_nullable(
+CAPI_INTERFACE(attribute_get_fill_value_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void** value,
     uint64_t* size,
-    uint8_t* valid) noexcept {
+    uint8_t* valid) {
   return api_entry_context<
       tiledb::api::tiledb_attribute_get_fill_value_nullable>(
       ctx, attr, value, size, valid);
 }
 
-capi_return_t tiledb_attribute_set_enumeration_name(
+CAPI_INTERFACE(attribute_set_enumeration_name,
     tiledb_ctx_t* ctx,
     tiledb_attribute_t* attr,
-    const char* enumeration_name) noexcept {
+    const char* enumeration_name) {
   return api_entry_context<tiledb::api::tiledb_attribute_set_enumeration_name>(
       ctx, attr, enumeration_name);
 }
 
-capi_return_t tiledb_attribute_get_enumeration_name(
+CAPI_INTERFACE(attribute_get_enumeration_name,
     tiledb_ctx_t* ctx,
     tiledb_attribute_t* attr,
-    tiledb_string_t** name) noexcept {
+    tiledb_string_t** name) {
   return api_entry_context<tiledb::api::tiledb_attribute_get_enumeration_name>(
       ctx, attr, name);
 }

--- a/tiledb/api/c_api/attribute/attribute_api.cc
+++ b/tiledb/api/c_api/attribute/attribute_api.cc
@@ -205,7 +205,8 @@ capi_return_t tiledb_attribute_get_enumeration_name(
 
 using tiledb::api::api_entry_context;
 
-CAPI_INTERFACE(attribute_alloc,
+CAPI_INTERFACE(
+    attribute_alloc,
     tiledb_ctx_t* ctx,
     const char* name,
     tiledb_datatype_t type,
@@ -214,11 +215,12 @@ CAPI_INTERFACE(attribute_alloc,
       ctx, name, type, attr);
 }
 
-CAPI_INTERFACE_VOID(attribute_free,tiledb_attribute_handle_t** attr) {
+CAPI_INTERFACE_VOID(attribute_free, tiledb_attribute_handle_t** attr) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_attribute_free>(attr);
 }
 
-CAPI_INTERFACE(attribute_set_nullable,
+CAPI_INTERFACE(
+    attribute_set_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     uint8_t nullable) {
@@ -226,7 +228,8 @@ CAPI_INTERFACE(attribute_set_nullable,
       ctx, attr, nullable);
 }
 
-CAPI_INTERFACE(attribute_set_filter_list,
+CAPI_INTERFACE(
+    attribute_set_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     tiledb_filter_list_t* filter_list) {
@@ -234,7 +237,8 @@ CAPI_INTERFACE(attribute_set_filter_list,
       ctx, attr, filter_list);
 }
 
-CAPI_INTERFACE(attribute_set_cell_val_num,
+CAPI_INTERFACE(
+    attribute_set_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     uint32_t cell_val_num) {
@@ -242,7 +246,8 @@ CAPI_INTERFACE(attribute_set_cell_val_num,
       ctx, attr, cell_val_num);
 }
 
-CAPI_INTERFACE(attribute_get_name,
+CAPI_INTERFACE(
+    attribute_get_name,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
     const char** name) {
@@ -250,7 +255,8 @@ CAPI_INTERFACE(attribute_get_name,
       ctx, attr, name);
 }
 
-CAPI_INTERFACE(attribute_get_type,
+CAPI_INTERFACE(
+    attribute_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
     tiledb_datatype_t* type) {
@@ -258,7 +264,8 @@ CAPI_INTERFACE(attribute_get_type,
       ctx, attr, type);
 }
 
-CAPI_INTERFACE(attribute_get_nullable,
+CAPI_INTERFACE(
+    attribute_get_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     uint8_t* nullable) {
@@ -266,7 +273,8 @@ CAPI_INTERFACE(attribute_get_nullable,
       ctx, attr, nullable);
 }
 
-CAPI_INTERFACE(attribute_get_filter_list,
+CAPI_INTERFACE(
+    attribute_get_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     tiledb_filter_list_t** filter_list) {
@@ -274,7 +282,8 @@ CAPI_INTERFACE(attribute_get_filter_list,
       ctx, attr, filter_list);
 }
 
-CAPI_INTERFACE(attribute_get_cell_val_num,
+CAPI_INTERFACE(
+    attribute_get_cell_val_num,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
     uint32_t* cell_val_num) {
@@ -282,7 +291,8 @@ CAPI_INTERFACE(attribute_get_cell_val_num,
       ctx, attr, cell_val_num);
 }
 
-CAPI_INTERFACE(attribute_get_cell_size,
+CAPI_INTERFACE(
+    attribute_get_cell_size,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
     uint64_t* cell_size) {
@@ -290,14 +300,16 @@ CAPI_INTERFACE(attribute_get_cell_size,
       ctx, attr, cell_size);
 }
 
-CAPI_INTERFACE(attribute_dump,
+CAPI_INTERFACE(
+    attribute_dump,
     tiledb_ctx_t* ctx,
     const tiledb_attribute_handle_t* attr,
     FILE* out) {
   return api_entry_context<tiledb::api::tiledb_attribute_dump>(ctx, attr, out);
 }
 
-CAPI_INTERFACE(attribute_set_fill_value,
+CAPI_INTERFACE(
+    attribute_set_fill_value,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void* value,
@@ -306,7 +318,8 @@ CAPI_INTERFACE(attribute_set_fill_value,
       ctx, attr, value, size);
 }
 
-CAPI_INTERFACE(attribute_get_fill_value,
+CAPI_INTERFACE(
+    attribute_get_fill_value,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void** value,
@@ -315,7 +328,8 @@ CAPI_INTERFACE(attribute_get_fill_value,
       ctx, attr, value, size);
 }
 
-CAPI_INTERFACE(attribute_set_fill_value_nullable,
+CAPI_INTERFACE(
+    attribute_set_fill_value_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void* value,
@@ -326,7 +340,8 @@ CAPI_INTERFACE(attribute_set_fill_value_nullable,
       ctx, attr, value, size, valid);
 }
 
-CAPI_INTERFACE(attribute_get_fill_value_nullable,
+CAPI_INTERFACE(
+    attribute_get_fill_value_nullable,
     tiledb_ctx_t* ctx,
     tiledb_attribute_handle_t* attr,
     const void** value,
@@ -337,7 +352,8 @@ CAPI_INTERFACE(attribute_get_fill_value_nullable,
       ctx, attr, value, size, valid);
 }
 
-CAPI_INTERFACE(attribute_set_enumeration_name,
+CAPI_INTERFACE(
+    attribute_set_enumeration_name,
     tiledb_ctx_t* ctx,
     tiledb_attribute_t* attr,
     const char* enumeration_name) {
@@ -345,7 +361,8 @@ CAPI_INTERFACE(attribute_set_enumeration_name,
       ctx, attr, enumeration_name);
 }
 
-CAPI_INTERFACE(attribute_get_enumeration_name,
+CAPI_INTERFACE(
+    attribute_get_enumeration_name,
     tiledb_ctx_t* ctx,
     tiledb_attribute_t* attr,
     tiledb_string_t** name) {

--- a/tiledb/api/c_api/buffer/buffer_api.cc
+++ b/tiledb/api/c_api/buffer/buffer_api.cc
@@ -98,45 +98,45 @@ capi_return_t tiledb_buffer_set_data(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-capi_return_t tiledb_buffer_alloc(
-    tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) noexcept {
+CAPI_INTERFACE(buffer_alloc,
+    tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) {
   return api_entry_context<tiledb::api::tiledb_buffer_alloc>(ctx, buffer);
 }
 
-void tiledb_buffer_free(tiledb_buffer_t** buffer) noexcept {
+CAPI_INTERFACE_VOID(buffer_free,tiledb_buffer_t** buffer) {
   return api_entry_void<tiledb::api::tiledb_buffer_free>(buffer);
 }
 
-capi_return_t tiledb_buffer_set_type(
+CAPI_INTERFACE(buffer_set_type,
     tiledb_ctx_t* ctx,
     tiledb_buffer_t* buffer,
-    tiledb_datatype_t datatype) noexcept {
+    tiledb_datatype_t datatype) {
   return api_entry_context<tiledb::api::tiledb_buffer_set_type>(
       ctx, buffer, datatype);
 }
 
-capi_return_t tiledb_buffer_get_type(
+CAPI_INTERFACE(buffer_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
-    tiledb_datatype_t* datatype) noexcept {
+    tiledb_datatype_t* datatype) {
   return api_entry_context<tiledb::api::tiledb_buffer_get_type>(
       ctx, buffer, datatype);
 }
 
-capi_return_t tiledb_buffer_get_data(
+CAPI_INTERFACE(buffer_get_data,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     void** data,
-    uint64_t* size) noexcept {
+    uint64_t* size) {
   return api_entry_context<tiledb::api::tiledb_buffer_get_data>(
       ctx, buffer, data, size);
 }
 
-capi_return_t tiledb_buffer_set_data(
+CAPI_INTERFACE(buffer_set_data,
     tiledb_ctx_t* ctx,
     tiledb_buffer_t* buffer,
     void* data,
-    uint64_t size) noexcept {
+    uint64_t size) {
   return api_entry_context<tiledb::api::tiledb_buffer_set_data>(
       ctx, buffer, data, size);
 }

--- a/tiledb/api/c_api/buffer/buffer_api.cc
+++ b/tiledb/api/c_api/buffer/buffer_api.cc
@@ -98,16 +98,16 @@ capi_return_t tiledb_buffer_set_data(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-CAPI_INTERFACE(buffer_alloc,
-    tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) {
+CAPI_INTERFACE(buffer_alloc, tiledb_ctx_t* ctx, tiledb_buffer_t** buffer) {
   return api_entry_context<tiledb::api::tiledb_buffer_alloc>(ctx, buffer);
 }
 
-CAPI_INTERFACE_VOID(buffer_free,tiledb_buffer_t** buffer) {
+CAPI_INTERFACE_VOID(buffer_free, tiledb_buffer_t** buffer) {
   return api_entry_void<tiledb::api::tiledb_buffer_free>(buffer);
 }
 
-CAPI_INTERFACE(buffer_set_type,
+CAPI_INTERFACE(
+    buffer_set_type,
     tiledb_ctx_t* ctx,
     tiledb_buffer_t* buffer,
     tiledb_datatype_t datatype) {
@@ -115,7 +115,8 @@ CAPI_INTERFACE(buffer_set_type,
       ctx, buffer, datatype);
 }
 
-CAPI_INTERFACE(buffer_get_type,
+CAPI_INTERFACE(
+    buffer_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_datatype_t* datatype) {
@@ -123,7 +124,8 @@ CAPI_INTERFACE(buffer_get_type,
       ctx, buffer, datatype);
 }
 
-CAPI_INTERFACE(buffer_get_data,
+CAPI_INTERFACE(
+    buffer_get_data,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     void** data,
@@ -132,7 +134,8 @@ CAPI_INTERFACE(buffer_get_data,
       ctx, buffer, data, size);
 }
 
-CAPI_INTERFACE(buffer_set_data,
+CAPI_INTERFACE(
+    buffer_set_data,
     tiledb_ctx_t* ctx,
     tiledb_buffer_t* buffer,
     void* data,

--- a/tiledb/api/c_api/buffer_list/buffer_list_api.cc
+++ b/tiledb/api/c_api/buffer_list/buffer_list_api.cc
@@ -121,45 +121,45 @@ capi_return_t tiledb_buffer_list_flatten(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-capi_return_t tiledb_buffer_list_alloc(
-    tiledb_ctx_t* ctx, tiledb_buffer_list_t** buffer_list) noexcept {
+CAPI_INTERFACE(buffer_list_alloc,
+    tiledb_ctx_t* ctx, tiledb_buffer_list_t** buffer_list) {
   return api_entry_context<tiledb::api::tiledb_buffer_list_alloc>(
       ctx, buffer_list);
 }
 
-void tiledb_buffer_list_free(tiledb_buffer_list_t** buffer_list) noexcept {
+CAPI_INTERFACE_VOID(buffer_list_free,tiledb_buffer_list_t** buffer_list) {
   return api_entry_void<tiledb::api::tiledb_buffer_list_free>(buffer_list);
 }
 
-capi_return_t tiledb_buffer_list_get_num_buffers(
+CAPI_INTERFACE(buffer_list_get_num_buffers,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_list_t* buffer_list,
-    uint64_t* num_buffers) noexcept {
+    uint64_t* num_buffers) {
   return api_entry_context<tiledb::api::tiledb_buffer_list_get_num_buffers>(
       ctx, buffer_list, num_buffers);
 }
 
-capi_return_t tiledb_buffer_list_get_buffer(
+CAPI_INTERFACE(buffer_list_get_buffer,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_list_t* buffer_list,
     uint64_t buffer_idx,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry_context<tiledb::api::tiledb_buffer_list_get_buffer>(
       ctx, buffer_list, buffer_idx, buffer);
 }
 
-capi_return_t tiledb_buffer_list_get_total_size(
+CAPI_INTERFACE(buffer_list_get_total_size,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_list_t* buffer_list,
-    uint64_t* total_size) noexcept {
+    uint64_t* total_size) {
   return api_entry_context<tiledb::api::tiledb_buffer_list_get_total_size>(
       ctx, buffer_list, total_size);
 }
 
-capi_return_t tiledb_buffer_list_flatten(
+CAPI_INTERFACE(buffer_list_flatten,
     tiledb_ctx_t* ctx,
     tiledb_buffer_list_t* buffer_list,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry_context<tiledb::api::tiledb_buffer_list_flatten>(
       ctx, buffer_list, buffer);
 }

--- a/tiledb/api/c_api/buffer_list/buffer_list_api.cc
+++ b/tiledb/api/c_api/buffer_list/buffer_list_api.cc
@@ -121,17 +121,18 @@ capi_return_t tiledb_buffer_list_flatten(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-CAPI_INTERFACE(buffer_list_alloc,
-    tiledb_ctx_t* ctx, tiledb_buffer_list_t** buffer_list) {
+CAPI_INTERFACE(
+    buffer_list_alloc, tiledb_ctx_t* ctx, tiledb_buffer_list_t** buffer_list) {
   return api_entry_context<tiledb::api::tiledb_buffer_list_alloc>(
       ctx, buffer_list);
 }
 
-CAPI_INTERFACE_VOID(buffer_list_free,tiledb_buffer_list_t** buffer_list) {
+CAPI_INTERFACE_VOID(buffer_list_free, tiledb_buffer_list_t** buffer_list) {
   return api_entry_void<tiledb::api::tiledb_buffer_list_free>(buffer_list);
 }
 
-CAPI_INTERFACE(buffer_list_get_num_buffers,
+CAPI_INTERFACE(
+    buffer_list_get_num_buffers,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_list_t* buffer_list,
     uint64_t* num_buffers) {
@@ -139,7 +140,8 @@ CAPI_INTERFACE(buffer_list_get_num_buffers,
       ctx, buffer_list, num_buffers);
 }
 
-CAPI_INTERFACE(buffer_list_get_buffer,
+CAPI_INTERFACE(
+    buffer_list_get_buffer,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_list_t* buffer_list,
     uint64_t buffer_idx,
@@ -148,7 +150,8 @@ CAPI_INTERFACE(buffer_list_get_buffer,
       ctx, buffer_list, buffer_idx, buffer);
 }
 
-CAPI_INTERFACE(buffer_list_get_total_size,
+CAPI_INTERFACE(
+    buffer_list_get_total_size,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_list_t* buffer_list,
     uint64_t* total_size) {
@@ -156,7 +159,8 @@ CAPI_INTERFACE(buffer_list_get_total_size,
       ctx, buffer_list, total_size);
 }
 
-CAPI_INTERFACE(buffer_list_flatten,
+CAPI_INTERFACE(
+    buffer_list_flatten,
     tiledb_ctx_t* ctx,
     tiledb_buffer_list_t* buffer_list,
     tiledb_buffer_t** buffer) {

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -156,7 +156,7 @@ CAPI_INTERFACE(
  */
 extern "C" {
 
-capi_return_t tiledb_ctx_alloc_with_error(/*{}*/
+capi_return_t tiledb_ctx_alloc_with_error(
     tiledb_config_handle_t* config,
     tiledb_ctx_handle_t** ctx,
     tiledb_error_handle_t** error) noexcept {

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -156,7 +156,7 @@ CAPI_INTERFACE(
  */
 extern "C" {
 
-capi_return_t tiledb_ctx_alloc_with_error(
+capi_return_t tiledb_ctx_alloc_with_error(/*{}*/
     tiledb_config_handle_t* config,
     tiledb_ctx_handle_t** ctx,
     tiledb_error_handle_t** error) noexcept {

--- a/tiledb/api/c_api/data_order/data_order_api.cc
+++ b/tiledb/api/c_api/data_order/data_order_api.cc
@@ -55,14 +55,14 @@ capi_return_t tiledb_data_order_from_str(
 
 using tiledb::api::api_entry_plain;
 
-capi_return_t tiledb_data_order_to_str(
-    tiledb_data_order_t data_order, const char** str) noexcept {
+CAPI_INTERFACE(data_order_to_str,
+    tiledb_data_order_t data_order, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_data_order_to_str>(
       data_order, str);
 }
 
-capi_return_t tiledb_data_order_from_str(
-    const char* str, tiledb_data_order_t* data_order) noexcept {
+CAPI_INTERFACE(data_order_from_str,
+    const char* str, tiledb_data_order_t* data_order) {
   return api_entry_plain<tiledb::api::tiledb_data_order_from_str>(
       str, data_order);
 }

--- a/tiledb/api/c_api/data_order/data_order_api.cc
+++ b/tiledb/api/c_api/data_order/data_order_api.cc
@@ -55,14 +55,14 @@ capi_return_t tiledb_data_order_from_str(
 
 using tiledb::api::api_entry_plain;
 
-CAPI_INTERFACE(data_order_to_str,
-    tiledb_data_order_t data_order, const char** str) {
+CAPI_INTERFACE(
+    data_order_to_str, tiledb_data_order_t data_order, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_data_order_to_str>(
       data_order, str);
 }
 
-CAPI_INTERFACE(data_order_from_str,
-    const char* str, tiledb_data_order_t* data_order) {
+CAPI_INTERFACE(
+    data_order_from_str, const char* str, tiledb_data_order_t* data_order) {
   return api_entry_plain<tiledb::api::tiledb_data_order_from_str>(
       str, data_order);
 }

--- a/tiledb/api/c_api/datatype/datatype_api.cc
+++ b/tiledb/api/c_api/datatype/datatype_api.cc
@@ -61,13 +61,12 @@ uint64_t tiledb_datatype_size(tiledb_datatype_t type) {
 
 using tiledb::api::api_entry_plain;
 
-CAPI_INTERFACE(datatype_to_str,
-    tiledb_datatype_t datatype, const char** str) {
+CAPI_INTERFACE(datatype_to_str, tiledb_datatype_t datatype, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_datatype_to_str>(datatype, str);
 }
 
-CAPI_INTERFACE(datatype_from_str,
-    const char* str, tiledb_datatype_t* datatype) {
+CAPI_INTERFACE(
+    datatype_from_str, const char* str, tiledb_datatype_t* datatype) {
   return api_entry_plain<tiledb::api::tiledb_datatype_from_str>(str, datatype);
 }
 

--- a/tiledb/api/c_api/datatype/datatype_api.cc
+++ b/tiledb/api/c_api/datatype/datatype_api.cc
@@ -61,13 +61,13 @@ uint64_t tiledb_datatype_size(tiledb_datatype_t type) {
 
 using tiledb::api::api_entry_plain;
 
-capi_return_t tiledb_datatype_to_str(
-    tiledb_datatype_t datatype, const char** str) noexcept {
+CAPI_INTERFACE(datatype_to_str,
+    tiledb_datatype_t datatype, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_datatype_to_str>(datatype, str);
 }
 
-capi_return_t tiledb_datatype_from_str(
-    const char* str, tiledb_datatype_t* datatype) noexcept {
+CAPI_INTERFACE(datatype_from_str,
+    const char* str, tiledb_datatype_t* datatype) {
   return api_entry_plain<tiledb::api::tiledb_datatype_from_str>(str, datatype);
 }
 

--- a/tiledb/api/c_api/dimension/dimension_api.cc
+++ b/tiledb/api/c_api/dimension/dimension_api.cc
@@ -141,86 +141,86 @@ int32_t tiledb_dimension_dump(const tiledb_dimension_t* dim, FILE* out) {
 
 using tiledb::api::api_entry_context;
 
-int32_t tiledb_dimension_alloc(
+CAPI_INTERFACE(dimension_alloc,
     tiledb_ctx_t* ctx,
     const char* name,
     tiledb_datatype_t type,
     const void* dim_domain,
     const void* tile_extent,
-    tiledb_dimension_t** dim) noexcept {
+    tiledb_dimension_t** dim) {
   return api_entry_context<tiledb::api::tiledb_dimension_alloc>(
       ctx, name, type, dim_domain, tile_extent, dim);
 }
 
-void tiledb_dimension_free(tiledb_dimension_t** dim) noexcept {
+CAPI_INTERFACE_VOID(dimension_free,tiledb_dimension_t** dim) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_dimension_free>(dim);
 }
 
-int32_t tiledb_dimension_set_filter_list(
+CAPI_INTERFACE(dimension_set_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_dimension_t* dim,
-    tiledb_filter_list_t* filter_list) noexcept {
+    tiledb_filter_list_t* filter_list) {
   return api_entry_context<tiledb::api::tiledb_dimension_set_filter_list>(
       ctx, dim, filter_list);
 }
 
-int32_t tiledb_dimension_set_cell_val_num(
+CAPI_INTERFACE(dimension_set_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_dimension_t* dim,
-    uint32_t cell_val_num) noexcept {
+    uint32_t cell_val_num) {
   return api_entry_context<tiledb::api::tiledb_dimension_set_cell_val_num>(
       ctx, dim, cell_val_num);
 }
 
-int32_t tiledb_dimension_get_filter_list(
+CAPI_INTERFACE(dimension_get_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_dimension_t* dim,
-    tiledb_filter_list_t** filter_list) noexcept {
+    tiledb_filter_list_t** filter_list) {
   return api_entry_context<tiledb::api::tiledb_dimension_get_filter_list>(
       ctx, dim, filter_list);
 }
 
-int32_t tiledb_dimension_get_cell_val_num(
+CAPI_INTERFACE(dimension_get_cell_val_num,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
-    uint32_t* cell_val_num) noexcept {
+    uint32_t* cell_val_num) {
   return api_entry_context<tiledb::api::tiledb_dimension_get_cell_val_num>(
       ctx, dim, cell_val_num);
 }
 
-int32_t tiledb_dimension_get_name(
+CAPI_INTERFACE(dimension_get_name,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
-    const char** name) noexcept {
+    const char** name) {
   return api_entry_context<tiledb::api::tiledb_dimension_get_name>(
       ctx, dim, name);
 }
 
-int32_t tiledb_dimension_get_type(
+CAPI_INTERFACE(dimension_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
-    tiledb_datatype_t* type) noexcept {
+    tiledb_datatype_t* type) {
   return api_entry_context<tiledb::api::tiledb_dimension_get_type>(
       ctx, dim, type);
 }
 
-int32_t tiledb_dimension_get_domain(
+CAPI_INTERFACE(dimension_get_domain,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
-    const void** domain) noexcept {
+    const void** domain) {
   return api_entry_context<tiledb::api::tiledb_dimension_get_domain>(
       ctx, dim, domain);
 }
 
-int32_t tiledb_dimension_get_tile_extent(
+CAPI_INTERFACE(dimension_get_tile_extent,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
-    const void** tile_extent) noexcept {
+    const void** tile_extent) {
   return api_entry_context<tiledb::api::tiledb_dimension_get_tile_extent>(
       ctx, dim, tile_extent);
 }
 
-int32_t tiledb_dimension_dump(
-    tiledb_ctx_t* ctx, const tiledb_dimension_t* dim, FILE* out) noexcept {
+CAPI_INTERFACE(dimension_dump,
+    tiledb_ctx_t* ctx, const tiledb_dimension_t* dim, FILE* out) {
   return api_entry_context<tiledb::api::tiledb_dimension_dump>(ctx, dim, out);
 }

--- a/tiledb/api/c_api/dimension/dimension_api.cc
+++ b/tiledb/api/c_api/dimension/dimension_api.cc
@@ -141,7 +141,8 @@ int32_t tiledb_dimension_dump(const tiledb_dimension_t* dim, FILE* out) {
 
 using tiledb::api::api_entry_context;
 
-CAPI_INTERFACE(dimension_alloc,
+CAPI_INTERFACE(
+    dimension_alloc,
     tiledb_ctx_t* ctx,
     const char* name,
     tiledb_datatype_t type,
@@ -152,11 +153,12 @@ CAPI_INTERFACE(dimension_alloc,
       ctx, name, type, dim_domain, tile_extent, dim);
 }
 
-CAPI_INTERFACE_VOID(dimension_free,tiledb_dimension_t** dim) {
+CAPI_INTERFACE_VOID(dimension_free, tiledb_dimension_t** dim) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_dimension_free>(dim);
 }
 
-CAPI_INTERFACE(dimension_set_filter_list,
+CAPI_INTERFACE(
+    dimension_set_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_dimension_t* dim,
     tiledb_filter_list_t* filter_list) {
@@ -164,7 +166,8 @@ CAPI_INTERFACE(dimension_set_filter_list,
       ctx, dim, filter_list);
 }
 
-CAPI_INTERFACE(dimension_set_cell_val_num,
+CAPI_INTERFACE(
+    dimension_set_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_dimension_t* dim,
     uint32_t cell_val_num) {
@@ -172,7 +175,8 @@ CAPI_INTERFACE(dimension_set_cell_val_num,
       ctx, dim, cell_val_num);
 }
 
-CAPI_INTERFACE(dimension_get_filter_list,
+CAPI_INTERFACE(
+    dimension_get_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_dimension_t* dim,
     tiledb_filter_list_t** filter_list) {
@@ -180,7 +184,8 @@ CAPI_INTERFACE(dimension_get_filter_list,
       ctx, dim, filter_list);
 }
 
-CAPI_INTERFACE(dimension_get_cell_val_num,
+CAPI_INTERFACE(
+    dimension_get_cell_val_num,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
     uint32_t* cell_val_num) {
@@ -188,7 +193,8 @@ CAPI_INTERFACE(dimension_get_cell_val_num,
       ctx, dim, cell_val_num);
 }
 
-CAPI_INTERFACE(dimension_get_name,
+CAPI_INTERFACE(
+    dimension_get_name,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
     const char** name) {
@@ -196,7 +202,8 @@ CAPI_INTERFACE(dimension_get_name,
       ctx, dim, name);
 }
 
-CAPI_INTERFACE(dimension_get_type,
+CAPI_INTERFACE(
+    dimension_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
     tiledb_datatype_t* type) {
@@ -204,7 +211,8 @@ CAPI_INTERFACE(dimension_get_type,
       ctx, dim, type);
 }
 
-CAPI_INTERFACE(dimension_get_domain,
+CAPI_INTERFACE(
+    dimension_get_domain,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
     const void** domain) {
@@ -212,7 +220,8 @@ CAPI_INTERFACE(dimension_get_domain,
       ctx, dim, domain);
 }
 
-CAPI_INTERFACE(dimension_get_tile_extent,
+CAPI_INTERFACE(
+    dimension_get_tile_extent,
     tiledb_ctx_t* ctx,
     const tiledb_dimension_t* dim,
     const void** tile_extent) {
@@ -220,7 +229,10 @@ CAPI_INTERFACE(dimension_get_tile_extent,
       ctx, dim, tile_extent);
 }
 
-CAPI_INTERFACE(dimension_dump,
-    tiledb_ctx_t* ctx, const tiledb_dimension_t* dim, FILE* out) {
+CAPI_INTERFACE(
+    dimension_dump,
+    tiledb_ctx_t* ctx,
+    const tiledb_dimension_t* dim,
+    FILE* out) {
   return api_entry_context<tiledb::api::tiledb_dimension_dump>(ctx, dim, out);
 }

--- a/tiledb/api/c_api/dimension_label/dimension_label_api.cc
+++ b/tiledb/api/c_api/dimension_label/dimension_label_api.cc
@@ -105,66 +105,66 @@ capi_return_t tiledb_dimension_label_get_uri(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-void tiledb_dimension_label_free(
-    tiledb_dimension_label_t** dim_label) noexcept {
+CAPI_INTERFACE_VOID(dimension_label_free,
+    tiledb_dimension_label_t** dim_label) {
   return api_entry_void<tiledb::api::tiledb_dimension_label_free>(dim_label);
 }
 
-capi_return_t tiledb_dimension_label_get_dimension_index(
+CAPI_INTERFACE(dimension_label_get_dimension_index,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    uint32_t* dim_index) noexcept {
+    uint32_t* dim_index) {
   return api_entry_context<
       tiledb::api::tiledb_dimension_label_get_dimension_index>(
       ctx, dim_label, dim_index);
 }
 
-capi_return_t tiledb_dimension_label_get_label_attr_name(
+CAPI_INTERFACE(dimension_label_get_label_attr_name,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    const char** label_attr_name) noexcept {
+    const char** label_attr_name) {
   return api_entry_context<
       tiledb::api::tiledb_dimension_label_get_label_attr_name>(
       ctx, dim_label, label_attr_name);
 }
 
-capi_return_t tiledb_dimension_label_get_label_cell_val_num(
+CAPI_INTERFACE(dimension_label_get_label_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    uint32_t* label_cell_val_num) noexcept {
+    uint32_t* label_cell_val_num) {
   return api_entry_context<
       tiledb::api::tiledb_dimension_label_get_label_cell_val_num>(
       ctx, dim_label, label_cell_val_num);
 }
 
-capi_return_t tiledb_dimension_label_get_label_order(
+CAPI_INTERFACE(dimension_label_get_label_order,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    tiledb_data_order_t* label_order) noexcept {
+    tiledb_data_order_t* label_order) {
   return api_entry_context<tiledb::api::tiledb_dimension_label_get_label_order>(
       ctx, dim_label, label_order);
 }
 
-capi_return_t tiledb_dimension_label_get_label_type(
+CAPI_INTERFACE(dimension_label_get_label_type,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    tiledb_datatype_t* label_type) noexcept {
+    tiledb_datatype_t* label_type) {
   return api_entry_context<tiledb::api::tiledb_dimension_label_get_label_type>(
       ctx, dim_label, label_type);
 }
 
-capi_return_t tiledb_dimension_label_get_name(
+CAPI_INTERFACE(dimension_label_get_name,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    const char** name) noexcept {
+    const char** name) {
   return api_entry_context<tiledb::api::tiledb_dimension_label_get_name>(
       ctx, dim_label, name);
 }
 
-capi_return_t tiledb_dimension_label_get_uri(
+CAPI_INTERFACE(dimension_label_get_uri,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
-    const char** uri) noexcept {
+    const char** uri) {
   return api_entry_context<tiledb::api::tiledb_dimension_label_get_uri>(
       ctx, dim_label, uri);
 }

--- a/tiledb/api/c_api/dimension_label/dimension_label_api.cc
+++ b/tiledb/api/c_api/dimension_label/dimension_label_api.cc
@@ -105,12 +105,13 @@ capi_return_t tiledb_dimension_label_get_uri(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-CAPI_INTERFACE_VOID(dimension_label_free,
-    tiledb_dimension_label_t** dim_label) {
+CAPI_INTERFACE_VOID(
+    dimension_label_free, tiledb_dimension_label_t** dim_label) {
   return api_entry_void<tiledb::api::tiledb_dimension_label_free>(dim_label);
 }
 
-CAPI_INTERFACE(dimension_label_get_dimension_index,
+CAPI_INTERFACE(
+    dimension_label_get_dimension_index,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     uint32_t* dim_index) {
@@ -119,7 +120,8 @@ CAPI_INTERFACE(dimension_label_get_dimension_index,
       ctx, dim_label, dim_index);
 }
 
-CAPI_INTERFACE(dimension_label_get_label_attr_name,
+CAPI_INTERFACE(
+    dimension_label_get_label_attr_name,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     const char** label_attr_name) {
@@ -128,7 +130,8 @@ CAPI_INTERFACE(dimension_label_get_label_attr_name,
       ctx, dim_label, label_attr_name);
 }
 
-CAPI_INTERFACE(dimension_label_get_label_cell_val_num,
+CAPI_INTERFACE(
+    dimension_label_get_label_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     uint32_t* label_cell_val_num) {
@@ -137,7 +140,8 @@ CAPI_INTERFACE(dimension_label_get_label_cell_val_num,
       ctx, dim_label, label_cell_val_num);
 }
 
-CAPI_INTERFACE(dimension_label_get_label_order,
+CAPI_INTERFACE(
+    dimension_label_get_label_order,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     tiledb_data_order_t* label_order) {
@@ -145,7 +149,8 @@ CAPI_INTERFACE(dimension_label_get_label_order,
       ctx, dim_label, label_order);
 }
 
-CAPI_INTERFACE(dimension_label_get_label_type,
+CAPI_INTERFACE(
+    dimension_label_get_label_type,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     tiledb_datatype_t* label_type) {
@@ -153,7 +158,8 @@ CAPI_INTERFACE(dimension_label_get_label_type,
       ctx, dim_label, label_type);
 }
 
-CAPI_INTERFACE(dimension_label_get_name,
+CAPI_INTERFACE(
+    dimension_label_get_name,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     const char** name) {
@@ -161,7 +167,8 @@ CAPI_INTERFACE(dimension_label_get_name,
       ctx, dim_label, name);
 }
 
-CAPI_INTERFACE(dimension_label_get_uri,
+CAPI_INTERFACE(
+    dimension_label_get_uri,
     tiledb_ctx_t* ctx,
     tiledb_dimension_label_t* dim_label,
     const char** uri) {

--- a/tiledb/api/c_api/domain/domain_api.cc
+++ b/tiledb/api/c_api/domain/domain_api.cc
@@ -146,65 +146,65 @@ int32_t tiledb_domain_dump(const tiledb_domain_t* domain, FILE* out) {
 
 using tiledb::api::api_entry_context;
 
-int32_t tiledb_domain_alloc(
-    tiledb_ctx_t* ctx, tiledb_domain_t** domain) noexcept {
+CAPI_INTERFACE(domain_alloc,
+    tiledb_ctx_t* ctx, tiledb_domain_t** domain) {
   return api_entry_context<tiledb::api::tiledb_domain_alloc>(ctx, domain);
 }
 
-void tiledb_domain_free(tiledb_domain_t** domain) noexcept {
+CAPI_INTERFACE_VOID(domain_free,tiledb_domain_t** domain) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_domain_free>(domain);
 }
 
-int32_t tiledb_domain_get_type(
+CAPI_INTERFACE(domain_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
-    tiledb_datatype_t* type) noexcept {
+    tiledb_datatype_t* type) {
   return api_entry_context<tiledb::api::tiledb_domain_get_type>(
       ctx, domain, type);
 }
 
-int32_t tiledb_domain_get_ndim(
-    tiledb_ctx_t* ctx, const tiledb_domain_t* domain, uint32_t* ndim) noexcept {
+CAPI_INTERFACE(domain_get_ndim,
+    tiledb_ctx_t* ctx, const tiledb_domain_t* domain, uint32_t* ndim) {
   return api_entry_context<tiledb::api::tiledb_domain_get_ndim>(
       ctx, domain, ndim);
 }
 
-int32_t tiledb_domain_add_dimension(
+CAPI_INTERFACE(domain_add_dimension,
     tiledb_ctx_t* ctx,
     tiledb_domain_t* domain,
-    tiledb_dimension_t* dim) noexcept {
+    tiledb_dimension_t* dim) {
   return api_entry_context<tiledb::api::tiledb_domain_add_dimension>(
       ctx, domain, dim);
 }
 
-int32_t tiledb_domain_get_dimension_from_index(
+CAPI_INTERFACE(domain_get_dimension_from_index,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     uint32_t index,
-    tiledb_dimension_t** dim) noexcept {
+    tiledb_dimension_t** dim) {
   return api_entry_context<tiledb::api::tiledb_domain_get_dimension_from_index>(
       ctx, domain, index, dim);
 }
 
-int32_t tiledb_domain_get_dimension_from_name(
+CAPI_INTERFACE(domain_get_dimension_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     const char* name,
-    tiledb_dimension_t** dim) noexcept {
+    tiledb_dimension_t** dim) {
   return api_entry_context<tiledb::api::tiledb_domain_get_dimension_from_name>(
       ctx, domain, name, dim);
 }
 
-int32_t tiledb_domain_has_dimension(
+CAPI_INTERFACE(domain_has_dimension,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     const char* name,
-    int32_t* has_dim) noexcept {
+    int32_t* has_dim) {
   return api_entry_context<tiledb::api::tiledb_domain_has_dimension>(
       ctx, domain, name, has_dim);
 }
 
-int32_t tiledb_domain_dump(
-    tiledb_ctx_t* ctx, const tiledb_domain_t* domain, FILE* out) noexcept {
+CAPI_INTERFACE(domain_dump,
+    tiledb_ctx_t* ctx, const tiledb_domain_t* domain, FILE* out) {
   return api_entry_context<tiledb::api::tiledb_domain_dump>(ctx, domain, out);
 }

--- a/tiledb/api/c_api/domain/domain_api.cc
+++ b/tiledb/api/c_api/domain/domain_api.cc
@@ -146,16 +146,16 @@ int32_t tiledb_domain_dump(const tiledb_domain_t* domain, FILE* out) {
 
 using tiledb::api::api_entry_context;
 
-CAPI_INTERFACE(domain_alloc,
-    tiledb_ctx_t* ctx, tiledb_domain_t** domain) {
+CAPI_INTERFACE(domain_alloc, tiledb_ctx_t* ctx, tiledb_domain_t** domain) {
   return api_entry_context<tiledb::api::tiledb_domain_alloc>(ctx, domain);
 }
 
-CAPI_INTERFACE_VOID(domain_free,tiledb_domain_t** domain) {
+CAPI_INTERFACE_VOID(domain_free, tiledb_domain_t** domain) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_domain_free>(domain);
 }
 
-CAPI_INTERFACE(domain_get_type,
+CAPI_INTERFACE(
+    domain_get_type,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     tiledb_datatype_t* type) {
@@ -163,13 +163,17 @@ CAPI_INTERFACE(domain_get_type,
       ctx, domain, type);
 }
 
-CAPI_INTERFACE(domain_get_ndim,
-    tiledb_ctx_t* ctx, const tiledb_domain_t* domain, uint32_t* ndim) {
+CAPI_INTERFACE(
+    domain_get_ndim,
+    tiledb_ctx_t* ctx,
+    const tiledb_domain_t* domain,
+    uint32_t* ndim) {
   return api_entry_context<tiledb::api::tiledb_domain_get_ndim>(
       ctx, domain, ndim);
 }
 
-CAPI_INTERFACE(domain_add_dimension,
+CAPI_INTERFACE(
+    domain_add_dimension,
     tiledb_ctx_t* ctx,
     tiledb_domain_t* domain,
     tiledb_dimension_t* dim) {
@@ -177,7 +181,8 @@ CAPI_INTERFACE(domain_add_dimension,
       ctx, domain, dim);
 }
 
-CAPI_INTERFACE(domain_get_dimension_from_index,
+CAPI_INTERFACE(
+    domain_get_dimension_from_index,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     uint32_t index,
@@ -186,7 +191,8 @@ CAPI_INTERFACE(domain_get_dimension_from_index,
       ctx, domain, index, dim);
 }
 
-CAPI_INTERFACE(domain_get_dimension_from_name,
+CAPI_INTERFACE(
+    domain_get_dimension_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     const char* name,
@@ -195,7 +201,8 @@ CAPI_INTERFACE(domain_get_dimension_from_name,
       ctx, domain, name, dim);
 }
 
-CAPI_INTERFACE(domain_has_dimension,
+CAPI_INTERFACE(
+    domain_has_dimension,
     tiledb_ctx_t* ctx,
     const tiledb_domain_t* domain,
     const char* name,
@@ -204,7 +211,7 @@ CAPI_INTERFACE(domain_has_dimension,
       ctx, domain, name, has_dim);
 }
 
-CAPI_INTERFACE(domain_dump,
-    tiledb_ctx_t* ctx, const tiledb_domain_t* domain, FILE* out) {
+CAPI_INTERFACE(
+    domain_dump, tiledb_ctx_t* ctx, const tiledb_domain_t* domain, FILE* out) {
   return api_entry_context<tiledb::api::tiledb_domain_dump>(ctx, domain, out);
 }

--- a/tiledb/api/c_api/enumeration/enumeration_api.cc
+++ b/tiledb/api/c_api/enumeration/enumeration_api.cc
@@ -179,7 +179,8 @@ capi_return_t tiledb_enumeration_dump(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-CAPI_INTERFACE(enumeration_alloc,
+CAPI_INTERFACE(
+    enumeration_alloc,
     tiledb_ctx_t* ctx,
     const char* name,
     tiledb_datatype_t type,
@@ -203,7 +204,8 @@ CAPI_INTERFACE(enumeration_alloc,
       enumeration);
 }
 
-CAPI_INTERFACE(enumeration_extend,
+CAPI_INTERFACE(
+    enumeration_extend,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* old_enumeration,
     const void* data,
@@ -221,11 +223,12 @@ CAPI_INTERFACE(enumeration_extend,
       new_enumeration);
 }
 
-CAPI_INTERFACE_VOID(enumeration_free,tiledb_enumeration_t** enumeration) {
+CAPI_INTERFACE_VOID(enumeration_free, tiledb_enumeration_t** enumeration) {
   return api_entry_void<tiledb::api::tiledb_enumeration_free>(enumeration);
 }
 
-CAPI_INTERFACE(enumeration_get_name,
+CAPI_INTERFACE(
+    enumeration_get_name,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     tiledb_string_t** name) {
@@ -233,7 +236,8 @@ CAPI_INTERFACE(enumeration_get_name,
       ctx, enumeration, name);
 }
 
-CAPI_INTERFACE(enumeration_get_type,
+CAPI_INTERFACE(
+    enumeration_get_type,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     tiledb_datatype_t* type) {
@@ -241,7 +245,8 @@ CAPI_INTERFACE(enumeration_get_type,
       ctx, enumeration, type);
 }
 
-CAPI_INTERFACE(enumeration_get_cell_val_num,
+CAPI_INTERFACE(
+    enumeration_get_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     uint32_t* cell_val_num) {
@@ -249,7 +254,8 @@ CAPI_INTERFACE(enumeration_get_cell_val_num,
       ctx, enumeration, cell_val_num);
 }
 
-CAPI_INTERFACE(enumeration_get_ordered,
+CAPI_INTERFACE(
+    enumeration_get_ordered,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     int* ordered) {
@@ -257,7 +263,8 @@ CAPI_INTERFACE(enumeration_get_ordered,
       ctx, enumeration, ordered);
 }
 
-CAPI_INTERFACE(enumeration_get_data,
+CAPI_INTERFACE(
+    enumeration_get_data,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     const void** data,
@@ -266,7 +273,8 @@ CAPI_INTERFACE(enumeration_get_data,
       ctx, enumeration, data, data_size);
 }
 
-CAPI_INTERFACE(enumeration_get_offsets,
+CAPI_INTERFACE(
+    enumeration_get_offsets,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     const void** offsets,
@@ -275,8 +283,11 @@ CAPI_INTERFACE(enumeration_get_offsets,
       ctx, enumeration, offsets, offsets_size);
 }
 
-CAPI_INTERFACE(enumeration_dump,
-    tiledb_ctx_t* ctx, tiledb_enumeration_t* enumeration, FILE* out) {
+CAPI_INTERFACE(
+    enumeration_dump,
+    tiledb_ctx_t* ctx,
+    tiledb_enumeration_t* enumeration,
+    FILE* out) {
   return api_entry_context<tiledb::api::tiledb_enumeration_dump>(
       ctx, enumeration, out);
 }

--- a/tiledb/api/c_api/enumeration/enumeration_api.cc
+++ b/tiledb/api/c_api/enumeration/enumeration_api.cc
@@ -179,7 +179,7 @@ capi_return_t tiledb_enumeration_dump(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 
-capi_return_t tiledb_enumeration_alloc(
+CAPI_INTERFACE(enumeration_alloc,
     tiledb_ctx_t* ctx,
     const char* name,
     tiledb_datatype_t type,
@@ -189,7 +189,7 @@ capi_return_t tiledb_enumeration_alloc(
     uint64_t data_size,
     const void* offsets,
     uint64_t offsets_size,
-    tiledb_enumeration_t** enumeration) noexcept {
+    tiledb_enumeration_t** enumeration) {
   return api_entry_context<tiledb::api::tiledb_enumeration_alloc>(
       ctx,
       name,
@@ -203,14 +203,14 @@ capi_return_t tiledb_enumeration_alloc(
       enumeration);
 }
 
-capi_return_t tiledb_enumeration_extend(
+CAPI_INTERFACE(enumeration_extend,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* old_enumeration,
     const void* data,
     uint64_t data_size,
     const void* offsets,
     uint64_t offsets_size,
-    tiledb_enumeration_t** new_enumeration) noexcept {
+    tiledb_enumeration_t** new_enumeration) {
   return api_entry_context<tiledb::api::tiledb_enumeration_extend>(
       ctx,
       old_enumeration,
@@ -221,62 +221,62 @@ capi_return_t tiledb_enumeration_extend(
       new_enumeration);
 }
 
-void tiledb_enumeration_free(tiledb_enumeration_t** enumeration) noexcept {
+CAPI_INTERFACE_VOID(enumeration_free,tiledb_enumeration_t** enumeration) {
   return api_entry_void<tiledb::api::tiledb_enumeration_free>(enumeration);
 }
 
-capi_return_t tiledb_enumeration_get_name(
+CAPI_INTERFACE(enumeration_get_name,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
-    tiledb_string_t** name) noexcept {
+    tiledb_string_t** name) {
   return api_entry_context<tiledb::api::tiledb_enumeration_get_name>(
       ctx, enumeration, name);
 }
 
-capi_return_t tiledb_enumeration_get_type(
+CAPI_INTERFACE(enumeration_get_type,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
-    tiledb_datatype_t* type) noexcept {
+    tiledb_datatype_t* type) {
   return api_entry_context<tiledb::api::tiledb_enumeration_get_type>(
       ctx, enumeration, type);
 }
 
-capi_return_t tiledb_enumeration_get_cell_val_num(
+CAPI_INTERFACE(enumeration_get_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
-    uint32_t* cell_val_num) noexcept {
+    uint32_t* cell_val_num) {
   return api_entry_context<tiledb::api::tiledb_enumeration_get_cell_val_num>(
       ctx, enumeration, cell_val_num);
 }
 
-capi_return_t tiledb_enumeration_get_ordered(
+CAPI_INTERFACE(enumeration_get_ordered,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
-    int* ordered) noexcept {
+    int* ordered) {
   return api_entry_context<tiledb::api::tiledb_enumeration_get_ordered>(
       ctx, enumeration, ordered);
 }
 
-capi_return_t tiledb_enumeration_get_data(
+CAPI_INTERFACE(enumeration_get_data,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     const void** data,
-    uint64_t* data_size) noexcept {
+    uint64_t* data_size) {
   return api_entry_context<tiledb::api::tiledb_enumeration_get_data>(
       ctx, enumeration, data, data_size);
 }
 
-capi_return_t tiledb_enumeration_get_offsets(
+CAPI_INTERFACE(enumeration_get_offsets,
     tiledb_ctx_t* ctx,
     tiledb_enumeration_t* enumeration,
     const void** offsets,
-    uint64_t* offsets_size) noexcept {
+    uint64_t* offsets_size) {
   return api_entry_context<tiledb::api::tiledb_enumeration_get_offsets>(
       ctx, enumeration, offsets, offsets_size);
 }
 
-capi_return_t tiledb_enumeration_dump(
-    tiledb_ctx_t* ctx, tiledb_enumeration_t* enumeration, FILE* out) noexcept {
+CAPI_INTERFACE(enumeration_dump,
+    tiledb_ctx_t* ctx, tiledb_enumeration_t* enumeration, FILE* out) {
   return api_entry_context<tiledb::api::tiledb_enumeration_dump>(
       ctx, enumeration, out);
 }

--- a/tiledb/api/c_api/filesystem/filesystem_api.cc
+++ b/tiledb/api/c_api/filesystem/filesystem_api.cc
@@ -58,14 +58,14 @@ capi_return_t tiledb_filesystem_from_str(
 
 using tiledb::api::api_entry_plain;
 
-capi_return_t tiledb_filesystem_to_str(
-    tiledb_filesystem_t filesystem, const char** str) noexcept {
+CAPI_INTERFACE(filesystem_to_str,
+    tiledb_filesystem_t filesystem, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_filesystem_to_str>(
       filesystem, str);
 }
 
-capi_return_t tiledb_filesystem_from_str(
-    const char* str, tiledb_filesystem_t* filesystem) noexcept {
+CAPI_INTERFACE(filesystem_from_str,
+    const char* str, tiledb_filesystem_t* filesystem) {
   return api_entry_plain<tiledb::api::tiledb_filesystem_from_str>(
       str, filesystem);
 }

--- a/tiledb/api/c_api/filesystem/filesystem_api.cc
+++ b/tiledb/api/c_api/filesystem/filesystem_api.cc
@@ -58,14 +58,14 @@ capi_return_t tiledb_filesystem_from_str(
 
 using tiledb::api::api_entry_plain;
 
-CAPI_INTERFACE(filesystem_to_str,
-    tiledb_filesystem_t filesystem, const char** str) {
+CAPI_INTERFACE(
+    filesystem_to_str, tiledb_filesystem_t filesystem, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_filesystem_to_str>(
       filesystem, str);
 }
 
-CAPI_INTERFACE(filesystem_from_str,
-    const char* str, tiledb_filesystem_t* filesystem) {
+CAPI_INTERFACE(
+    filesystem_from_str, const char* str, tiledb_filesystem_t* filesystem) {
   return api_entry_plain<tiledb::api::tiledb_filesystem_from_str>(
       str, filesystem);
 }

--- a/tiledb/api/c_api/filter/filter_api.cc
+++ b/tiledb/api/c_api/filter/filter_api.cc
@@ -122,7 +122,8 @@ capi_return_t tiledb_filter_option_from_str(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_plain;
 
-CAPI_INTERFACE(filter_alloc,
+CAPI_INTERFACE(
+    filter_alloc,
     tiledb_ctx_t* ctx,
     tiledb_filter_type_t type,
     tiledb_filter_t** filter) {
@@ -130,11 +131,12 @@ CAPI_INTERFACE(filter_alloc,
       ctx, type, filter);
 }
 
-CAPI_INTERFACE_VOID(filter_free,tiledb_filter_t** filter) {
+CAPI_INTERFACE_VOID(filter_free, tiledb_filter_t** filter) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_filter_free>(filter);
 }
 
-CAPI_INTERFACE(filter_get_type,
+CAPI_INTERFACE(
+    filter_get_type,
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
     tiledb_filter_type_t* type) {
@@ -142,7 +144,8 @@ CAPI_INTERFACE(filter_get_type,
       ctx, filter, type);
 }
 
-CAPI_INTERFACE(filter_set_option,
+CAPI_INTERFACE(
+    filter_set_option,
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
     tiledb_filter_option_t option,
@@ -151,7 +154,8 @@ CAPI_INTERFACE(filter_set_option,
       ctx, filter, option, value);
 }
 
-CAPI_INTERFACE(filter_get_option,
+CAPI_INTERFACE(
+    filter_get_option,
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
     tiledb_filter_option_t option,
@@ -160,26 +164,30 @@ CAPI_INTERFACE(filter_get_option,
       ctx, filter, option, value);
 }
 
-CAPI_INTERFACE(filter_type_to_str,
-    tiledb_filter_type_t filter_type, const char** str) {
+CAPI_INTERFACE(
+    filter_type_to_str, tiledb_filter_type_t filter_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_filter_type_to_str>(
       filter_type, str);
 }
 
-CAPI_INTERFACE(filter_type_from_str,
-    const char* str, tiledb_filter_type_t* filter_type) {
+CAPI_INTERFACE(
+    filter_type_from_str, const char* str, tiledb_filter_type_t* filter_type) {
   return api_entry_plain<tiledb::api::tiledb_filter_type_from_str>(
       str, filter_type);
 }
 
-CAPI_INTERFACE(filter_option_to_str,
-    tiledb_filter_option_t filter_option, const char** str) {
+CAPI_INTERFACE(
+    filter_option_to_str,
+    tiledb_filter_option_t filter_option,
+    const char** str) {
   return api_entry_plain<tiledb::api::tiledb_filter_option_to_str>(
       filter_option, str);
 }
 
-CAPI_INTERFACE(filter_option_from_str,
-    const char* str, tiledb_filter_option_t* filter_option) {
+CAPI_INTERFACE(
+    filter_option_from_str,
+    const char* str,
+    tiledb_filter_option_t* filter_option) {
   return api_entry_plain<tiledb::api::tiledb_filter_option_from_str>(
       str, filter_option);
 }

--- a/tiledb/api/c_api/filter/filter_api.cc
+++ b/tiledb/api/c_api/filter/filter_api.cc
@@ -122,64 +122,64 @@ capi_return_t tiledb_filter_option_from_str(
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_plain;
 
-capi_return_t tiledb_filter_alloc(
+CAPI_INTERFACE(filter_alloc,
     tiledb_ctx_t* ctx,
     tiledb_filter_type_t type,
-    tiledb_filter_t** filter) noexcept {
+    tiledb_filter_t** filter) {
   return tiledb::api::api_entry_with_context<tiledb::api::tiledb_filter_alloc>(
       ctx, type, filter);
 }
 
-void tiledb_filter_free(tiledb_filter_t** filter) noexcept {
+CAPI_INTERFACE_VOID(filter_free,tiledb_filter_t** filter) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_filter_free>(filter);
 }
 
-capi_return_t tiledb_filter_get_type(
+CAPI_INTERFACE(filter_get_type,
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
-    tiledb_filter_type_t* type) noexcept {
+    tiledb_filter_type_t* type) {
   return api_entry_context<tiledb::api::tiledb_filter_get_type>(
       ctx, filter, type);
 }
 
-capi_return_t tiledb_filter_set_option(
+CAPI_INTERFACE(filter_set_option,
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
     tiledb_filter_option_t option,
-    const void* value) noexcept {
+    const void* value) {
   return api_entry_context<tiledb::api::tiledb_filter_set_option>(
       ctx, filter, option, value);
 }
 
-capi_return_t tiledb_filter_get_option(
+CAPI_INTERFACE(filter_get_option,
     tiledb_ctx_t* ctx,
     tiledb_filter_t* filter,
     tiledb_filter_option_t option,
-    void* value) noexcept {
+    void* value) {
   return api_entry_context<tiledb::api::tiledb_filter_get_option>(
       ctx, filter, option, value);
 }
 
-capi_return_t tiledb_filter_type_to_str(
-    tiledb_filter_type_t filter_type, const char** str) noexcept {
+CAPI_INTERFACE(filter_type_to_str,
+    tiledb_filter_type_t filter_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_filter_type_to_str>(
       filter_type, str);
 }
 
-capi_return_t tiledb_filter_type_from_str(
-    const char* str, tiledb_filter_type_t* filter_type) noexcept {
+CAPI_INTERFACE(filter_type_from_str,
+    const char* str, tiledb_filter_type_t* filter_type) {
   return api_entry_plain<tiledb::api::tiledb_filter_type_from_str>(
       str, filter_type);
 }
 
-capi_return_t tiledb_filter_option_to_str(
-    tiledb_filter_option_t filter_option, const char** str) noexcept {
+CAPI_INTERFACE(filter_option_to_str,
+    tiledb_filter_option_t filter_option, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_filter_option_to_str>(
       filter_option, str);
 }
 
-capi_return_t tiledb_filter_option_from_str(
-    const char* str, tiledb_filter_option_t* filter_option) noexcept {
+CAPI_INTERFACE(filter_option_from_str,
+    const char* str, tiledb_filter_option_t* filter_option) {
   return api_entry_plain<tiledb::api::tiledb_filter_option_from_str>(
       str, filter_option);
 }

--- a/tiledb/api/c_api/filter_list/filter_list_api.cc
+++ b/tiledb/api/c_api/filter_list/filter_list_api.cc
@@ -108,55 +108,55 @@ capi_return_t tiledb_filter_list_get_max_chunk_size(
 
 using tiledb::api::api_entry_context;
 
-capi_return_t tiledb_filter_list_alloc(
-    tiledb_ctx_t* ctx, tiledb_filter_list_t** filter_list) noexcept {
+CAPI_INTERFACE(filter_list_alloc,
+    tiledb_ctx_t* ctx, tiledb_filter_list_t** filter_list) {
   return tiledb::api::api_entry_with_context<
       tiledb::api::tiledb_filter_list_alloc>(ctx, filter_list);
 }
 
-void tiledb_filter_list_free(tiledb_filter_list_t** filter_list) noexcept {
+CAPI_INTERFACE_VOID(filter_list_free,tiledb_filter_list_t** filter_list) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_filter_list_free>(
       filter_list);
 }
 
-capi_return_t tiledb_filter_list_add_filter(
+CAPI_INTERFACE(filter_list_add_filter,
     tiledb_ctx_t* ctx,
     tiledb_filter_list_t* filter_list,
-    tiledb_filter_t* filter) noexcept {
+    tiledb_filter_t* filter) {
   return api_entry_context<tiledb::api::tiledb_filter_list_add_filter>(
       ctx, filter_list, filter);
 }
 
-capi_return_t tiledb_filter_list_set_max_chunk_size(
+CAPI_INTERFACE(filter_list_set_max_chunk_size,
     tiledb_ctx_t* ctx,
     tiledb_filter_list_t* filter_list,
-    uint32_t max_chunk_size) noexcept {
+    uint32_t max_chunk_size) {
   return api_entry_context<tiledb::api::tiledb_filter_list_set_max_chunk_size>(
       ctx, filter_list, max_chunk_size);
 }
 
-capi_return_t tiledb_filter_list_get_nfilters(
+CAPI_INTERFACE(filter_list_get_nfilters,
     tiledb_ctx_t* ctx,
     const tiledb_filter_list_t* filter_list,
-    uint32_t* nfilters) noexcept {
+    uint32_t* nfilters) {
   return api_entry_context<tiledb::api::tiledb_filter_list_get_nfilters>(
       ctx, filter_list, nfilters);
 }
 
-capi_return_t tiledb_filter_list_get_filter_from_index(
+CAPI_INTERFACE(filter_list_get_filter_from_index,
     tiledb_ctx_t* ctx,
     const tiledb_filter_list_t* filter_list,
     uint32_t index,
-    tiledb_filter_t** filter) noexcept {
+    tiledb_filter_t** filter) {
   return api_entry_context<
       tiledb::api::tiledb_filter_list_get_filter_from_index>(
       ctx, filter_list, index, filter);
 }
 
-capi_return_t tiledb_filter_list_get_max_chunk_size(
+CAPI_INTERFACE(filter_list_get_max_chunk_size,
     tiledb_ctx_t* ctx,
     const tiledb_filter_list_t* filter_list,
-    uint32_t* max_chunk_size) noexcept {
+    uint32_t* max_chunk_size) {
   return api_entry_context<tiledb::api::tiledb_filter_list_get_max_chunk_size>(
       ctx, filter_list, max_chunk_size);
 }

--- a/tiledb/api/c_api/filter_list/filter_list_api.cc
+++ b/tiledb/api/c_api/filter_list/filter_list_api.cc
@@ -108,18 +108,19 @@ capi_return_t tiledb_filter_list_get_max_chunk_size(
 
 using tiledb::api::api_entry_context;
 
-CAPI_INTERFACE(filter_list_alloc,
-    tiledb_ctx_t* ctx, tiledb_filter_list_t** filter_list) {
+CAPI_INTERFACE(
+    filter_list_alloc, tiledb_ctx_t* ctx, tiledb_filter_list_t** filter_list) {
   return tiledb::api::api_entry_with_context<
       tiledb::api::tiledb_filter_list_alloc>(ctx, filter_list);
 }
 
-CAPI_INTERFACE_VOID(filter_list_free,tiledb_filter_list_t** filter_list) {
+CAPI_INTERFACE_VOID(filter_list_free, tiledb_filter_list_t** filter_list) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_filter_list_free>(
       filter_list);
 }
 
-CAPI_INTERFACE(filter_list_add_filter,
+CAPI_INTERFACE(
+    filter_list_add_filter,
     tiledb_ctx_t* ctx,
     tiledb_filter_list_t* filter_list,
     tiledb_filter_t* filter) {
@@ -127,7 +128,8 @@ CAPI_INTERFACE(filter_list_add_filter,
       ctx, filter_list, filter);
 }
 
-CAPI_INTERFACE(filter_list_set_max_chunk_size,
+CAPI_INTERFACE(
+    filter_list_set_max_chunk_size,
     tiledb_ctx_t* ctx,
     tiledb_filter_list_t* filter_list,
     uint32_t max_chunk_size) {
@@ -135,7 +137,8 @@ CAPI_INTERFACE(filter_list_set_max_chunk_size,
       ctx, filter_list, max_chunk_size);
 }
 
-CAPI_INTERFACE(filter_list_get_nfilters,
+CAPI_INTERFACE(
+    filter_list_get_nfilters,
     tiledb_ctx_t* ctx,
     const tiledb_filter_list_t* filter_list,
     uint32_t* nfilters) {
@@ -143,7 +146,8 @@ CAPI_INTERFACE(filter_list_get_nfilters,
       ctx, filter_list, nfilters);
 }
 
-CAPI_INTERFACE(filter_list_get_filter_from_index,
+CAPI_INTERFACE(
+    filter_list_get_filter_from_index,
     tiledb_ctx_t* ctx,
     const tiledb_filter_list_t* filter_list,
     uint32_t index,
@@ -153,7 +157,8 @@ CAPI_INTERFACE(filter_list_get_filter_from_index,
       ctx, filter_list, index, filter);
 }
 
-CAPI_INTERFACE(filter_list_get_max_chunk_size,
+CAPI_INTERFACE(
+    filter_list_get_max_chunk_size,
     tiledb_ctx_t* ctx,
     const tiledb_filter_list_t* filter_list,
     uint32_t* max_chunk_size) {

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -549,19 +549,22 @@ using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 using tiledb::api::api_entry_with_context;
 
-CAPI_INTERFACE(group_create,
-    tiledb_ctx_t* ctx, const char* group_uri) {
+CAPI_INTERFACE(group_create, tiledb_ctx_t* ctx, const char* group_uri) {
   return api_entry_with_context<tiledb::api::tiledb_group_create>(
       ctx, group_uri);
 }
 
-CAPI_INTERFACE(group_alloc,
-    tiledb_ctx_t* ctx, const char* group_uri, tiledb_group_t** group) {
+CAPI_INTERFACE(
+    group_alloc,
+    tiledb_ctx_t* ctx,
+    const char* group_uri,
+    tiledb_group_t** group) {
   return api_entry_with_context<tiledb::api::tiledb_group_alloc>(
       ctx, group_uri, group);
 }
 
-CAPI_INTERFACE(group_open,
+CAPI_INTERFACE(
+    group_open,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_query_type_t query_type) {
@@ -569,16 +572,16 @@ CAPI_INTERFACE(group_open,
       ctx, group, query_type);
 }
 
-CAPI_INTERFACE(group_close,
-    tiledb_ctx_t* ctx, tiledb_group_t* group) {
+CAPI_INTERFACE(group_close, tiledb_ctx_t* ctx, tiledb_group_t* group) {
   return api_entry_context<tiledb::api::tiledb_group_close>(ctx, group);
 }
 
-CAPI_INTERFACE_VOID(group_free,tiledb_group_t** group) {
+CAPI_INTERFACE_VOID(group_free, tiledb_group_t** group) {
   return api_entry_void<tiledb::api::tiledb_group_free>(group);
 }
 
-CAPI_INTERFACE(group_set_config,
+CAPI_INTERFACE(
+    group_set_config,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_config_t* config) {
@@ -586,7 +589,8 @@ CAPI_INTERFACE(group_set_config,
       ctx, group, config);
 }
 
-CAPI_INTERFACE(group_get_config,
+CAPI_INTERFACE(
+    group_get_config,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_config_t** config) {
@@ -594,7 +598,8 @@ CAPI_INTERFACE(group_get_config,
       ctx, group, config);
 }
 
-CAPI_INTERFACE(group_put_metadata,
+CAPI_INTERFACE(
+    group_put_metadata,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* key,
@@ -605,7 +610,8 @@ CAPI_INTERFACE(group_put_metadata,
       ctx, group, key, value_type, value_num, value);
 }
 
-CAPI_INTERFACE(group_delete_group,
+CAPI_INTERFACE(
+    group_delete_group,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* uri,
@@ -614,13 +620,17 @@ CAPI_INTERFACE(group_delete_group,
       ctx, group, uri, recursive);
 }
 
-CAPI_INTERFACE(group_delete_metadata,
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* key) {
+CAPI_INTERFACE(
+    group_delete_metadata,
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* key) {
   return api_entry_context<tiledb::api::tiledb_group_delete_metadata>(
       ctx, group, key);
 }
 
-CAPI_INTERFACE(group_get_metadata,
+CAPI_INTERFACE(
+    group_get_metadata,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* key,
@@ -631,13 +641,17 @@ CAPI_INTERFACE(group_get_metadata,
       ctx, group, key, value_type, value_num, value);
 }
 
-CAPI_INTERFACE(group_get_metadata_num,
-    tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* num) {
+CAPI_INTERFACE(
+    group_get_metadata_num,
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    uint64_t* num) {
   return api_entry_context<tiledb::api::tiledb_group_get_metadata_num>(
       ctx, group, num);
 }
 
-CAPI_INTERFACE(group_get_metadata_from_index,
+CAPI_INTERFACE(
+    group_get_metadata_from_index,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     uint64_t index,
@@ -650,7 +664,8 @@ CAPI_INTERFACE(group_get_metadata_from_index,
       ctx, group, index, key, key_len, value_type, value_num, value);
 }
 
-CAPI_INTERFACE(group_has_metadata_key,
+CAPI_INTERFACE(
+    group_has_metadata_key,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* key,
@@ -660,7 +675,8 @@ CAPI_INTERFACE(group_has_metadata_key,
       ctx, group, key, value_type, has_key);
 }
 
-CAPI_INTERFACE(group_add_member,
+CAPI_INTERFACE(
+    group_add_member,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* uri,
@@ -670,19 +686,26 @@ CAPI_INTERFACE(group_add_member,
       ctx, group, uri, relative, name);
 }
 
-CAPI_INTERFACE(group_remove_member,
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* name) {
+CAPI_INTERFACE(
+    group_remove_member,
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* name) {
   return api_entry_context<tiledb::api::tiledb_group_remove_member>(
       ctx, group, name);
 }
 
-CAPI_INTERFACE(group_get_member_count,
-    tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* count) {
+CAPI_INTERFACE(
+    group_get_member_count,
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    uint64_t* count) {
   return api_entry_context<tiledb::api::tiledb_group_get_member_count>(
       ctx, group, count);
 }
 
-CAPI_INTERFACE(group_get_member_by_index,
+CAPI_INTERFACE(
+    group_get_member_by_index,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     uint64_t index,
@@ -693,7 +716,8 @@ CAPI_INTERFACE(group_get_member_by_index,
       ctx, group, index, uri, type, name);
 }
 
-CAPI_INTERFACE(group_get_member_by_name,
+CAPI_INTERFACE(
+    group_get_member_by_name,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* name,
@@ -703,7 +727,8 @@ CAPI_INTERFACE(group_get_member_by_name,
       ctx, group, name, uri, type);
 }
 
-CAPI_INTERFACE(group_get_is_relative_uri_by_name,
+CAPI_INTERFACE(
+    group_get_is_relative_uri_by_name,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* name,
@@ -713,19 +738,23 @@ CAPI_INTERFACE(group_get_is_relative_uri_by_name,
       ctx, group, name, relative);
 }
 
-CAPI_INTERFACE(group_is_open,
-    tiledb_ctx_t* ctx, tiledb_group_t* group, int32_t* is_open) {
+CAPI_INTERFACE(
+    group_is_open, tiledb_ctx_t* ctx, tiledb_group_t* group, int32_t* is_open) {
   return api_entry_context<tiledb::api::tiledb_group_is_open>(
       ctx, group, is_open);
 }
 
-CAPI_INTERFACE(group_get_uri,
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char** group_uri) {
+CAPI_INTERFACE(
+    group_get_uri,
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char** group_uri) {
   return api_entry_context<tiledb::api::tiledb_group_get_uri>(
       ctx, group, group_uri);
 }
 
-CAPI_INTERFACE(group_get_query_type,
+CAPI_INTERFACE(
+    group_get_query_type,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_query_type_t* query_type) {
@@ -733,7 +762,8 @@ CAPI_INTERFACE(group_get_query_type,
       ctx, group, query_type);
 }
 
-CAPI_INTERFACE(group_dump_str,
+CAPI_INTERFACE(
+    group_dump_str,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     char** dump_ascii,
@@ -742,7 +772,8 @@ CAPI_INTERFACE(group_dump_str,
       ctx, group, dump_ascii, recursive);
 }
 
-CAPI_INTERFACE(serialize_group,
+CAPI_INTERFACE(
+    serialize_group,
     tiledb_ctx_t* ctx,
     const tiledb_group_t* group,
     tiledb_serialization_type_t serialize_type,
@@ -752,7 +783,8 @@ CAPI_INTERFACE(serialize_group,
       ctx, group, serialize_type, client_side, buffer_list);
 }
 
-CAPI_INTERFACE(deserialize_group,
+CAPI_INTERFACE(
+    deserialize_group,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -762,7 +794,8 @@ CAPI_INTERFACE(deserialize_group,
       ctx, buffer, serialize_type, client_side, group);
 }
 
-CAPI_INTERFACE(serialize_group_metadata,
+CAPI_INTERFACE(
+    serialize_group_metadata,
     tiledb_ctx_t* ctx,
     const tiledb_group_t* group,
     tiledb_serialization_type_t serialization_type,
@@ -771,7 +804,8 @@ CAPI_INTERFACE(serialize_group_metadata,
       ctx, group, serialization_type, buffer);
 }
 
-CAPI_INTERFACE(deserialize_group_metadata,
+CAPI_INTERFACE(
+    deserialize_group_metadata,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_serialization_type_t serialization_type,
@@ -780,7 +814,8 @@ CAPI_INTERFACE(deserialize_group_metadata,
       ctx, group, serialization_type, buffer);
 }
 
-CAPI_INTERFACE(group_consolidate_metadata,
+CAPI_INTERFACE(
+    group_consolidate_metadata,
     tiledb_ctx_t* ctx,
     const char* group_uri,
     tiledb_config_t* config) {
@@ -788,7 +823,8 @@ CAPI_INTERFACE(group_consolidate_metadata,
       ctx, group_uri, config);
 }
 
-CAPI_INTERFACE(group_vacuum_metadata,
+CAPI_INTERFACE(
+    group_vacuum_metadata,
     tiledb_ctx_t* ctx,
     const char* group_uri,
     tiledb_config_t* config) {

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -549,95 +549,95 @@ using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_void;
 using tiledb::api::api_entry_with_context;
 
-capi_return_t tiledb_group_create(
-    tiledb_ctx_t* ctx, const char* group_uri) noexcept {
+CAPI_INTERFACE(group_create,
+    tiledb_ctx_t* ctx, const char* group_uri) {
   return api_entry_with_context<tiledb::api::tiledb_group_create>(
       ctx, group_uri);
 }
 
-capi_return_t tiledb_group_alloc(
-    tiledb_ctx_t* ctx, const char* group_uri, tiledb_group_t** group) noexcept {
+CAPI_INTERFACE(group_alloc,
+    tiledb_ctx_t* ctx, const char* group_uri, tiledb_group_t** group) {
   return api_entry_with_context<tiledb::api::tiledb_group_alloc>(
       ctx, group_uri, group);
 }
 
-capi_return_t tiledb_group_open(
+CAPI_INTERFACE(group_open,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
-    tiledb_query_type_t query_type) noexcept {
+    tiledb_query_type_t query_type) {
   return api_entry_context<tiledb::api::tiledb_group_open>(
       ctx, group, query_type);
 }
 
-capi_return_t tiledb_group_close(
-    tiledb_ctx_t* ctx, tiledb_group_t* group) noexcept {
+CAPI_INTERFACE(group_close,
+    tiledb_ctx_t* ctx, tiledb_group_t* group) {
   return api_entry_context<tiledb::api::tiledb_group_close>(ctx, group);
 }
 
-void tiledb_group_free(tiledb_group_t** group) noexcept {
+CAPI_INTERFACE_VOID(group_free,tiledb_group_t** group) {
   return api_entry_void<tiledb::api::tiledb_group_free>(group);
 }
 
-capi_return_t tiledb_group_set_config(
+CAPI_INTERFACE(group_set_config,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry_context<tiledb::api::tiledb_group_set_config>(
       ctx, group, config);
 }
 
-capi_return_t tiledb_group_get_config(
+CAPI_INTERFACE(group_get_config,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
-    tiledb_config_t** config) noexcept {
+    tiledb_config_t** config) {
   return api_entry_context<tiledb::api::tiledb_group_get_config>(
       ctx, group, config);
 }
 
-capi_return_t tiledb_group_put_metadata(
+CAPI_INTERFACE(group_put_metadata,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* key,
     tiledb_datatype_t value_type,
     uint32_t value_num,
-    const void* value) noexcept {
+    const void* value) {
   return api_entry_context<tiledb::api::tiledb_group_put_metadata>(
       ctx, group, key, value_type, value_num, value);
 }
 
-capi_return_t tiledb_group_delete_group(
+CAPI_INTERFACE(group_delete_group,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* uri,
-    const uint8_t recursive) noexcept {
+    const uint8_t recursive) {
   return api_entry_context<tiledb::api::tiledb_group_delete_group>(
       ctx, group, uri, recursive);
 }
 
-capi_return_t tiledb_group_delete_metadata(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* key) noexcept {
+CAPI_INTERFACE(group_delete_metadata,
+    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* key) {
   return api_entry_context<tiledb::api::tiledb_group_delete_metadata>(
       ctx, group, key);
 }
 
-capi_return_t tiledb_group_get_metadata(
+CAPI_INTERFACE(group_get_metadata,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* key,
     tiledb_datatype_t* value_type,
     uint32_t* value_num,
-    const void** value) noexcept {
+    const void** value) {
   return api_entry_context<tiledb::api::tiledb_group_get_metadata>(
       ctx, group, key, value_type, value_num, value);
 }
 
-capi_return_t tiledb_group_get_metadata_num(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* num) noexcept {
+CAPI_INTERFACE(group_get_metadata_num,
+    tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* num) {
   return api_entry_context<tiledb::api::tiledb_group_get_metadata_num>(
       ctx, group, num);
 }
 
-capi_return_t tiledb_group_get_metadata_from_index(
+CAPI_INTERFACE(group_get_metadata_from_index,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     uint64_t index,
@@ -645,153 +645,153 @@ capi_return_t tiledb_group_get_metadata_from_index(
     uint32_t* key_len,
     tiledb_datatype_t* value_type,
     uint32_t* value_num,
-    const void** value) noexcept {
+    const void** value) {
   return api_entry_context<tiledb::api::tiledb_group_get_metadata_from_index>(
       ctx, group, index, key, key_len, value_type, value_num, value);
 }
 
-capi_return_t tiledb_group_has_metadata_key(
+CAPI_INTERFACE(group_has_metadata_key,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* key,
     tiledb_datatype_t* value_type,
-    int32_t* has_key) noexcept {
+    int32_t* has_key) {
   return api_entry_context<tiledb::api::tiledb_group_has_metadata_key>(
       ctx, group, key, value_type, has_key);
 }
 
-capi_return_t tiledb_group_add_member(
+CAPI_INTERFACE(group_add_member,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* uri,
     const uint8_t relative,
-    const char* name) noexcept {
+    const char* name) {
   return api_entry_context<tiledb::api::tiledb_group_add_member>(
       ctx, group, uri, relative, name);
 }
 
-capi_return_t tiledb_group_remove_member(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* name) noexcept {
+CAPI_INTERFACE(group_remove_member,
+    tiledb_ctx_t* ctx, tiledb_group_t* group, const char* name) {
   return api_entry_context<tiledb::api::tiledb_group_remove_member>(
       ctx, group, name);
 }
 
-capi_return_t tiledb_group_get_member_count(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* count) noexcept {
+CAPI_INTERFACE(group_get_member_count,
+    tiledb_ctx_t* ctx, tiledb_group_t* group, uint64_t* count) {
   return api_entry_context<tiledb::api::tiledb_group_get_member_count>(
       ctx, group, count);
 }
 
-capi_return_t tiledb_group_get_member_by_index(
+CAPI_INTERFACE(group_get_member_by_index,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     uint64_t index,
     char** uri,
     tiledb_object_t* type,
-    char** name) noexcept {
+    char** name) {
   return api_entry_context<tiledb::api::tiledb_group_get_member_by_index>(
       ctx, group, index, uri, type, name);
 }
 
-capi_return_t tiledb_group_get_member_by_name(
+CAPI_INTERFACE(group_get_member_by_name,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* name,
     char** uri,
-    tiledb_object_t* type) noexcept {
+    tiledb_object_t* type) {
   return api_entry_context<tiledb::api::tiledb_group_get_member_by_name>(
       ctx, group, name, uri, type);
 }
 
-capi_return_t tiledb_group_get_is_relative_uri_by_name(
+CAPI_INTERFACE(group_get_is_relative_uri_by_name,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     const char* name,
-    uint8_t* relative) noexcept {
+    uint8_t* relative) {
   return api_entry_context<
       tiledb::api::tiledb_group_get_is_relative_uri_by_name>(
       ctx, group, name, relative);
 }
 
-capi_return_t tiledb_group_is_open(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, int32_t* is_open) noexcept {
+CAPI_INTERFACE(group_is_open,
+    tiledb_ctx_t* ctx, tiledb_group_t* group, int32_t* is_open) {
   return api_entry_context<tiledb::api::tiledb_group_is_open>(
       ctx, group, is_open);
 }
 
-capi_return_t tiledb_group_get_uri(
-    tiledb_ctx_t* ctx, tiledb_group_t* group, const char** group_uri) noexcept {
+CAPI_INTERFACE(group_get_uri,
+    tiledb_ctx_t* ctx, tiledb_group_t* group, const char** group_uri) {
   return api_entry_context<tiledb::api::tiledb_group_get_uri>(
       ctx, group, group_uri);
 }
 
-capi_return_t tiledb_group_get_query_type(
+CAPI_INTERFACE(group_get_query_type,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
-    tiledb_query_type_t* query_type) noexcept {
+    tiledb_query_type_t* query_type) {
   return api_entry_context<tiledb::api::tiledb_group_get_query_type>(
       ctx, group, query_type);
 }
 
-capi_return_t tiledb_group_dump_str(
+CAPI_INTERFACE(group_dump_str,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     char** dump_ascii,
-    const uint8_t recursive) noexcept {
+    const uint8_t recursive) {
   return api_entry_context<tiledb::api::tiledb_group_dump_str>(
       ctx, group, dump_ascii, recursive);
 }
 
-capi_return_t tiledb_serialize_group(
+CAPI_INTERFACE(serialize_group,
     tiledb_ctx_t* ctx,
     const tiledb_group_t* group,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer_list) noexcept {
+    tiledb_buffer_t** buffer_list) {
   return api_entry_context<tiledb::api::tiledb_serialize_group>(
       ctx, group, serialize_type, client_side, buffer_list);
 }
 
-capi_return_t tiledb_deserialize_group(
+CAPI_INTERFACE(deserialize_group,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_group_t* group) noexcept {
+    tiledb_group_t* group) {
   return api_entry_context<tiledb::api::tiledb_deserialize_group>(
       ctx, buffer, serialize_type, client_side, group);
 }
 
-capi_return_t tiledb_serialize_group_metadata(
+CAPI_INTERFACE(serialize_group_metadata,
     tiledb_ctx_t* ctx,
     const tiledb_group_t* group,
     tiledb_serialization_type_t serialization_type,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry_context<tiledb::api::tiledb_serialize_group_metadata>(
       ctx, group, serialization_type, buffer);
 }
 
-capi_return_t tiledb_deserialize_group_metadata(
+CAPI_INTERFACE(deserialize_group_metadata,
     tiledb_ctx_t* ctx,
     tiledb_group_t* group,
     tiledb_serialization_type_t serialization_type,
-    const tiledb_buffer_t* buffer) noexcept {
+    const tiledb_buffer_t* buffer) {
   return api_entry_context<tiledb::api::tiledb_deserialize_group_metadata>(
       ctx, group, serialization_type, buffer);
 }
 
-capi_return_t tiledb_group_consolidate_metadata(
+CAPI_INTERFACE(group_consolidate_metadata,
     tiledb_ctx_t* ctx,
     const char* group_uri,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry_with_context<tiledb::api::tiledb_group_consolidate_metadata>(
       ctx, group_uri, config);
 }
 
-capi_return_t tiledb_group_vacuum_metadata(
+CAPI_INTERFACE(group_vacuum_metadata,
     tiledb_ctx_t* ctx,
     const char* group_uri,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry_with_context<tiledb::api::tiledb_group_vacuum_metadata>(
       ctx, group_uri, config);
 }

--- a/tiledb/api/c_api/object/object_api.cc
+++ b/tiledb/api/c_api/object/object_api.cc
@@ -88,26 +88,26 @@ capi_return_t tiledb_walk_order_from_str(
 using tiledb::api::api_entry_plain;
 using tiledb::api::api_entry_with_context;
 
-capi_return_t tiledb_object_type_to_str(
-    tiledb_object_t object_type, const char** str) noexcept {
+CAPI_INTERFACE(object_type_to_str,
+    tiledb_object_t object_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_object_type_to_str>(
       object_type, str);
 }
 
-capi_return_t tiledb_object_type_from_str(
-    const char* str, tiledb_object_t* object_type) noexcept {
+CAPI_INTERFACE(object_type_from_str,
+    const char* str, tiledb_object_t* object_type) {
   return api_entry_plain<tiledb::api::tiledb_object_type_from_str>(
       str, object_type);
 }
 
-capi_return_t tiledb_walk_order_to_str(
-    tiledb_walk_order_t walk_order, const char** str) noexcept {
+CAPI_INTERFACE(walk_order_to_str,
+    tiledb_walk_order_t walk_order, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_walk_order_to_str>(
       walk_order, str);
 }
 
-capi_return_t tiledb_walk_order_from_str(
-    const char* str, tiledb_walk_order_t* walk_order) noexcept {
+CAPI_INTERFACE(walk_order_from_str,
+    const char* str, tiledb_walk_order_t* walk_order) {
   return api_entry_plain<tiledb::api::tiledb_walk_order_from_str>(
       str, walk_order);
 }

--- a/tiledb/api/c_api/object/object_api.cc
+++ b/tiledb/api/c_api/object/object_api.cc
@@ -88,26 +88,26 @@ capi_return_t tiledb_walk_order_from_str(
 using tiledb::api::api_entry_plain;
 using tiledb::api::api_entry_with_context;
 
-CAPI_INTERFACE(object_type_to_str,
-    tiledb_object_t object_type, const char** str) {
+CAPI_INTERFACE(
+    object_type_to_str, tiledb_object_t object_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_object_type_to_str>(
       object_type, str);
 }
 
-CAPI_INTERFACE(object_type_from_str,
-    const char* str, tiledb_object_t* object_type) {
+CAPI_INTERFACE(
+    object_type_from_str, const char* str, tiledb_object_t* object_type) {
   return api_entry_plain<tiledb::api::tiledb_object_type_from_str>(
       str, object_type);
 }
 
-CAPI_INTERFACE(walk_order_to_str,
-    tiledb_walk_order_t walk_order, const char** str) {
+CAPI_INTERFACE(
+    walk_order_to_str, tiledb_walk_order_t walk_order, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_walk_order_to_str>(
       walk_order, str);
 }
 
-CAPI_INTERFACE(walk_order_from_str,
-    const char* str, tiledb_walk_order_t* walk_order) {
+CAPI_INTERFACE(
+    walk_order_from_str, const char* str, tiledb_walk_order_t* walk_order) {
   return api_entry_plain<tiledb::api::tiledb_walk_order_from_str>(
       str, walk_order);
 }

--- a/tiledb/api/c_api/query/query_api.cc
+++ b/tiledb/api/c_api/query/query_api.cc
@@ -57,14 +57,14 @@ int32_t tiledb_query_type_from_str(
 
 using tiledb::api::api_entry_plain;
 
-int32_t tiledb_query_type_to_str(
-    tiledb_query_type_t query_type, const char** str) noexcept {
+CAPI_INTERFACE(query_type_to_str,
+    tiledb_query_type_t query_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_query_type_to_str>(
       query_type, str);
 }
 
-int32_t tiledb_query_type_from_str(
-    const char* str, tiledb_query_type_t* query_type) noexcept {
+CAPI_INTERFACE(query_type_from_str,
+    const char* str, tiledb_query_type_t* query_type) {
   return api_entry_plain<tiledb::api::tiledb_query_type_from_str>(
       str, query_type);
 }

--- a/tiledb/api/c_api/query/query_api.cc
+++ b/tiledb/api/c_api/query/query_api.cc
@@ -57,14 +57,14 @@ int32_t tiledb_query_type_from_str(
 
 using tiledb::api::api_entry_plain;
 
-CAPI_INTERFACE(query_type_to_str,
-    tiledb_query_type_t query_type, const char** str) {
+CAPI_INTERFACE(
+    query_type_to_str, tiledb_query_type_t query_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_query_type_to_str>(
       query_type, str);
 }
 
-CAPI_INTERFACE(query_type_from_str,
-    const char* str, tiledb_query_type_t* query_type) {
+CAPI_INTERFACE(
+    query_type_from_str, const char* str, tiledb_query_type_t* query_type) {
   return api_entry_plain<tiledb::api::tiledb_query_type_from_str>(
       str, query_type);
 }

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -269,43 +269,56 @@ tiledb_channel_operator_handle_t::make_operation(
 
 using tiledb::api::api_entry_with_context;
 
-CAPI_INTERFACE(channel_operator_sum_get,
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+CAPI_INTERFACE(
+    channel_operator_sum_get,
+    tiledb_ctx_t* ctx,
+    const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_sum_get>(
       ctx, op);
 }
 
-CAPI_INTERFACE(channel_operator_mean_get,
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+CAPI_INTERFACE(
+    channel_operator_mean_get,
+    tiledb_ctx_t* ctx,
+    const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_mean_get>(
       ctx, op);
 }
 
-CAPI_INTERFACE(channel_operator_min_get,
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+CAPI_INTERFACE(
+    channel_operator_min_get,
+    tiledb_ctx_t* ctx,
+    const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_min_get>(
       ctx, op);
 }
 
-CAPI_INTERFACE(channel_operator_max_get,
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+CAPI_INTERFACE(
+    channel_operator_max_get,
+    tiledb_ctx_t* ctx,
+    const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_max_get>(
       ctx, op);
 }
 
-CAPI_INTERFACE(channel_operator_null_count_get,
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
+CAPI_INTERFACE(
+    channel_operator_null_count_get,
+    tiledb_ctx_t* ctx,
+    const tiledb_channel_operator_t** op) {
   return api_entry_with_context<
       tiledb::api::tiledb_channel_operator_null_count_get>(ctx, op);
 }
 
-CAPI_INTERFACE(aggregate_count_get,
-    tiledb_ctx_t* ctx, const tiledb_channel_operation_t** operation) {
+CAPI_INTERFACE(
+    aggregate_count_get,
+    tiledb_ctx_t* ctx,
+    const tiledb_channel_operation_t** operation) {
   return api_entry_with_context<tiledb::api::tiledb_aggregate_count_get>(
       ctx, operation);
 }
 
-CAPI_INTERFACE(query_get_default_channel,
+CAPI_INTERFACE(
+    query_get_default_channel,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_query_channel_t** channel) {
@@ -313,7 +326,8 @@ CAPI_INTERFACE(query_get_default_channel,
       ctx, query, channel);
 }
 
-CAPI_INTERFACE(create_unary_aggregate,
+CAPI_INTERFACE(
+    create_unary_aggregate,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const tiledb_channel_operator_t* op,
@@ -323,7 +337,8 @@ CAPI_INTERFACE(create_unary_aggregate,
       ctx, query, op, input_field_name, operation);
 }
 
-CAPI_INTERFACE(channel_apply_aggregate,
+CAPI_INTERFACE(
+    channel_apply_aggregate,
     tiledb_ctx_t* ctx,
     tiledb_query_channel_t* channel,
     const char* output_field_name,
@@ -332,14 +347,14 @@ CAPI_INTERFACE(channel_apply_aggregate,
       ctx, channel, output_field_name, operation);
 }
 
-CAPI_INTERFACE(aggregate_free,
-    tiledb_ctx_t* ctx, tiledb_channel_operation_t** operation) {
+CAPI_INTERFACE(
+    aggregate_free, tiledb_ctx_t* ctx, tiledb_channel_operation_t** operation) {
   return tiledb::api::api_entry_with_context<
       tiledb::api::tiledb_aggregate_free>(ctx, operation);
 }
 
-CAPI_INTERFACE(query_channel_free,
-    tiledb_ctx_t* ctx, tiledb_query_channel_t** channel) {
+CAPI_INTERFACE(
+    query_channel_free, tiledb_ctx_t* ctx, tiledb_query_channel_t** channel) {
   return tiledb::api::api_entry_with_context<
       tiledb::api::tiledb_query_channel_free>(ctx, channel);
 }

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -269,77 +269,77 @@ tiledb_channel_operator_handle_t::make_operation(
 
 using tiledb::api::api_entry_with_context;
 
-capi_return_t tiledb_channel_operator_sum_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+CAPI_INTERFACE(channel_operator_sum_get,
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_sum_get>(
       ctx, op);
 }
 
-capi_return_t tiledb_channel_operator_mean_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+CAPI_INTERFACE(channel_operator_mean_get,
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_mean_get>(
       ctx, op);
 }
 
-capi_return_t tiledb_channel_operator_min_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+CAPI_INTERFACE(channel_operator_min_get,
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_min_get>(
       ctx, op);
 }
 
-capi_return_t tiledb_channel_operator_max_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+CAPI_INTERFACE(channel_operator_max_get,
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
   return api_entry_with_context<tiledb::api::tiledb_channel_operator_max_get>(
       ctx, op);
 }
 
-capi_return_t tiledb_channel_operator_null_count_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) noexcept {
+CAPI_INTERFACE(channel_operator_null_count_get,
+    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
   return api_entry_with_context<
       tiledb::api::tiledb_channel_operator_null_count_get>(ctx, op);
 }
 
-capi_return_t tiledb_aggregate_count_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operation_t** operation) noexcept {
+CAPI_INTERFACE(aggregate_count_get,
+    tiledb_ctx_t* ctx, const tiledb_channel_operation_t** operation) {
   return api_entry_with_context<tiledb::api::tiledb_aggregate_count_get>(
       ctx, operation);
 }
 
-capi_return_t tiledb_query_get_default_channel(
+CAPI_INTERFACE(query_get_default_channel,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_query_channel_t** channel) noexcept {
+    tiledb_query_channel_t** channel) {
   return api_entry_with_context<tiledb::api::tiledb_query_get_default_channel>(
       ctx, query, channel);
 }
 
-capi_return_t tiledb_create_unary_aggregate(
+CAPI_INTERFACE(create_unary_aggregate,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const tiledb_channel_operator_t* op,
     const char* input_field_name,
-    tiledb_channel_operation_t** operation) noexcept {
+    tiledb_channel_operation_t** operation) {
   return api_entry_with_context<tiledb::api::tiledb_create_unary_aggregate>(
       ctx, query, op, input_field_name, operation);
 }
 
-capi_return_t tiledb_channel_apply_aggregate(
+CAPI_INTERFACE(channel_apply_aggregate,
     tiledb_ctx_t* ctx,
     tiledb_query_channel_t* channel,
     const char* output_field_name,
-    const tiledb_channel_operation_t* operation) noexcept {
+    const tiledb_channel_operation_t* operation) {
   return api_entry_with_context<tiledb::api::tiledb_channel_apply_aggregate>(
       ctx, channel, output_field_name, operation);
 }
 
-capi_return_t tiledb_aggregate_free(
-    tiledb_ctx_t* ctx, tiledb_channel_operation_t** operation) noexcept {
+CAPI_INTERFACE(aggregate_free,
+    tiledb_ctx_t* ctx, tiledb_channel_operation_t** operation) {
   return tiledb::api::api_entry_with_context<
       tiledb::api::tiledb_aggregate_free>(ctx, operation);
 }
 
-capi_return_t tiledb_query_channel_free(
-    tiledb_ctx_t* ctx, tiledb_query_channel_t** channel) noexcept {
+CAPI_INTERFACE(query_channel_free,
+    tiledb_ctx_t* ctx, tiledb_query_channel_t** channel) {
   return tiledb::api::api_entry_with_context<
       tiledb::api::tiledb_query_channel_free>(ctx, channel);
 }

--- a/tiledb/api/c_api/query_field/query_field_api.cc
+++ b/tiledb/api/c_api/query_field/query_field_api.cc
@@ -161,7 +161,8 @@ capi_return_t tiledb_field_channel(
 
 using tiledb::api::api_entry_context;
 
-CAPI_INTERFACE(query_get_field,
+CAPI_INTERFACE(
+    query_get_field,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* field_name,
@@ -170,12 +171,13 @@ CAPI_INTERFACE(query_get_field,
       ctx, query, field_name, field);
 }
 
-CAPI_INTERFACE(query_field_free,
-    tiledb_ctx_t* ctx, tiledb_query_field_t** field) {
+CAPI_INTERFACE(
+    query_field_free, tiledb_ctx_t* ctx, tiledb_query_field_t** field) {
   return api_entry_context<tiledb::api::tiledb_query_field_free>(ctx, field);
 }
 
-CAPI_INTERFACE(field_datatype,
+CAPI_INTERFACE(
+    field_datatype,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
     tiledb_datatype_t* type) {
@@ -183,7 +185,8 @@ CAPI_INTERFACE(field_datatype,
       ctx, field, type);
 }
 
-CAPI_INTERFACE(field_cell_val_num,
+CAPI_INTERFACE(
+    field_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
     uint32_t* cell_val_num) {
@@ -191,7 +194,8 @@ CAPI_INTERFACE(field_cell_val_num,
       ctx, field, cell_val_num);
 }
 
-CAPI_INTERFACE(field_origin,
+CAPI_INTERFACE(
+    field_origin,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
     tiledb_field_origin_t* origin) {
@@ -199,7 +203,8 @@ CAPI_INTERFACE(field_origin,
       ctx, field, origin);
 }
 
-CAPI_INTERFACE(field_channel,
+CAPI_INTERFACE(
+    field_channel,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
     tiledb_query_channel_handle_t** channel) {

--- a/tiledb/api/c_api/query_field/query_field_api.cc
+++ b/tiledb/api/c_api/query_field/query_field_api.cc
@@ -161,48 +161,48 @@ capi_return_t tiledb_field_channel(
 
 using tiledb::api::api_entry_context;
 
-capi_return_t tiledb_query_get_field(
+CAPI_INTERFACE(query_get_field,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* field_name,
-    tiledb_query_field_t** field) noexcept {
+    tiledb_query_field_t** field) {
   return api_entry_context<tiledb::api::tiledb_query_get_field>(
       ctx, query, field_name, field);
 }
 
-capi_return_t tiledb_query_field_free(
-    tiledb_ctx_t* ctx, tiledb_query_field_t** field) noexcept {
+CAPI_INTERFACE(query_field_free,
+    tiledb_ctx_t* ctx, tiledb_query_field_t** field) {
   return api_entry_context<tiledb::api::tiledb_query_field_free>(ctx, field);
 }
 
-capi_return_t tiledb_field_datatype(
+CAPI_INTERFACE(field_datatype,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
-    tiledb_datatype_t* type) noexcept {
+    tiledb_datatype_t* type) {
   return api_entry_context<tiledb::api::tiledb_field_datatype>(
       ctx, field, type);
 }
 
-capi_return_t tiledb_field_cell_val_num(
+CAPI_INTERFACE(field_cell_val_num,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
-    uint32_t* cell_val_num) noexcept {
+    uint32_t* cell_val_num) {
   return api_entry_context<tiledb::api::tiledb_field_cell_val_num>(
       ctx, field, cell_val_num);
 }
 
-capi_return_t tiledb_field_origin(
+CAPI_INTERFACE(field_origin,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
-    tiledb_field_origin_t* origin) noexcept {
+    tiledb_field_origin_t* origin) {
   return api_entry_context<tiledb::api::tiledb_field_origin>(
       ctx, field, origin);
 }
 
-capi_return_t tiledb_field_channel(
+CAPI_INTERFACE(field_channel,
     tiledb_ctx_t* ctx,
     tiledb_query_field_t* field,
-    tiledb_query_channel_handle_t** channel) noexcept {
+    tiledb_query_channel_handle_t** channel) {
   return api_entry_context<tiledb::api::tiledb_field_channel>(
       ctx, field, channel);
 }

--- a/tiledb/api/c_api/query_plan/query_plan_api.cc
+++ b/tiledb/api/c_api/query_plan/query_plan_api.cc
@@ -59,7 +59,8 @@ capi_return_t tiledb_query_get_plan(
 
 using tiledb::api::api_entry_with_context;
 
-CAPI_INTERFACE(query_get_plan,
+CAPI_INTERFACE(
+    query_get_plan,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_string_handle_t** rv) {

--- a/tiledb/api/c_api/query_plan/query_plan_api.cc
+++ b/tiledb/api/c_api/query_plan/query_plan_api.cc
@@ -59,10 +59,10 @@ capi_return_t tiledb_query_get_plan(
 
 using tiledb::api::api_entry_with_context;
 
-capi_return_t tiledb_query_get_plan(
+CAPI_INTERFACE(query_get_plan,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_string_handle_t** rv) noexcept {
+    tiledb_string_handle_t** rv) {
   return api_entry_with_context<tiledb::api::tiledb_query_get_plan>(
       ctx, query, rv);
 }

--- a/tiledb/api/c_api/string/string_api.cc
+++ b/tiledb/api/c_api/string/string_api.cc
@@ -56,12 +56,12 @@ capi_return_t tiledb_string_free(tiledb_string_handle_t** s) {
 
 }  // namespace tiledb::api
 
-capi_return_t tiledb_string_view(
-    tiledb_string_t* s, const char** data, size_t* length) noexcept {
+CAPI_INTERFACE(string_view,
+    tiledb_string_t* s, const char** data, size_t* length) {
   return tiledb::api::api_entry_plain<tiledb::api::tiledb_string_view>(
       s, data, length);
 }
 
-capi_return_t tiledb_string_free(tiledb_string_handle_t** s) noexcept {
+CAPI_INTERFACE(string_free,tiledb_string_handle_t** s) {
   return tiledb::api::api_entry_plain<tiledb::api::tiledb_string_free>(s);
 }

--- a/tiledb/api/c_api/string/string_api.cc
+++ b/tiledb/api/c_api/string/string_api.cc
@@ -56,12 +56,12 @@ capi_return_t tiledb_string_free(tiledb_string_handle_t** s) {
 
 }  // namespace tiledb::api
 
-CAPI_INTERFACE(string_view,
-    tiledb_string_t* s, const char** data, size_t* length) {
+CAPI_INTERFACE(
+    string_view, tiledb_string_t* s, const char** data, size_t* length) {
   return tiledb::api::api_entry_plain<tiledb::api::tiledb_string_view>(
       s, data, length);
 }
 
-CAPI_INTERFACE(string_free,tiledb_string_handle_t** s) {
+CAPI_INTERFACE(string_free, tiledb_string_handle_t** s) {
   return tiledb::api::api_entry_plain<tiledb::api::tiledb_string_free>(s);
 }

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -316,213 +316,213 @@ capi_return_t tiledb_vfs_touch(tiledb_vfs_t* vfs, const char* uri) {
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_plain;
 
-capi_return_t tiledb_vfs_mode_to_str(
-    tiledb_vfs_mode_t vfs_mode, const char** str) noexcept {
+CAPI_INTERFACE(vfs_mode_to_str,
+    tiledb_vfs_mode_t vfs_mode, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_vfs_mode_to_str>(vfs_mode, str);
 }
 
-capi_return_t tiledb_vfs_mode_from_str(
-    const char* str, tiledb_vfs_mode_t* vfs_mode) noexcept {
+CAPI_INTERFACE(vfs_mode_from_str,
+    const char* str, tiledb_vfs_mode_t* vfs_mode) {
   return api_entry_plain<tiledb::api::tiledb_vfs_mode_from_str>(str, vfs_mode);
 }
 
-capi_return_t tiledb_vfs_alloc(
-    tiledb_ctx_t* ctx, tiledb_config_t* config, tiledb_vfs_t** vfs) noexcept {
+CAPI_INTERFACE(vfs_alloc,
+    tiledb_ctx_t* ctx, tiledb_config_t* config, tiledb_vfs_t** vfs) {
   return tiledb::api::api_entry_with_context<tiledb::api::tiledb_vfs_alloc>(
       ctx, config, vfs);
 }
 
-void tiledb_vfs_free(tiledb_vfs_t** vfs) noexcept {
+CAPI_INTERFACE_VOID(vfs_free,tiledb_vfs_t** vfs) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_vfs_free>(vfs);
 }
 
-capi_return_t tiledb_vfs_get_config(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, tiledb_config_t** config) noexcept {
+CAPI_INTERFACE(vfs_get_config,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, tiledb_config_t** config) {
   return api_entry_context<tiledb::api::tiledb_vfs_get_config>(
       ctx, vfs, config);
 }
 
-capi_return_t tiledb_vfs_create_bucket(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_create_bucket,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_create_bucket>(
       ctx, vfs, uri);
 }
 
-capi_return_t tiledb_vfs_remove_bucket(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_remove_bucket,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_remove_bucket>(
       ctx, vfs, uri);
 }
 
-capi_return_t tiledb_vfs_empty_bucket(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_empty_bucket,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_empty_bucket>(ctx, vfs, uri);
 }
 
-capi_return_t tiledb_vfs_is_empty_bucket(
+CAPI_INTERFACE(vfs_is_empty_bucket,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry_context<tiledb::api::tiledb_vfs_is_empty_bucket>(
       ctx, vfs, uri, is_empty);
 }
 
-capi_return_t tiledb_vfs_is_bucket(
+CAPI_INTERFACE(vfs_is_bucket,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
-    int32_t* is_bucket) noexcept {
+    int32_t* is_bucket) {
   return api_entry_context<tiledb::api::tiledb_vfs_is_bucket>(
       ctx, vfs, uri, is_bucket);
 }
 
-capi_return_t tiledb_vfs_create_dir(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_create_dir,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_create_dir>(ctx, vfs, uri);
 }
 
-capi_return_t tiledb_vfs_is_dir(
+CAPI_INTERFACE(vfs_is_dir,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
-    int32_t* is_dir) noexcept {
+    int32_t* is_dir) {
   return api_entry_context<tiledb::api::tiledb_vfs_is_dir>(
       ctx, vfs, uri, is_dir);
 }
 
-capi_return_t tiledb_vfs_remove_dir(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_remove_dir,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_remove_dir>(ctx, vfs, uri);
 }
 
-capi_return_t tiledb_vfs_is_file(
+CAPI_INTERFACE(vfs_is_file,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
-    int32_t* is_file) noexcept {
+    int32_t* is_file) {
   return api_entry_context<tiledb::api::tiledb_vfs_is_file>(
       ctx, vfs, uri, is_file);
 }
 
-capi_return_t tiledb_vfs_remove_file(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_remove_file,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_remove_file>(ctx, vfs, uri);
 }
 
-capi_return_t tiledb_vfs_dir_size(
+CAPI_INTERFACE(vfs_dir_size,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
-    uint64_t* size) noexcept {
+    uint64_t* size) {
   return api_entry_context<tiledb::api::tiledb_vfs_dir_size>(
       ctx, vfs, uri, size);
 }
 
-capi_return_t tiledb_vfs_file_size(
+CAPI_INTERFACE(vfs_file_size,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
-    uint64_t* size) noexcept {
+    uint64_t* size) {
   return api_entry_context<tiledb::api::tiledb_vfs_file_size>(
       ctx, vfs, uri, size);
 }
 
-capi_return_t tiledb_vfs_move_file(
+CAPI_INTERFACE(vfs_move_file,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
-    const char* new_uri) noexcept {
+    const char* new_uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_move_file>(
       ctx, vfs, old_uri, new_uri);
 }
 
-capi_return_t tiledb_vfs_move_dir(
+CAPI_INTERFACE(vfs_move_dir,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
-    const char* new_uri) noexcept {
+    const char* new_uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_move_dir>(
       ctx, vfs, old_uri, new_uri);
 }
 
-capi_return_t tiledb_vfs_copy_file(
+CAPI_INTERFACE(vfs_copy_file,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
-    const char* new_uri) noexcept {
+    const char* new_uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_copy_file>(
       ctx, vfs, old_uri, new_uri);
 }
 
-capi_return_t tiledb_vfs_copy_dir(
+CAPI_INTERFACE(vfs_copy_dir,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
-    const char* new_uri) noexcept {
+    const char* new_uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_copy_dir>(
       ctx, vfs, old_uri, new_uri);
 }
 
-capi_return_t tiledb_vfs_open(
+CAPI_INTERFACE(vfs_open,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
     tiledb_vfs_mode_t mode,
-    tiledb_vfs_fh_t** fh) noexcept {
+    tiledb_vfs_fh_t** fh) {
   return api_entry_context<tiledb::api::tiledb_vfs_open>(
       ctx, vfs, uri, mode, fh);
 }
 
-capi_return_t tiledb_vfs_close(
-    tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) noexcept {
+CAPI_INTERFACE(vfs_close,
+    tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
   return api_entry_context<tiledb::api::tiledb_vfs_close>(ctx, fh);
 }
 
-capi_return_t tiledb_vfs_read(
+CAPI_INTERFACE(vfs_read,
     tiledb_ctx_t* ctx,
     tiledb_vfs_fh_t* fh,
     uint64_t offset,
     void* buffer,
-    uint64_t nbytes) noexcept {
+    uint64_t nbytes) {
   return api_entry_context<tiledb::api::tiledb_vfs_read>(
       ctx, fh, offset, buffer, nbytes);
 }
 
-capi_return_t tiledb_vfs_write(
+CAPI_INTERFACE(vfs_write,
     tiledb_ctx_t* ctx,
     tiledb_vfs_fh_t* fh,
     const void* buffer,
-    uint64_t nbytes) noexcept {
+    uint64_t nbytes) {
   return api_entry_context<tiledb::api::tiledb_vfs_write>(
       ctx, fh, buffer, nbytes);
 }
 
-capi_return_t tiledb_vfs_sync(tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) noexcept {
+CAPI_INTERFACE(vfs_sync,tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
   return api_entry_context<tiledb::api::tiledb_vfs_sync>(ctx, fh);
 }
 
-capi_return_t tiledb_vfs_ls(
+CAPI_INTERFACE(vfs_ls,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
     int32_t (*callback)(const char*, void*),
-    void* data) noexcept {
+    void* data) {
   return api_entry_context<tiledb::api::tiledb_vfs_ls>(
       ctx, vfs, path, callback, data);
 }
 
-void tiledb_vfs_fh_free(tiledb_vfs_fh_t** fh) noexcept {
+CAPI_INTERFACE_VOID(vfs_fh_free,tiledb_vfs_fh_t** fh) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_vfs_fh_free>(fh);
 }
 
-capi_return_t tiledb_vfs_fh_is_closed(
-    tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh, int32_t* is_closed) noexcept {
+CAPI_INTERFACE(vfs_fh_is_closed,
+    tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh, int32_t* is_closed) {
   return api_entry_context<tiledb::api::tiledb_vfs_fh_is_closed>(
       ctx, fh, is_closed);
 }
 
-capi_return_t tiledb_vfs_touch(
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) noexcept {
+CAPI_INTERFACE(vfs_touch,
+    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_touch>(ctx, vfs, uri);
 }

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -316,50 +316,53 @@ capi_return_t tiledb_vfs_touch(tiledb_vfs_t* vfs, const char* uri) {
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_plain;
 
-CAPI_INTERFACE(vfs_mode_to_str,
-    tiledb_vfs_mode_t vfs_mode, const char** str) {
+CAPI_INTERFACE(vfs_mode_to_str, tiledb_vfs_mode_t vfs_mode, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_vfs_mode_to_str>(vfs_mode, str);
 }
 
-CAPI_INTERFACE(vfs_mode_from_str,
-    const char* str, tiledb_vfs_mode_t* vfs_mode) {
+CAPI_INTERFACE(
+    vfs_mode_from_str, const char* str, tiledb_vfs_mode_t* vfs_mode) {
   return api_entry_plain<tiledb::api::tiledb_vfs_mode_from_str>(str, vfs_mode);
 }
 
-CAPI_INTERFACE(vfs_alloc,
-    tiledb_ctx_t* ctx, tiledb_config_t* config, tiledb_vfs_t** vfs) {
+CAPI_INTERFACE(
+    vfs_alloc, tiledb_ctx_t* ctx, tiledb_config_t* config, tiledb_vfs_t** vfs) {
   return tiledb::api::api_entry_with_context<tiledb::api::tiledb_vfs_alloc>(
       ctx, config, vfs);
 }
 
-CAPI_INTERFACE_VOID(vfs_free,tiledb_vfs_t** vfs) {
+CAPI_INTERFACE_VOID(vfs_free, tiledb_vfs_t** vfs) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_vfs_free>(vfs);
 }
 
-CAPI_INTERFACE(vfs_get_config,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, tiledb_config_t** config) {
+CAPI_INTERFACE(
+    vfs_get_config,
+    tiledb_ctx_t* ctx,
+    tiledb_vfs_t* vfs,
+    tiledb_config_t** config) {
   return api_entry_context<tiledb::api::tiledb_vfs_get_config>(
       ctx, vfs, config);
 }
 
-CAPI_INTERFACE(vfs_create_bucket,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_create_bucket, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_create_bucket>(
       ctx, vfs, uri);
 }
 
-CAPI_INTERFACE(vfs_remove_bucket,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_remove_bucket, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_remove_bucket>(
       ctx, vfs, uri);
 }
 
-CAPI_INTERFACE(vfs_empty_bucket,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_empty_bucket, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_empty_bucket>(ctx, vfs, uri);
 }
 
-CAPI_INTERFACE(vfs_is_empty_bucket,
+CAPI_INTERFACE(
+    vfs_is_empty_bucket,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -368,7 +371,8 @@ CAPI_INTERFACE(vfs_is_empty_bucket,
       ctx, vfs, uri, is_empty);
 }
 
-CAPI_INTERFACE(vfs_is_bucket,
+CAPI_INTERFACE(
+    vfs_is_bucket,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -377,12 +381,13 @@ CAPI_INTERFACE(vfs_is_bucket,
       ctx, vfs, uri, is_bucket);
 }
 
-CAPI_INTERFACE(vfs_create_dir,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_create_dir, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_create_dir>(ctx, vfs, uri);
 }
 
-CAPI_INTERFACE(vfs_is_dir,
+CAPI_INTERFACE(
+    vfs_is_dir,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -391,12 +396,13 @@ CAPI_INTERFACE(vfs_is_dir,
       ctx, vfs, uri, is_dir);
 }
 
-CAPI_INTERFACE(vfs_remove_dir,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_remove_dir, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_remove_dir>(ctx, vfs, uri);
 }
 
-CAPI_INTERFACE(vfs_is_file,
+CAPI_INTERFACE(
+    vfs_is_file,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -405,12 +411,13 @@ CAPI_INTERFACE(vfs_is_file,
       ctx, vfs, uri, is_file);
 }
 
-CAPI_INTERFACE(vfs_remove_file,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_remove_file, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_remove_file>(ctx, vfs, uri);
 }
 
-CAPI_INTERFACE(vfs_dir_size,
+CAPI_INTERFACE(
+    vfs_dir_size,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -419,7 +426,8 @@ CAPI_INTERFACE(vfs_dir_size,
       ctx, vfs, uri, size);
 }
 
-CAPI_INTERFACE(vfs_file_size,
+CAPI_INTERFACE(
+    vfs_file_size,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -428,7 +436,8 @@ CAPI_INTERFACE(vfs_file_size,
       ctx, vfs, uri, size);
 }
 
-CAPI_INTERFACE(vfs_move_file,
+CAPI_INTERFACE(
+    vfs_move_file,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
@@ -437,7 +446,8 @@ CAPI_INTERFACE(vfs_move_file,
       ctx, vfs, old_uri, new_uri);
 }
 
-CAPI_INTERFACE(vfs_move_dir,
+CAPI_INTERFACE(
+    vfs_move_dir,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
@@ -446,7 +456,8 @@ CAPI_INTERFACE(vfs_move_dir,
       ctx, vfs, old_uri, new_uri);
 }
 
-CAPI_INTERFACE(vfs_copy_file,
+CAPI_INTERFACE(
+    vfs_copy_file,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
@@ -455,7 +466,8 @@ CAPI_INTERFACE(vfs_copy_file,
       ctx, vfs, old_uri, new_uri);
 }
 
-CAPI_INTERFACE(vfs_copy_dir,
+CAPI_INTERFACE(
+    vfs_copy_dir,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* old_uri,
@@ -464,7 +476,8 @@ CAPI_INTERFACE(vfs_copy_dir,
       ctx, vfs, old_uri, new_uri);
 }
 
-CAPI_INTERFACE(vfs_open,
+CAPI_INTERFACE(
+    vfs_open,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* uri,
@@ -474,12 +487,12 @@ CAPI_INTERFACE(vfs_open,
       ctx, vfs, uri, mode, fh);
 }
 
-CAPI_INTERFACE(vfs_close,
-    tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
+CAPI_INTERFACE(vfs_close, tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
   return api_entry_context<tiledb::api::tiledb_vfs_close>(ctx, fh);
 }
 
-CAPI_INTERFACE(vfs_read,
+CAPI_INTERFACE(
+    vfs_read,
     tiledb_ctx_t* ctx,
     tiledb_vfs_fh_t* fh,
     uint64_t offset,
@@ -489,7 +502,8 @@ CAPI_INTERFACE(vfs_read,
       ctx, fh, offset, buffer, nbytes);
 }
 
-CAPI_INTERFACE(vfs_write,
+CAPI_INTERFACE(
+    vfs_write,
     tiledb_ctx_t* ctx,
     tiledb_vfs_fh_t* fh,
     const void* buffer,
@@ -498,11 +512,12 @@ CAPI_INTERFACE(vfs_write,
       ctx, fh, buffer, nbytes);
 }
 
-CAPI_INTERFACE(vfs_sync,tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
+CAPI_INTERFACE(vfs_sync, tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh) {
   return api_entry_context<tiledb::api::tiledb_vfs_sync>(ctx, fh);
 }
 
-CAPI_INTERFACE(vfs_ls,
+CAPI_INTERFACE(
+    vfs_ls,
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
@@ -512,17 +527,20 @@ CAPI_INTERFACE(vfs_ls,
       ctx, vfs, path, callback, data);
 }
 
-CAPI_INTERFACE_VOID(vfs_fh_free,tiledb_vfs_fh_t** fh) {
+CAPI_INTERFACE_VOID(vfs_fh_free, tiledb_vfs_fh_t** fh) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_vfs_fh_free>(fh);
 }
 
-CAPI_INTERFACE(vfs_fh_is_closed,
-    tiledb_ctx_t* ctx, tiledb_vfs_fh_t* fh, int32_t* is_closed) {
+CAPI_INTERFACE(
+    vfs_fh_is_closed,
+    tiledb_ctx_t* ctx,
+    tiledb_vfs_fh_t* fh,
+    int32_t* is_closed) {
   return api_entry_context<tiledb::api::tiledb_vfs_fh_is_closed>(
       ctx, fh, is_closed);
 }
 
-CAPI_INTERFACE(vfs_touch,
-    tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
+CAPI_INTERFACE(
+    vfs_touch, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const char* uri) {
   return api_entry_context<tiledb::api::tiledb_vfs_touch>(ctx, vfs, uri);
 }

--- a/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
+++ b/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
@@ -56,6 +56,13 @@ capi_return_t tiledb_##root(__VA_ARGS__) noexcept
 CAPI_PREFIX(root)                      \
 void tiledb_##root(__VA_ARGS__) noexcept
 
+/*
+ * A variant of CAPI_INTERFACE for the handful of functions without arguments.
+ */
+#define CAPI_INTERFACE_NULL(root) \
+CAPI_PREFIX(root)                 \
+capi_return_t tiledb_##root(void) noexcept
+
 /* clang-format on */
 
 #endif  // TILEDB_CAPI_DEFINITION_H

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5251,60 +5251,60 @@ constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
 /* ****************************** */
 /*       ENUMS TO/FROM STR        */
 /* ****************************** */
-int32_t tiledb_array_type_to_str(
-    tiledb_array_type_t array_type, const char** str) noexcept {
+CAPI_INTERFACE(array_type_to_str,
+    tiledb_array_type_t array_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_array_type_to_str>(
       array_type, str);
 }
 
-int32_t tiledb_array_type_from_str(
-    const char* str, tiledb_array_type_t* array_type) noexcept {
+CAPI_INTERFACE(array_type_from_str,
+    const char* str, tiledb_array_type_t* array_type) {
   return api_entry_plain<tiledb::api::tiledb_array_type_from_str>(
       str, array_type);
 }
 
-int32_t tiledb_layout_to_str(
-    tiledb_layout_t layout, const char** str) noexcept {
+CAPI_INTERFACE(layout_to_str,
+    tiledb_layout_t layout, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_layout_to_str>(layout, str);
 }
 
-int32_t tiledb_layout_from_str(
-    const char* str, tiledb_layout_t* layout) noexcept {
+CAPI_INTERFACE(layout_from_str,
+    const char* str, tiledb_layout_t* layout) {
   return api_entry_plain<tiledb::api::tiledb_layout_from_str>(str, layout);
 }
 
-int32_t tiledb_encryption_type_to_str(
-    tiledb_encryption_type_t encryption_type, const char** str) noexcept {
+CAPI_INTERFACE(encryption_type_to_str,
+    tiledb_encryption_type_t encryption_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_encryption_type_to_str>(
       encryption_type, str);
 }
 
-int32_t tiledb_encryption_type_from_str(
-    const char* str, tiledb_encryption_type_t* encryption_type) noexcept {
+CAPI_INTERFACE(encryption_type_from_str,
+    const char* str, tiledb_encryption_type_t* encryption_type) {
   return api_entry_plain<tiledb::api::tiledb_encryption_type_from_str>(
       str, encryption_type);
 }
 
-int32_t tiledb_query_status_to_str(
-    tiledb_query_status_t query_status, const char** str) noexcept {
+CAPI_INTERFACE(query_status_to_str,
+    tiledb_query_status_t query_status, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_query_status_to_str>(
       query_status, str);
 }
 
-int32_t tiledb_query_status_from_str(
-    const char* str, tiledb_query_status_t* query_status) noexcept {
+CAPI_INTERFACE(query_status_from_str,
+    const char* str, tiledb_query_status_t* query_status) {
   return api_entry_plain<tiledb::api::tiledb_query_status_from_str>(
       str, query_status);
 }
 
-int32_t tiledb_serialization_type_to_str(
-    tiledb_serialization_type_t serialization_type, const char** str) noexcept {
+CAPI_INTERFACE(serialization_type_to_str,
+    tiledb_serialization_type_t serialization_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_serialization_type_to_str>(
       serialization_type, str);
 }
 
-int32_t tiledb_serialization_type_from_str(
-    const char* str, tiledb_serialization_type_t* serialization_type) noexcept {
+CAPI_INTERFACE(serialization_type_from_str,
+    const char* str, tiledb_serialization_type_t* serialization_type) {
   return api_entry_plain<tiledb::api::tiledb_serialization_type_from_str>(
       str, serialization_type);
 }
@@ -5347,7 +5347,7 @@ const char* tiledb_timestamps() noexcept {
 /*            VERSION             */
 /* ****************************** */
 
-void tiledb_version(int32_t* major, int32_t* minor, int32_t* rev) noexcept {
+CAPI_INTERFACE_VOID(version,int32_t* major, int32_t* minor, int32_t* rev) {
   *major = tiledb::sm::constants::library_version[0];
   *minor = tiledb::sm::constants::library_version[1];
   *rev = tiledb::sm::constants::library_version[2];
@@ -5357,14 +5357,14 @@ void tiledb_version(int32_t* major, int32_t* minor, int32_t* rev) noexcept {
 /*             LOGGING               */
 /* ********************************* */
 
-capi_return_t tiledb_log_warn(tiledb_ctx_t* ctx, const char* message) {
+CAPI_INTERFACE(log_warn,tiledb_ctx_t* ctx, const char* message) {
   return api_entry<tiledb::api::tiledb_log_warn>(ctx, message);
 }
 
 /* ********************************* */
 /*              AS BUILT             */
 /* ********************************* */
-capi_return_t tiledb_as_built_dump(tiledb_string_t** out) noexcept {
+CAPI_INTERFACE(as_built_dump,tiledb_string_t** out) {
   return api_entry_plain<tiledb::api::tiledb_as_built_dump>(out);
 }
 
@@ -5372,143 +5372,143 @@ capi_return_t tiledb_as_built_dump(tiledb_string_t** out) noexcept {
 /*           ARRAY SCHEMA         */
 /* ****************************** */
 
-int32_t tiledb_array_schema_alloc(
+CAPI_INTERFACE(array_schema_alloc,
     tiledb_ctx_t* ctx,
     tiledb_array_type_t array_type,
-    tiledb_array_schema_t** array_schema) noexcept {
+    tiledb_array_schema_t** array_schema) {
   return api_entry<tiledb::api::tiledb_array_schema_alloc>(
       ctx, array_type, array_schema);
 }
 
-void tiledb_array_schema_free(tiledb_array_schema_t** array_schema) noexcept {
+CAPI_INTERFACE_VOID(array_schema_free,tiledb_array_schema_t** array_schema) {
   return api_entry_void<tiledb::api::tiledb_array_schema_free>(array_schema);
 }
 
-int32_t tiledb_array_schema_add_attribute(
+CAPI_INTERFACE(array_schema_add_attribute,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_attribute_t* attr) noexcept {
+    tiledb_attribute_t* attr) {
   return api_entry<tiledb::api::tiledb_array_schema_add_attribute>(
       ctx, array_schema, attr);
 }
 
-int32_t tiledb_array_schema_set_allows_dups(
+CAPI_INTERFACE(array_schema_set_allows_dups,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    int allows_dups) noexcept {
+    int allows_dups) {
   return api_entry<tiledb::api::tiledb_array_schema_set_allows_dups>(
       ctx, array_schema, allows_dups);
 }
 
-int32_t tiledb_array_schema_get_allows_dups(
+CAPI_INTERFACE(array_schema_get_allows_dups,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    int* allows_dups) noexcept {
+    int* allows_dups) {
   return api_entry<tiledb::api::tiledb_array_schema_get_allows_dups>(
       ctx, array_schema, allows_dups);
 }
 
-int32_t tiledb_array_schema_get_version(
+CAPI_INTERFACE(array_schema_get_version,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    uint32_t* version) noexcept {
+    uint32_t* version) {
   return api_entry<tiledb::api::tiledb_array_schema_get_version>(
       ctx, array_schema, version);
 }
 
-int32_t tiledb_array_schema_set_domain(
+CAPI_INTERFACE(array_schema_set_domain,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_domain_t* domain) noexcept {
+    tiledb_domain_t* domain) {
   return api_entry<tiledb::api::tiledb_array_schema_set_domain>(
       ctx, array_schema, domain);
 }
 
-int32_t tiledb_array_schema_set_capacity(
+CAPI_INTERFACE(array_schema_set_capacity,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    uint64_t capacity) noexcept {
+    uint64_t capacity) {
   return api_entry<tiledb::api::tiledb_array_schema_set_capacity>(
       ctx, array_schema, capacity);
 }
 
-int32_t tiledb_array_schema_set_cell_order(
+CAPI_INTERFACE(array_schema_set_cell_order,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_layout_t cell_order) noexcept {
+    tiledb_layout_t cell_order) {
   return api_entry<tiledb::api::tiledb_array_schema_set_cell_order>(
       ctx, array_schema, cell_order);
 }
 
-int32_t tiledb_array_schema_set_tile_order(
+CAPI_INTERFACE(array_schema_set_tile_order,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_layout_t tile_order) noexcept {
+    tiledb_layout_t tile_order) {
   return api_entry<tiledb::api::tiledb_array_schema_set_tile_order>(
       ctx, array_schema, tile_order);
 }
 
-int32_t tiledb_array_schema_timestamp_range(
+CAPI_INTERFACE(array_schema_timestamp_range,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t* lo,
-    uint64_t* hi) noexcept {
+    uint64_t* hi) {
   return api_entry<tiledb::api::tiledb_array_schema_timestamp_range>(
       ctx, array_schema, lo, hi);
 }
 
-int32_t tiledb_array_schema_add_enumeration(
+CAPI_INTERFACE(array_schema_add_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_enumeration_t* enumeration) noexcept {
+    tiledb_enumeration_t* enumeration) {
   return api_entry<tiledb::api::tiledb_array_schema_add_enumeration>(
       ctx, array_schema, enumeration);
 }
 
-int32_t tiledb_array_schema_set_coords_filter_list(
+CAPI_INTERFACE(array_schema_set_coords_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_filter_list_t* filter_list) noexcept {
+    tiledb_filter_list_t* filter_list) {
   return api_entry<tiledb::api::tiledb_array_schema_set_coords_filter_list>(
       ctx, array_schema, filter_list);
 }
 
-int32_t tiledb_array_schema_set_offsets_filter_list(
+CAPI_INTERFACE(array_schema_set_offsets_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_filter_list_t* filter_list) noexcept {
+    tiledb_filter_list_t* filter_list) {
   return api_entry<tiledb::api::tiledb_array_schema_set_offsets_filter_list>(
       ctx, array_schema, filter_list);
 }
 
-int32_t tiledb_array_schema_set_validity_filter_list(
+CAPI_INTERFACE(array_schema_set_validity_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_filter_list_t* filter_list) noexcept {
+    tiledb_filter_list_t* filter_list) {
   return api_entry<tiledb::api::tiledb_array_schema_set_validity_filter_list>(
       ctx, array_schema, filter_list);
 }
 
-int32_t tiledb_array_schema_check(
-    tiledb_ctx_t* ctx, tiledb_array_schema_t* array_schema) noexcept {
+CAPI_INTERFACE(array_schema_check,
+    tiledb_ctx_t* ctx, tiledb_array_schema_t* array_schema) {
   return api_entry<tiledb::api::tiledb_array_schema_check>(ctx, array_schema);
 }
 
-int32_t tiledb_array_schema_load(
+CAPI_INTERFACE(array_schema_load,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_array_schema_t** array_schema) noexcept {
+    tiledb_array_schema_t** array_schema) {
   return api_entry<tiledb::api::tiledb_array_schema_load>(
       ctx, array_uri, array_schema);
 }
 
-int32_t tiledb_array_schema_load_with_key(
+CAPI_INTERFACE(array_schema_load_with_key,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,
     const void* encryption_key,
     uint32_t key_length,
-    tiledb_array_schema_t** array_schema) noexcept {
+    tiledb_array_schema_t** array_schema) {
   return api_entry<tiledb::api::tiledb_array_schema_load_with_key>(
       ctx,
       array_uri,
@@ -5518,109 +5518,109 @@ int32_t tiledb_array_schema_load_with_key(
       array_schema);
 }
 
-int32_t tiledb_array_schema_get_array_type(
+CAPI_INTERFACE(array_schema_get_array_type,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    tiledb_array_type_t* array_type) noexcept {
+    tiledb_array_type_t* array_type) {
   return api_entry<tiledb::api::tiledb_array_schema_get_array_type>(
       ctx, array_schema, array_type);
 }
 
-int32_t tiledb_array_schema_get_capacity(
+CAPI_INTERFACE(array_schema_get_capacity,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    uint64_t* capacity) noexcept {
+    uint64_t* capacity) {
   return api_entry<tiledb::api::tiledb_array_schema_get_capacity>(
       ctx, array_schema, capacity);
 }
 
-int32_t tiledb_array_schema_get_cell_order(
+CAPI_INTERFACE(array_schema_get_cell_order,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    tiledb_layout_t* cell_order) noexcept {
+    tiledb_layout_t* cell_order) {
   return api_entry<tiledb::api::tiledb_array_schema_get_cell_order>(
       ctx, array_schema, cell_order);
 }
 
-int32_t tiledb_array_schema_get_coords_filter_list(
+CAPI_INTERFACE(array_schema_get_coords_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_filter_list_t** filter_list) noexcept {
+    tiledb_filter_list_t** filter_list) {
   return api_entry<tiledb::api::tiledb_array_schema_get_coords_filter_list>(
       ctx, array_schema, filter_list);
 }
 
-int32_t tiledb_array_schema_get_offsets_filter_list(
+CAPI_INTERFACE(array_schema_get_offsets_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_filter_list_t** filter_list) noexcept {
+    tiledb_filter_list_t** filter_list) {
   return api_entry<tiledb::api::tiledb_array_schema_get_offsets_filter_list>(
       ctx, array_schema, filter_list);
 }
 
-int32_t tiledb_array_schema_get_validity_filter_list(
+CAPI_INTERFACE(array_schema_get_validity_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    tiledb_filter_list_t** filter_list) noexcept {
+    tiledb_filter_list_t** filter_list) {
   return api_entry<tiledb::api::tiledb_array_schema_get_validity_filter_list>(
       ctx, array_schema, filter_list);
 }
 
-int32_t tiledb_array_schema_get_domain(
+CAPI_INTERFACE(array_schema_get_domain,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    tiledb_domain_t** domain) noexcept {
+    tiledb_domain_t** domain) {
   return api_entry<tiledb::api::tiledb_array_schema_get_domain>(
       ctx, array_schema, domain);
 }
 
-int32_t tiledb_array_schema_get_tile_order(
+CAPI_INTERFACE(array_schema_get_tile_order,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    tiledb_layout_t* tile_order) noexcept {
+    tiledb_layout_t* tile_order) {
   return api_entry<tiledb::api::tiledb_array_schema_get_tile_order>(
       ctx, array_schema, tile_order);
 }
 
-int32_t tiledb_array_schema_get_attribute_num(
+CAPI_INTERFACE(array_schema_get_attribute_num,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    uint32_t* attribute_num) noexcept {
+    uint32_t* attribute_num) {
   return api_entry<tiledb::api::tiledb_array_schema_get_attribute_num>(
       ctx, array_schema, attribute_num);
 }
 
-int32_t tiledb_array_schema_dump(
+CAPI_INTERFACE(array_schema_dump,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
-    FILE* out) noexcept {
+    FILE* out) {
   return api_entry<tiledb::api::tiledb_array_schema_dump>(
       ctx, array_schema, out);
 }
 
-int32_t tiledb_array_schema_get_attribute_from_index(
+CAPI_INTERFACE(array_schema_get_attribute_from_index,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     uint32_t index,
-    tiledb_attribute_t** attr) noexcept {
+    tiledb_attribute_t** attr) {
   return api_entry<tiledb::api::tiledb_array_schema_get_attribute_from_index>(
       ctx, array_schema, index, attr);
 }
 
-int32_t tiledb_array_schema_get_attribute_from_name(
+CAPI_INTERFACE(array_schema_get_attribute_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     const char* name,
-    tiledb_attribute_t** attr) noexcept {
+    tiledb_attribute_t** attr) {
   return api_entry<tiledb::api::tiledb_array_schema_get_attribute_from_name>(
       ctx, array_schema, name, attr);
 }
 
-int32_t tiledb_array_schema_has_attribute(
+CAPI_INTERFACE(array_schema_has_attribute,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     const char* name,
-    int32_t* has_attr) noexcept {
+    int32_t* has_attr) {
   return api_entry<tiledb::api::tiledb_array_schema_has_attribute>(
       ctx, array_schema, name, has_attr);
 }
@@ -5629,56 +5629,56 @@ int32_t tiledb_array_schema_has_attribute(
 /*            SCHEMA EVOLUTION       */
 /* ********************************* */
 
-int32_t tiledb_array_schema_evolution_alloc(
+CAPI_INTERFACE(array_schema_evolution_alloc,
     tiledb_ctx_t* ctx,
-    tiledb_array_schema_evolution_t** array_schema_evolution) noexcept {
+    tiledb_array_schema_evolution_t** array_schema_evolution) {
   return api_entry<tiledb::api::tiledb_array_schema_evolution_alloc>(
       ctx, array_schema_evolution);
 }
 
-void tiledb_array_schema_evolution_free(
-    tiledb_array_schema_evolution_t** array_schema_evolution) noexcept {
+CAPI_INTERFACE_VOID(array_schema_evolution_free,
+    tiledb_array_schema_evolution_t** array_schema_evolution) {
   return api_entry_void<tiledb::api::tiledb_array_schema_evolution_free>(
       array_schema_evolution);
 }
 
-int32_t tiledb_array_schema_evolution_add_attribute(
+CAPI_INTERFACE(array_schema_evolution_add_attribute,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
-    tiledb_attribute_t* attr) noexcept {
+    tiledb_attribute_t* attr) {
   return api_entry<tiledb::api::tiledb_array_schema_evolution_add_attribute>(
       ctx, array_schema_evolution, attr);
 }
 
-int32_t tiledb_array_schema_evolution_drop_attribute(
+CAPI_INTERFACE(array_schema_evolution_drop_attribute,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
-    const char* attribute_name) noexcept {
+    const char* attribute_name) {
   return api_entry<tiledb::api::tiledb_array_schema_evolution_drop_attribute>(
       ctx, array_schema_evolution, attribute_name);
 }
 
-int32_t tiledb_array_schema_evolution_add_enumeration(
+CAPI_INTERFACE(array_schema_evolution_add_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
-    tiledb_enumeration_t* enmr) noexcept {
+    tiledb_enumeration_t* enmr) {
   return api_entry<tiledb::api::tiledb_array_schema_evolution_add_enumeration>(
       ctx, array_schema_evolution, enmr);
 }
 
-capi_return_t tiledb_array_schema_evolution_extend_enumeration(
+CAPI_INTERFACE(array_schema_evolution_extend_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
-    tiledb_enumeration_t* enmr) noexcept {
+    tiledb_enumeration_t* enmr) {
   return api_entry<
       tiledb::api::tiledb_array_schema_evolution_extend_enumeration>(
       ctx, array_schema_evolution, enmr);
 }
 
-capi_return_t tiledb_array_schema_evolution_drop_enumeration(
+CAPI_INTERFACE(array_schema_evolution_drop_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
-    const char* enumeration_name) noexcept {
+    const char* enumeration_name) {
   return api_entry<tiledb::api::tiledb_array_schema_evolution_drop_enumeration>(
       ctx, array_schema_evolution, enumeration_name);
 }
@@ -5697,400 +5697,400 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(
 /*              QUERY             */
 /* ****************************** */
 
-int32_t tiledb_query_alloc(
+CAPI_INTERFACE(query_alloc,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t query_type,
-    tiledb_query_t** query) noexcept {
+    tiledb_query_t** query) {
   return api_entry<tiledb::api::tiledb_query_alloc>(
       ctx, array, query_type, query);
 }
 
-int32_t tiledb_query_get_stats(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, char** stats_json) noexcept {
+CAPI_INTERFACE(query_get_stats,
+    tiledb_ctx_t* ctx, tiledb_query_t* query, char** stats_json) {
   return api_entry<tiledb::api::tiledb_query_get_stats>(ctx, query, stats_json);
 }
 
-int32_t tiledb_query_set_config(
+CAPI_INTERFACE(query_set_config,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_query_set_config>(ctx, query, config);
 }
 
-int32_t tiledb_query_get_config(
+CAPI_INTERFACE(query_get_config,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_config_t** config) noexcept {
+    tiledb_config_t** config) {
   return api_entry<tiledb::api::tiledb_query_get_config>(ctx, query, config);
 }
 
-int32_t tiledb_query_set_subarray(
+CAPI_INTERFACE(query_set_subarray,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    const void* subarray_vals) noexcept {
+    const void* subarray_vals) {
   return api_entry<tiledb::api::tiledb_query_set_subarray>(
       ctx, query, subarray_vals);
 }
 
-int32_t tiledb_query_set_subarray_t(
+CAPI_INTERFACE(query_set_subarray_t,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    const tiledb_subarray_t* subarray) noexcept {
+    const tiledb_subarray_t* subarray) {
   return api_entry<tiledb::api::tiledb_query_set_subarray_t>(
       ctx, query, subarray);
 }
 
-int32_t tiledb_query_set_data_buffer(
+CAPI_INTERFACE(query_set_data_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
     void* buffer,
-    uint64_t* buffer_size) noexcept {
+    uint64_t* buffer_size) {
   return api_entry<tiledb::api::tiledb_query_set_data_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
-int32_t tiledb_query_set_offsets_buffer(
+CAPI_INTERFACE(query_set_offsets_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
     uint64_t* buffer_offsets,
-    uint64_t* buffer_offsets_size) noexcept {
+    uint64_t* buffer_offsets_size) {
   return api_entry<tiledb::api::tiledb_query_set_offsets_buffer>(
       ctx, query, name, buffer_offsets, buffer_offsets_size);
 }
 
-int32_t tiledb_query_set_validity_buffer(
+CAPI_INTERFACE(query_set_validity_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
     uint8_t* buffer_validity,
-    uint64_t* buffer_validity_size) noexcept {
+    uint64_t* buffer_validity_size) {
   return api_entry<tiledb::api::tiledb_query_set_validity_buffer>(
       ctx, query, name, buffer_validity, buffer_validity_size);
 }
 
-int32_t tiledb_query_get_data_buffer(
+CAPI_INTERFACE(query_get_data_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
     void** buffer,
-    uint64_t** buffer_size) noexcept {
+    uint64_t** buffer_size) {
   return api_entry<tiledb::api::tiledb_query_get_data_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
-int32_t tiledb_query_get_offsets_buffer(
+CAPI_INTERFACE(query_get_offsets_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
     uint64_t** buffer,
-    uint64_t** buffer_size) noexcept {
+    uint64_t** buffer_size) {
   return api_entry<tiledb::api::tiledb_query_get_offsets_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
-int32_t tiledb_query_get_validity_buffer(
+CAPI_INTERFACE(query_get_validity_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
     uint8_t** buffer,
-    uint64_t** buffer_size) noexcept {
+    uint64_t** buffer_size) {
   return api_entry<tiledb::api::tiledb_query_get_validity_buffer>(
       ctx, query, name, buffer, buffer_size);
 }
 
-int32_t tiledb_query_set_layout(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_layout_t layout) noexcept {
+CAPI_INTERFACE(query_set_layout,
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_layout_t layout) {
   return api_entry<tiledb::api::tiledb_query_set_layout>(ctx, query, layout);
 }
 
-int32_t tiledb_query_set_condition(
+CAPI_INTERFACE(query_set_condition,
     tiledb_ctx_t* const ctx,
     tiledb_query_t* const query,
-    const tiledb_query_condition_t* const cond) noexcept {
+    const tiledb_query_condition_t* const cond) {
   return api_entry<tiledb::api::tiledb_query_set_condition>(ctx, query, cond);
 }
 
-int32_t tiledb_query_finalize(
-    tiledb_ctx_t* ctx, tiledb_query_t* query) noexcept {
+CAPI_INTERFACE(query_finalize,
+    tiledb_ctx_t* ctx, tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_query_finalize>(ctx, query);
 }
 
-int32_t tiledb_query_submit_and_finalize(
-    tiledb_ctx_t* ctx, tiledb_query_t* query) noexcept {
+CAPI_INTERFACE(query_submit_and_finalize,
+    tiledb_ctx_t* ctx, tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_query_submit_and_finalize>(ctx, query);
 }
 
-void tiledb_query_free(tiledb_query_t** query) noexcept {
+CAPI_INTERFACE_VOID(query_free,tiledb_query_t** query) {
   return api_entry_void<tiledb::api::tiledb_query_free>(query);
 }
 
-int32_t tiledb_query_submit(tiledb_ctx_t* ctx, tiledb_query_t* query) noexcept {
+CAPI_INTERFACE(query_submit,tiledb_ctx_t* ctx, tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_query_submit>(ctx, query);
 }
 
-int32_t tiledb_query_submit_async(
+CAPI_INTERFACE(query_submit_async,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     void (*callback)(void*),
-    void* callback_data) noexcept {
+    void* callback_data) {
   return api_entry<tiledb::api::tiledb_query_submit_async>(
       ctx, query, callback, callback_data);
 }
 
-int32_t tiledb_query_has_results(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, int32_t* has_results) noexcept {
+CAPI_INTERFACE(query_has_results,
+    tiledb_ctx_t* ctx, tiledb_query_t* query, int32_t* has_results) {
   return api_entry<tiledb::api::tiledb_query_has_results>(
       ctx, query, has_results);
 }
 
-int32_t tiledb_query_get_status(
+CAPI_INTERFACE(query_get_status,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_query_status_t* status) noexcept {
+    tiledb_query_status_t* status) {
   return api_entry<tiledb::api::tiledb_query_get_status>(ctx, query, status);
 }
 
-int32_t tiledb_query_get_type(
+CAPI_INTERFACE(query_get_type,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_query_type_t* query_type) noexcept {
+    tiledb_query_type_t* query_type) {
   return api_entry<tiledb::api::tiledb_query_get_type>(ctx, query, query_type);
 }
 
-int32_t tiledb_query_get_layout(
+CAPI_INTERFACE(query_get_layout,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_layout_t* query_layout) noexcept {
+    tiledb_layout_t* query_layout) {
   return api_entry<tiledb::api::tiledb_query_get_layout>(
       ctx, query, query_layout);
 }
 
-int32_t tiledb_query_get_array(
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** array) noexcept {
+CAPI_INTERFACE(query_get_array,
+    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_query_get_array>(ctx, query, array);
 }
 
-int32_t tiledb_query_add_range(
+CAPI_INTERFACE(query_add_range,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     uint32_t dim_idx,
     const void* start,
     const void* end,
-    const void* stride) noexcept {
+    const void* stride) {
   return api_entry<tiledb::api::tiledb_query_add_range>(
       ctx, query, dim_idx, start, end, stride);
 }
 
-int32_t tiledb_query_add_point_ranges(
+CAPI_INTERFACE(query_add_point_ranges,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     uint32_t dim_idx,
     const void* start,
-    uint64_t count) noexcept {
+    uint64_t count) {
   return api_entry<tiledb::api::tiledb_query_add_point_ranges>(
       ctx, query, dim_idx, start, count);
 }
 
-int32_t tiledb_query_add_range_by_name(
+CAPI_INTERFACE(query_add_range_by_name,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* dim_name,
     const void* start,
     const void* end,
-    const void* stride) noexcept {
+    const void* stride) {
   return api_entry<tiledb::api::tiledb_query_add_range_by_name>(
       ctx, query, dim_name, start, end, stride);
 }
 
-int32_t tiledb_query_add_range_var(
+CAPI_INTERFACE(query_add_range_var,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     uint32_t dim_idx,
     const void* start,
     uint64_t start_size,
     const void* end,
-    uint64_t end_size) noexcept {
+    uint64_t end_size) {
   return api_entry<tiledb::api::tiledb_query_add_range_var>(
       ctx, query, dim_idx, start, start_size, end, end_size);
 }
 
-int32_t tiledb_query_add_range_var_by_name(
+CAPI_INTERFACE(query_add_range_var_by_name,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* dim_name,
     const void* start,
     uint64_t start_size,
     const void* end,
-    uint64_t end_size) noexcept {
+    uint64_t end_size) {
   return api_entry<tiledb::api::tiledb_query_add_range_var_by_name>(
       ctx, query, dim_name, start, start_size, end, end_size);
 }
 
-int32_t tiledb_query_get_range_num(
+CAPI_INTERFACE(query_get_range_num,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
-    uint64_t* range_num) noexcept {
+    uint64_t* range_num) {
   return api_entry<tiledb::api::tiledb_query_get_range_num>(
       ctx, query, dim_idx, range_num);
 }
 
-int32_t tiledb_query_get_range_num_from_name(
+CAPI_INTERFACE(query_get_range_num_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
-    uint64_t* range_num) noexcept {
+    uint64_t* range_num) {
   return api_entry<tiledb::api::tiledb_query_get_range_num_from_name>(
       ctx, query, dim_name, range_num);
 }
 
-int32_t tiledb_query_get_range(
+CAPI_INTERFACE(query_get_range,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
     uint64_t range_idx,
     const void** start,
     const void** end,
-    const void** stride) noexcept {
+    const void** stride) {
   return api_entry<tiledb::api::tiledb_query_get_range>(
       ctx, query, dim_idx, range_idx, start, end, stride);
 }
 
-int32_t tiledb_query_get_range_from_name(
+CAPI_INTERFACE(query_get_range_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
     uint64_t range_idx,
     const void** start,
     const void** end,
-    const void** stride) noexcept {
+    const void** stride) {
   return api_entry<tiledb::api::tiledb_query_get_range_from_name>(
       ctx, query, dim_name, range_idx, start, end, stride);
 }
 
-int32_t tiledb_query_get_range_var_size(
+CAPI_INTERFACE(query_get_range_var_size,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
     uint64_t range_idx,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<tiledb::api::tiledb_query_get_range_var_size>(
       ctx, query, dim_idx, range_idx, start_size, end_size);
 }
 
-int32_t tiledb_query_get_range_var_size_from_name(
+CAPI_INTERFACE(query_get_range_var_size_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
     uint64_t range_idx,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<tiledb::api::tiledb_query_get_range_var_size_from_name>(
       ctx, query, dim_name, range_idx, start_size, end_size);
 }
 
-int32_t tiledb_query_get_range_var(
+CAPI_INTERFACE(query_get_range_var,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
     uint64_t range_idx,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<tiledb::api::tiledb_query_get_range_var>(
       ctx, query, dim_idx, range_idx, start, end);
 }
 
-int32_t tiledb_query_get_range_var_from_name(
+CAPI_INTERFACE(query_get_range_var_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
     uint64_t range_idx,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<tiledb::api::tiledb_query_get_range_var_from_name>(
       ctx, query, dim_name, range_idx, start, end);
 }
 
-int32_t tiledb_query_get_est_result_size(
+CAPI_INTERFACE(query_get_est_result_size,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
-    uint64_t* size) noexcept {
+    uint64_t* size) {
   return api_entry<tiledb::api::tiledb_query_get_est_result_size>(
       ctx, query, name, size);
 }
 
-int32_t tiledb_query_get_est_result_size_var(
+CAPI_INTERFACE(query_get_est_result_size_var,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
     uint64_t* size_off,
-    uint64_t* size_val) noexcept {
+    uint64_t* size_val) {
   return api_entry<tiledb::api::tiledb_query_get_est_result_size_var>(
       ctx, query, name, size_off, size_val);
 }
 
-int32_t tiledb_query_get_est_result_size_nullable(
+CAPI_INTERFACE(query_get_est_result_size_nullable,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
     uint64_t* size_val,
-    uint64_t* size_validity) noexcept {
+    uint64_t* size_validity) {
   return api_entry<tiledb::api::tiledb_query_get_est_result_size_nullable>(
       ctx, query, name, size_val, size_validity);
 }
 
-int32_t tiledb_query_get_est_result_size_var_nullable(
+CAPI_INTERFACE(query_get_est_result_size_var_nullable,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
     uint64_t* size_off,
     uint64_t* size_val,
-    uint64_t* size_validity) noexcept {
+    uint64_t* size_validity) {
   return api_entry<tiledb::api::tiledb_query_get_est_result_size_var_nullable>(
       ctx, query, name, size_off, size_val, size_validity);
 }
 
-int32_t tiledb_query_get_fragment_num(
-    tiledb_ctx_t* ctx, const tiledb_query_t* query, uint32_t* num) noexcept {
+CAPI_INTERFACE(query_get_fragment_num,
+    tiledb_ctx_t* ctx, const tiledb_query_t* query, uint32_t* num) {
   return api_entry<tiledb::api::tiledb_query_get_fragment_num>(ctx, query, num);
 }
 
-int32_t tiledb_query_get_fragment_uri(
+CAPI_INTERFACE(query_get_fragment_uri,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint64_t idx,
-    const char** uri) noexcept {
+    const char** uri) {
   return api_entry<tiledb::api::tiledb_query_get_fragment_uri>(
       ctx, query, idx, uri);
 }
 
-int32_t tiledb_query_get_fragment_timestamp_range(
+CAPI_INTERFACE(query_get_fragment_timestamp_range,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint64_t idx,
     uint64_t* t1,
-    uint64_t* t2) noexcept {
+    uint64_t* t2) {
   return api_entry<tiledb::api::tiledb_query_get_fragment_timestamp_range>(
       ctx, query, idx, t1, t2);
 }
 
-int32_t tiledb_query_get_subarray_t(
+CAPI_INTERFACE(query_get_subarray_t,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
-    tiledb_subarray_t** subarray) noexcept {
+    tiledb_subarray_t** subarray) {
   return api_entry<tiledb::api::tiledb_query_get_subarray_t>(
       ctx, query, subarray);
 }
 
-int32_t tiledb_query_get_relevant_fragment_num(
+CAPI_INTERFACE(query_get_relevant_fragment_num,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
-    uint64_t* relevant_fragment_num) noexcept {
+    uint64_t* relevant_fragment_num) {
   return api_entry<tiledb::api::tiledb_query_get_relevant_fragment_num>(
       ctx, query, relevant_fragment_num);
 }
@@ -6099,179 +6099,179 @@ int32_t tiledb_query_get_relevant_fragment_num(
 /*         SUBARRAY               */
 /* ****************************** */
 
-int32_t tiledb_subarray_alloc(
+CAPI_INTERFACE(subarray_alloc,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
-    tiledb_subarray_t** subarray) noexcept {
+    tiledb_subarray_t** subarray) {
   return api_entry<tiledb::api::tiledb_subarray_alloc>(ctx, array, subarray);
 }
 
-int32_t tiledb_subarray_set_config(
+CAPI_INTERFACE(subarray_set_config,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_subarray_set_config>(
       ctx, subarray, config);
 }
 
-void tiledb_subarray_free(tiledb_subarray_t** subarray) noexcept {
+CAPI_INTERFACE_VOID(subarray_free,tiledb_subarray_t** subarray) {
   return api_entry_void<tiledb::api::tiledb_subarray_free>(subarray);
 }
 
-int32_t tiledb_subarray_set_coalesce_ranges(
+CAPI_INTERFACE(subarray_set_coalesce_ranges,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
-    int coalesce_ranges) noexcept {
+    int coalesce_ranges) {
   return api_entry<tiledb::api::tiledb_subarray_set_coalesce_ranges>(
       ctx, subarray, coalesce_ranges);
 }
 
-int32_t tiledb_subarray_set_subarray(
+CAPI_INTERFACE(subarray_set_subarray,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray_obj,
-    const void* subarray_vals) noexcept {
+    const void* subarray_vals) {
   return api_entry<tiledb::api::tiledb_subarray_set_subarray>(
       ctx, subarray_obj, subarray_vals);
 }
 
-int32_t tiledb_subarray_add_range(
+CAPI_INTERFACE(subarray_add_range,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const void* start,
     const void* end,
-    const void* stride) noexcept {
+    const void* stride) {
   return api_entry<tiledb::api::tiledb_subarray_add_range>(
       ctx, subarray, dim_idx, start, end, stride);
 }
 
-int32_t tiledb_subarray_add_point_ranges(
+CAPI_INTERFACE(subarray_add_point_ranges,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const void* start,
-    uint64_t count) noexcept {
+    uint64_t count) {
   return api_entry<tiledb::api::tiledb_subarray_add_point_ranges>(
       ctx, subarray, dim_idx, start, count);
 }
 
-int32_t tiledb_subarray_add_range_by_name(
+CAPI_INTERFACE(subarray_add_range_by_name,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* dim_name,
     const void* start,
     const void* end,
-    const void* stride) noexcept {
+    const void* stride) {
   return api_entry<tiledb::api::tiledb_subarray_add_range_by_name>(
       ctx, subarray, dim_name, start, end, stride);
 }
 
-int32_t tiledb_subarray_add_range_var(
+CAPI_INTERFACE(subarray_add_range_var,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const void* start,
     uint64_t start_size,
     const void* end,
-    uint64_t end_size) noexcept {
+    uint64_t end_size) {
   return api_entry<tiledb::api::tiledb_subarray_add_range_var>(
       ctx, subarray, dim_idx, start, start_size, end, end_size);
 }
 
-int32_t tiledb_subarray_add_range_var_by_name(
+CAPI_INTERFACE(subarray_add_range_var_by_name,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* dim_name,
     const void* start,
     uint64_t start_size,
     const void* end,
-    uint64_t end_size) noexcept {
+    uint64_t end_size) {
   return api_entry<tiledb::api::tiledb_subarray_add_range_var_by_name>(
       ctx, subarray, dim_name, start, start_size, end, end_size);
 }
 
-int32_t tiledb_subarray_get_range_num(
+CAPI_INTERFACE(subarray_get_range_num,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
-    uint64_t* range_num) noexcept {
+    uint64_t* range_num) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_num>(
       ctx, subarray, dim_idx, range_num);
 }
 
-int32_t tiledb_subarray_get_range_num_from_name(
+CAPI_INTERFACE(subarray_get_range_num_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
-    uint64_t* range_num) noexcept {
+    uint64_t* range_num) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_num_from_name>(
       ctx, subarray, dim_name, range_num);
 }
 
-int32_t tiledb_subarray_get_range(
+CAPI_INTERFACE(subarray_get_range,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t range_idx,
     const void** start,
     const void** end,
-    const void** stride) noexcept {
+    const void** stride) {
   return api_entry<tiledb::api::tiledb_subarray_get_range>(
       ctx, subarray, dim_idx, range_idx, start, end, stride);
 }
 
-int32_t tiledb_subarray_get_range_var_size(
+CAPI_INTERFACE(subarray_get_range_var_size,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t range_idx,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_var_size>(
       ctx, subarray, dim_idx, range_idx, start_size, end_size);
 }
 
-int32_t tiledb_subarray_get_range_from_name(
+CAPI_INTERFACE(subarray_get_range_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     const void** start,
     const void** end,
-    const void** stride) noexcept {
+    const void** stride) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_from_name>(
       ctx, subarray, dim_name, range_idx, start, end, stride);
 }
 
-int32_t tiledb_subarray_get_range_var_size_from_name(
+CAPI_INTERFACE(subarray_get_range_var_size_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_var_size_from_name>(
       ctx, subarray, dim_name, range_idx, start_size, end_size);
 }
 
-int32_t tiledb_subarray_get_range_var(
+CAPI_INTERFACE(subarray_get_range_var,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t range_idx,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_var>(
       ctx, subarray, dim_idx, range_idx, start, end);
 }
 
-int32_t tiledb_subarray_get_range_var_from_name(
+CAPI_INTERFACE(subarray_get_range_var_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<tiledb::api::tiledb_subarray_get_range_var_from_name>(
       ctx, subarray, dim_name, range_idx, start, end);
 }
@@ -6280,12 +6280,12 @@ int32_t tiledb_subarray_get_range_var_from_name(
 /*          QUERY CONDITION       */
 /* ****************************** */
 
-int32_t tiledb_query_condition_alloc(
-    tiledb_ctx_t* const ctx, tiledb_query_condition_t** const cond) noexcept {
+CAPI_INTERFACE(query_condition_alloc,
+    tiledb_ctx_t* const ctx, tiledb_query_condition_t** const cond) {
   return api_entry<tiledb::api::tiledb_query_condition_alloc>(ctx, cond);
 }
 
-capi_return_t tiledb_query_condition_alloc_set_membership(
+CAPI_INTERFACE(query_condition_alloc_set_membership,
     tiledb_ctx_t* ctx,
     const char* field_name,
     const void* data,
@@ -6293,49 +6293,49 @@ capi_return_t tiledb_query_condition_alloc_set_membership(
     const void* offsets,
     uint64_t offsets_size,
     tiledb_query_condition_op_t op,
-    tiledb_query_condition_t** cond) noexcept {
+    tiledb_query_condition_t** cond) {
   return api_entry_context<
       tiledb::api::tiledb_query_condition_alloc_set_membership>(
       ctx, field_name, data, data_size, offsets, offsets_size, op, cond);
 }
 
-void tiledb_query_condition_free(tiledb_query_condition_t** cond) noexcept {
+CAPI_INTERFACE_VOID(query_condition_free,tiledb_query_condition_t** cond) {
   return api_entry_void<tiledb::api::tiledb_query_condition_free>(cond);
 }
 
-int32_t tiledb_query_condition_init(
+CAPI_INTERFACE(query_condition_init,
     tiledb_ctx_t* const ctx,
     tiledb_query_condition_t* const cond,
     const char* const attribute_name,
     const void* const condition_value,
     const uint64_t condition_value_size,
-    const tiledb_query_condition_op_t op) noexcept {
+    const tiledb_query_condition_op_t op) {
   return api_entry<tiledb::api::tiledb_query_condition_init>(
       ctx, cond, attribute_name, condition_value, condition_value_size, op);
 }
 
-int32_t tiledb_query_condition_combine(
+CAPI_INTERFACE(query_condition_combine,
     tiledb_ctx_t* const ctx,
     const tiledb_query_condition_t* const left_cond,
     const tiledb_query_condition_t* const right_cond,
     const tiledb_query_condition_combination_op_t combination_op,
-    tiledb_query_condition_t** const combined_cond) noexcept {
+    tiledb_query_condition_t** const combined_cond) {
   return api_entry<tiledb::api::tiledb_query_condition_combine>(
       ctx, left_cond, right_cond, combination_op, combined_cond);
 }
 
-int32_t tiledb_query_condition_negate(
+CAPI_INTERFACE(query_condition_negate,
     tiledb_ctx_t* const ctx,
     const tiledb_query_condition_t* const cond,
-    tiledb_query_condition_t** const negated_cond) noexcept {
+    tiledb_query_condition_t** const negated_cond) {
   return api_entry<tiledb::api::tiledb_query_condition_negate>(
       ctx, cond, negated_cond);
 }
 
-capi_return_t tiledb_query_condition_set_use_enumeration(
+CAPI_INTERFACE(query_condition_set_use_enumeration,
     tiledb_ctx_t* const ctx,
     const tiledb_query_condition_t* const cond,
-    int use_enumeration) noexcept {
+    int use_enumeration) {
   return api_entry<tiledb::api::tiledb_query_condition_set_use_enumeration>(
       ctx, cond, use_enumeration);
 }
@@ -6344,12 +6344,12 @@ capi_return_t tiledb_query_condition_set_use_enumeration(
 /*         UPDATE CONDITION       */
 /* ****************************** */
 
-int32_t tiledb_query_add_update_value(
+CAPI_INTERFACE(query_add_update_value,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* field_name,
     const void* update_value,
-    uint64_t update_value_size) noexcept {
+    uint64_t update_value_size) {
   return api_entry<tiledb::api::tiledb_query_add_update_value>(
       ctx, query, field_name, update_value, update_value_size);
 }
@@ -6358,147 +6358,147 @@ int32_t tiledb_query_add_update_value(
 /*              ARRAY             */
 /* ****************************** */
 
-int32_t tiledb_array_alloc(
-    tiledb_ctx_t* ctx, const char* array_uri, tiledb_array_t** array) noexcept {
+CAPI_INTERFACE(array_alloc,
+    tiledb_ctx_t* ctx, const char* array_uri, tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_array_alloc>(ctx, array_uri, array);
 }
 
-int32_t tiledb_array_set_open_timestamp_start(
+CAPI_INTERFACE(array_set_open_timestamp_start,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    uint64_t timestamp_start) noexcept {
+    uint64_t timestamp_start) {
   return api_entry<tiledb::api::tiledb_array_set_open_timestamp_start>(
       ctx, array, timestamp_start);
 }
 
-int32_t tiledb_array_set_open_timestamp_end(
-    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_end) noexcept {
+CAPI_INTERFACE(array_set_open_timestamp_end,
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_end) {
   return api_entry<tiledb::api::tiledb_array_set_open_timestamp_end>(
       ctx, array, timestamp_end);
 }
 
-int32_t tiledb_array_get_open_timestamp_start(
+CAPI_INTERFACE(array_get_open_timestamp_start,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    uint64_t* timestamp_start) noexcept {
+    uint64_t* timestamp_start) {
   return api_entry<tiledb::api::tiledb_array_get_open_timestamp_start>(
       ctx, array, timestamp_start);
 }
 
-int32_t tiledb_array_get_open_timestamp_end(
+CAPI_INTERFACE(array_get_open_timestamp_end,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    uint64_t* timestamp_end) noexcept {
+    uint64_t* timestamp_end) {
   return api_entry<tiledb::api::tiledb_array_get_open_timestamp_end>(
       ctx, array, timestamp_end);
 }
 
-int32_t tiledb_array_delete(tiledb_ctx_t* ctx, const char* uri) noexcept {
+CAPI_INTERFACE(array_delete,tiledb_ctx_t* ctx, const char* uri) {
   return api_entry<tiledb::api::tiledb_array_delete>(ctx, uri);
 }
 
-int32_t tiledb_array_delete_array(
-    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* uri) noexcept {
+CAPI_INTERFACE(array_delete_array,
+    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* uri) {
   return api_entry<tiledb::api::tiledb_array_delete_array>(ctx, array, uri);
 }
 
-int32_t tiledb_array_delete_fragments(
+CAPI_INTERFACE(array_delete_fragments,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* uri,
     uint64_t timestamp_start,
-    uint64_t timestamp_end) noexcept {
+    uint64_t timestamp_end) {
   return api_entry<tiledb::api::tiledb_array_delete_fragments>(
       ctx, array, uri, timestamp_start, timestamp_end);
 }
 
-capi_return_t tiledb_array_delete_fragments_v2(
+CAPI_INTERFACE(array_delete_fragments_v2,
     tiledb_ctx_t* ctx,
     const char* uri_str,
     uint64_t timestamp_start,
-    uint64_t timestamp_end) noexcept {
+    uint64_t timestamp_end) {
   return api_entry<tiledb::api::tiledb_array_delete_fragments_v2>(
       ctx, uri_str, timestamp_start, timestamp_end);
 }
 
-capi_return_t tiledb_array_delete_fragments_list(
+CAPI_INTERFACE(array_delete_fragments_list,
     tiledb_ctx_t* ctx,
     const char* uri_str,
     const char* fragment_uris[],
-    const size_t num_fragments) noexcept {
+    const size_t num_fragments) {
   return api_entry<tiledb::api::tiledb_array_delete_fragments_list>(
       ctx, uri_str, fragment_uris, num_fragments);
 }
 
-int32_t tiledb_array_open(
+CAPI_INTERFACE(array_open,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    tiledb_query_type_t query_type) noexcept {
+    tiledb_query_type_t query_type) {
   return api_entry<tiledb::api::tiledb_array_open>(ctx, array, query_type);
 }
 
-int32_t tiledb_array_is_open(
-    tiledb_ctx_t* ctx, tiledb_array_t* array, int32_t* is_open) noexcept {
+CAPI_INTERFACE(array_is_open,
+    tiledb_ctx_t* ctx, tiledb_array_t* array, int32_t* is_open) {
   return api_entry<tiledb::api::tiledb_array_is_open>(ctx, array, is_open);
 }
 
-int32_t tiledb_array_reopen(tiledb_ctx_t* ctx, tiledb_array_t* array) noexcept {
+CAPI_INTERFACE(array_reopen,tiledb_ctx_t* ctx, tiledb_array_t* array) {
   return api_entry<tiledb::api::tiledb_array_reopen>(ctx, array);
 }
 
-int32_t tiledb_array_set_config(
+CAPI_INTERFACE(array_set_config,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_set_config>(ctx, array, config);
 }
 
-int32_t tiledb_array_get_config(
+CAPI_INTERFACE(array_get_config,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    tiledb_config_t** config) noexcept {
+    tiledb_config_t** config) {
   return api_entry<tiledb::api::tiledb_array_get_config>(ctx, array, config);
 }
 
-int32_t tiledb_array_close(tiledb_ctx_t* ctx, tiledb_array_t* array) noexcept {
+CAPI_INTERFACE(array_close,tiledb_ctx_t* ctx, tiledb_array_t* array) {
   return api_entry<tiledb::api::tiledb_array_close>(ctx, array);
 }
 
-void tiledb_array_free(tiledb_array_t** array) noexcept {
+CAPI_INTERFACE_VOID(array_free,tiledb_array_t** array) {
   return api_entry_void<tiledb::api::tiledb_array_free>(array);
 }
 
-int32_t tiledb_array_get_schema(
+CAPI_INTERFACE(array_get_schema,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    tiledb_array_schema_t** array_schema) noexcept {
+    tiledb_array_schema_t** array_schema) {
   return api_entry<tiledb::api::tiledb_array_get_schema>(
       ctx, array, array_schema);
 }
 
-int32_t tiledb_array_get_query_type(
+CAPI_INTERFACE(array_get_query_type,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
-    tiledb_query_type_t* query_type) noexcept {
+    tiledb_query_type_t* query_type) {
   return api_entry<tiledb::api::tiledb_array_get_query_type>(
       ctx, array, query_type);
 }
 
-int32_t tiledb_array_create(
+CAPI_INTERFACE(array_create,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    const tiledb_array_schema_t* array_schema) noexcept {
+    const tiledb_array_schema_t* array_schema) {
   return api_entry<tiledb::api::tiledb_array_create>(
       ctx, array_uri, array_schema);
 }
 
-int32_t tiledb_array_create_with_key(
+CAPI_INTERFACE(array_create_with_key,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const tiledb_array_schema_t* array_schema,
     tiledb_encryption_type_t encryption_type,
     const void* encryption_key,
-    uint32_t key_length) noexcept {
+    uint32_t key_length) {
   return api_entry<tiledb::api::tiledb_array_create_with_key>(
       ctx,
       array_uri,
@@ -6508,165 +6508,165 @@ int32_t tiledb_array_create_with_key(
       key_length);
 }
 
-int32_t tiledb_array_consolidate(
+CAPI_INTERFACE(array_consolidate,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_consolidate>(
       ctx, array_uri, config);
 }
 
-int32_t tiledb_array_consolidate_with_key(
+CAPI_INTERFACE(array_consolidate_with_key,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,
     const void* encryption_key,
     uint32_t key_length,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_consolidate_with_key>(
       ctx, array_uri, encryption_type, encryption_key, key_length, config);
 }
 
-int32_t tiledb_array_consolidate_fragments(
+CAPI_INTERFACE(array_consolidate_fragments,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const char** fragment_uris,
     const uint64_t num_fragments,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_consolidate_fragments>(
       ctx, array_uri, fragment_uris, num_fragments, config);
 }
 
-int32_t tiledb_array_vacuum(
+CAPI_INTERFACE(array_vacuum,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_vacuum>(ctx, array_uri, config);
 }
 
-int32_t tiledb_array_get_non_empty_domain(
+CAPI_INTERFACE(array_get_non_empty_domain,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     void* domain,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<tiledb::api::tiledb_array_get_non_empty_domain>(
       ctx, array, domain, is_empty);
 }
 
-int32_t tiledb_array_get_non_empty_domain_from_index(
+CAPI_INTERFACE(array_get_non_empty_domain_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint32_t idx,
     void* domain,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<tiledb::api::tiledb_array_get_non_empty_domain_from_index>(
       ctx, array, idx, domain, is_empty);
 }
 
-int32_t tiledb_array_get_non_empty_domain_from_name(
+CAPI_INTERFACE(array_get_non_empty_domain_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
     void* domain,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<tiledb::api::tiledb_array_get_non_empty_domain_from_name>(
       ctx, array, name, domain, is_empty);
 }
 
-int32_t tiledb_array_get_non_empty_domain_var_size_from_index(
+CAPI_INTERFACE(array_get_non_empty_domain_var_size_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint32_t idx,
     uint64_t* start_size,
     uint64_t* end_size,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<
       tiledb::api::tiledb_array_get_non_empty_domain_var_size_from_index>(
       ctx, array, idx, start_size, end_size, is_empty);
 }
 
-int32_t tiledb_array_get_non_empty_domain_var_size_from_name(
+CAPI_INTERFACE(array_get_non_empty_domain_var_size_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
     uint64_t* start_size,
     uint64_t* end_size,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<
       tiledb::api::tiledb_array_get_non_empty_domain_var_size_from_name>(
       ctx, array, name, start_size, end_size, is_empty);
 }
 
-int32_t tiledb_array_get_non_empty_domain_var_from_index(
+CAPI_INTERFACE(array_get_non_empty_domain_var_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint32_t idx,
     void* start,
     void* end,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<
       tiledb::api::tiledb_array_get_non_empty_domain_var_from_index>(
       ctx, array, idx, start, end, is_empty);
 }
 
-int32_t tiledb_array_get_non_empty_domain_var_from_name(
+CAPI_INTERFACE(array_get_non_empty_domain_var_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
     void* start,
     void* end,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<
       tiledb::api::tiledb_array_get_non_empty_domain_var_from_name>(
       ctx, array, name, start, end, is_empty);
 }
 
-int32_t tiledb_array_get_uri(
-    tiledb_ctx_t* ctx, tiledb_array_t* array, const char** array_uri) noexcept {
+CAPI_INTERFACE(array_get_uri,
+    tiledb_ctx_t* ctx, tiledb_array_t* array, const char** array_uri) {
   return api_entry<tiledb::api::tiledb_array_get_uri>(ctx, array, array_uri);
 }
 
-int32_t tiledb_array_encryption_type(
+CAPI_INTERFACE(array_encryption_type,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_encryption_type_t* encryption_type) noexcept {
+    tiledb_encryption_type_t* encryption_type) {
   return api_entry<tiledb::api::tiledb_array_encryption_type>(
       ctx, array_uri, encryption_type);
 }
 
-int32_t tiledb_array_put_metadata(
+CAPI_INTERFACE(array_put_metadata,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* key,
     tiledb_datatype_t value_type,
     uint32_t value_num,
-    const void* value) noexcept {
+    const void* value) {
   return api_entry<tiledb::api::tiledb_array_put_metadata>(
       ctx, array, key, value_type, value_num, value);
 }
 
-int32_t tiledb_array_delete_metadata(
-    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* key) noexcept {
+CAPI_INTERFACE(array_delete_metadata,
+    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* key) {
   return api_entry<tiledb::api::tiledb_array_delete_metadata>(ctx, array, key);
 }
 
-int32_t tiledb_array_get_metadata(
+CAPI_INTERFACE(array_get_metadata,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* key,
     tiledb_datatype_t* value_type,
     uint32_t* value_num,
-    const void** value) noexcept {
+    const void** value) {
   return api_entry<tiledb::api::tiledb_array_get_metadata>(
       ctx, array, key, value_type, value_num, value);
 }
 
-int32_t tiledb_array_get_metadata_num(
-    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* num) noexcept {
+CAPI_INTERFACE(array_get_metadata_num,
+    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* num) {
   return api_entry<tiledb::api::tiledb_array_get_metadata_num>(ctx, array, num);
 }
 
-int32_t tiledb_array_get_metadata_from_index(
+CAPI_INTERFACE(array_get_metadata_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t index,
@@ -6674,47 +6674,47 @@ int32_t tiledb_array_get_metadata_from_index(
     uint32_t* key_len,
     tiledb_datatype_t* value_type,
     uint32_t* value_num,
-    const void** value) noexcept {
+    const void** value) {
   return api_entry<tiledb::api::tiledb_array_get_metadata_from_index>(
       ctx, array, index, key, key_len, value_type, value_num, value);
 }
 
-int32_t tiledb_array_has_metadata_key(
+CAPI_INTERFACE(array_has_metadata_key,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* key,
     tiledb_datatype_t* value_type,
-    int32_t* has_key) noexcept {
+    int32_t* has_key) {
   return api_entry<tiledb::api::tiledb_array_has_metadata_key>(
       ctx, array, key, value_type, has_key);
 }
 
-int32_t tiledb_array_evolve(
+CAPI_INTERFACE(array_evolve,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_array_schema_evolution_t* array_schema_evolution) noexcept {
+    tiledb_array_schema_evolution_t* array_schema_evolution) {
   return api_entry<tiledb::api::tiledb_array_evolve>(
       ctx, array_uri, array_schema_evolution);
 }
 
-capi_return_t tiledb_array_get_enumeration(
+CAPI_INTERFACE(array_get_enumeration,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const char* attr_name,
-    tiledb_enumeration_t** enumeration) noexcept {
+    tiledb_enumeration_t** enumeration) {
   return api_entry<tiledb::api::tiledb_array_get_enumeration>(
       ctx, array, attr_name, enumeration);
 }
 
-capi_return_t tiledb_array_load_all_enumerations(
-    tiledb_ctx_t* ctx, const tiledb_array_t* array) noexcept {
+CAPI_INTERFACE(array_load_all_enumerations,
+    tiledb_ctx_t* ctx, const tiledb_array_t* array) {
   return api_entry<tiledb::api::tiledb_array_load_all_enumerations>(ctx, array);
 }
 
-int32_t tiledb_array_upgrade_version(
+CAPI_INTERFACE(array_upgrade_version,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_upgrade_version>(
       ctx, array_uri, config);
 }
@@ -6723,35 +6723,35 @@ int32_t tiledb_array_upgrade_version(
 /*         OBJECT MANAGEMENT      */
 /* ****************************** */
 
-int32_t tiledb_object_type(
-    tiledb_ctx_t* ctx, const char* path, tiledb_object_t* type) noexcept {
+CAPI_INTERFACE(object_type,
+    tiledb_ctx_t* ctx, const char* path, tiledb_object_t* type) {
   return api_entry<tiledb::api::tiledb_object_type>(ctx, path, type);
 }
 
-int32_t tiledb_object_remove(tiledb_ctx_t* ctx, const char* path) noexcept {
+CAPI_INTERFACE(object_remove,tiledb_ctx_t* ctx, const char* path) {
   return api_entry<tiledb::api::tiledb_object_remove>(ctx, path);
 }
 
-int32_t tiledb_object_move(
-    tiledb_ctx_t* ctx, const char* old_path, const char* new_path) noexcept {
+CAPI_INTERFACE(object_move,
+    tiledb_ctx_t* ctx, const char* old_path, const char* new_path) {
   return api_entry<tiledb::api::tiledb_object_move>(ctx, old_path, new_path);
 }
 
-int32_t tiledb_object_walk(
+CAPI_INTERFACE(object_walk,
     tiledb_ctx_t* ctx,
     const char* path,
     tiledb_walk_order_t order,
     int32_t (*callback)(const char*, tiledb_object_t, void*),
-    void* data) noexcept {
+    void* data) {
   return api_entry<tiledb::api::tiledb_object_walk>(
       ctx, path, order, callback, data);
 }
 
-int32_t tiledb_object_ls(
+CAPI_INTERFACE(object_ls,
     tiledb_ctx_t* ctx,
     const char* path,
     int32_t (*callback)(const char*, tiledb_object_t, void*),
-    void* data) noexcept {
+    void* data) {
   return api_entry<tiledb::api::tiledb_object_ls>(ctx, path, callback, data);
 }
 
@@ -6759,11 +6759,11 @@ int32_t tiledb_object_ls(
 /*              URI               */
 /* ****************************** */
 
-int32_t tiledb_uri_to_path(
+CAPI_INTERFACE(uri_to_path,
     tiledb_ctx_t* ctx,
     const char* uri,
     char* path_out,
-    uint32_t* path_length) noexcept {
+    uint32_t* path_length) {
   return api_entry<tiledb::api::tiledb_uri_to_path>(
       ctx, uri, path_out, path_length);
 }
@@ -6772,35 +6772,35 @@ int32_t tiledb_uri_to_path(
 /*             Stats              */
 /* ****************************** */
 
-int32_t tiledb_stats_enable() noexcept {
+CAPI_INTERFACE_NULL(stats_enable) {
   return api_entry_plain<tiledb::api::tiledb_stats_enable>();
 }
 
-int32_t tiledb_stats_disable() noexcept {
+CAPI_INTERFACE_NULL(stats_disable) {
   return api_entry_plain<tiledb::api::tiledb_stats_disable>();
 }
 
-int32_t tiledb_stats_reset() noexcept {
+CAPI_INTERFACE_NULL(stats_reset) {
   return api_entry_plain<tiledb::api::tiledb_stats_reset>();
 }
 
-int32_t tiledb_stats_dump(FILE* out) noexcept {
+CAPI_INTERFACE(stats_dump,FILE* out) {
   return api_entry_plain<tiledb::api::tiledb_stats_dump>(out);
 }
 
-int32_t tiledb_stats_dump_str(char** out) noexcept {
+CAPI_INTERFACE(stats_dump_str,char** out) {
   return api_entry_plain<tiledb::api::tiledb_stats_dump_str>(out);
 }
 
-int32_t tiledb_stats_raw_dump(FILE* out) noexcept {
+CAPI_INTERFACE(stats_raw_dump,FILE* out) {
   return api_entry_plain<tiledb::api::tiledb_stats_raw_dump>(out);
 }
 
-int32_t tiledb_stats_raw_dump_str(char** out) noexcept {
+CAPI_INTERFACE(stats_raw_dump_str,char** out) {
   return api_entry_plain<tiledb::api::tiledb_stats_raw_dump_str>(out);
 }
 
-int32_t tiledb_stats_free_str(char** out) noexcept {
+CAPI_INTERFACE(stats_free_str,char** out) {
   return api_entry_plain<tiledb::api::tiledb_stats_free_str>(out);
 }
 
@@ -6808,11 +6808,11 @@ int32_t tiledb_stats_free_str(char** out) noexcept {
 /*          Heap Profiler         */
 /* ****************************** */
 
-int32_t tiledb_heap_profiler_enable(
+CAPI_INTERFACE(heap_profiler_enable,
     const char* const file_name_prefix,
     const uint64_t dump_interval_ms,
     const uint64_t dump_interval_bytes,
-    const uint64_t dump_threshold_bytes) noexcept {
+    const uint64_t dump_threshold_bytes) {
   return api_entry_plain<tiledb::api::tiledb_heap_profiler_enable>(
       file_name_prefix,
       dump_interval_ms,
@@ -6824,126 +6824,126 @@ int32_t tiledb_heap_profiler_enable(
 /*          Serialization         */
 /* ****************************** */
 
-int32_t tiledb_serialize_array(
+CAPI_INTERFACE(serialize_array,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array>(
       ctx, array, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_array(
+CAPI_INTERFACE(deserialize_array,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_array_t** array) noexcept {
+    tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_deserialize_array>(
       ctx, buffer, serialize_type, client_side, array);
 }
 
-int32_t tiledb_serialize_array_schema(
+CAPI_INTERFACE(serialize_array_schema,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array_schema>(
       ctx, array_schema, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_array_schema(
+CAPI_INTERFACE(deserialize_array_schema,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_array_schema_t** array_schema) noexcept {
+    tiledb_array_schema_t** array_schema) {
   return api_entry<tiledb::api::tiledb_deserialize_array_schema>(
       ctx, buffer, serialize_type, client_side, array_schema);
 }
 
-int32_t tiledb_serialize_array_open(
+CAPI_INTERFACE(serialize_array_open,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array_open>(
       ctx, array, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_array_open(
+CAPI_INTERFACE(deserialize_array_open,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_array_t** array) noexcept {
+    tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_deserialize_array_open>(
       ctx, buffer, serialize_type, client_side, array);
 }
 
-int32_t tiledb_serialize_array_schema_evolution(
+CAPI_INTERFACE(serialize_array_schema_evolution,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_evolution_t* array_schema_evolution,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array_schema_evolution>(
       ctx, array_schema_evolution, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_array_schema_evolution(
+CAPI_INTERFACE(deserialize_array_schema_evolution,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_array_schema_evolution_t** array_schema_evolution) noexcept {
+    tiledb_array_schema_evolution_t** array_schema_evolution) {
   return api_entry<tiledb::api::tiledb_deserialize_array_schema_evolution>(
       ctx, buffer, serialize_type, client_side, array_schema_evolution);
 }
 
-int32_t tiledb_serialize_query(
+CAPI_INTERFACE(serialize_query,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_list_t** buffer_list) noexcept {
+    tiledb_buffer_list_t** buffer_list) {
   return api_entry<tiledb::api::tiledb_serialize_query>(
       ctx, query, serialize_type, client_side, buffer_list);
 }
 
-int32_t tiledb_deserialize_query(
+CAPI_INTERFACE(deserialize_query,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_query_t* query) noexcept {
+    tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_deserialize_query>(
       ctx, buffer, serialize_type, client_side, query);
 }
 
-int32_t tiledb_deserialize_query_and_array(
+CAPI_INTERFACE(deserialize_query_and_array,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
     const char* array_uri,
     tiledb_query_t** query,
-    tiledb_array_t** array) noexcept {
+    tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_deserialize_query_and_array>(
       ctx, buffer, serialize_type, client_side, array_uri, query, array);
 }
 
-int32_t tiledb_serialize_array_nonempty_domain(
+CAPI_INTERFACE(serialize_array_nonempty_domain,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const void* nonempty_domain,
     int32_t is_empty,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array_nonempty_domain>(
       ctx,
       array,
@@ -6954,14 +6954,14 @@ int32_t tiledb_serialize_array_nonempty_domain(
       buffer);
 }
 
-int32_t tiledb_deserialize_array_nonempty_domain(
+CAPI_INTERFACE(deserialize_array_nonempty_domain,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
     void* nonempty_domain,
-    int32_t* is_empty) noexcept {
+    int32_t* is_empty) {
   return api_entry<tiledb::api::tiledb_deserialize_array_nonempty_domain>(
       ctx,
       array,
@@ -6972,173 +6972,173 @@ int32_t tiledb_deserialize_array_nonempty_domain(
       is_empty);
 }
 
-int32_t tiledb_serialize_array_non_empty_domain_all_dimensions(
+CAPI_INTERFACE(serialize_array_non_empty_domain_all_dimensions,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<
       tiledb::api::tiledb_serialize_array_non_empty_domain_all_dimensions>(
       ctx, array, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_array_non_empty_domain_all_dimensions(
+CAPI_INTERFACE(deserialize_array_non_empty_domain_all_dimensions,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
-    int32_t client_side) noexcept {
+    int32_t client_side) {
   return api_entry<
       tiledb::api::tiledb_deserialize_array_non_empty_domain_all_dimensions>(
       ctx, array, buffer, serialize_type, client_side);
 }
 
-int32_t tiledb_serialize_array_max_buffer_sizes(
+CAPI_INTERFACE(serialize_array_max_buffer_sizes,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const void* subarray,
     tiledb_serialization_type_t serialize_type,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array_max_buffer_sizes>(
       ctx, array, subarray, serialize_type, buffer);
 }
 
-capi_return_t tiledb_handle_array_delete_fragments_timestamps_request(
+CAPI_INTERFACE(handle_array_delete_fragments_timestamps_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
-    const tiledb_buffer_t* request) noexcept {
+    const tiledb_buffer_t* request) {
   return api_entry<
       tiledb::api::tiledb_handle_array_delete_fragments_timestamps_request>(
       ctx, array, serialize_type, request);
 }
 
-capi_return_t tiledb_handle_array_delete_fragments_list_request(
+CAPI_INTERFACE(handle_array_delete_fragments_list_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
-    const tiledb_buffer_t* request) noexcept {
+    const tiledb_buffer_t* request) {
   return api_entry<
       tiledb::api::tiledb_handle_array_delete_fragments_list_request>(
       ctx, array, serialize_type, request);
 }
 
-int32_t tiledb_serialize_array_metadata(
+CAPI_INTERFACE(serialize_array_metadata,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_array_metadata>(
       ctx, array, serialize_type, buffer);
 }
 
-int32_t tiledb_deserialize_array_metadata(
+CAPI_INTERFACE(deserialize_array_metadata,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
-    const tiledb_buffer_t* buffer) noexcept {
+    const tiledb_buffer_t* buffer) {
   return api_entry<tiledb::api::tiledb_deserialize_array_metadata>(
       ctx, array, serialize_type, buffer);
 }
 
-int32_t tiledb_serialize_query_est_result_sizes(
+CAPI_INTERFACE(serialize_query_est_result_sizes,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_query_est_result_sizes>(
       ctx, query, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_query_est_result_sizes(
+CAPI_INTERFACE(deserialize_query_est_result_sizes,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    const tiledb_buffer_t* buffer) noexcept {
+    const tiledb_buffer_t* buffer) {
   return api_entry<tiledb::api::tiledb_deserialize_query_est_result_sizes>(
       ctx, query, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_serialize_config(
+CAPI_INTERFACE(serialize_config,
     tiledb_ctx_t* ctx,
     const tiledb_config_t* config,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_config>(
       ctx, config, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_config(
+CAPI_INTERFACE(deserialize_config,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_config_t** config) noexcept {
+    tiledb_config_t** config) {
   return api_entry_context<tiledb::api::tiledb_deserialize_config>(
       ctx, buffer, serialize_type, client_side, config);
 }
 
-int32_t tiledb_serialize_fragment_info_request(
+CAPI_INTERFACE(serialize_fragment_info_request,
     tiledb_ctx_t* ctx,
     const tiledb_fragment_info_t* fragment_info,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_fragment_info_request>(
       ctx, fragment_info, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_fragment_info_request(
+CAPI_INTERFACE(deserialize_fragment_info_request,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_fragment_info_t* fragment_info) noexcept {
+    tiledb_fragment_info_t* fragment_info) {
   return api_entry<tiledb::api::tiledb_deserialize_fragment_info_request>(
       ctx, buffer, serialize_type, client_side, fragment_info);
 }
 
-int32_t tiledb_serialize_fragment_info(
+CAPI_INTERFACE(serialize_fragment_info,
     tiledb_ctx_t* ctx,
     const tiledb_fragment_info_t* fragment_info,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
-    tiledb_buffer_t** buffer) noexcept {
+    tiledb_buffer_t** buffer) {
   return api_entry<tiledb::api::tiledb_serialize_fragment_info>(
       ctx, fragment_info, serialize_type, client_side, buffer);
 }
 
-int32_t tiledb_deserialize_fragment_info(
+CAPI_INTERFACE(deserialize_fragment_info,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     const char* array_uri,
     int32_t client_side,
-    tiledb_fragment_info_t* fragment_info) noexcept {
+    tiledb_fragment_info_t* fragment_info) {
   return api_entry<tiledb::api::tiledb_deserialize_fragment_info>(
       ctx, buffer, serialize_type, array_uri, client_side, fragment_info);
 }
 
-capi_return_t tiledb_handle_load_array_schema_request(
+CAPI_INTERFACE(handle_load_array_schema_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialization_type,
     const tiledb_buffer_t* request,
-    tiledb_buffer_t* response) noexcept {
+    tiledb_buffer_t* response) {
   return api_entry<tiledb::api::tiledb_handle_load_array_schema_request>(
       ctx, array, serialization_type, request, response);
 }
 
-capi_return_t tiledb_handle_load_enumerations_request(
+CAPI_INTERFACE(handle_load_enumerations_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialization_type,
     const tiledb_buffer_t* request,
-    tiledb_buffer_t* response) noexcept {
+    tiledb_buffer_t* response) {
   return api_entry<tiledb::api::tiledb_handle_load_enumerations_request>(
       ctx, array, serialization_type, request, response);
 }
@@ -7159,348 +7159,348 @@ int32_t tiledb::impl::tiledb_query_submit_async_func(
 /*          FRAGMENT INFO         */
 /* ****************************** */
 
-int32_t tiledb_fragment_info_alloc(
+CAPI_INTERFACE(fragment_info_alloc,
     tiledb_ctx_t* ctx,
     const char* array_uri,
-    tiledb_fragment_info_t** fragment_info) noexcept {
+    tiledb_fragment_info_t** fragment_info) {
   return api_entry<tiledb::api::tiledb_fragment_info_alloc>(
       ctx, array_uri, fragment_info);
 }
 
-void tiledb_fragment_info_free(
-    tiledb_fragment_info_t** fragment_info) noexcept {
+CAPI_INTERFACE_VOID(fragment_info_free,
+    tiledb_fragment_info_t** fragment_info) {
   return api_entry_void<tiledb::api::tiledb_fragment_info_free>(fragment_info);
 }
 
-int32_t tiledb_fragment_info_set_config(
+CAPI_INTERFACE(fragment_info_set_config,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
-    tiledb_config_t* config) noexcept {
+    tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_fragment_info_set_config>(
       ctx, fragment_info, config);
 }
 
-int32_t tiledb_fragment_info_get_config(
+CAPI_INTERFACE(fragment_info_get_config,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
-    tiledb_config_t** config) noexcept {
+    tiledb_config_t** config) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_config>(
       ctx, fragment_info, config);
 }
 
-int32_t tiledb_fragment_info_load(
-    tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info) noexcept {
+CAPI_INTERFACE(fragment_info_load,
+    tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info) {
   return api_entry<tiledb::api::tiledb_fragment_info_load>(ctx, fragment_info);
 }
 
-int32_t tiledb_fragment_info_get_fragment_name(
+CAPI_INTERFACE(fragment_info_get_fragment_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    const char** name) noexcept {
+    const char** name) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_fragment_name>(
       ctx, fragment_info, fid, name);
 }
 
-int32_t tiledb_fragment_info_get_fragment_name_v2(
+CAPI_INTERFACE(fragment_info_get_fragment_name_v2,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    tiledb_string_t** name) noexcept {
+    tiledb_string_t** name) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_fragment_name_v2>(
       ctx, fragment_info, fid, name);
 }
 
-int32_t tiledb_fragment_info_get_fragment_num(
+CAPI_INTERFACE(fragment_info_get_fragment_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
-    uint32_t* fragment_num) noexcept {
+    uint32_t* fragment_num) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_fragment_num>(
       ctx, fragment_info, fragment_num);
 }
 
-int32_t tiledb_fragment_info_get_fragment_uri(
+CAPI_INTERFACE(fragment_info_get_fragment_uri,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    const char** uri) noexcept {
+    const char** uri) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_fragment_uri>(
       ctx, fragment_info, fid, uri);
 }
 
-int32_t tiledb_fragment_info_get_fragment_size(
+CAPI_INTERFACE(fragment_info_get_fragment_size,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    uint64_t* size) noexcept {
+    uint64_t* size) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_fragment_size>(
       ctx, fragment_info, fid, size);
 }
 
-int32_t tiledb_fragment_info_get_dense(
+CAPI_INTERFACE(fragment_info_get_dense,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    int32_t* dense) noexcept {
+    int32_t* dense) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_dense>(
       ctx, fragment_info, fid, dense);
 }
 
-int32_t tiledb_fragment_info_get_sparse(
+CAPI_INTERFACE(fragment_info_get_sparse,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    int32_t* sparse) noexcept {
+    int32_t* sparse) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_sparse>(
       ctx, fragment_info, fid, sparse);
 }
 
-int32_t tiledb_fragment_info_get_timestamp_range(
+CAPI_INTERFACE(fragment_info_get_timestamp_range,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint64_t* start,
-    uint64_t* end) noexcept {
+    uint64_t* end) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_timestamp_range>(
       ctx, fragment_info, fid, start, end);
 }
 
-int32_t tiledb_fragment_info_get_non_empty_domain_from_index(
+CAPI_INTERFACE(fragment_info_get_non_empty_domain_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t did,
-    void* domain) noexcept {
+    void* domain) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_non_empty_domain_from_index>(
       ctx, fragment_info, fid, did, domain);
 }
 
-int32_t tiledb_fragment_info_get_non_empty_domain_from_name(
+CAPI_INTERFACE(fragment_info_get_non_empty_domain_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     const char* dim_name,
-    void* domain) noexcept {
+    void* domain) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_non_empty_domain_from_name>(
       ctx, fragment_info, fid, dim_name, domain);
 }
 
-int32_t tiledb_fragment_info_get_non_empty_domain_var_size_from_index(
+CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_size_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t did,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<
       tiledb::api::
           tiledb_fragment_info_get_non_empty_domain_var_size_from_index>(
       ctx, fragment_info, fid, did, start_size, end_size);
 }
 
-int32_t tiledb_fragment_info_get_non_empty_domain_var_size_from_name(
+CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_size_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     const char* dim_name,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<
       tiledb::api::
           tiledb_fragment_info_get_non_empty_domain_var_size_from_name>(
       ctx, fragment_info, fid, dim_name, start_size, end_size);
 }
 
-int32_t tiledb_fragment_info_get_non_empty_domain_var_from_index(
+CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t did,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_non_empty_domain_var_from_index>(
       ctx, fragment_info, fid, did, start, end);
 }
 
-int32_t tiledb_fragment_info_get_non_empty_domain_var_from_name(
+CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     const char* dim_name,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_non_empty_domain_var_from_name>(
       ctx, fragment_info, fid, dim_name, start, end);
 }
 
-int32_t tiledb_fragment_info_get_mbr_num(
+CAPI_INTERFACE(fragment_info_get_mbr_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    uint64_t* mbr_num) noexcept {
+    uint64_t* mbr_num) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_mbr_num>(
       ctx, fragment_info, fid, mbr_num);
 }
 
-int32_t tiledb_fragment_info_get_mbr_from_index(
+CAPI_INTERFACE(fragment_info_get_mbr_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t mid,
     uint32_t did,
-    void* mbr) noexcept {
+    void* mbr) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_mbr_from_index>(
       ctx, fragment_info, fid, mid, did, mbr);
 }
 
-int32_t tiledb_fragment_info_get_mbr_from_name(
+CAPI_INTERFACE(fragment_info_get_mbr_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t mid,
     const char* dim_name,
-    void* mbr) noexcept {
+    void* mbr) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_mbr_from_name>(
       ctx, fragment_info, fid, mid, dim_name, mbr);
 }
 
-int32_t tiledb_fragment_info_get_mbr_var_size_from_index(
+CAPI_INTERFACE(fragment_info_get_mbr_var_size_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t mid,
     uint32_t did,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_mbr_var_size_from_index>(
       ctx, fragment_info, fid, mid, did, start_size, end_size);
 }
 
-int32_t tiledb_fragment_info_get_mbr_var_size_from_name(
+CAPI_INTERFACE(fragment_info_get_mbr_var_size_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t mid,
     const char* dim_name,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_mbr_var_size_from_name>(
       ctx, fragment_info, fid, mid, dim_name, start_size, end_size);
 }
 
-int32_t tiledb_fragment_info_get_mbr_var_from_index(
+CAPI_INTERFACE(fragment_info_get_mbr_var_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t mid,
     uint32_t did,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_mbr_var_from_index>(
       ctx, fragment_info, fid, mid, did, start, end);
 }
 
-int32_t tiledb_fragment_info_get_mbr_var_from_name(
+CAPI_INTERFACE(fragment_info_get_mbr_var_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
     uint32_t mid,
     const char* dim_name,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_mbr_var_from_name>(
       ctx, fragment_info, fid, mid, dim_name, start, end);
 }
 
-int32_t tiledb_fragment_info_get_cell_num(
+CAPI_INTERFACE(fragment_info_get_cell_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    uint64_t* cell_num) noexcept {
+    uint64_t* cell_num) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_cell_num>(
       ctx, fragment_info, fid, cell_num);
 }
 
-int32_t tiledb_fragment_info_get_total_cell_num(
+CAPI_INTERFACE(fragment_info_get_total_cell_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
-    uint64_t* cell_num) noexcept {
+    uint64_t* cell_num) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_total_cell_num>(
       ctx, fragment_info, cell_num);
 }
 
-int32_t tiledb_fragment_info_get_version(
+CAPI_INTERFACE(fragment_info_get_version,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    uint32_t* version) noexcept {
+    uint32_t* version) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_version>(
       ctx, fragment_info, fid, version);
 }
 
-int32_t tiledb_fragment_info_has_consolidated_metadata(
+CAPI_INTERFACE(fragment_info_has_consolidated_metadata,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    int32_t* has) noexcept {
+    int32_t* has) {
   return api_entry<tiledb::api::tiledb_fragment_info_has_consolidated_metadata>(
       ctx, fragment_info, fid, has);
 }
 
-int32_t tiledb_fragment_info_get_unconsolidated_metadata_num(
+CAPI_INTERFACE(fragment_info_get_unconsolidated_metadata_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
-    uint32_t* unconsolidated) noexcept {
+    uint32_t* unconsolidated) {
   return api_entry<
       tiledb::api::tiledb_fragment_info_get_unconsolidated_metadata_num>(
       ctx, fragment_info, unconsolidated);
 }
 
-int32_t tiledb_fragment_info_get_to_vacuum_num(
+CAPI_INTERFACE(fragment_info_get_to_vacuum_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
-    uint32_t* to_vacuum_num) noexcept {
+    uint32_t* to_vacuum_num) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_to_vacuum_num>(
       ctx, fragment_info, to_vacuum_num);
 }
 
-int32_t tiledb_fragment_info_get_to_vacuum_uri(
+CAPI_INTERFACE(fragment_info_get_to_vacuum_uri,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    const char** uri) noexcept {
+    const char** uri) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_to_vacuum_uri>(
       ctx, fragment_info, fid, uri);
 }
 
-int32_t tiledb_fragment_info_get_array_schema(
+CAPI_INTERFACE(fragment_info_get_array_schema,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    tiledb_array_schema_t** array_schema) noexcept {
+    tiledb_array_schema_t** array_schema) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_array_schema>(
       ctx, fragment_info, fid, array_schema);
 }
 
-int32_t tiledb_fragment_info_get_array_schema_name(
+CAPI_INTERFACE(fragment_info_get_array_schema_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
-    const char** schema_name) noexcept {
+    const char** schema_name) {
   return api_entry<tiledb::api::tiledb_fragment_info_get_array_schema_name>(
       ctx, fragment_info, fid, schema_name);
 }
 
-int32_t tiledb_fragment_info_dump(
+CAPI_INTERFACE(fragment_info_dump,
     tiledb_ctx_t* ctx,
     const tiledb_fragment_info_t* fragment_info,
-    FILE* out) noexcept {
+    FILE* out) {
   return api_entry<tiledb::api::tiledb_fragment_info_dump>(
       ctx, fragment_info, out);
 }
@@ -7509,65 +7509,65 @@ int32_t tiledb_fragment_info_dump(
 /*          EXPERIMENTAL APIs        */
 /* ********************************* */
 
-TILEDB_EXPORT int32_t tiledb_query_get_status_details(
+TILEDB_EXPORT CAPI_INTERFACE(query_get_status_details,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
-    tiledb_query_status_details_t* status) noexcept {
+    tiledb_query_status_details_t* status) {
   return api_entry<tiledb::api::tiledb_query_get_status_details>(
       ctx, query, status);
 }
 
-int32_t tiledb_consolidation_plan_create_with_mbr(
+CAPI_INTERFACE(consolidation_plan_create_with_mbr,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t fragment_size,
-    tiledb_consolidation_plan_t** consolidation_plan) noexcept {
+    tiledb_consolidation_plan_t** consolidation_plan) {
   return api_entry<tiledb::api::tiledb_consolidation_plan_create_with_mbr>(
       ctx, array, fragment_size, consolidation_plan);
 }
 
-void tiledb_consolidation_plan_free(
-    tiledb_consolidation_plan_t** consolidation_plan) noexcept {
+CAPI_INTERFACE_VOID(consolidation_plan_free,
+    tiledb_consolidation_plan_t** consolidation_plan) {
   return api_entry_void<tiledb::api::tiledb_consolidation_plan_free>(
       consolidation_plan);
 }
 
-int32_t tiledb_consolidation_plan_get_num_nodes(
+CAPI_INTERFACE(consolidation_plan_get_num_nodes,
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
-    uint64_t* num_nodes) noexcept {
+    uint64_t* num_nodes) {
   return api_entry<tiledb::api::tiledb_consolidation_plan_get_num_nodes>(
       ctx, consolidation_plan, num_nodes);
 }
 
-int32_t tiledb_consolidation_plan_get_num_fragments(
+CAPI_INTERFACE(consolidation_plan_get_num_fragments,
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t node_index,
-    uint64_t* num_fragments) noexcept {
+    uint64_t* num_fragments) {
   return api_entry<tiledb::api::tiledb_consolidation_plan_get_num_fragments>(
       ctx, consolidation_plan, node_index, num_fragments);
 }
 
-int32_t tiledb_consolidation_plan_get_fragment_uri(
+CAPI_INTERFACE(consolidation_plan_get_fragment_uri,
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t node_index,
     uint64_t fragment_index,
-    const char** uri) noexcept {
+    const char** uri) {
   return api_entry<tiledb::api::tiledb_consolidation_plan_get_fragment_uri>(
       ctx, consolidation_plan, node_index, fragment_index, uri);
 }
 
-int32_t tiledb_consolidation_plan_dump_json_str(
+CAPI_INTERFACE(consolidation_plan_dump_json_str,
     tiledb_ctx_t* ctx,
     const tiledb_consolidation_plan_t* consolidation_plan,
-    char** out) noexcept {
+    char** out) {
   return api_entry<tiledb::api::tiledb_consolidation_plan_dump_json_str>(
       ctx, consolidation_plan, out);
 }
 
-int32_t tiledb_consolidation_plan_free_json_str(char** out) noexcept {
+CAPI_INTERFACE(consolidation_plan_free_json_str,char** out) {
   return api_entry_plain<tiledb::api::tiledb_consolidation_plan_free_json_str>(
       out);
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5251,60 +5251,68 @@ constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
 /* ****************************** */
 /*       ENUMS TO/FROM STR        */
 /* ****************************** */
-CAPI_INTERFACE(array_type_to_str,
-    tiledb_array_type_t array_type, const char** str) {
+CAPI_INTERFACE(
+    array_type_to_str, tiledb_array_type_t array_type, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_array_type_to_str>(
       array_type, str);
 }
 
-CAPI_INTERFACE(array_type_from_str,
-    const char* str, tiledb_array_type_t* array_type) {
+CAPI_INTERFACE(
+    array_type_from_str, const char* str, tiledb_array_type_t* array_type) {
   return api_entry_plain<tiledb::api::tiledb_array_type_from_str>(
       str, array_type);
 }
 
-CAPI_INTERFACE(layout_to_str,
-    tiledb_layout_t layout, const char** str) {
+CAPI_INTERFACE(layout_to_str, tiledb_layout_t layout, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_layout_to_str>(layout, str);
 }
 
-CAPI_INTERFACE(layout_from_str,
-    const char* str, tiledb_layout_t* layout) {
+CAPI_INTERFACE(layout_from_str, const char* str, tiledb_layout_t* layout) {
   return api_entry_plain<tiledb::api::tiledb_layout_from_str>(str, layout);
 }
 
-CAPI_INTERFACE(encryption_type_to_str,
-    tiledb_encryption_type_t encryption_type, const char** str) {
+CAPI_INTERFACE(
+    encryption_type_to_str,
+    tiledb_encryption_type_t encryption_type,
+    const char** str) {
   return api_entry_plain<tiledb::api::tiledb_encryption_type_to_str>(
       encryption_type, str);
 }
 
-CAPI_INTERFACE(encryption_type_from_str,
-    const char* str, tiledb_encryption_type_t* encryption_type) {
+CAPI_INTERFACE(
+    encryption_type_from_str,
+    const char* str,
+    tiledb_encryption_type_t* encryption_type) {
   return api_entry_plain<tiledb::api::tiledb_encryption_type_from_str>(
       str, encryption_type);
 }
 
-CAPI_INTERFACE(query_status_to_str,
-    tiledb_query_status_t query_status, const char** str) {
+CAPI_INTERFACE(
+    query_status_to_str, tiledb_query_status_t query_status, const char** str) {
   return api_entry_plain<tiledb::api::tiledb_query_status_to_str>(
       query_status, str);
 }
 
-CAPI_INTERFACE(query_status_from_str,
-    const char* str, tiledb_query_status_t* query_status) {
+CAPI_INTERFACE(
+    query_status_from_str,
+    const char* str,
+    tiledb_query_status_t* query_status) {
   return api_entry_plain<tiledb::api::tiledb_query_status_from_str>(
       str, query_status);
 }
 
-CAPI_INTERFACE(serialization_type_to_str,
-    tiledb_serialization_type_t serialization_type, const char** str) {
+CAPI_INTERFACE(
+    serialization_type_to_str,
+    tiledb_serialization_type_t serialization_type,
+    const char** str) {
   return api_entry_plain<tiledb::api::tiledb_serialization_type_to_str>(
       serialization_type, str);
 }
 
-CAPI_INTERFACE(serialization_type_from_str,
-    const char* str, tiledb_serialization_type_t* serialization_type) {
+CAPI_INTERFACE(
+    serialization_type_from_str,
+    const char* str,
+    tiledb_serialization_type_t* serialization_type) {
   return api_entry_plain<tiledb::api::tiledb_serialization_type_from_str>(
       str, serialization_type);
 }
@@ -5347,7 +5355,7 @@ const char* tiledb_timestamps() noexcept {
 /*            VERSION             */
 /* ****************************** */
 
-CAPI_INTERFACE_VOID(version,int32_t* major, int32_t* minor, int32_t* rev) {
+CAPI_INTERFACE_VOID(version, int32_t* major, int32_t* minor, int32_t* rev) {
   *major = tiledb::sm::constants::library_version[0];
   *minor = tiledb::sm::constants::library_version[1];
   *rev = tiledb::sm::constants::library_version[2];
@@ -5357,14 +5365,14 @@ CAPI_INTERFACE_VOID(version,int32_t* major, int32_t* minor, int32_t* rev) {
 /*             LOGGING               */
 /* ********************************* */
 
-CAPI_INTERFACE(log_warn,tiledb_ctx_t* ctx, const char* message) {
+CAPI_INTERFACE(log_warn, tiledb_ctx_t* ctx, const char* message) {
   return api_entry<tiledb::api::tiledb_log_warn>(ctx, message);
 }
 
 /* ********************************* */
 /*              AS BUILT             */
 /* ********************************* */
-CAPI_INTERFACE(as_built_dump,tiledb_string_t** out) {
+CAPI_INTERFACE(as_built_dump, tiledb_string_t** out) {
   return api_entry_plain<tiledb::api::tiledb_as_built_dump>(out);
 }
 
@@ -5372,7 +5380,8 @@ CAPI_INTERFACE(as_built_dump,tiledb_string_t** out) {
 /*           ARRAY SCHEMA         */
 /* ****************************** */
 
-CAPI_INTERFACE(array_schema_alloc,
+CAPI_INTERFACE(
+    array_schema_alloc,
     tiledb_ctx_t* ctx,
     tiledb_array_type_t array_type,
     tiledb_array_schema_t** array_schema) {
@@ -5380,11 +5389,12 @@ CAPI_INTERFACE(array_schema_alloc,
       ctx, array_type, array_schema);
 }
 
-CAPI_INTERFACE_VOID(array_schema_free,tiledb_array_schema_t** array_schema) {
+CAPI_INTERFACE_VOID(array_schema_free, tiledb_array_schema_t** array_schema) {
   return api_entry_void<tiledb::api::tiledb_array_schema_free>(array_schema);
 }
 
-CAPI_INTERFACE(array_schema_add_attribute,
+CAPI_INTERFACE(
+    array_schema_add_attribute,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_attribute_t* attr) {
@@ -5392,7 +5402,8 @@ CAPI_INTERFACE(array_schema_add_attribute,
       ctx, array_schema, attr);
 }
 
-CAPI_INTERFACE(array_schema_set_allows_dups,
+CAPI_INTERFACE(
+    array_schema_set_allows_dups,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     int allows_dups) {
@@ -5400,7 +5411,8 @@ CAPI_INTERFACE(array_schema_set_allows_dups,
       ctx, array_schema, allows_dups);
 }
 
-CAPI_INTERFACE(array_schema_get_allows_dups,
+CAPI_INTERFACE(
+    array_schema_get_allows_dups,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     int* allows_dups) {
@@ -5408,7 +5420,8 @@ CAPI_INTERFACE(array_schema_get_allows_dups,
       ctx, array_schema, allows_dups);
 }
 
-CAPI_INTERFACE(array_schema_get_version,
+CAPI_INTERFACE(
+    array_schema_get_version,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint32_t* version) {
@@ -5416,7 +5429,8 @@ CAPI_INTERFACE(array_schema_get_version,
       ctx, array_schema, version);
 }
 
-CAPI_INTERFACE(array_schema_set_domain,
+CAPI_INTERFACE(
+    array_schema_set_domain,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_domain_t* domain) {
@@ -5424,7 +5438,8 @@ CAPI_INTERFACE(array_schema_set_domain,
       ctx, array_schema, domain);
 }
 
-CAPI_INTERFACE(array_schema_set_capacity,
+CAPI_INTERFACE(
+    array_schema_set_capacity,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t capacity) {
@@ -5432,7 +5447,8 @@ CAPI_INTERFACE(array_schema_set_capacity,
       ctx, array_schema, capacity);
 }
 
-CAPI_INTERFACE(array_schema_set_cell_order,
+CAPI_INTERFACE(
+    array_schema_set_cell_order,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_layout_t cell_order) {
@@ -5440,7 +5456,8 @@ CAPI_INTERFACE(array_schema_set_cell_order,
       ctx, array_schema, cell_order);
 }
 
-CAPI_INTERFACE(array_schema_set_tile_order,
+CAPI_INTERFACE(
+    array_schema_set_tile_order,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_layout_t tile_order) {
@@ -5448,7 +5465,8 @@ CAPI_INTERFACE(array_schema_set_tile_order,
       ctx, array_schema, tile_order);
 }
 
-CAPI_INTERFACE(array_schema_timestamp_range,
+CAPI_INTERFACE(
+    array_schema_timestamp_range,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t* lo,
@@ -5457,7 +5475,8 @@ CAPI_INTERFACE(array_schema_timestamp_range,
       ctx, array_schema, lo, hi);
 }
 
-CAPI_INTERFACE(array_schema_add_enumeration,
+CAPI_INTERFACE(
+    array_schema_add_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_enumeration_t* enumeration) {
@@ -5465,7 +5484,8 @@ CAPI_INTERFACE(array_schema_add_enumeration,
       ctx, array_schema, enumeration);
 }
 
-CAPI_INTERFACE(array_schema_set_coords_filter_list,
+CAPI_INTERFACE(
+    array_schema_set_coords_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_filter_list_t* filter_list) {
@@ -5473,7 +5493,8 @@ CAPI_INTERFACE(array_schema_set_coords_filter_list,
       ctx, array_schema, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_set_offsets_filter_list,
+CAPI_INTERFACE(
+    array_schema_set_offsets_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_filter_list_t* filter_list) {
@@ -5481,7 +5502,8 @@ CAPI_INTERFACE(array_schema_set_offsets_filter_list,
       ctx, array_schema, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_set_validity_filter_list,
+CAPI_INTERFACE(
+    array_schema_set_validity_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_filter_list_t* filter_list) {
@@ -5489,12 +5511,15 @@ CAPI_INTERFACE(array_schema_set_validity_filter_list,
       ctx, array_schema, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_check,
-    tiledb_ctx_t* ctx, tiledb_array_schema_t* array_schema) {
+CAPI_INTERFACE(
+    array_schema_check,
+    tiledb_ctx_t* ctx,
+    tiledb_array_schema_t* array_schema) {
   return api_entry<tiledb::api::tiledb_array_schema_check>(ctx, array_schema);
 }
 
-CAPI_INTERFACE(array_schema_load,
+CAPI_INTERFACE(
+    array_schema_load,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_array_schema_t** array_schema) {
@@ -5502,7 +5527,8 @@ CAPI_INTERFACE(array_schema_load,
       ctx, array_uri, array_schema);
 }
 
-CAPI_INTERFACE(array_schema_load_with_key,
+CAPI_INTERFACE(
+    array_schema_load_with_key,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,
@@ -5518,7 +5544,8 @@ CAPI_INTERFACE(array_schema_load_with_key,
       array_schema);
 }
 
-CAPI_INTERFACE(array_schema_get_array_type,
+CAPI_INTERFACE(
+    array_schema_get_array_type,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     tiledb_array_type_t* array_type) {
@@ -5526,7 +5553,8 @@ CAPI_INTERFACE(array_schema_get_array_type,
       ctx, array_schema, array_type);
 }
 
-CAPI_INTERFACE(array_schema_get_capacity,
+CAPI_INTERFACE(
+    array_schema_get_capacity,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     uint64_t* capacity) {
@@ -5534,7 +5562,8 @@ CAPI_INTERFACE(array_schema_get_capacity,
       ctx, array_schema, capacity);
 }
 
-CAPI_INTERFACE(array_schema_get_cell_order,
+CAPI_INTERFACE(
+    array_schema_get_cell_order,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     tiledb_layout_t* cell_order) {
@@ -5542,7 +5571,8 @@ CAPI_INTERFACE(array_schema_get_cell_order,
       ctx, array_schema, cell_order);
 }
 
-CAPI_INTERFACE(array_schema_get_coords_filter_list,
+CAPI_INTERFACE(
+    array_schema_get_coords_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_filter_list_t** filter_list) {
@@ -5550,7 +5580,8 @@ CAPI_INTERFACE(array_schema_get_coords_filter_list,
       ctx, array_schema, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_get_offsets_filter_list,
+CAPI_INTERFACE(
+    array_schema_get_offsets_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_filter_list_t** filter_list) {
@@ -5558,7 +5589,8 @@ CAPI_INTERFACE(array_schema_get_offsets_filter_list,
       ctx, array_schema, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_get_validity_filter_list,
+CAPI_INTERFACE(
+    array_schema_get_validity_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     tiledb_filter_list_t** filter_list) {
@@ -5566,7 +5598,8 @@ CAPI_INTERFACE(array_schema_get_validity_filter_list,
       ctx, array_schema, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_get_domain,
+CAPI_INTERFACE(
+    array_schema_get_domain,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     tiledb_domain_t** domain) {
@@ -5574,7 +5607,8 @@ CAPI_INTERFACE(array_schema_get_domain,
       ctx, array_schema, domain);
 }
 
-CAPI_INTERFACE(array_schema_get_tile_order,
+CAPI_INTERFACE(
+    array_schema_get_tile_order,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     tiledb_layout_t* tile_order) {
@@ -5582,7 +5616,8 @@ CAPI_INTERFACE(array_schema_get_tile_order,
       ctx, array_schema, tile_order);
 }
 
-CAPI_INTERFACE(array_schema_get_attribute_num,
+CAPI_INTERFACE(
+    array_schema_get_attribute_num,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     uint32_t* attribute_num) {
@@ -5590,7 +5625,8 @@ CAPI_INTERFACE(array_schema_get_attribute_num,
       ctx, array_schema, attribute_num);
 }
 
-CAPI_INTERFACE(array_schema_dump,
+CAPI_INTERFACE(
+    array_schema_dump,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     FILE* out) {
@@ -5598,7 +5634,8 @@ CAPI_INTERFACE(array_schema_dump,
       ctx, array_schema, out);
 }
 
-CAPI_INTERFACE(array_schema_get_attribute_from_index,
+CAPI_INTERFACE(
+    array_schema_get_attribute_from_index,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     uint32_t index,
@@ -5607,7 +5644,8 @@ CAPI_INTERFACE(array_schema_get_attribute_from_index,
       ctx, array_schema, index, attr);
 }
 
-CAPI_INTERFACE(array_schema_get_attribute_from_name,
+CAPI_INTERFACE(
+    array_schema_get_attribute_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     const char* name,
@@ -5616,7 +5654,8 @@ CAPI_INTERFACE(array_schema_get_attribute_from_name,
       ctx, array_schema, name, attr);
 }
 
-CAPI_INTERFACE(array_schema_has_attribute,
+CAPI_INTERFACE(
+    array_schema_has_attribute,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     const char* name,
@@ -5629,20 +5668,23 @@ CAPI_INTERFACE(array_schema_has_attribute,
 /*            SCHEMA EVOLUTION       */
 /* ********************************* */
 
-CAPI_INTERFACE(array_schema_evolution_alloc,
+CAPI_INTERFACE(
+    array_schema_evolution_alloc,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t** array_schema_evolution) {
   return api_entry<tiledb::api::tiledb_array_schema_evolution_alloc>(
       ctx, array_schema_evolution);
 }
 
-CAPI_INTERFACE_VOID(array_schema_evolution_free,
+CAPI_INTERFACE_VOID(
+    array_schema_evolution_free,
     tiledb_array_schema_evolution_t** array_schema_evolution) {
   return api_entry_void<tiledb::api::tiledb_array_schema_evolution_free>(
       array_schema_evolution);
 }
 
-CAPI_INTERFACE(array_schema_evolution_add_attribute,
+CAPI_INTERFACE(
+    array_schema_evolution_add_attribute,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     tiledb_attribute_t* attr) {
@@ -5650,7 +5692,8 @@ CAPI_INTERFACE(array_schema_evolution_add_attribute,
       ctx, array_schema_evolution, attr);
 }
 
-CAPI_INTERFACE(array_schema_evolution_drop_attribute,
+CAPI_INTERFACE(
+    array_schema_evolution_drop_attribute,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     const char* attribute_name) {
@@ -5658,7 +5701,8 @@ CAPI_INTERFACE(array_schema_evolution_drop_attribute,
       ctx, array_schema_evolution, attribute_name);
 }
 
-CAPI_INTERFACE(array_schema_evolution_add_enumeration,
+CAPI_INTERFACE(
+    array_schema_evolution_add_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     tiledb_enumeration_t* enmr) {
@@ -5666,7 +5710,8 @@ CAPI_INTERFACE(array_schema_evolution_add_enumeration,
       ctx, array_schema_evolution, enmr);
 }
 
-CAPI_INTERFACE(array_schema_evolution_extend_enumeration,
+CAPI_INTERFACE(
+    array_schema_evolution_extend_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     tiledb_enumeration_t* enmr) {
@@ -5675,7 +5720,8 @@ CAPI_INTERFACE(array_schema_evolution_extend_enumeration,
       ctx, array_schema_evolution, enmr);
 }
 
-CAPI_INTERFACE(array_schema_evolution_drop_enumeration,
+CAPI_INTERFACE(
+    array_schema_evolution_drop_enumeration,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     const char* enumeration_name) {
@@ -5697,7 +5743,8 @@ TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(
 /*              QUERY             */
 /* ****************************** */
 
-CAPI_INTERFACE(query_alloc,
+CAPI_INTERFACE(
+    query_alloc,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t query_type,
@@ -5706,26 +5753,32 @@ CAPI_INTERFACE(query_alloc,
       ctx, array, query_type, query);
 }
 
-CAPI_INTERFACE(query_get_stats,
-    tiledb_ctx_t* ctx, tiledb_query_t* query, char** stats_json) {
+CAPI_INTERFACE(
+    query_get_stats,
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    char** stats_json) {
   return api_entry<tiledb::api::tiledb_query_get_stats>(ctx, query, stats_json);
 }
 
-CAPI_INTERFACE(query_set_config,
+CAPI_INTERFACE(
+    query_set_config,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_query_set_config>(ctx, query, config);
 }
 
-CAPI_INTERFACE(query_get_config,
+CAPI_INTERFACE(
+    query_get_config,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_config_t** config) {
   return api_entry<tiledb::api::tiledb_query_get_config>(ctx, query, config);
 }
 
-CAPI_INTERFACE(query_set_subarray,
+CAPI_INTERFACE(
+    query_set_subarray,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const void* subarray_vals) {
@@ -5733,7 +5786,8 @@ CAPI_INTERFACE(query_set_subarray,
       ctx, query, subarray_vals);
 }
 
-CAPI_INTERFACE(query_set_subarray_t,
+CAPI_INTERFACE(
+    query_set_subarray_t,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const tiledb_subarray_t* subarray) {
@@ -5741,7 +5795,8 @@ CAPI_INTERFACE(query_set_subarray_t,
       ctx, query, subarray);
 }
 
-CAPI_INTERFACE(query_set_data_buffer,
+CAPI_INTERFACE(
+    query_set_data_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
@@ -5751,7 +5806,8 @@ CAPI_INTERFACE(query_set_data_buffer,
       ctx, query, name, buffer, buffer_size);
 }
 
-CAPI_INTERFACE(query_set_offsets_buffer,
+CAPI_INTERFACE(
+    query_set_offsets_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
@@ -5761,7 +5817,8 @@ CAPI_INTERFACE(query_set_offsets_buffer,
       ctx, query, name, buffer_offsets, buffer_offsets_size);
 }
 
-CAPI_INTERFACE(query_set_validity_buffer,
+CAPI_INTERFACE(
+    query_set_validity_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
@@ -5771,7 +5828,8 @@ CAPI_INTERFACE(query_set_validity_buffer,
       ctx, query, name, buffer_validity, buffer_validity_size);
 }
 
-CAPI_INTERFACE(query_get_data_buffer,
+CAPI_INTERFACE(
+    query_get_data_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
@@ -5781,7 +5839,8 @@ CAPI_INTERFACE(query_get_data_buffer,
       ctx, query, name, buffer, buffer_size);
 }
 
-CAPI_INTERFACE(query_get_offsets_buffer,
+CAPI_INTERFACE(
+    query_get_offsets_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
@@ -5791,7 +5850,8 @@ CAPI_INTERFACE(query_get_offsets_buffer,
       ctx, query, name, buffer, buffer_size);
 }
 
-CAPI_INTERFACE(query_get_validity_buffer,
+CAPI_INTERFACE(
+    query_get_validity_buffer,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* name,
@@ -5801,37 +5861,41 @@ CAPI_INTERFACE(query_get_validity_buffer,
       ctx, query, name, buffer, buffer_size);
 }
 
-CAPI_INTERFACE(query_set_layout,
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_layout_t layout) {
+CAPI_INTERFACE(
+    query_set_layout,
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    tiledb_layout_t layout) {
   return api_entry<tiledb::api::tiledb_query_set_layout>(ctx, query, layout);
 }
 
-CAPI_INTERFACE(query_set_condition,
+CAPI_INTERFACE(
+    query_set_condition,
     tiledb_ctx_t* const ctx,
     tiledb_query_t* const query,
     const tiledb_query_condition_t* const cond) {
   return api_entry<tiledb::api::tiledb_query_set_condition>(ctx, query, cond);
 }
 
-CAPI_INTERFACE(query_finalize,
-    tiledb_ctx_t* ctx, tiledb_query_t* query) {
+CAPI_INTERFACE(query_finalize, tiledb_ctx_t* ctx, tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_query_finalize>(ctx, query);
 }
 
-CAPI_INTERFACE(query_submit_and_finalize,
-    tiledb_ctx_t* ctx, tiledb_query_t* query) {
+CAPI_INTERFACE(
+    query_submit_and_finalize, tiledb_ctx_t* ctx, tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_query_submit_and_finalize>(ctx, query);
 }
 
-CAPI_INTERFACE_VOID(query_free,tiledb_query_t** query) {
+CAPI_INTERFACE_VOID(query_free, tiledb_query_t** query) {
   return api_entry_void<tiledb::api::tiledb_query_free>(query);
 }
 
-CAPI_INTERFACE(query_submit,tiledb_ctx_t* ctx, tiledb_query_t* query) {
+CAPI_INTERFACE(query_submit, tiledb_ctx_t* ctx, tiledb_query_t* query) {
   return api_entry<tiledb::api::tiledb_query_submit>(ctx, query);
 }
 
-CAPI_INTERFACE(query_submit_async,
+CAPI_INTERFACE(
+    query_submit_async,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     void (*callback)(void*),
@@ -5840,27 +5904,33 @@ CAPI_INTERFACE(query_submit_async,
       ctx, query, callback, callback_data);
 }
 
-CAPI_INTERFACE(query_has_results,
-    tiledb_ctx_t* ctx, tiledb_query_t* query, int32_t* has_results) {
+CAPI_INTERFACE(
+    query_has_results,
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    int32_t* has_results) {
   return api_entry<tiledb::api::tiledb_query_has_results>(
       ctx, query, has_results);
 }
 
-CAPI_INTERFACE(query_get_status,
+CAPI_INTERFACE(
+    query_get_status,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_query_status_t* status) {
   return api_entry<tiledb::api::tiledb_query_get_status>(ctx, query, status);
 }
 
-CAPI_INTERFACE(query_get_type,
+CAPI_INTERFACE(
+    query_get_type,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_query_type_t* query_type) {
   return api_entry<tiledb::api::tiledb_query_get_type>(ctx, query, query_type);
 }
 
-CAPI_INTERFACE(query_get_layout,
+CAPI_INTERFACE(
+    query_get_layout,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_layout_t* query_layout) {
@@ -5868,12 +5938,16 @@ CAPI_INTERFACE(query_get_layout,
       ctx, query, query_layout);
 }
 
-CAPI_INTERFACE(query_get_array,
-    tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_array_t** array) {
+CAPI_INTERFACE(
+    query_get_array,
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_query_get_array>(ctx, query, array);
 }
 
-CAPI_INTERFACE(query_add_range,
+CAPI_INTERFACE(
+    query_add_range,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     uint32_t dim_idx,
@@ -5884,7 +5958,8 @@ CAPI_INTERFACE(query_add_range,
       ctx, query, dim_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(query_add_point_ranges,
+CAPI_INTERFACE(
+    query_add_point_ranges,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     uint32_t dim_idx,
@@ -5894,7 +5969,8 @@ CAPI_INTERFACE(query_add_point_ranges,
       ctx, query, dim_idx, start, count);
 }
 
-CAPI_INTERFACE(query_add_range_by_name,
+CAPI_INTERFACE(
+    query_add_range_by_name,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* dim_name,
@@ -5905,7 +5981,8 @@ CAPI_INTERFACE(query_add_range_by_name,
       ctx, query, dim_name, start, end, stride);
 }
 
-CAPI_INTERFACE(query_add_range_var,
+CAPI_INTERFACE(
+    query_add_range_var,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     uint32_t dim_idx,
@@ -5917,7 +5994,8 @@ CAPI_INTERFACE(query_add_range_var,
       ctx, query, dim_idx, start, start_size, end, end_size);
 }
 
-CAPI_INTERFACE(query_add_range_var_by_name,
+CAPI_INTERFACE(
+    query_add_range_var_by_name,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* dim_name,
@@ -5929,7 +6007,8 @@ CAPI_INTERFACE(query_add_range_var_by_name,
       ctx, query, dim_name, start, start_size, end, end_size);
 }
 
-CAPI_INTERFACE(query_get_range_num,
+CAPI_INTERFACE(
+    query_get_range_num,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
@@ -5938,7 +6017,8 @@ CAPI_INTERFACE(query_get_range_num,
       ctx, query, dim_idx, range_num);
 }
 
-CAPI_INTERFACE(query_get_range_num_from_name,
+CAPI_INTERFACE(
+    query_get_range_num_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
@@ -5947,7 +6027,8 @@ CAPI_INTERFACE(query_get_range_num_from_name,
       ctx, query, dim_name, range_num);
 }
 
-CAPI_INTERFACE(query_get_range,
+CAPI_INTERFACE(
+    query_get_range,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
@@ -5959,7 +6040,8 @@ CAPI_INTERFACE(query_get_range,
       ctx, query, dim_idx, range_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(query_get_range_from_name,
+CAPI_INTERFACE(
+    query_get_range_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
@@ -5971,7 +6053,8 @@ CAPI_INTERFACE(query_get_range_from_name,
       ctx, query, dim_name, range_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(query_get_range_var_size,
+CAPI_INTERFACE(
+    query_get_range_var_size,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
@@ -5982,7 +6065,8 @@ CAPI_INTERFACE(query_get_range_var_size,
       ctx, query, dim_idx, range_idx, start_size, end_size);
 }
 
-CAPI_INTERFACE(query_get_range_var_size_from_name,
+CAPI_INTERFACE(
+    query_get_range_var_size_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
@@ -5993,7 +6077,8 @@ CAPI_INTERFACE(query_get_range_var_size_from_name,
       ctx, query, dim_name, range_idx, start_size, end_size);
 }
 
-CAPI_INTERFACE(query_get_range_var,
+CAPI_INTERFACE(
+    query_get_range_var,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint32_t dim_idx,
@@ -6004,7 +6089,8 @@ CAPI_INTERFACE(query_get_range_var,
       ctx, query, dim_idx, range_idx, start, end);
 }
 
-CAPI_INTERFACE(query_get_range_var_from_name,
+CAPI_INTERFACE(
+    query_get_range_var_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* dim_name,
@@ -6015,7 +6101,8 @@ CAPI_INTERFACE(query_get_range_var_from_name,
       ctx, query, dim_name, range_idx, start, end);
 }
 
-CAPI_INTERFACE(query_get_est_result_size,
+CAPI_INTERFACE(
+    query_get_est_result_size,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
@@ -6024,7 +6111,8 @@ CAPI_INTERFACE(query_get_est_result_size,
       ctx, query, name, size);
 }
 
-CAPI_INTERFACE(query_get_est_result_size_var,
+CAPI_INTERFACE(
+    query_get_est_result_size_var,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
@@ -6034,7 +6122,8 @@ CAPI_INTERFACE(query_get_est_result_size_var,
       ctx, query, name, size_off, size_val);
 }
 
-CAPI_INTERFACE(query_get_est_result_size_nullable,
+CAPI_INTERFACE(
+    query_get_est_result_size_nullable,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
@@ -6044,7 +6133,8 @@ CAPI_INTERFACE(query_get_est_result_size_nullable,
       ctx, query, name, size_val, size_validity);
 }
 
-CAPI_INTERFACE(query_get_est_result_size_var_nullable,
+CAPI_INTERFACE(
+    query_get_est_result_size_var_nullable,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     const char* name,
@@ -6055,12 +6145,16 @@ CAPI_INTERFACE(query_get_est_result_size_var_nullable,
       ctx, query, name, size_off, size_val, size_validity);
 }
 
-CAPI_INTERFACE(query_get_fragment_num,
-    tiledb_ctx_t* ctx, const tiledb_query_t* query, uint32_t* num) {
+CAPI_INTERFACE(
+    query_get_fragment_num,
+    tiledb_ctx_t* ctx,
+    const tiledb_query_t* query,
+    uint32_t* num) {
   return api_entry<tiledb::api::tiledb_query_get_fragment_num>(ctx, query, num);
 }
 
-CAPI_INTERFACE(query_get_fragment_uri,
+CAPI_INTERFACE(
+    query_get_fragment_uri,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint64_t idx,
@@ -6069,7 +6163,8 @@ CAPI_INTERFACE(query_get_fragment_uri,
       ctx, query, idx, uri);
 }
 
-CAPI_INTERFACE(query_get_fragment_timestamp_range,
+CAPI_INTERFACE(
+    query_get_fragment_timestamp_range,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint64_t idx,
@@ -6079,7 +6174,8 @@ CAPI_INTERFACE(query_get_fragment_timestamp_range,
       ctx, query, idx, t1, t2);
 }
 
-CAPI_INTERFACE(query_get_subarray_t,
+CAPI_INTERFACE(
+    query_get_subarray_t,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     tiledb_subarray_t** subarray) {
@@ -6087,7 +6183,8 @@ CAPI_INTERFACE(query_get_subarray_t,
       ctx, query, subarray);
 }
 
-CAPI_INTERFACE(query_get_relevant_fragment_num,
+CAPI_INTERFACE(
+    query_get_relevant_fragment_num,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     uint64_t* relevant_fragment_num) {
@@ -6099,14 +6196,16 @@ CAPI_INTERFACE(query_get_relevant_fragment_num,
 /*         SUBARRAY               */
 /* ****************************** */
 
-CAPI_INTERFACE(subarray_alloc,
+CAPI_INTERFACE(
+    subarray_alloc,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_subarray_t** subarray) {
   return api_entry<tiledb::api::tiledb_subarray_alloc>(ctx, array, subarray);
 }
 
-CAPI_INTERFACE(subarray_set_config,
+CAPI_INTERFACE(
+    subarray_set_config,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     tiledb_config_t* config) {
@@ -6114,11 +6213,12 @@ CAPI_INTERFACE(subarray_set_config,
       ctx, subarray, config);
 }
 
-CAPI_INTERFACE_VOID(subarray_free,tiledb_subarray_t** subarray) {
+CAPI_INTERFACE_VOID(subarray_free, tiledb_subarray_t** subarray) {
   return api_entry_void<tiledb::api::tiledb_subarray_free>(subarray);
 }
 
-CAPI_INTERFACE(subarray_set_coalesce_ranges,
+CAPI_INTERFACE(
+    subarray_set_coalesce_ranges,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     int coalesce_ranges) {
@@ -6126,7 +6226,8 @@ CAPI_INTERFACE(subarray_set_coalesce_ranges,
       ctx, subarray, coalesce_ranges);
 }
 
-CAPI_INTERFACE(subarray_set_subarray,
+CAPI_INTERFACE(
+    subarray_set_subarray,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray_obj,
     const void* subarray_vals) {
@@ -6134,7 +6235,8 @@ CAPI_INTERFACE(subarray_set_subarray,
       ctx, subarray_obj, subarray_vals);
 }
 
-CAPI_INTERFACE(subarray_add_range,
+CAPI_INTERFACE(
+    subarray_add_range,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6145,7 +6247,8 @@ CAPI_INTERFACE(subarray_add_range,
       ctx, subarray, dim_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(subarray_add_point_ranges,
+CAPI_INTERFACE(
+    subarray_add_point_ranges,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6155,7 +6258,8 @@ CAPI_INTERFACE(subarray_add_point_ranges,
       ctx, subarray, dim_idx, start, count);
 }
 
-CAPI_INTERFACE(subarray_add_range_by_name,
+CAPI_INTERFACE(
+    subarray_add_range_by_name,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -6166,7 +6270,8 @@ CAPI_INTERFACE(subarray_add_range_by_name,
       ctx, subarray, dim_name, start, end, stride);
 }
 
-CAPI_INTERFACE(subarray_add_range_var,
+CAPI_INTERFACE(
+    subarray_add_range_var,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6178,7 +6283,8 @@ CAPI_INTERFACE(subarray_add_range_var,
       ctx, subarray, dim_idx, start, start_size, end, end_size);
 }
 
-CAPI_INTERFACE(subarray_add_range_var_by_name,
+CAPI_INTERFACE(
+    subarray_add_range_var_by_name,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -6190,7 +6296,8 @@ CAPI_INTERFACE(subarray_add_range_var_by_name,
       ctx, subarray, dim_name, start, start_size, end, end_size);
 }
 
-CAPI_INTERFACE(subarray_get_range_num,
+CAPI_INTERFACE(
+    subarray_get_range_num,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6199,7 +6306,8 @@ CAPI_INTERFACE(subarray_get_range_num,
       ctx, subarray, dim_idx, range_num);
 }
 
-CAPI_INTERFACE(subarray_get_range_num_from_name,
+CAPI_INTERFACE(
+    subarray_get_range_num_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -6208,7 +6316,8 @@ CAPI_INTERFACE(subarray_get_range_num_from_name,
       ctx, subarray, dim_name, range_num);
 }
 
-CAPI_INTERFACE(subarray_get_range,
+CAPI_INTERFACE(
+    subarray_get_range,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6220,7 +6329,8 @@ CAPI_INTERFACE(subarray_get_range,
       ctx, subarray, dim_idx, range_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(subarray_get_range_var_size,
+CAPI_INTERFACE(
+    subarray_get_range_var_size,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6231,7 +6341,8 @@ CAPI_INTERFACE(subarray_get_range_var_size,
       ctx, subarray, dim_idx, range_idx, start_size, end_size);
 }
 
-CAPI_INTERFACE(subarray_get_range_from_name,
+CAPI_INTERFACE(
+    subarray_get_range_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -6243,7 +6354,8 @@ CAPI_INTERFACE(subarray_get_range_from_name,
       ctx, subarray, dim_name, range_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(subarray_get_range_var_size_from_name,
+CAPI_INTERFACE(
+    subarray_get_range_var_size_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -6254,7 +6366,8 @@ CAPI_INTERFACE(subarray_get_range_var_size_from_name,
       ctx, subarray, dim_name, range_idx, start_size, end_size);
 }
 
-CAPI_INTERFACE(subarray_get_range_var,
+CAPI_INTERFACE(
+    subarray_get_range_var,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -6265,7 +6378,8 @@ CAPI_INTERFACE(subarray_get_range_var,
       ctx, subarray, dim_idx, range_idx, start, end);
 }
 
-CAPI_INTERFACE(subarray_get_range_var_from_name,
+CAPI_INTERFACE(
+    subarray_get_range_var_from_name,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -6280,12 +6394,15 @@ CAPI_INTERFACE(subarray_get_range_var_from_name,
 /*          QUERY CONDITION       */
 /* ****************************** */
 
-CAPI_INTERFACE(query_condition_alloc,
-    tiledb_ctx_t* const ctx, tiledb_query_condition_t** const cond) {
+CAPI_INTERFACE(
+    query_condition_alloc,
+    tiledb_ctx_t* const ctx,
+    tiledb_query_condition_t** const cond) {
   return api_entry<tiledb::api::tiledb_query_condition_alloc>(ctx, cond);
 }
 
-CAPI_INTERFACE(query_condition_alloc_set_membership,
+CAPI_INTERFACE(
+    query_condition_alloc_set_membership,
     tiledb_ctx_t* ctx,
     const char* field_name,
     const void* data,
@@ -6299,11 +6416,12 @@ CAPI_INTERFACE(query_condition_alloc_set_membership,
       ctx, field_name, data, data_size, offsets, offsets_size, op, cond);
 }
 
-CAPI_INTERFACE_VOID(query_condition_free,tiledb_query_condition_t** cond) {
+CAPI_INTERFACE_VOID(query_condition_free, tiledb_query_condition_t** cond) {
   return api_entry_void<tiledb::api::tiledb_query_condition_free>(cond);
 }
 
-CAPI_INTERFACE(query_condition_init,
+CAPI_INTERFACE(
+    query_condition_init,
     tiledb_ctx_t* const ctx,
     tiledb_query_condition_t* const cond,
     const char* const attribute_name,
@@ -6314,7 +6432,8 @@ CAPI_INTERFACE(query_condition_init,
       ctx, cond, attribute_name, condition_value, condition_value_size, op);
 }
 
-CAPI_INTERFACE(query_condition_combine,
+CAPI_INTERFACE(
+    query_condition_combine,
     tiledb_ctx_t* const ctx,
     const tiledb_query_condition_t* const left_cond,
     const tiledb_query_condition_t* const right_cond,
@@ -6324,7 +6443,8 @@ CAPI_INTERFACE(query_condition_combine,
       ctx, left_cond, right_cond, combination_op, combined_cond);
 }
 
-CAPI_INTERFACE(query_condition_negate,
+CAPI_INTERFACE(
+    query_condition_negate,
     tiledb_ctx_t* const ctx,
     const tiledb_query_condition_t* const cond,
     tiledb_query_condition_t** const negated_cond) {
@@ -6332,7 +6452,8 @@ CAPI_INTERFACE(query_condition_negate,
       ctx, cond, negated_cond);
 }
 
-CAPI_INTERFACE(query_condition_set_use_enumeration,
+CAPI_INTERFACE(
+    query_condition_set_use_enumeration,
     tiledb_ctx_t* const ctx,
     const tiledb_query_condition_t* const cond,
     int use_enumeration) {
@@ -6344,7 +6465,8 @@ CAPI_INTERFACE(query_condition_set_use_enumeration,
 /*         UPDATE CONDITION       */
 /* ****************************** */
 
-CAPI_INTERFACE(query_add_update_value,
+CAPI_INTERFACE(
+    query_add_update_value,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     const char* field_name,
@@ -6358,12 +6480,16 @@ CAPI_INTERFACE(query_add_update_value,
 /*              ARRAY             */
 /* ****************************** */
 
-CAPI_INTERFACE(array_alloc,
-    tiledb_ctx_t* ctx, const char* array_uri, tiledb_array_t** array) {
+CAPI_INTERFACE(
+    array_alloc,
+    tiledb_ctx_t* ctx,
+    const char* array_uri,
+    tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_array_alloc>(ctx, array_uri, array);
 }
 
-CAPI_INTERFACE(array_set_open_timestamp_start,
+CAPI_INTERFACE(
+    array_set_open_timestamp_start,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t timestamp_start) {
@@ -6371,13 +6497,17 @@ CAPI_INTERFACE(array_set_open_timestamp_start,
       ctx, array, timestamp_start);
 }
 
-CAPI_INTERFACE(array_set_open_timestamp_end,
-    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t timestamp_end) {
+CAPI_INTERFACE(
+    array_set_open_timestamp_end,
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    uint64_t timestamp_end) {
   return api_entry<tiledb::api::tiledb_array_set_open_timestamp_end>(
       ctx, array, timestamp_end);
 }
 
-CAPI_INTERFACE(array_get_open_timestamp_start,
+CAPI_INTERFACE(
+    array_get_open_timestamp_start,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t* timestamp_start) {
@@ -6385,7 +6515,8 @@ CAPI_INTERFACE(array_get_open_timestamp_start,
       ctx, array, timestamp_start);
 }
 
-CAPI_INTERFACE(array_get_open_timestamp_end,
+CAPI_INTERFACE(
+    array_get_open_timestamp_end,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t* timestamp_end) {
@@ -6393,16 +6524,20 @@ CAPI_INTERFACE(array_get_open_timestamp_end,
       ctx, array, timestamp_end);
 }
 
-CAPI_INTERFACE(array_delete,tiledb_ctx_t* ctx, const char* uri) {
+CAPI_INTERFACE(array_delete, tiledb_ctx_t* ctx, const char* uri) {
   return api_entry<tiledb::api::tiledb_array_delete>(ctx, uri);
 }
 
-CAPI_INTERFACE(array_delete_array,
-    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* uri) {
+CAPI_INTERFACE(
+    array_delete_array,
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* uri) {
   return api_entry<tiledb::api::tiledb_array_delete_array>(ctx, array, uri);
 }
 
-CAPI_INTERFACE(array_delete_fragments,
+CAPI_INTERFACE(
+    array_delete_fragments,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* uri,
@@ -6412,7 +6547,8 @@ CAPI_INTERFACE(array_delete_fragments,
       ctx, array, uri, timestamp_start, timestamp_end);
 }
 
-CAPI_INTERFACE(array_delete_fragments_v2,
+CAPI_INTERFACE(
+    array_delete_fragments_v2,
     tiledb_ctx_t* ctx,
     const char* uri_str,
     uint64_t timestamp_start,
@@ -6421,7 +6557,8 @@ CAPI_INTERFACE(array_delete_fragments_v2,
       ctx, uri_str, timestamp_start, timestamp_end);
 }
 
-CAPI_INTERFACE(array_delete_fragments_list,
+CAPI_INTERFACE(
+    array_delete_fragments_list,
     tiledb_ctx_t* ctx,
     const char* uri_str,
     const char* fragment_uris[],
@@ -6430,45 +6567,49 @@ CAPI_INTERFACE(array_delete_fragments_list,
       ctx, uri_str, fragment_uris, num_fragments);
 }
 
-CAPI_INTERFACE(array_open,
+CAPI_INTERFACE(
+    array_open,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t query_type) {
   return api_entry<tiledb::api::tiledb_array_open>(ctx, array, query_type);
 }
 
-CAPI_INTERFACE(array_is_open,
-    tiledb_ctx_t* ctx, tiledb_array_t* array, int32_t* is_open) {
+CAPI_INTERFACE(
+    array_is_open, tiledb_ctx_t* ctx, tiledb_array_t* array, int32_t* is_open) {
   return api_entry<tiledb::api::tiledb_array_is_open>(ctx, array, is_open);
 }
 
-CAPI_INTERFACE(array_reopen,tiledb_ctx_t* ctx, tiledb_array_t* array) {
+CAPI_INTERFACE(array_reopen, tiledb_ctx_t* ctx, tiledb_array_t* array) {
   return api_entry<tiledb::api::tiledb_array_reopen>(ctx, array);
 }
 
-CAPI_INTERFACE(array_set_config,
+CAPI_INTERFACE(
+    array_set_config,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_set_config>(ctx, array, config);
 }
 
-CAPI_INTERFACE(array_get_config,
+CAPI_INTERFACE(
+    array_get_config,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_config_t** config) {
   return api_entry<tiledb::api::tiledb_array_get_config>(ctx, array, config);
 }
 
-CAPI_INTERFACE(array_close,tiledb_ctx_t* ctx, tiledb_array_t* array) {
+CAPI_INTERFACE(array_close, tiledb_ctx_t* ctx, tiledb_array_t* array) {
   return api_entry<tiledb::api::tiledb_array_close>(ctx, array);
 }
 
-CAPI_INTERFACE_VOID(array_free,tiledb_array_t** array) {
+CAPI_INTERFACE_VOID(array_free, tiledb_array_t** array) {
   return api_entry_void<tiledb::api::tiledb_array_free>(array);
 }
 
-CAPI_INTERFACE(array_get_schema,
+CAPI_INTERFACE(
+    array_get_schema,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_array_schema_t** array_schema) {
@@ -6476,7 +6617,8 @@ CAPI_INTERFACE(array_get_schema,
       ctx, array, array_schema);
 }
 
-CAPI_INTERFACE(array_get_query_type,
+CAPI_INTERFACE(
+    array_get_query_type,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_query_type_t* query_type) {
@@ -6484,7 +6626,8 @@ CAPI_INTERFACE(array_get_query_type,
       ctx, array, query_type);
 }
 
-CAPI_INTERFACE(array_create,
+CAPI_INTERFACE(
+    array_create,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const tiledb_array_schema_t* array_schema) {
@@ -6492,7 +6635,8 @@ CAPI_INTERFACE(array_create,
       ctx, array_uri, array_schema);
 }
 
-CAPI_INTERFACE(array_create_with_key,
+CAPI_INTERFACE(
+    array_create_with_key,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const tiledb_array_schema_t* array_schema,
@@ -6508,7 +6652,8 @@ CAPI_INTERFACE(array_create_with_key,
       key_length);
 }
 
-CAPI_INTERFACE(array_consolidate,
+CAPI_INTERFACE(
+    array_consolidate,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_config_t* config) {
@@ -6516,7 +6661,8 @@ CAPI_INTERFACE(array_consolidate,
       ctx, array_uri, config);
 }
 
-CAPI_INTERFACE(array_consolidate_with_key,
+CAPI_INTERFACE(
+    array_consolidate_with_key,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t encryption_type,
@@ -6527,7 +6673,8 @@ CAPI_INTERFACE(array_consolidate_with_key,
       ctx, array_uri, encryption_type, encryption_key, key_length, config);
 }
 
-CAPI_INTERFACE(array_consolidate_fragments,
+CAPI_INTERFACE(
+    array_consolidate_fragments,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     const char** fragment_uris,
@@ -6537,14 +6684,16 @@ CAPI_INTERFACE(array_consolidate_fragments,
       ctx, array_uri, fragment_uris, num_fragments, config);
 }
 
-CAPI_INTERFACE(array_vacuum,
+CAPI_INTERFACE(
+    array_vacuum,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_config_t* config) {
   return api_entry<tiledb::api::tiledb_array_vacuum>(ctx, array_uri, config);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain,
+CAPI_INTERFACE(
+    array_get_non_empty_domain,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     void* domain,
@@ -6553,7 +6702,8 @@ CAPI_INTERFACE(array_get_non_empty_domain,
       ctx, array, domain, is_empty);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain_from_index,
+CAPI_INTERFACE(
+    array_get_non_empty_domain_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint32_t idx,
@@ -6563,7 +6713,8 @@ CAPI_INTERFACE(array_get_non_empty_domain_from_index,
       ctx, array, idx, domain, is_empty);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain_from_name,
+CAPI_INTERFACE(
+    array_get_non_empty_domain_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
@@ -6573,7 +6724,8 @@ CAPI_INTERFACE(array_get_non_empty_domain_from_name,
       ctx, array, name, domain, is_empty);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain_var_size_from_index,
+CAPI_INTERFACE(
+    array_get_non_empty_domain_var_size_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint32_t idx,
@@ -6585,7 +6737,8 @@ CAPI_INTERFACE(array_get_non_empty_domain_var_size_from_index,
       ctx, array, idx, start_size, end_size, is_empty);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain_var_size_from_name,
+CAPI_INTERFACE(
+    array_get_non_empty_domain_var_size_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
@@ -6597,7 +6750,8 @@ CAPI_INTERFACE(array_get_non_empty_domain_var_size_from_name,
       ctx, array, name, start_size, end_size, is_empty);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain_var_from_index,
+CAPI_INTERFACE(
+    array_get_non_empty_domain_var_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint32_t idx,
@@ -6609,7 +6763,8 @@ CAPI_INTERFACE(array_get_non_empty_domain_var_from_index,
       ctx, array, idx, start, end, is_empty);
 }
 
-CAPI_INTERFACE(array_get_non_empty_domain_var_from_name,
+CAPI_INTERFACE(
+    array_get_non_empty_domain_var_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* name,
@@ -6621,12 +6776,16 @@ CAPI_INTERFACE(array_get_non_empty_domain_var_from_name,
       ctx, array, name, start, end, is_empty);
 }
 
-CAPI_INTERFACE(array_get_uri,
-    tiledb_ctx_t* ctx, tiledb_array_t* array, const char** array_uri) {
+CAPI_INTERFACE(
+    array_get_uri,
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char** array_uri) {
   return api_entry<tiledb::api::tiledb_array_get_uri>(ctx, array, array_uri);
 }
 
-CAPI_INTERFACE(array_encryption_type,
+CAPI_INTERFACE(
+    array_encryption_type,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_encryption_type_t* encryption_type) {
@@ -6634,7 +6793,8 @@ CAPI_INTERFACE(array_encryption_type,
       ctx, array_uri, encryption_type);
 }
 
-CAPI_INTERFACE(array_put_metadata,
+CAPI_INTERFACE(
+    array_put_metadata,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* key,
@@ -6645,12 +6805,16 @@ CAPI_INTERFACE(array_put_metadata,
       ctx, array, key, value_type, value_num, value);
 }
 
-CAPI_INTERFACE(array_delete_metadata,
-    tiledb_ctx_t* ctx, tiledb_array_t* array, const char* key) {
+CAPI_INTERFACE(
+    array_delete_metadata,
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    const char* key) {
   return api_entry<tiledb::api::tiledb_array_delete_metadata>(ctx, array, key);
 }
 
-CAPI_INTERFACE(array_get_metadata,
+CAPI_INTERFACE(
+    array_get_metadata,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* key,
@@ -6661,12 +6825,16 @@ CAPI_INTERFACE(array_get_metadata,
       ctx, array, key, value_type, value_num, value);
 }
 
-CAPI_INTERFACE(array_get_metadata_num,
-    tiledb_ctx_t* ctx, tiledb_array_t* array, uint64_t* num) {
+CAPI_INTERFACE(
+    array_get_metadata_num,
+    tiledb_ctx_t* ctx,
+    tiledb_array_t* array,
+    uint64_t* num) {
   return api_entry<tiledb::api::tiledb_array_get_metadata_num>(ctx, array, num);
 }
 
-CAPI_INTERFACE(array_get_metadata_from_index,
+CAPI_INTERFACE(
+    array_get_metadata_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t index,
@@ -6679,7 +6847,8 @@ CAPI_INTERFACE(array_get_metadata_from_index,
       ctx, array, index, key, key_len, value_type, value_num, value);
 }
 
-CAPI_INTERFACE(array_has_metadata_key,
+CAPI_INTERFACE(
+    array_has_metadata_key,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const char* key,
@@ -6689,7 +6858,8 @@ CAPI_INTERFACE(array_has_metadata_key,
       ctx, array, key, value_type, has_key);
 }
 
-CAPI_INTERFACE(array_evolve,
+CAPI_INTERFACE(
+    array_evolve,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_array_schema_evolution_t* array_schema_evolution) {
@@ -6697,7 +6867,8 @@ CAPI_INTERFACE(array_evolve,
       ctx, array_uri, array_schema_evolution);
 }
 
-CAPI_INTERFACE(array_get_enumeration,
+CAPI_INTERFACE(
+    array_get_enumeration,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const char* attr_name,
@@ -6706,12 +6877,15 @@ CAPI_INTERFACE(array_get_enumeration,
       ctx, array, attr_name, enumeration);
 }
 
-CAPI_INTERFACE(array_load_all_enumerations,
-    tiledb_ctx_t* ctx, const tiledb_array_t* array) {
+CAPI_INTERFACE(
+    array_load_all_enumerations,
+    tiledb_ctx_t* ctx,
+    const tiledb_array_t* array) {
   return api_entry<tiledb::api::tiledb_array_load_all_enumerations>(ctx, array);
 }
 
-CAPI_INTERFACE(array_upgrade_version,
+CAPI_INTERFACE(
+    array_upgrade_version,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_config_t* config) {
@@ -6723,21 +6897,25 @@ CAPI_INTERFACE(array_upgrade_version,
 /*         OBJECT MANAGEMENT      */
 /* ****************************** */
 
-CAPI_INTERFACE(object_type,
-    tiledb_ctx_t* ctx, const char* path, tiledb_object_t* type) {
+CAPI_INTERFACE(
+    object_type, tiledb_ctx_t* ctx, const char* path, tiledb_object_t* type) {
   return api_entry<tiledb::api::tiledb_object_type>(ctx, path, type);
 }
 
-CAPI_INTERFACE(object_remove,tiledb_ctx_t* ctx, const char* path) {
+CAPI_INTERFACE(object_remove, tiledb_ctx_t* ctx, const char* path) {
   return api_entry<tiledb::api::tiledb_object_remove>(ctx, path);
 }
 
-CAPI_INTERFACE(object_move,
-    tiledb_ctx_t* ctx, const char* old_path, const char* new_path) {
+CAPI_INTERFACE(
+    object_move,
+    tiledb_ctx_t* ctx,
+    const char* old_path,
+    const char* new_path) {
   return api_entry<tiledb::api::tiledb_object_move>(ctx, old_path, new_path);
 }
 
-CAPI_INTERFACE(object_walk,
+CAPI_INTERFACE(
+    object_walk,
     tiledb_ctx_t* ctx,
     const char* path,
     tiledb_walk_order_t order,
@@ -6747,7 +6925,8 @@ CAPI_INTERFACE(object_walk,
       ctx, path, order, callback, data);
 }
 
-CAPI_INTERFACE(object_ls,
+CAPI_INTERFACE(
+    object_ls,
     tiledb_ctx_t* ctx,
     const char* path,
     int32_t (*callback)(const char*, tiledb_object_t, void*),
@@ -6759,7 +6938,8 @@ CAPI_INTERFACE(object_ls,
 /*              URI               */
 /* ****************************** */
 
-CAPI_INTERFACE(uri_to_path,
+CAPI_INTERFACE(
+    uri_to_path,
     tiledb_ctx_t* ctx,
     const char* uri,
     char* path_out,
@@ -6784,23 +6964,23 @@ CAPI_INTERFACE_NULL(stats_reset) {
   return api_entry_plain<tiledb::api::tiledb_stats_reset>();
 }
 
-CAPI_INTERFACE(stats_dump,FILE* out) {
+CAPI_INTERFACE(stats_dump, FILE* out) {
   return api_entry_plain<tiledb::api::tiledb_stats_dump>(out);
 }
 
-CAPI_INTERFACE(stats_dump_str,char** out) {
+CAPI_INTERFACE(stats_dump_str, char** out) {
   return api_entry_plain<tiledb::api::tiledb_stats_dump_str>(out);
 }
 
-CAPI_INTERFACE(stats_raw_dump,FILE* out) {
+CAPI_INTERFACE(stats_raw_dump, FILE* out) {
   return api_entry_plain<tiledb::api::tiledb_stats_raw_dump>(out);
 }
 
-CAPI_INTERFACE(stats_raw_dump_str,char** out) {
+CAPI_INTERFACE(stats_raw_dump_str, char** out) {
   return api_entry_plain<tiledb::api::tiledb_stats_raw_dump_str>(out);
 }
 
-CAPI_INTERFACE(stats_free_str,char** out) {
+CAPI_INTERFACE(stats_free_str, char** out) {
   return api_entry_plain<tiledb::api::tiledb_stats_free_str>(out);
 }
 
@@ -6808,7 +6988,8 @@ CAPI_INTERFACE(stats_free_str,char** out) {
 /*          Heap Profiler         */
 /* ****************************** */
 
-CAPI_INTERFACE(heap_profiler_enable,
+CAPI_INTERFACE(
+    heap_profiler_enable,
     const char* const file_name_prefix,
     const uint64_t dump_interval_ms,
     const uint64_t dump_interval_bytes,
@@ -6824,7 +7005,8 @@ CAPI_INTERFACE(heap_profiler_enable,
 /*          Serialization         */
 /* ****************************** */
 
-CAPI_INTERFACE(serialize_array,
+CAPI_INTERFACE(
+    serialize_array,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -6834,7 +7016,8 @@ CAPI_INTERFACE(serialize_array,
       ctx, array, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_array,
+CAPI_INTERFACE(
+    deserialize_array,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -6844,7 +7027,8 @@ CAPI_INTERFACE(deserialize_array,
       ctx, buffer, serialize_type, client_side, array);
 }
 
-CAPI_INTERFACE(serialize_array_schema,
+CAPI_INTERFACE(
+    serialize_array_schema,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     tiledb_serialization_type_t serialize_type,
@@ -6854,7 +7038,8 @@ CAPI_INTERFACE(serialize_array_schema,
       ctx, array_schema, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_array_schema,
+CAPI_INTERFACE(
+    deserialize_array_schema,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -6864,7 +7049,8 @@ CAPI_INTERFACE(deserialize_array_schema,
       ctx, buffer, serialize_type, client_side, array_schema);
 }
 
-CAPI_INTERFACE(serialize_array_open,
+CAPI_INTERFACE(
+    serialize_array_open,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -6874,7 +7060,8 @@ CAPI_INTERFACE(serialize_array_open,
       ctx, array, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_array_open,
+CAPI_INTERFACE(
+    deserialize_array_open,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -6884,7 +7071,8 @@ CAPI_INTERFACE(deserialize_array_open,
       ctx, buffer, serialize_type, client_side, array);
 }
 
-CAPI_INTERFACE(serialize_array_schema_evolution,
+CAPI_INTERFACE(
+    serialize_array_schema_evolution,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_evolution_t* array_schema_evolution,
     tiledb_serialization_type_t serialize_type,
@@ -6894,7 +7082,8 @@ CAPI_INTERFACE(serialize_array_schema_evolution,
       ctx, array_schema_evolution, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_array_schema_evolution,
+CAPI_INTERFACE(
+    deserialize_array_schema_evolution,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -6904,7 +7093,8 @@ CAPI_INTERFACE(deserialize_array_schema_evolution,
       ctx, buffer, serialize_type, client_side, array_schema_evolution);
 }
 
-CAPI_INTERFACE(serialize_query,
+CAPI_INTERFACE(
+    serialize_query,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
@@ -6914,7 +7104,8 @@ CAPI_INTERFACE(serialize_query,
       ctx, query, serialize_type, client_side, buffer_list);
 }
 
-CAPI_INTERFACE(deserialize_query,
+CAPI_INTERFACE(
+    deserialize_query,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -6924,7 +7115,8 @@ CAPI_INTERFACE(deserialize_query,
       ctx, buffer, serialize_type, client_side, query);
 }
 
-CAPI_INTERFACE(deserialize_query_and_array,
+CAPI_INTERFACE(
+    deserialize_query_and_array,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -6936,7 +7128,8 @@ CAPI_INTERFACE(deserialize_query_and_array,
       ctx, buffer, serialize_type, client_side, array_uri, query, array);
 }
 
-CAPI_INTERFACE(serialize_array_nonempty_domain,
+CAPI_INTERFACE(
+    serialize_array_nonempty_domain,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const void* nonempty_domain,
@@ -6954,7 +7147,8 @@ CAPI_INTERFACE(serialize_array_nonempty_domain,
       buffer);
 }
 
-CAPI_INTERFACE(deserialize_array_nonempty_domain,
+CAPI_INTERFACE(
+    deserialize_array_nonempty_domain,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const tiledb_buffer_t* buffer,
@@ -6972,7 +7166,8 @@ CAPI_INTERFACE(deserialize_array_nonempty_domain,
       is_empty);
 }
 
-CAPI_INTERFACE(serialize_array_non_empty_domain_all_dimensions,
+CAPI_INTERFACE(
+    serialize_array_non_empty_domain_all_dimensions,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -6983,7 +7178,8 @@ CAPI_INTERFACE(serialize_array_non_empty_domain_all_dimensions,
       ctx, array, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_array_non_empty_domain_all_dimensions,
+CAPI_INTERFACE(
+    deserialize_array_non_empty_domain_all_dimensions,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     const tiledb_buffer_t* buffer,
@@ -6994,7 +7190,8 @@ CAPI_INTERFACE(deserialize_array_non_empty_domain_all_dimensions,
       ctx, array, buffer, serialize_type, client_side);
 }
 
-CAPI_INTERFACE(serialize_array_max_buffer_sizes,
+CAPI_INTERFACE(
+    serialize_array_max_buffer_sizes,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     const void* subarray,
@@ -7004,7 +7201,8 @@ CAPI_INTERFACE(serialize_array_max_buffer_sizes,
       ctx, array, subarray, serialize_type, buffer);
 }
 
-CAPI_INTERFACE(handle_array_delete_fragments_timestamps_request,
+CAPI_INTERFACE(
+    handle_array_delete_fragments_timestamps_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -7014,7 +7212,8 @@ CAPI_INTERFACE(handle_array_delete_fragments_timestamps_request,
       ctx, array, serialize_type, request);
 }
 
-CAPI_INTERFACE(handle_array_delete_fragments_list_request,
+CAPI_INTERFACE(
+    handle_array_delete_fragments_list_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -7024,7 +7223,8 @@ CAPI_INTERFACE(handle_array_delete_fragments_list_request,
       ctx, array, serialize_type, request);
 }
 
-CAPI_INTERFACE(serialize_array_metadata,
+CAPI_INTERFACE(
+    serialize_array_metadata,
     tiledb_ctx_t* ctx,
     const tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -7033,7 +7233,8 @@ CAPI_INTERFACE(serialize_array_metadata,
       ctx, array, serialize_type, buffer);
 }
 
-CAPI_INTERFACE(deserialize_array_metadata,
+CAPI_INTERFACE(
+    deserialize_array_metadata,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialize_type,
@@ -7042,7 +7243,8 @@ CAPI_INTERFACE(deserialize_array_metadata,
       ctx, array, serialize_type, buffer);
 }
 
-CAPI_INTERFACE(serialize_query_est_result_sizes,
+CAPI_INTERFACE(
+    serialize_query_est_result_sizes,
     tiledb_ctx_t* ctx,
     const tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
@@ -7052,7 +7254,8 @@ CAPI_INTERFACE(serialize_query_est_result_sizes,
       ctx, query, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_query_est_result_sizes,
+CAPI_INTERFACE(
+    deserialize_query_est_result_sizes,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_serialization_type_t serialize_type,
@@ -7062,7 +7265,8 @@ CAPI_INTERFACE(deserialize_query_est_result_sizes,
       ctx, query, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(serialize_config,
+CAPI_INTERFACE(
+    serialize_config,
     tiledb_ctx_t* ctx,
     const tiledb_config_t* config,
     tiledb_serialization_type_t serialize_type,
@@ -7072,7 +7276,8 @@ CAPI_INTERFACE(serialize_config,
       ctx, config, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_config,
+CAPI_INTERFACE(
+    deserialize_config,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -7082,7 +7287,8 @@ CAPI_INTERFACE(deserialize_config,
       ctx, buffer, serialize_type, client_side, config);
 }
 
-CAPI_INTERFACE(serialize_fragment_info_request,
+CAPI_INTERFACE(
+    serialize_fragment_info_request,
     tiledb_ctx_t* ctx,
     const tiledb_fragment_info_t* fragment_info,
     tiledb_serialization_type_t serialize_type,
@@ -7092,7 +7298,8 @@ CAPI_INTERFACE(serialize_fragment_info_request,
       ctx, fragment_info, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_fragment_info_request,
+CAPI_INTERFACE(
+    deserialize_fragment_info_request,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -7102,7 +7309,8 @@ CAPI_INTERFACE(deserialize_fragment_info_request,
       ctx, buffer, serialize_type, client_side, fragment_info);
 }
 
-CAPI_INTERFACE(serialize_fragment_info,
+CAPI_INTERFACE(
+    serialize_fragment_info,
     tiledb_ctx_t* ctx,
     const tiledb_fragment_info_t* fragment_info,
     tiledb_serialization_type_t serialize_type,
@@ -7112,7 +7320,8 @@ CAPI_INTERFACE(serialize_fragment_info,
       ctx, fragment_info, serialize_type, client_side, buffer);
 }
 
-CAPI_INTERFACE(deserialize_fragment_info,
+CAPI_INTERFACE(
+    deserialize_fragment_info,
     tiledb_ctx_t* ctx,
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
@@ -7123,7 +7332,8 @@ CAPI_INTERFACE(deserialize_fragment_info,
       ctx, buffer, serialize_type, array_uri, client_side, fragment_info);
 }
 
-CAPI_INTERFACE(handle_load_array_schema_request,
+CAPI_INTERFACE(
+    handle_load_array_schema_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialization_type,
@@ -7133,7 +7343,8 @@ CAPI_INTERFACE(handle_load_array_schema_request,
       ctx, array, serialization_type, request, response);
 }
 
-CAPI_INTERFACE(handle_load_enumerations_request,
+CAPI_INTERFACE(
+    handle_load_enumerations_request,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     tiledb_serialization_type_t serialization_type,
@@ -7159,7 +7370,8 @@ int32_t tiledb::impl::tiledb_query_submit_async_func(
 /*          FRAGMENT INFO         */
 /* ****************************** */
 
-CAPI_INTERFACE(fragment_info_alloc,
+CAPI_INTERFACE(
+    fragment_info_alloc,
     tiledb_ctx_t* ctx,
     const char* array_uri,
     tiledb_fragment_info_t** fragment_info) {
@@ -7167,12 +7379,13 @@ CAPI_INTERFACE(fragment_info_alloc,
       ctx, array_uri, fragment_info);
 }
 
-CAPI_INTERFACE_VOID(fragment_info_free,
-    tiledb_fragment_info_t** fragment_info) {
+CAPI_INTERFACE_VOID(
+    fragment_info_free, tiledb_fragment_info_t** fragment_info) {
   return api_entry_void<tiledb::api::tiledb_fragment_info_free>(fragment_info);
 }
 
-CAPI_INTERFACE(fragment_info_set_config,
+CAPI_INTERFACE(
+    fragment_info_set_config,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     tiledb_config_t* config) {
@@ -7180,7 +7393,8 @@ CAPI_INTERFACE(fragment_info_set_config,
       ctx, fragment_info, config);
 }
 
-CAPI_INTERFACE(fragment_info_get_config,
+CAPI_INTERFACE(
+    fragment_info_get_config,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     tiledb_config_t** config) {
@@ -7188,12 +7402,15 @@ CAPI_INTERFACE(fragment_info_get_config,
       ctx, fragment_info, config);
 }
 
-CAPI_INTERFACE(fragment_info_load,
-    tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info) {
+CAPI_INTERFACE(
+    fragment_info_load,
+    tiledb_ctx_t* ctx,
+    tiledb_fragment_info_t* fragment_info) {
   return api_entry<tiledb::api::tiledb_fragment_info_load>(ctx, fragment_info);
 }
 
-CAPI_INTERFACE(fragment_info_get_fragment_name,
+CAPI_INTERFACE(
+    fragment_info_get_fragment_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7202,7 +7419,8 @@ CAPI_INTERFACE(fragment_info_get_fragment_name,
       ctx, fragment_info, fid, name);
 }
 
-CAPI_INTERFACE(fragment_info_get_fragment_name_v2,
+CAPI_INTERFACE(
+    fragment_info_get_fragment_name_v2,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7211,7 +7429,8 @@ CAPI_INTERFACE(fragment_info_get_fragment_name_v2,
       ctx, fragment_info, fid, name);
 }
 
-CAPI_INTERFACE(fragment_info_get_fragment_num,
+CAPI_INTERFACE(
+    fragment_info_get_fragment_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t* fragment_num) {
@@ -7219,7 +7438,8 @@ CAPI_INTERFACE(fragment_info_get_fragment_num,
       ctx, fragment_info, fragment_num);
 }
 
-CAPI_INTERFACE(fragment_info_get_fragment_uri,
+CAPI_INTERFACE(
+    fragment_info_get_fragment_uri,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7228,7 +7448,8 @@ CAPI_INTERFACE(fragment_info_get_fragment_uri,
       ctx, fragment_info, fid, uri);
 }
 
-CAPI_INTERFACE(fragment_info_get_fragment_size,
+CAPI_INTERFACE(
+    fragment_info_get_fragment_size,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7237,7 +7458,8 @@ CAPI_INTERFACE(fragment_info_get_fragment_size,
       ctx, fragment_info, fid, size);
 }
 
-CAPI_INTERFACE(fragment_info_get_dense,
+CAPI_INTERFACE(
+    fragment_info_get_dense,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7246,7 +7468,8 @@ CAPI_INTERFACE(fragment_info_get_dense,
       ctx, fragment_info, fid, dense);
 }
 
-CAPI_INTERFACE(fragment_info_get_sparse,
+CAPI_INTERFACE(
+    fragment_info_get_sparse,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7255,7 +7478,8 @@ CAPI_INTERFACE(fragment_info_get_sparse,
       ctx, fragment_info, fid, sparse);
 }
 
-CAPI_INTERFACE(fragment_info_get_timestamp_range,
+CAPI_INTERFACE(
+    fragment_info_get_timestamp_range,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7265,7 +7489,8 @@ CAPI_INTERFACE(fragment_info_get_timestamp_range,
       ctx, fragment_info, fid, start, end);
 }
 
-CAPI_INTERFACE(fragment_info_get_non_empty_domain_from_index,
+CAPI_INTERFACE(
+    fragment_info_get_non_empty_domain_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7276,7 +7501,8 @@ CAPI_INTERFACE(fragment_info_get_non_empty_domain_from_index,
       ctx, fragment_info, fid, did, domain);
 }
 
-CAPI_INTERFACE(fragment_info_get_non_empty_domain_from_name,
+CAPI_INTERFACE(
+    fragment_info_get_non_empty_domain_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7287,7 +7513,8 @@ CAPI_INTERFACE(fragment_info_get_non_empty_domain_from_name,
       ctx, fragment_info, fid, dim_name, domain);
 }
 
-CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_size_from_index,
+CAPI_INTERFACE(
+    fragment_info_get_non_empty_domain_var_size_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7300,7 +7527,8 @@ CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_size_from_index,
       ctx, fragment_info, fid, did, start_size, end_size);
 }
 
-CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_size_from_name,
+CAPI_INTERFACE(
+    fragment_info_get_non_empty_domain_var_size_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7313,7 +7541,8 @@ CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_size_from_name,
       ctx, fragment_info, fid, dim_name, start_size, end_size);
 }
 
-CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_from_index,
+CAPI_INTERFACE(
+    fragment_info_get_non_empty_domain_var_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7325,7 +7554,8 @@ CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_from_index,
       ctx, fragment_info, fid, did, start, end);
 }
 
-CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_from_name,
+CAPI_INTERFACE(
+    fragment_info_get_non_empty_domain_var_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7337,7 +7567,8 @@ CAPI_INTERFACE(fragment_info_get_non_empty_domain_var_from_name,
       ctx, fragment_info, fid, dim_name, start, end);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_num,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7346,7 +7577,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_num,
       ctx, fragment_info, fid, mbr_num);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_from_index,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7357,7 +7589,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_from_index,
       ctx, fragment_info, fid, mid, did, mbr);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_from_name,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7368,7 +7601,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_from_name,
       ctx, fragment_info, fid, mid, dim_name, mbr);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_var_size_from_index,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_var_size_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7381,7 +7615,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_var_size_from_index,
       ctx, fragment_info, fid, mid, did, start_size, end_size);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_var_size_from_name,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_var_size_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7394,7 +7629,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_var_size_from_name,
       ctx, fragment_info, fid, mid, dim_name, start_size, end_size);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_var_from_index,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_var_from_index,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7406,7 +7642,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_var_from_index,
       ctx, fragment_info, fid, mid, did, start, end);
 }
 
-CAPI_INTERFACE(fragment_info_get_mbr_var_from_name,
+CAPI_INTERFACE(
+    fragment_info_get_mbr_var_from_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7418,7 +7655,8 @@ CAPI_INTERFACE(fragment_info_get_mbr_var_from_name,
       ctx, fragment_info, fid, mid, dim_name, start, end);
 }
 
-CAPI_INTERFACE(fragment_info_get_cell_num,
+CAPI_INTERFACE(
+    fragment_info_get_cell_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7427,7 +7665,8 @@ CAPI_INTERFACE(fragment_info_get_cell_num,
       ctx, fragment_info, fid, cell_num);
 }
 
-CAPI_INTERFACE(fragment_info_get_total_cell_num,
+CAPI_INTERFACE(
+    fragment_info_get_total_cell_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint64_t* cell_num) {
@@ -7435,7 +7674,8 @@ CAPI_INTERFACE(fragment_info_get_total_cell_num,
       ctx, fragment_info, cell_num);
 }
 
-CAPI_INTERFACE(fragment_info_get_version,
+CAPI_INTERFACE(
+    fragment_info_get_version,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7444,7 +7684,8 @@ CAPI_INTERFACE(fragment_info_get_version,
       ctx, fragment_info, fid, version);
 }
 
-CAPI_INTERFACE(fragment_info_has_consolidated_metadata,
+CAPI_INTERFACE(
+    fragment_info_has_consolidated_metadata,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7453,7 +7694,8 @@ CAPI_INTERFACE(fragment_info_has_consolidated_metadata,
       ctx, fragment_info, fid, has);
 }
 
-CAPI_INTERFACE(fragment_info_get_unconsolidated_metadata_num,
+CAPI_INTERFACE(
+    fragment_info_get_unconsolidated_metadata_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t* unconsolidated) {
@@ -7462,7 +7704,8 @@ CAPI_INTERFACE(fragment_info_get_unconsolidated_metadata_num,
       ctx, fragment_info, unconsolidated);
 }
 
-CAPI_INTERFACE(fragment_info_get_to_vacuum_num,
+CAPI_INTERFACE(
+    fragment_info_get_to_vacuum_num,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t* to_vacuum_num) {
@@ -7470,7 +7713,8 @@ CAPI_INTERFACE(fragment_info_get_to_vacuum_num,
       ctx, fragment_info, to_vacuum_num);
 }
 
-CAPI_INTERFACE(fragment_info_get_to_vacuum_uri,
+CAPI_INTERFACE(
+    fragment_info_get_to_vacuum_uri,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7479,7 +7723,8 @@ CAPI_INTERFACE(fragment_info_get_to_vacuum_uri,
       ctx, fragment_info, fid, uri);
 }
 
-CAPI_INTERFACE(fragment_info_get_array_schema,
+CAPI_INTERFACE(
+    fragment_info_get_array_schema,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7488,7 +7733,8 @@ CAPI_INTERFACE(fragment_info_get_array_schema,
       ctx, fragment_info, fid, array_schema);
 }
 
-CAPI_INTERFACE(fragment_info_get_array_schema_name,
+CAPI_INTERFACE(
+    fragment_info_get_array_schema_name,
     tiledb_ctx_t* ctx,
     tiledb_fragment_info_t* fragment_info,
     uint32_t fid,
@@ -7497,7 +7743,8 @@ CAPI_INTERFACE(fragment_info_get_array_schema_name,
       ctx, fragment_info, fid, schema_name);
 }
 
-CAPI_INTERFACE(fragment_info_dump,
+CAPI_INTERFACE(
+    fragment_info_dump,
     tiledb_ctx_t* ctx,
     const tiledb_fragment_info_t* fragment_info,
     FILE* out) {
@@ -7509,7 +7756,8 @@ CAPI_INTERFACE(fragment_info_dump,
 /*          EXPERIMENTAL APIs        */
 /* ********************************* */
 
-TILEDB_EXPORT CAPI_INTERFACE(query_get_status_details,
+TILEDB_EXPORT CAPI_INTERFACE(
+    query_get_status_details,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,
     tiledb_query_status_details_t* status) {
@@ -7517,7 +7765,8 @@ TILEDB_EXPORT CAPI_INTERFACE(query_get_status_details,
       ctx, query, status);
 }
 
-CAPI_INTERFACE(consolidation_plan_create_with_mbr,
+CAPI_INTERFACE(
+    consolidation_plan_create_with_mbr,
     tiledb_ctx_t* ctx,
     tiledb_array_t* array,
     uint64_t fragment_size,
@@ -7526,13 +7775,14 @@ CAPI_INTERFACE(consolidation_plan_create_with_mbr,
       ctx, array, fragment_size, consolidation_plan);
 }
 
-CAPI_INTERFACE_VOID(consolidation_plan_free,
-    tiledb_consolidation_plan_t** consolidation_plan) {
+CAPI_INTERFACE_VOID(
+    consolidation_plan_free, tiledb_consolidation_plan_t** consolidation_plan) {
   return api_entry_void<tiledb::api::tiledb_consolidation_plan_free>(
       consolidation_plan);
 }
 
-CAPI_INTERFACE(consolidation_plan_get_num_nodes,
+CAPI_INTERFACE(
+    consolidation_plan_get_num_nodes,
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t* num_nodes) {
@@ -7540,7 +7790,8 @@ CAPI_INTERFACE(consolidation_plan_get_num_nodes,
       ctx, consolidation_plan, num_nodes);
 }
 
-CAPI_INTERFACE(consolidation_plan_get_num_fragments,
+CAPI_INTERFACE(
+    consolidation_plan_get_num_fragments,
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t node_index,
@@ -7549,7 +7800,8 @@ CAPI_INTERFACE(consolidation_plan_get_num_fragments,
       ctx, consolidation_plan, node_index, num_fragments);
 }
 
-CAPI_INTERFACE(consolidation_plan_get_fragment_uri,
+CAPI_INTERFACE(
+    consolidation_plan_get_fragment_uri,
     tiledb_ctx_t* ctx,
     tiledb_consolidation_plan_t* consolidation_plan,
     uint64_t node_index,
@@ -7559,7 +7811,8 @@ CAPI_INTERFACE(consolidation_plan_get_fragment_uri,
       ctx, consolidation_plan, node_index, fragment_index, uri);
 }
 
-CAPI_INTERFACE(consolidation_plan_dump_json_str,
+CAPI_INTERFACE(
+    consolidation_plan_dump_json_str,
     tiledb_ctx_t* ctx,
     const tiledb_consolidation_plan_t* consolidation_plan,
     char** out) {
@@ -7567,7 +7820,7 @@ CAPI_INTERFACE(consolidation_plan_dump_json_str,
       ctx, consolidation_plan, out);
 }
 
-CAPI_INTERFACE(consolidation_plan_free_json_str,char** out) {
+CAPI_INTERFACE(consolidation_plan_free_json_str, char** out) {
   return api_entry_plain<tiledb::api::tiledb_consolidation_plan_free_json_str>(
       out);
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5355,7 +5355,7 @@ const char* tiledb_timestamps() noexcept {
 /*            VERSION             */
 /* ****************************** */
 
-CAPI_INTERFACE_VOID(version, int32_t* major, int32_t* minor, int32_t* rev) {
+void tiledb_version(int32_t* major, int32_t* minor, int32_t* rev) noexcept {
   *major = tiledb::sm::constants::library_version[0];
   *minor = tiledb::sm::constants::library_version[1];
   *rev = tiledb::sm::constants::library_version[2];
@@ -7756,7 +7756,7 @@ CAPI_INTERFACE(
 /*          EXPERIMENTAL APIs        */
 /* ********************************* */
 
-TILEDB_EXPORT CAPI_INTERFACE(
+CAPI_INTERFACE(
     query_get_status_details,
     tiledb_ctx_t* ctx,
     tiledb_query_t* query,

--- a/tiledb/sm/c_api/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/tiledb_dimension_label.cc
@@ -35,9 +35,7 @@
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_dimension_label_experimental.h"
 
-using namespace tiledb::common;
-
-namespace tiledb::common::detail {
+namespace tiledb::api {
 
 capi_return_t tiledb_array_schema_add_dimension_label(
     tiledb_ctx_t* ctx,
@@ -204,7 +202,7 @@ capi_return_t tiledb_subarray_has_label_ranges(
   return TILEDB_OK;
 }
 
-}  // namespace tiledb::common::detail
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_with_context;
@@ -220,7 +218,7 @@ CAPI_INTERFACE(
     const char* name,
     tiledb_data_order_t label_order,
     tiledb_datatype_t label_type) {
-  return api_entry<detail::tiledb_array_schema_add_dimension_label>(
+  return api_entry<tiledb::api::tiledb_array_schema_add_dimension_label>(
       ctx, array_schema, dim_index, name, label_order, label_type);
 }
 
@@ -231,7 +229,7 @@ CAPI_INTERFACE(
     const char* label_name,
     tiledb_dimension_label_t** dim_label) {
   return api_entry_with_context<
-      detail::tiledb_array_schema_get_dimension_label_from_name>(
+      tiledb::api::tiledb_array_schema_get_dimension_label_from_name>(
       ctx, array_schema, label_name, dim_label);
 }
 
@@ -241,7 +239,8 @@ CAPI_INTERFACE(
     const tiledb_array_schema_t* array_schema,
     const char* name,
     int32_t* has_dim_label) {
-  return api_entry_context<detail::tiledb_array_schema_has_dimension_label>(
+  return api_entry_context<
+      tiledb::api::tiledb_array_schema_has_dimension_label>(
       ctx, array_schema, name, has_dim_label);
 }
 
@@ -251,7 +250,8 @@ CAPI_INTERFACE(
     tiledb_array_schema_t* array_schema,
     const char* label_name,
     tiledb_filter_list_t* filter_list) {
-  return api_entry<detail::tiledb_array_schema_set_dimension_label_filter_list>(
+  return api_entry<
+      tiledb::api::tiledb_array_schema_set_dimension_label_filter_list>(
       ctx, array_schema, label_name, filter_list);
 }
 
@@ -262,7 +262,8 @@ CAPI_INTERFACE(
     const char* label_name,
     tiledb_datatype_t type,
     const void* tile_extent) {
-  return api_entry<detail::tiledb_array_schema_set_dimension_label_tile_extent>(
+  return api_entry<
+      tiledb::api::tiledb_array_schema_set_dimension_label_tile_extent>(
       ctx, array_schema, label_name, type, tile_extent);
 }
 
@@ -271,7 +272,8 @@ CAPI_INTERFACE(
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t* dim_label_num) {
-  return api_entry_context<detail::tiledb_array_schema_get_dimension_label_num>(
+  return api_entry_context<
+      tiledb::api::tiledb_array_schema_get_dimension_label_num>(
       ctx, array_schema, dim_label_num);
 }
 
@@ -282,7 +284,7 @@ CAPI_INTERFACE(
     uint64_t dim_label_index,
     tiledb_dimension_label_t** dim_label) {
   return api_entry_context<
-      detail::tiledb_array_schema_get_dimension_label_from_index>(
+      tiledb::api::tiledb_array_schema_get_dimension_label_from_index>(
       ctx, array_schema, dim_label_index, dim_label);
 }
 
@@ -294,7 +296,7 @@ CAPI_INTERFACE(
     const void* start,
     const void* end,
     const void* stride) {
-  return api_entry_context<detail::tiledb_subarray_add_label_range>(
+  return api_entry_context<tiledb::api::tiledb_subarray_add_label_range>(
       ctx, subarray, label_name, start, end, stride);
 }
 
@@ -307,7 +309,7 @@ CAPI_INTERFACE(
     uint64_t start_size,
     const void* end,
     uint64_t end_size) {
-  return api_entry_context<detail::tiledb_subarray_add_label_range_var>(
+  return api_entry_context<tiledb::api::tiledb_subarray_add_label_range_var>(
       ctx, subarray, label_name, start, start_size, end, end_size);
 }
 
@@ -317,7 +319,7 @@ CAPI_INTERFACE(
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const char** label_name) {
-  return api_entry_context<detail::tiledb_subarray_get_label_name>(
+  return api_entry_context<tiledb::api::tiledb_subarray_get_label_name>(
       ctx, subarray, dim_idx, label_name);
 }
 
@@ -330,7 +332,7 @@ CAPI_INTERFACE(
     const void** start,
     const void** end,
     const void** stride) {
-  return api_entry_context<detail::tiledb_subarray_get_label_range>(
+  return api_entry_context<tiledb::api::tiledb_subarray_get_label_range>(
       ctx, subarray, dim_name, range_idx, start, end, stride);
 }
 
@@ -340,7 +342,7 @@ CAPI_INTERFACE(
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t* range_num) {
-  return api_entry_context<detail::tiledb_subarray_get_label_range_num>(
+  return api_entry_context<tiledb::api::tiledb_subarray_get_label_range_num>(
       ctx, subarray, dim_name, range_num);
 }
 
@@ -352,7 +354,7 @@ CAPI_INTERFACE(
     uint64_t range_idx,
     void* start,
     void* end) {
-  return api_entry_context<detail::tiledb_subarray_get_label_range_var>(
+  return api_entry_context<tiledb::api::tiledb_subarray_get_label_range_var>(
       ctx, subarray, dim_name, range_idx, start, end);
 }
 
@@ -364,7 +366,8 @@ CAPI_INTERFACE(
     uint64_t range_idx,
     uint64_t* start_size,
     uint64_t* end_size) {
-  return api_entry_context<detail::tiledb_subarray_get_label_range_var_size>(
+  return api_entry_context<
+      tiledb::api::tiledb_subarray_get_label_range_var_size>(
       ctx, subarray, dim_name, range_idx, start_size, end_size);
 }
 
@@ -374,6 +377,6 @@ CAPI_INTERFACE(
     const tiledb_subarray_t* subarray,
     const uint32_t dim_idx,
     int32_t* has_label_ranges) {
-  return api_entry_context<detail::tiledb_subarray_has_label_ranges>(
+  return api_entry_context<tiledb::api::tiledb_subarray_has_label_ranges>(
       ctx, subarray, dim_idx, has_label_ranges);
 }

--- a/tiledb/sm/c_api/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/tiledb_dimension_label.cc
@@ -212,153 +212,153 @@ using tiledb::api::api_entry_with_context;
 template <auto f>
 constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
 
-capi_return_t tiledb_array_schema_add_dimension_label(
+CAPI_INTERFACE(array_schema_add_dimension_label,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const uint32_t dim_index,
     const char* name,
     tiledb_data_order_t label_order,
-    tiledb_datatype_t label_type) noexcept {
+    tiledb_datatype_t label_type) {
   return api_entry<detail::tiledb_array_schema_add_dimension_label>(
       ctx, array_schema, dim_index, name, label_order, label_type);
 }
 
-capi_return_t tiledb_array_schema_get_dimension_label_from_name(
+CAPI_INTERFACE(array_schema_get_dimension_label_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const char* label_name,
-    tiledb_dimension_label_t** dim_label) noexcept {
+    tiledb_dimension_label_t** dim_label) {
   return api_entry_with_context<
       detail::tiledb_array_schema_get_dimension_label_from_name>(
       ctx, array_schema, label_name, dim_label);
 }
 
-capi_return_t tiledb_array_schema_has_dimension_label(
+CAPI_INTERFACE(array_schema_has_dimension_label,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     const char* name,
-    int32_t* has_dim_label) noexcept {
+    int32_t* has_dim_label) {
   return api_entry_context<detail::tiledb_array_schema_has_dimension_label>(
       ctx, array_schema, name, has_dim_label);
 }
 
-capi_return_t tiledb_array_schema_set_dimension_label_filter_list(
+CAPI_INTERFACE(array_schema_set_dimension_label_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const char* label_name,
-    tiledb_filter_list_t* filter_list) noexcept {
+    tiledb_filter_list_t* filter_list) {
   return api_entry<detail::tiledb_array_schema_set_dimension_label_filter_list>(
       ctx, array_schema, label_name, filter_list);
 }
 
-capi_return_t tiledb_array_schema_set_dimension_label_tile_extent(
+CAPI_INTERFACE(array_schema_set_dimension_label_tile_extent,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const char* label_name,
     tiledb_datatype_t type,
-    const void* tile_extent) noexcept {
+    const void* tile_extent) {
   return api_entry<detail::tiledb_array_schema_set_dimension_label_tile_extent>(
       ctx, array_schema, label_name, type, tile_extent);
 }
 
-capi_return_t tiledb_array_schema_get_dimension_label_num(
+CAPI_INTERFACE(array_schema_get_dimension_label_num,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
-    uint64_t* dim_label_num) noexcept {
+    uint64_t* dim_label_num) {
   return api_entry_context<detail::tiledb_array_schema_get_dimension_label_num>(
       ctx, array_schema, dim_label_num);
 }
 
-capi_return_t tiledb_array_schema_get_dimension_label_from_index(
+CAPI_INTERFACE(array_schema_get_dimension_label_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t dim_label_index,
-    tiledb_dimension_label_t** dim_label) noexcept {
+    tiledb_dimension_label_t** dim_label) {
   return api_entry_context<
       detail::tiledb_array_schema_get_dimension_label_from_index>(
       ctx, array_schema, dim_label_index, dim_label);
 }
 
-capi_return_t tiledb_subarray_add_label_range(
+CAPI_INTERFACE(subarray_add_label_range,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* label_name,
     const void* start,
     const void* end,
-    const void* stride) noexcept {
+    const void* stride) {
   return api_entry_context<detail::tiledb_subarray_add_label_range>(
       ctx, subarray, label_name, start, end, stride);
 }
 
-capi_return_t tiledb_subarray_add_label_range_var(
+CAPI_INTERFACE(subarray_add_label_range_var,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* label_name,
     const void* start,
     uint64_t start_size,
     const void* end,
-    uint64_t end_size) noexcept {
+    uint64_t end_size) {
   return api_entry_context<detail::tiledb_subarray_add_label_range_var>(
       ctx, subarray, label_name, start, start_size, end, end_size);
 }
 
-capi_return_t tiledb_subarray_get_label_name(
+CAPI_INTERFACE(subarray_get_label_name,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
-    const char** label_name) noexcept {
+    const char** label_name) {
   return api_entry_context<detail::tiledb_subarray_get_label_name>(
       ctx, subarray, dim_idx, label_name);
 }
 
-capi_return_t tiledb_subarray_get_label_range(
+CAPI_INTERFACE(subarray_get_label_range,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     const void** start,
     const void** end,
-    const void** stride) noexcept {
+    const void** stride) {
   return api_entry_context<detail::tiledb_subarray_get_label_range>(
       ctx, subarray, dim_name, range_idx, start, end, stride);
 }
 
-capi_return_t tiledb_subarray_get_label_range_num(
+CAPI_INTERFACE(subarray_get_label_range_num,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
-    uint64_t* range_num) noexcept {
+    uint64_t* range_num) {
   return api_entry_context<detail::tiledb_subarray_get_label_range_num>(
       ctx, subarray, dim_name, range_num);
 }
 
-capi_return_t tiledb_subarray_get_label_range_var(
+CAPI_INTERFACE(subarray_get_label_range_var,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     void* start,
-    void* end) noexcept {
+    void* end) {
   return api_entry_context<detail::tiledb_subarray_get_label_range_var>(
       ctx, subarray, dim_name, range_idx, start, end);
 }
 
-capi_return_t tiledb_subarray_get_label_range_var_size(
+CAPI_INTERFACE(subarray_get_label_range_var_size,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     uint64_t* start_size,
-    uint64_t* end_size) noexcept {
+    uint64_t* end_size) {
   return api_entry_context<detail::tiledb_subarray_get_label_range_var_size>(
       ctx, subarray, dim_name, range_idx, start_size, end_size);
 }
 
-capi_return_t tiledb_subarray_has_label_ranges(
+CAPI_INTERFACE(subarray_has_label_ranges,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const uint32_t dim_idx,
-    int32_t* has_label_ranges) noexcept {
+    int32_t* has_label_ranges) {
   return api_entry_context<detail::tiledb_subarray_has_label_ranges>(
       ctx, subarray, dim_idx, has_label_ranges);
 }

--- a/tiledb/sm/c_api/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/tiledb_dimension_label.cc
@@ -212,7 +212,8 @@ using tiledb::api::api_entry_with_context;
 template <auto f>
 constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
 
-CAPI_INTERFACE(array_schema_add_dimension_label,
+CAPI_INTERFACE(
+    array_schema_add_dimension_label,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const uint32_t dim_index,
@@ -223,7 +224,8 @@ CAPI_INTERFACE(array_schema_add_dimension_label,
       ctx, array_schema, dim_index, name, label_order, label_type);
 }
 
-CAPI_INTERFACE(array_schema_get_dimension_label_from_name,
+CAPI_INTERFACE(
+    array_schema_get_dimension_label_from_name,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const char* label_name,
@@ -233,7 +235,8 @@ CAPI_INTERFACE(array_schema_get_dimension_label_from_name,
       ctx, array_schema, label_name, dim_label);
 }
 
-CAPI_INTERFACE(array_schema_has_dimension_label,
+CAPI_INTERFACE(
+    array_schema_has_dimension_label,
     tiledb_ctx_t* ctx,
     const tiledb_array_schema_t* array_schema,
     const char* name,
@@ -242,7 +245,8 @@ CAPI_INTERFACE(array_schema_has_dimension_label,
       ctx, array_schema, name, has_dim_label);
 }
 
-CAPI_INTERFACE(array_schema_set_dimension_label_filter_list,
+CAPI_INTERFACE(
+    array_schema_set_dimension_label_filter_list,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const char* label_name,
@@ -251,7 +255,8 @@ CAPI_INTERFACE(array_schema_set_dimension_label_filter_list,
       ctx, array_schema, label_name, filter_list);
 }
 
-CAPI_INTERFACE(array_schema_set_dimension_label_tile_extent,
+CAPI_INTERFACE(
+    array_schema_set_dimension_label_tile_extent,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     const char* label_name,
@@ -261,7 +266,8 @@ CAPI_INTERFACE(array_schema_set_dimension_label_tile_extent,
       ctx, array_schema, label_name, type, tile_extent);
 }
 
-CAPI_INTERFACE(array_schema_get_dimension_label_num,
+CAPI_INTERFACE(
+    array_schema_get_dimension_label_num,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t* dim_label_num) {
@@ -269,7 +275,8 @@ CAPI_INTERFACE(array_schema_get_dimension_label_num,
       ctx, array_schema, dim_label_num);
 }
 
-CAPI_INTERFACE(array_schema_get_dimension_label_from_index,
+CAPI_INTERFACE(
+    array_schema_get_dimension_label_from_index,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_t* array_schema,
     uint64_t dim_label_index,
@@ -279,7 +286,8 @@ CAPI_INTERFACE(array_schema_get_dimension_label_from_index,
       ctx, array_schema, dim_label_index, dim_label);
 }
 
-CAPI_INTERFACE(subarray_add_label_range,
+CAPI_INTERFACE(
+    subarray_add_label_range,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* label_name,
@@ -290,7 +298,8 @@ CAPI_INTERFACE(subarray_add_label_range,
       ctx, subarray, label_name, start, end, stride);
 }
 
-CAPI_INTERFACE(subarray_add_label_range_var,
+CAPI_INTERFACE(
+    subarray_add_label_range_var,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     const char* label_name,
@@ -302,7 +311,8 @@ CAPI_INTERFACE(subarray_add_label_range_var,
       ctx, subarray, label_name, start, start_size, end, end_size);
 }
 
-CAPI_INTERFACE(subarray_get_label_name,
+CAPI_INTERFACE(
+    subarray_get_label_name,
     tiledb_ctx_t* ctx,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -311,7 +321,8 @@ CAPI_INTERFACE(subarray_get_label_name,
       ctx, subarray, dim_idx, label_name);
 }
 
-CAPI_INTERFACE(subarray_get_label_range,
+CAPI_INTERFACE(
+    subarray_get_label_range,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -323,7 +334,8 @@ CAPI_INTERFACE(subarray_get_label_range,
       ctx, subarray, dim_name, range_idx, start, end, stride);
 }
 
-CAPI_INTERFACE(subarray_get_label_range_num,
+CAPI_INTERFACE(
+    subarray_get_label_range_num,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -332,7 +344,8 @@ CAPI_INTERFACE(subarray_get_label_range_num,
       ctx, subarray, dim_name, range_num);
 }
 
-CAPI_INTERFACE(subarray_get_label_range_var,
+CAPI_INTERFACE(
+    subarray_get_label_range_var,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -343,7 +356,8 @@ CAPI_INTERFACE(subarray_get_label_range_var,
       ctx, subarray, dim_name, range_idx, start, end);
 }
 
-CAPI_INTERFACE(subarray_get_label_range_var_size,
+CAPI_INTERFACE(
+    subarray_get_label_range_var_size,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
@@ -354,7 +368,8 @@ CAPI_INTERFACE(subarray_get_label_range_var_size,
       ctx, subarray, dim_name, range_idx, start_size, end_size);
 }
 
-CAPI_INTERFACE(subarray_has_label_ranges,
+CAPI_INTERFACE(
+    subarray_has_label_ranges,
     tiledb_ctx_t* ctx,
     const tiledb_subarray_t* subarray,
     const uint32_t dim_idx,

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -75,7 +75,7 @@ extern "C" {
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t
-tiledb_log_warn(tiledb_ctx_t* ctx, const char* message);
+tiledb_log_warn(tiledb_ctx_t* ctx, const char* message) TILEDB_NOEXCEPT;
 
 /* ********************************* */
 /*              AS BUILT             */

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -62,7 +62,7 @@
 #include "tiledb/sm/subarray/subarray.h"
 #include "tiledb/type/range/range.h"
 
-namespace tiledb::common::detail {
+namespace tiledb::api {
 
 // Forward declarations
 uint64_t compute_tile_extent_based_on_file_size(uint64_t file_size);
@@ -809,69 +809,78 @@ uint64_t get_buffer_size_from_config(
   return buffer_size;
 }
 
-}  // namespace tiledb::common::detail
+}  // namespace tiledb::api
 
 using tiledb::api::api_entry_plain;
 template <auto f>
 constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
 
-int32_t tiledb_filestore_schema_create(
+CAPI_INTERFACE(
+    filestore_schema_create,
     tiledb_ctx_t* ctx,
     const char* uri,
-    tiledb_array_schema_t** array_schema) noexcept {
-  return api_entry<detail::tiledb_filestore_schema_create>(
+    tiledb_array_schema_t** array_schema) {
+  return api_entry<tiledb::api::tiledb_filestore_schema_create>(
       ctx, uri, array_schema);
 }
 
-int32_t tiledb_filestore_uri_import(
+CAPI_INTERFACE(
+    filestore_uri_import,
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     const char* file_uri,
-    tiledb_mime_type_t mime_type) noexcept {
-  return api_entry<detail::tiledb_filestore_uri_import>(
+    tiledb_mime_type_t mime_type) {
+  return api_entry<tiledb::api::tiledb_filestore_uri_import>(
       ctx, filestore_array_uri, file_uri, mime_type);
 }
 
-int32_t tiledb_filestore_uri_export(
+CAPI_INTERFACE(
+    filestore_uri_export,
     tiledb_ctx_t* ctx,
     const char* file_uri,
-    const char* filestore_array_uri) noexcept {
-  return api_entry<detail::tiledb_filestore_uri_export>(
+    const char* filestore_array_uri) {
+  return api_entry<tiledb::api::tiledb_filestore_uri_export>(
       ctx, file_uri, filestore_array_uri);
 }
 
-int32_t tiledb_filestore_buffer_import(
+CAPI_INTERFACE(
+    filestore_buffer_import,
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     void* buf,
     size_t size,
-    tiledb_mime_type_t mime_type) noexcept {
-  return api_entry<detail::tiledb_filestore_buffer_import>(
+    tiledb_mime_type_t mime_type) {
+  return api_entry<tiledb::api::tiledb_filestore_buffer_import>(
       ctx, filestore_array_uri, buf, size, mime_type);
 }
 
-int32_t tiledb_filestore_buffer_export(
+CAPI_INTERFACE(
+    filestore_buffer_export,
     tiledb_ctx_t* ctx,
     const char* filestore_array_uri,
     size_t offset,
     void* buf,
-    size_t size) noexcept {
-  return api_entry<detail::tiledb_filestore_buffer_export>(
+    size_t size) {
+  return api_entry<tiledb::api::tiledb_filestore_buffer_export>(
       ctx, filestore_array_uri, offset, buf, size);
 }
 
-int32_t tiledb_filestore_size(
-    tiledb_ctx_t* ctx, const char* filestore_array_uri, size_t* size) noexcept {
-  return api_entry<detail::tiledb_filestore_size>(
+CAPI_INTERFACE(
+    filestore_size,
+    tiledb_ctx_t* ctx,
+    const char* filestore_array_uri,
+    size_t* size) {
+  return api_entry<tiledb::api::tiledb_filestore_size>(
       ctx, filestore_array_uri, size);
 }
 
-int32_t tiledb_mime_type_to_str(
-    tiledb_mime_type_t mime_type, const char** str) noexcept {
-  return api_entry_plain<detail::tiledb_mime_type_to_str>(mime_type, str);
+CAPI_INTERFACE(
+    mime_type_to_str, tiledb_mime_type_t mime_type, const char** str) {
+  return api_entry_plain<tiledb::api::tiledb_mime_type_to_str>(mime_type, str);
 }
 
-int32_t tiledb_mime_type_from_str(
-    const char* str, tiledb_mime_type_t* mime_type) noexcept {
-  return api_entry_plain<detail::tiledb_mime_type_from_str>(str, mime_type);
+CAPI_INTERFACE(
+    mime_type_from_str, const char* str, tiledb_mime_type_t* mime_type) {
+  return api_entry_plain<tiledb::api::tiledb_mime_type_from_str>(
+      str, mime_type);
 }


### PR DESCRIPTION
Convert C API interface functions to use `CAPI_INTERFACE`. This completes the work in #4430.

There are a very small number of functions not converted. One is not in the C API (i.e. it doesn't have `extern "C"` linkage), but is used by the C++ API, and on top of that it's for a deprecated operation. The others are small, informational functions that do return values directly and do not use `capi_return_t`.

---
TYPE: NO_HISTORY
DESC: Convert C API interface functions to CAPI_INTERFACE
