### PR TITLE
Fragment metadata: adding get_tile_metadata.

### DIFF
--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -1553,9 +1553,8 @@ struct CPPTileMetadataStringDimFx {
     {
       // Validate mins.
       auto& min = frag_meta[0]->get_min("a");
-      double correct_min = 4;
       CHECK(min.size() == sizeof(double));
-      CHECK(0 == memcmp(min.data(), &correct_min, min.size()));
+      CHECK(*static_cast<double*>(static_cast<void*>(min.data())) == 4);
 
       CHECK_THROWS_WITH(
           frag_meta[0]->get_min("d1"),
@@ -1569,9 +1568,8 @@ struct CPPTileMetadataStringDimFx {
 
       // Validate maxs.
       auto& max = frag_meta[0]->get_max("a");
-      double correct_max = 7;
       CHECK(max.size() == sizeof(double));
-      CHECK(0 == memcmp(max.data(), &correct_max, max.size()));
+      CHECK(*static_cast<double*>(static_cast<void*>(max.data())) == 7);
 
       CHECK_THROWS_WITH(
           frag_meta[0]->get_max("d1"),

--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -35,6 +35,7 @@
 #include "test/support/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/query/readers/aggregators/tile_metadata.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
 
 using namespace tiledb;
@@ -296,6 +297,7 @@ struct CPPFixedTileMetadataFx {
     bool has_coords = layout != TILEDB_ROW_MAJOR;
     if (has_coords) {
       std::vector<std::string> names{"d"};
+      frag_meta[f]->load_rtree(enc_key);
       frag_meta[f]->load_tile_min_values(enc_key, names);
       frag_meta[f]->load_tile_max_values(enc_key, names);
       frag_meta[f]->load_tile_sum_values(enc_key, names);
@@ -347,6 +349,12 @@ struct CPPFixedTileMetadataFx {
           // Validate sum.
           auto sum = frag_meta[f]->get_tile_sum("d", tile_idx);
           CHECK(*(int64_t*)sum == correct_sum);
+
+          // Validate the tile metadata structure.
+          auto full_tile_data = frag_meta[f]->get_tile_metadata("d", tile_idx);
+          CHECK(correct_min == full_tile_data.min_as<uint32_t>());
+          CHECK(correct_max == full_tile_data.max_as<uint32_t>());
+          CHECK(correct_sum == full_tile_data.sum_as<int64_t>());
         }
       }
     }
@@ -483,11 +491,12 @@ struct CPPFixedTileMetadataFx {
 
             // For strings, the index is stored in a signed value, switch to
             // the index to unsigned.
-            int64_t idx = (int64_t)correct_tile_mins_[f][tile_idx] -
-                          (int64_t)std::numeric_limits<char>::min();
+            int64_t min_idx = (int64_t)correct_tile_mins_[f][tile_idx] -
+                              (int64_t)std::numeric_limits<char>::min();
             CHECK(
                 0 ==
-                strncmp(min.data(), string_ascii_[idx].c_str(), cell_val_num));
+                strncmp(
+                    min.data(), string_ascii_[min_idx].c_str(), cell_val_num));
 
             // Validate max.
             const auto max =
@@ -496,11 +505,12 @@ struct CPPFixedTileMetadataFx {
 
             // For strings, the index is stored in a signed value, switch to
             // the index to unsigned.
-            idx = (int64_t)correct_tile_maxs_[f][tile_idx] -
-                  (int64_t)std::numeric_limits<char>::min();
+            int64_t max_idx = (int64_t)correct_tile_maxs_[f][tile_idx] -
+                              (int64_t)std::numeric_limits<char>::min();
             CHECK(
                 0 ==
-                strncmp(max.data(), string_ascii_[idx].c_str(), cell_val_num));
+                strncmp(
+                    max.data(), string_ascii_[max_idx].c_str(), cell_val_num));
 
             // Validate no sum.
             CHECK_THROWS_WITH(
@@ -508,6 +518,16 @@ struct CPPFixedTileMetadataFx {
                 "FragmentMetadata: Trying to access tile sum metadata that's "
                 "not "
                 "present");
+
+            // Validate the tile metadata structure.
+            auto full_tile_data =
+                frag_meta[f]->get_tile_metadata("a", tile_idx);
+            CHECK(
+                string_ascii_[min_idx] ==
+                full_tile_data.min_as<std::string_view>());
+            CHECK(
+                string_ascii_[max_idx] ==
+                full_tile_data.max_as<std::string_view>());
           }
         } else {
           (void)cell_val_num;
@@ -528,13 +548,29 @@ struct CPPFixedTileMetadataFx {
                 memcmp(
                     &max, &correct_tile_maxs_[f][tile_idx], sizeof(TestType)));
 
+            // Validate the tile metadata structure.
+            auto full_tile_data =
+                frag_meta[f]->get_tile_metadata("a", tile_idx);
+            CHECK(
+                correct_tile_mins_[f][tile_idx] ==
+                full_tile_data.min_as<TestType>());
+            CHECK(
+                correct_tile_maxs_[f][tile_idx] ==
+                full_tile_data.max_as<TestType>());
+
             if constexpr (!std::is_same<TestType, unsigned char>::value) {
               // Validate sum.
               auto sum = frag_meta[f]->get_tile_sum("a", tile_idx);
               if constexpr (std::is_integral_v<TestType>) {
                 CHECK(*(int64_t*)sum == correct_tile_sums_int_[f][tile_idx]);
+                CHECK(
+                    correct_tile_sums_int_[f][tile_idx] ==
+                    full_tile_data.sum_as<int64_t>());
               } else {
                 CHECK(*(double*)sum == correct_tile_sums_double_[f][tile_idx]);
+                CHECK(
+                    correct_tile_sums_double_[f][tile_idx] ==
+                    full_tile_data.sum_as<double>());
               }
             }
           }
@@ -552,6 +588,20 @@ struct CPPFixedTileMetadataFx {
             frag_meta[f]->get_tile_null_count("a", tile_idx),
             "FragmentMetadata: Trying to access tile null count metadata "
             "that's not present");
+      }
+    }
+
+    if constexpr (!std::is_same<TestType, std::byte>::value) {
+      // Validate the full tile data structure for null count
+      for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
+        auto full_tile_data = frag_meta[f]->get_tile_metadata("a", tile_idx);
+        if (nullable) {
+          CHECK(
+              full_tile_data.null_count() ==
+              correct_tile_null_counts_[f][tile_idx]);
+        } else {
+          CHECK(full_tile_data.null_count() == 0);
+        }
       }
     }
 
@@ -819,6 +869,7 @@ struct CPPVarTileMetadataFx {
     bool has_coords = layout != TILEDB_ROW_MAJOR;
     if (has_coords) {
       std::vector<std::string> names{"d"};
+      frag_meta[f]->load_rtree(enc_key);
       frag_meta[f]->load_tile_min_values(enc_key, names);
       frag_meta[f]->load_tile_max_values(enc_key, names);
       frag_meta[f]->load_tile_sum_values(enc_key, names);
@@ -870,6 +921,12 @@ struct CPPVarTileMetadataFx {
           // Validate sum.
           auto sum = frag_meta[f]->get_tile_sum("d", tile_idx);
           CHECK(*(int64_t*)sum == correct_sum);
+
+          // Validate the tile metadata structure.
+          auto full_tile_data = frag_meta[f]->get_tile_metadata("d", tile_idx);
+          CHECK(correct_min == full_tile_data.min_as<uint32_t>());
+          CHECK(correct_max == full_tile_data.max_as<uint32_t>());
+          CHECK(correct_sum == full_tile_data.sum_as<int64_t>());
         }
       }
     }
@@ -929,26 +986,35 @@ struct CPPVarTileMetadataFx {
         // Validate min.
         const auto min =
             frag_meta[f]->get_tile_min_as<std::string_view>("a", tile_idx);
-        int idx = correct_tile_mins_[f][tile_idx];
-        CHECK(min.size() == strings_[idx].size());
+        int min_idx = correct_tile_mins_[f][tile_idx];
+        CHECK(min.size() == strings_[min_idx].size());
         CHECK(
-            0 ==
-            strncmp(min.data(), strings_[idx].c_str(), strings_[idx].size()));
+            0 == strncmp(
+                     min.data(),
+                     strings_[min_idx].c_str(),
+                     strings_[min_idx].size()));
 
         // Validate max.
         const auto max =
             frag_meta[f]->get_tile_max_as<std::string_view>("a", tile_idx);
-        idx = correct_tile_maxs_[f][tile_idx];
-        CHECK(max.size() == strings_[idx].size());
+        int max_idx = correct_tile_maxs_[f][tile_idx];
+        CHECK(max.size() == strings_[max_idx].size());
         CHECK(
-            0 ==
-            strncmp(max.data(), strings_[idx].c_str(), strings_[idx].size()));
+            0 == strncmp(
+                     max.data(),
+                     strings_[max_idx].c_str(),
+                     strings_[max_idx].size()));
 
         // Validate no sum.
         CHECK_THROWS_WITH(
             frag_meta[f]->get_tile_sum("a", tile_idx),
             "FragmentMetadata: Trying to access tile sum metadata that's not "
             "present");
