### PR TITLE
[Backport release-2.18] Always use `FetchContent` to get vcpkg.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -74,13 +74,6 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
-        id: runvcpkg
-        with:
-          vcpkgJsonGlob: 'vcpkg.json'
-          vcpkgDirectory: '${{ github.workspace }}/external/vcpkg'
-
       - name: Prints output of run-vcpkg's action.
         run: |
           echo "run-vcpkg outputs:"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/vcpkg"]
-	path = external/vcpkg
-	url = https://github.com/microsoft/vcpkg

--- a/cmake/Options/TileDBToolchain.cmake
+++ b/cmake/Options/TileDBToolchain.cmake
@@ -15,17 +15,10 @@ if(DEFINED ENV{VCPKG_ROOT})
     set(CMAKE_TOOLCHAIN_FILE
         "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
         CACHE STRING "Vcpkg toolchain file")
-# Try to initialize the submodule only if we are in a Git repository.
-elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../.git")
-    include(init-submodule)
-    set(CMAKE_TOOLCHAIN_FILE
-        "${CMAKE_CURRENT_SOURCE_DIR}/external/vcpkg/scripts/buildsystems/vcpkg.cmake"
-        CACHE STRING "Vcpkg toolchain file")
 elseif(NOT DEFINED ENV{TILEDB_DISABLE_AUTO_VCPKG})
     # Inspired from https://github.com/Azure/azure-sdk-for-cpp/blob/azure-core_1.10.3/cmake-modules/AzureVcpkg.cmake
     message("TILEDB_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
     # To help with resolving conflicts, when you update the commit, also update its date.
-    # Also make sure the externals/vcpkg submodule is updated to the same commit.
     set(VCPKG_COMMIT_STRING 1b4d69f3028d74401a001aa316986a670ca6289a) # 2023-09-27
     message("Vcpkg commit string used: ${VCPKG_COMMIT_STRING}")
     include(FetchContent)

--- a/scripts/ci/patch_vcpkg_triplets.py
+++ b/scripts/ci/patch_vcpkg_triplets.py
@@ -1,8 +1,7 @@
 import os
 
 workspace = os.curdir
-triplet_paths = [os.path.join(workspace, "external", "vcpkg", "triplets"),
-                 os.path.join(workspace, "ports", "triplets")]
+triplet_paths = [os.path.join(workspace, "ports", "triplets")]
 
 for triplet_path in triplet_paths:
   for path, dnames, fnames in os.walk(triplet_path):

--- a/scripts/install-azurite.sh
+++ b/scripts/install-azurite.sh
@@ -31,6 +31,7 @@ die() {
 }
 
 install_apt_pkgs() {
+  sudo apt-get update || die "could not update apt-get"
   sudo apt-get -y install libnode-dev node-gyp libssl1.0 npm || die "could not install nodejs dependency"
 }
 


### PR DESCRIPTION
Backport 1f4ed0a69eca76a01183cca45a9d48fa0be5ecc6 from #4484.

---
TYPE: BUILD
DESC: Remove the `externals/vcpkg` submodule. Vcpkg is always downloaded by CMake.