### PR TITLE
Add target link libraries for unit_readers target

### DIFF
--- a/tiledb/sm/query/readers/test/CMakeLists.txt
+++ b/tiledb/sm/query/readers/test/CMakeLists.txt
@@ -28,4 +28,5 @@ include(unit_test)
 
 commence(unit_test readers)
     this_target_sources(main.cc unit_reader_base.cc)
+    this_target_link_libraries(TILEDB_CORE_OBJECTS TILEDB_CORE_OBJECTS_ILIB)
 conclude(unit_test)

--- a/tiledb/sm/query/readers/test/CMakeLists.txt
+++ b/tiledb/sm/query/readers/test/CMakeLists.txt
@@ -28,5 +28,5 @@ include(unit_test)
 
 commence(unit_test readers)
     this_target_sources(main.cc unit_reader_base.cc)
-    this_target_link_libraries(TILEDB_CORE_OBJECTS TILEDB_CORE_OBJECTS_ILIB)
+    this_target_object_libraries(baseline)
 conclude(unit_test)


### PR DESCRIPTION
Fix issue with `unit_readers` not linking in Debug mode.

This is due to missing object library dependency on `baseline`.

---
TYPE: NO_HISTORY
DESC: Fix issue with `unit_readers` not linking in Debug mode.
