### PR TITLE
Remove use of Status by Tile classes

### DIFF
--- a/test/src/test-capi-dimension-label-encrypted.cc
+++ b/test/src/test-capi-dimension-label-encrypted.cc
@@ -101,7 +101,7 @@ TEST_CASE_METHOD(
   tiledb_array_schema_t* loaded_array_schema{nullptr};
   check_tiledb_error_with(
       tiledb_array_schema_load(ctx, array_name.c_str(), &loaded_array_schema),
-      "[TileDB::TileIO] Error: Error reading generic tile; tile is encrypted "
+      "GenericTileIO: Error reading generic tile; tile is encrypted "
       "with AES_256_GCM but given key is for NO_ENCRYPTION");
 
   // Check the array schema can be loaded with the encryption key.
@@ -123,7 +123,7 @@ TEST_CASE_METHOD(
   tiledb_array_schema_t* loaded_label_array_schema{nullptr};
   require_tiledb_error_with(
       tiledb_array_schema_load(ctx, dim_label_uri, &loaded_label_array_schema),
-      "[TileDB::TileIO] Error: Error reading generic tile; tile is encrypted "
+      "GenericTileIO: Error reading generic tile; tile is encrypted "
       "with AES_256_GCM but given key is for NO_ENCRYPTION");
 
   // Check the dimension label can be opened with the encryption key.

--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -174,7 +174,7 @@ template <class T>
 bool DenseTilerFx::check_tile(WriterTile& tile, const std::vector<T>& data) {
   std::vector<T> tile_data(data.size());
   CHECK(tile.size_as<T>() == data.size());
-  CHECK(tile.read(&tile_data[0], 0, data.size() * sizeof(T)).ok());
+  CHECK_NOTHROW(tile.read(&tile_data[0], 0, data.size() * sizeof(T)));
   CHECK(tile_data == data);
   return tile_data == data;
 }

--- a/test/src/unit-filter-pipeline.cc
+++ b/test/src/unit-filter-pipeline.cc
@@ -75,7 +75,7 @@ WriterTile make_increasing_tile(const uint64_t nelts) {
   WriterTile tile(
       constants::format_version, Datatype::UINT64, cell_size, tile_size);
   for (uint64_t i = 0; i < nelts; i++) {
-    CHECK(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+    CHECK_NOTHROW(tile.write(&i, i * sizeof(uint64_t), sizeof(uint64_t)));
   }
 
   return tile;
@@ -93,12 +93,10 @@ WriterTile make_offsets_tile(std::vector<uint64_t>& offsets) {
 
   // Set up test data
   for (uint64_t i = 0; i < offsets.size(); i++) {
-    CHECK(offsets_tile
-              .write(
-                  &offsets[i],
-                  i * constants::cell_var_offset_size,
-                  constants::cell_var_offset_size)
-              .ok());
+    CHECK_NOTHROW(offsets_tile.write(
+        &offsets[i],
+        i * constants::cell_var_offset_size,
+        constants::cell_var_offset_size));
   }
 
   return offsets_tile;
@@ -652,8 +650,8 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 }
@@ -741,8 +739,8 @@ TEST_CASE(
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 
@@ -798,8 +796,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -845,8 +843,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -938,8 +936,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -990,8 +988,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1050,8 +1048,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1097,8 +1095,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1190,8 +1188,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1242,8 +1240,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1301,8 +1299,8 @@ TEST_CASE(
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 }
@@ -1394,8 +1392,8 @@ TEST_CASE(
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 
@@ -1441,8 +1439,8 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1464,8 +1462,8 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1489,8 +1487,8 @@ TEST_CASE("Filter: Test compression", "[filter][compression]") {
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1569,8 +1567,8 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1595,8 +1593,8 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1623,8 +1621,8 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
     // Check all elements original values.
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1689,8 +1687,8 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1754,8 +1752,8 @@ TEST_CASE("Filter: Test pseudo-checksum", "[filter][pseudo-checksum]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1856,8 +1854,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1922,8 +1920,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -1987,8 +1985,8 @@ TEST_CASE("Filter: Test pipeline modify filter", "[filter][modify]") {
 
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 }
@@ -2088,8 +2086,8 @@ TEST_CASE("Filter: Test pipeline modify filter var", "[filter][modify][var]") {
 
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 
@@ -2166,8 +2164,8 @@ TEST_CASE("Filter: Test pipeline copy", "[filter][copy]") {
 
   for (uint64_t i = 0; i < nelts; i++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == i);
   }
 }
@@ -2253,8 +2251,8 @@ TEST_CASE("Filter: Test random pipeline", "[filter][random]") {
 
     for (uint64_t n = 0; n < nelts; n++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == n);
     }
   }
@@ -2284,8 +2282,8 @@ TEST_CASE(
 
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == n);
   }
 
@@ -2305,8 +2303,8 @@ TEST_CASE(
   run_reverse(config, tp, unfiltered_tile2, sha_256_pipeline);
   for (uint64_t n = 0; n < nelts; n++) {
     uint64_t elt = 0;
-    CHECK(unfiltered_tile2.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t))
-              .ok());
+    CHECK_NOTHROW(
+        unfiltered_tile2.read(&elt, n * sizeof(uint64_t), sizeof(uint64_t)));
     CHECK(elt == n);
   }
 }
@@ -2359,8 +2357,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -2383,8 +2381,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
       run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                  .ok());
+        CHECK_NOTHROW(
+            unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
         CHECK(elt == i);
       }
     }
@@ -2406,7 +2404,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t val = (uint64_t)rng(gen);
-      CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)));
     }
 
     CHECK(
@@ -2418,8 +2416,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK((int64_t)elt == rng(gen_copy));
     }
   }
@@ -2442,7 +2440,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
       uint32_t val = (uint32_t)rng(gen);
-      CHECK(tile.write(&val, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint32_t), sizeof(uint32_t)));
     }
 
     CHECK(
@@ -2454,8 +2452,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t)));
       CHECK(elt == rng(gen_copy));
     }
   }
@@ -2470,7 +2468,7 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t val = i % 257;
-      CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)));
     }
 
     CHECK(
@@ -2482,8 +2480,8 @@ TEST_CASE("Filter: Test bit width reduction", "[filter][bit-width-reduction]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i % 257);
     }
   }
@@ -2594,8 +2592,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -2620,8 +2618,8 @@ TEST_CASE(
       run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                  .ok());
+        CHECK_NOTHROW(
+            unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
         CHECK(elt == i);
       }
     }
@@ -2645,7 +2643,7 @@ TEST_CASE(
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t val = (uint64_t)rng(gen);
-      CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)));
     }
 
     CHECK(pipeline.run_forward(&test::g_helper_stats, &tile, &offsets_tile, &tp)
@@ -2657,8 +2655,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK((int64_t)elt == rng(gen_copy));
     }
   }
@@ -2682,7 +2680,7 @@ TEST_CASE(
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
       uint32_t val = (uint32_t)rng(gen);
-      CHECK(tile.write(&val, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint32_t), sizeof(uint32_t)));
     }
 
     std::vector<uint64_t> offsets32(offsets);
@@ -2698,12 +2696,10 @@ TEST_CASE(
 
     // Set up test data
     for (uint64_t i = 0; i < offsets.size(); i++) {
-      CHECK(offsets_tile32
-                .write(
-                    &offsets32[i],
-                    i * constants::cell_var_offset_size,
-                    constants::cell_var_offset_size)
-                .ok());
+      CHECK_NOTHROW(offsets_tile32.write(
+          &offsets32[i],
+          i * constants::cell_var_offset_size,
+          constants::cell_var_offset_size));
     }
 
     CHECK(
@@ -2716,8 +2712,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       int32_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(int32_t), sizeof(int32_t)));
       CHECK(elt == rng(gen_copy));
     }
   }
