### PR TITLE
Add function random_label to utilize PRNG for random string generation

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -106,7 +106,6 @@ struct ArrayFx {
   void create_dense_vector(const std::string& path);
   void create_dense_array(const std::string& path);
   void write_fragment(tiledb_array_t* array, uint64_t timestamp);
-  static std::string random_name(const std::string& prefix);
   static int get_fragment_timestamps(const char* path, void* data);
 };
 
@@ -139,13 +138,6 @@ void ArrayFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string ArrayFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 int ArrayFx::get_fragment_timestamps(const char* path, void* data) {

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -123,7 +123,6 @@ struct ArraySchemaFx {
   void delete_array(const std::string& path);
   bool is_array(const std::string& path);
   void load_and_check_array_schema(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 
   int array_create_wrapper(
       const std::string& path, tiledb_array_schema_t* array_schema);
@@ -943,13 +942,6 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
   tiledb_dimension_free(&dim);
   tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);
-}
-
-std::string ArraySchemaFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 int ArraySchemaFx::get_schema_file_struct(const char* path, void* data) {

--- a/test/src/unit-capi-attributes.cc
+++ b/test/src/unit-capi-attributes.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB Inc.
+ * @copyright Copyright (c) 2021-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -77,7 +77,6 @@ struct Attributesfx {
       const std::string& path,
       const std::string& attr_name,
       tiledb_datatype_t attr_type);
-  static std::string random_name(const std::string& prefix);
 };
 
 Attributesfx::Attributesfx()
@@ -103,13 +102,6 @@ void Attributesfx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string Attributesfx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void Attributesfx::create_dense_vector(

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -150,7 +150,6 @@ struct DenseArrayFx {
       const tiledb_layout_t layout,
       std::vector<TestRange>& ranges,
       std::vector<uint64_t>& a1);
-  static std::string random_name(const std::string& prefix);
 
   /**
    * Creates a 2D dense array.
@@ -3093,13 +3092,6 @@ void DenseArrayFx::check_non_empty_domain(const std::string& path) {
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
 };
-
-std::string DenseArrayFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
-}
 
 TEST_CASE_METHOD(
     DenseArrayFx,

--- a/test/src/unit-capi-dense_neg.cc
+++ b/test/src/unit-capi-dense_neg.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -76,7 +76,6 @@ struct DenseNegFx {
   void read_dense_array_global(const std::string& path);
   void read_dense_array_row(const std::string& path);
   void read_dense_array_col(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 DenseNegFx::DenseNegFx()
@@ -102,13 +101,6 @@ void DenseNegFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string DenseNegFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void DenseNegFx::create_dense_vector(const std::string& path) {

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -72,7 +72,6 @@ struct DenseVectorFx {
   void check_update(const std::string& path);
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 DenseVectorFx::DenseVectorFx()
@@ -98,13 +97,6 @@ void DenseVectorFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string DenseVectorFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void DenseVectorFx::create_dense_vector(

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,7 +84,6 @@ struct GroupFx {
   void remove_temp_dir(const std::string& path) const;
   std::string get_golden_walk(const std::string& path);
   std::string get_golden_ls(const std::string& path);
-  static std::string random_name(const std::string& prefix);
   std::vector<std::pair<tiledb::sm::URI, tiledb_object_t>> read_group(
       tiledb_group_t* group, bool use_get_member_by_index_v2 = true) const;
   void set_group_timestamp(
@@ -357,13 +356,6 @@ std::string GroupFx::get_golden_ls(const std::string& path) {
   golden += path + "sparse_arrays GROUP\n";
 
   return golden;
-}
-
-std::string GroupFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,6 @@ struct ObjectMgmtFx {
   std::string get_golden_walk(const std::string& path);
   std::string get_golden_ls(const std::string& path);
   static int write_path(const char* path, tiledb_object_t type, void* data);
-  static std::string random_name(const std::string& prefix);
 };
 
 ObjectMgmtFx::ObjectMgmtFx()
@@ -355,13 +354,6 @@ int ObjectMgmtFx::write_path(
 
   // Always iterate till the end
   return 1;
-}
-
-std::string ObjectMgmtFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -71,7 +71,6 @@ struct QueryFx {
   void test_get_buffer_write_decoupled(const std::string& path);
   void test_get_buffer_read(const std::string& path);
   void test_get_buffer_read_decoupled(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 QueryFx::QueryFx()
@@ -85,13 +84,6 @@ QueryFx::~QueryFx() {
   REQUIRE(vfs_test_close(fs_vec_, ctx_, vfs_).ok());
   tiledb_vfs_free(&vfs_);
   tiledb_ctx_free(&ctx_);
-}
-
-std::string QueryFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void QueryFx::create_temp_dir(const std::string& path) {

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -98,7 +98,6 @@ struct DenseArrayRESTFx {
   void create_dense_array_1_attribute(const std::string& array_name);
   void write_dense_array(const std::string& array_name);
   void write_dense_array_missing_attributes(const std::string& array_name);
-  static std::string random_name(const std::string& prefix);
 
   /**
    * Creates a 2D dense array.

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -133,7 +133,6 @@ struct SparseArrayFx {
       const std::vector<float>& a3);
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
-  static std::string random_name(const std::string& prefix);
   void check_sorted_reads(
       const std::string& array_name,
       tiledb_filter_type_t compressor,
@@ -259,13 +258,6 @@ void SparseArrayFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string SparseArrayFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void SparseArrayFx::create_sparse_array_2D(

--- a/test/src/unit-capi-sparse_heter.cc
+++ b/test/src/unit-capi-sparse_heter.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -118,7 +118,6 @@ struct SparseHeterFx {
       const std::vector<int64_t>& buff_d1,
       const std::vector<float>& buff_d2,
       const std::vector<int32_t>& buff_a);
-  static std::string random_name(const std::string& prefix);
   int tiledb_array_get_non_empty_domain_from_index_wrapper(
       tiledb_ctx_t* ctx,
       tiledb_array_t* array,
@@ -320,13 +319,6 @@ void SparseHeterFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string SparseHeterFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void SparseHeterFx::check_non_empty_domain_float_int64(

--- a/test/src/unit-capi-sparse_neg.cc
+++ b/test/src/unit-capi-sparse_neg.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,6 @@ struct SparseNegFx {
   void read_sparse_array_global(const std::string& path);
   void read_sparse_array_row(const std::string& path);
   void read_sparse_array_col(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 SparseNegFx::SparseNegFx()
@@ -100,13 +99,6 @@ void SparseNegFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string SparseNegFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void SparseNegFx::create_sparse_vector(const std::string& path) {

--- a/test/src/unit-capi-sparse_neg_2.cc
+++ b/test/src/unit-capi-sparse_neg_2.cc
@@ -1,11 +1,11 @@
 /**
- * @file   unit-capi-sparse_neg.cc
+ * @file   unit-capi-sparse_neg_2.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -73,7 +73,6 @@ struct SparseNegFx2 {
   void read_sparse_vector(const std::string& path);
   void read_sparse_array_row(const std::string& path);
   void read_sparse_array_col(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 SparseNegFx2::SparseNegFx2()
@@ -99,13 +98,6 @@ void SparseNegFx2::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string SparseNegFx2::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void SparseNegFx2::create_sparse_vector(const std::string& path) {

--- a/test/src/unit-capi-sparse_real.cc
+++ b/test/src/unit-capi-sparse_real.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,7 +66,6 @@ struct SparseRealFx {
   void write_sparse_array_next_partition_bug(const std::string& path);
   void read_sparse_array(const std::string& path);
   void read_sparse_array_next_partition_bug(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 SparseRealFx::SparseRealFx()
@@ -92,13 +91,6 @@ void SparseRealFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string SparseRealFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void SparseRealFx::create_sparse_array(const std::string& path) {

--- a/test/src/unit-capi-sparse_real_2.cc
+++ b/test/src/unit-capi-sparse_real_2.cc
@@ -1,11 +1,11 @@
 /**
- * @file   unit-capi-sparse_real.cc
+ * @file   unit-capi-sparse_real_2.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,7 +65,6 @@ struct SparseRealFx2 {
   void write_sparse_array_next_partition_bug(const std::string& path);
   void read_sparse_array(const std::string& path);
   void read_sparse_array_next_partition_bug(const std::string& path);
-  static std::string random_name(const std::string& prefix);
 };
 
 SparseRealFx2::SparseRealFx2()
@@ -91,13 +90,6 @@ void SparseRealFx2::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string SparseRealFx2::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 void SparseRealFx2::create_sparse_array(const std::string& path) {

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -80,7 +80,6 @@ struct StringDimsFx {
   ~StringDimsFx();
   void create_temp_dir(const std::string& path);
   void remove_temp_dir(const std::string& path);
-  std::string random_name(const std::string& prefix);
   int array_create_wrapper(
       const std::string& path, tiledb_array_schema_t* array_schema);
   int array_schema_load_wrapper(
@@ -199,13 +198,6 @@ void StringDimsFx::remove_temp_dir(const std::string& path) {
   REQUIRE(tiledb_vfs_is_dir(ctx_, vfs_, path.c_str(), &is_dir) == TILEDB_OK);
   if (is_dir)
     REQUIRE(tiledb_vfs_remove_dir(ctx_, vfs_, path.c_str()) == TILEDB_OK);
-}
-
-std::string StringDimsFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
 }
 
 int StringDimsFx::get_dir_num(const char* path, void* data) {

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -145,7 +145,7 @@ TEST_CASE("C API: Test virtual filesystem", "[capi][vfs]") {
   std::string s3_bucket;
   if (s3_enabled) {
     SECTION("Filesystem: S3") {
-      path = "s3://" + random_name("tiledb") + "/tiledb_test/";
+      path = "s3://" + random_label("tiledb-") + "/tiledb_test/";
       s3_bucket = path.substr(0, path.find("tiledb_test/"));
 
       // Check S3 bucket functionality
@@ -171,7 +171,7 @@ TEST_CASE("C API: Test virtual filesystem", "[capi][vfs]") {
   /** Note: Azure testing not currently enabled.
   if (azure_enabled) {
     SECTION("Filesystem: Azure") {
-      path = "azure://" + random_name("tiledb") + "/tiledb_test/";
+      path = "azure://" + random_label("tiledb-") + "/tiledb_test/";
     }
   } */
 
@@ -403,7 +403,7 @@ TEST_CASE("C API: Test virtual filesystem", "[capi][vfs]") {
 
     // Move from one bucket to another (only for S3)
     if (backend_is_s3) {
-      std::string bucket2 = "s3://" + random_name("tiledb") + "/";
+      std::string bucket2 = "s3://" + random_label("tiledb-") + "/";
       std::string subdir3 = bucket2 + "tiledb_test/subdir3/";
 
       // Remove and recreate bucket if already exists
@@ -481,7 +481,7 @@ TEST_CASE("C API: Test virtual filesystem", "[capi][vfs]") {
 
         // Copy from one bucket to another (only for S3)
         if (backend_is_s3) {
-          std::string bucket2 = "s3://" + random_name("tiledb") + "/";
+          std::string bucket2 = "s3://" + random_label("tiledb-") + "/";
           std::string subdir3 = bucket2 + "tiledb_test/subdir3/";
 
           // Remove and recreate bucket if already exists

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1879,7 +1879,7 @@ TEST_CASE("C++ API: Array write and read from MemFS", "[cppapi][memfs]") {
 TEST_CASE(
     "C++ API: Array on s3 with empty subfolders",
     "[cppapi][s3][empty_subfolders]") {
-  const std::string array_bucket = "s3://" + random_name("tiledb") + "/";
+  const std::string array_bucket = "s3://" + random_label("tiledb") + "/";
   const std::string array_name = array_bucket + "cpp_unit_array/";
 
   tiledb::Config cfg;

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1879,7 +1879,7 @@ TEST_CASE("C++ API: Array write and read from MemFS", "[cppapi][memfs]") {
 TEST_CASE(
     "C++ API: Array on s3 with empty subfolders",
     "[cppapi][s3][empty_subfolders]") {
-  const std::string array_bucket = "s3://" + random_label("tiledb") + "/";
+  const std::string array_bucket = "s3://" + random_label("tiledb-") + "/";
   const std::string array_name = array_bucket + "cpp_unit_array/";
 
   tiledb::Config cfg;

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -479,7 +479,7 @@ TEST_CASE(
       tiledb_ctx_is_supported_fs(ctx.ptr().get(), TILEDB_S3, &s3) == TILEDB_OK);
   if (s3) {
     tiledb::VFS vfs(ctx);
-    std::string bucket_name = "s3://" + random_label("tiledb") + "/";
+    std::string bucket_name = "s3://" + random_label("tiledb-") + "/";
     if (vfs.is_bucket(bucket_name)) {
       REQUIRE_NOTHROW(vfs.remove_bucket(bucket_name));
     }

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2023 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -479,8 +479,7 @@ TEST_CASE(
       tiledb_ctx_is_supported_fs(ctx.ptr().get(), TILEDB_S3, &s3) == TILEDB_OK);
   if (s3) {
     tiledb::VFS vfs(ctx);
-    std::string bucket_name =
-        "s3://" + tiledb::test::random_name("tiledb") + "/";
+    std::string bucket_name = "s3://" + random_label("tiledb") + "/";
     if (vfs.is_bucket(bucket_name)) {
       REQUIRE_NOTHROW(vfs.remove_bucket(bucket_name));
     }

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -54,7 +54,7 @@ struct S3DirectFx {
 
   const std::string S3_PREFIX = "s3://";
   const tiledb::sm::URI S3_BUCKET =
-      tiledb::sm::URI(S3_PREFIX + random_label("tiledb") + "/");
+      tiledb::sm::URI(S3_PREFIX + random_label("tiledb-") + "/");
   const std::string TEST_DIR = S3_BUCKET.to_string() + "tiledb_test_dir/";
   ThreadPool thread_pool_{2};
   tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, set_config_params()};

--- a/test/src/unit-s3-no-multipart.cc
+++ b/test/src/unit-s3-no-multipart.cc
@@ -51,11 +51,10 @@ struct S3DirectFx {
   S3DirectFx();
   ~S3DirectFx();
   static Config set_config_params();
-  static std::string random_name(const std::string& prefix);
 
   const std::string S3_PREFIX = "s3://";
   const tiledb::sm::URI S3_BUCKET =
-      tiledb::sm::URI(S3_PREFIX + random_name("tiledb") + "/");
+      tiledb::sm::URI(S3_PREFIX + random_label("tiledb") + "/");
   const std::string TEST_DIR = S3_BUCKET.to_string() + "tiledb_test_dir/";
   ThreadPool thread_pool_{2};
   tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, set_config_params()};
@@ -107,13 +106,6 @@ Config S3DirectFx::set_config_params() {
   REQUIRE(config.set("vfs.s3.multipart_part_size", "10000000").ok());
   REQUIRE(config.set("vfs.s3.use_multipart_upload", "false").ok());
   return config;
-}
-
-std::string S3DirectFx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << tiledb::sm::utils::time::timestamp_now_ms();
-  return ss.str();
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -54,7 +54,7 @@ struct S3Fx {
 
   const std::string S3_PREFIX = "s3://";
   const tiledb::sm::URI S3_BUCKET =
-      tiledb::sm::URI(S3_PREFIX + random_label("tiledb") + "/");
+      tiledb::sm::URI(S3_PREFIX + random_label("tiledb-") + "/");
   const std::string TEST_DIR = S3_BUCKET.to_string() + "tiledb_test_dir/";
   ThreadPool thread_pool_{2};
   tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, set_config_params()};

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -51,11 +51,10 @@ struct S3Fx {
   S3Fx();
   ~S3Fx();
   static Config set_config_params();
-  static std::string random_name(const std::string& prefix);
 
   const std::string S3_PREFIX = "s3://";
   const tiledb::sm::URI S3_BUCKET =
-      tiledb::sm::URI(S3_PREFIX + random_name("tiledb") + "/");
+      tiledb::sm::URI(S3_PREFIX + random_label("tiledb") + "/");
   const std::string TEST_DIR = S3_BUCKET.to_string() + "tiledb_test_dir/";
   ThreadPool thread_pool_{2};
   tiledb::sm::S3 s3_{&g_helper_stats, &thread_pool_, set_config_params()};
@@ -103,13 +102,6 @@ Config S3Fx::set_config_params() {
   REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
 #endif
   return config;
-}
-
-std::string S3Fx::random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << tiledb::sm::utils::time::timestamp_now_ms();
-  return ss.str();
 }
 
 TEST_CASE_METHOD(S3Fx, "Test S3 filesystem, file management", "[s3]") {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -154,12 +154,12 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
     REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
 
     root_pairs.emplace_back(
-        URI("s3://" + random_label("vfs") + "/"), std::move(config));
+        URI("s3://" + random_label("vfs-") + "/"), std::move(config));
   }
   if constexpr (tiledb::sm::filesystem::hdfs_enabled) {
     Config config;
     root_pairs.emplace_back(
-        URI("hdfs:///" + random_label("vfs") + "/"), std::move(config));
+        URI("hdfs:///" + random_label("vfs-") + "/"), std::move(config));
   }
   if constexpr (tiledb::sm::filesystem::azure_enabled) {
     Config config;
@@ -179,17 +179,17 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
                 .ok());
 
     root_pairs.emplace_back(
-        URI("azure://" + random_label("vfs") + "/"), std::move(config));
+        URI("azure://" + random_label("vfs-") + "/"), std::move(config));
   }
 
   Config config;
 #ifdef _WIN32
   root_pairs.emplace_back(
-      URI(tiledb::sm::Win::current_dir() + "\\" + random_label("vfs") + "\\"),
+      URI(tiledb::sm::Win::current_dir() + "\\" + random_label("vfs-") + "\\"),
       std::move(config));
 #else
   root_pairs.emplace_back(
-      URI(Posix::current_dir() + "/" + random_label("vfs") + "/"),
+      URI(Posix::current_dir() + "/" + random_label("vfs-") + "/"),
       std::move(config));
 #endif
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -154,14 +154,12 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
     REQUIRE(config.set("vfs.s3.verify_ssl", "false").ok());
 
     root_pairs.emplace_back(
-        URI("s3://" + tiledb::test::random_name("vfs") + "/"),
-        std::move(config));
+        URI("s3://" + random_label("vfs") + "/"), std::move(config));
   }
   if constexpr (tiledb::sm::filesystem::hdfs_enabled) {
     Config config;
     root_pairs.emplace_back(
-        URI("hdfs:///" + tiledb::test::random_name("vfs") + "/"),
-        std::move(config));
+        URI("hdfs:///" + random_label("vfs") + "/"), std::move(config));
   }
   if constexpr (tiledb::sm::filesystem::azure_enabled) {
     Config config;
@@ -181,19 +179,17 @@ TEST_CASE("VFS: URI semantics", "[vfs][uri]") {
                 .ok());
 
     root_pairs.emplace_back(
-        URI("azure://" + tiledb::test::random_name("vfs") + "/"),
-        std::move(config));
+        URI("azure://" + random_label("vfs") + "/"), std::move(config));
   }
 
   Config config;
 #ifdef _WIN32
   root_pairs.emplace_back(
-      URI(tiledb::sm::Win::current_dir() + "\\" +
-          tiledb::test::random_name("vfs") + "\\"),
+      URI(tiledb::sm::Win::current_dir() + "\\" + random_label("vfs") + "\\"),
       std::move(config));
 #else
   root_pairs.emplace_back(
-      URI(Posix::current_dir() + "/" + tiledb::test::random_name("vfs") + "/"),
+      URI(Posix::current_dir() + "/" + random_label("vfs") + "/"),
       std::move(config));
 #endif
 

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -926,13 +926,6 @@ void open_array(
   CHECK(rc == TILEDB_OK);
 }
 
-std::string random_name(const std::string& prefix) {
-  std::stringstream ss;
-  ss << prefix << "-" << std::this_thread::get_id() << "-"
-     << TILEDB_TIMESTAMP_NOW_MS;
-  return ss.str();
-}
-
 void remove_dir(const std::string& path, tiledb_ctx_t* ctx, tiledb_vfs_t* vfs) {
   int is_dir = 0;
   REQUIRE(tiledb_vfs_is_dir(ctx, vfs, path.c_str(), &is_dir) == TILEDB_OK);

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -37,6 +37,7 @@
 #include "test/support/src/coords_workaround.h"
 #include "tiledb.h"
 #include "tiledb/common/common.h"
+#include "tiledb/common/random/helpers.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/enums/layout.h"
@@ -503,15 +504,6 @@ void get_supported_fs(
  * @param query_type The query type.
  */
 void open_array(tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t);
-
-/**
- * Returns a random bucket name, with `prefix` as prefix and using
- * the thread id as a "random" suffix.
- *
- * @param prefix The prefix of the bucket name.
- * @return A random bucket name.
- */
-std::string random_name(const std::string& prefix);
 
 /**
  * Helper method that removes a directory.

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -37,7 +37,7 @@
 #include "test/support/src/coords_workaround.h"
 #include "tiledb.h"
 #include "tiledb/common/common.h"
-#include "tiledb/common/random/helpers.h"
+#include "tiledb/common/random/random_label.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/enums/layout.h"

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -148,7 +148,7 @@ class SupportedFsS3 : public SupportedFs {
  public:
   SupportedFsS3()
       : s3_prefix_("s3://")
-      , s3_bucket_(s3_prefix_ + random_label("tiledb") + "/")
+      , s3_bucket_(s3_prefix_ + random_label("tiledb-") + "/")
       , temp_dir_(s3_bucket_ + "tiledb_test/") {
   }
 
@@ -275,7 +275,7 @@ class SupportedFsAzure : public SupportedFs {
  public:
   SupportedFsAzure()
       : azure_prefix_("azure://")
-      , container_(azure_prefix_ + random_label("tiledb") + "/")
+      , container_(azure_prefix_ + random_label("tiledb-") + "/")
       , temp_dir_(container_ + "tiledb_test/") {
   }
 
@@ -342,7 +342,7 @@ class SupportedFsGCS : public SupportedFs {
  public:
   SupportedFsGCS(std::string prefix = "gcs://")
       : prefix_(prefix)
-      , bucket_(prefix_ + random_label("tiledb") + "/")
+      , bucket_(prefix_ + random_label("tiledb-") + "/")
       , temp_dir_(bucket_ + "tiledb_test/") {
   }
 

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -148,7 +148,7 @@ class SupportedFsS3 : public SupportedFs {
  public:
   SupportedFsS3()
       : s3_prefix_("s3://")
-      , s3_bucket_(s3_prefix_ + random_name("tiledb") + "/")
+      , s3_bucket_(s3_prefix_ + random_label("tiledb") + "/")
       , temp_dir_(s3_bucket_ + "tiledb_test/") {
   }
 
@@ -275,7 +275,7 @@ class SupportedFsAzure : public SupportedFs {
  public:
   SupportedFsAzure()
       : azure_prefix_("azure://")
-      , container_(azure_prefix_ + random_name("tiledb") + "/")
+      , container_(azure_prefix_ + random_label("tiledb") + "/")
       , temp_dir_(container_ + "tiledb_test/") {
   }
 
@@ -342,7 +342,7 @@ class SupportedFsGCS : public SupportedFs {
  public:
   SupportedFsGCS(std::string prefix = "gcs://")
       : prefix_(prefix)
-      , bucket_(prefix_ + random_name("tiledb") + "/")
+      , bucket_(prefix_ + random_label("tiledb") + "/")
       , temp_dir_(bucket_ + "tiledb_test/") {
   }
 

--- a/tiledb/common/random/CMakeLists.txt
+++ b/tiledb/common/random/CMakeLists.txt
@@ -28,8 +28,8 @@ include(common NO_POLICY_SCOPE)
 include(object_library)
 
 list(APPEND SOURCES
-  helpers.cc  
-  prng.cc    
+  prng.cc
+  random_label.cc
   seeder.cc
 )
 gather_sources(${SOURCES})

--- a/tiledb/common/random/CMakeLists.txt
+++ b/tiledb/common/random/CMakeLists.txt
@@ -28,6 +28,7 @@ include(common NO_POLICY_SCOPE)
 include(object_library)
 
 list(APPEND SOURCES
+  helpers.cc  
   prng.cc    
   seeder.cc
 )

--- a/tiledb/common/random/helpers.cc
+++ b/tiledb/common/random/helpers.cc
@@ -1,0 +1,52 @@
+/**
+ * @file   helpers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines some random helper functions.
+ */
+
+#include "tiledb/common/random/helpers.h"
+#include "tiledb/common/random/prng.h"
+
+namespace tiledb::common {
+
+std::string random_label(std::string prefix) {
+  // Generate random number using global PRNG
+  PRNG& prng = PRNG::get();
+  auto rand = prng();
+
+  // Ensure prefix ends with "-"
+  if (!prefix.ends_with("-")) {
+    prefix = prefix + "-";
+  }
+
+  // Generate random label
+  return prefix + std::to_string(rand);
+}
+
+}  // namespace tiledb::common

--- a/tiledb/common/random/helpers.h
+++ b/tiledb/common/random/helpers.h
@@ -1,0 +1,50 @@
+/**
+ * @file   helpers.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares some random helper functions.
+ */
+
+#ifndef TILEDB_HELPERS_H
+#define TILEDB_HELPERS_H
+
+#include <string>
+
+namespace tiledb::common {
+
+/**
+ * Returns a random label, with given prefix and a random number as suffix.
+ *
+ * @param prefix The prefix of the label.
+ * @return A random label.
+ */
+std::string random_label(std::string prefix);
+
+}  // namespace tiledb::common
+
+#endif  // TILEDB_HELPERS_H

--- a/tiledb/common/random/random_label.cc
+++ b/tiledb/common/random/random_label.cc
@@ -1,5 +1,5 @@
 /**
- * @file   helpers.h
+ * @file   random_label.cc
  *
  * @section LICENSE
  *
@@ -27,24 +27,37 @@
  *
  * @section DESCRIPTION
  *
- * This file declares some random helper functions.
+ * This file defines a random label generator.
  */
 
-#ifndef TILEDB_HELPERS_H
-#define TILEDB_HELPERS_H
+#include "tiledb/common/random/random_label.h"
+#include "tiledb/common/random/prng.h"
 
-#include <string>
+#include <iomanip>
+#include <sstream>
 
 namespace tiledb::common {
 
 /**
- * Returns a random label, with given prefix and a random number as suffix.
+ * Legacy code provides randomness using UUIDs, which are always 128 bits,
+ * represented as a 32-digit hexadecimal value.
  *
- * @param prefix The prefix of the label.
- * @return A random label.
+ * To ensure backward compatibility, this function formats the PRNG-generated
+ * values to be precisely a 32-digit hexadecimal value. Each value is padded
+ * with 0s such that it makes up one 16-digit half of the full 32-digit number.
  */
-std::string random_label(std::string prefix);
+std::string random_label(std::string prefix) {
+  PRNG& prng = PRNG::get();
+  std::stringstream ss;
+
+  // Generate and format a 128-bit, 32-digit hexadecimal random number
+  auto rand1 = prng();
+  ss << std::hex << std::setw(16) << std::setfill('0') << rand1;
+  auto rand2 = prng();
+  ss << std::hex << std::setw(16) << std::setfill('0') << rand2;
+
+  // Return label string
+  return prefix + ss.str();
+}
 
 }  // namespace tiledb::common
-
-#endif  // TILEDB_HELPERS_H

--- a/tiledb/common/random/random_label.h
+++ b/tiledb/common/random/random_label.h
@@ -41,11 +41,11 @@ namespace tiledb::common {
  * Returns a PRNG-generated random label with the optionally-provided prefix.
  *
  * Given prefix "tiledb-", this function will return a label with syntax
- * tiledb-<32-bit hexadecimal random number>.
+ * tiledb-<32-digit hexadecimal random number>.
  * (Ex. tiledb-f258d22d4db9139204eef2b4b5d860cc).
  *
- * Note: the random number is actually the combination of two 16-bit numbers.
- * The values are 0-padded to ensure exactly a 32-bit length.
+ * Note: the random number is actually the combination of two 16-digit numbers.
+ * The values are 0-padded to ensure exactly a 128-bit, 32-digit length.
  *
  * @param prefix The optional prefix of the label.
  * @return A random label.

--- a/tiledb/common/random/random_label.h
+++ b/tiledb/common/random/random_label.h
@@ -1,5 +1,5 @@
 /**
- * @file   helpers.cc
+ * @file   random_label.h
  *
  * @section LICENSE
  *
@@ -27,26 +27,31 @@
  *
  * @section DESCRIPTION
  *
- * This file defines some random helper functions.
+ * This file declares a random label generator.
  */
 
-#include "tiledb/common/random/helpers.h"
-#include "tiledb/common/random/prng.h"
+#ifndef TILEDB_HELPERS_H
+#define TILEDB_HELPERS_H
+
+#include <string>
 
 namespace tiledb::common {
 
-std::string random_label(std::string prefix) {
-  // Generate random number using global PRNG
-  PRNG& prng = PRNG::get();
-  auto rand = prng();
-
-  // Ensure prefix ends with "-"
-  if (!prefix.ends_with("-")) {
-    prefix = prefix + "-";
-  }
-
-  // Generate random label
-  return prefix + std::to_string(rand);
-}
+/**
+ * Returns a PRNG-generated random label with the optionally-provided prefix.
+ *
+ * Given prefix "tiledb-", this function will return a label with syntax
+ * tiledb-<32-bit hexadecimal random number>.
+ * (Ex. tiledb-f258d22d4db9139204eef2b4b5d860cc).
+ *
+ * Note: the random number is actually the combination of two 16-bit numbers.
+ * The values are 0-padded to ensure exactly a 32-bit length.
+ *
+ * @param prefix The optional prefix of the label.
+ * @return A random label.
+ */
+std::string random_label(std::string prefix = "");
 
 }  // namespace tiledb::common
+
+#endif  // TILEDB_HELPERS_H

--- a/tiledb/common/random/test/unit_seedable_global_PRNG.cc
+++ b/tiledb/common/random/test/unit_seedable_global_PRNG.cc
@@ -30,9 +30,8 @@
 
 #include <test/support/tdb_catch.h>
 #include "../prng.h"
+#include "../random_label.h"
 #include "../seeder.h"
-
-#include <iostream>
 
 using namespace tiledb::common;
 
@@ -96,7 +95,7 @@ TEST_CASE(
 TEST_CASE(
     "SeedableGlobalPRNG: operator",
     "[SeedableGlobalPRNG][operator][multiple]") {
-  PRNG prng;
+  PRNG& prng = PRNG::get();
   auto rand_num1 = prng();
   CHECK(rand_num1 != 0);
 
@@ -127,4 +126,13 @@ TEST_CASE(
         seeder_.seed(),
         Catch::Matchers::ContainsSubstring("Seed can only be used once"));
   }
+}
+
+TEST_CASE("random_label", "[random_label]") {
+  auto rand_label1 = random_label();
+  CHECK(rand_label1.length() == 32);
+
+  auto rand_label2 = random_label();
+  CHECK(rand_label2.length() == 32);
+  CHECK(rand_label1 != rand_label2);
 }


### PR DESCRIPTION
Add function `random_label` to utilize PRNG for random string generation.
This function is a migration of `random_name` from `test/support/src/helpers` into `common/random`, which has been modified to use the PRNG. Excess declarations of in-test `random_name` have been removed from `tiledb_unit`

---
TYPE: IMPROVEMENT
DESC: Add function random_label to utilize PRNG for random string generation
