### PR TITLE
Groups: don't try to load metadata on client open requests.

### DIFF
--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -166,7 +166,12 @@ Status group_details_to_capnp(
   }
 
   Metadata* metadata;
-  RETURN_NOT_OK(group->metadata(&metadata));
+  if (group->group_uri().is_tiledb()) {
+    metadata = const_cast<Metadata*>(group->metadata());
+  } else {
+    RETURN_NOT_OK(group->metadata(&metadata));
+  }
+
   if (metadata->num()) {
     auto group_metadata_builder = group_details_builder->initMetadata();
     RETURN_NOT_OK(metadata_to_capnp(metadata, &group_metadata_builder));


### PR DESCRIPTION
This change makes sure that the client doesn't try to load the group metadata client side when doing a REST request that will end up returning the group metadata. This would actually end up causing two REST requests, one to the load metadata route, then one to the group open route.

---
TYPE: NO_HISTORY
DESC: Groups: don't try to load metadata on client open requests.
