### PR TITLE
Add constexpr for Filesystem support

### DIFF
--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -73,9 +73,6 @@ struct VFSFx {
   tiledb_ctx_t* ctx_;
   tiledb_vfs_t* vfs_;
 
-  // Supported filesystems
-  bool supports_hdfs_;
-
   // Functions
   VFSFx();
   ~VFSFx();
@@ -90,9 +87,6 @@ struct VFSFx {
 };
 
 VFSFx::VFSFx() {
-  // Supported filesystem vector
-  get_supported_fs(&supports_hdfs_);
-
   create_ctx_and_vfs(&ctx_, &vfs_);
 }
 
@@ -389,8 +383,9 @@ void VFSFx::check_move(const std::string& path) {
 #ifndef _WIN32
 void VFSFx::check_copy(const std::string& path) {
   // Do not support HDFS
-  if (supports_hdfs_)
+  if constexpr (TILEDB_HDFS_ENABLED) {
     return;
+  }
 
   // Copy file
   auto file = path + "file";
@@ -815,7 +810,7 @@ TEST_CASE_METHOD(VFSFx, "C API: Test virtual filesystem", "[capi][vfs]") {
 
   if constexpr (TILEDB_S3_ENABLED) {
     check_vfs(S3_TEMP_DIR);
-  } else if (supports_hdfs_) {
+  } else if constexpr (TILEDB_HDFS_ENABLED) {
     check_vfs(HDFS_TEMP_DIR);
   } else {
     check_vfs(FILE_TEMP_DIR);
@@ -894,7 +889,7 @@ TEST_CASE_METHOD(VFSFx, "C API: Test VFS parallel I/O", "[capi][vfs]") {
 
   if constexpr (TILEDB_S3_ENABLED) {
     check_vfs(S3_TEMP_DIR);
-  } else if (supports_hdfs_) {
+  } else if constexpr (TILEDB_HDFS_ENABLED) {
     check_vfs(HDFS_TEMP_DIR);
   } else {
     check_vfs(FILE_TEMP_DIR);

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -74,9 +74,7 @@ struct VFSFx {
   tiledb_vfs_t* vfs_;
 
   // Supported filesystems
-  bool supports_s3_;
   bool supports_hdfs_;
-  bool supports_azure_;
 
   // Functions
   VFSFx();
@@ -93,11 +91,9 @@ struct VFSFx {
 
 VFSFx::VFSFx() {
   // Supported filesystem vector
-  bool supports_gcs;  // unused
-  get_supported_fs(
-      &supports_s3_, &supports_hdfs_, &supports_azure_, &supports_gcs);
+  get_supported_fs(&supports_hdfs_);
 
-  create_ctx_and_vfs(supports_s3_, supports_azure_, &ctx_, &vfs_);
+  create_ctx_and_vfs(&ctx_, &vfs_);
 }
 
 VFSFx::~VFSFx() {

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -106,7 +106,7 @@ VFSFx::~VFSFx() {
 }
 
 void VFSFx::check_vfs(const std::string& path) {
-  if (supports_s3_) {
+  if constexpr (TILEDB_S3_ENABLED) {
     // Check S3 bucket functionality
     if (path == S3_TEMP_DIR) {
       int is_bucket = 0;
@@ -239,29 +239,35 @@ void VFSFx::check_vfs(const std::string& path) {
   // Ls
   check_ls(path);
 
-  if (supports_s3_ && path == S3_TEMP_DIR) {
-    int is_empty;
-    rc = tiledb_vfs_is_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_empty);
-    REQUIRE(rc == TILEDB_OK);
-    REQUIRE(!(bool)is_empty);
+  if constexpr (TILEDB_S3_ENABLED) {
+    if (path == S3_TEMP_DIR) {
+      int is_empty;
+      rc = tiledb_vfs_is_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_empty);
+      REQUIRE(rc == TILEDB_OK);
+      REQUIRE(!(bool)is_empty);
+    }
   }
 
-  if (!supports_s3_ && path != FILE_TEMP_DIR) {
-    rc = tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str());
-    REQUIRE(rc == TILEDB_OK);
+  if constexpr (!TILEDB_S3_ENABLED) {
+    if (path != FILE_TEMP_DIR) {
+      rc = tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str());
+      REQUIRE(rc == TILEDB_OK);
+    }
   }
 
-  if (supports_s3_ && path == S3_TEMP_DIR) {
-    rc = tiledb_vfs_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str());
-    REQUIRE(rc == TILEDB_OK);
+  if constexpr (TILEDB_S3_ENABLED) {
+    if (path == S3_TEMP_DIR) {
+      rc = tiledb_vfs_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+      REQUIRE(rc == TILEDB_OK);
 
-    int is_empty;
-    rc = tiledb_vfs_is_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_empty);
-    REQUIRE(rc == TILEDB_OK);
-    REQUIRE((bool)is_empty);
+      int is_empty;
+      rc = tiledb_vfs_is_empty_bucket(ctx_, vfs_, S3_BUCKET.c_str(), &is_empty);
+      REQUIRE(rc == TILEDB_OK);
+      REQUIRE((bool)is_empty);
 
-    rc = tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str());
-    REQUIRE(rc == TILEDB_OK);
+      rc = tiledb_vfs_remove_bucket(ctx_, vfs_, S3_BUCKET.c_str());
+      REQUIRE(rc == TILEDB_OK);
+    }
   }
 }
 
@@ -355,7 +361,7 @@ void VFSFx::check_move(const std::string& path) {
   REQUIRE(is_file);
 
   // Move from one bucket to another (only for S3)
-  if (supports_s3_) {
+  if constexpr (TILEDB_S3_ENABLED) {
     if (path == S3_TEMP_DIR) {
       std::string bucket2 = S3_PREFIX + random_name("tiledb") + "/";
       std::string subdir3 = bucket2 + "tiledb_test/subdir3/";
@@ -467,7 +473,7 @@ void VFSFx::check_copy(const std::string& path) {
   REQUIRE(is_file);
 
   // Copy from one bucket to another (only for S3)
-  if (supports_s3_) {
+  if constexpr (TILEDB_S3_ENABLED) {
     std::string bucket2 = S3_PREFIX + random_name("tiledb") + "/";
     std::string subdir3 = bucket2 + "tiledb_test/subdir3/";
     std::string file3 = subdir3 + "file2";
@@ -811,11 +817,11 @@ TEST_CASE_METHOD(VFSFx, "C API: Test virtual filesystem", "[capi][vfs]") {
   tiledb_stats_enable();
   tiledb_stats_reset();
 
-  if (supports_s3_)
+  if constexpr (TILEDB_S3_ENABLED) {
     check_vfs(S3_TEMP_DIR);
-  else if (supports_hdfs_)
+  } else if (supports_hdfs_) {
     check_vfs(HDFS_TEMP_DIR);
-  else {
+  } else {
     check_vfs(FILE_TEMP_DIR);
     check_vfs(MEMFS_TEMP_DIR);
   }
@@ -825,7 +831,7 @@ TEST_CASE_METHOD(
     VFSFx,
     "C API: Test virtual filesystem when S3 is not supported",
     "[capi][vfs]") {
-  if (!supports_s3_) {
+  if constexpr (!TILEDB_S3_ENABLED) {
     tiledb_vfs_t* vfs;
     int rc = tiledb_vfs_alloc(ctx_, nullptr, &vfs);
     REQUIRE(rc == TILEDB_OK);
@@ -890,7 +896,7 @@ TEST_CASE_METHOD(VFSFx, "C API: Test VFS parallel I/O", "[capi][vfs]") {
       TILEDB_OK);
   REQUIRE(error == nullptr);
 
-  if (supports_s3_) {
+  if constexpr (TILEDB_S3_ENABLED) {
     check_vfs(S3_TEMP_DIR);
   } else if (supports_hdfs_) {
     check_vfs(HDFS_TEMP_DIR);

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -144,11 +144,8 @@ TEST_CASE("VFS: Test long posix paths", "[vfs]") {
 TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
-
-  bool hdfs_supported = false;
-  tiledb::test::get_supported_fs(&hdfs_supported);
-
   std::vector<std::pair<URI, Config>> root_pairs;
+
   if constexpr (TILEDB_S3_ENABLED) {
     Config config;
     REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
@@ -160,7 +157,7 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
         URI("s3://" + tiledb::test::random_name("vfs") + "/"),
         std::move(config));
   }
-  if (hdfs_supported) {
+  if constexpr (TILEDB_HDFS_ENABLED) {
     Config config;
     root_pairs.emplace_back(
         URI("hdfs:///" + tiledb::test::random_name("vfs") + "/"),

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -145,12 +145,8 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
 
-  bool s3_supported = false;
   bool hdfs_supported = false;
-  bool azure_supported = false;
-  bool gcs_supported = false;
-  tiledb::test::get_supported_fs(
-      &s3_supported, &hdfs_supported, &azure_supported, &gcs_supported);
+  tiledb::test::get_supported_fs(&hdfs_supported);
 
   std::vector<std::pair<URI, Config>> root_pairs;
   if constexpr (TILEDB_S3_ENABLED) {
@@ -170,7 +166,7 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
         URI("hdfs:///" + tiledb::test::random_name("vfs") + "/"),
         std::move(config));
   }
-  if (azure_supported) {
+  if constexpr (TILEDB_AZURE_ENABLED) {
     Config config;
     REQUIRE(
         config.set("vfs.azure.storage_account_name", "devstoreaccount1").ok());

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -153,7 +153,7 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
       &s3_supported, &hdfs_supported, &azure_supported, &gcs_supported);
 
   std::vector<std::pair<URI, Config>> root_pairs;
-  if (s3_supported) {
+  if constexpr (TILEDB_S3_ENABLED) {
     Config config;
     REQUIRE(config.set("vfs.s3.endpoint_override", "localhost:9999").ok());
     REQUIRE(config.set("vfs.s3.scheme", "https").ok());

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -909,45 +909,6 @@ void create_subarray(
   *returned_subarray = psubarray;
 }
 
-void get_supported_fs(bool* hdfs_supported) {
-  tiledb_ctx_t* ctx = nullptr;
-  REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
-
-  int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  *hdfs_supported = (bool)is_supported;
-
-  // Override VFS support if the user used the '--vfs' command line argument.
-  if (!g_vfs.empty()) {
-    REQUIRE(
-        (g_vfs == "native" || g_vfs == "s3" || g_vfs == "hdfs" ||
-         g_vfs == "azure" || g_vfs == "gcs"));
-
-    if (g_vfs == "native") {
-      *hdfs_supported = false;
-    }
-
-    if (g_vfs == "s3") {
-      *hdfs_supported = false;
-    }
-
-    if (g_vfs == "hdfs") {
-      *hdfs_supported = true;
-    }
-
-    if (g_vfs == "azure") {
-      *hdfs_supported = false;
-    }
-
-    if (g_vfs == "gcs") {
-      *hdfs_supported = false;
-    }
-  }
-
-  tiledb_ctx_free(&ctx);
-}
-
 void open_array(
     tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type) {
   int rc = tiledb_array_open(ctx, array, query_type);

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -58,8 +58,7 @@
 
 std::mutex catch2_macro_mutex;
 
-namespace tiledb {
-namespace test {
+namespace tiledb::test {
 
 // Command line arguments.
 std::string g_vfs;
@@ -923,10 +922,10 @@ void get_supported_fs(
   REQUIRE(tiledb_ctx_alloc(nullptr, &ctx) == TILEDB_OK);
 
   int is_supported = 0;
-  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_S3, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  *s3_supported = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
+  if constexpr (TILEDB_S3_ENABLED) {
+    *s3_supported = true;
+  }
+  int rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_HDFS, &is_supported);
   REQUIRE(rc == TILEDB_OK);
   *hdfs_supported = (bool)is_supported;
   rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_AZURE, &is_supported);
@@ -2375,6 +2374,4 @@ template void check_counts<int32_t>(
 template void check_counts<uint64_t>(
     span<uint64_t> vals, std::vector<uint64_t> expected);
 
-}  // End of namespace test
-
-}  // End of namespace tiledb
+}  // namespace tiledb::test

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -931,9 +931,10 @@ void get_supported_fs(
   rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_AZURE, &is_supported);
   REQUIRE(rc == TILEDB_OK);
   *azure_supported = (bool)is_supported;
-  rc = tiledb_ctx_is_supported_fs(ctx, TILEDB_GCS, &is_supported);
-  REQUIRE(rc == TILEDB_OK);
-  *gcs_supported = (bool)is_supported;
+
+  if constexpr (TILEDB_GCS_ENABLED) {
+    *gcs_supported = true;
+  }
 
   // Override VFS support if the user used the '--vfs' command line argument.
   if (!g_vfs.empty()) {

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -492,14 +492,6 @@ void create_subarray(
 void create_ctx_and_vfs(tiledb_ctx_t** ctx, tiledb_vfs_t** vfs);
 
 /**
- * Helper function to get the supported filesystems.
- * #TODO Remove (dead code)
- *
- * @param hdfs_supported Set to `true` if HDFS is supported.
- */
-void get_supported_fs(bool* hdfs_supported);
-
-/**
  * Opens an array.
  *
  * @param ctx The TileDB context.
@@ -511,6 +503,7 @@ void open_array(tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t);
 /**
  * Returns a random bucket name, with `prefix` as prefix and using
  * the thread id as a "random" suffix.
+ * #TODO Use PRNG & remove in-test definitions of random_name
  *
  * @param prefix The prefix of the bucket name.
  * @return A random bucket name.

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -67,13 +67,11 @@ extern std::mutex catch2_macro_mutex;
     REQUIRE(a);                                           \
   }
 
-namespace tiledb {
-
-namespace sm {
+namespace tiledb::sm {
 class SubarrayPartitioner;
 }
 
-namespace test {
+namespace tiledb::test {
 
 // A dummy `Stats` instance. This is useful for constructing
 // objects that require a parent `Stats` object. These stats are
@@ -400,6 +398,7 @@ void create_dir(const std::string& path, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs);
 
 /**
  * Helper method that creates an S3 bucket (if it does not already exist).
+ * #TODO Remove (dead code)
  *
  * @param bucket_name The name of the bucket to be created.
  * @param s3_supported The bucket will be created only if this is `true`.
@@ -414,6 +413,7 @@ void create_s3_bucket(
 
 /**
  * Helper method that creates an Azure container (if it does not already exist).
+ * #TODO Remove (dead code)
  *
  * @param container_name The name of the container to be created.
  * @param azure_supported The container will be created only if this is `true`.
@@ -484,31 +484,20 @@ void create_subarray(
 
 /**
  * Helper method that creates a TileDB context and a VFS object.
+ * #TODO Remove (dead code)
  *
- * @param s3_supported Indicates whether S3 is supported or not.
- * @param azure_supported Indicates whether Azure is supported or not.
  * @param ctx The TileDB context to be created.
  * @param vfs The VFS object to be created.
  */
-void create_ctx_and_vfs(
-    bool s3_supported,
-    bool azure_supported,
-    tiledb_ctx_t** ctx,
-    tiledb_vfs_t** vfs);
+void create_ctx_and_vfs(tiledb_ctx_t** ctx, tiledb_vfs_t** vfs);
 
 /**
  * Helper function to get the supported filesystems.
+ * #TODO Remove (dead code)
  *
- * @param s3_supported Set to `true` if S3 is supported.
  * @param hdfs_supported Set to `true` if HDFS is supported.
- * @param azure_supported Set to `true` if Azure is supported.
- * @param gcs_supported Set to `true` if GCS is supported.
  */
-void get_supported_fs(
-    bool* s3_supported,
-    bool* hdfs_supported,
-    bool* azure_supported,
-    bool* gcs_supported);
+void get_supported_fs(bool* hdfs_supported);
 
 /**
  * Opens an array.
@@ -1015,8 +1004,6 @@ void allocate_query_buffers_server_side(
     tiledb_query_t* query,
     ServerQueryBuffers& query_buffers);
 
-}  // End of namespace test
-
-}  // End of namespace tiledb
+}  // namespace tiledb::test
 
 #endif

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2023 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,8 +46,7 @@
 #include "test/support/src/helpers.h"
 #include "test/support/src/vfs_helpers.h"
 
-namespace tiledb {
-namespace test {
+namespace tiledb::test {
 
 std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
   std::vector<std::unique_ptr<SupportedFs>> fs_vec;
@@ -58,7 +57,7 @@ std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
   bool supports_gcs = false;
   get_supported_fs(
       &supports_s3, &supports_hdfs, &supports_azure, &supports_gcs);
-  if (supports_s3) {
+  if constexpr (TILEDB_S3_ENABLED) {
     fs_vec.emplace_back(std::make_unique<SupportedFsS3>());
   }
 
@@ -415,5 +414,4 @@ std::string TemporaryDirectoryFixture::create_temporary_array(
   return array_uri;
 }
 
-}  // End of namespace test
-}  // End of namespace tiledb
+}  // namespace tiledb::test

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -50,14 +50,11 @@ namespace tiledb::test {
 
 std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
   std::vector<std::unique_ptr<SupportedFs>> fs_vec;
-
-  bool supports_hdfs = false;
-  get_supported_fs(&supports_hdfs);
   if constexpr (TILEDB_S3_ENABLED) {
     fs_vec.emplace_back(std::make_unique<SupportedFsS3>());
   }
 
-  if (supports_hdfs) {
+  if constexpr (TILEDB_HDFS_ENABLED) {
     fs_vec.emplace_back(std::make_unique<SupportedFsHDFS>());
   }
 

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -51,12 +51,8 @@ namespace tiledb::test {
 std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
   std::vector<std::unique_ptr<SupportedFs>> fs_vec;
 
-  bool supports_s3 = false;
   bool supports_hdfs = false;
-  bool supports_azure = false;
-  bool supports_gcs = false;
-  get_supported_fs(
-      &supports_s3, &supports_hdfs, &supports_azure, &supports_gcs);
+  get_supported_fs(&supports_hdfs);
   if constexpr (TILEDB_S3_ENABLED) {
     fs_vec.emplace_back(std::make_unique<SupportedFsS3>());
   }
@@ -65,7 +61,7 @@ std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
     fs_vec.emplace_back(std::make_unique<SupportedFsHDFS>());
   }
 
-  if (supports_azure) {
+  if constexpr (TILEDB_AZURE_ENABLED) {
     fs_vec.emplace_back(std::make_unique<SupportedFsAzure>());
   }
 

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -69,7 +69,7 @@ std::vector<std::unique_ptr<SupportedFs>> vfs_test_get_fs_vec() {
     fs_vec.emplace_back(std::make_unique<SupportedFsAzure>());
   }
 
-  if (supports_gcs) {
+  if constexpr (TILEDB_GCS_ENABLED) {
     fs_vec.emplace_back(std::make_unique<SupportedFsGCS>());
     fs_vec.emplace_back(std::make_unique<SupportedFsGCS>("gs://"));
   }

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -54,25 +54,39 @@
 
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/win.h"
+static constexpr bool TILEDB_WIN_ENABLED = true;
 #else
 #include "tiledb/sm/filesystem/posix.h"
+static constexpr bool TILEDB_WIN_ENABLED = false;
 #endif
 
 #ifdef HAVE_GCS
 #include "tiledb/sm/filesystem/gcs.h"
-#endif
+static constexpr bool TILEDB_GCS_ENABLED = true;
+#else
+static constexpr bool TILEDB_GCS_ENABLED = false;
+#endif  // HAVE_GCS
 
 #ifdef HAVE_S3
 #include "tiledb/sm/filesystem/s3.h"
-#endif
+static constexpr bool TILEDB_S3_ENABLED = true;
+#else
+static constexpr bool TILEDB_S3_ENABLED = false;
+#endif  // HAVE_S3
 
 #ifdef HAVE_HDFS
 #include "tiledb/sm/filesystem/hdfs_filesystem.h"
-#endif
+static constexpr bool TILEDB_HDFS_ENABLED = true;
+#else
+static constexpr bool TILEDB_HDFS_ENABLED = false;
+#endif  // HAVE_HDFS
 
 #ifdef HAVE_AZURE
 #include "tiledb/sm/filesystem/azure.h"
-#endif
+static constexpr bool TILEDB_AZURE_ENABLED = true;
+#else
+static constexpr bool TILEDB_AZURE_ENABLED = false;
+#endif  // HAVE_AZURE
 
 using namespace tiledb::common;
 


### PR DESCRIPTION
One step toward `VFS` and `tiledb_unit` cleanup. In `vis.h`, add `constexpr` to represent whether or not a filesystem is supported. Additionally, do some miscellaneous, related cleanup.

---
TYPE: IMPROVEMENT
DESC: Use constexpr to check for filesystem support
