### PR TITLE
Aggregates: don't read tiles when using fragment metadata.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1888,6 +1888,13 @@ void SparseGlobalOrderReader<BitmapType>::process_slabs(
     bool agg_only = aggregate_only(names[buffer_idx]);
     if (agg_only && result_tiles_agg_only == nullopt) {
       result_tiles_agg_only = result_tiles_to_load(result_cell_slabs, true);
+
+      // If we hit an overflow, it might have changed the tiles we need to load.
+      // Recompute the memory usage.
+      if (last_field_to_overflow != nullopt) {
+        mem_usage_per_attr = respect_copy_memory_budget(
+            names, result_cell_slabs, user_buffers_full);
+      }
     }
 
     // Read and unfilter as many attributes as can fit in the budget.

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1890,7 +1890,12 @@ void SparseGlobalOrderReader<BitmapType>::process_slabs(
       result_tiles_agg_only = result_tiles_to_load(result_cell_slabs, true);
 
       // If we hit an overflow, it might have changed the tiles we need to load.
-      // Recompute the memory usage.
+      // Recompute the memory usage. This is because a tile where we might have
+      // included the full tile in a cell slab (0 to 'cell_num()') and not
+      // loaded might now be truncated to fit the user buffers. Since we can't
+      // use the fragment metadata to compute the aggregates for this tile on
+      // this iteration, the memory usage for this attribute needs to be
+      // recomputed.
       if (last_field_to_overflow != nullopt) {
         mem_usage_per_attr = respect_copy_memory_budget(
             names, result_cell_slabs, user_buffers_full);

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -513,6 +513,16 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
       QueryBuffer& query_buffer);
 
   /**
+   * Get the sorted unique result tile list from the result cell slabs.
+   *
+   * @param result_cell_slabs Result cell slabs.
+   * @param aggregate_only Are we generating the list for aggregate only fields?
+   * @return vector of result tiles.
+   */
+  std::vector<ResultTile*> result_tiles_to_load(
+      std::vector<ResultCellSlab>& result_cell_slabs, bool aggregate_only);
+
+  /**
    * Copy cell slabs.
    *
    * @param names Attribute/dimensions to compute for.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -671,6 +671,19 @@ class SparseIndexReaderBase : public ReaderBase {
   template <class ResultTileType, class BitmapType>
   void apply_query_condition(std::vector<ResultTile*>& result_tiles);
 
+  /** Returns wether the field is for aggregation only or not. */
+  bool aggregate_only(const std::string& name) const {
+    if (qc_loaded_attr_names_set_.count(name) != 0) {
+      return false;
+    }
+
+    if (buffers_.count(name) != 0) {
+      return false;
+    }
+
+    return true;
+  }
+
   /**
    * Read and unfilter as many attributes as can fit in the memory budget and
    * return the names loaded in 'names_to_copy'. Also keep the 'buffer_idx'
@@ -680,6 +693,7 @@ class SparseIndexReaderBase : public ReaderBase {
    * @param mem_usage_per_attr Computed per attribute memory usage.
    * @param buffer_idx Stores/return the current buffer index in process.
    * @param result_tiles Result tiles to process.
+   * @param agg_only Are we loading for aggregates only field.
    *
    * @return names_to_copy.
    */
@@ -687,7 +701,8 @@ class SparseIndexReaderBase : public ReaderBase {
       const std::vector<std::string>& names,
       const std::vector<uint64_t>& mem_usage_per_attr,
       uint64_t* buffer_idx,
-      std::vector<ResultTile*>& result_tiles);
+      std::vector<ResultTile*>& result_tiles,
+      bool agg_only);
 
   /**
    * Get the field names to process.


### PR DESCRIPTION
This change modifies the readers to not read tiles when using the fragment metadata as it is not necessary.

---
TYPE: IMPROVEMENT
DESC: Aggregates: don't read tiles when using fragment metadata.
