### PR TITLE
Aggregates: use tile metadata.

### DIFF
--- a/format_spec/FORMAT_SPEC.md
+++ b/format_spec/FORMAT_SPEC.md
@@ -4,7 +4,7 @@ title: Format Specification
 
 **Notes:**
 
-* The current TileDB format version number is **20** (`uint32_t`).
+* The current TileDB format version number is **21** (`uint32_t`).
 * Data written by TileDB and referenced in this document is **little-endian**
   with the following exceptions:
 

--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -620,9 +620,9 @@ void CppAggregatesFx<T>::create_array_and_write_fragments() {
     write_sparse({0, 1, 2, 3}, {1, 1, 1, 2}, {1, 2, 4, 3}, 1, validity_values);
     write_sparse({4, 5, 6, 7}, {2, 2, 3, 3}, {2, 4, 2, 3}, 3, validity_values);
     write_sparse(
-        {8, 9, 10, 11}, {2, 1, 3, 4}, {1, 3, 1, 1}, 4, validity_values);
-    write_sparse(
-        {12, 13, 14, 15}, {4, 3, 3, 4}, {2, 3, 4, 4}, 6, validity_values);
+        {8, 9, 10, 11}, {2, 1, 3, 4}, {1, 3, 1, 1}, 5, validity_values);
+    write_sparse({12, 13}, {4, 3}, {2, 3}, 7, validity_values);
+    write_sparse({14, 15}, {3, 4}, {4, 4}, 9, validity_values);
   }
 }
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -676,7 +676,7 @@ const int32_t library_version[3] = {
     TILEDB_VERSION_MAJOR, TILEDB_VERSION_MINOR, TILEDB_VERSION_PATCH};
 
 /** The TileDB serialization base format version number. */
-const format_version_t base_format_version = 20;
+const format_version_t base_format_version = 21;
 
 /**
  * The TileDB serialization format version number.

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -431,6 +431,18 @@ class ReaderBase : public StrategyBase {
       const RelevantFragments& relevant_fragments,
       const std::vector<std::string>& names);
 
+  /*
+   * Loads tile metadata for each attribute/dimension name into
+   * their associated element in `fragment_metadata_`. This is done for
+   * attributes with aggregates.
+   *
+   * @param relevant_fragments List of relevant fragments.
+   * @param names The attribute/dimension names.
+   */
+  void load_tile_metadata(
+      const RelevantFragments& relevant_fragments,
+      const std::vector<std::string>& names);
+
   /**
    * Loads processed conditions from fragment metadata.
    *

--- a/tiledb/sm/query/readers/result_space_tile.h
+++ b/tiledb/sm/query/readers/result_space_tile.h
@@ -152,6 +152,32 @@ class ResultSpaceTile {
            result_tiles_ == rst.result_tiles_;
   }
 
+  /** The query condition filtered a result for this tile. */
+  inline void set_qc_filtered_results() {
+    qc_filtered_results_ = true;
+  }
+
+  /**
+   * Returns if the query condition filtered any results for this tile or not.
+   */
+  inline bool qc_filtered_results() const {
+    return qc_filtered_results_;
+  }
+
+  /**
+   * Returns the only result tile in this space tile or throws if there are more
+   * than one.
+   */
+  inline ResultTile& single_result_tile() {
+    if (result_tiles_.size() != 1) {
+      throw std::runtime_error(
+          "Shouldn't call single_result_tile on tiles with more than one "
+          "fragment domain.");
+    }
+
+    return result_tiles_[frag_domains_[0].fid()];
+  }
+
  private:
   /** The (global) coordinates of the first cell in the space tile. */
   std::vector<T> start_coords_;
@@ -168,6 +194,9 @@ class ResultSpaceTile {
    * `(fragment id) -> (result tile)`.
    */
   std::map<unsigned, ResultTile> result_tiles_;
+
+  /** Did the query condition filter any result for this space tile. */
+  bool qc_filtered_results_ = false;
 };
 
 }  // namespace sm

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -568,6 +568,20 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       ResultTile& rt);
 
   /**
+   * Returns wether or not we can aggregate the tile with only the fragment
+   * metadata.
+   *
+   * @param rcs Result cell slab.
+   * @return If we can do the aggregation with the frag md or not.
+   */
+  inline bool can_aggregate_tile_with_frag_md(ResultCellSlab& rcs) {
+    auto rt = static_cast<GlobalOrderResultTile<BitmapType>*>(rcs.tile_);
+    auto& frag_md = fragment_metadata_[rt->frag_idx()];
+    return rt->copy_full_tile() && rcs.start_ == 0 &&
+           rcs.length_ == rt->cell_num() && frag_md->has_tile_metadata();
+  }
+
+  /**
    * Process aggregates.
    *
    * @param num_range_threads Total number of range threads.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -508,6 +508,9 @@ void SparseIndexReaderBase::load_tile_offsets_for_fragments(
   // Load tile offsets and var sizes for attributes.
   load_tile_var_sizes(relevant_fragments, var_size_to_load_);
   load_tile_offsets(relevant_fragments, attr_tile_offsets_to_load_);
+
+  // Load tile metadata.
+  load_tile_metadata(relevant_fragments, attr_tile_offsets_to_load_);
 }
 
 Status SparseIndexReaderBase::read_and_unfilter_coords(

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -513,6 +513,19 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
       UnorderedWithDupsResultTile<BitmapType>& rt);
 
   /**
+   * Returns wether or not we can aggregate the tile with only the fragment
+   * metadata.
+   *
+   * @param rt Result tile.
+   * @return If we can do the aggregation with the frag md or not.
+   */
+  inline bool can_aggregate_tile_with_frag_md(
+      UnorderedWithDupsResultTile<BitmapType>* rt) {
+    auto& frag_md = fragment_metadata_[rt->frag_idx()];
+    return rt->copy_full_tile() && frag_md->has_tile_metadata();
+  }
+
+  /**
    * Process aggregates.
    *
    * @param num_range_threads Total number of range threads.

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -522,6 +522,10 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   inline bool can_aggregate_tile_with_frag_md(
       UnorderedWithDupsResultTile<BitmapType>* rt) {
     auto& frag_md = fragment_metadata_[rt->frag_idx()];
+
+    // Here we only aggregate a full tile if first of all there are no missing
+    // cells in the bitmap. This can be validated with 'copy_full_tile'.
+    // Finally, we check the fragment metadata has indeed tile metadata.
     return rt->copy_full_tile() && frag_md->has_tile_metadata();
   }
 

--- a/tiledb/sm/tile/tile_metadata_generator.cc
+++ b/tiledb/sm/tile/tile_metadata_generator.cc
@@ -458,7 +458,7 @@ void TileMetadataGenerator::min_max_nullable<char>(
     uint64_t start,
     uint64_t end) {
   // Get pointers to the data and cell num.
-  auto value = tile.data_as<char>();
+  auto value = tile.data_as<char>() + cell_size_ * start;
   auto validity_values = validity_tile.data_as<uint8_t>();
 
   // Process cell by cell.


### PR DESCRIPTION
This allows the readers to use the tile metadata to do aggregation. The tiles still get loaded into memory even when not required but that will be addressed in a follow up change.

---
TYPE: IMPROVEMENT
DESC: Aggregates: use tile metadata.
