### PR TITLE
Remove tests against hidden libwebp symbols in link_webp_test1.cc

### DIFF
--- a/tiledb/sm/compressors/test/link_webp_test1.cc
+++ b/tiledb/sm/compressors/test/link_webp_test1.cc
@@ -130,16 +130,9 @@ int main(int argc, const char* argv[]) {
     // *** turns out, there is -NO- symbol in webpdecoder that is not also in
     // webp! left here anyway, in case libraries are ever de-dupped.
     const int dec_version = WebPGetDecoderVersion();
-    auto vp8l_dec = VP8LNew();
-    VP8LClear(vp8l_dec);
 
     VP8StatusCode status;
     WebPDecoderOptions webpdecoptions;
-    WebPDecBuffer webpdec_buffer;
-    status = WebPAllocateDecBuffer(512, 512, &webpdecoptions, &webpdec_buffer);
-    if (status == VP8_STATUS_OK) {
-      WebPFreeDecBuffer(&webpdec_buffer);
-    }
 
     // webpdemux
     const int demux_version = WebPGetDemuxVersion();

--- a/tiledb/sm/compressors/test/link_webp_test1.cc
+++ b/tiledb/sm/compressors/test/link_webp_test1.cc
@@ -98,15 +98,7 @@ uint64_t reference_a_value(uint64_t v) {
 
 extern "C" int WebPGetDemuxVersion(void);
 extern "C" int WebPGetMuxVersion(void);
-extern "C" VP8StatusCode WebPAllocateDecBuffer(
-    int width,
-    int height,
-    const WebPDecoderOptions* const options,
-    WebPDecBuffer* const buffer);
 extern "C" void WebPFreeDecBuffer(WebPDecBuffer* const buffer);
-typedef void VP8LDecoder;
-extern "C" VP8LDecoder* VP8LNew(void);
-extern "C" void VP8LClear(VP8LDecoder*);
 
 int main(int argc, const char* argv[]) {
   int return_value = -1;

--- a/tiledb/sm/compressors/test/link_webp_test1.cc
+++ b/tiledb/sm/compressors/test/link_webp_test1.cc
@@ -96,10 +96,6 @@ uint64_t reference_a_value(uint64_t v) {
 #pragma warning(disable : 4701)  // 'config', 'picture_no_alpha'
 #endif
 
-extern "C" int WebPGetDemuxVersion(void);
-extern "C" int WebPGetMuxVersion(void);
-extern "C" void WebPFreeDecBuffer(WebPDecBuffer* const buffer);
-
 int main(int argc, const char* argv[]) {
   int return_value = -1;
   const char *in_file = NULL, *out_file = NULL;

--- a/tiledb/sm/compressors/test/link_webp_test1.cc
+++ b/tiledb/sm/compressors/test/link_webp_test1.cc
@@ -127,17 +127,12 @@ int main(int argc, const char* argv[]) {
     // webp! left here anyway, in case libraries are ever de-dupped.
     const int dec_version = WebPGetDecoderVersion();
 
-    // webpdemux
-    const int demux_version = WebPGetDemuxVersion();
-    // webpmux
-    const int mux_version = WebPGetMuxVersion();
-
     // webp
     // in testing, even when WebP::webp was -not- added as link item, this
     // library was still being placed in link_webp_test project.
     auto enc_version = WebPGetEncoderVersion();
 
-    reference_a_value(dec_version + demux_version + mux_version + enc_version);
+    reference_a_value(dec_version + enc_version);
   }
 
   if (argc == 1) {

--- a/tiledb/sm/compressors/test/link_webp_test1.cc
+++ b/tiledb/sm/compressors/test/link_webp_test1.cc
@@ -131,9 +131,6 @@ int main(int argc, const char* argv[]) {
     // webp! left here anyway, in case libraries are ever de-dupped.
     const int dec_version = WebPGetDecoderVersion();
 
-    VP8StatusCode status;
-    WebPDecoderOptions webpdecoptions;
-
     // webpdemux
     const int demux_version = WebPGetDemuxVersion();
     // webpmux


### PR DESCRIPTION
`link_webp_test1.cc` currently tests linking against a few internal-only symbols of the webp library. This sort of works with a static webp, but fails for a shared version.

Here's what objdump shows for these symbols in the latest version of libwebp.

Static:
```
objdump -t ~/.conan2/p/libwe0ab986b34fa07/p/lib/*.a | grep -P 'WebPGetDemuxVersion|WebPGetMuxVersion|WebPAllocateDecBuffer|WebPFreeDecBuffer|VP8LNew|VP8LClear' | grep -v '*UND*' | sort -u
0000000000000000 g     F .text	0000000000000006 WebPGetMuxVersion
00000000000000f0 g     F .text	0000000000000428 .hidden WebPAllocateDecBuffer
0000000000000570 g     F .text	000000000000003b WebPFreeDecBuffer
0000000000000a40 g     F .text	0000000000000031 .hidden VP8LClearBackwardRefs
0000000000000bb0 g     F .text	0000000000000006 WebPGetDemuxVersion
0000000000002860 g     F .text	000000000000002f .hidden VP8LNew
0000000000002890 g     F .text	0000000000000101 .hidden VP8LClear
```

Shared:
```
objdump -T ~/.conan2/p/libwed5d42768c6b93/p/lib/*.so | grep -P 'WebPGetDemuxVersion|WebPGetMuxVersion|WebPAllocateDecBuffer|WebPFreeDecBuffer|VP8LNew|VP8LClear' | LC_COLLATE=C sort -u
0000000000002780 g    DF .text	0000000000000006  Base        WebPGetDemuxVersion
0000000000002da0 g    DF .text	000000000000003b  Base        WebPFreeDecBuffer
0000000000003f10 g    DF .text	000000000000003b  Base        WebPFreeDecBuffer
00000000000064a0 g    DF .text	0000000000000006  Base        WebPGetMuxVersion
```

For context, this cropped up in a PR for adding a TileDB recipe to the Conan Center Index: https://github.com/conan-io/conan-center-index/pull/19381

---
TYPE: BUG
DESC: Fix broken linking tests against a shared WebP library
