### PR TITLE
Remove UnitTestConfig::array_encryption_key_length

### DIFF
--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -196,17 +196,14 @@ TEST_CASE(
   encrypt = GENERATE(false, true);
   tiledb_encryption_type_t encryption_type;
   const char* key;
-  int key_length;
   uint64_t expected_fragment_size;
   if (encrypt) {
     encryption_type = tiledb_encryption_type_t::TILEDB_AES_256_GCM;
     key = "12345678901234567890123456789012";
-    key_length = 32;
     expected_fragment_size = 5585;
   } else {
     encryption_type = tiledb_encryption_type_t::TILEDB_NO_ENCRYPTION;
     key = "";
-    key_length = 0;
     expected_fragment_size = 3202;
   }
 
@@ -218,7 +215,6 @@ TEST_CASE(
       array_name,
       encryption_type,
       key,
-      key_length,
       TILEDB_DENSE,
       {"d"},
       {TILEDB_UINT64},
@@ -323,7 +319,6 @@ TEST_CASE(
       array_name,
       encryption_type,
       key,
-      key_length,
       1,
       subarray,
       TILEDB_ROW_MAJOR,
@@ -380,7 +375,6 @@ TEST_CASE(
       array_name,
       encryption_type,
       key,
-      key_length,
       2,
       subarray,
       TILEDB_ROW_MAJOR,
@@ -398,7 +392,6 @@ TEST_CASE(
       array_name,
       encryption_type,
       key,
-      key_length,
       3,
       subarray,
       TILEDB_ROW_MAJOR,
@@ -593,7 +586,6 @@ TEST_CASE("C API: Test MBR fragment info", "[capi][fragment_info][mbr]") {
       array_name,
       TILEDB_AES_256_GCM,
       key,
-      32,
       TILEDB_SPARSE,
       {"d1", "d2"},
       {TILEDB_UINT64, TILEDB_UINT64},
@@ -635,7 +627,6 @@ TEST_CASE("C API: Test MBR fragment info", "[capi][fragment_info][mbr]") {
       array_name,
       TILEDB_AES_256_GCM,
       key,
-      32,
       1,
       TILEDB_UNORDERED,
       buffers,
@@ -656,7 +647,6 @@ TEST_CASE("C API: Test MBR fragment info", "[capi][fragment_info][mbr]") {
       array_name,
       TILEDB_AES_256_GCM,
       key,
-      32,
       2,
       TILEDB_UNORDERED,
       buffers,
@@ -677,7 +667,6 @@ TEST_CASE("C API: Test MBR fragment info", "[capi][fragment_info][mbr]") {
       array_name,
       TILEDB_AES_256_GCM,
       key,
-      32,
       3,
       TILEDB_UNORDERED,
       buffers,

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -65,8 +65,6 @@ struct CMetadataFx {
   const char* ARRAY_NAME = "test_metadata";
   tiledb_array_t* array_ = nullptr;
   const char* key_ = "0123456789abcdeF0123456789abcdeF";
-  const uint32_t key_len_ =
-      (uint32_t)strlen("0123456789abcdeF0123456789abcdeF");
   const tiledb_encryption_type_t enc_type_ = TILEDB_AES_256_GCM;
 
   void create_default_array_1d();
@@ -149,7 +147,6 @@ void CMetadataFx::create_default_array_1d_with_key() {
       array_name_,
       enc_type_,
       key_,
-      key_len_,
       TILEDB_DENSE,
       {"d"},
       {TILEDB_UINT64},
@@ -230,8 +227,6 @@ TEST_CASE_METHOD(
   rc = tiledb_config_set(config, "sm.encryption_key", key_, &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
-  tiledb::sm::UnitTestConfig::instance().array_encryption_key_length.set(
-      key_len_);
   rc = tiledb_array_set_config(ctx_, array, config);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
@@ -1030,8 +1025,6 @@ TEST_CASE_METHOD(
   REQUIRE(error == nullptr);
   rc = tiledb_array_set_config(ctx_, array, config);
   REQUIRE(rc == TILEDB_OK);
-  tiledb::sm::UnitTestConfig::instance().array_encryption_key_length.set(
-      key_len_);
   rc = tiledb_array_open(ctx_, array, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
@@ -1163,8 +1156,6 @@ TEST_CASE_METHOD(
   REQUIRE(error == nullptr);
   rc = tiledb_array_set_config(ctx_, array, config);
   REQUIRE(rc == TILEDB_OK);
-  tiledb::sm::UnitTestConfig::instance().array_encryption_key_length.set(
-      key_len_);
   rc = tiledb_array_open(ctx_, array, TILEDB_READ);
   REQUIRE(rc == TILEDB_OK);
 

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -66,8 +66,6 @@ struct CPPMetadataFx {
   const char* ARRAY_NAME = "test_metadata";
   tiledb_array_t* array_ = nullptr;
   const char* key_ = "0123456789abcdeF0123456789abcdeF";
-  const uint32_t key_len_ =
-      (uint32_t)strlen("0123456789abcdeF0123456789abcdeF");
   const tiledb_encryption_type_t enc_type_ = TILEDB_AES_256_GCM;
 
   void create_default_array_1d();
@@ -135,7 +133,6 @@ void CPPMetadataFx::create_default_array_1d_with_key() {
       array_name_,
       enc_type_,
       key_,
-      key_len_,
       TILEDB_DENSE,
       {"d"},
       {TILEDB_UINT64},

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -558,7 +558,6 @@ void create_array(
     const std::string& array_name,
     tiledb_encryption_type_t enc_type,
     const char* key,
-    uint32_t key_len,
     tiledb_array_type_t array_type,
     const std::vector<std::string>& dim_names,
     const std::vector<tiledb_datatype_t>& dim_types,
@@ -651,8 +650,6 @@ void create_array(
   rc = tiledb_config_set(config, "sm.encryption_key", key, &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
-  tiledb::sm::UnitTestConfig::instance().array_encryption_key_length.set(
-      key_len);
   tiledb_ctx_t* ctx_array;
   REQUIRE(tiledb_ctx_alloc(config, &ctx_array) == TILEDB_OK);
   rc = tiledb_array_create(ctx_array, array_name.c_str(), array_schema);
@@ -1079,7 +1076,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     tiledb_layout_t layout,
     const QueryBuffers& buffers) {
@@ -1088,7 +1084,6 @@ void write_array(
       array_name,
       encryption_type,
       key,
-      key_len,
       timestamp,
       nullptr,
       layout,
@@ -1122,7 +1117,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     const void* subarray,
     tiledb_layout_t layout,
@@ -1133,7 +1127,6 @@ void write_array(
       array_name,
       encryption_type,
       key,
-      key_len,
       timestamp,
       subarray,
       layout,
@@ -1157,7 +1150,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     tiledb_layout_t layout,
     const QueryBuffers& buffers,
@@ -1167,7 +1159,6 @@ void write_array(
       array_name,
       encryption_type,
       key,
-      key_len,
       timestamp,
       nullptr,
       layout,
@@ -1187,8 +1178,7 @@ void write_array(
       ctx,
       array_name,
       TILEDB_NO_ENCRYPTION,
-      nullptr,
-      0,
+      "",
       timestamp,
       subarray,
       layout,
@@ -1201,7 +1191,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     const void* sub,
     tiledb_layout_t layout,
@@ -1232,8 +1221,6 @@ void write_array(
     REQUIRE(err == nullptr);
     rc = tiledb_array_set_config(ctx, array, cfg);
     REQUIRE(rc == TILEDB_OK);
-    tiledb::sm::UnitTestConfig::instance().array_encryption_key_length.set(
-        key_len);
   }
   rc = tiledb_array_open(ctx, array, TILEDB_WRITE);
   CHECK(rc == TILEDB_OK);

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -307,7 +307,6 @@ void create_array(
  * @param array_name The array name.
  * @param enc_type The encryption type.
  * @param key The key to encrypt the array with.
- * @param key_len The key length.
  * @param array_type The array type (dense or sparse).
  * @param dim_names The names of dimensions.
  * @param dim_types The types of dimensions.
@@ -327,7 +326,6 @@ void create_array(
     const std::string& array_name,
     tiledb_encryption_type_t enc_type,
     const char* key,
-    uint32_t key_len,
     tiledb_array_type_t array_type,
     const std::vector<std::string>& dim_names,
     const std::vector<tiledb_datatype_t>& dim_types,
@@ -577,7 +575,6 @@ void write_array(
  * @param array_name The array name.
  * @param encyrption_type The type of encryption.
  * @param key The encryption key.
- * @param key_len The encryption key length.
  * @param timestamp The timestamp to write at.
  * @param layout The layout to write into.
  * @param buffers The attribute/dimension buffers to be written.
@@ -587,7 +584,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     tiledb_layout_t layout,
     const QueryBuffers& buffers);
@@ -649,7 +645,6 @@ void write_array(
  * @param array_name The array name.
  * @param encyrption_type The type of encryption.
  * @param key The encryption key.
- * @param key_len The encryption key length.
  * @param timestamp The timestamp to write at.
  * @param subarray The subarray to write into.
  * @param layout The layout to write into.
@@ -660,7 +655,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     const void* subarray,
     tiledb_layout_t layout,
@@ -691,7 +685,6 @@ void write_array(
  * @param array_name The array name.
  * @param encyrption_type The type of encryption.
  * @param key The encryption key.
- * @param key_len The encryption key length.
  * @param timestamp The timestamp to write at.
  * @param layout The layout to write into.
  * @param buffers The attribute/dimension buffers to be written.
@@ -702,7 +695,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     tiledb_layout_t layout,
     const QueryBuffers& buffers,
@@ -737,7 +729,6 @@ void write_array(
  * @param array_name The array name.
  * @param encyrption_type The type of encryption.
  * @param key The encryption key.
- * @param key_len The encryption key length.
  * @param timestamp The timestamp to write at.
  * @param subarray The subarray to write into.
  * @param layout The layout to write into.
@@ -749,7 +740,6 @@ void write_array(
     const std::string& array_name,
     tiledb_encryption_type_t encryption_type,
     const char* key,
-    uint64_t key_len,
     uint64_t timestamp,
     const void* subarray,
     tiledb_layout_t layout,

--- a/tiledb/sm/crypto/encryption_key.cc
+++ b/tiledb/sm/crypto/encryption_key.cc
@@ -80,9 +80,10 @@ Status EncryptionKey::set_key(
     EncryptionType encryption_type,
     const void* key_bytes,
     uint32_t key_length) {
-  if (!is_valid_key_length(encryption_type, key_length))
-    return LOG_STATUS(Status_EncryptionError(
+  if (!is_valid_key_length(encryption_type, key_length)) {
+    throw StatusException(Status_EncryptionError(
         "Cannot create key; invalid key length for encryption type."));
+  }
 
   encryption_type_ = encryption_type;
   key_length_ = key_length;

--- a/tiledb/sm/global_state/unit_test_config.h
+++ b/tiledb/sm/global_state/unit_test_config.h
@@ -126,9 +126,6 @@ class UnitTestConfig {
   /** For every nth multipart upload request, return a non-OK status. */
   Attribute<unsigned int> s3_fail_every_nth_upload_request;
 
-  /** Used when setting a non-standard key_length. */
-  Attribute<uint32_t> array_encryption_key_length;
-
  private:
   /** Constructor. */
   UnitTestConfig() = default;

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -110,6 +110,7 @@ Status Group::open(
 
   if (!encryption_key_from_cfg.empty()) {
     encryption_key = encryption_key_from_cfg.c_str();
+    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
     std::string encryption_type_from_cfg;
     encryption_type_from_cfg = config_.get("sm.encryption_type", &found);
     assert(found);
@@ -117,16 +118,9 @@ Status Group::open(
     RETURN_NOT_OK(st);
     encryption_type = et.value();
 
-    if (EncryptionKey::is_valid_key_length(
+    if (!EncryptionKey::is_valid_key_length(
             encryption_type,
             static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      const UnitTestConfig& unit_test_cfg = UnitTestConfig::instance();
-      if (unit_test_cfg.array_encryption_key_length.is_set()) {
-        key_length = unit_test_cfg.array_encryption_key_length.get();
-      } else {
-        key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-      }
-    } else {
       encryption_key = nullptr;
       key_length = 0;
     }

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -205,6 +205,7 @@ Status StorageManagerCanonical::array_consolidate(
 
   if (!encryption_key_from_cfg.empty()) {
     encryption_key = encryption_key_from_cfg.c_str();
+    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
     std::string encryption_type_from_cfg;
     bool found = false;
     encryption_type_from_cfg = config.get("sm.encryption_type", &found);
@@ -213,16 +214,9 @@ Status StorageManagerCanonical::array_consolidate(
     RETURN_NOT_OK(st);
     encryption_type = et.value();
 
-    if (EncryptionKey::is_valid_key_length(
+    if (!EncryptionKey::is_valid_key_length(
             encryption_type,
             static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      const UnitTestConfig& unit_test_cfg = UnitTestConfig::instance();
-      if (unit_test_cfg.array_encryption_key_length.is_set()) {
-        key_length = unit_test_cfg.array_encryption_key_length.get();
-      } else {
-        key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-      }
-    } else {
       encryption_key = nullptr;
       key_length = 0;
     }
@@ -268,6 +262,7 @@ Status StorageManagerCanonical::fragments_consolidate(
 
   if (!encryption_key_from_cfg.empty()) {
     encryption_key = encryption_key_from_cfg.c_str();
+    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
     std::string encryption_type_from_cfg;
     bool found = false;
     encryption_type_from_cfg = config.get("sm.encryption_type", &found);
@@ -276,16 +271,9 @@ Status StorageManagerCanonical::fragments_consolidate(
     RETURN_NOT_OK(st);
     encryption_type = et.value();
 
-    if (EncryptionKey::is_valid_key_length(
+    if (!EncryptionKey::is_valid_key_length(
             encryption_type,
             static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      const UnitTestConfig& unit_test_cfg = UnitTestConfig::instance();
-      if (unit_test_cfg.array_encryption_key_length.is_set()) {
-        key_length = unit_test_cfg.array_encryption_key_length.get();
-      } else {
-        key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-      }
-    } else {
       encryption_key = nullptr;
       key_length = 0;
     }
@@ -504,6 +492,7 @@ Status StorageManagerCanonical::array_metadata_consolidate(
 
   if (!encryption_key_from_cfg.empty()) {
     encryption_key = encryption_key_from_cfg.c_str();
+    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
     std::string encryption_type_from_cfg;
     bool found = false;
     encryption_type_from_cfg = config.get("sm.encryption_type", &found);
@@ -512,16 +501,9 @@ Status StorageManagerCanonical::array_metadata_consolidate(
     RETURN_NOT_OK(st);
     encryption_type = et.value();
 
-    if (EncryptionKey::is_valid_key_length(
+    if (!EncryptionKey::is_valid_key_length(
             encryption_type,
             static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      const UnitTestConfig& unit_test_cfg = UnitTestConfig::instance();
-      if (unit_test_cfg.array_encryption_key_length.is_set()) {
-        key_length = unit_test_cfg.array_encryption_key_length.get();
-      } else {
-        key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-      }
-    } else {
       encryption_key = nullptr;
       key_length = 0;
     }
@@ -612,21 +594,10 @@ Status StorageManagerCanonical::array_create(
       RETURN_NOT_OK(
           encryption_key_cfg.set_key(encryption_type_cfg, nullptr, 0));
     } else {
-      uint32_t key_length = 0;
-      if (EncryptionKey::is_valid_key_length(
-              encryption_type_cfg,
-              static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-        const UnitTestConfig& unit_test_cfg = UnitTestConfig::instance();
-        if (unit_test_cfg.array_encryption_key_length.is_set()) {
-          key_length = unit_test_cfg.array_encryption_key_length.get();
-        } else {
-          key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-        }
-      }
       RETURN_NOT_OK(encryption_key_cfg.set_key(
           encryption_type_cfg,
           (const void*)encryption_key_from_cfg.c_str(),
-          key_length));
+          static_cast<uint32_t>(encryption_key_from_cfg.size())));
     }
     st = store_array_schema(array_schema, encryption_key_cfg);
   } else {
@@ -740,21 +711,10 @@ Status StorageManagerCanonical::array_upgrade_version(
   if (encryption_key_from_cfg.empty()) {
     RETURN_NOT_OK(encryption_key_cfg.set_key(encryption_type_cfg, nullptr, 0));
   } else {
-    uint32_t key_length = 0;
-    if (EncryptionKey::is_valid_key_length(
-            encryption_type_cfg,
-            static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      const UnitTestConfig& unit_test_cfg = UnitTestConfig::instance();
-      if (unit_test_cfg.array_encryption_key_length.is_set()) {
-        key_length = unit_test_cfg.array_encryption_key_length.get();
-      } else {
-        key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-      }
-    }
     RETURN_NOT_OK(encryption_key_cfg.set_key(
         encryption_type_cfg,
         (const void*)encryption_key_from_cfg.c_str(),
-        key_length));
+        static_cast<uint32_t>(encryption_key_from_cfg.size())));
   }
 
   auto&& array_schema = array_dir.load_array_schema_latest(encryption_key_cfg);


### PR DESCRIPTION
This field existed to force invalid key lengths. This is unnecessary since we can just set the invalid key lengths in the test. The reason I stopped to remove this is because the test state is improperly persisted between unit tests. If you run `tiledb_unit -d y [capi][encryption]` it will fail because the UnitTestConfig is not reset.

It took me so long to debug this issue that I decided to light it on fire and just remove the whole global state and write the tests properly.

---
TYPE: IMPROVEMENT
DESC: Remove UnitTestConfig::array_encryption_key_length
