### PR TITLE
Build shared libraries by default.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -371,6 +371,8 @@ jobs:
         run: |
           cd $env:BUILD_SOURCESDIRECTORY\examples\cmake_project
 
+          $env:Path += ";$env:BUILD_BUILDDIRECTORY\dist\bin;$env:BUILD_BUILDDIRECTORY\externals\install\bin"
+
           $CMakeBuildType = $env:TILEDB_CMAKE_BUILD_TYPE
 
           mkdir build

--- a/bootstrap
+++ b/bootstrap
@@ -37,7 +37,7 @@ Configuration:
     --enable-vcpkg                  use vcpkg for downloading and building dependencies
     --dependency=DIRs               specify the dependencies at DIRs, separated by colon
                                     ['"${default_dependency}"']
-    --linkage                       specify the linkage of tiledb. Defaults to static.
+    --linkage                       specify the linkage of tiledb. Defaults to shared.
                                     [static|shared]
     --force-build-all-deps          force building of all dependencies, even those
                                     already installed at system-level
@@ -143,7 +143,7 @@ while test $# != 0; do
     --enable-azure) tiledb_azure="ON";;
     --enable-gcs) tiledb_gcs="ON";;
     --enable-serialization) tiledb_serialization="ON";;
-    --enable-static-tiledb) echo "Argument '--enable-static-tiledb' is obsolete and will be removed in a future version. TileDB is now built as a static library by default and linkage is controlled with the --linkage option."
+    --enable-static-tiledb) echo "Argument '--enable-static-tiledb' is obsolete and will be removed in a future version. Use --linkage=static instead."
                             enable_static_tiledb="ON";;
     --enable-sanitizer=*) san=`arg "$1"`
                 sanitizer="$san";;
@@ -180,7 +180,7 @@ for en in "${enables[@]}"; do
     ccache) tiledb_ccache="ON";;
     arrow-tests) tiledb_arrow_tests="ON";;
     hdfs) tiledb_hdfs="ON";;
-    static-tiledb) echo "Argument '--enable-static-tiledb' is obsolete and will be removed in a future version. TileDB is now built as a static library by default and linkage is controlled with the --linkage option."
+    static-tiledb) echo "Argument '--enable-static-tiledb' is obsolete and will be removed in a future version. Use --linkage=static instead."
                     enable_static_tiledb="ON";;
     experimental-features) tiledb_experimental_features="ON";;
     rest-tests) tiledb_tests_enable_rest="ON";;
@@ -193,16 +193,16 @@ if [ "${source_dir}" = "${binary_dir}" ]; then
     die "cannot build the project in the source directory! Out-of-source build is enforced!"
 fi
 
-if [ "${linkage}" = "static" ] || [ "${linkage}" = "" ]; then
-    build_shared_libs="OFF"
-elif [ "${linkage}" = "shared" ]; then
+if [ "${linkage}" = "shared" ] || [ "${linkage}" = "" ]; then
     build_shared_libs="ON"
+elif [ "${linkage}" = "static" ] || [ "${enable_static_tiledb}" = "ON" ]; then
+    build_shared_libs="OFF"
 else
     die "unknown linkage: ${linkage}"
 fi
 
 # Fail if both --linkage=shared and --enable-static-tiledb are specified
-if [ "${build_shared_libs}" = "ON" ] && [ "${enable_static_tiledb}" = "ON" ]; then
+if [ "${linkage}" = "shared" ] && [ "${enable_static_tiledb}" = "ON" ]; then
     die "cannot specify both --linkage=shared and --enable-static-tiledb"
 fi
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -18,7 +18,7 @@ Semicolon separated list to binary dependencies.
 
 .PARAMETER Linkage
 Specify the linkage type to build TileDB with. Valid values are
-"static" and "shared". Default is "static".
+"static" and "shared". Default is "shared".
 
 .PARAMETER CMakeGenerator
 Optionally specify the CMake generator string, e.g. "Visual Studio 15
