### PR TITLE
[Backport release-2.19] Always install libraries in the `lib` directory.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=./dist \
+            -DTILEDB_INSTALL_LIBDIR=lib \
             -DTILEDB_S3=ON \
             -DTILEDB_AZURE=ON \
             -DTILEDB_GCS=ON \


### PR DESCRIPTION
Backport ae5cc5ae20aa5c3d3fd9568adadf4b106afdd7b1 from #4562.

---
TYPE: BUG
DESC: Fix regression when libraries were sometimes installed in the `lib64` directory.