### PR TITLE
Add include array to cpp_api type.h

### DIFF
--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -37,6 +37,7 @@
 
 #include "tiledb.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
The file `type.h` in `tiledb/sm/cpp_api` used `std::array` but does not `#include <array>`.  This causes failure when compiling with `clang++-14` on ubuntu.  

Added `#include <array>` to `tiledb/sm/cpp_api/type.h`.

---
TYPE: BUG
DESC: Added `#include <array>` to `tiledb/sm/cpp_api/type.h`.
