### PR TITLE
Bump REST CI timeout to 90m

### DIFF
--- a/.github/workflows/ci-rest.yml
+++ b/.github/workflows/ci-rest.yml
@@ -27,3 +27,4 @@ jobs:
           # Pass TileDB core ref to test against REST.
           # github.head_ref will only be set for PRs, so fallback to github.ref_name if triggered via push event.
           inputs: '{ "tiledb_ref": "${{ github.head_ref || github.ref_name }}"}'
+          wait-for-completion-timeout: 90m


### PR DESCRIPTION
Bumps REST CI timeout to 90m from the default of 1h to prevent failures we've seen where the dispatched workflow takes just over 1h to complete normally.

---
TYPE: NO_HISTORY
DESC: Bump REST CI timeout to 90m
