### PR TITLE
Update generate_uri member functions to use the StorageFormat

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile.h"

--- a/tiledb/sm/array_schema/CMakeLists.txt
+++ b/tiledb/sm/array_schema/CMakeLists.txt
@@ -72,7 +72,7 @@ conclude(object_library)
 commence(object_library array_schema)
     this_target_sources(array_schema.cc dimension_label.cc)
     this_target_object_libraries(
-        attribute domain enumeration time uri_format uuid vfs)
+        attribute domain enumeration time uri_format vfs)
 conclude(object_library)
 
 # This is linked outside the object_library scope because ContextResources

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -42,7 +42,6 @@
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/hilbert.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 
 using namespace tiledb::common;
@@ -547,7 +546,7 @@ class ArraySchema {
   format_version_t version() const;
 
   /** Set a timestamp range for the array schema */
-  Status set_timestamp_range(
+  void set_timestamp_range(
       const std::pair<uint64_t, uint64_t>& timestamp_range);
 
   /** Returns the timestamp range. */
@@ -565,11 +564,10 @@ class ArraySchema {
   /** Set the schema name. */
   void set_name(const std::string& name);
 
-  /** Generates a new array schema URI. */
-  Status generate_uri();
-
-  /** Generates a new array schema URI with specified timestamp range. */
-  Status generate_uri(const std::pair<uint64_t, uint64_t>& timestamp_range);
+  /** Generates a new array schema URI with optional timestamp range. */
+  void generate_uri(
+      std::optional<std::pair<uint64_t, uint64_t>> timestamp_range =
+          std::nullopt);
 
  private:
   /* ********************************* */

--- a/tiledb/sm/array_schema/array_schema_evolution.cc
+++ b/tiledb/sm/array_schema/array_schema_evolution.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -57,8 +57,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Class for locally generated exceptions. */
 class ArraySchemaEvolutionException : public StatusException {
@@ -142,11 +141,10 @@ shared_ptr<ArraySchema> ArraySchemaEvolution::evolve_schema(
 
   // Set timestamp, if specified
   if (std::get<0>(timestamp_range_) != 0) {
-    throw_if_not_ok(schema.get()->set_timestamp_range(timestamp_range_));
-    throw_if_not_ok(schema->generate_uri(timestamp_range_));
+    schema->generate_uri(timestamp_range_);
   } else {
     // Generate new schema URI
-    throw_if_not_ok(schema->generate_uri());
+    schema->generate_uri();
   }
 
   return schema;
@@ -331,10 +329,10 @@ std::vector<std::string> ArraySchemaEvolution::enumeration_names_to_drop()
 void ArraySchemaEvolution::set_timestamp_range(
     const std::pair<uint64_t, uint64_t>& timestamp_range) {
   if (timestamp_range.first != timestamp_range.second) {
-    throw std::runtime_error(std::string(
+    throw ArraySchemaEvolutionException(
         "Cannot set timestamp range; first element " +
         std::to_string(timestamp_range.first) + " and second element " +
-        std::to_string(timestamp_range.second) + " are not equal!"));
+        std::to_string(timestamp_range.second) + " are not equal!");
   }
   timestamp_range_ = timestamp_range;
 }
@@ -356,5 +354,4 @@ void ArraySchemaEvolution::clear() {
   timestamp_range_ = {0, 0};
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/array_schema/array_schema_evolution.h
+++ b/tiledb/sm/array_schema/array_schema_evolution.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -42,12 +42,10 @@
 #include "tiledb/sm/filter/filter_pipeline.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/hilbert.h"
-#include "tiledb/sm/misc/uuid.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Attribute;
 class Buffer;
@@ -223,7 +221,6 @@ class ArraySchemaEvolution {
   void clear();
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_SCHEMA_EVOLUTION_H

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,6 @@
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/compression_filter.h"
 #include "tiledb/sm/misc/parse_argument.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/type/range/range.h"
 
 #include <cassert>
@@ -48,8 +47,7 @@
 using namespace tiledb::common;
 using namespace tiledb::type;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Class for locally generated status exceptions. */
 class AttributeStatusException : public StatusException {
@@ -496,5 +494,4 @@ std::string Attribute::fill_value_str() const {
   return ret;
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -108,22 +108,8 @@ Status ArrayMetaConsolidator::consolidate(
   // Metadata uris to delete
   const auto to_vacuum = metadata_w->loaded_metadata_uris();
 
-  // Generate new name for consolidated metadata
-  st = metadata_w->generate_uri(array_uri);
-  if (!st.ok()) {
-    throw_if_not_ok(array_for_reads.close());
-    throw_if_not_ok(array_for_writes.close());
-    return st;
-  }
-
-  // Get the new URI name
-  URI new_uri;
-  st = metadata_w->get_uri(array_uri, &new_uri);
-  if (!st.ok()) {
-    throw_if_not_ok(array_for_reads.close());
-    throw_if_not_ok(array_for_writes.close());
-    return st;
-  }
+  // Get the new URI name for consolidated metadata
+  URI new_uri = metadata_w->get_uri(array_uri);
 
   // Close arrays
   RETURN_NOT_OK_ELSE(

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -101,22 +101,8 @@ Status GroupMetaConsolidator::consolidate(
   // Metadata uris to delete
   const auto to_vacuum = metadata_w->loaded_metadata_uris();
 
-  // Generate new name for consolidated metadata
-  st = metadata_w->generate_uri(group_uri);
-  if (!st.ok()) {
-    throw_if_not_ok(group_for_reads.close());
-    throw_if_not_ok(group_for_writes.close());
-    return st;
-  }
-
-  // Get the new URI name
-  URI new_uri;
-  st = metadata_w->get_uri(group_uri, &new_uri);
-  if (!st.ok()) {
-    throw_if_not_ok(group_for_reads.close());
-    throw_if_not_ok(group_for_writes.close());
-    return st;
-  }
+  // Get the new URI name for consolidated metadata
+  URI new_uri = metadata_w->get_uri(group_uri);
 
   // Close groups
   RETURN_NOT_OK_ELSE(

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -47,8 +47,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class GroupDetailsException : public StatusException {
  public:
@@ -301,9 +300,9 @@ class Group {
   /**
    * Function to generate a URL of a detail file
    *
-   * @return tuple of status and uri
+   * @return uri
    */
-  tuple<Status, optional<URI>> generate_detail_uri() const;
+  URI generate_detail_uri() const;
 
   /**
    * Have changes been applied to a group in write mode
@@ -453,15 +452,7 @@ class Group {
    * Load group metadata, handles remote groups vs non-remote groups
    */
   void load_metadata();
-
-  /**
-   * Generate new name in the form of timestmap_timestamp_uuid
-   *
-   * @return tuple of status and optional string
-   */
-  tuple<Status, optional<std::string>> generate_name() const;
 };
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_GROUP_H

--- a/tiledb/sm/group/group_details.cc
+++ b/tiledb/sm/group/group_details.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,13 +43,11 @@
 #include "tiledb/sm/group/group_member_v2.h"
 #include "tiledb/sm/metadata/metadata.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/rest/rest_client.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 GroupDetails::GroupDetails(const URI& group_uri, uint32_t version)
     : group_uri_(group_uri)
@@ -334,5 +332,4 @@ void GroupDetails::invalidate_lookups() {
   duplicated_uris_ = nullopt;
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/group/group_member.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/utils.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/storage_format/uri/parse_uri.h"
 
 using namespace tiledb::common;

--- a/tiledb/sm/metadata/CMakeLists.txt
+++ b/tiledb/sm/metadata/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2021-2022 TileDB, Inc.
+# Copyright (c) 2021-2023 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ include(object_library)
 #
 commence(object_library metadata)
     this_target_sources(metadata.cc)
-    this_target_object_libraries(baseline buffer constants time uuid vfs)
+    this_target_object_libraries(baseline buffer constants time uri_format vfs)
 conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,8 +46,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Buffer;
 class ConstBuffer;
@@ -111,10 +110,10 @@ class Metadata {
   void clear();
 
   /** Retrieves the array metadata URI. */
-  Status get_uri(const URI& array_uri, URI* meta_uri);
+  URI get_uri(const URI& array_uri);
 
   /** Generates a new array metadata URI. */
-  Status generate_uri(const URI& array_uri);
+  void generate_uri(const URI& array_uri);
 
   /**
    * Deserializes the input metadata buffers. Note that the buffers are
@@ -272,7 +271,6 @@ class Metadata {
   void build_metadata_index();
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_METADATA_H

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,6 @@
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/uuid.h"
 
 using namespace tiledb;
 using namespace tiledb::common;

--- a/tiledb/sm/misc/uuid.cc
+++ b/tiledb/sm/misc/uuid.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,9 +45,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
-namespace uuid {
+namespace tiledb::sm::uuid {
 
 /** Mutex to guard UUID generation. */
 static std::mutex uuid_mtx;
@@ -173,6 +171,4 @@ Status generate_uuid(std::string* uuid, bool hyphenate) {
   return Status::Ok();
 }
 
-}  // namespace uuid
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::uuid

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -44,7 +44,6 @@
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/misc/utils.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,6 @@
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/misc/utils.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"
@@ -59,8 +58,7 @@ using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -393,5 +391,4 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -46,7 +46,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -152,11 +152,10 @@ Status StorageManagerCanonical::group_close_for_writes(Group* group) {
   // Store any changes required
   if (group->changes_applied()) {
     const URI& group_detail_folder_uri = group->group_detail_uri();
-    auto&& [st, group_detail_uri] = group->generate_detail_uri();
-    RETURN_NOT_OK(st);
+    auto group_detail_uri = group->generate_detail_uri();
     RETURN_NOT_OK(store_group_detail(
         group_detail_folder_uri,
-        group_detail_uri.value(),
+        group_detail_uri,
         group->group_details(),
         *group->encryption_key()));
   }
@@ -1637,8 +1636,7 @@ Status StorageManagerCanonical::store_metadata(
   stats()->add_counter("write_meta_size", serializer.size());
 
   // Create a metadata file name
-  URI metadata_uri;
-  RETURN_NOT_OK(metadata->get_uri(uri, &metadata_uri));
+  URI metadata_uri = metadata->get_uri(uri);
 
   RETURN_NOT_OK(store_data_to_generic_tile(tile, metadata_uri, encryption_key));
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -63,7 +63,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/misc/utils.h"
-#include "tiledb/sm/misc/uuid.h"
 #include "tiledb/sm/query/deletes_and_updates/serialization.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/query/update_value.h"
@@ -535,7 +534,7 @@ Status StorageManagerCanonical::array_create(
 
   std::lock_guard<std::mutex> lock{object_create_mtx_};
   array_schema->set_array_uri(array_uri);
-  RETURN_NOT_OK(array_schema->generate_uri());
+  array_schema->generate_uri();
   array_schema->check(config_);
 
   // Create array directory
@@ -720,14 +719,13 @@ Status StorageManagerCanonical::array_upgrade_version(
   auto&& array_schema = array_dir.load_array_schema_latest(encryption_key_cfg);
 
   if (array_schema->version() < constants::format_version) {
-    auto st = array_schema->generate_uri();
-    RETURN_NOT_OK_ELSE(st, logger_->status_no_return_value(st));
+    array_schema->generate_uri();
     array_schema->set_version(constants::format_version);
 
     // Create array schema directory if necessary
     URI array_schema_dir_uri =
         array_uri.join_path(constants::array_schema_dir_name);
-    st = vfs()->create_dir(array_schema_dir_uri);
+    auto st = vfs()->create_dir(array_schema_dir_uri);
     RETURN_NOT_OK_ELSE(st, logger_->status_no_return_value(st));
 
     // Store array schema

--- a/tiledb/storage_format/uri/generate_uri.cc
+++ b/tiledb/storage_format/uri/generate_uri.cc
@@ -53,8 +53,9 @@ std::string generate_timestamped_name(
   std::stringstream ss;
   ss << "/__" << timestamp_start << "_" << timestamp_end << "_" << uuid;
 
-  if (version != std::nullopt)
+  if (version.has_value()) {
     ss << "_" << version.value();
+  }
 
   return ss.str();
 }

--- a/tiledb/storage_format/uri/generate_uri.cc
+++ b/tiledb/storage_format/uri/generate_uri.cc
@@ -38,7 +38,9 @@ using namespace tiledb::common;
 namespace tiledb::storage_format {
 
 std::string generate_timestamped_name(
-    uint64_t timestamp_start, uint64_t timestamp_end, uint32_t version) {
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    std::optional<format_version_t> version) {
   std::string uuid;
   throw_if_not_ok(sm::uuid::generate_uuid(&uuid, false));
 
@@ -49,8 +51,10 @@ std::string generate_timestamped_name(
   }
 
   std::stringstream ss;
-  ss << "/__" << timestamp_start << "_" << timestamp_end << "_" << uuid << "_"
-     << version;
+  ss << "/__" << timestamp_start << "_" << timestamp_end << "_" << uuid;
+
+  if (version != std::nullopt)
+    ss << "_" << version.value();
 
   return ss.str();
 }
@@ -70,7 +74,7 @@ std::string generate_consolidated_fragment_name(
   throw_if_not_ok(utils::parse::get_timestamp_range(last, &t_last));
 
   return generate_timestamped_name(
-      t_first.first, t_last.second, (uint64_t)format_version);
+      t_first.first, t_last.second, format_version);
 }
 
 }  // namespace tiledb::storage_format

--- a/tiledb/storage_format/uri/generate_uri.h
+++ b/tiledb/storage_format/uri/generate_uri.h
@@ -36,6 +36,8 @@
 #include "tiledb/common/common.h"
 #include "tiledb/sm/filesystem/uri.h"
 
+#include <optional>
+
 using namespace tiledb::common;
 using namespace tiledb::sm;
 
@@ -44,19 +46,21 @@ namespace tiledb::storage_format {
 /**
  * Generate a new URI in the form `__t1_t2_uuid_v`, where `t1` is the starting
  * timestamp, `t2` is the ending timestamp,  and `v` is the current format
- * version. For instance,
+ * version, if provided. For instance,
  * `__1458759561320_1458759561480_6ba7b8129dad11d180b400c04fd430c8_3`.
  *
  * @param timestamp_start The staring timestamp. It is in ms since
  *     1970-01-01 00:00:00 +0000 (UTC).
  * @param timestamp_end The ending timestamp. It is in ms since
  *     1970-01-01 00:00:00 +0000 (UTC).
- * @param version Version number to append to the URI.
+ * @param version Optional version number to append to the URI.
  *
  * @return The new URI.
  */
 std::string generate_timestamped_name(
-    uint64_t timestamp_start, uint64_t timestamp_end, uint32_t version);
+    uint64_t timestamp_start,
+    uint64_t timestamp_end,
+    std::optional<format_version_t> version);
 
 /**
  * Generates a new fragment name.

--- a/tiledb/storage_format/uri/test/unit_uri_format.cc
+++ b/tiledb/storage_format/uri/test/unit_uri_format.cc
@@ -55,20 +55,37 @@ TEST_CASE(
     // Check new fragment name's timestamp range
     auto name_timestamps{name.substr(0, 6)};
     CHECK(name_timestamps == "/__1_1");
+
+    // Check new fragment name's format version
+    auto name_version{name.substr(name.find_last_of("_"))};
+    CHECK(name_version == "_5");
   }
 
   SECTION("two timestamps") {
-    // Generate new fragment name
-    name = generate_timestamped_name(start, end, (uint32_t)format_version);
+    SECTION("with format version") {
+      // Generate new fragment name
+      name = generate_timestamped_name(start, end, format_version);
+
+      // Check new fragment name's format version
+      auto name_version{name.substr(name.find_last_of("_"))};
+      CHECK(name_version == "_5");
+    }
+
+    SECTION("without format version") {
+      // Generate new fragment name
+      name = generate_timestamped_name(start, end, std::nullopt);
+
+      // Ensure new fragment name has no format version (ends in uuid)
+      // Precautionary measure: Check that the length is greater than 10
+      // Note that format versions are currently no longer than 2 chars
+      auto name_end{name.substr(name.find_last_of("_"))};
+      CHECK(name_end.length() > 5);
+    }
 
     // Check new fragment name's timestamp range
     auto name_timestamps{name.substr(0, 6)};
     CHECK(name_timestamps == "/__1_2");
   }
-
-  // Check new fragment name's format version
-  auto name_version{name.substr(name.find_last_of("_"))};
-  CHECK(name_version == "_5");
 }
 
 TEST_CASE(


### PR DESCRIPTION
Member functions should not generate uuids to create their own timestamped fragment and uri names. Instead, they need only to use the StorageFormat's APIs.

---
TYPE: IMPROVEMENT
DESC: Use StorageFormat APIs to generate timestamped uris
