### PR TITLE
Refactor filter pipeline unit tests

### DIFF
--- a/tiledb/sm/filter/test/CMakeLists.txt
+++ b/tiledb/sm/filter/test/CMakeLists.txt
@@ -45,6 +45,7 @@ commence(unit_test run_filter_pipeline)
         add_1_out_of_place_filter.cc
         add_n_in_place_filter.cc
         filter_test_support.cc
+        # input_tile_test_data.cc
         pseudo_checksum_filter.cc
         unit_run_filter_pipeline.cc
     )

--- a/tiledb/sm/filter/test/CMakeLists.txt
+++ b/tiledb/sm/filter/test/CMakeLists.txt
@@ -44,6 +44,7 @@ commence(unit_test run_filter_pipeline)
         add_1_including_metadata_filter.cc
         add_1_out_of_place_filter.cc
         add_n_in_place_filter.cc
+        filter_test_support.cc
         pseudo_checksum_filter.cc
         unit_run_filter_pipeline.cc
     )

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -66,7 +66,7 @@ FilteredBufferChunkInfo::FilteredBufferChunkInfo(const FilteredBuffer& buffer)
   size_ = current_offset;
 }
 
-void ChunkCheckerBase::check(
+void ChunkChecker::check(
     const FilteredBuffer& buffer,
     const FilteredBufferChunkInfo& buffer_info,
     uint64_t chunk_index) const {

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -1,0 +1,87 @@
+/**
+ * @file filter_test_support.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "filter_test_support.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+ChunkInfo::ChunkInfo(
+    uint32_t original_chunk_length,
+    uint32_t filtered_chunk_length,
+    uint32_t metadata_length)
+    : original_chunk_length_{original_chunk_length}
+    , filtered_chunk_length_{filtered_chunk_length}
+    , metadata_length_{metadata_length} {
+}
+
+ChunkInfo::ChunkInfo(const FilteredBuffer& buffer, uint32_t chunk_offset)
+    : original_chunk_length_{buffer.value_at_as<uint32_t>(chunk_offset)}
+    , filtered_chunk_length_{buffer.value_at_as<uint32_t>(
+          chunk_offset + sizeof(uint32_t))}
+    , metadata_length_{
+          buffer.value_at_as<uint32_t>(chunk_offset + 2 * sizeof(uint32_t))} {
+}
+
+FilteredBufferChunkInfo::FilteredBufferChunkInfo(const FilteredBuffer& buffer)
+    : nchunks_{buffer.value_at_as<uint64_t>(0)}
+    , chunk_info_{}
+    , offsets_{} {
+  chunk_info_.reserve(nchunks_);
+  offsets_.reserve(nchunks_);
+  uint64_t current_offset = sizeof(uint64_t);
+  for (uint64_t index = 0; index < nchunks_; ++index) {
+    chunk_info_.emplace_back(buffer, current_offset);
+    offsets_.push_back(current_offset);
+    current_offset += chunk_info_[index].size();
+  }
+  size_ = current_offset;
+}
+
+void ChunkCheckerBase::check(
+    const FilteredBuffer& buffer,
+    const FilteredBufferChunkInfo& buffer_info,
+    uint64_t chunk_index) const {
+  auto chunk_info = buffer_info.chunk_info(chunk_index);
+  auto chunk_offset = buffer_info.chunk_offset(chunk_index);
+
+  // Check the value of the original chunk length.
+  CHECK(
+      chunk_info.original_chunk_length() ==
+      expected_chunk_info().original_chunk_length());
+
+  // Check the metadata.
+  check_metadata(buffer, chunk_info, chunk_offset);
+
+  // Check the filtered chunk data.
+  check_filtered_data(buffer, chunk_info, chunk_offset);
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/filter/test/filter_test_support.h
+++ b/tiledb/sm/filter/test/filter_test_support.h
@@ -116,9 +116,9 @@ class FilteredBufferChunkInfo {
  *
  * @tparam Type of the filtered data.
  */
-class ChunkCheckerBase {
+class ChunkChecker {
  public:
-  virtual ~ChunkCheckerBase() = default;
+  virtual ~ChunkChecker() = default;
 
   void check(
       const FilteredBuffer& buffer,
@@ -139,7 +139,7 @@ class ChunkCheckerBase {
 };
 
 template <typename T>
-class GridChunkChecker : public ChunkCheckerBase {
+class GridChunkChecker : public ChunkChecker {
  public:
   GridChunkChecker(
       uint32_t original_chunk_length,
@@ -211,31 +211,7 @@ class FilteredBufferChecker {
   void check(const FilteredBuffer& buffer) const;
 
  private:
-  std::vector<tdb_unique_ptr<ChunkCheckerBase>> chunk_checkers_;
-};
-
-template <typename T>
-class GridTileChecker {
- public:
-  GridTileChecker(uint64_t num_elements, T starting_value, T spacing)
-      : num_elements_{num_elements}
-      , starting_value_{starting_value}
-      , spacing_{spacing} {
-  }
-
-  void check(const Tile& tile) {
-    for (uint64_t index = 0; index < num_elements_; ++index) {
-      T expected_value = starting_value_ + index * spacing_;
-      T actual_value{};
-      CHECK_NOTHROW(tile.read(&actual_value, index * sizeof(T), sizeof(T)));
-      CHECK(actual_value == expected_value);
-    }
-  }
-
- private:
-  uint64_t num_elements_{};
-  T starting_value_{};
-  T spacing_{};
+  std::vector<tdb_unique_ptr<ChunkChecker>> chunk_checkers_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/filter/test/filter_test_support.h
+++ b/tiledb/sm/filter/test/filter_test_support.h
@@ -36,6 +36,19 @@ class ChunkCheckerBase {
   virtual void check_metadata(
       const FilteredBuffer& buffer, uint64_t chunk_offset) const = 0;
 
+  uint64_t expected_total_chunk_size() const {
+    return 3 * sizeof(uint32_t) + expected_original_chunk_length() +
+           expected_filtered_chunk_length() + expected_metadata_length();
+  }
+
+  uint64_t actual_total_chunk_size(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const {
+    return 3 * sizeof(uint32_t) +
+           actual_original_chunk_length(buffer, chunk_offset) +
+           actual_filtered_chunk_length(buffer, chunk_offset) +
+           actual_metadata_length(buffer, chunk_offset);
+  }
+
  protected:
   inline uint32_t actual_original_chunk_length(
       const FilteredBuffer& buffer, uint64_t chunk_offset) const {
@@ -70,9 +83,9 @@ class ChunkCheckerBase {
 };
 
 template <typename T>
-class OffsetChunkChecker : public ChunkCheckerBase {
+class GridChunkChecker : public ChunkCheckerBase {
  public:
-  OffsetChunkChecker(
+  GridChunkChecker(
       uint32_t original_chunk_length,
       uint32_t num_elements,
       T starting_value,
@@ -82,10 +95,6 @@ class OffsetChunkChecker : public ChunkCheckerBase {
       , starting_value_{starting_value}
       , spacing_{spacing} {
   }
-
-  OffsetChunkChecker() = delete;
-
-  virtual ~OffsetChunkChecker() = default;
 
   void check_filtered_data(
       const FilteredBuffer& buffer, uint64_t chunk_offset) const override {

--- a/tiledb/sm/filter/test/filter_test_support.h
+++ b/tiledb/sm/filter/test/filter_test_support.h
@@ -1,0 +1,156 @@
+#ifndef TILEDB_FILTER_TEST_SUPPORT_H
+#define TILEDB_FILTER_TEST_SUPPORT_H
+
+#include <test/support/tdb_catch.h>
+
+#include "tiledb/sm/tile/filtered_buffer.h"
+#include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::sm;
+
+/**
+ * Helper for checking chunk data.
+ *
+ * @tparam Type of the filtered data.
+ */
+class ChunkCheckerBase {
+ public:
+  virtual ~ChunkCheckerBase() = default;
+
+  void check(const FilteredBuffer& buffer, uint64_t chunk_offset) const {
+    // Check the value of the original chunk length.
+    CHECK(
+        actual_original_chunk_length(buffer, chunk_offset) ==
+        expected_original_chunk_length());
+
+    // Check the metadata.
+    check_metadata(buffer, chunk_offset);
+
+    // Check the filtered chunk data.
+    check_filtered_data(buffer, chunk_offset);
+  }
+
+  virtual void check_filtered_data(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const = 0;
+
+  virtual void check_metadata(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const = 0;
+
+ protected:
+  inline uint32_t actual_original_chunk_length(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const {
+    return buffer.value_at_as<uint32_t>(chunk_offset);
+  }
+
+  inline uint32_t actual_filtered_chunk_length(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const {
+    return buffer.value_at_as<uint32_t>(chunk_offset + sizeof(uint32_t));
+  }
+
+  inline uint32_t actual_metadata_length(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const {
+    return buffer.value_at_as<uint32_t>(chunk_offset + 2 * sizeof(uint32_t));
+  }
+
+  inline uint64_t data_offset(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const {
+    return metadata_offset(chunk_offset) +
+           static_cast<uint64_t>(actual_metadata_length(buffer, chunk_offset));
+  }
+
+  virtual uint32_t expected_original_chunk_length() const = 0;
+
+  virtual uint32_t expected_filtered_chunk_length() const = 0;
+
+  virtual uint32_t expected_metadata_length() const = 0;
+
+  inline uint64_t metadata_offset(uint64_t chunk_offset) const {
+    return chunk_offset + 3 * sizeof(uint32_t);
+  }
+};
+
+template <typename T>
+class OffsetChunkChecker : public ChunkCheckerBase {
+ public:
+  OffsetChunkChecker(
+      uint32_t original_chunk_length,
+      uint32_t num_elements,
+      T starting_value,
+      T spacing)
+      : original_chunk_length_{original_chunk_length}
+      , num_elements_{num_elements}
+      , starting_value_{starting_value}
+      , spacing_{spacing} {
+  }
+
+  OffsetChunkChecker() = delete;
+
+  virtual ~OffsetChunkChecker() = default;
+
+  void check_filtered_data(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const override {
+    // Check the size of the filtered data. If it does not match the expected
+    // size, then end the test as a failure.
+    auto data_size = actual_filtered_chunk_length(buffer, chunk_offset);
+    REQUIRE(data_size == expected_filtered_chunk_length());
+
+    // Check the data.
+    auto data_offset_value = data_offset(buffer, chunk_offset);
+    for (uint32_t index = 0; index < num_elements_; ++index) {
+      auto offset = data_offset_value + index * sizeof(T);
+      T expected_value = starting_value_ + index * spacing_;
+      T actual_value = buffer.value_at_as<uint64_t>(offset);
+      CHECK(actual_value == expected_value);
+    }
+  }
+
+  void check_metadata(
+      const FilteredBuffer& buffer, uint64_t chunk_offset) const override {
+    CHECK(actual_metadata_length(buffer, chunk_offset) == 0);
+  }
+
+ protected:
+  uint32_t expected_original_chunk_length() const override {
+    return original_chunk_length_;
+  }
+
+  uint32_t expected_filtered_chunk_length() const override {
+    return num_elements_ * sizeof(T);
+  }
+
+  uint32_t expected_metadata_length() const override {
+    return 0;
+  }
+
+ private:
+  uint32_t original_chunk_length_{};
+  uint32_t num_elements_{};
+  T starting_value_{};
+  T spacing_{};
+};
+
+template <typename T>
+class GridTileChecker {
+ public:
+  GridTileChecker(uint64_t num_elements, T starting_value, T spacing)
+      : num_elements_{num_elements}
+      , starting_value_{starting_value}
+      , spacing_{spacing} {
+  }
+
+  void check(const Tile& tile) {
+    for (uint64_t index = 0; index < num_elements_; ++index) {
+      T expected_value = starting_value_ + index * spacing_;
+      T actual_value{};
+      CHECK_NOTHROW(tile.read(&actual_value, index * sizeof(T), sizeof(T)));
+      CHECK(actual_value == expected_value);
+    }
+  }
+
+ private:
+  uint64_t num_elements_{};
+  T starting_value_{};
+  T spacing_{};
+};
+
+#endif

--- a/tiledb/sm/filter/test/filter_test_support.h
+++ b/tiledb/sm/filter/test/filter_test_support.h
@@ -33,7 +33,7 @@
 #define TILEDB_FILTER_TEST_SUPPORT_H
 
 #include <test/support/tdb_catch.h>
-
+#include <vector>
 #include "tiledb/sm/tile/filtered_buffer.h"
 #include "tiledb/sm/tile/tile.h"
 
@@ -156,8 +156,8 @@ class GridChunkChecker : public ChunkCheckerBase {
       const FilteredBuffer& buffer,
       const ChunkInfo& chunk_info,
       uint64_t chunk_offset) const override {
-    // Check the size of the filtered data. If it does not match the expected
-    // size, then end the test as a failure.
+    // Check the size of the filtered data. If it does not match the
+    // expected size, then end the test as a failure.
     REQUIRE(
         chunk_info.filtered_chunk_length() ==
         expected_chunk_info_.filtered_chunk_length());
@@ -188,6 +188,30 @@ class GridChunkChecker : public ChunkCheckerBase {
   uint32_t num_filtered_elements_{};
   T starting_value_{};
   T spacing_{};
+};
+
+class FilteredBufferChecker {
+ public:
+  FilteredBufferChecker() = default;
+
+  template <typename T>
+  void add_grid_chunk_checker(
+      uint32_t original_chunk_length,
+      uint32_t num_filtered_elements,
+      T starting_value,
+      T spacing = 1) {
+    chunk_checkers_.emplace_back(tdb_new(
+        GridChunkChecker<T>,
+        original_chunk_length,
+        num_filtered_elements,
+        starting_value,
+        spacing));
+  }
+
+  void check(const FilteredBuffer& buffer) const;
+
+ private:
+  std::vector<tdb_unique_ptr<ChunkCheckerBase>> chunk_checkers_;
 };
 
 template <typename T>

--- a/tiledb/sm/filter/test/input_tile_test_data.cc
+++ b/tiledb/sm/filter/test/input_tile_test_data.cc
@@ -1,0 +1,36 @@
+/**
+ * @file input_tile_test_data.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "input_tile_test_data.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+//
+}  // namespace tiledb::sm

--- a/tiledb/sm/filter/test/input_tile_test_data.h
+++ b/tiledb/sm/filter/test/input_tile_test_data.h
@@ -1,0 +1,98 @@
+/**
+ * @file input_filter_test_data.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ * TODO: Add description before merging.
+ */
+
+#ifndef TILEDB_INPUT_TILE_TEST_DATA_H
+#define TILEDB_INPUT_TILE_TEST_DATA_H
+
+#include <test/support/tdb_catch.h>
+#include "tiledb/sm/tile/tile.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+class InputTileTestData {
+ public:
+  virtual ~InputTileTestData() = default;
+  virtual uint64_t cell_size() const = 0;
+  virtual void check_tile_data(const Tile& tile) const = 0;
+  virtual WriterTile create_tile() const = 0;
+  virtual uint64_t tile_size() const = 0;
+};
+
+template <typename T>
+class IncreasingInputTileTestData : public InputTileTestData {
+ public:
+  IncreasingInputTileTestData(uint64_t num_elements)
+      : num_elements_{num_elements} {
+  }
+
+  void check_tile_data(const Tile& tile) const override {
+    INFO("Place holder");
+    for (uint64_t index = 0; index < num_elements_; ++index) {
+      uint64_t element{};
+      CHECK_NOTHROW(
+          tile.read(&element, index * sizeof(uint64_t), sizeof(uint64_t)));
+      CHECK(element == index);
+    }
+  }
+
+  uint64_t cell_size() const override {
+    return num_elements_ * sizeof(T);
+  }
+
+  uint64_t tile_size() const override {
+    return num_elements_ * sizeof(T);
+  }
+
+  WriterTile create_tile() const override;
+
+ private:
+  uint64_t num_elements_;
+};
+
+template <>
+WriterTile IncreasingInputTileTestData<uint64_t>::create_tile() const {
+  const uint64_t tile_size = num_elements_ * sizeof(uint64_t);
+  const uint64_t cell_size = sizeof(uint64_t);
+  WriterTile tile(
+      constants::format_version, Datatype::UINT64, cell_size, tile_size);
+  for (uint64_t index = 0; index < num_elements_; ++index) {
+    CHECK_NOTHROW(
+        tile.write(&index, index * sizeof(uint64_t), sizeof(uint64_t)));
+  }
+
+  return tile;
+}
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -282,29 +282,6 @@ TEST_CASE(
         filtered_buffer, buffer_chunk_info, chunk_index);
   }
 
-  uint64_t el = 0;
-  offset = sizeof(uint64_t);
-  for (uint64_t i = 0; i < 9; i++) {
-    CHECK(
-        tile.filtered_buffer().value_at_as<uint32_t>(offset) ==
-        out_sizes[i]);  // Chunk orig size
-    offset += sizeof(uint32_t);
-    CHECK(
-        tile.filtered_buffer().value_at_as<uint32_t>(offset) ==
-        out_sizes[i]);  // Chunk filtered size
-    offset += sizeof(uint32_t);
-    CHECK(
-        tile.filtered_buffer().value_at_as<uint32_t>(offset) ==
-        0);  // Chunk metadata size
-    offset += sizeof(uint32_t);
-
-    // Check all elements unchanged.
-    for (uint64_t j = 0; j < out_sizes[i] / sizeof(uint64_t); j++) {
-      CHECK(tile.filtered_buffer().value_at_as<uint64_t>(offset) == el++);
-      offset += sizeof(uint64_t);
-    }
-  }
-
   auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
   run_reverse(config, tp, unfiltered_tile, pipeline);
   for (uint64_t i = 0; i < nelts; i++) {

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -143,16 +143,16 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
   // Set up test data
   const uint64_t nelts = 100;
 
-  IncreasingInputTileTestData<uint64_t> input_data(nelts);
+  SimpleFixedTileData test_data(nelts);
 
-  auto tile = input_data.create_tile();
+  auto tile = test_data.create_writer_tile();
 
   FilterPipeline pipeline;
   ThreadPool tp(4);
 
   FilteredBufferChecker filtered_buffer_checker{};
   filtered_buffer_checker.add_grid_chunk_checker<uint64_t>(
-      input_data.tile_size(), nelts, 0, 1);
+      test_data.original_tile_size(), nelts, 0, 1);
 
   // Run the pipeline forward.
   CHECK(pipeline.run_forward(&dummy_stats, &tile, nullptr, &tp).ok());
@@ -161,15 +161,15 @@ TEST_CASE("Filter: Test empty pipeline", "[filter][empty-pipeline]") {
   CHECK(tile.size() == 0);
 
   // Check the filtered buffer has the expected data.
-  const auto& filtered_buffer = tile.filtered_buffer();
+  auto filtered_buffer = tile.filtered_buffer();
   filtered_buffer_checker.check(filtered_buffer);
 
   // Run the data in reverse.
-  auto unfiltered_tile = create_tile_for_unfiltering(nelts, tile);
+  auto unfiltered_tile = test_data.create_filtered_buffer_tile(filtered_buffer);
   run_reverse(config, tp, unfiltered_tile, pipeline);
 
   // Check the original data is reverted.
-  input_data.check_tile_data(unfiltered_tile);
+  test_data.check_tile_data(unfiltered_tile);
 }
 
 TEST_CASE(


### PR DESCRIPTION
This PR refactors the filter pipeline unit tests by creating classes that can be used to reduce the amount of copied code.

---
TYPE: NO_HISTORY
