### PR TITLE
Fix docs of `tiledb_array_schema_evolution_extend_enumeration`.

### DIFF
--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -233,7 +233,7 @@ TILEDB_EXPORT capi_return_t tiledb_array_schema_evolution_add_enumeration(
  * tiledb_array_schema_evolution_extend_enumeration(
  *     ctx,
  *     array_schema_evolution,
- *     enmr);
+ *     new_enmr);
  * @endcode
  *
  * @param ctx The TileDB context.


### PR DESCRIPTION
There is not an `enmr` variable in the example.

---
TYPE: NO_HISTORY