### PR TITLE
Fix delta filter deserialization for format ver 19.

### DIFF
--- a/tiledb/sm/filter/filter_create.cc
+++ b/tiledb/sm/filter/filter_create.cc
@@ -126,8 +126,8 @@ shared_ptr<tiledb::sm::Filter> tiledb::sm::FilterCreate::deserialize(
       uint8_t compressor_char = deserializer.read<uint8_t>();
       int compression_level = deserializer.read<int32_t>();
       Datatype reinterpret_type = Datatype::ANY;
-      if (version >= 20 && (filtertype == FilterType::FILTER_DELTA ||
-                            filtertype == FilterType::FILTER_DOUBLE_DELTA)) {
+      if ((version >= 20 && filtertype == FilterType::FILTER_DOUBLE_DELTA) ||
+          (version >= 19 && filtertype == FilterType::FILTER_DELTA)) {
         uint8_t reinterpret = deserializer.read<uint8_t>();
         reinterpret_type = static_cast<Datatype>(reinterpret);
       }


### PR DESCRIPTION
This fixes the delta filter deserialization for version 19. In that version, we already included the extra reinterpret type.

---
TYPE: BUG
DESC: Fix delta filter deserialization for format ver 19.
