### PR TITLE
Stop including the static library when releasing on Windows.

### DIFF
--- a/scripts/azure-windows-release.yml
+++ b/scripts/azure-windows-release.yml
@@ -27,7 +27,7 @@ steps:
       $host.SetShouldExit(3)
     }
 
-    $bootstrapOptions = "-EnableVerbose -EnableStaticTileDB -DisableTests"
+    $bootstrapOptions = "-EnableVerbose -DisableTests"
     if ($env:TILEDB_S3 -eq "ON") {
       $bootstrapOptions = "-EnableS3 " + $bootstrapOptions
     }
@@ -41,10 +41,9 @@ steps:
     if ($env:TILEDB_SERIALIZATION -eq "ON") {
       $bootstrapOptions = "-EnableSerialization " + $bootstrapOptions
     }
-    # static already added above as initial default
-    # if ($env:TILEDB_STATIC -eq "ON") {
-    #  $bootstrapOptions = $bootstrapOptions + " -EnableStaticTileDB"
-    # }
+    if ($env:TILEDB_STATIC -eq "ON") {
+      $bootstrapOptions = $bootstrapOptions + " -EnableStaticTileDB"
+    }
     # if ($env:TILEDB_HDFS -eq "ON") {
     #  $bootstrapOptions = $bootstrapOptions + " -EnableHDFS"
     #}
@@ -59,10 +58,6 @@ steps:
     # }
     # if ($env:TILEDB_CI_TSAN -eq "ON") {
     #  $bootstrapOptions = $bootstrapOptions + " -EnableSanitizer thread -EnableDebug"
-    # }
-    # static already added above as initial default
-    # if ($env:TILEDB_FORCE_BUILD_DEPS" -eq "ON") {
-    #   $bootstrapOptions = $bootstrapOptions + " -EnableBuildDeps"
     # }
     if ($env:TILEDB_WEBP -eq "OFF") {
       $bootstrapOptions = $bootstrapOptions + " -DisableWebP"


### PR DESCRIPTION
This PR stops passing `-EnableStaticTileDB` on the Windows release workflow, which means that the release artifacts will include include only the dynamic library, like on other platforms. The size of these artifacts on Windows drops from 175MB [to just 7MB](https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=35970&view=artifacts&pathAsName=false&type=publishedArtifacts).

Users that want to statically link to TileDB will have to build it themselves. TileDB-Java used to do that until TileDB-Inc/TileDB-Java#314, and according to [a search](https://github.com/search?q=TileDB%3A%3Atiledb_static++NOT+is%3Aarchived+NOT+is%3Afork&type=code) of the `TileDB::tiledb_static` string on public non-archived and non-forked repositories, none of these uses would be broken.

> [!NOTE]
> TileDB-R links statically on Windows as well but it does not use these artifacts so it will not be affected.

---
TYPE: BREAKING_BEHAVIOR
DESC: The Windows release artifacts no longer include static libraries.