@@ -2733,7 +2729,7 @@ TEST_CASE(
     // Set up test data
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t val = i % 257;
-      CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)));
     }
 
     auto offsets_tile = make_offsets_tile(offsets);
@@ -2747,8 +2743,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i % 257);
     }
   }
@@ -2803,8 +2799,8 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -2826,8 +2822,8 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
       run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                  .ok());
+        CHECK_NOTHROW(
+            unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
         CHECK(elt == i);
       }
     }
@@ -2837,7 +2833,7 @@ TEST_CASE("Filter: Test positive-delta encoding", "[filter][positive-delta]") {
     auto tile = make_increasing_tile(nelts);
     for (uint64_t i = 0; i < nelts; i++) {
       auto val = nelts - i;
-      CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)));
     }
 
     CHECK(
@@ -2948,8 +2944,8 @@ TEST_CASE(
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -2975,8 +2971,8 @@ TEST_CASE(
       run_reverse(config, tp, unfiltered_tile, pipeline);
       for (uint64_t i = 0; i < nelts; i++) {
         uint64_t elt = 0;
-        CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                  .ok());
+        CHECK_NOTHROW(
+            unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
         CHECK(elt == i);
       }
     }
@@ -2989,7 +2985,7 @@ TEST_CASE(
     WriterTile::set_max_tile_chunk_size(80);
     for (uint64_t i = 0; i < nelts; i++) {
       auto val = nelts - i;
-      CHECK(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)).ok());
+      CHECK_NOTHROW(tile.write(&val, i * sizeof(uint64_t), sizeof(uint64_t)));
     }
 
     CHECK(
@@ -3021,8 +3017,8 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -3039,7 +3035,7 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
-      CHECK(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK_NOTHROW(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)));
     }
 
     CHECK(
@@ -3051,8 +3047,8 @@ TEST_CASE("Filter: Test bitshuffle", "[filter][bitshuffle]") {
     run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)));
       CHECK(elt == i);
     }
   }
@@ -3110,8 +3106,8 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -3129,7 +3125,7 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
-      CHECK(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK_NOTHROW(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)));
     }
 
     CHECK(
@@ -3142,8 +3138,8 @@ TEST_CASE("Filter: Test bitshuffle var", "[filter][bitshuffle][var]") {
     run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)));
       CHECK(elt == i);
     }
   }
@@ -3172,8 +3168,8 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -3190,7 +3186,7 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
-      CHECK(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK_NOTHROW(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)));
     }
 
     CHECK(
@@ -3202,8 +3198,8 @@ TEST_CASE("Filter: Test byteshuffle", "[filter][byteshuffle]") {
     run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)));
       CHECK(elt == i);
     }
   }
@@ -3261,8 +3257,8 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -3280,7 +3276,7 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
 
     // Set up test data
     for (uint32_t i = 0; i < nelts2; i++) {
-      CHECK(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)).ok());
+      CHECK_NOTHROW(tile2.write(&i, i * sizeof(uint32_t), sizeof(uint32_t)));
     }
 
     CHECK(
@@ -3293,8 +3289,8 @@ TEST_CASE("Filter: Test byteshuffle var", "[filter][byteshuffle][var]") {
     run_reverse(config, tp, unfiltered_tile2, pipeline);
     for (uint64_t i = 0; i < nelts2; i++) {
       uint32_t elt = 0;
-      CHECK(unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile2.read(&elt, i * sizeof(uint32_t), sizeof(uint32_t)));
       CHECK(elt == i);
     }
   }
@@ -3335,8 +3331,8 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
     run_reverse(config, tp, unfiltered_tile, pipeline);
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
 
@@ -3358,8 +3354,8 @@ TEST_CASE("Filter: Test encryption", "[filter][encryption]") {
 
     for (uint64_t i = 0; i < nelts; i++) {
       uint64_t elt = 0;
-      CHECK(unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t))
-                .ok());
+      CHECK_NOTHROW(
+          unfiltered_tile.read(&elt, i * sizeof(uint64_t), sizeof(uint64_t)));
       CHECK(elt == i);
     }
   }
