### PR TITLE
Wrap scandir in an excepion safe wrapper.

### DIFF
--- a/tiledb/common/heap_memory.h
+++ b/tiledb/common/heap_memory.h
@@ -136,6 +136,16 @@ struct TileDBUniquePtrDeleter {
 template <class T>
 using tiledb_unique_ptr = std::unique_ptr<T, TileDBUniquePtrDeleter<T>>;
 
+/** Unique pointer with std::free as a deleter. */
+struct TileDBFreeDeleter {
+  void operator()(void* const p) const {
+    std::free(p);
+  }
+};
+
+template <class T>
+using tiledb_unique_c_ptr = std::unique_ptr<T, TileDBFreeDeleter>;
+
 }  // namespace common
 }  // namespace tiledb
 

--- a/tiledb/sm/filesystem/posix_directory_entries.h
+++ b/tiledb/sm/filesystem/posix_directory_entries.h
@@ -1,0 +1,122 @@
+/**
+ * @file   posix_directory_entries.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file includes a wrapper class for the `scandir` API for posix.
+ */
+
+#ifndef TILEDB_POSIX_DIRECTORY_ENTRIES_H
+#define TILEDB_POSIX_DIRECTORY_ENTRIES_H
+
+#ifndef _WIN32
+
+#include "tiledb/common/common.h"
+
+#include <dirent.h>
+
+using namespace tiledb::common;
+
+namespace tiledb {
+namespace sm {
+
+/**
+ * This is a wrapper for the scandir function on posix. It ensures that all the
+ * memory allocated by the call is freed when the object goes out of scope.
+ */
+class PosixDirectoryEntries {
+ public:
+  /* ********************************* */
+  /*            CONSTRUCTORS           */
+  /* ********************************* */
+
+  /**
+   * @brief Construct a new Posix Directory Listing object.
+   *
+   * @param directory_path Path to use for listing.
+   */
+  PosixDirectoryEntries(const std::string directory_path) {
+    // Make the call to scandir.
+    dirent** directory_entries;
+    int num_entries =
+        scandir(directory_path.c_str(), &directory_entries, NULL, alphasort);
+
+    if (num_entries < 0) {
+      throw std::runtime_error(
+          std::string("Cannot list files in directory '") + directory_path +
+          "'; " + strerror(errno));
+    }
+
+    // Paths contains an array that needs to be freed, put it in a unique
+    // pointer that will call std::free on destruction.
+    directory_entries_.reset(directory_entries);
+
+    // Reserve can throw, but that means we are out of memory, so we don't clean
+    // up here.
+    directory_entries_pointers_.reserve(num_entries);
+
+    // Put every pointers in `paths` in it's own unique pointer that will call
+    // std::free on desctuction of this object.
+    for (int i = 0; i < num_entries; i++) {
+      directory_entries_pointers_.emplace_back(directory_entries[i]);
+    }
+  }
+
+  /* ********************************* */
+  /*               API                 */
+  /* ********************************* */
+
+  /** Get the directory entry at index `idx` */
+  const dirent& operator[](size_t idx) const {
+    return *directory_entries_pointers_[idx].get();
+  }
+
+  /** Get the size of the listing. */
+  size_t size() {
+    return directory_entries_pointers_.size();
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /**
+   * Unique pointer that will free the directory entries array on destruction.
+   */
+  tiledb_unique_c_ptr<dirent*> directory_entries_;
+
+  /** Vector that holds unique pointers to each directory entry. */
+  std::vector<tiledb_unique_c_ptr<dirent>> directory_entries_pointers_;
+};
+
+}  // namespace sm
+}  // namespace tiledb
+
+#endif  // !_WIN32
+
+#endif  // TILEDB_POSIX_DIRECTORY_ENTRIES_H

--- a/tiledb/sm/filesystem/test/CMakeLists.txt
+++ b/tiledb/sm/filesystem/test/CMakeLists.txt
@@ -27,7 +27,10 @@ include(unit_test)
 
 commence(unit_test vfs)
     this_target_object_libraries(vfs)
-    this_target_sources(main.cc unit_uri.cc)
+    this_target_sources(main.cc unit_posix_directory_entries.cc unit_uri.cc)
+    this_target_compile_definitions(vfs PRIVATE
+        -DTILEDB_TEST_INPUTS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../../../test/inputs"
+    )
 conclude(unit_test)
 
 commence(unit_test vfs_read_log_modes)

--- a/tiledb/sm/filesystem/test/unit_posix_directory_entries.cc
+++ b/tiledb/sm/filesystem/test/unit_posix_directory_entries.cc
@@ -1,0 +1,84 @@
+/**
+ * @file unit_posix_directory_entries.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the posix directory entries class.
+ */
+
+#include <test/support/tdb_catch.h>
+#include "../posix_directory_entries.h"
+
+#include <iostream>
+
+using namespace tiledb::sm;
+
+#ifndef _WIN32
+
+static const std::string arrays_dir =
+    std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays";
+
+TEST_CASE(
+    "Posix directory entries: invalid directory",
+    "[posix][directory-entries]") {
+  CHECK_THROWS_WITH(
+      PosixDirectoryEntries(arrays_dir + "1"),
+      Catch::Matchers::ContainsSubstring("Cannot list files in directory"));
+}
+
+TEST_CASE(
+    "Posix directory entries: directories", "[posix][directory-entries]") {
+  PosixDirectoryEntries entries(arrays_dir);
+  std::unordered_set<std::string> expected_dirs = {
+      "dense_array_v1_3_0", "non_split_coords_v1_4_0"};
+  size_t found = 0;
+  for (size_t i = 0; i < entries.size(); i++) {
+    if (expected_dirs.count(entries[i].d_name) != 0 &&
+        entries[i].d_type == DT_DIR) {
+      found++;
+    }
+  }
+
+  CHECK(found == 2);
+}
+
+TEST_CASE("Posix directory entries: files", "[posix][directory-entries]") {
+  PosixDirectoryEntries entries(arrays_dir + "/dense_array_v1_3_0");
+  std::unordered_set<std::string> expected_files = {
+      "__array_schema.tdb", "__lock.tdb"};
+  size_t found = 0;
+  for (size_t i = 0; i < entries.size(); i++) {
+    if (expected_files.count(entries[i].d_name) != 0 &&
+        entries[i].d_type == DT_REG) {
+      found++;
+    }
+  }
+
+  CHECK(found == 2);
+}
+
+#endif  // !_WIN32

--- a/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
+++ b/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
@@ -1,5 +1,5 @@
 /**
- * @file unit-vfs-read-log-modes.cc
+ * @file unit_vfs_read_log_modes.cc
  *
  * @section LICENSE
  *


### PR DESCRIPTION
This wraps calls to the scandir posix API in a class so that the objects created by the API are freed on destruction.

The class only exposes an index operator and a size API to get access to the underlying dirent structures. Note that no iterator is provided to enable range based loops as this would overcomplicate the class, which will only be used in a handful of places.

---
TYPE: FEATURE
DESC: Wrap scandir in an excepion safe wrapper.
