### PR TITLE
Add base class for VFS filesystems

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -202,6 +202,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/vfs.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/vfs_file_handle.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/win.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/filesystem_base.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/bit_width_reduction_filter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/bitshuffle_filter.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filter/byteshuffle_filter.cc

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -69,80 +69,98 @@ struct tiledb_vfs_handle_t
     return vfs_.config();
   }
 
-  Status create_bucket(const tiledb::sm::URI& uri) const {
+  Status create_bucket(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.create_bucket(uri);
   }
 
-  Status remove_bucket(const tiledb::sm::URI& uri) const {
+  Status remove_bucket(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.remove_bucket(uri);
   }
 
-  Status empty_bucket(const tiledb::sm::URI& uri) const {
+  Status empty_bucket(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.empty_bucket(uri);
   }
 
-  Status is_empty_bucket(const tiledb::sm::URI& uri, bool* is_empty) const {
+  Status is_empty_bucket(const tiledb::sm::URI& uri, bool* is_empty) {
+    vfs_.create_fs(uri);
     return vfs_.is_empty_bucket(uri, is_empty);
   }
 
-  Status is_bucket(const tiledb::sm::URI& uri, bool* is_bucket) const {
+  Status is_bucket(const tiledb::sm::URI& uri, bool* is_bucket) {
+    vfs_.create_fs(uri);
     return vfs_.is_bucket(uri, is_bucket);
   }
 
-  Status create_dir(const tiledb::sm::URI& uri) const {
+  Status create_dir(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.create_dir(uri);
   }
 
-  Status is_dir(const tiledb::sm::URI& uri, bool* is_dir) const {
+  Status is_dir(const tiledb::sm::URI& uri, bool* is_dir) {
+    vfs_.create_fs(uri);
     return vfs_.is_dir(uri, is_dir);
   }
 
-  Status remove_dir(const tiledb::sm::URI& uri) const {
+  Status remove_dir(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.remove_dir(uri);
   }
 
-  Status is_file(const tiledb::sm::URI& uri, bool* is_file) const {
+  Status is_file(const tiledb::sm::URI& uri, bool* is_file) {
+    vfs_.create_fs(uri);
     return vfs_.is_file(uri, is_file);
   }
 
-  Status remove_file(const tiledb::sm::URI& uri) const {
+  Status remove_file(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.remove_file(uri);
   }
 
-  Status dir_size(const tiledb::sm::URI& dir_name, uint64_t* dir_size) const {
+  Status dir_size(const tiledb::sm::URI& dir_name, uint64_t* dir_size) {
+    vfs_.create_fs(dir_name);
     return vfs_.dir_size(dir_name, dir_size);
   }
 
-  Status file_size(const tiledb::sm::URI& uri, uint64_t* size) const {
+  Status file_size(const tiledb::sm::URI& uri, uint64_t* size) {
+    vfs_.create_fs(uri);
     return vfs_.file_size(uri, size);
   }
 
   Status move_file(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
+    vfs_.create_fs(old_uri);
     return vfs_.move_file(old_uri, new_uri);
   }
 
   Status move_dir(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
+    vfs_.create_fs(old_uri);
     return vfs_.move_dir(old_uri, new_uri);
   }
 
   Status copy_file(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
+    vfs_.create_fs(old_uri);
     return vfs_.copy_file(old_uri, new_uri);
   }
 
   Status copy_dir(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
+    vfs_.create_fs(old_uri);
     return vfs_.copy_dir(old_uri, new_uri);
   }
 
   Status ls(
-      const tiledb::sm::URI& parent, std::vector<tiledb::sm::URI>* uris) const {
+      const tiledb::sm::URI& parent, std::vector<tiledb::sm::URI>* uris) {
+    vfs_.create_fs(parent);
     return vfs_.ls(parent, uris);
   }
 
-  Status touch(const tiledb::sm::URI& uri) const {
+  Status touch(const tiledb::sm::URI& uri) {
+    vfs_.create_fs(uri);
     return vfs_.touch(uri);
   }
 };

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -69,98 +69,80 @@ struct tiledb_vfs_handle_t
     return vfs_.config();
   }
 
-  Status create_bucket(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status create_bucket(const tiledb::sm::URI& uri) const {
     return vfs_.create_bucket(uri);
   }
 
-  Status remove_bucket(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status remove_bucket(const tiledb::sm::URI& uri) const {
     return vfs_.remove_bucket(uri);
   }
 
-  Status empty_bucket(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status empty_bucket(const tiledb::sm::URI& uri) const {
     return vfs_.empty_bucket(uri);
   }
 
-  Status is_empty_bucket(const tiledb::sm::URI& uri, bool* is_empty) {
-    vfs_.create_fs(uri);
+  Status is_empty_bucket(const tiledb::sm::URI& uri, bool* is_empty) const {
     return vfs_.is_empty_bucket(uri, is_empty);
   }
 
-  Status is_bucket(const tiledb::sm::URI& uri, bool* is_bucket) {
-    vfs_.create_fs(uri);
+  Status is_bucket(const tiledb::sm::URI& uri, bool* is_bucket) const {
     return vfs_.is_bucket(uri, is_bucket);
   }
 
-  Status create_dir(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status create_dir(const tiledb::sm::URI& uri) const {
     return vfs_.create_dir(uri);
   }
 
-  Status is_dir(const tiledb::sm::URI& uri, bool* is_dir) {
-    vfs_.create_fs(uri);
+  Status is_dir(const tiledb::sm::URI& uri, bool* is_dir) const {
     return vfs_.is_dir(uri, is_dir);
   }
 
-  Status remove_dir(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status remove_dir(const tiledb::sm::URI& uri) const {
     return vfs_.remove_dir(uri);
   }
 
-  Status is_file(const tiledb::sm::URI& uri, bool* is_file) {
-    vfs_.create_fs(uri);
+  Status is_file(const tiledb::sm::URI& uri, bool* is_file) const {
     return vfs_.is_file(uri, is_file);
   }
 
-  Status remove_file(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status remove_file(const tiledb::sm::URI& uri) const {
     return vfs_.remove_file(uri);
   }
 
-  Status dir_size(const tiledb::sm::URI& dir_name, uint64_t* dir_size) {
-    vfs_.create_fs(dir_name);
+  Status dir_size(const tiledb::sm::URI& dir_name, uint64_t* dir_size) const {
     return vfs_.dir_size(dir_name, dir_size);
   }
 
-  Status file_size(const tiledb::sm::URI& uri, uint64_t* size) {
-    vfs_.create_fs(uri);
+  Status file_size(const tiledb::sm::URI& uri, uint64_t* size) const {
     return vfs_.file_size(uri, size);
   }
 
   Status move_file(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    vfs_.create_fs(old_uri);
     return vfs_.move_file(old_uri, new_uri);
   }
 
   Status move_dir(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    vfs_.create_fs(old_uri);
     return vfs_.move_dir(old_uri, new_uri);
   }
 
   Status copy_file(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    vfs_.create_fs(old_uri);
     return vfs_.copy_file(old_uri, new_uri);
   }
 
   Status copy_dir(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    vfs_.create_fs(old_uri);
     return vfs_.copy_dir(old_uri, new_uri);
   }
 
   Status ls(
-      const tiledb::sm::URI& parent, std::vector<tiledb::sm::URI>* uris) {
-    vfs_.create_fs(parent);
+      const tiledb::sm::URI& parent, std::vector<tiledb::sm::URI>* uris) const {
     return vfs_.ls(parent, uris);
   }
 
-  Status touch(const tiledb::sm::URI& uri) {
-    vfs_.create_fs(uri);
+  Status touch(const tiledb::sm::URI& uri) const {
     return vfs_.touch(uri);
   }
 };

--- a/tiledb/sm/filesystem/CMakeLists.txt
+++ b/tiledb/sm/filesystem/CMakeLists.txt
@@ -39,6 +39,7 @@ commence(object_library vfs)
         vfs.cc
         vfs_file_handle.cc
         win.cc
+        filesystem_base.cc
         ../curl/curl_init.cc
     )
     if (TILEDB_S3)

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -1,33 +1,33 @@
 /**
-* @file filesystem_base.h
-*
-* @section LICENSE
-*
-* The MIT License
-*
-* @copyright Copyright (c) 2017-2023 TileDB, Inc.
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy
-* of this software and associated documentation files (the "Software"), to deal
-* in the Software without restriction, including without limitation the rights
-* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is
-* furnished to do so, subject to the following conditions:
-*
-* The above copyright notice and this permission notice shall be included in
-* all copies or substantial portions of the Software.
-*
-* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-* THE SOFTWARE.
-*
-* @section DESCRIPTION
-*
-* This file implements the FilesystemBase class.
+ * @file filesystem_base.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the FilesystemBase class.
  */
 
 #include "filesystem_base.h"

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -1,0 +1,33 @@
+/**
+* @file filesystem_base.h
+*
+* @section LICENSE
+*
+* The MIT License
+*
+* @copyright Copyright (c) 2017-2023 TileDB, Inc.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*
+* @section DESCRIPTION
+*
+* This file implements the FilesystemBase class.
+ */
+
+#include "filesystem_base.h"

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -1,0 +1,196 @@
+/**
+ * @file filesystem.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the Filesystem base class.
+ */
+
+#ifndef TILEDB_FILESYSTEMBASE_H
+#define TILEDB_FILESYSTEMBASE_H
+
+#include "tiledb/common/filesystem/directory_entry.h"
+#include "tiledb/sm/config/config.h"
+#include "tiledb/sm/enums/filesystem.h"
+#include "uri.h"
+
+#include <sys/stat.h>
+
+// TODO: filesystem namespace
+namespace tiledb::sm {
+enum FilesystemType {
+  HDFS = 0, S3, AZURE, GCS, MEMFS, WIN, POSIX
+};
+
+class VFS;
+
+class FilesystemBase {
+  friend class VFS;
+
+ public:
+  FilesystemBase(const Config& config)
+      : config_(config) {
+  }
+
+  virtual ~FilesystemBase() = default;
+
+  /**
+   * Creates a directory.
+   *
+   * - On S3, this is a noop.
+   * - On all other backends, if the directory exists, the function
+   *   just succeeds without doing anything.
+   *
+   * @param uri The URI of the directory.
+   * @return Status
+   */
+  virtual Status create_dir(const URI& uri) const = 0;
+
+  /**
+   * Creates an empty file.
+   *
+   * @param uri The URI of the file.
+   * @return Status
+   */
+  virtual Status touch(const URI& uri) const = 0;
+
+  virtual bool is_dir(const URI& uri) const = 0;
+
+  virtual bool is_file(const URI& uri) const = 0;
+
+  /**
+   * Removes a given directory (recursive)
+   *
+   * @param uri The uri of the directory to be removed
+   * @return Status
+   */
+  virtual Status remove_dir(const URI& uri) const = 0;
+
+  /**
+   * Deletes a file.
+   *
+   * @param uri The URI of the file.
+   * @return Status
+   */
+  virtual Status remove_file(const URI& uri) const = 0;
+
+  /**
+   * Retrieves the size of a file.
+   *
+   * @param uri The URI of the file.
+   * @param size The file size to be retrieved.
+   * @return Status
+   */
+  virtual Status file_size(const URI& uri, uint64_t* size) const = 0;
+
+  /**
+   * Retrieves all the entries contained in the parent.
+   *
+   * @param parent The target directory to list.
+   * @return All entries that are contained in the parent
+   */
+  virtual tuple<
+      Status,
+      optional<std::vector<common::filesystem::directory_entry>>>
+  ls_with_sizes(const URI& parent) const = 0;
+
+  /**
+   * Renames a file.
+   *
+   * @param old_uri The old URI.
+   * @param new_uri The new URI.
+   * @return Status
+   */
+  virtual Status move_file(const URI& old_uri, const URI& new_uri) = 0;
+
+  /**
+   * Copies a file.
+   *
+   * @param old_uri The old URI.
+   * @param new_uri The new URI.
+   * @return Status
+   */
+  virtual Status copy_file(const URI& old_uri, const URI& new_uri) = 0;
+
+  /**
+   * Copies directory.
+   *
+   * @param old_uri The old URI.
+   * @param new_uri The new URI.
+   * @return Status
+   */
+  virtual Status copy_dir(const URI& old_uri, const URI& new_uri) = 0;
+
+  /**
+   * Reads from a file.
+   *
+   * @param uri The URI of the file.
+   * @param offset The offset where the read begins.
+   * @param buffer The buffer to read into.
+   * @param nbytes Number of bytes to read.
+   * @param use_read_ahead Whether to use the read-ahead cache.
+   * @return Status
+   */
+  virtual Status read(
+      const URI& uri,
+      uint64_t offset,
+      void* buffer,
+      uint64_t nbytes,
+      bool use_read_ahead = true) = 0;
+
+  /**
+   * Syncs (flushes) a file. Note that for S3 this is a noop.
+   *
+   * @param uri The URI of the file.
+   * @return Status
+   */
+  virtual Status sync(const URI& uri) = 0;
+
+  /**
+   * Writes the contents of a buffer into a file.
+   *
+   * @param uri The URI of the file.
+   * @param buffer The buffer to write from.
+   * @param buffer_size The buffer size.
+   * @param remote_global_order_write Remote global order write
+   * @return Status
+   */
+  virtual Status write(
+      const URI& uri,
+      const void* buffer,
+      uint64_t buffer_size,
+      bool remote_global_order_write = false) = 0;
+
+ protected:
+  Config config_;
+
+  FilesystemType fs_type_;
+};
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_FILESYSTEMBASE_H

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -40,11 +40,7 @@
 
 #include <sys/stat.h>
 
-// TODO: filesystem namespace
 namespace tiledb::sm {
-enum FilesystemType {
-  HDFS = 0, S3, AZURE, GCS, MEMFS, WIN, POSIX
-};
 
 class VFS;
 
@@ -52,9 +48,7 @@ class FilesystemBase {
   friend class VFS;
 
  public:
-  FilesystemBase(const Config& config)
-      : config_(config) {
-  }
+  FilesystemBase() = default;
 
   virtual ~FilesystemBase() = default;
 
@@ -78,8 +72,20 @@ class FilesystemBase {
    */
   virtual Status touch(const URI& uri) const = 0;
 
+  /**
+   * Checks if a directory exists.
+   *
+   * @param uri The URI to check for existence.
+   * @return True if the directory exists, else False.
+   */
   virtual bool is_dir(const URI& uri) const = 0;
 
+  /**
+   * Checks if a file exists.
+   *
+   * @param uri The URI to check for existence.
+   * @return True if the file exists, else False.
+   */
   virtual bool is_file(const URI& uri) const = 0;
 
   /**
@@ -125,7 +131,7 @@ class FilesystemBase {
    * @param new_uri The new URI.
    * @return Status
    */
-  virtual Status move_file(const URI& old_uri, const URI& new_uri) = 0;
+  virtual Status move_file(const URI& old_uri, const URI& new_uri) const = 0;
 
   /**
    * Copies a file.
@@ -134,7 +140,7 @@ class FilesystemBase {
    * @param new_uri The new URI.
    * @return Status
    */
-  virtual Status copy_file(const URI& old_uri, const URI& new_uri) = 0;
+  virtual Status copy_file(const URI& old_uri, const URI& new_uri) const = 0;
 
   /**
    * Copies directory.
@@ -143,7 +149,7 @@ class FilesystemBase {
    * @param new_uri The new URI.
    * @return Status
    */
-  virtual Status copy_dir(const URI& old_uri, const URI& new_uri) = 0;
+  virtual Status copy_dir(const URI& old_uri, const URI& new_uri) const = 0;
 
   /**
    * Reads from a file.
@@ -184,11 +190,6 @@ class FilesystemBase {
       const void* buffer,
       uint64_t buffer_size,
       bool remote_global_order_write = false) = 0;
-
- protected:
-  Config config_;
-
-  FilesystemType fs_type_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -34,11 +34,9 @@
 #define TILEDB_FILESYSTEMBASE_H
 
 #include "tiledb/common/filesystem/directory_entry.h"
-#include "tiledb/sm/config/config.h"
-#include "tiledb/sm/enums/filesystem.h"
 #include "uri.h"
 
-#include <sys/stat.h>
+#include <vector>
 
 namespace tiledb::sm {
 

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -43,8 +43,6 @@ namespace tiledb::sm {
 class VFS;
 
 class FilesystemBase {
-  friend class VFS;
-
  public:
   FilesystemBase() = default;
 
@@ -124,6 +122,7 @@ class FilesystemBase {
 
   /**
    * Renames a file.
+   * Both URI must be of the same backend type. (e.g. both s3://, file://, etc)
    *
    * @param old_uri The old URI.
    * @param new_uri The new URI.
@@ -133,6 +132,7 @@ class FilesystemBase {
 
   /**
    * Copies a file.
+   * Both URI must be of the same backend type. (e.g. both s3://, file://, etc)
    *
    * @param old_uri The old URI.
    * @param new_uri The new URI.
@@ -142,6 +142,7 @@ class FilesystemBase {
 
   /**
    * Copies directory.
+   * Both URI must be of the same backend type. (e.g. both s3://, file://, etc)
    *
    * @param old_uri The old URI.
    * @param new_uri The new URI.

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -44,6 +44,7 @@
 
 #include "tiledb/common/status.h"
 #include "tiledb/sm/config/config.h"
+#include "tiledb/sm/filesystem/filesystem_base.h"
 
 using namespace tiledb::common;
 
@@ -60,13 +61,13 @@ class URI;
 /**
  * This class implements the POSIX filesystem functions.
  */
-class Posix {
+class Posix : public FilesystemBase {
  public:
   /** Constructor. */
-  Posix();
+  explicit Posix(const Config& config);
 
   /** Destructor. */
-  ~Posix() = default;
+  ~Posix() override = default;
 
   /**
    * Returns the absolute posix (string) path of the input in the
@@ -80,7 +81,7 @@ class Posix {
    * @param dir The name of the directory to be created.
    * @return Status
    */
-  Status create_dir(const std::string& path) const;
+  Status create_dir(const URI& uri) const override;
 
   /**
    * Creates an empty file.
@@ -88,7 +89,7 @@ class Posix {
    * @param filename The name of the file to be created.
    * @return Status
    */
-  Status touch(const std::string& filename) const;
+  Status touch(const URI& uri) const override;
 
   /**
    * Returns the directory where the program is executed.
@@ -105,7 +106,7 @@ class Posix {
    * @param path The path of the directory to be deleted.
    * @return Status
    */
-  Status remove_dir(const std::string& path) const;
+  Status remove_dir(const URI& path) const override;
 
   /** Deletes the file in the input path. */
 
@@ -115,7 +116,7 @@ class Posix {
    * @param path The path of the file / empty directory to be deleted.
    * @return Status
    */
-  Status remove_file(const std::string& path) const;
+  Status remove_file(const URI& path) const override;
 
   /**
    * Returns the size of the input file.
@@ -124,7 +125,7 @@ class Posix {
    * @param nbytes Pointer to a value
    * @return Status
    */
-  Status file_size(const std::string& path, uint64_t* size) const;
+  Status file_size(const URI& path, uint64_t* size) const override;
 
   /**
    * Initialize this instance with the given config.
@@ -140,7 +141,7 @@ class Posix {
    * @param dir The directory to be checked.
    * @return *True* if *dir* is an existing directory, and *False* otherwise.
    */
-  bool is_dir(const std::string& path) const;
+  bool is_dir(const URI& uri) const override;
 
   /**
    * Checks if the input is an existing file.
@@ -148,7 +149,7 @@ class Posix {
    * @param file The file to be checked.
    * @return *True* if *file* is an existing file, and *false* otherwise.
    */
-  bool is_file(const std::string& path) const;
+  bool is_file(const URI& uri) const override;
 
   /**
    *
@@ -168,7 +169,7 @@ class Posix {
    * @return A list of directory_entry objects
    */
   tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(const URI& uri) const;
+  ls_with_sizes(const URI& uri) const override;
 
   /**
    * Move a given filesystem path.
@@ -177,7 +178,7 @@ class Posix {
    * @param new_path The new path.
    * @return Status
    */
-  Status move_path(const std::string& old_path, const std::string& new_path);
+  Status move_file(const URI& old_path, const URI& new_path) override;
 
   /**
    * Copy a given filesystem file.
@@ -186,7 +187,7 @@ class Posix {
    * @param new_path The new path.
    * @return Status
    */
-  Status copy_file(const std::string& old_path, const std::string& new_path);
+  Status copy_file(const URI& old_uri, const URI& new_uri) override;
 
   /**
    * Copy a given filesystem directory.
@@ -195,7 +196,7 @@ class Posix {
    * @param new_path The new path.
    * @return Status
    */
-  Status copy_dir(const std::string& old_path, const std::string& new_path);
+  Status copy_dir(const URI& old_path, const URI& new_path) override;
 
   /**
    * Reads data from a file into a buffer.
@@ -207,10 +208,11 @@ class Posix {
    * @return Status.
    */
   Status read(
-      const std::string& path,
+      const URI& uri,
       uint64_t offset,
       void* buffer,
-      uint64_t nbytes) const;
+      uint64_t nbytes,
+      bool use_read_ahead = true) override;
 
   /**
    * Syncs a file or directory.
@@ -218,7 +220,7 @@ class Posix {
    * @param path The name of the file.
    * @return Status
    */
-  Status sync(const std::string& path);
+  Status sync(const URI& uri) override;
 
   /**
    * Writes the input buffer to a file.
@@ -232,15 +234,12 @@ class Posix {
    * @return Status
    */
   Status write(
-      const std::string& path, const void* buffer, uint64_t buffer_size);
+      const URI& uri,
+      const void* buffer,
+      uint64_t buffer_size,
+      bool remote_global_order_write = false) override;
 
  private:
-  /** Default config. */
-  Config default_config_;
-
-  /** Config parameters inherited from parent VFS. */
-  std::reference_wrapper<const Config> config_;
-
   static void adjacent_slashes_dedup(std::string* path);
 
   static bool both_slashes(char a, char b);

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -113,8 +113,6 @@ class Posix : public FilesystemBase {
    */
   Status remove_dir(const URI& path) const override;
 
-  /** Deletes the file in the input path. */
-
   /**
    * Removes a given path.
    *
@@ -170,6 +168,7 @@ class Posix : public FilesystemBase {
 
   /**
    * Move a given filesystem path.
+   * Both URI must be of the same file:// backend type.
    *
    * @param old_path The old path.
    * @param new_path The new path.
@@ -179,6 +178,7 @@ class Posix : public FilesystemBase {
 
   /**
    * Copy a given filesystem file.
+   * Both URI must be of the same file:// backend type.
    *
    * @param old_path The old path.
    * @param new_path The new path.
@@ -188,6 +188,7 @@ class Posix : public FilesystemBase {
 
   /**
    * Copy a given filesystem directory.
+   * Both URI must be of the same file:// backend type.
    *
    * @param old_path The old path.
    * @param new_path The new path.

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -63,6 +63,11 @@ class URI;
  */
 class Posix : public FilesystemBase {
  public:
+  /** Default constructor. */
+  Posix()
+      : Posix(Config()) {
+  }
+
   /** Constructor. */
   explicit Posix(const Config& config);
 
@@ -128,14 +133,6 @@ class Posix : public FilesystemBase {
   Status file_size(const URI& path, uint64_t* size) const override;
 
   /**
-   * Initialize this instance with the given config.
-   *
-   * @param config Config parameters.
-   * @return Status
-   */
-  Status init(const Config& config);
-
-  /**
    * Checks if the input is an existing directory.
    *
    * @param dir The directory to be checked.
@@ -178,7 +175,7 @@ class Posix : public FilesystemBase {
    * @param new_path The new path.
    * @return Status
    */
-  Status move_file(const URI& old_path, const URI& new_path) override;
+  Status move_file(const URI& old_path, const URI& new_path) const override;
 
   /**
    * Copy a given filesystem file.
@@ -187,7 +184,7 @@ class Posix : public FilesystemBase {
    * @param new_path The new path.
    * @return Status
    */
-  Status copy_file(const URI& old_uri, const URI& new_uri) override;
+  Status copy_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Copy a given filesystem directory.
@@ -196,7 +193,7 @@ class Posix : public FilesystemBase {
    * @param new_path The new path.
    * @return Status
    */
-  Status copy_dir(const URI& old_path, const URI& new_path) override;
+  Status copy_dir(const URI& old_path, const URI& new_path) const override;
 
   /**
    * Reads data from a file into a buffer.
@@ -291,19 +288,8 @@ class Posix : public FilesystemBase {
   static Status write_at(
       int fd, uint64_t file_offset, const void* buffer, uint64_t buffer_size);
 
-  /**
-   * Parse config to get posix permissions for creating new files
-   * @param permissions parsed permissions are set to this parameter
-   * @return Status
-   */
-  Status get_posix_file_permissions(uint32_t* permissions) const;
-
-  /**
-   * Parse config to get posix permissions for creating new directories
-   * @param permissions parsed permissions are set to this parameter
-   * @return Status
-   */
-  Status get_posix_directory_permissions(uint32_t* permissions) const;
+ private:
+  uint32_t file_permissions_, directory_permissions_;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -39,10 +39,12 @@
 #include <string>
 #include <vector>
 
+#include "filesystem_base.h"
 #include "tiledb/common/common.h"
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
+#include "tiledb/platform/platform.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/cache/lru_cache.h"
 #include "tiledb/sm/config/config.h"
@@ -334,7 +336,7 @@ class VFS : private VFSBase, S3_within_VFS {
    * @param compute_tp The compute-bound ThreadPool.
    * @param uris The URIs of the directories.
    */
-  void remove_dirs(ThreadPool* compute_tp, const std::vector<URI>& uris) const;
+  void remove_dirs(ThreadPool* compute_tp, const std::vector<URI>& uris);
 
   /**
    * Deletes a file.
@@ -434,7 +436,7 @@ class VFS : private VFSBase, S3_within_VFS {
    * @param new_uri The new URI.
    * @return Status
    */
-  Status move_file(const URI& old_uri, const URI& new_uri);
+  Status move_file(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Renames a directory.
@@ -443,7 +445,7 @@ class VFS : private VFSBase, S3_within_VFS {
    * @param new_uri The new URI.
    * @return Status
    */
-  Status move_dir(const URI& old_uri, const URI& new_uri);
+  Status move_dir(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Copies a file.
@@ -452,7 +454,7 @@ class VFS : private VFSBase, S3_within_VFS {
    * @param new_uri The new URI.
    * @return Status
    */
-  Status copy_file(const URI& old_uri, const URI& new_uri);
+  Status copy_file(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Copies directory.
@@ -461,7 +463,7 @@ class VFS : private VFSBase, S3_within_VFS {
    * @param new_uri The new URI.
    * @return Status
    */
-  Status copy_dir(const URI& old_uri, const URI& new_uri);
+  Status copy_dir(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Reads from a file.
@@ -580,6 +582,21 @@ class VFS : private VFSBase, S3_within_VFS {
 
   inline stats::Stats* stats() const {
     return stats_;
+  }
+
+  void create_fs(const URI& uri) {
+    if (uri.is_file()) {
+      if constexpr (tiledb::platform::is_os_windows) {
+        //        fs_ = tdb_unique_ptr<FilesystemBase>(tdb_new(W, config_));
+      } else {
+        if (fs_ != nullptr && fs_->fs_type_ == FilesystemType::POSIX) {
+          return;
+        }
+        fs_ = tdb_unique_ptr<FilesystemBase>(tdb_new(Posix, config_));
+      }
+    } else {
+      throw StatusException(Status_VFSError("Failed to create_fs"));
+    }
   }
 
  private:
@@ -754,13 +771,16 @@ class VFS : private VFSBase, S3_within_VFS {
 
 #ifdef _WIN32
   Win win_;
-#else
-  Posix posix_;
 #endif
 
 #ifdef HAVE_HDFS
   tdb_unique_ptr<hdfs::HDFS> hdfs_;
 #endif
+
+  tdb_unique_ptr<FilesystemBase> fs_;
+
+  /** The class stats. */
+  stats::Stats* stats_;
 
   /** The in-memory filesystem which is always supported */
   MemFilesystem memfs_;


### PR DESCRIPTION
Adds `FilesystemBase` class to use as a common base class between filesystems. This also updates `tiledb::sm::Posix` to inherit from `FilesystemBase`, remaining filesystems are to be converted in separate PRs.

---
TYPE: IMPROVEMENT
DESC: Add base class for VFS filesystems
