### PR TITLE
Don't segfault in ArraySchema::dump

### DIFF
--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -48,6 +48,7 @@ if (TILEDB_CPP_API)
   list(APPEND SOURCES targets/sc-29682.cc)
   list(APPEND SOURCES targets/sc-33480.cc)
   list(APPEND SOURCES targets/sc-35424.cc)
+  list(APPEND SOURCES targets/sc-38300.cc)
 endif()
 
 add_executable(tiledb_regression

--- a/test/regression/targets/sc-38300.cc
+++ b/test/regression/targets/sc-38300.cc
@@ -1,0 +1,59 @@
+#include <chrono>
+#include <climits>
+#include <thread>
+
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
+#include <test/support/tdb_catch.h>
+
+using namespace tiledb;
+
+static void create_array(const std::string& array_uri);
+static void dump_schema(const std::string& array_uri);
+
+TEST_CASE(
+    "Don't segfault in ArraySchema::dump with unloaded enumerations",
+    "[array-schema][enumeration][bug][sc38300]") {
+  std::string array_uri = "test_array_schema_dump";
+
+  // Test setup
+  create_array(array_uri);
+  dump_schema(array_uri);
+}
+
+void create_array(const std::string& array_uri) {
+  Context ctx;
+
+  auto obj = Object::object(ctx, array_uri);
+  if (obj.type() != Object::Type::Invalid) {
+    Object::remove(ctx, array_uri);
+  }
+
+  auto dim = Dimension::create<int32_t>(ctx, "d", {{0, 1024}});
+
+  Domain dom(ctx);
+  dom.add_dimension(dim);
+
+  std::vector<std::string> values = {"fred", "wilma", "barney", "pebbles"};
+  auto enmr = Enumeration::create(ctx, "flintstones", values);
+
+  auto attr = Attribute::create<int32_t>(ctx, "a");
+  AttributeExperimental::set_enumeration_name(ctx, attr, "flintstones");
+
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  ArraySchemaExperimental::add_enumeration(ctx, schema, enmr);
+  schema.set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}})
+      .set_domain(dom)
+      .add_attribute(attr);
+
+  Array::create(array_uri, schema);
+}
+
+void dump_schema(const std::string& array_uri) {
+  Context ctx;
+  Array array(ctx, array_uri, TILEDB_READ);
+  array.schema().dump();
+  ArrayExperimental::load_all_enumerations(ctx, array);
+  array.schema().dump();
+}

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -679,7 +679,15 @@ void ArraySchema::dump(FILE* out) const {
 
   for (auto& enmr_iter : enumeration_map_) {
     fprintf(out, "\n");
-    enmr_iter.second->dump(out);
+    if (enmr_iter.second != nullptr) {
+      enmr_iter.second->dump(out);
+    } else {
+      std::stringstream ss;
+      ss << "### Enumeration ###" << std::endl;
+      ss << "- Name: " << enmr_iter.first << std::endl;
+      ss << "- Loaded: false" << std::endl;
+      fprintf(out, "%s", ss.str().c_str());
+    }
   }
 
   for (auto& label : dimension_labels_) {

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -224,6 +224,10 @@ void Attribute::dump(FILE* out) const {
     fprintf(out, "\n");
     fprintf(out, "- Data ordering: %s", data_order_str(order_).c_str());
   }
+  if (enumeration_name_.has_value()) {
+    fprintf(out, "\n");
+    fprintf(out, "- Enumeration name: %s", enumeration_name_.value().c_str());
+  }
   fprintf(out, "\n");
 }
 

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -396,6 +396,7 @@ void Enumeration::dump(FILE* out) const {
   std::stringstream ss;
   ss << "### Enumeration ###" << std::endl;
   ss << "- Name: " << name_ << std::endl;
+  ss << "- Loaded: true" << std::endl;
   ss << "- Type: " << datatype_str(type_) << std::endl;
   ss << "- Cell Val Num: " << cell_val_num_ << std::endl;
   ss << "- Ordered: " << (ordered_ ? "true" : "false") << std::endl;


### PR DESCRIPTION
There was no check for whether an enumeration was loaded before attempting to dump it during a call to ArraySchema::dump. Obviously, dereferencing nullptr is bad so this avoids doing that.

The new output now shows the following when a Enumeration isn't loaded:

```
### Attribute ###
- Name: a
- Type: INT32
- Nullable: false
- Cell val num: 1
- Filters: 0
- Fill value: -2147483648
- Enumeration name: flintstones

### Enumeration ###
- Name: flintstones
- Loaded: false
```

And after calling `load_all_enumerations`:

```
### Attribute ###
- Name: a
- Type: INT32
- Nullable: false
- Cell val num: 1
- Filters: 0
- Fill value: -2147483648
- Enumeration name: flintstones

### Enumeration ###
- Name: flintstones
- Loaded: true
- Type: STRING_ASCII
- Cell Val Num: 4294967295
- Ordered: false
- Element Count: 4
```

---
TYPE: BUG
DESC: Don't segfault in ArraySchema::dump