+
+        // Validate the tile metadata structure.
+        auto full_tile_data = frag_meta[f]->get_tile_metadata("a", tile_idx);
+        CHECK(strings_[min_idx] == full_tile_data.min_as<std::string_view>());
+        CHECK(strings_[max_idx] == full_tile_data.max_as<std::string_view>());
       }
     }
 
@@ -1185,6 +1251,15 @@ struct CPPFixedTileMetadataPartialFx {
       // Validate sum.
       auto sum = frag_meta[0]->get_tile_sum("a", tile_idx);
       CHECK(*(double*)sum - correct_tile_sums[tile_idx] < 0.0001);
+
+      // Validate the tile metadata structure.
+      auto full_tile_data = frag_meta[0]->get_tile_metadata("a", tile_idx);
+      CHECK(correct_tile_mins[tile_idx] == full_tile_data.min_as<double>());
+      CHECK(correct_tile_maxs[tile_idx] == full_tile_data.max_as<double>());
+      CHECK(
+          std::abs(
+              correct_tile_sums[tile_idx] - full_tile_data.sum_as<double>()) <
+          0.0001);
     }
 
     // Close array.
@@ -1244,7 +1319,7 @@ struct CPPVarTileMetadataPartialFx {
     tiledb_domain_add_dimension(ctx, domain, d1);
     tiledb_domain_add_dimension(ctx, domain, d2);
 
-    // Create a single attribute "a" so each (i,j) cell can store an integer
+    // Create a single attribute "a" so each (i,j) cell can store a string
     tiledb_attribute_t* a;
     tiledb_attribute_alloc(ctx, "a", TILEDB_STRING_ASCII, &a);
     tiledb_attribute_set_cell_val_num(ctx, a, TILEDB_VAR_NUM);
@@ -1350,6 +1425,15 @@ struct CPPVarTileMetadataPartialFx {
       CHECK(
           0 ==
           memcmp(max.data(), correct_tile_maxs[tile_idx].data(), max.size()));
+
+      // Validate the tile metadata structure.
+      auto full_tile_data = frag_meta[0]->get_tile_metadata("a", tile_idx);
+      CHECK(
+          correct_tile_mins[tile_idx] ==
+          full_tile_data.min_as<std::string_view>());
+      CHECK(
+          correct_tile_maxs[tile_idx] ==
+          full_tile_data.max_as<std::string_view>());
     }
 
     // Close array.
@@ -1371,6 +1455,201 @@ TEST_CASE_METHOD(
     CPPVarTileMetadataPartialFx,
     "TileMetadata: partial tile var",
     "[tile-metadata][var][partial]") {
+  // Create the array.
+  create_array();
+  write_fragment();
+  check_metadata();
+}
+
+struct CPPTileMetadataStringDimFx {
+  CPPTileMetadataStringDimFx()
+      : vfs_(ctx_) {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  ~CPPTileMetadataStringDimFx() {
+    if (vfs_.is_dir(ARRAY_NAME))
+      vfs_.remove_dir(ARRAY_NAME);
+  }
+
+  void create_array() {
+    // Create TileDB context
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+
+    // The array will be two string dimension "d1" and "d2".
+    tiledb_dimension_t* d1;
+    tiledb_dimension_alloc(ctx, "d1", TILEDB_STRING_ASCII, 0, 0, &d1);
+    tiledb_dimension_t* d2;
+    tiledb_dimension_alloc(ctx, "d2", TILEDB_STRING_ASCII, 0, 0, &d2);
+
+    // Create domain
+    tiledb_domain_t* domain;
+    tiledb_domain_alloc(ctx, &domain);
+    tiledb_domain_add_dimension(ctx, domain, d1);
+    tiledb_domain_add_dimension(ctx, domain, d2);
+
+    // Create a single attribute "a" so each (i,j) cell can store a double
+    tiledb_attribute_t* a;
+    tiledb_attribute_alloc(ctx, "a", TILEDB_FLOAT64, &a);
+
+    // Create array schema
+    tiledb_array_schema_t* array_schema;
+    tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+    tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+    tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+    tiledb_array_schema_set_domain(ctx, array_schema, domain);
+    tiledb_array_schema_add_attribute(ctx, array_schema, a);
+
+    // Create array
+    tiledb_array_create(ctx, ARRAY_NAME, array_schema);
+
+    // Clean up
+    tiledb_attribute_free(&a);
+    tiledb_dimension_free(&d1);
+    tiledb_dimension_free(&d2);
+    tiledb_domain_free(&domain);
+    tiledb_array_schema_free(&array_schema);
+    tiledb_ctx_free(&ctx);
+  }
+
+  void write_fragment() {
+    // Write to the array.
+    auto array = tiledb::Array(ctx_, ARRAY_NAME, TILEDB_WRITE);
+    auto query = tiledb::Query(ctx_, array, TILEDB_WRITE);
+
+    std::string d1 = "abbcccdddd";
+    std::vector<uint64_t> d1_offsets{0, 1, 3, 6};
+    std::string d2 = "abcd";
+    std::vector<uint64_t> d2_offsets{0, 1, 2, 3};
+    std::vector<double> a{4, 5, 6, 7};
+    query.set_layout(TILEDB_UNORDERED);
+    query.set_data_buffer("d1", d1).set_offsets_buffer("d1", d1_offsets);
+    query.set_data_buffer("d2", d2).set_offsets_buffer("d2", d2_offsets);
+    query.set_data_buffer("a", a);
+
+    query.submit();
+    query.finalize();
+    array.close();
+  }
+
+  void check_metadata() {
+    // Open array.
+    tiledb_ctx_t* ctx;
+    tiledb_ctx_alloc(NULL, &ctx);
+    tiledb_array_t* array;
+    int rc = tiledb_array_alloc(ctx, ARRAY_NAME, &array);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_array_open(ctx, array, TILEDB_READ);
+    CHECK(rc == TILEDB_OK);
+
+    // Load fragment metadata.
+    auto frag_meta = array->array_->fragment_metadata();
+    auto& enc_key = array->array_->get_encryption_key();
+    frag_meta[0]->load_fragment_min_max_sum_null_count(enc_key);
+
+    // Do fragment metadata first.
+    {
+      // Validate mins.
+      auto& min = frag_meta[0]->get_min("a");
+      double correct_min = 4;
+      CHECK(min.size() == sizeof(double));
+      CHECK(0 == memcmp(min.data(), &correct_min, min.size()));
+
+      CHECK_THROWS_WITH(
+          frag_meta[0]->get_min("d1"),
+          "FragmentMetadata: Trying to access fragment min metadata that's "
+          "not present");
+
+      CHECK_THROWS_WITH(
+          frag_meta[0]->get_min("d2"),
+          "FragmentMetadata: Trying to access fragment min metadata that's "
+          "not present");
+
+      // Validate maxs.
+      auto& max = frag_meta[0]->get_max("a");
+      double correct_max = 7;
+      CHECK(max.size() == sizeof(double));
+      CHECK(0 == memcmp(max.data(), &correct_max, max.size()));
+
+      CHECK_THROWS_WITH(
+          frag_meta[0]->get_max("d1"),
+          "FragmentMetadata: Trying to access fragment max metadata that's "
+          "not present");
+
+      CHECK_THROWS_WITH(
+          frag_meta[0]->get_max("d2"),
+          "FragmentMetadata: Trying to access fragment max metadata that's "
+          "not present");
+    }
+
+    // Load metadata.
+    std::vector<std::string> names{"a", "d1", "d2"};
+    frag_meta[0]->load_rtree(enc_key);
+    frag_meta[0]->load_tile_min_values(enc_key, names);
+    frag_meta[0]->load_tile_max_values(enc_key, names);
+    frag_meta[0]->load_tile_sum_values(enc_key, names);
+    frag_meta[0]->load_tile_null_count_values(enc_key, names);
+
+    // Validate min.
+    CHECK(frag_meta[0]->get_tile_min_as<double>("a", 0) == 4);
+    CHECK_THROWS_WITH(
+        frag_meta[0]->get_tile_min_as<std::string_view>("d1", 0),
+        "FragmentMetadata: Trying to access tile min metadata that's not "
+        "present");
+    CHECK_THROWS_WITH(
+        frag_meta[0]->get_tile_min_as<std::string_view>("d2", 0),
+        "FragmentMetadata: Trying to access tile min metadata that's not "
+        "present");
+
+    // Validate max.
+    CHECK(frag_meta[0]->get_tile_max_as<double>("a", 0) == 7);
+    CHECK_THROWS_WITH(
+        frag_meta[0]->get_tile_max_as<std::string_view>("d1", 0),
+        "FragmentMetadata: Trying to access tile max metadata that's not "
+        "present");
+    CHECK_THROWS_WITH(
+        frag_meta[0]->get_tile_max_as<std::string_view>("d2", 0),
+        "FragmentMetadata: Trying to access tile max metadata that's not "
+        "present");
+
+    // Validate sum.
+    CHECK(*(double*)frag_meta[0]->get_tile_sum("a", 0) == 22);
+
+    // Validate the tile metadata structure.
+    auto full_tile_data_a = frag_meta[0]->get_tile_metadata("a", 0);
+    CHECK(4 == full_tile_data_a.min_as<double>());
+    CHECK(7 == full_tile_data_a.max_as<double>());
+    CHECK(22 == full_tile_data_a.sum_as<double>());
+
+    auto full_tile_data_d1 = frag_meta[0]->get_tile_metadata("d1", 0);
+    CHECK("a" == full_tile_data_d1.min_as<std::string_view>());
+    CHECK("dddd" == full_tile_data_d1.max_as<std::string_view>());
+
+    auto full_tile_data_d2 = frag_meta[0]->get_tile_metadata("d2", 0);
+    CHECK("a" == full_tile_data_d2.min_as<std::string_view>());
+    CHECK("d" == full_tile_data_d2.max_as<std::string_view>());
+
+    // Close array.
+    rc = tiledb_array_close(ctx, array);
+    CHECK(rc == TILEDB_OK);
+
+    // Clean up.
+    tiledb_array_free(&array);
+    tiledb_ctx_free(&ctx);
+  }
+
+  const char* ARRAY_NAME = "tile_metadata_unit_array";
+  const uint64_t tile_extent_ = 4;
+  tiledb::Context ctx_;
+  tiledb::VFS vfs_;
+};
+
+TEST_CASE_METHOD(
+    CPPTileMetadataStringDimFx,
+    "TileMetadata: string dims",
+    "[tile-metadata][string-dims]") {
   // Create the array.
   create_array();
   write_fragment();

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1708,7 +1708,7 @@ T FragmentMetadata::get_tile_min_as(
 
   auto size = array_schema_->cell_size(name);
   const void* min = &tile_min_buffer_[idx][tile_idx * size];
-  if constexpr (std::is_same<T, const void*>::value) {
+  if constexpr (std::is_same_v<T, const void*>) {
     return min;
   } else {
     return *static_cast<const T*>(min);
@@ -1792,7 +1792,7 @@ T FragmentMetadata::get_tile_max_as(
 
   auto size = array_schema_->cell_size(name);
   const void* max = &tile_max_buffer_[idx][tile_idx * size];
-  if constexpr (std::is_same<T, const void*>::value) {
+  if constexpr (std::is_same_v<T, const void*>) {
     return max;
   } else {
     return *static_cast<const T*>(max);
@@ -2016,9 +2016,9 @@ TileMetadata FragmentMetadata::get_tile_metadata(
 
     const auto type = array_schema_->type(name);
     const auto cell_val_num = array_schema_->cell_val_num(name);
-    void* sum = nullptr;
+    const void* sum = nullptr;
     if (TileMetadataGenerator::has_sum_metadata(type, false, cell_val_num)) {
-      sum = const_cast<void*>(get_tile_sum(name, tile_idx));
+      sum = get_tile_sum(name, tile_idx);
     }
 
     return {count, null_count, min, cell_size, max, cell_size, sum};

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -59,6 +59,7 @@ namespace sm {
 class ArraySchema;
 class Buffer;
 class EncryptionKey;
+class TileMetadata;
 class MemoryTracker;
 
 /** Stores the metadata structures of a fragment. */
@@ -287,6 +288,10 @@ class FragmentMetadata {
   /** Returns true if the fragment has delete metadata. */
   inline bool has_delete_meta() const {
     return has_delete_meta_;
+  }
+
+  inline bool has_tile_metadata() {
+    return version_ >= constants::tile_metadata_min_version;
   }
 
   /** Returns the sizes of each attribute file. */
@@ -898,6 +903,15 @@ class FragmentMetadata {
    * @return Count.
    */
   uint64_t get_null_count(const std::string& name);
+
+  /**
+   * Returns the tile metadata for a tile.
+   *
+   * @param name Name of the attribute to get the data for.
+   * @param tile_idx Tile index.
+   */
+  TileMetadata get_tile_metadata(
+      const std::string& name, const uint64_t tile_idx) const;
 
   /**
    * Set the processed conditions. The processed conditions is the list


### PR DESCRIPTION
This adds the ability to get the tile metadata to later be used by the aggregates pipeline.

---
TYPE: IMPROVEMENT
DESC: Fragment metadata: adding get_tile_metadata.
