### PR TITLE
Add setting to disable install_sigpipe_handler on S3.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -324,6 +324,7 @@ void check_save_to_file() {
   ss << "vfs.s3.connect_max_tries 5\n";
   ss << "vfs.s3.connect_scale_factor 25\n";
   ss << "vfs.s3.connect_timeout_ms 10800\n";
+  ss << "vfs.s3.install_sigpipe_handler true\n";
   ss << "vfs.s3.logging_level Off\n";
   ss << "vfs.s3.max_parallel_ops " << std::thread::hardware_concurrency()
      << "\n";
@@ -741,6 +742,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.s3.proxy_username"] = "";
   all_param_values["vfs.s3.verify_ssl"] = "true";
   all_param_values["vfs.s3.no_sign_request"] = "false";
+  all_param_values["vfs.s3.install_sigpipe_handler"] = "true";
   all_param_values["vfs.hdfs.username"] = "stavros";
   all_param_values["vfs.hdfs.kerb_ticket_cache_path"] = "";
   all_param_values["vfs.hdfs.name_node_uri"] = "";
@@ -813,6 +815,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["s3.bucket_canned_acl"] = "NOT_SET";
   vfs_param_values["s3.object_canned_acl"] = "NOT_SET";
   vfs_param_values["s3.config_source"] = "auto";
+  vfs_param_values["s3.install_sigpipe_handler"] = "true";
   vfs_param_values["hdfs.username"] = "stavros";
   vfs_param_values["hdfs.kerb_ticket_cache_path"] = "";
   vfs_param_values["hdfs.name_node_uri"] = "";
@@ -877,6 +880,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   s3_param_values["bucket_canned_acl"] = "NOT_SET";
   s3_param_values["object_canned_acl"] = "NOT_SET";
   s3_param_values["config_source"] = "auto";
+  s3_param_values["install_sigpipe_handler"] = "true";
 
   // Create an iterator and iterate over all parameters
   tiledb_config_iter_t* config_iter = nullptr;

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -67,7 +67,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 64);
+  CHECK(names.size() == 65);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -561,6 +561,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * from config files with support for web tokens, commonly used by EKS/ECS).
  *    **Default**: auto
  *    <br>
+ * - `vfs.s3.install_sigpipe_handler` <br>
+ *    When set to `true`, the S3 SDK uses a handler that ignores SIGPIPE
+ *    signals.
+ *    **Default**: "true"
  * - `vfs.hdfs.name_node_uri"` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -227,6 +227,7 @@ const std::string Config::VFS_S3_NO_SIGN_REQUEST = "false";
 const std::string Config::VFS_S3_BUCKET_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_S3_OBJECT_CANNED_ACL = "NOT_SET";
 const std::string Config::VFS_S3_CONFIG_SOURCE = "auto";
+const std::string Config::VFS_S3_INSTALL_SIGPIPE_HANDLER = "true";
 const std::string Config::VFS_HDFS_KERB_TICKET_CACHE_PATH = "";
 const std::string Config::VFS_HDFS_NAME_NODE_URI = "";
 const std::string Config::VFS_HDFS_USERNAME = "";
@@ -478,6 +479,9 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "vfs.s3.object_canned_acl", Config::VFS_S3_OBJECT_CANNED_ACL),
     std::make_pair("vfs.s3.config_source", Config::VFS_S3_CONFIG_SOURCE),
+    std::make_pair(
+        "vfs.s3.install_sigpipe_handler",
+        Config::VFS_S3_INSTALL_SIGPIPE_HANDLER),
     std::make_pair("vfs.hdfs.name_node_uri", Config::VFS_HDFS_NAME_NODE_URI),
     std::make_pair("vfs.hdfs.username", Config::VFS_HDFS_USERNAME),
     std::make_pair(

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -568,6 +568,12 @@ class Config {
   /** Force making an unsigned request to s3 (false). */
   static const std::string VFS_S3_NO_SIGN_REQUEST;
 
+  /**
+   * When set to `true`, the S3 SDK uses a handler that ignores SIGPIPE
+   * signals.
+   */
+  static const std::string VFS_S3_INSTALL_SIGPIPE_HANDLER;
+
   /** HDFS default kerb ticket cache path. */
   static const std::string VFS_HDFS_KERB_TICKET_CACHE_PATH;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -739,6 +739,10 @@ class Config {
    * from config files with support for web tokens, commonly used by EKS/ECS).
    *    **Default**: auto
    *    <br>
+   * - `vfs.s3.install_sigpipe_handler` <br>
+   *    When set to `true`, the S3 SDK uses a handler that ignores SIGPIPE
+   *    signals.
+   *    **Default**: "true"
    * - `vfs.hdfs.name_node_uri"` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -329,7 +329,8 @@ S3::S3(
   // the AWS SDK to set its own signal handler to ignore SIGPIPE signals. A
   // SIGPIPE may be raised from the socket library when the peer disconnects
   // unexpectedly.
-  options_.httpOptions.installSigPipeHandler = true;
+  options_.httpOptions.installSigPipeHandler =
+      config.get<bool>("vfs.s3.install_sigpipe_handler", Config::must_find);
 
   // Initialize the library once per process.
   if (!s3_params_.skip_init_)


### PR DESCRIPTION
This adds a setting that allows to disable install_sigpipe_handler on S3. When set to `true`, the S3 SDK uses a handler that ignores SIGPIPE signals.

---
TYPE: IMPROVEMENT
DESC: Add setting to disable install_sigpipe_handler on S3.
