### PR TITLE
Null count aggregate: only load validity tiles when possible.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -131,7 +131,9 @@ struct CppAggregatesFx {
       std::vector<uint8_t>& a1_validity,
       const bool validate_count = true);
   void validate_tiles_read(Query& query, bool is_count = false);
+  void validate_tiles_read_null_count(Query& query);
   void validate_tiles_read_var(Query& query);
+  void validate_tiles_read_null_count_var(Query& query);
   void remove_array();
   void remove_array(const std::string& array_name);
   bool is_array(const std::string& array_name);
@@ -1139,24 +1141,28 @@ void CppAggregatesFx<T>::validate_data_var(
   }
 }
 
+uint64_t get_stat(std::string name, std::string& stats) {
+  // Parse num_tiles_read from the stats.
+  std::string to_find =
+      "\"Context.StorageManager.Query.Reader." + name + "\": ";
+  auto start_pos = stats.find(to_find);
+
+  if (start_pos != std::string::npos) {
+    start_pos += to_find.length();
+    auto end_pos = stats.find("\n", start_pos);
+    auto str = stats.substr(start_pos, end_pos - start_pos);
+    return std::stoull(str);
+  }
+
+  return 0;
+}
+
 template <class T>
 void CppAggregatesFx<T>::validate_tiles_read(Query& query, bool is_count) {
   // Validate the number of tiles read.
   auto stats = query.stats();
 
-  // Parse num_tiles_read from the stats.
-  std::string to_find =
-      "\"Context.StorageManager.Query.Reader.num_tiles_read\": ";
-  auto start_pos = stats.find(to_find);
-
-  uint64_t num_tiles_read = 0;
-  if (start_pos != std::string::npos) {
-    start_pos += to_find.length();
-    auto end_pos = stats.find("\n", start_pos);
-    auto str = stats.substr(start_pos, end_pos - start_pos);
-    num_tiles_read = std::stoull(str);
-  }
-
+  uint64_t num_tiles_read = get_stat("num_tiles_read", stats);
   uint64_t expected_num_tiles_read;
   if (dense_) {
     // Dense has 5 tiles. If we request data or have a query condition, we'll
@@ -1164,21 +1170,30 @@ void CppAggregatesFx<T>::validate_tiles_read(Query& query, bool is_count) {
     if (request_data_ || set_qc_) {
       expected_num_tiles_read = 5;
     } else if (set_ranges_) {
-      // If we request range, we split all tiles, we'll have to read all.
+      // If we request range, we split all tiles, we'll have to read all instead
+      // of using fragment metadata.
       expected_num_tiles_read = is_count ? 0 : 5;
     } else {
-      // One space tile has two result tiles, we'll have to read them.
+      // One space tile has two result tiles, we'll have to read them instead of
+      // using fragment metadata.
       expected_num_tiles_read = is_count ? 0 : 2;
     }
   } else {
     if (request_data_) {
+      // Sparse has 5 tiles * 3 (2 dims/1 attr). One of them will be filtered
+      // out when we set ranges.
       if (set_ranges_) {
+        // If we set ranges, we filter out one of the 5 tiles.
         expected_num_tiles_read = 12;
       } else {
+        // Everything is read.
         expected_num_tiles_read = 15;
       }
     } else {
       if (set_ranges_) {
+        // For count, we only read dimension tiles, one of which is filtered so
+        // we read 2 dims * 4 tiles. For the attribute, we can process 2 tiles
+        // with duplicates and 1 without using the fragment metadata.
         if (allow_dups_) {
           expected_num_tiles_read = is_count ? 8 : 10;
         } else {
@@ -1186,8 +1201,13 @@ void CppAggregatesFx<T>::validate_tiles_read(Query& query, bool is_count) {
         }
       } else {
         if (allow_dups_) {
+          // No ranges, array with duplicates can do it all with fragment
+          // metadata only.
           expected_num_tiles_read = 0;
         } else {
+          // Arrays without duplicates need to run deduplication, so we read the
+          // dimension tiles (2 dims * 5 tiles). Only one tile for the attribute
+          // can be processed with fragment metadata only.
           expected_num_tiles_read = is_count ? 10 : 14;
         }
       }
@@ -1198,23 +1218,76 @@ void CppAggregatesFx<T>::validate_tiles_read(Query& query, bool is_count) {
 }
 
 template <class T>
+void CppAggregatesFx<T>::validate_tiles_read_null_count(Query& query) {
+  // Validate the number of tiles read.
+  auto stats = query.stats();
+
+  uint64_t num_tiles_alloced = get_stat("tiles_allocated", stats);
+  uint64_t num_tiles_unfiltered = get_stat("tiles_unfiltered", stats);
+  uint64_t expected_num_tiles;
+  if (dense_) {
+    // Dense has 5 tiles. If we request data or have a query condition, we'll
+    // read all of them.
+    if (request_data_ || set_qc_) {
+      expected_num_tiles = 10;
+    } else if (set_ranges_) {
+      // If we request range, we split all tiles, we'll have to read all, but
+      // only nullable tiles.
+      expected_num_tiles = 5;
+    } else {
+      // One space tile has two result tiles, we'll have to read them.
+      expected_num_tiles = 2;
+    }
+  } else {
+    // Sparse has 5 tiles * 4 (2 dims/1 attr (fixed tile + nullable tile)). One
+    // of them will be filtered out when we set ranges.
+    if (request_data_) {
+      if (set_ranges_) {
+        // If we set ranges, we filter out one of the 5 tiles.
+        expected_num_tiles = 16;
+      } else {
+        // Everything is read.
+        expected_num_tiles = 20;
+      }
+    } else {
+      if (set_ranges_) {
+        // We read dimension tiles to filter ranges, one of which is filtered so
+        // we read 2 dims * 4 tiles. For the attribute, we can process 2 tiles
+        // with duplicates and 1 without using the fragment metadata. Note that
+        // we only add one per space tile for the attribute because we only read
+        // the validity tile.
+        if (allow_dups_) {
+          expected_num_tiles = 10;
+        } else {
+          expected_num_tiles = 11;
+        }
+      } else {
+        if (allow_dups_) {
+          // No ranges, array with duplicates can do it all with fragment
+          // metadata only.
+          expected_num_tiles = 0;
+        } else {
+          // Arrays without duplicates need to run deduplication, so we read the
+          // dimension tiles (2 dims * 5 tiles). Only one tile for the attribute
+          // can be processed with fragment metadata only. Note that we only add
+          // one per space tile for the attribute because we only read the
+          // validity tile.
+          expected_num_tiles = 14;
+        }
+      }
+    }
+  }
+
+  CHECK(num_tiles_alloced == expected_num_tiles);
+  CHECK(num_tiles_unfiltered == expected_num_tiles);
+}
+
+template <class T>
 void CppAggregatesFx<T>::validate_tiles_read_var(Query& query) {
   // Validate the number of tiles read.
   auto stats = query.stats();
 
-  // Parse num_tiles_read from the stats.
-  std::string to_find =
-      "\"Context.StorageManager.Query.Reader.num_tiles_read\": ";
-  auto start_pos = stats.find(to_find);
-
-  uint64_t num_tiles_read = 0;
-  if (start_pos != std::string::npos) {
-    start_pos += to_find.length();
-    auto end_pos = stats.find("\n", start_pos);
-    auto str = stats.substr(start_pos, end_pos - start_pos);
-    num_tiles_read = std::stoull(str);
-  }
-
+  uint64_t num_tiles_read = get_stat("num_tiles_read", stats);
   uint64_t expected_num_tiles_read;
   if (dense_) {
     // Dense has 5 tiles. If we request data or have a query condition or set
@@ -1226,7 +1299,11 @@ void CppAggregatesFx<T>::validate_tiles_read_var(Query& query) {
       expected_num_tiles_read = 2;
     }
   } else {
+    // Sparse has 4 tiles * 3 (2 dims/1 attr). One of them will be filtered
+    // out when we set ranges.
     if (request_data_) {
+      // We request data so everything is read. With ranges we read 3 tiles,
+      // without 4. 2 dims, 1 attr, means we have to multiply by 3.
       if (set_ranges_) {
         expected_num_tiles_read = 9;
       } else {
@@ -1234,12 +1311,20 @@ void CppAggregatesFx<T>::validate_tiles_read_var(Query& query) {
       }
     } else {
       if (set_ranges_) {
+        // To process ranges, we read 3 tiles * 2 dims at a minimum. For the
+        // attribute, the array with duplicates can process one tile with the
+        // fragment metadata, which is not the case for the array with no
+        // duplicates.
         if (allow_dups_) {
           expected_num_tiles_read = 8;
         } else {
           expected_num_tiles_read = 9;
         }
       } else {
+        // No ranges, the array with no duplicates can do it all with only
+        // fragment metadata. The array with no duplicates cannot because the
+        // cell slab structure never includes a full tile. It needs to read all
+        // coordinate tiles and all attribute tiles.
         if (allow_dups_) {
           expected_num_tiles_read = 0;
         } else {
@@ -1250,6 +1335,71 @@ void CppAggregatesFx<T>::validate_tiles_read_var(Query& query) {
   }
 
   CHECK(num_tiles_read == expected_num_tiles_read);
+}
+
+template <class T>
+void CppAggregatesFx<T>::validate_tiles_read_null_count_var(Query& query) {
+  // Validate the number of tiles read.
+  auto stats = query.stats();
+
+  uint64_t num_tiles_alloced = get_stat("tiles_allocated", stats);
+  uint64_t num_tiles_unfiltered = get_stat("tiles_unfiltered", stats);
+  uint64_t expected_num_tiles;
+  if (dense_) {
+    // Dense has 5 tiles. If we request data or have a query condition we'll
+    // read all of them.
+    if (request_data_ || set_qc_) {
+      expected_num_tiles = 15;
+    } else if (set_ranges_) {
+      // If we set ranges, we only read the validity tiles.
+      expected_num_tiles = 5;
+    } else {
+      // One space tile has two result tiles, we'll have to read them.
+      expected_num_tiles = 2;
+    }
+  } else {
+    // Sparse has 4 tiles * 5 (2 dims/1 attr (offset tile + var tile + nullable
+    // tile)). One of them will be filtered out when we set ranges.
+    if (request_data_) {
+      // We request data so everything is read. With ranges we read 3 tiles,
+      // without 4. 2 dims, 1 nullable var attr, means we have to multiply by 5.
+      if (set_ranges_) {
+        expected_num_tiles = 15;
+      } else {
+        expected_num_tiles = 20;
+      }
+    } else {
+      if (set_ranges_) {
+        // To process ranges, we read 3 tiles * 2 dims at a minimum. For the
+        // attribute, the array with duplicates can process one tile with the
+        // fragment metadata, which is not the case for the array with no
+        // duplicates. Note that we only add one per space tile for the
+        // attribute because we only read the validity tile.
+        if (allow_dups_) {
+          expected_num_tiles = 8;
+        } else {
+          // 3 * 2 for dims, 3 * 1 for attr.
+          expected_num_tiles = 9;
+        }
+      } else {
+        // No ranges, the array with no duplicates can do it all with only
+        // fragment metadata. The array with no duplicates cannot because the
+        // cell slab structure never includes a full tile. It needs to read all
+        // coordinate tiles and all attribute tiles. Note that we only add one
+        // per space tile for the attribute because we only read the validity
+        // tile.
+        if (allow_dups_) {
+          expected_num_tiles = 0;
+        } else {
+          // 4 * 2 for dims, 4 * 1 for attr.
+          expected_num_tiles = 12;
+        }
+      }
+    }
+  }
+
+  CHECK(num_tiles_alloced == expected_num_tiles);
+  CHECK(num_tiles_unfiltered == expected_num_tiles);
 }
 
 template <class T>
@@ -1973,6 +2123,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
           }
 
           CppAggregatesFx<T>::validate_tiles_read(query);
+          CppAggregatesFx<T>::validate_tiles_read_null_count(query);
         }
       }
     }
@@ -2068,6 +2219,7 @@ TEST_CASE_METHOD(
           }
 
           validate_tiles_read_var(query);
+          validate_tiles_read_null_count_var(query);
         }
       }
     }

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1664,8 +1664,8 @@ Status Reader::compute_result_coords(
     std::vector<std::string> timestamps = {constants::timestamps};
     load_tile_offsets(
         read_state_.partitioner_.subarray().relevant_fragments(), timestamps);
-    RETURN_CANCEL_OR_ERROR(
-        read_and_unfilter_attribute_tiles(timestamps, tmp_result_tiles));
+    RETURN_CANCEL_OR_ERROR(read_and_unfilter_attribute_tiles(
+        NameToLoad::from_string_vec(timestamps), tmp_result_tiles));
   }
 
   // Read and unfilter delete timestamps.
@@ -1674,8 +1674,8 @@ Status Reader::compute_result_coords(
     load_tile_offsets(
         read_state_.partitioner_.subarray().relevant_fragments(),
         delete_timestamps);
-    RETURN_CANCEL_OR_ERROR(
-        read_and_unfilter_attribute_tiles(delete_timestamps, tmp_result_tiles));
+    RETURN_CANCEL_OR_ERROR(read_and_unfilter_attribute_tiles(
+        NameToLoad::from_string_vec(delete_timestamps), tmp_result_tiles));
   }
 
   // Compute the read coordinates for all fragments for each subarray range.

--- a/tiledb/sm/query/readers/aggregators/count_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/count_aggregator.h
@@ -149,6 +149,11 @@ class CountAggregator : public CountAggregatorBase<NonNull> {
   std::string aggregate_name() override {
     return constants::aggregate_count_str;
   }
+
+  /** Returns if the aggregation is for validity only data. */
+  bool aggregation_validity_only() override {
+    return false;
+  }
 };
 
 class NullCountAggregator : public CountAggregatorBase<Null>,
@@ -172,6 +177,11 @@ class NullCountAggregator : public CountAggregatorBase<Null>,
   /** Returns name of the aggregate. */
   std::string aggregate_name() override {
     return constants::aggregate_null_count_str;
+  }
+
+  /** Returns if the aggregation is for validity only data. */
+  bool aggregation_validity_only() override {
+    return true;
   }
 
  private:

--- a/tiledb/sm/query/readers/aggregators/iaggregator.h
+++ b/tiledb/sm/query/readers/aggregators/iaggregator.h
@@ -72,6 +72,9 @@ class IAggregator {
   /** Returns if the aggregation is nullable or not. */
   virtual bool aggregation_nullable() = 0;
 
+  /** Returns if the aggregation is for validity only data. */
+  virtual bool aggregation_validity_only() = 0;
+
   /**
    * Validate the result buffer.
    *

--- a/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/min_max_aggregator.h
@@ -150,6 +150,11 @@ class ComparatorAggregator : public ComparatorAggregatorBase<T>,
     return ComparatorAggregatorBase<T>::field_info_.is_nullable_;
   }
 
+  /** Returns if the aggregation is for validity only data. */
+  bool aggregation_validity_only() override {
+    return false;
+  }
+
   /** Returns if the aggregate needs to be recomputed on overflow. */
   bool need_recompute_on_overflow() override {
     return false;

--- a/tiledb/sm/query/readers/aggregators/sum_aggregator.h
+++ b/tiledb/sm/query/readers/aggregators/sum_aggregator.h
@@ -86,6 +86,11 @@ class SumWithCountAggregator : public InputFieldValidator,
     return field_info_.is_nullable_;
   }
 
+  /** Returns if the aggregation is for validity only data. */
+  bool aggregation_validity_only() override {
+    return false;
+  }
+
   /** Returns if the aggregate needs to be recomputed on overflow. */
   bool need_recompute_on_overflow() override {
     return true;

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -278,19 +278,6 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       ResultTile::TileTuple* tile_tuple,
       optional<void*> bitmap_data);
 
-  /** Returns wether the field is for aggregation only or not. */
-  bool aggregate_only(const std::string& name) const {
-    if (condition_.has_value() && condition_->field_names().count(name) != 0) {
-      return false;
-    }
-
-    if (buffers_.count(name) != 0) {
-      return false;
-    }
-
-    return true;
-  }
-
   /**
    * Returns wether or not we can aggregate the tile with only the fragment
    * metadata.

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -153,9 +153,10 @@ class FilteredData {
    * @param result_tiles Sorted list (per fragment/tile index) of result tiles.
    * Only the fragment index and tile index of each result tiles is used here.
    * Nothing is mutated inside of the vector.
-   * @param name Name of the attribute.
-   * @param var_sized Is the attribute var sized?
-   * @param nullable Is the attribute nullable?
+   * @param name Name of the field.
+   * @param var_sized Is the field var sized?
+   * @param nullable Is the field nullable?
+   * @param validity_only Is the field read for validity only?
    * @param storage_manager Storage manager.
    * @param read_tasks Read tasks to queue new tasks on for new data blocks.
    */
@@ -169,6 +170,7 @@ class FilteredData {
       const std::string& name,
       const bool var_sized,
       const bool nullable,
+      const bool validity_only,
       StorageManager* storage_manager,
       std::vector<ThreadPool::Task>& read_tasks)
       : name_(name)
@@ -180,6 +182,8 @@ class FilteredData {
     if (result_tiles.size() == 0) {
       return;
     }
+
+    uint64_t tiles_allocated = 0;
 
     // Store data on the datablock in progress for fixed, var and nullable data.
     std::optional<unsigned> current_frag_idx{nullopt};
@@ -199,18 +203,22 @@ class FilteredData {
 
       // Make new blocks, if required as we go for fixed, var and nullable data.
       auto fragment{fragment_metadata[rt->frag_idx()].get()};
-      make_new_block_if_required(
-          fragment,
-          min_batch_size,
-          max_batch_size,
-          min_batch_gap,
-          current_frag_idx,
-          current_fixed_offset,
-          current_fixed_size,
-          rt,
-          TileType::FIXED);
+      if (!validity_only) {
+        tiles_allocated++;
+        make_new_block_if_required(
+            fragment,
+            min_batch_size,
+            max_batch_size,
+            min_batch_gap,
+            current_frag_idx,
+            current_fixed_offset,
+            current_fixed_size,
+            rt,
+            TileType::FIXED);
+      }
 
-      if (var_sized) {
+      if (var_sized && !validity_only) {
+        tiles_allocated++;
         make_new_block_if_required(
             fragment,
             min_batch_size,
@@ -224,6 +232,7 @@ class FilteredData {
       }
 
       if (nullable) {
+        tiles_allocated++;
         make_new_block_if_required(
             fragment,
             min_batch_size,
@@ -257,6 +266,8 @@ class FilteredData {
           *current_frag_idx, current_nullable_offset, current_nullable_size);
       queue_last_block_for_read(TileType::NULLABLE);
     }
+
+    reader.stats()->add_counter("tiles_allocated", tiles_allocated);
 
     current_fixed_data_block_ = fixed_data_blocks_.begin();
     current_var_data_block_ = var_data_blocks_.begin();

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -91,11 +91,12 @@ class ResultTile {
         std::string name,
         const bool var_size,
         const bool nullable,
+        const bool validity_only,
         const uint64_t tile_idx)
-        : tile_size_(fragment->tile_size(name, tile_idx))
+        : tile_size_(validity_only ? 0 : fragment->tile_size(name, tile_idx))
         , tile_persisted_size_(fragment->persisted_tile_size(name, tile_idx))
         , tile_var_size_(
-              var_size ?
+              var_size && !validity_only ?
                   std::optional(fragment->tile_var_size(name, tile_idx)) :
                   std::nullopt)
         , tile_var_persisted_size_(

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -2117,6 +2117,7 @@ void SparseGlobalOrderReader<BitmapType>::process_aggregates(
     std::vector<uint64_t>& cell_offsets,
     std::vector<ResultCellSlab>& result_cell_slabs) {
   auto& aggregates = aggregates_[name];
+  const bool validity_only = null_count_aggregate_only(name);
 
   bool var_sized = false;
   bool nullable = false;
@@ -2163,7 +2164,7 @@ void SparseGlobalOrderReader<BitmapType>::process_aggregates(
           // Compute aggregate.
           AggregateBuffer aggregate_buffer{make_aggregate_buffer(
               name,
-              var_sized,
+              var_sized && !validity_only,
               nullable,
               cell_val_num,
               min_pos,

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -671,19 +671,6 @@ class SparseIndexReaderBase : public ReaderBase {
   template <class ResultTileType, class BitmapType>
   void apply_query_condition(std::vector<ResultTile*>& result_tiles);
 
-  /** Returns wether the field is for aggregation only or not. */
-  bool aggregate_only(const std::string& name) const {
-    if (qc_loaded_attr_names_set_.count(name) != 0) {
-      return false;
-    }
-
-    if (buffers_.count(name) != 0) {
-      return false;
-    }
-
-    return true;
-  }
-
   /**
    * Read and unfilter as many attributes as can fit in the memory budget and
    * return the names loaded in 'names_to_copy'. Also keep the 'buffer_idx'

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -1931,6 +1931,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::process_aggregates(
     std::vector<uint64_t>& cell_offsets,
     std::vector<ResultTile*>& result_tiles) {
   auto& aggregates = aggregates_[name];
+  const bool validity_only = null_count_aggregate_only(name);
 
   bool var_sized = false;
   bool nullable = false;
@@ -1988,7 +1989,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::process_aggregates(
           // Compute aggregate.
           AggregateBuffer aggregate_buffer{make_aggregate_buffer(
               name,
-              var_sized,
+              var_sized && !validity_only,
               nullable,
               cell_val_num,
               count_bitmap,


### PR DESCRIPTION
This will only read/unfilter the validity tile when a field is required for null count aggregation only.

---
TYPE: IMPROVEMENT
DESC: Null count aggregate: only load validity tiles when possible.
