### PR TITLE
Add a test for write access failures.

### DIFF
--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -782,6 +782,15 @@ TEST_CASE_METHOD(
     rc = tiledb_query_submit(ctx, query);
     REQUIRE(rc != TILEDB_OK);
 
+    tiledb_error_t* err;
+    rc = tiledb_ctx_get_last_error(ctx, &err);
+    REQUIRE(rc == TILEDB_OK);
+    const char* msg;
+    rc = tiledb_error_message(err, &msg);
+    REQUIRE(rc == TILEDB_OK);
+    REQUIRE(std::string(msg).find("Cannot create directory") != std::string::npos);
+
+    tiledb_error_free(&err);
     tiledb_query_free(&query);
     tiledb_array_free(&array);
   }

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -702,8 +702,8 @@ class DenyWriteAccess {
       , previous_perms_(std::filesystem::status(path).permissions()) {
     std::filesystem::permissions(
         path_,
-        std::filesystem::perms::owner_read,
-        std::filesystem::perm_options::replace);
+        std::filesystem::perms::owner_write,
+        std::filesystem::perm_options::remove);
   }
 
   ~DenyWriteAccess() {

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_VFS_HELPERS_H
 #define TILEDB_VFS_HELPERS_H
 
+#include <filesystem>
 #include "test/support/src/helpers.h"
 #include "test/support/tdb_catch.h"
 
@@ -681,6 +682,41 @@ struct TemporaryDirectoryFixture {
  private:
   /** Vector of supported filesystems. Used to initialize ``vfs_``. */
   const std::vector<std::unique_ptr<SupportedFs>> supported_filesystems_;
+};
+
+/**
+ * Denies write access to a local filesystem path.
+ *
+ * Not supported on Windows. The permissions function there sets the
+ * readonly bit on the path, which is not supported on directories.
+ *
+ * To support it on Windows we would have to add and remove Access Control
+ * Lists, which is a nontrivial thing to do.
+ */
+class DenyWriteAccess {
+ public:
+  DenyWriteAccess() = delete;
+
+  DenyWriteAccess(const std::string& path)
+      : path_(path)
+      , previous_perms_(std::filesystem::status(path).permissions()) {
+    std::filesystem::permissions(
+        path_,
+        std::filesystem::perms::owner_read,
+        std::filesystem::perm_options::replace);
+  }
+
+  ~DenyWriteAccess() {
+    std::filesystem::permissions(
+        path_, previous_perms_, std::filesystem::perm_options::replace);
+  }
+
+ private:
+  /** The path. */
+  const std::string path_;
+
+  /** The previous permissions of the path. */
+  const std::filesystem::perms previous_perms_;
 };
 
 }  // End of namespace test


### PR DESCRIPTION
[SC-35061](https://app.shortcut.com/tiledb-inc/story/35061/add-tests-for-write-access-failures)

See also https://github.com/TileDB-Inc/TileDB/pull/4052#pullrequestreview-1395205256.

The test runs on non-Windows only.

---
TYPE: NO_HISTORY