### PR TITLE
[Backport release-2.17] Fix serialization of empty enumerations

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1500,6 +1500,39 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
+    "Cap'N Proto - ArraySchema Serialization with Empty Enumerations",
+    "[enumeration][capnp][array-schema][empty-enumerations]") {
+  create_array();
+
+  auto client_side = GENERATE(true, false);
+  auto ser_type = GENERATE(SerializationType::CAPNP, SerializationType::JSON);
+
+  auto schema1 = create_schema();
+
+  auto enmr1 = Enumeration::create(
+      "empty_fixed", Datatype::INT32, 1, false, nullptr, 0, nullptr, 0);
+  auto enmr2 = Enumeration::create(
+      "empty_var",
+      Datatype::STRING_ASCII,
+      constants::var_num,
+      false,
+      nullptr,
+      0,
+      nullptr,
+      0);
+
+  schema1->add_enumeration(enmr1);
+  schema1->add_enumeration(enmr2);
+
+  auto schema2 = ser_des_array_schema(schema1, client_side, ser_type);
+
+  auto all_names1 = schema1->get_enumeration_names();
+  auto all_names2 = schema2.get_enumeration_names();
+  REQUIRE(vec_cmp(all_names1, all_names2));
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
     "Cap'N Proto - Basic ArraySchemaEvolution Serialization",
     "[enumeration][capnp][basic][array-schema-evolution]") {
   auto client_side = GENERATE(true, false);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3537,7 +3537,7 @@ int32_t tiledb_deserialize_array_schema(
   } catch (...) {
     delete *array_schema;
     *array_schema = nullptr;
-    return TILEDB_ERR;
+    throw;
   }
 
   return TILEDB_OK;


### PR DESCRIPTION
Backport 9163edf046e5a6c25c6fab36c0dab84f62890cce from #4472.

---
TYPE: NO_HISTORY