@@ -118,7 +118,7 @@ https://github.com/TileDB-Inc/TileDB
 Param(
     [string]$Prefix,
     [string]$Dependency,
-    [string]$Linkage = "static",
+    [string]$Linkage = "shared",
     [string]$CMakeGenerator,
     [switch]$EnableAssert,
     [switch]$EnableDebug,
@@ -246,17 +246,18 @@ if ($DisableWebP.IsPresent) {
   $BuildWebP="OFF"
 }
 
-$BuildSharedLibs = "OFF";
-if ($Linkage -eq "shared") {
-    $BuildSharedLibs = "ON"
+$BuildSharedLibs = "ON";
+if ($Linkage -eq "static") {
+    $BuildSharedLibs = "OFF"
 }
-elseif ($Linkage -ne "static") {
+elseif ($Linkage -ne "shared") {
     Write-Error "Invalid linkage type: $Linkage. Valid values are 'static' and 'shared'."
     exit 1
 }
 
 if ($EnableStaticTileDB.IsPresent) {
-    Write-Warning "-EnableStaticTileDB is deprecated and will be removed in a future version. TileDB is now built as a static library by default. Use -Linkage shared to build a shared library."
+    Write-Warning "-EnableStaticTileDB is deprecated and will be removed in a future version. Use -Linkage static instead."
+    $BuildSharedLibs = "OFF"
     if ($Linkage -eq "shared") {
         Write-Error "Cannot specify -EnableStaticTileDB alongside -Linkage shared."
         exit 1

--- a/cmake/Options/BuildOptions.cmake
+++ b/cmake/Options/BuildOptions.cmake
@@ -21,7 +21,7 @@ option(TILEDB_ASSERTIONS "Build with assertions enabled (default off for release
 option(TILEDB_CPP_API "Enables building of the TileDB C++ API." ON)
 option(TILEDB_CMAKE_IDE "(Used for CLion builds). Disables superbuild and sets the EP install dir." OFF)
 option(TILEDB_STATS "Enables internal TileDB statistics gathering." ON)
-option(BUILD_SHARED_LIBS "Enables building TileDB as a shared library." OFF)
+option(BUILD_SHARED_LIBS "Enables building TileDB as a shared library." ON)
 option(TILEDB_TESTS "If true, enables building the TileDB unit test suite" ON)
 option(TILEDB_TOOLS "If true, enables building the TileDB tools" OFF)
 option(TILEDB_SERIALIZATION "If true, enables building with support for query serialization" OFF)

--- a/test/support/CMakeLists.txt
+++ b/test/support/CMakeLists.txt
@@ -50,7 +50,7 @@ if (TILEDB_VERBOSE)
   add_definitions(-DTILEDB_VERBOSE)
 endif()
 
-add_library(tiledb_test_support_lib EXCLUDE_FROM_ALL
+add_library(tiledb_test_support_lib STATIC EXCLUDE_FROM_ALL
   $<TARGET_OBJECTS:TILEDB_CORE_OBJECTS>
   ${TILEDB_TEST_SUPPORT_SOURCES}
 )

--- a/tiledb/sm/query/ast/test/CMakeLists.txt
+++ b/tiledb/sm/query/ast/test/CMakeLists.txt
@@ -36,7 +36,7 @@ set(AST_TEST_SUPPORT_SOURCES
     ${CMAKE_SOURCE_DIR}/test/support/src/ast_helpers.h
     ${CMAKE_SOURCE_DIR}/test/support/src/ast_helpers.cc
     )
-add_library(ast_test_support_lib EXCLUDE_FROM_ALL ${AST_TEST_SUPPORT_SOURCES})
+add_library(ast_test_support_lib STATIC EXCLUDE_FROM_ALL ${AST_TEST_SUPPORT_SOURCES})
 # We want tests to continue as normal even as the API is changing,
 # so don't warn for deprecations, since they'll be escalated to errors.
 if (NOT MSVC)


### PR DESCRIPTION
Restores default behavior to prior to #4528.

Supersedes #4560.

Fixes TileDB-Inc/TileDB-MariaDB#294
Fixes TileDB-Inc/TileDB-CSharp#339
Fixes TileDB-Inc/TileDB-CSharp#340
Fixes TileDB-Inc/TileDB-CSharp#341

---
TYPE: BUILD
DESC: `BUILD_SHARED_LIBS` is enabled by default.