### PR TITLE
Always install libraries in the `lib` directory.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX=./dist \
+            -DTILEDB_INSTALL_LIBDIR=lib \
             -DTILEDB_S3=ON \
             -DTILEDB_AZURE=ON \
             -DTILEDB_GCS=ON \


### PR DESCRIPTION
Fixes regression introduced in #4518.

---
TYPE: BUG
DESC: Fix regression when libraries were sometimes installed in the `lib64` directory.