@@ -3403,7 +3399,8 @@ void testing_float_scaling_filter() {
 
   for (uint64_t i = 0; i < nelts; i++) {
     FloatingType f = dis(gen);
-    CHECK(tile.write(&f, i * sizeof(FloatingType), sizeof(FloatingType)).ok());
+    CHECK_NOTHROW(
+        tile.write(&f, i * sizeof(FloatingType), sizeof(FloatingType)));
 
     IntType val = static_cast<IntType>(round(
         (f - static_cast<FloatingType>(foffset)) /
@@ -3437,9 +3434,8 @@ void testing_float_scaling_filter() {
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     FloatingType elt = 0.0f;
-    CHECK(unfiltered_tile
-              .read(&elt, i * sizeof(FloatingType), sizeof(FloatingType))
-              .ok());
+    CHECK_NOTHROW(unfiltered_tile.read(
+        &elt, i * sizeof(FloatingType), sizeof(FloatingType)));
     CHECK(elt == float_result_vec[i]);
   }
 }
@@ -3481,7 +3477,7 @@ void testing_xor_filter(Datatype t) {
 
   for (uint64_t i = 0; i < nelts; i++) {
     T val = static_cast<T>(dis(gen));
-    CHECK(tile.write(&val, i * sizeof(T), sizeof(T)).ok());
+    CHECK_NOTHROW(tile.write(&val, i * sizeof(T), sizeof(T)));
     results.push_back(val);
   }
 
@@ -3499,7 +3495,7 @@ void testing_xor_filter(Datatype t) {
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {
     T elt = 0;
-    CHECK(unfiltered_tile.read(&elt, i * sizeof(T), sizeof(T)).ok());
+    CHECK_NOTHROW(unfiltered_tile.read(&elt, i * sizeof(T), sizeof(T)));
     CHECK(elt == results[i]);
   }
 }
@@ -3598,7 +3594,7 @@ TEST_CASE("Filter: Pipeline filtered output types", "[filter][pipeline]") {
       sizeof(float),
       sizeof(float) * data.size());
   for (size_t i = 0; i < data.size(); i++) {
-    CHECK(tile.write(&data[i], i * sizeof(float), sizeof(float)).ok());
+    CHECK_NOTHROW(tile.write(&data[i], i * sizeof(float), sizeof(float)));
   }
 
   ThreadPool tp(4);
@@ -3625,7 +3621,7 @@ TEST_CASE("Filter: Pipeline filtered output types", "[filter][pipeline]") {
       1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f};
   for (size_t i = 0; i < data.size(); i++) {
     float val = 0;
-    CHECK(unfiltered_tile.read(&val, i * sizeof(float), sizeof(float)).ok());
+    CHECK_NOTHROW(unfiltered_tile.read(&val, i * sizeof(float), sizeof(float)));
     if (pipeline.has_filter(tiledb::sm::FilterType::FILTER_SCALE_FLOAT)) {
       // Loss of precision from rounding in FloatScale filter.
       CHECK(val == results[i]);

--- a/test/src/unit-tile-metadata-generator.cc
+++ b/test/src/unit-tile-metadata-generator.cc
@@ -387,8 +387,8 @@ TEST_CASE(
 
     *offsets_tile_buff = offset;
     auto& val = strings[values[i]];
-    CHECK(
-        writer_tile.var_tile().write_var(val.c_str(), offset, val.size()).ok());
+    CHECK_NOTHROW(
+        writer_tile.var_tile().write_var(val.c_str(), offset, val.size()));
 
     offset += val.size();
     offsets_tile_buff++;
@@ -446,7 +446,7 @@ TEST_CASE(
 
   // Initialize var tile.
   std::string data = "12312";
-  CHECK(writer_tile.var_tile().write_var(data.c_str(), 0, 5).ok());
+  CHECK_NOTHROW(writer_tile.var_tile().write_var(data.c_str(), 0, 5));
   writer_tile.var_tile().set_size(5);
 
   // Call the tile metadata generator.

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -173,7 +173,7 @@ Status FragmentMetaConsolidator::consolidate(
 
   GenericTileIO tile_io(storage_manager_->resources(), uri);
   [[maybe_unused]] uint64_t nbytes = 0;
-  RETURN_NOT_OK(tile_io.write_generic(&tile, enc_key, &nbytes));
+  tile_io.write_generic(&tile, enc_key, &nbytes);
   RETURN_NOT_OK(storage_manager_->vfs()->close_file(uri));
 
   return Status::Ok();

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -3635,10 +3635,7 @@ void FragmentMetadata::load_v1_v2(
       std::string(constants::fragment_metadata_filename));
   // Read metadata
   GenericTileIO tile_io(*resources_, fragment_metadata_uri);
-  auto&& [st, tile_opt] =
-      tile_io.read_generic(0, encryption_key, resources_->config());
-  throw_if_not_ok(st);
-  auto& tile = *tile_opt;
+  auto tile = tile_io.read_generic(0, encryption_key, resources_->config());
 
   resources_->stats().add_counter("read_frag_meta_size", tile.size());
 
@@ -3978,11 +3975,7 @@ Tile FragmentMetadata::read_generic_tile_from_file(
 
   // Read metadata
   GenericTileIO tile_io(*resources_, fragment_metadata_uri);
-  auto&& [st, tile_opt] =
-      tile_io.read_generic(offset, encryption_key, resources_->config());
-  throw_if_not_ok(st);
-
-  return std::move(*tile_opt);
+  return tile_io.read_generic(offset, encryption_key, resources_->config());
 }
 
 void FragmentMetadata::read_file_footer(
@@ -4025,7 +4018,7 @@ void FragmentMetadata::write_generic_tile_to_file(
       std::string(constants::fragment_metadata_filename));
 
   GenericTileIO tile_io(*resources_, fragment_metadata_uri);
-  throw_if_not_ok(tile_io.write_generic(&tile, encryption_key, nbytes));
+  tile_io.write_generic(&tile, encryption_key, nbytes);
 }
 
 void FragmentMetadata::write_footer_to_file(WriterTile& tile) const {

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1360,11 +1360,11 @@ Status Reader::copy_partitioned_var_cells(
         const uint64_t tile_var_offset =
             tile_offsets[cell_idx] - tile_offsets[0];
 
-        RETURN_NOT_OK(tile_var->read(var_dest, tile_var_offset, cell_var_size));
+        tile_var->read(var_dest, tile_var_offset, cell_var_size);
 
         if (nullable)
-          RETURN_NOT_OK(tile_validity->read(
-              validity_dest, cell_idx, constants::cell_validity_size));
+          tile_validity->read(
+              validity_dest, cell_idx, constants::cell_validity_size);
       }
     }
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -772,7 +772,7 @@ Status ReaderBase::zip_tile_coordinates(
         array_schema_.filters(name).get_filter<CompressionFilter>() != nullptr;
     auto version = tile->format_version();
     if (version > 1 || using_compression) {
-      RETURN_NOT_OK(tile->zip_coordinates());
+      tile->zip_coordinates();
     }
   }
   return Status::Ok();

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1458,7 +1458,7 @@ void test_apply_tile<char*>(
     values[i * 2] = 'a';
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
-  REQUIRE(tile->write(values.data(), 0, 2 * cells * sizeof(char)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, 2 * cells * sizeof(char)));
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
@@ -1468,9 +1468,8 @@ void test_apply_tile<char*>(
       offsets[i] = offset;
       offset += 2;
     }
-    REQUIRE(
-        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-            .ok());
+    REQUIRE_NOTHROW(
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
   }
 
   if (nullable) {
@@ -1479,8 +1478,8 @@ void test_apply_tile<char*>(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(
-        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+    REQUIRE_NOTHROW(
+        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
   }
 
   test_apply_operators<char*>(
@@ -1506,7 +1505,7 @@ void test_apply_tile(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = static_cast<T>(i);
   }
-  REQUIRE(tile->write(values.data(), 0, cells * sizeof(T)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, cells * sizeof(T)));
 
   test_apply_operators<T>(
       field_name,
@@ -1770,7 +1769,8 @@ TEST_CASE(
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
 
-  REQUIRE(tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)).ok());
+  REQUIRE_NOTHROW(
+      tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)));
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
@@ -1783,9 +1783,8 @@ TEST_CASE(
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
     offsets[cells] = offset;
-    REQUIRE(
-        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-            .ok());
+    REQUIRE_NOTHROW(
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
   }
 
   if (nullable) {
@@ -1794,8 +1793,8 @@ TEST_CASE(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(
-        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+    REQUIRE_NOTHROW(
+        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
   }
 
   // Empty string or null string as condition value
@@ -2170,7 +2169,7 @@ void test_apply_tile_dense<char*>(
     values[i * 2] = 'a';
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
-  REQUIRE(tile->write(values.data(), 0, 2 * cells * sizeof(char)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, 2 * cells * sizeof(char)));
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
@@ -2180,9 +2179,8 @@ void test_apply_tile_dense<char*>(
       offsets[i] = offset;
       offset += 2;
     }
-    REQUIRE(
-        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-            .ok());
+    REQUIRE_NOTHROW(
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
   }
 
   if (nullable) {
@@ -2191,8 +2189,8 @@ void test_apply_tile_dense<char*>(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(
-        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+    REQUIRE_NOTHROW(
+        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
   }
 
   test_apply_operators_dense<char*>(
@@ -2218,7 +2216,7 @@ void test_apply_tile_dense(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = static_cast<T>(i);
   }
-  REQUIRE(tile->write(values.data(), 0, cells * sizeof(T)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, cells * sizeof(T)));
 
   test_apply_operators_dense<T>(
       field_name,
@@ -2487,7 +2485,8 @@ TEST_CASE(
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
 
-  REQUIRE(tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)).ok());
+  REQUIRE_NOTHROW(
+      tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)));
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
@@ -2500,9 +2499,8 @@ TEST_CASE(
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
     offsets[cells] = offset;
-    REQUIRE(
-        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-            .ok());
+    REQUIRE_NOTHROW(
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
   }
 
   if (nullable) {
@@ -2511,8 +2509,8 @@ TEST_CASE(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(
-        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+    REQUIRE_NOTHROW(
+        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
   }
 
   // Empty string or null string as condition value
@@ -2870,7 +2868,7 @@ void test_apply_tile_sparse<char*>(
     values[i * 2] = 'a';
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
-  REQUIRE(tile->write(values.data(), 0, 2 * cells * sizeof(char)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, 2 * cells * sizeof(char)));
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
@@ -2880,9 +2878,8 @@ void test_apply_tile_sparse<char*>(
       offsets[i] = offset;
       offset += 2;
     }
-    REQUIRE(
-        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-            .ok());
+    REQUIRE_NOTHROW(
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
   }
 
   if (nullable) {
@@ -2891,8 +2888,8 @@ void test_apply_tile_sparse<char*>(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(
-        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+    REQUIRE_NOTHROW(
+        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
   }
 
   test_apply_operators_sparse<char*>(
@@ -2918,7 +2915,7 @@ void test_apply_tile_sparse(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = static_cast<T>(i);
   }
-  REQUIRE(tile->write(values.data(), 0, cells * sizeof(T)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, cells * sizeof(T)));
 
   test_apply_operators_sparse<T>(
       field_name,
@@ -3838,7 +3835,7 @@ TEST_CASE(
   for (uint64_t i = 0; i < cells; ++i) {
     values[i] = i;
   }
-  REQUIRE(tile->write(values.data(), 0, cells * sizeof(uint64_t)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, cells * sizeof(uint64_t)));
 
   std::vector<TestParams> tp_vec;
   populate_test_params_vector(field_name, &result_tile, tp_vec);
@@ -4122,12 +4119,12 @@ TEST_CASE(
   Tile* const tile = &tile_tuple->var_tile();
 
   std::vector<uint64_t> offsets = {0, 5, 8, 13, 17, 21, 26, 31, 36, 40, 44};
-  REQUIRE(tile->write(data.c_str(), 0, data.size()).ok());
+  REQUIRE_NOTHROW(tile->write(data.c_str(), 0, data.size()));
 
   // Write the tile offsets.
   Tile* const tile_offsets = &tile_tuple->fixed_tile();
-  REQUIRE(tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-              .ok());
+  REQUIRE_NOTHROW(
+      tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
 
   std::vector<TestParams> tp_vec;
   populate_string_test_params_vector(field_name, &result_tile, tp_vec);
@@ -4533,12 +4530,12 @@ TEST_CASE(
   ResultTile::TileTuple* const tile_tuple = result_tile.tile_tuple(field_name);
   Tile* const tile = &tile_tuple->var_tile();
 
-  REQUIRE(tile->write(data.c_str(), 0, data.size()).ok());
+  REQUIRE_NOTHROW(tile->write(data.c_str(), 0, data.size()));
 
   // Write the tile offsets.
   Tile* const tile_offsets = &tile_tuple->fixed_tile();
-  REQUIRE(tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-              .ok());
+  REQUIRE_NOTHROW(
+      tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
 
   std::vector<TestParams> tp_vec;
   populate_utf8_string_test_params_vector(field_name, &result_tile, tp_vec);
@@ -4798,15 +4795,15 @@ TEST_CASE(
   // Populate the data tile.
   std::vector<float> values = {
       3.4f, 1.3f, 2.2f, 4.5f, 2.8f, 2.1f, 1.7f, 3.3f, 1.9f, 4.2f};
-  REQUIRE(tile->write(values.data(), 0, cells * sizeof(float)).ok());
+  REQUIRE_NOTHROW(tile->write(values.data(), 0, cells * sizeof(float)));
 
   Tile* const tile_validity = &tile_tuple->validity_tile();
   std::vector<uint8_t> validity(cells);
   for (uint64_t i = 0; i < cells; ++i) {
     validity[i] = i % 2;
   }
-  REQUIRE(
-      tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+  REQUIRE_NOTHROW(
+      tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
 
   std::vector<TestParams> tp_vec;
   populate_nullable_test_params_vector(field_name, &result_tile, tp_vec);
@@ -4907,7 +4904,8 @@ TEST_CASE(
     values[(i * 2) + 1] = 'a' + static_cast<char>(i);
   }
 
-  REQUIRE(tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)).ok());
+  REQUIRE_NOTHROW(
+      tile->write(values.data(), 0, 2 * (cells - 2) * sizeof(char)));
 
   if (var_size) {
     Tile* const tile_offsets = &tile_tuple->fixed_tile();
@@ -4920,9 +4918,8 @@ TEST_CASE(
     offsets[cells - 2] = offset;
     offsets[cells - 1] = offset;
     offsets[cells] = offset;
-    REQUIRE(
-        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t))
-            .ok());
+    REQUIRE_NOTHROW(
+        tile_offsets->write(offsets.data(), 0, (cells + 1) * sizeof(uint64_t)));
   }
 
   if (nullable) {
@@ -4931,8 +4928,8 @@ TEST_CASE(
     for (uint64_t i = 0; i < cells; ++i) {
       validity[i] = i % 2;
     }
-    REQUIRE(
-        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)).ok());
+    REQUIRE_NOTHROW(
+        tile_validity->write(validity.data(), 0, cells * sizeof(uint8_t)));
   }
 
   // Empty string or null string as condition value

--- a/tiledb/sm/query/writers/dense_tiler.cc
+++ b/tiledb/sm/query/writers/dense_tiler.cc
@@ -228,7 +228,7 @@ Status DenseTiler<T>::get_tile(
     // Fill entire tile with MAX_UINT64
     std::vector<offsets_t> to_write(
         cell_num_in_tile, std::numeric_limits<offsets_t>::max());
-    RETURN_NOT_OK(tile_pos.write(to_write.data(), 0, tile_off_size));
+    tile_pos.write(to_write.data(), 0, tile_off_size);
     to_write.clear();
     to_write.shrink_to_fit();
 
@@ -250,10 +250,10 @@ Status DenseTiler<T>::get_tile(
     auto& tile_val = tile.var_tile();
     for (uint64_t i = 0; i < cell_num_in_tile; ++i) {
       pos = tile_pos_buff[i];
-      RETURN_NOT_OK(tile_off.write(&offset, tile_off_offset, sizeof(offset)));
+      tile_off.write(&offset, tile_off_offset, sizeof(offset));
       tile_off_offset += sizeof(offset);
       if (pos == std::numeric_limits<uint64_t>::max()) {  // Empty
-        RETURN_NOT_OK(tile_val.write_var(&fill_var[0], offset, cell_size));
+        tile_val.write_var(&fill_var[0], offset, cell_size);
         offset += cell_size;
       } else {  // Non-empty
         val_offset = ((offsets_bytesize_ == 8) ?
@@ -267,8 +267,7 @@ Status DenseTiler<T>::get_tile(
                             mul -
                         val_offset) :
                        buff_var_size - val_offset;
-        RETURN_NOT_OK(
-            tile_val.write_var(&buff_var[val_offset], offset, val_size));
+        tile_val.write_var(&buff_var[val_offset], offset, val_size);
         offset += val_size;
       }
     }
@@ -540,8 +539,7 @@ Status DenseTiler<T>::copy_tile(
   auto d = dim_num - 1;
   while (true) {
     // Copy a slab
-    RETURN_NOT_OK(
-        tile.write(&buff[sub_offsets[d]], tile_offsets[d], copy_nbytes));
+    tile.write(&buff[sub_offsets[d]], tile_offsets[d], copy_nbytes);
 
     // Advance cell coordinates, tile and buffer offsets
     auto last_dim_changed = d;

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -935,15 +935,15 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
   if (last_tile_cell_idx != 0) {
     if (coord_dups.empty()) {
       do {
-        RETURN_NOT_OK(last_tile.fixed_tile().write(
+        last_tile.fixed_tile().write(
             buffer + cell_idx * cell_size,
             last_tile_cell_idx * cell_size,
-            cell_size));
+            cell_size);
         if (nullable) {
-          RETURN_NOT_OK(last_tile.validity_tile().write(
+          last_tile.validity_tile().write(
               buffer_validity + cell_idx * constants::cell_validity_size,
               last_tile_cell_idx * constants::cell_validity_size,
-              constants::cell_validity_size));
+              constants::cell_validity_size);
         }
         ++cell_idx;
         ++last_tile_cell_idx;
@@ -951,15 +951,15 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
     } else {
       do {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
-          RETURN_NOT_OK(last_tile.fixed_tile().write(
+          last_tile.fixed_tile().write(
               buffer + cell_idx * cell_size,
               last_tile_cell_idx * cell_size,
-              cell_size));
+              cell_size);
           if (nullable) {
-            RETURN_NOT_OK(last_tile.validity_tile().write(
+            last_tile.validity_tile().write(
                 buffer_validity + cell_idx * constants::cell_validity_size,
                 last_tile_cell_idx * constants::cell_validity_size,
-                constants::cell_validity_size));
+                constants::cell_validity_size);
           }
           ++last_tile_cell_idx;
         }
@@ -998,14 +998,14 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
     // Write all remaining cells one by one
     if (coord_dups.empty()) {
       for (uint64_t i = 0; i < cell_num_to_write;) {
-        RETURN_NOT_OK(tile_it->fixed_tile().write(
-            buffer + cell_idx * cell_size, 0, cell_size * cell_num_per_tile));
+        tile_it->fixed_tile().write(
+            buffer + cell_idx * cell_size, 0, cell_size * cell_num_per_tile);
 
         if (nullable) {
-          RETURN_NOT_OK(tile_it->validity_tile().write(
+          tile_it->validity_tile().write(
               buffer_validity + cell_idx * constants::cell_validity_size,
               0,
-              constants::cell_validity_size * cell_num_per_tile));
+              constants::cell_validity_size * cell_num_per_tile);
         }
 
         cell_idx += cell_num_per_tile;
@@ -1021,14 +1021,14 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
         }
 
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
-          RETURN_NOT_OK(tile_it->fixed_tile().write(
-              buffer + cell_idx * cell_size, cell_idx * cell_size, cell_size));
+          tile_it->fixed_tile().write(
+              buffer + cell_idx * cell_size, cell_idx * cell_size, cell_size);
 
           if (nullable) {
-            RETURN_NOT_OK(tile_it->validity_tile().write(
+            tile_it->validity_tile().write(
                 buffer_validity + cell_idx * constants::cell_validity_size,
                 cell_idx * constants::cell_validity_size,
-                constants::cell_validity_size));
+                constants::cell_validity_size);
           }
         }
       }
@@ -1039,29 +1039,29 @@ Status GlobalOrderWriter::prepare_full_tiles_fixed(
   last_tile_cell_idx = 0;
   if (coord_dups.empty()) {
     for (; cell_idx < cell_num; ++cell_idx, ++last_tile_cell_idx) {
-      RETURN_NOT_OK(last_tile.fixed_tile().write(
+      last_tile.fixed_tile().write(
           buffer + cell_idx * cell_size,
           last_tile_cell_idx * cell_size,
-          cell_size));
+          cell_size);
       if (nullable) {
-        RETURN_NOT_OK(last_tile.validity_tile().write(
+        last_tile.validity_tile().write(
             buffer_validity + cell_idx * constants::cell_validity_size,
             last_tile_cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+            constants::cell_validity_size);
       }
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
       if (coord_dups.find(cell_idx) == coord_dups.end()) {
-        RETURN_NOT_OK(last_tile.fixed_tile().write(
+        last_tile.fixed_tile().write(
             buffer + cell_idx * cell_size,
             last_tile_cell_idx * cell_size,
-            cell_size));
+            cell_size);
         if (nullable) {
-          RETURN_NOT_OK(last_tile.validity_tile().write(
+          last_tile.validity_tile().write(
               buffer_validity + cell_idx * constants::cell_validity_size,
               last_tile_cell_idx * constants::cell_validity_size,
-              constants::cell_validity_size));
+              constants::cell_validity_size);
         }
         ++last_tile_cell_idx;
       }
@@ -1108,10 +1108,10 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
     if (coord_dups.empty()) {
       do {
         // Write offset.
-        RETURN_NOT_OK(last_tile.offset_tile().write(
+        last_tile.offset_tile().write(
             &last_var_offset,
             last_tile_cell_idx * sizeof(last_var_offset),
-            sizeof(last_var_offset)));
+            sizeof(last_var_offset));
 
         // Write var-sized value(s).
         auto buff_offset =
@@ -1121,16 +1121,16 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
                                 prepare_buffer_offset(
                                     buffer, cell_idx + 1, attr_datatype_size) -
                                     buff_offset;
-        RETURN_NOT_OK(last_tile.var_tile().write_var(
-            buffer_var + buff_offset, last_var_offset, var_size));
+        last_tile.var_tile().write_var(
+            buffer_var + buff_offset, last_var_offset, var_size);
         last_var_offset += var_size;
 
         // Write validity value(s).
         if (nullable) {
-          RETURN_NOT_OK(last_tile.validity_tile().write(
+          last_tile.validity_tile().write(
               buffer_validity + cell_idx,
               last_tile_cell_idx * constants::cell_validity_size,
-              constants::cell_validity_size));
+              constants::cell_validity_size);
         }
 
         ++cell_idx;
@@ -1140,10 +1140,10 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
       do {
         if (coord_dups.find(cell_idx) == coord_dups.end()) {
           // Write offset.
-          RETURN_NOT_OK(last_tile.offset_tile().write(
+          last_tile.offset_tile().write(
               &last_var_offset,
               last_tile_cell_idx * sizeof(last_var_offset),
-              sizeof(last_var_offset)));
+              sizeof(last_var_offset));
 
           // Write var-sized value(s).
           auto buff_offset =
@@ -1154,16 +1154,16 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
                   prepare_buffer_offset(
                       buffer, cell_idx + 1, attr_datatype_size) -
                       buff_offset;
-          RETURN_NOT_OK(last_tile.var_tile().write_var(
-              buffer_var + buff_offset, last_var_offset, var_size));
+          last_tile.var_tile().write_var(
+              buffer_var + buff_offset, last_var_offset, var_size);
           last_var_offset += var_size;
 
           // Write validity value(s).
           if (nullable) {
-            RETURN_NOT_OK(last_tile.validity_tile().write(
+            last_tile.validity_tile().write(
                 buffer_validity + cell_idx,
                 last_tile_cell_idx * constants::cell_validity_size,
-                constants::cell_validity_size));
+                constants::cell_validity_size);
           }
           ++last_tile_cell_idx;
         }
@@ -1218,10 +1218,10 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
           }
 
           // Write offset.
-          RETURN_NOT_OK(tile_it->offset_tile().write(
+          tile_it->offset_tile().write(
               &last_var_offset,
               current_tile_cell_idx * sizeof(last_var_offset),
-              sizeof(last_var_offset)));
+              sizeof(last_var_offset));
 
           // Write var-sized value(s).
           auto buff_offset =
@@ -1232,16 +1232,16 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
                   prepare_buffer_offset(
                       buffer, cell_idx + 1, attr_datatype_size) -
                       buff_offset;
-          RETURN_NOT_OK(tile_it->var_tile().write_var(
-              buffer_var + buff_offset, last_var_offset, var_size));
+          tile_it->var_tile().write_var(
+              buffer_var + buff_offset, last_var_offset, var_size);
           last_var_offset += var_size;
 
           // Write validity value(s).
           if (nullable) {
-            RETURN_NOT_OK(tile_it->validity_tile().write(
+            tile_it->validity_tile().write(
                 buffer_validity + cell_idx,
                 current_tile_cell_idx * constants::cell_validity_size,
-                constants::cell_validity_size));
+                constants::cell_validity_size);
           }
         }
       } else {
@@ -1255,10 +1255,10 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
             }
 
             // Write offset.
-            RETURN_NOT_OK(tile_it->offset_tile().write(
+            tile_it->offset_tile().write(
                 &last_var_offset,
                 current_tile_cell_idx * sizeof(last_var_offset),
-                sizeof(last_var_offset)));
+                sizeof(last_var_offset));
 
             // Write var-sized value(s).
             auto buff_offset =
@@ -1269,16 +1269,16 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
                     prepare_buffer_offset(
                         buffer, cell_idx + 1, attr_datatype_size) -
                         buff_offset;
-            RETURN_NOT_OK(tile_it->var_tile().write_var(
-                buffer_var + buff_offset, last_var_offset, var_size));
+            tile_it->var_tile().write_var(
+                buffer_var + buff_offset, last_var_offset, var_size);
             last_var_offset += var_size;
 
             // Write validity value(s).
             if (nullable) {
-              RETURN_NOT_OK(tile_it->validity_tile().write(
+              tile_it->validity_tile().write(
                   buffer_validity + cell_idx,
                   current_tile_cell_idx * constants::cell_validity_size,
-                  constants::cell_validity_size));
+                  constants::cell_validity_size);
             }
 
             ++current_tile_cell_idx;
@@ -1296,10 +1296,10 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
   if (coord_dups.empty()) {
     for (; cell_idx < cell_num; ++cell_idx, ++last_tile_cell_idx) {
       // Write offset.
-      RETURN_NOT_OK(last_tile.offset_tile().write(
+      last_tile.offset_tile().write(
           &last_var_offset,
           last_tile_cell_idx * sizeof(last_var_offset),
-          sizeof(last_var_offset)));
+          sizeof(last_var_offset));
 
       // Write var-sized value(s).
       auto buff_offset =
@@ -1309,26 +1309,26 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
               *buffer_var_size - buff_offset :
               prepare_buffer_offset(buffer, cell_idx + 1, attr_datatype_size) -
                   buff_offset;
-      RETURN_NOT_OK(last_tile.var_tile().write_var(
-          buffer_var + buff_offset, last_var_offset, var_size));
+      last_tile.var_tile().write_var(
+          buffer_var + buff_offset, last_var_offset, var_size);
       last_var_offset += var_size;
 
       // Write validity value(s).
       if (nullable) {
-        RETURN_NOT_OK(last_tile.validity_tile().write(
+        last_tile.validity_tile().write(
             buffer_validity + cell_idx,
             last_tile_cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+            constants::cell_validity_size);
       }
     }
   } else {
     for (; cell_idx < cell_num; ++cell_idx) {
       if (coord_dups.find(cell_idx) == coord_dups.end()) {
         // Write offset.
-        RETURN_NOT_OK(last_tile.offset_tile().write(
+        last_tile.offset_tile().write(
             &last_var_offset,
             last_tile_cell_idx * sizeof(last_var_offset),
-            sizeof(last_var_offset)));
+            sizeof(last_var_offset));
 
         // Write var-sized value(s).
         auto buff_offset =
@@ -1338,16 +1338,16 @@ Status GlobalOrderWriter::prepare_full_tiles_var(
                                 prepare_buffer_offset(
                                     buffer, cell_idx + 1, attr_datatype_size) -
                                     buff_offset;
-        RETURN_NOT_OK(last_tile.var_tile().write_var(
-            buffer_var + buff_offset, last_var_offset, var_size));
+        last_tile.var_tile().write_var(
+            buffer_var + buff_offset, last_var_offset, var_size);
         last_var_offset += var_size;
 
         // Write validity value(s).
         if (nullable) {
-          RETURN_NOT_OK(last_tile.validity_tile().write(
+          last_tile.validity_tile().write(
               buffer_validity + cell_idx,
               last_tile_cell_idx * constants::cell_validity_size,
-              constants::cell_validity_size));
+              constants::cell_validity_size);
         }
 
         ++last_tile_cell_idx;

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -455,13 +455,13 @@ Status UnorderedWriter::prepare_tiles_fixed(
         cell_idx = 0;
       }
 
-      RETURN_NOT_OK(tile_it->fixed_tile().write(
-          buffer + cell_pos_[i] * cell_size, cell_idx * cell_size, cell_size));
+      tile_it->fixed_tile().write(
+          buffer + cell_pos_[i] * cell_size, cell_idx * cell_size, cell_size);
       if (nullable)
-        RETURN_NOT_OK(tile_it->validity_tile().write(
+        tile_it->validity_tile().write(
             buffer_validity + cell_pos_[i] * constants::cell_validity_size,
             cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+            constants::cell_validity_size);
     }
   } else {
     for (uint64_t i = 0; i < cell_num; ++i) {
@@ -473,13 +473,13 @@ Status UnorderedWriter::prepare_tiles_fixed(
         cell_idx = 0;
       }
 
-      RETURN_NOT_OK(tile_it->fixed_tile().write(
-          buffer + cell_pos_[i] * cell_size, cell_idx * cell_size, cell_size));
+      tile_it->fixed_tile().write(
+          buffer + cell_pos_[i] * cell_size, cell_idx * cell_size, cell_size);
       if (nullable)
-        RETURN_NOT_OK(tile_it->validity_tile().write(
+        tile_it->validity_tile().write(
             buffer_validity + cell_pos_[i] * constants::cell_validity_size,
             cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+            constants::cell_validity_size);
       ++cell_idx;
     }
   }
@@ -530,8 +530,8 @@ Status UnorderedWriter::prepare_tiles_var(
       }
 
       // Write offset.
-      RETURN_NOT_OK(tile_it->offset_tile().write(
-          &offset, cell_idx * sizeof(offset), sizeof(offset)));
+      tile_it->offset_tile().write(
+          &offset, cell_idx * sizeof(offset), sizeof(offset));
 
       // Write var-sized value(s).
       auto buff_offset =
@@ -542,16 +542,15 @@ Status UnorderedWriter::prepare_tiles_var(
               prepare_buffer_offset(
                   buffer, cell_pos_[i] + 1, attr_datatype_size) -
                   buff_offset;
-      RETURN_NOT_OK(tile_it->var_tile().write_var(
-          buffer_var + buff_offset, offset, var_size));
+      tile_it->var_tile().write_var(buffer_var + buff_offset, offset, var_size);
       offset += var_size;
 
       // Write validity value(s).
       if (nullable) {
-        RETURN_NOT_OK(tile_it->validity_tile().write(
+        tile_it->validity_tile().write(
             buffer_validity + cell_pos_[i],
             cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+            constants::cell_validity_size);
       }
     }
   } else {
@@ -567,8 +566,8 @@ Status UnorderedWriter::prepare_tiles_var(
       }
 
       // Write offset.
-      RETURN_NOT_OK(tile_it->offset_tile().write(
-          &offset, cell_idx * sizeof(offset), sizeof(offset)));
+      tile_it->offset_tile().write(
+          &offset, cell_idx * sizeof(offset), sizeof(offset));
 
       // Write var-sized value(s).
       auto buff_offset =
@@ -579,16 +578,15 @@ Status UnorderedWriter::prepare_tiles_var(
               prepare_buffer_offset(
                   buffer, cell_pos_[i] + 1, attr_datatype_size) -
                   buff_offset;
-      RETURN_NOT_OK(tile_it->var_tile().write_var(
-          buffer_var + buff_offset, offset, var_size));
+      tile_it->var_tile().write_var(buffer_var + buff_offset, offset, var_size);
       offset += var_size;
 
       // Write validity value(s).
       if (nullable) {
-        RETURN_NOT_OK(tile_it->validity_tile().write(
+        tile_it->validity_tile().write(
             buffer_validity + cell_pos_[i],
             cell_idx * constants::cell_validity_size,
-            constants::cell_validity_size));
+            constants::cell_validity_size);
       }
 
       ++cell_idx;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1691,13 +1691,8 @@ Status StorageManagerCanonical::store_data_to_generic_tile(
     WriterTile& tile, const URI& uri, const EncryptionKey& encryption_key) {
   GenericTileIO tile_io(resources_, uri);
   uint64_t nbytes = 0;
-  Status st = tile_io.write_generic(&tile, encryption_key, &nbytes);
-
-  if (st.ok()) {
-    st = vfs()->close_file(uri);
-  }
-
-  return st;
+  tile_io.write_generic(&tile, encryption_key, &nbytes);
+  return vfs()->close_file(uri);
 }
 
 void StorageManagerCanonical::wait_for_zero_in_progress() {

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -46,6 +46,14 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+/** Class for locally generated status exceptions. */
+class GenericTileIOException : public StatusException {
+ public:
+  explicit GenericTileIOException(const std::string& msg)
+      : StatusException("GenericTileIO", msg) {
+  }
+};
+
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -69,21 +77,15 @@ Tile GenericTileIO::load(
   // Get encryption key from config
   if (encryption_key.encryption_type() == EncryptionType::NO_ENCRYPTION) {
     EncryptionKey cfg_enc_key(resources.config());
-    auto&& [st1, tile_opt] =
-        tile_io.read_generic(offset, cfg_enc_key, resources.config());
-    throw_if_not_ok(st1);
-    return std::move(*tile_opt);
+    return tile_io.read_generic(offset, cfg_enc_key, resources.config());
   } else {
-    auto&& [st1, tile_opt] =
-        tile_io.read_generic(offset, encryption_key, resources.config());
-    throw_if_not_ok(st1);
-    return std::move(*tile_opt);
+    return tile_io.read_generic(offset, encryption_key, resources.config());
   }
 
   stdx::unreachable();
 }
 
-tuple<Status, optional<Tile>> GenericTileIO::read_generic(
+Tile GenericTileIO::read_generic(
     uint64_t file_offset,
     const EncryptionKey& encryption_key,
     const Config& config) {
@@ -91,17 +93,14 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
 
   if (encryption_key.encryption_type() !=
       (EncryptionType)header.encryption_type) {
-    return {
-        LOG_STATUS(Status_TileIOError(
-            "Error reading generic tile; tile is encrypted with " +
-            encryption_type_str((EncryptionType)header.encryption_type) +
-            " but given key is for " +
-            encryption_type_str(encryption_key.encryption_type()))),
-        nullopt};
+    throw GenericTileIOException(
+        "Error reading generic tile; tile is encrypted with " +
+        encryption_type_str((EncryptionType)header.encryption_type) +
+        " but given key is for " +
+        encryption_type_str(encryption_key.encryption_type()));
   }
 
-  RETURN_NOT_OK_TUPLE(
-      configure_encryption_filter(&header, encryption_key), nullopt);
+  configure_encryption_filter(&header, encryption_key);
 
   const auto tile_data_offset =
       GenericTileHeader::BASE_SIZE + header.filter_pipeline_size;
@@ -117,20 +116,18 @@ tuple<Status, optional<Tile>> GenericTileIO::read_generic(
       header.persisted_size);
 
   // Read the tile.
-  RETURN_NOT_OK_TUPLE(
-      resources_.vfs().read(
-          uri_,
-          file_offset + tile_data_offset,
-          tile.filtered_data(),
-          header.persisted_size),
-      nullopt);
+  throw_if_not_ok(resources_.vfs().read(
+      uri_,
+      file_offset + tile_data_offset,
+      tile.filtered_data(),
+      header.persisted_size));
 
   // Unfilter
   assert(tile.filtered());
   header.filters.run_reverse_generic_tile(&resources_.stats(), tile, config);
   assert(!tile.filtered());
 
-  return {Status::Ok(), std::move(tile)};
+  return tile;
 }
 
 GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
@@ -171,28 +168,26 @@ GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
   return header;
 }
 
-Status GenericTileIO::write_generic(
+void GenericTileIO::write_generic(
     WriterTile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes) {
   // Create a header
   GenericTileHeader header;
-  RETURN_NOT_OK(init_generic_tile_header(tile, &header, encryption_key));
+  init_generic_tile_header(tile, &header, encryption_key);
 
   // Filter tile
   assert(!tile->filtered());
-  RETURN_NOT_OK(header.filters.run_forward(
+  throw_if_not_ok(header.filters.run_forward(
       &resources_.stats(), tile, nullptr, &resources_.compute_tp()));
   header.persisted_size = tile->filtered_buffer().size();
   assert(tile->filtered());
 
-  RETURN_NOT_OK(write_generic_tile_header(&header));
+  write_generic_tile_header(&header);
 
-  RETURN_NOT_OK(resources_.vfs().write(
+  throw_if_not_ok(resources_.vfs().write(
       uri_, tile->filtered_buffer().data(), tile->filtered_buffer().size()));
 
   *nbytes = GenericTileIO::GenericTileHeader::BASE_SIZE +
             header.filter_pipeline_size + header.persisted_size;
-
-  return Status::Ok();
 }
 
 template <class T>
@@ -208,7 +203,7 @@ void GenericTileIO::serialize_generic_tile_header(
   header.filters.serialize(serializer);
 }
 
-Status GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
+void GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
   SizeComputationSerializer fp_size_computation_serializer;
   header->filters.serialize(fp_size_computation_serializer);
   header->filter_pipeline_size = fp_size_computation_serializer.size();
@@ -221,12 +216,10 @@ Status GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
   serialize_generic_tile_header(serializer, *header);
 
   // Write buffer to file
-  RETURN_NOT_OK(resources_.vfs().write(uri_, data.data(), data.size()));
-
-  return Status::Ok();
+  throw_if_not_ok(resources_.vfs().write(uri_, data.data(), data.size()));
 }
 
-Status GenericTileIO::configure_encryption_filter(
+void GenericTileIO::configure_encryption_filter(
     GenericTileHeader* header, const EncryptionKey& encryption_key) const {
   switch ((EncryptionType)header->encryption_type) {
     case EncryptionType::NO_ENCRYPTION:
@@ -235,20 +228,18 @@ Status GenericTileIO::configure_encryption_filter(
     case EncryptionType::AES_256_GCM: {
       auto* f = header->filters.get_filter<EncryptionAES256GCMFilter>();
       if (f == nullptr)
-        return Status_TileIOError(
+        throw GenericTileIOException(
             "Error getting generic tile; no encryption filter.");
       f->set_key(encryption_key);
       break;
     }
     default:
-      return Status_TileIOError(
+      throw GenericTileIOException(
           "Error getting generic tile; invalid encryption type.");
   }
-
-  return Status::Ok();
 }
 
-Status GenericTileIO::init_generic_tile_header(
+void GenericTileIO::init_generic_tile_header(
     WriterTile* tile,
     GenericTileHeader* header,
     const EncryptionKey& encryption_key) const {
@@ -262,10 +253,8 @@ Status GenericTileIO::init_generic_tile_header(
       constants::generic_tile_compression_level,
       tile->type()));
 
-  RETURN_NOT_OK(FilterPipeline::append_encryption_filter(
+  throw_if_not_ok(FilterPipeline::append_encryption_filter(
       &header->filters, encryption_key));
-
-  return Status::Ok();
 }
 
 }  // namespace sm

--- a/tiledb/sm/tile/generic_tile_io.h
+++ b/tiledb/sm/tile/generic_tile_io.h
@@ -143,7 +143,7 @@ class GenericTileIO {
    * @param config The storage manager's config.
    * @return Status, Tile
    */
-  tuple<Status, optional<Tile>> read_generic(
+  Tile read_generic(
       uint64_t file_offset,
       const EncryptionKey& encryption_key,
       const Config& config);
@@ -172,7 +172,7 @@ class GenericTileIO {
    * @param nbytes The total number of bytes written to the file.
    * @return Status
    */
-  Status write_generic(
+  void write_generic(
       WriterTile* tile, const EncryptionKey& encryption_key, uint64_t* nbytes);
 
   /**
@@ -190,7 +190,7 @@ class GenericTileIO {
    * @param header The header to write
    * @return Status
    */
-  Status write_generic_tile_header(GenericTileHeader* header);
+  void write_generic_tile_header(GenericTileHeader* header);
 
  private:
   /* ********************************* */
@@ -210,7 +210,7 @@ class GenericTileIO {
    * @param encryption_key The encryption key to use.
    * @return Status
    */
-  Status configure_encryption_filter(
+  void configure_encryption_filter(
       GenericTileHeader* header, const EncryptionKey& encryption_key) const;
 
   /**
@@ -223,7 +223,7 @@ class GenericTileIO {
    * @param encryption_key The encryption key to use.
    * @return Status
    */
-  Status init_generic_tile_header(
+  void init_generic_tile_header(
       WriterTile* tile,
       GenericTileHeader* header,
       const EncryptionKey& encryption_key) const;

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -57,7 +57,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   }
 
   // Write the buffer to the test Tile.
-  CHECK(tile.write(write_buffer.data(), 0, tile_size).ok());
+  CHECK_NOTHROW(tile.write(write_buffer.data(), 0, tile_size));
   CHECK(tile.size() == tile_size);
 
   // Ensure the internal data was deep-copied:
@@ -67,40 +67,43 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   // Test a partial read at offset 8, which should be a uint32_t with
   // a value of two.
   uint32_t two = 0;
-  CHECK(tile.read(&two, 8, sizeof(uint32_t)).ok());
+  CHECK_NOTHROW(tile.read(&two, 8, sizeof(uint32_t)));
   CHECK(two == 2);
 
   // Test a full read.
   std::vector<uint32_t> read_buffer(buffer_len);
   uint64_t read_offset = 0;
-  CHECK(tile.read(read_buffer.data(), read_offset, tile_size).ok());
+  CHECK_NOTHROW(tile.read(read_buffer.data(), read_offset, tile_size));
   CHECK(memcmp(read_buffer.data(), write_buffer.data(), tile_size) == 0);
 
   // Test a write at a non-zero offset. Overwrite the two at offset 8.
   uint32_t magic = 5234549;
-  CHECK(tile.write(&magic, 8, sizeof(uint32_t)).ok());
+  CHECK_NOTHROW(tile.write(&magic, 8, sizeof(uint32_t)));
 
   // Read the magic number to ensure the '2' value was overwritten.
   two = 0;
-  CHECK(tile.read(&two, 8, sizeof(uint32_t)).ok());
+  CHECK_NOTHROW(tile.read(&two, 8, sizeof(uint32_t)));
   CHECK(two == magic);
 
   // Restore the state without the magic number.
   two = 2;
-  CHECK(tile.write(&two, 8, sizeof(uint32_t)).ok());
+  CHECK_NOTHROW(tile.write(&two, 8, sizeof(uint32_t)));
 
   // Test a read at an out-of-bounds offset.
   memset(read_buffer.data(), 0, tile_size);
   read_offset = tile_size;
-  CHECK(!tile.read(read_buffer.data(), read_offset, tile_size).ok());
+  auto matcher = Catch::Matchers::ContainsSubstring("Read tile overflow");
+  CHECK_THROWS_WITH(
+      tile.read(read_buffer.data(), read_offset, tile_size), matcher);
 
   // Test a read at a valid offset but with a size that
   // exceeds the written buffer size.
   const uint32_t large_buffer_size = tile_size * 2;
   std::vector<uint32_t> large_read_buffer(buffer_len * 2);
   read_offset = 0;
-  CHECK(!tile.read(large_read_buffer.data(), read_offset, large_buffer_size)
-             .ok());
+  CHECK_THROWS_WITH(
+      tile.read(large_read_buffer.data(), read_offset, large_buffer_size),
+      matcher);
 
   // Free the write buffer to ensure that it was deep-copied
   // within the initial write.
@@ -108,7 +111,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
   write_buffer.clear();
   memset(read_buffer.data(), 0, tile_size);
   read_offset = 0;
-  CHECK(tile.read(read_buffer.data(), read_offset, tile_size).ok());
+  CHECK_NOTHROW(tile.read(read_buffer.data(), read_offset, tile_size));
   CHECK(memcmp(read_buffer.data(), write_buffer_copy.data(), tile_size) == 0);
 }
 
@@ -130,7 +133,7 @@ TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
   }
 
   // Write the buffer to the first test Tile.
-  CHECK(tile1.write(buffer.data(), 0, tile_size).ok());
+  CHECK_NOTHROW(tile1.write(buffer.data(), 0, tile_size));
 
   // Instantiate a second test tile with the move constructor.
   Tile tile2(std::move(tile1));
@@ -148,7 +151,7 @@ TEST_CASE("Tile: Test move constructor", "[Tile][move_constructor]") {
   // written to the first test tile.
   std::vector<uint32_t> read_buffer(buffer_len);
   uint64_t read_offset = 0;
-  CHECK(tile2.read(read_buffer.data(), read_offset, tile_size).ok());
+  CHECK_NOTHROW(tile2.read(read_buffer.data(), read_offset, tile_size));
   CHECK(memcmp(read_buffer.data(), buffer.data(), tile_size) == 0);
 }
 
@@ -170,7 +173,7 @@ TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
   }
 
   // Write the buffer to the first test Tile.
-  CHECK(tile1.write(buffer.data(), 0, tile_size).ok());
+  CHECK_NOTHROW(tile1.write(buffer.data(), 0, tile_size));
 
   // Instantiate a third test tile with the move constructor.
   Tile tile2 = std::move(tile1);
@@ -188,6 +191,6 @@ TEST_CASE("Tile: Test move-assignment", "[Tile][move_assignment]") {
   // written to the first test tile.
   std::vector<uint32_t> read_buffer(buffer_len);
   uint64_t read_offset = 0;
-  CHECK(tile2.read(read_buffer.data(), read_offset, tile_size).ok());
+  CHECK_NOTHROW(tile2.read(read_buffer.data(), read_offset, tile_size));
   CHECK(memcmp(read_buffer.data(), buffer.data(), tile_size) == 0);
 }

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -109,7 +109,7 @@ class TileBase {
    * buffer of size nbytes. Does not mutate the internal offset.
    * Thread-safe among readers.
    */
-  Status read(void* buffer, uint64_t offset, uint64_t nbytes) const;
+  void read(void* buffer, uint64_t offset, uint64_t nbytes) const;
 
   /** Returns the tile size. */
   inline uint64_t size() const {
@@ -127,7 +127,7 @@ class TileBase {
    * @note This function assumes that the tile buffer has already been
    *     properly allocated. It does not alter the tile offset and size.
    */
-  Status write(const void* data, uint64_t offset, uint64_t nbytes);
+  void write(const void* data, uint64_t offset, uint64_t nbytes);
 
   /**
    * Adds an extra offset at the end of this tile representing the size of the
@@ -265,7 +265,7 @@ class Tile : public TileBase {
    * Zips the coordinate values such that a cell's coordinates across
    * all dimensions appear contiguously in the buffer.
    */
-  Status zip_coordinates();
+  void zip_coordinates();
 
   /**
    * Reads the chunk data of a tile buffer and populates a chunk data structure.
@@ -433,9 +433,8 @@ class WriterTile : public TileBase {
    * @param data Pointer to the data to write.
    * @param offset Offset to write into the tile buffer.
    * @param nbytes Number of bytes to write.
-   * @return Status.
    */
-  Status write_var(const void* data, uint64_t offset, uint64_t nbytes);
+  void write_var(const void* data, uint64_t offset, uint64_t nbytes);
 
   /**
    * Sets the size of the tile.


### PR DESCRIPTION
This is a standard mechanical removal of the Status class from the headers in `tiledb/sm/tile/*.h` and then fixing every compiler error that comes up.

---
TYPE: NO_HISTORY
DESC: Remove use of Status by Tile classes
