### PR TITLE
Use `find_package` for the compression libraries when vcpkg is enabled.

### DIFF
--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -29,49 +29,54 @@
 #   - BZIP2_INCLUDE_DIR, directory containing headers
 #   - BZIP2_LIBRARIES, the Bzip2 library path
 #   - BZIP2_FOUND, whether Bzip2 has been found
-#   - The Bzip2::Bzip2 imported target
+#   - The BZip2::BZip2 imported target
 
 # Include some common helper functions.
 include(TileDBCommon)
 
-# First check for a static version in the EP prefix.
-find_library(BZIP2_LIBRARIES
-  NAMES
-    libbz2static${CMAKE_STATIC_LIBRARY_SUFFIX}
-    libbz2${CMAKE_STATIC_LIBRARY_SUFFIX}
-  PATHS ${TILEDB_EP_INSTALL_PREFIX}
-  PATH_SUFFIXES lib
-  NO_DEFAULT_PATH
-)
-
-if (BZIP2_LIBRARIES)
-  set(BZIP2_STATIC_EP_FOUND TRUE)
-  find_path(BZIP2_INCLUDE_DIR
-    NAMES bzlib.h
-    PATHS ${TILEDB_EP_INSTALL_PREFIX}
-    PATH_SUFFIXES include
-    NO_DEFAULT_PATH
-  )
-elseif(NOT TILEDB_FORCE_ALL_DEPS)
-  set(BZIP2_STATIC_EP_FOUND FALSE)
-  # Static EP not found, search in system paths.
+if(TILEDB_VCPKG)
+  find_package(BZip2 REQUIRED)
+  set(BZIP2_FOUND TRUE)
+else()
+  # First check for a static version in the EP prefix.
   find_library(BZIP2_LIBRARIES
     NAMES
-      bz2 libbz2
-    PATH_SUFFIXES lib bin
-    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+      libbz2static${CMAKE_STATIC_LIBRARY_SUFFIX}
+      libbz2${CMAKE_STATIC_LIBRARY_SUFFIX}
+    PATHS ${TILEDB_EP_INSTALL_PREFIX}
+    PATH_SUFFIXES lib
+    NO_DEFAULT_PATH
   )
-  find_path(BZIP2_INCLUDE_DIR
-    NAMES bzlib.h
-    PATH_SUFFIXES include
-    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+
+  if (BZIP2_LIBRARIES)
+    set(BZIP2_STATIC_EP_FOUND TRUE)
+    find_path(BZIP2_INCLUDE_DIR
+      NAMES bzlib.h
+      PATHS ${TILEDB_EP_INSTALL_PREFIX}
+      PATH_SUFFIXES include
+      NO_DEFAULT_PATH
+    )
+  elseif(NOT TILEDB_FORCE_ALL_DEPS)
+    set(BZIP2_STATIC_EP_FOUND FALSE)
+    # Static EP not found, search in system paths.
+    find_library(BZIP2_LIBRARIES
+      NAMES
+        bz2 libbz2
+      PATH_SUFFIXES lib bin
+      ${TILEDB_DEPS_NO_DEFAULT_PATH}
+    )
+    find_path(BZIP2_INCLUDE_DIR
+      NAMES bzlib.h
+      PATH_SUFFIXES include
+      ${TILEDB_DEPS_NO_DEFAULT_PATH}
+    )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Bzip2
+    REQUIRED_VARS BZIP2_LIBRARIES BZIP2_INCLUDE_DIR
   )
 endif()
-
-include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Bzip2
-  REQUIRED_VARS BZIP2_LIBRARIES BZIP2_INCLUDE_DIR
-)
 
 if (NOT BZIP2_FOUND)
   if (TILEDB_SUPERBUILD)
@@ -128,9 +133,9 @@ if (NOT BZIP2_FOUND)
   endif()
 endif()
 
