### PR TITLE
Aggregates: enable full support.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -140,9 +140,7 @@ struct CppAggregatesFx {
 template <class T>
 CppAggregatesFx<T>::CppAggregatesFx()
     : vfs_(ctx_) {
-  Config cfg;
-  cfg["sm.allow_aggregates_experimental"] = "true";
-  ctx_ = Context(cfg);
+  ctx_ = Context();
   vfs_ = VFS(ctx_);
 
   remove_array();

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -241,7 +241,6 @@ void check_save_to_file() {
   ss << "rest.server_serialization_format CAPNP\n";
   ss << "rest.use_refactored_array_open false\n";
   ss << "rest.use_refactored_array_open_and_query_submit false\n";
-  ss << "sm.allow_aggregates_experimental false\n";
   ss << "sm.allow_separate_attribute_writes false\n";
   ss << "sm.allow_updates_experimental false\n";
   ss << "sm.check_coord_dups true\n";
@@ -611,7 +610,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.load_enumerations_on_array_open"] = "false";
   all_param_values["rest.use_refactored_array_open"] = "true";
   all_param_values["rest.use_refactored_array_open_and_query_submit"] = "true";
-  all_param_values["sm.allow_aggregates_experimental"] = "false";
   all_param_values["sm.allow_separate_attribute_writes"] = "false";
   all_param_values["sm.allow_updates_experimental"] = "false";
   all_param_values["sm.encryption_key"] = "";

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -91,11 +91,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *
  * **Parameters**
  *
- * - `sm.allow_aggregates_experimental` <br>
- *    **Experimental** <br>
- *    Allow query aggregates APIs. Experimental for testing purposes,
- *    do not use.<br>
- *    **Default**: false
  * - `sm.allow_separate_attribute_writes` <br>
  *    **Experimental** <br>
  *    Allow separate attribute write queries.<br>

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -114,69 +114,50 @@ inline void ensure_query_channel_is_valid(
   ensure_handle_is_valid(channel);
 }
 
-inline void ensure_aggregates_enabled_via_config(tiledb_ctx_t* ctx) {
-  bool enabled = ctx->context().resources().config().get<bool>(
-      "sm.allow_aggregates_experimental", sm::Config::MustFindMarker());
-  if (!enabled) {
-    throw CAPIStatusException(
-        "The aggregates API is disabled. Please set the "
-        "sm.allow_aggregates_experimental config option to enable it");
-  }
-}
-
 capi_return_t tiledb_channel_operator_sum_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, const tiledb_channel_operator_t** op) {
   ensure_output_pointer_is_valid(op);
   *op = tiledb_channel_operator_sum;
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_channel_operator_mean_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, const tiledb_channel_operator_t** op) {
   ensure_output_pointer_is_valid(op);
   *op = tiledb_channel_operator_mean;
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_channel_operator_null_count_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, const tiledb_channel_operator_t** op) {
   ensure_output_pointer_is_valid(op);
   *op = tiledb_channel_operator_null_count;
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_channel_operator_min_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, const tiledb_channel_operator_t** op) {
   ensure_output_pointer_is_valid(op);
   *op = tiledb_channel_operator_min;
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_channel_operator_max_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operator_t** op) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, const tiledb_channel_operator_t** op) {
   ensure_output_pointer_is_valid(op);
   *op = tiledb_channel_operator_max;
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_aggregate_count_get(
-    tiledb_ctx_t* ctx, const tiledb_channel_operation_t** operation) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, const tiledb_channel_operation_t** operation) {
   ensure_output_pointer_is_valid(operation);
   *operation = tiledb_aggregate_count;
   return TILEDB_OK;
 }
 
 capi_return_t tiledb_query_get_default_channel(
-    tiledb_ctx_t* ctx,
-    tiledb_query_t* query,
-    tiledb_query_channel_t** channel) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, tiledb_query_t* query, tiledb_query_channel_t** channel) {
   ensure_query_is_valid(query);
   ensure_output_pointer_is_valid(channel);
 
@@ -194,7 +175,6 @@ capi_return_t tiledb_create_unary_aggregate(
     const tiledb_channel_operator_t* op,
     const char* input_field_name,
     tiledb_channel_operation_t** operation) {
-  ensure_aggregates_enabled_via_config(ctx);
   ensure_query_is_valid(query);
   ensure_query_is_not_initialized(query);
   ensure_channel_operator_is_valid(op);
@@ -225,11 +205,10 @@ capi_return_t tiledb_create_unary_aggregate(
 }
 
 capi_return_t tiledb_channel_apply_aggregate(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_query_channel_t* channel,
     const char* output_field_name,
     const tiledb_channel_operation_t* operation) {
-  ensure_aggregates_enabled_via_config(ctx);
   ensure_query_channel_is_valid(channel);
   ensure_query_is_not_initialized(channel->query_);
   ensure_output_field_is_valid(output_field_name);
@@ -240,8 +219,7 @@ capi_return_t tiledb_channel_apply_aggregate(
 }
 
 capi_return_t tiledb_aggregate_free(
-    tiledb_ctx_t* ctx, tiledb_channel_operation_t** operation) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, tiledb_channel_operation_t** operation) {
   ensure_output_pointer_is_valid(operation);
   ensure_operation_is_valid(*operation);
   tiledb_channel_operation_handle_t::break_handle(*operation);
@@ -250,8 +228,7 @@ capi_return_t tiledb_aggregate_free(
 }
 
 capi_return_t tiledb_query_channel_free(
-    tiledb_ctx_t* ctx, tiledb_query_channel_t** channel) {
-  ensure_aggregates_enabled_via_config(ctx);
+    tiledb_ctx_t*, tiledb_query_channel_t** channel) {
   ensure_output_pointer_is_valid(channel);
   ensure_query_channel_is_valid(*channel);
   tiledb_query_channel_handle_t::break_handle(*channel);

--- a/tiledb/api/c_api/query_aggregate/test/unit_capi_query_aggregate.cc
+++ b/tiledb/api/c_api/query_aggregate/test/unit_capi_query_aggregate.cc
@@ -48,12 +48,6 @@ struct QueryAggregateFx : TemporaryDirectoryFixture {
 
   QueryAggregateFx()
       : array_name_(temp_dir_ + "queryaggregate_array") {
-    CHECK(
-        ctx->resources()
-            .config()
-            .set("sm.allow_aggregates_experimental", "true")
-            .ok() == true);
-
     rm_array();
     create_sparse_array();
     write_sparse_array();

--- a/tiledb/api/c_api/query_field/test/unit_capi_query_field.cc
+++ b/tiledb/api/c_api/query_field/test/unit_capi_query_field.cc
@@ -40,12 +40,6 @@ using namespace tiledb::test;
 
 struct QueryFieldFx : TemporaryDirectoryFixture {
   QueryFieldFx() {
-    REQUIRE(
-        ctx->resources()
-            .config()
-            .set("sm.allow_aggregates_experimental", "true")
-            .ok() == true);
-
     create_sparse_array(array_name());
     write_sparse_array(array_name());
   }

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -96,7 +96,6 @@ const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_USE_REFACTORED_ARRAY_OPEN = "false";
 const std::string Config::REST_USE_REFACTORED_QUERY_SUBMIT = "false";
-const std::string Config::SM_ALLOW_AGGREGATES_EXPERIMENTAL = "false";
 const std::string Config::SM_ALLOW_SEPARATE_ATTRIBUTE_WRITES = "false";
 const std::string Config::SM_ALLOW_UPDATES_EXPERIMENTAL = "false";
 const std::string Config::SM_ENCRYPTION_KEY = "";
@@ -268,9 +267,6 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair("config.logging_level", Config::CONFIG_LOGGING_LEVEL),
     std::make_pair(
         "config.logging_format", Config::CONFIG_LOGGING_DEFAULT_FORMAT),
-    std::make_pair(
-        "sm.allow_aggregates_experimental",
-        Config::SM_ALLOW_AGGREGATES_EXPERIMENTAL),
     std::make_pair(
         "sm.allow_separate_attribute_writes",
         Config::SM_ALLOW_SEPARATE_ATTRIBUTE_WRITES),
@@ -717,8 +713,6 @@ Status Config::sanity_check(
     if (value != "DEFAULT" && value != "JSON")
       return LOG_STATUS(
           Status_ConfigError("Invalid logging format parameter value"));
-  } else if (param == "sm.allow_aggregates_experimental") {
-    RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.allow_separate_attribute_writes") {
     RETURN_NOT_OK(utils::parse::convert(value, &v));
   } else if (param == "sm.allow_updates_experimental") {

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -130,9 +130,6 @@ class Config {
   /** The default format for logging. */
   static const std::string CONFIG_LOGGING_DEFAULT_FORMAT;
 
-  /** Allow aggregates API or not. */
-  static const std::string SM_ALLOW_AGGREGATES_EXPERIMENTAL;
-
   /** Allow separate attribute writes or not. */
   static const std::string SM_ALLOW_SEPARATE_ATTRIBUTE_WRITES;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -265,11 +265,6 @@ class Config {
    *
    * **Parameters**
    *
-   * - `sm.allow_aggregates_experimental` <br>
-   *    **Experimental** <br>
-   *    Allow aggregates APIs. Experimental for testing purposes,
-   *    do not use.<br>
-   *    **Default**: false
    * - `sm.allow_separate_attribute_writes` <br>
    *    **Experimental** <br>
    *    Allow separate attribute write queries.<br>


### PR DESCRIPTION
This removes the need for a configuration setting to use aggregates. It will be merged into 2.18.

Also fixed is the serialization code paths so that we can run queries with aggregates on 2.18. I tested that the aggregates work with a REST server.

---
TYPE: NO_HISTORY
DESC: Aggregates: enable full support.
