### PR TITLE
Aggregates: allow aggregates pipeline the processing of full tiles.

### DIFF
--- a/tiledb/sm/query/readers/aggregators/count_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.cc
@@ -34,6 +34,7 @@
 
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
+#include "tiledb/sm/query/readers/aggregators/full_tile_data.h"
 
 namespace tiledb::sm {
 
@@ -74,6 +75,19 @@ void CountAggregatorBase<ValidityPolicy>::aggregate_data(
   }
 
   count_ += std::get<1>(res);
+}
+
+template <class ValidityPolicy>
+void CountAggregatorBase<ValidityPolicy>::aggregate_full_tile(
+    FullTileData& input_data) {
+  uint64_t count;
+  if constexpr (std::is_same<ValidityPolicy, NonNull>::value) {
+    count = input_data.count();
+  } else {
+    count = input_data.null_count();
+  }
+
+  count_ += count;
 }
 
 template <class ValidityPolicy>

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.cc
@@ -34,7 +34,6 @@
 
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
-#include "tiledb/sm/query/readers/aggregators/full_tile_data.h"
 
 namespace tiledb::sm {
 
@@ -78,13 +77,13 @@ void CountAggregatorBase<ValidityPolicy>::aggregate_data(
 }
 
 template <class ValidityPolicy>
-void CountAggregatorBase<ValidityPolicy>::aggregate_full_tile(
-    FullTileData& input_data) {
+void CountAggregatorBase<ValidityPolicy>::aggregate_tile_with_frag_md(
+    TileMetadata& tile_metadata) {
   uint64_t count;
   if constexpr (std::is_same<ValidityPolicy, NonNull>::value) {
-    count = input_data.count();
+    count = tile_metadata.count();
   } else {
-    count = input_data.null_count();
+    count = tile_metadata.null_count();
   }
 
   count_ += count;

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.h
@@ -92,11 +92,11 @@ class CountAggregatorBase : public OutputBufferValidator, public IAggregator {
   void aggregate_data(AggregateBuffer& input_data) override;
 
   /**
-   * Aggregate a full tile.
+   * Aggregate a tile with fragment metadata.
    *
-   * @param full_tile_data Full tile data for aggregation.
+   * @param tile_metadata Tile metadata for aggregation.
    */
-  void aggregate_full_tile(FullTileData& input_data) override;
+  void aggregate_tile_with_frag_md(TileMetadata& tile_metadata) override;
 
   /**
    * Copy final data to the user buffer.

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.h
@@ -92,6 +92,13 @@ class CountAggregatorBase : public OutputBufferValidator, public IAggregator {
   void aggregate_data(AggregateBuffer& input_data) override;
 
   /**
+   * Aggregate a full tile.
+   *
+   * @param full_tile_data Full tile data for aggregation.
+   */
+  void aggregate_full_tile(FullTileData& input_data) override;
+
+  /**
    * Copy final data to the user buffer.
    *
    * @param output_field_name Name for the output buffer.

--- a/tiledb/sm/query/readers/aggregators/full_tile_data.h
+++ b/tiledb/sm/query/readers/aggregators/full_tile_data.h
@@ -1,0 +1,161 @@
+/**
+ * @file   full_tile_data.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class FullTileData.
+ */
+
+#ifndef TILEDB_FULL_TILE_DATA_H
+#define TILEDB_FULL_TILE_DATA_H
+
+#include "tiledb/common/common.h"
+
+namespace tiledb::sm {
+
+class FullTileDataStatusException : public StatusException {
+ public:
+  explicit FullTileDataStatusException(const std::string& message)
+      : StatusException("FullTileData", message) {
+  }
+};
+
+class FullTileData {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /**
+   * Constructor.
+   *
+   * @param count Number of cells for this tile.
+   * @param null_count Number of null values for this tile.
+   * @param min Pointer to the min data.
+   * @param min_size Size of the min data.
+   * @param max Pointer to the max data.
+   * @param max_size Size of the max data.
+   * @param sum Pointer to the sum data.
+   */
+  FullTileData(
+      const uint64_t count,
+      const uint64_t null_count,
+      const void* min,
+      const storage_size_t min_size,
+      const void* max,
+      const storage_size_t max_size,
+      const void* sum)
+      : count_(count)
+      , null_count_(null_count)
+      , min_(min)
+      , min_size_(min_size)
+      , max_(max)
+      , max_size_(max_size)
+      , sum_(sum) {
+  }
+
+  DISABLE_COPY_AND_COPY_ASSIGN(FullTileData);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(FullTileData);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /** Returns the count. */
+  inline uint64_t count() const {
+    return count_;
+  }
+
+  /** Returns the null count. */
+  inline uint64_t null_count() const {
+    return null_count_;
+  }
+
+  /** Returns the min as a specific type. */
+  template <typename T>
+  T min_as() const {
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      return {static_cast<const char*>(min_), min_size_};
+    } else {
+      if (min_size_ != sizeof(T)) {
+        throw FullTileDataStatusException("Unexpected min size.");
+      }
+
+      return *static_cast<const T*>(min_);
+    }
+  }
+
+  /** Returns the max as a specific type. */
+  template <class T>
+  T max_as() const {
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      return {static_cast<const char*>(max_), max_size_};
+    } else {
+      if (max_size_ != sizeof(T)) {
+        throw FullTileDataStatusException("Unexpected max size.");
+      }
+
+      return *static_cast<const T*>(max_);
+    }
+  }
+
+  /** Returns the sum as a specific type. */
+  template <class T>
+  T sum_as() const {
+    return *static_cast<const T*>(sum_);
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Count of cells. */
+  const uint64_t count_;
+
+  /** Null count. */
+  const uint64_t null_count_;
+
+  /** Min value. */
+  const void* min_;
+
+  /** Min size. */
+  const storage_size_t min_size_;
+
+  /** Max value. */
+  const void* max_;
+
+  /** Max size. */
+  const storage_size_t max_size_;
+
+  /** Sum value. */
+  const void* sum_;
+};
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_FULL_TILE_DATA_H

--- a/tiledb/sm/query/readers/aggregators/iaggregator.h
+++ b/tiledb/sm/query/readers/aggregators/iaggregator.h
@@ -42,6 +42,7 @@ namespace tiledb::sm {
 
 class QueryBuffer;
 class AggregateBuffer;
+class FullTileData;
 class IAggregator;
 
 typedef std::unordered_map<std::string, shared_ptr<IAggregator>>
@@ -87,6 +88,13 @@ class IAggregator {
    * @param input_data Input data for aggregation.
    */
   virtual void aggregate_data(AggregateBuffer& input_data) = 0;
+
+  /**
+   * Aggregate a full tile.
+   *
+   * @param full_tile_data Full tile data for aggregation.
+   */
+  virtual void aggregate_full_tile(FullTileData& input_data) = 0;
 
   /**
    * Copy final data to the user buffer.

--- a/tiledb/sm/query/readers/aggregators/iaggregator.h
+++ b/tiledb/sm/query/readers/aggregators/iaggregator.h
@@ -37,12 +37,12 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/query/readers/aggregators/input_field_validator.h"
 #include "tiledb/sm/query/readers/aggregators/output_buffer_validator.h"
+#include "tiledb/sm/query/readers/aggregators/tile_metadata.h"
 
 namespace tiledb::sm {
 
 class QueryBuffer;
 class AggregateBuffer;
-class FullTileData;
 class IAggregator;
 
 typedef std::unordered_map<std::string, shared_ptr<IAggregator>>
@@ -90,11 +90,11 @@ class IAggregator {
   virtual void aggregate_data(AggregateBuffer& input_data) = 0;
 
   /**
-   * Aggregate a full tile.
+   * Aggregate a tile with fragment metadata.
    *
-   * @param full_tile_data Full tile data for aggregation.
+   * @param tile_metadata Tile metadata for aggregation.
    */
-  virtual void aggregate_full_tile(FullTileData& input_data) = 0;
+  virtual void aggregate_tile_with_frag_md(TileMetadata& tile_metadata) = 0;
 
   /**
    * Copy final data to the user buffer.

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
@@ -151,10 +151,10 @@ void ComparatorAggregator<T, Op>::aggregate_data(AggregateBuffer& input_data) {
 }
 
 template <typename T, typename Op>
-void ComparatorAggregator<T, Op>::aggregate_full_tile(
-    FullTileData& input_data) {
-  const auto value = full_tile_value(input_data);
-  const auto count = input_data.count() - input_data.null_count();
+void ComparatorAggregator<T, Op>::aggregate_tile_with_frag_md(
+    TileMetadata& tile_metadata) {
+  const auto value = tile_metadata_value(tile_metadata);
+  const auto count = tile_metadata.count() - tile_metadata.null_count();
   update_value(value, count);
 }
 

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
@@ -34,7 +34,6 @@
 #define TILEDB_MIN_MAX_AGGREGATOR_H
 
 #include "tiledb/sm/query/readers/aggregators/aggregate_with_count.h"
-#include "tiledb/sm/query/readers/aggregators/full_tile_data.h"
 #include "tiledb/sm/query/readers/aggregators/iaggregator.h"
 #include "tiledb/sm/query/readers/aggregators/min_max.h"
 #include "tiledb/sm/query/readers/aggregators/validity_policies.h"
@@ -174,11 +173,11 @@ class ComparatorAggregator : public ComparatorAggregatorBase<T>,
   void aggregate_data(AggregateBuffer& input_data) override;
 
   /**
-   * Aggregate a full tile.
+   * Aggregate a tile with fragment metadata.
    *
-   * @param full_tile_data Full tile data for aggregation.
+   * @param tile_metadata Tile metadata for aggregation.
    */
-  void aggregate_full_tile(FullTileData& input_data) override;
+  void aggregate_tile_with_frag_md(TileMetadata& tile_metadata) override;
 
   /**
    * Copy final data to the user buffer.
@@ -200,8 +199,8 @@ class ComparatorAggregator : public ComparatorAggregatorBase<T>,
   /*         PRIVATE FUNCTIONS         */
   /* ********************************* */
 
-  /** Returns the full tile value for the full tile data. */
-  virtual VALUE_T full_tile_value(FullTileData& input_data) = 0;
+  /** Returns the tile metadata value for the full tile data. */
+  virtual VALUE_T tile_metadata_value(TileMetadata& tile_metadata) = 0;
 
   /**
    * Update the value of the aggregation, if required.
@@ -264,9 +263,9 @@ class MinAggregator : public ComparatorAggregator<
   /*         PRIVATE FUNCTIONS         */
   /* ********************************* */
 
-  /** Returns the full tile value for the full tile data. */
-  VALUE_T full_tile_value(FullTileData& input_data) override {
-    return input_data.min_as<VALUE_T>();
+  /** Returns the tile metadata value for the full tile data. */
+  VALUE_T tile_metadata_value(TileMetadata& tile_metadata) override {
+    return tile_metadata.min_as<VALUE_T>();
   }
 };
 
@@ -310,9 +309,9 @@ class MaxAggregator : public ComparatorAggregator<
   /*         PRIVATE FUNCTIONS         */
   /* ********************************* */
 
-  /** Returns the full tile value for the full tile data. */
-  VALUE_T full_tile_value(FullTileData& input_data) override {
-    return input_data.max_as<VALUE_T>();
+  /** Returns the tile metadata value for the full tile data. */
+  VALUE_T tile_metadata_value(TileMetadata& tile_metadata) override {
+    return tile_metadata.max_as<VALUE_T>();
   }
 };
 

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.cc
@@ -34,7 +34,6 @@
 
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/aggregators/aggregate_buffer.h"
-#include "tiledb/sm/query/readers/aggregators/full_tile_data.h"
 
 namespace tiledb::sm {
 
@@ -92,9 +91,10 @@ void SumWithCountAggregator<T>::aggregate_data(AggregateBuffer& input_data) {
 }
 
 template <typename T>
-void SumWithCountAggregator<T>::aggregate_full_tile(FullTileData& input_data) {
-  const auto sum = input_data.sum_as<SUM_T>();
-  const auto count = input_data.count() - input_data.null_count();
+void SumWithCountAggregator<T>::aggregate_tile_with_frag_md(
+    TileMetadata& tile_metadata) {
+  const auto sum = tile_metadata.sum_as<SUM_T>();
+  const auto count = tile_metadata.count() - tile_metadata.null_count();
   update_sum(sum, count);
 }
 

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.h
@@ -109,11 +109,11 @@ class SumWithCountAggregator : public InputFieldValidator,
   void aggregate_data(AggregateBuffer& input_data) override;
 
   /**
-   * Aggregate a full tile.
+   * Aggregate a tile with fragment metadata.
    *
-   * @param full_tile_data Full tile data for aggregation.
+   * @param tile_metadata Tile metadata for aggregation.
    */
-  void aggregate_full_tile(FullTileData& input_data) override;
+  void aggregate_tile_with_frag_md(TileMetadata& tile_metadata) override;
 
   /**
    * Copy final validity value to the user buffer.

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.h
@@ -49,6 +49,8 @@ class SumWithCountAggregator : public InputFieldValidator,
                                public OutputBufferValidator,
                                public IAggregator {
  public:
+  using SUM_T = typename sum_type_data<T>::sum_type;
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -107,6 +109,13 @@ class SumWithCountAggregator : public InputFieldValidator,
   void aggregate_data(AggregateBuffer& input_data) override;
 
   /**
+   * Aggregate a full tile.
+   *
+   * @param full_tile_data Full tile data for aggregation.
+   */
+  void aggregate_full_tile(FullTileData& input_data) override;
+
+  /**
    * Copy final validity value to the user buffer.
    *
    * @param result_buffer Query buffer to copy to.
@@ -115,6 +124,18 @@ class SumWithCountAggregator : public InputFieldValidator,
 
  protected:
   /* ********************************* */
+  /*        PROTECTED FUNCTIONS        */
+  /* ********************************* */
+
+  /**
+   * Update the sum.
+   *
+   * @param sum Sum.
+   * @param count Count of values summed.
+   */
+  void update_sum(SUM_T sum, uint64_t count);
+
+  /* ********************************* */
   /*        PROTECTED ATTRIBUTES       */
   /* ********************************* */
 
@@ -122,11 +143,10 @@ class SumWithCountAggregator : public InputFieldValidator,
   const FieldInfo field_info_;
 
   /** AggregateWithCount to do summation of AggregateBuffer data. */
-  AggregateWithCount<T, typename sum_type_data<T>::sum_type, SafeSum, NonNull>
-      aggregate_with_count_;
+  AggregateWithCount<T, SUM_T, SafeSum, NonNull> aggregate_with_count_;
 
   /** Computed sum. */
-  std::atomic<typename sum_type_data<T>::sum_type> sum_;
+  std::atomic<SUM_T> sum_;
 
   /** Count of values. */
   std::atomic<uint64_t> count_;

--- a/tiledb/sm/query/readers/aggregators/test/unit_aggregators.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_aggregators.cc
@@ -477,7 +477,7 @@ void basic_aggregation_test(std::vector<double> expected_results) {
           10);
     }
 
-    auto full_tile_data_all_null = FullTileData(
+    auto tile_metadata_all_null = TileMetadata(
         10,
         10,
         &fixed_data[0],
@@ -485,7 +485,7 @@ void basic_aggregation_test(std::vector<double> expected_results) {
         &fixed_data[0],
         sizeof(T),
         zero.data());
-    auto full_tile_data = FullTileData(
+    auto tile_metadata = TileMetadata(
         10,
         5,
         &fixed_data[0],
@@ -501,11 +501,11 @@ void basic_aggregation_test(std::vector<double> expected_results) {
       aggregator->copy_to_user_buffer("Agg", buffers);
       check_value(RES(), res, expected_results[0]);
 
-      aggregator->aggregate_full_tile(full_tile_data_all_null);
+      aggregator->aggregate_tile_with_frag_md(tile_metadata_all_null);
       aggregator->copy_to_user_buffer("Agg", buffers);
       check_value(RES(), res, expected_results[1]);
 
-      aggregator->aggregate_full_tile(full_tile_data);
+      aggregator->aggregate_tile_with_frag_md(tile_metadata);
       aggregator->copy_to_user_buffer("Agg", buffers);
       check_value(RES(), res, expected_results[2]);
     }
@@ -525,12 +525,12 @@ void basic_aggregation_test(std::vector<double> expected_results) {
     check_value(RES(), res2, expected_results[3]);
     check_validity<AGGREGATOR>(validity, 1);
 
-    aggregator_nullable.aggregate_full_tile(full_tile_data_all_null);
+    aggregator_nullable.aggregate_tile_with_frag_md(tile_metadata_all_null);
     aggregator_nullable.copy_to_user_buffer("Agg2", buffers);
     check_value(RES(), res2, expected_results[4]);
     check_validity<AGGREGATOR>(validity, 1);
 
-    aggregator_nullable.aggregate_full_tile(full_tile_data);
+    aggregator_nullable.aggregate_tile_with_frag_md(tile_metadata);
     aggregator_nullable.copy_to_user_buffer("Agg2", buffers);
     check_value(RES(), res2, expected_results[5]);
     check_validity<AGGREGATOR>(validity, 1);
@@ -994,7 +994,7 @@ void basic_string_aggregation_test(std::vector<RES> expected_results) {
 
   SECTION("No bitmap") {
     ByteVecValue unused(8);
-    auto full_tile_data_all_null = FullTileData(
+    auto tile_metadata_all_null = TileMetadata(
         10,
         10,
         &var_data[offsets[0]],
@@ -1002,7 +1002,7 @@ void basic_string_aggregation_test(std::vector<RES> expected_results) {
         &var_data[offsets[5]],
         offsets[6] - offsets[5],
         unused.data());
-    auto full_tile_data = FullTileData(
+    auto tile_metadata = TileMetadata(
         10,
         5,
         &var_data[offsets[0]],
@@ -1019,11 +1019,11 @@ void basic_string_aggregation_test(std::vector<RES> expected_results) {
       aggregator->copy_to_user_buffer("Agg", buffers);
       check_value_string(fixed_data, value_size, value, expected_results[0]);
 
-      aggregator->aggregate_full_tile(full_tile_data_all_null);
+      aggregator->aggregate_tile_with_frag_md(tile_metadata_all_null);
       aggregator->copy_to_user_buffer("Agg", buffers);
       check_value_string(fixed_data, value_size, value, expected_results[1]);
 
-      aggregator->aggregate_full_tile(full_tile_data);
+      aggregator->aggregate_tile_with_frag_md(tile_metadata);
       aggregator->copy_to_user_buffer("Agg", buffers);
       check_value_string(fixed_data, value_size, value, expected_results[2]);
     }
@@ -1043,11 +1043,11 @@ void basic_string_aggregation_test(std::vector<RES> expected_results) {
     check_value_string(fixed_data2, value_size2, value2, expected_results[3]);
     check_validity<AGGREGATOR>(validity, 1);
 
-    aggregator_nullable.aggregate_full_tile(full_tile_data_all_null);
+    aggregator_nullable.aggregate_tile_with_frag_md(tile_metadata_all_null);
     aggregator_nullable.copy_to_user_buffer("Agg2", buffers);
     check_value_string(fixed_data2, value_size2, value2, expected_results[4]);
 
-    aggregator_nullable.aggregate_full_tile(full_tile_data);
+    aggregator_nullable.aggregate_tile_with_frag_md(tile_metadata);
     aggregator_nullable.copy_to_user_buffer("Agg2", buffers);
     check_value_string(fixed_data2, value_size2, value2, expected_results[5]);
   }

--- a/tiledb/sm/query/readers/aggregators/tile_metadata.h
+++ b/tiledb/sm/query/readers/aggregators/tile_metadata.h
@@ -1,5 +1,5 @@
 /**
- * @file   full_tile_data.h
+ * @file   tile_metadata.h
  *
  * @section LICENSE
  *
@@ -27,24 +27,24 @@
  *
  * @section DESCRIPTION
  *
- * This file defines class FullTileData.
+ * This file defines class TileMetadata.
  */
 
-#ifndef TILEDB_FULL_TILE_DATA_H
-#define TILEDB_FULL_TILE_DATA_H
+#ifndef TILEDB_TILE_METADATA_H
+#define TILEDB_TILE_METADATA_H
 
 #include "tiledb/common/common.h"
 
 namespace tiledb::sm {
 
-class FullTileDataStatusException : public StatusException {
+class TileMetadataStatusException : public StatusException {
  public:
-  explicit FullTileDataStatusException(const std::string& message)
-      : StatusException("FullTileData", message) {
+  explicit TileMetadataStatusException(const std::string& message)
+      : StatusException("TileMetadata", message) {
   }
 };
 
-class FullTileData {
+class TileMetadata {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -61,7 +61,7 @@ class FullTileData {
    * @param max_size Size of the max data.
    * @param sum Pointer to the sum data.
    */
-  FullTileData(
+  TileMetadata(
       const uint64_t count,
       const uint64_t null_count,
       const void* min,
@@ -78,8 +78,8 @@ class FullTileData {
       , sum_(sum) {
   }
 
-  DISABLE_COPY_AND_COPY_ASSIGN(FullTileData);
-  DISABLE_MOVE_AND_MOVE_ASSIGN(FullTileData);
+  DISABLE_COPY_AND_COPY_ASSIGN(TileMetadata);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(TileMetadata);
 
   /* ********************************* */
   /*                API                */
@@ -102,7 +102,7 @@ class FullTileData {
       return {static_cast<const char*>(min_), min_size_};
     } else {
       if (min_size_ != sizeof(T)) {
-        throw FullTileDataStatusException("Unexpected min size.");
+        throw TileMetadataStatusException("Unexpected min size.");
       }
 
       return *static_cast<const T*>(min_);
@@ -116,7 +116,7 @@ class FullTileData {
       return {static_cast<const char*>(max_), max_size_};
     } else {
       if (max_size_ != sizeof(T)) {
-        throw FullTileDataStatusException("Unexpected max size.");
+        throw TileMetadataStatusException("Unexpected max size.");
       }
 
       return *static_cast<const T*>(max_);
@@ -158,4 +158,4 @@ class FullTileData {
 
 }  // namespace tiledb::sm
 
-#endif  // TILEDB_FULL_TILE_DATA_H
+#endif  // TILEDB_TILE_METADATA_H


### PR DESCRIPTION
This adds a new aggregate_full_tile interface to iaggregator so that we can later use the data in the fragment metadata to improve aggregation performance. The data is packaged in the new FullTileData class, which will later be produced by the fragment metadata.

Note that this only implements the aggregators side of the work... Reader/FragmentMetadata changes will follow.

---
TYPE: FEATURE
DESC: Aggregates: allow aggregates pipeline the processing of full tiles.
