### PR TITLE
Support running REST CI on workflow-dispatch.

### DIFF
--- a/.github/workflows/ci-rest.yml
+++ b/.github/workflows/ci-rest.yml
@@ -1,5 +1,8 @@
 name: REST CI
-on: workflow_call
+
+on:
+  - workflow_call
+  - workflow_dispatch
 
 jobs:
   rest-ci:


### PR DESCRIPTION
REST CI can not run on pull requests from forks (because it needs a secret to access a private repository, and that secret is not available there). This PR makes possible one way to run it on such pull requests, by copying the branch to the `TileDB-Inc/TileDB` repo and running it manually, without having to run all other CI jobs.

---
TYPE: NO_HISTORY