-if (BZIP2_FOUND AND NOT TARGET Bzip2::Bzip2)
-  add_library(Bzip2::Bzip2 UNKNOWN IMPORTED)
-  set_target_properties(Bzip2::Bzip2 PROPERTIES
+if (BZIP2_FOUND AND NOT TARGET BZip2::BZip2)
+  add_library(BZip2::BZip2 UNKNOWN IMPORTED)
+  set_target_properties(BZip2::BZip2 PROPERTIES
     IMPORTED_LOCATION "${BZIP2_LIBRARIES}"
     INTERFACE_INCLUDE_DIRECTORIES "${BZIP2_INCLUDE_DIR}"
   )
@@ -138,5 +143,5 @@ endif()
 
 # If we built a static EP, install it if required.
 if (BZIP2_STATIC_EP_FOUND AND TILEDB_INSTALL_STATIC_DEPS)
-  install_target_libs(Bzip2::Bzip2)
+  install_target_libs(BZip2::BZip2)
 endif()

--- a/cmake/Modules/FindBzip2_EP.cmake
+++ b/cmake/Modules/FindBzip2_EP.cmake
@@ -36,47 +36,48 @@ include(TileDBCommon)
 
 if(TILEDB_VCPKG)
   find_package(BZip2 REQUIRED)
-  set(BZIP2_FOUND TRUE)
-else()
-  # First check for a static version in the EP prefix.
-  find_library(BZIP2_LIBRARIES
-    NAMES
-      libbz2static${CMAKE_STATIC_LIBRARY_SUFFIX}
-      libbz2${CMAKE_STATIC_LIBRARY_SUFFIX}
+  install_target_libs(BZip2::BZip2)
+  return()
+endif()
+
+# First check for a static version in the EP prefix.
+find_library(BZIP2_LIBRARIES
+  NAMES
+    libbz2static${CMAKE_STATIC_LIBRARY_SUFFIX}
+    libbz2${CMAKE_STATIC_LIBRARY_SUFFIX}
+  PATHS ${TILEDB_EP_INSTALL_PREFIX}
+  PATH_SUFFIXES lib
+  NO_DEFAULT_PATH
+)
+
+if (BZIP2_LIBRARIES)
+  set(BZIP2_STATIC_EP_FOUND TRUE)
+  find_path(BZIP2_INCLUDE_DIR
+    NAMES bzlib.h
     PATHS ${TILEDB_EP_INSTALL_PREFIX}
-    PATH_SUFFIXES lib
+    PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )
-
-  if (BZIP2_LIBRARIES)
-    set(BZIP2_STATIC_EP_FOUND TRUE)
-    find_path(BZIP2_INCLUDE_DIR
-      NAMES bzlib.h
-      PATHS ${TILEDB_EP_INSTALL_PREFIX}
-      PATH_SUFFIXES include
-      NO_DEFAULT_PATH
-    )
-  elseif(NOT TILEDB_FORCE_ALL_DEPS)
-    set(BZIP2_STATIC_EP_FOUND FALSE)
-    # Static EP not found, search in system paths.
-    find_library(BZIP2_LIBRARIES
-      NAMES
-        bz2 libbz2
-      PATH_SUFFIXES lib bin
-      ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
-    find_path(BZIP2_INCLUDE_DIR
-      NAMES bzlib.h
-      PATH_SUFFIXES include
-      ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
-  endif()
-
-  include(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Bzip2
-    REQUIRED_VARS BZIP2_LIBRARIES BZIP2_INCLUDE_DIR
+elseif(NOT TILEDB_FORCE_ALL_DEPS)
+  set(BZIP2_STATIC_EP_FOUND FALSE)
+  # Static EP not found, search in system paths.
+  find_library(BZIP2_LIBRARIES
+    NAMES
+      bz2 libbz2
+    PATH_SUFFIXES lib bin
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+  )
+  find_path(BZIP2_INCLUDE_DIR
+    NAMES bzlib.h
+    PATH_SUFFIXES include
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Bzip2
+  REQUIRED_VARS BZIP2_LIBRARIES BZIP2_INCLUDE_DIR
+)
 
 if (NOT BZIP2_FOUND)
   if (TILEDB_SUPERBUILD)

--- a/cmake/Modules/FindLZ4_EP.cmake
+++ b/cmake/Modules/FindLZ4_EP.cmake
@@ -29,50 +29,55 @@
 #   - LZ4_INCLUDE_DIR, directory containing headers
 #   - LZ4_LIBRARIES, the LZ4 library path
 #   - LZ4_FOUND, whether LZ4 has been found
-#   - The LZ4::LZ4 imported target
+#   - The lz4::lz4 imported target
 
 # Include some common helper functions.
 include(TileDBCommon)
 
-# First check for a static version in the EP prefix.
-find_library(LZ4_LIBRARIES
-  NAMES
-    liblz4${CMAKE_STATIC_LIBRARY_SUFFIX}
-    liblz4_static${CMAKE_STATIC_LIBRARY_SUFFIX}
-    lz4${CMAKE_STATIC_LIBRARY_SUFFIX}
-  PATHS ${TILEDB_EP_INSTALL_PREFIX}
-  PATH_SUFFIXES lib
-  NO_DEFAULT_PATH
-)
-
-if (LZ4_LIBRARIES)
-  set(LZ4_STATIC_EP_FOUND TRUE)
-  find_path(LZ4_INCLUDE_DIR
-    NAMES lz4.h
-    PATHS ${TILEDB_EP_INSTALL_PREFIX}
-    PATH_SUFFIXES include
-    NO_DEFAULT_PATH
-  )
-elseif(NOT TILEDB_FORCE_ALL_DEPS)
-  set(LZ4_STATIC_EP_FOUND FALSE)
-  # Static EP not found, search in system paths.
+if(TILEDB_VCPKG)
+  find_package(lz4 REQUIRED)
+  set(LZ4_FOUND TRUE)
+else()
+  # First check for a static version in the EP prefix.
   find_library(LZ4_LIBRARIES
     NAMES
-      lz4 liblz4
-    PATH_SUFFIXES lib bin
-    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+      liblz4${CMAKE_STATIC_LIBRARY_SUFFIX}
+      liblz4_static${CMAKE_STATIC_LIBRARY_SUFFIX}
+      lz4${CMAKE_STATIC_LIBRARY_SUFFIX}
+    PATHS ${TILEDB_EP_INSTALL_PREFIX}
+    PATH_SUFFIXES lib
+    NO_DEFAULT_PATH
   )
-  find_path(LZ4_INCLUDE_DIR
-    NAMES lz4.h
-    PATH_SUFFIXES include
-    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+
+  if (LZ4_LIBRARIES)
+    set(LZ4_STATIC_EP_FOUND TRUE)
+    find_path(LZ4_INCLUDE_DIR
+      NAMES lz4.h
+      PATHS ${TILEDB_EP_INSTALL_PREFIX}
+      PATH_SUFFIXES include
+      NO_DEFAULT_PATH
+    )
+  elseif(NOT TILEDB_FORCE_ALL_DEPS)
+    set(LZ4_STATIC_EP_FOUND FALSE)
+    # Static EP not found, search in system paths.
+    find_library(LZ4_LIBRARIES
+      NAMES
+        lz4 liblz4
+      PATH_SUFFIXES lib bin
+      ${TILEDB_DEPS_NO_DEFAULT_PATH}
+    )
+    find_path(LZ4_INCLUDE_DIR
+      NAMES lz4.h
+      PATH_SUFFIXES include
+      ${TILEDB_DEPS_NO_DEFAULT_PATH}
+    )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZ4
+    REQUIRED_VARS LZ4_LIBRARIES LZ4_INCLUDE_DIR
   )
 endif()
-
-include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZ4
-  REQUIRED_VARS LZ4_LIBRARIES LZ4_INCLUDE_DIR
-)
 
 if (NOT LZ4_FOUND)
   if (TILEDB_SUPERBUILD)
@@ -116,9 +121,9 @@ endif()
 
 set(ignoreUnusedWarning "${TILEDB_LZ4_EP_BUILT}")
 
-if (LZ4_FOUND AND NOT TARGET LZ4::LZ4)
-  add_library(LZ4::LZ4 UNKNOWN IMPORTED)
-  set_target_properties(LZ4::LZ4 PROPERTIES
+if (LZ4_FOUND AND NOT TARGET lz4::lz4)
+  add_library(lz4::lz4 UNKNOWN IMPORTED)
+  set_target_properties(lz4::lz4 PROPERTIES
     IMPORTED_LOCATION "${LZ4_LIBRARIES}"
     INTERFACE_INCLUDE_DIRECTORIES "${LZ4_INCLUDE_DIR}"
   )
@@ -126,5 +131,5 @@ endif()
 
 # If we built a static EP, install it if required.
 if (LZ4_STATIC_EP_FOUND AND TILEDB_INSTALL_STATIC_DEPS)
-  install_target_libs(LZ4::LZ4)
+  install_target_libs(lz4::lz4)
 endif()

--- a/cmake/Modules/FindLZ4_EP.cmake
+++ b/cmake/Modules/FindLZ4_EP.cmake
@@ -36,48 +36,49 @@ include(TileDBCommon)
 
 if(TILEDB_VCPKG)
   find_package(lz4 REQUIRED)
-  set(LZ4_FOUND TRUE)
-else()
-  # First check for a static version in the EP prefix.
-  find_library(LZ4_LIBRARIES
-    NAMES
-      liblz4${CMAKE_STATIC_LIBRARY_SUFFIX}
-      liblz4_static${CMAKE_STATIC_LIBRARY_SUFFIX}
-      lz4${CMAKE_STATIC_LIBRARY_SUFFIX}
+  install_target_libs(lz4::lz4)
+  return()
+endif()
+
+# First check for a static version in the EP prefix.
+find_library(LZ4_LIBRARIES
+  NAMES
+    liblz4${CMAKE_STATIC_LIBRARY_SUFFIX}
+    liblz4_static${CMAKE_STATIC_LIBRARY_SUFFIX}
+    lz4${CMAKE_STATIC_LIBRARY_SUFFIX}
+  PATHS ${TILEDB_EP_INSTALL_PREFIX}
+  PATH_SUFFIXES lib
+  NO_DEFAULT_PATH
+)
+
+if (LZ4_LIBRARIES)
+  set(LZ4_STATIC_EP_FOUND TRUE)
+  find_path(LZ4_INCLUDE_DIR
+    NAMES lz4.h
     PATHS ${TILEDB_EP_INSTALL_PREFIX}
-    PATH_SUFFIXES lib
+    PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )
-
-  if (LZ4_LIBRARIES)
-    set(LZ4_STATIC_EP_FOUND TRUE)
-    find_path(LZ4_INCLUDE_DIR
-      NAMES lz4.h
-      PATHS ${TILEDB_EP_INSTALL_PREFIX}
-      PATH_SUFFIXES include
-      NO_DEFAULT_PATH
-    )
-  elseif(NOT TILEDB_FORCE_ALL_DEPS)
-    set(LZ4_STATIC_EP_FOUND FALSE)
-    # Static EP not found, search in system paths.
-    find_library(LZ4_LIBRARIES
-      NAMES
-        lz4 liblz4
-      PATH_SUFFIXES lib bin
-      ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
-    find_path(LZ4_INCLUDE_DIR
-      NAMES lz4.h
-      PATH_SUFFIXES include
-      ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
-  endif()
-
-  include(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZ4
-    REQUIRED_VARS LZ4_LIBRARIES LZ4_INCLUDE_DIR
+elseif(NOT TILEDB_FORCE_ALL_DEPS)
+  set(LZ4_STATIC_EP_FOUND FALSE)
+  # Static EP not found, search in system paths.
+  find_library(LZ4_LIBRARIES
+    NAMES
+      lz4 liblz4
+    PATH_SUFFIXES lib bin
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+  )
+  find_path(LZ4_INCLUDE_DIR
+    NAMES lz4.h
+    PATH_SUFFIXES include
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZ4
+  REQUIRED_VARS LZ4_LIBRARIES LZ4_INCLUDE_DIR
+)
 
 if (NOT LZ4_FOUND)
   if (TILEDB_SUPERBUILD)

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -30,7 +30,7 @@
 #   - ZSTD_INCLUDE_DIR, directory containing headers
 #   - ZSTD_LIBRARIES, the Zstd library path
 #   - ZSTD_FOUND, whether Zstd has been found
-#   - The zstd::libzstd imported target
+#   - The ${ZSTD_TARGET} imported target
 
 # Include some common helper functions.
 include(TileDBCommon)
@@ -38,9 +38,10 @@ include(TileDBCommon)
 if (TILEDB_VCPKG)
   find_package(zstd CONFIG REQUIRED)
   if (TARGET zstd::libzstd_static)
-    add_library(zstd::libzstd ALIAS zstd::libzstd_static)
+    set(ZSTD_TARGET zstd::libzstd_static)
+    set(ZSTD_STATIC_EP_FOUND TRUE)
   else()
-    add_library(zstd::libzstd ALIAS zstd::libzstd_shared)
+    set(ZSTD_TARGET zstd::libzstd_shared)
   endif()
   set(ZSTD_FOUND TRUE)
 else()
@@ -128,15 +129,16 @@ if (NOT ZSTD_FOUND)
   endif()
 endif()
 
-if (ZSTD_FOUND AND NOT TARGET zstd::libzstd)
+if (ZSTD_FOUND AND NOT ZSTD_TARGET)
   add_library(zstd::libzstd UNKNOWN IMPORTED)
   set_target_properties(zstd::libzstd PROPERTIES
     IMPORTED_LOCATION "${ZSTD_LIBRARIES}"
     INTERFACE_INCLUDE_DIRECTORIES "${ZSTD_INCLUDE_DIR}"
   )
+  set(ZSTD_TARGET zstd::libzstd)
 endif()
 
 # If we built a static EP, install it if required.
 if (ZSTD_STATIC_EP_FOUND AND TILEDB_INSTALL_STATIC_DEPS)
-  install_target_libs(zstd::libzstd)
+  install_target_libs(${ZSTD_TARGET})
 endif()

--- a/cmake/Modules/FindZstd_EP.cmake
+++ b/cmake/Modules/FindZstd_EP.cmake
@@ -39,51 +39,51 @@ if (TILEDB_VCPKG)
   find_package(zstd CONFIG REQUIRED)
   if (TARGET zstd::libzstd_static)
     set(ZSTD_TARGET zstd::libzstd_static)
-    set(ZSTD_STATIC_EP_FOUND TRUE)
   else()
     set(ZSTD_TARGET zstd::libzstd_shared)
   endif()
-  set(ZSTD_FOUND TRUE)
-else()
-  # First check for a static version in the EP prefix.
-  find_library(ZSTD_LIBRARIES
-    NAMES
-      libzstd${CMAKE_STATIC_LIBRARY_SUFFIX}
-      zstd_static${CMAKE_STATIC_LIBRARY_SUFFIX}
+  install_target_libs(${ZSTD_TARGET})
+  return()
+endif()
+
+# First check for a static version in the EP prefix.
+find_library(ZSTD_LIBRARIES
+  NAMES
+    libzstd${CMAKE_STATIC_LIBRARY_SUFFIX}
+    zstd_static${CMAKE_STATIC_LIBRARY_SUFFIX}
+  PATHS ${TILEDB_EP_INSTALL_PREFIX}
+  PATH_SUFFIXES lib
+  NO_DEFAULT_PATH
+)
+
+if (ZSTD_LIBRARIES)
+  set(ZSTD_STATIC_EP_FOUND TRUE)
+  find_path(ZSTD_INCLUDE_DIR
+    NAMES zstd.h
     PATHS ${TILEDB_EP_INSTALL_PREFIX}
-    PATH_SUFFIXES lib
+    PATH_SUFFIXES include
     NO_DEFAULT_PATH
   )
-
-  if (ZSTD_LIBRARIES)
-    set(ZSTD_STATIC_EP_FOUND TRUE)
-    find_path(ZSTD_INCLUDE_DIR
-      NAMES zstd.h
-      PATHS ${TILEDB_EP_INSTALL_PREFIX}
-      PATH_SUFFIXES include
-      NO_DEFAULT_PATH
-    )
-  elseif(NOT TILEDB_FORCE_ALL_DEPS)
-    set(ZSTD_STATIC_EP_FOUND FALSE)
-    # Static EP not found, search in system paths.
-    find_library(ZSTD_LIBRARIES
-      NAMES
-        zstd libzstd
-      PATH_SUFFIXES lib bin
-      ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
-    find_path(ZSTD_INCLUDE_DIR
-      NAMES zstd.h
-      PATH_SUFFIXES include
-      ${TILEDB_DEPS_NO_DEFAULT_PATH}
-    )
-  endif()
-
-  include(FindPackageHandleStandardArgs)
-  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Zstd
-    REQUIRED_VARS ZSTD_LIBRARIES ZSTD_INCLUDE_DIR
+elseif(NOT TILEDB_FORCE_ALL_DEPS)
+  set(ZSTD_STATIC_EP_FOUND FALSE)
+  # Static EP not found, search in system paths.
+  find_library(ZSTD_LIBRARIES
+    NAMES
+      zstd libzstd
+    PATH_SUFFIXES lib bin
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
+  )
+  find_path(ZSTD_INCLUDE_DIR
+    NAMES zstd.h
+    PATH_SUFFIXES include
+    ${TILEDB_DEPS_NO_DEFAULT_PATH}
   )
 endif()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Zstd
+  REQUIRED_VARS ZSTD_LIBRARIES ZSTD_INCLUDE_DIR
+)
 
 if (NOT ZSTD_FOUND)
   if (TILEDB_SUPERBUILD)

--- a/experimental/experimental_examples/cpp_api/CMakeLists.txt
+++ b/experimental/experimental_examples/cpp_api/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(Bzip2_EP REQUIRED)
 function(build_TileDB_experimental_example_cppapi TARGET)
   add_executable(${TARGET}_exp_cpp EXCLUDE_FROM_ALL ${TARGET}.cc)
   target_link_libraries(${TARGET}_exp_cpp PUBLIC local_install tiledb_shared)
-  target_link_libraries(${TARGET}_exp_cpp PUBLIC Bzip2::Bzip2)
+  target_link_libraries(${TARGET}_exp_cpp PUBLIC BZip2::BZip2)
   if (NOT WIN32)
     # On Linux, must explicitly link -lpthread -ldl in order for static linking
     # to libzstd or libcurl to work.

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -697,7 +697,7 @@ target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
     BZip2::BZip2
     lz4::lz4
     ZLIB::ZLIB
-    zstd::libzstd
+    ${ZSTD_TARGET}
     libmagic
 )
 if (TILEDB_VCPKG)
@@ -990,7 +990,7 @@ if (TILEDB_STATIC)
   append_dep_lib(BZip2::BZip2)
   append_dep_lib(lz4::lz4)
   append_dep_lib(ZLIB::ZLIB)
-  append_dep_lib(zstd::libzstd)
+  append_dep_lib(${ZSTD_TARGET})
   append_dep_lib(CapnProto::capnp)
   append_dep_lib(CapnProto::capnp-json)
   append_dep_lib(CapnProto::kj)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -694,10 +694,10 @@ find_package(Zstd_EP REQUIRED)
 find_package(Magic_EP REQUIRED)
 target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
   INTERFACE
-    Bzip2::Bzip2
-    LZ4::LZ4
+    BZip2::BZip2
+    lz4::lz4
     ZLIB::ZLIB
-    Zstd::Zstd
+    zstd::libzstd
     libmagic
 )
 if (TILEDB_VCPKG)
@@ -987,10 +987,10 @@ if (TILEDB_STATIC)
     endif()
   endmacro()
 
-  append_dep_lib(Bzip2::Bzip2)
-  append_dep_lib(LZ4::LZ4)
+  append_dep_lib(BZip2::BZip2)
+  append_dep_lib(lz4::lz4)
   append_dep_lib(ZLIB::ZLIB)
-  append_dep_lib(Zstd::Zstd)
+  append_dep_lib(zstd::libzstd)
   append_dep_lib(CapnProto::capnp)
   append_dep_lib(CapnProto::capnp-json)
   append_dep_lib(CapnProto::kj)

--- a/tiledb/sm/compressors/CMakeLists.txt
+++ b/tiledb/sm/compressors/CMakeLists.txt
@@ -40,7 +40,7 @@ commence(object_library compressors)
     find_package(LZ4_EP REQUIRED)
     find_package(Zlib_EP REQUIRED)
     find_package(Zstd_EP REQUIRED)
-    this_target_link_libraries(BZip2::BZip2 lz4::lz4 ZLIB::ZLIB zstd::libzstd)
+    this_target_link_libraries(BZip2::BZip2 lz4::lz4 ZLIB::ZLIB ${ZSTD_TARGET})
 conclude(object_library)
 
 #

--- a/tiledb/sm/compressors/CMakeLists.txt
+++ b/tiledb/sm/compressors/CMakeLists.txt
@@ -40,7 +40,7 @@ commence(object_library compressors)
     find_package(LZ4_EP REQUIRED)
     find_package(Zlib_EP REQUIRED)
     find_package(Zstd_EP REQUIRED)
-    this_target_link_libraries(Bzip2::Bzip2 LZ4::LZ4 ZLIB::ZLIB Zstd::Zstd)
+    this_target_link_libraries(BZip2::BZip2 lz4::lz4 ZLIB::ZLIB zstd::libzstd)
 conclude(object_library)
 
 #


### PR DESCRIPTION
All of our compression libraries provide native CMake integration with `find_package`. This PR makes use of it when vcpkg is enabled.

---
TYPE: BUILD
DESC: Use the provided CMake packages to import the compression libraries when vcpkg is enabled.