### PR TITLE
Make consolidation tests faster.

### DIFF
--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -1270,6 +1270,11 @@ TEST_CASE(
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 
+  rc = tiledb_config_set(
+      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
   // Consolidate
   rc = tiledb_array_consolidate(ctx, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
@@ -1630,9 +1635,22 @@ TEST_CASE(
       buffers,
       &written_frag_uri_3);
 
+  // Consolidate fragments
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  rc = tiledb_config_set(
+      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
   // Consolidate
-  rc = tiledb_array_consolidate(ctx, array_name.c_str(), nullptr);
+  rc = tiledb_array_consolidate(ctx, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
+
+  tiledb_config_free(&config);
 
   // Create fragment info object
   tiledb_fragment_info_t* fragment_info = nullptr;

--- a/test/src/unit-capi-sparse_heter.cc
+++ b/test/src/unit-capi-sparse_heter.cc
@@ -988,8 +988,21 @@ TEST_CASE_METHOD(
 
   // ####### CONSOLIDATE #######
 
-  int rc = tiledb_array_consolidate(ctx_, array_name.c_str(), nullptr);
+  // Consolidate fragments
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  auto rc = tiledb_config_set(
+      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
+
+  tiledb_config_free(&config);
 
   // Check non-empty domain
   c_dom_f = {1.1f, 1.5f};
@@ -1342,8 +1355,21 @@ TEST_CASE_METHOD(
 
   // ####### CONSOLIDATE #######
 
-  int rc = tiledb_array_consolidate(ctx_, array_name.c_str(), nullptr);
+  // Consolidate fragments
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  int rc = tiledb_config_set(
+      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
+
+  tiledb_config_free(&config);
 
   // Check non-empty domain
   c_dom_i = {1, 6};

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -2284,6 +2284,9 @@ TEST_CASE_METHOD(
   rc = tiledb_config_set(
       config, "sm.consolidation.mode", "fragment_meta", &error);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_config_set(
+      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  CHECK(rc == TILEDB_OK);
 
   // Consolidate fragment metadata
   rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);
@@ -2328,8 +2331,11 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
 
+  rc = tiledb_config_set(config, "sm.consolidation.mode", "fragments", &error);
+  CHECK(rc == TILEDB_OK);
+
   // Consolidate
-  rc = tiledb_array_consolidate(ctx_, array_name.c_str(), nullptr);
+  rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_vacuum(ctx_, array_name.c_str(), nullptr);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -693,7 +693,9 @@ TEST_CASE("C++ API: Consolidation of empty arrays", "[cppapi][consolidation]") {
 TEST_CASE(
     "C++ API: Consolidation of sequential fragment writes",
     "[cppapi][consolidation][sequential]") {
-  Context ctx;
+  tiledb::Config cfg;
+  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+  Context ctx(cfg);
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";
 
@@ -743,6 +745,7 @@ TEST_CASE(
 TEST_CASE("C++ API: Encrypted array", "[cppapi][encryption]") {
   const char key[] = "0123456789abcdeF0123456789abcdeF";
   tiledb::Config cfg;
+  cfg["sm.consolidation.total_buffer_size"] = "1048576";
   cfg["sm.encryption_type"] = "AES_256_GCM";
   cfg["sm.encryption_key"] = key;
   Context ctx(cfg);
@@ -827,6 +830,7 @@ TEST_CASE("C++ API: Encrypted array, std::string key", "[cppapi][encryption]") {
   tiledb::Config cfg;
   cfg["sm.encryption_type"] = "AES_256_GCM";
   cfg["sm.encryption_key"] = key.c_str();
+  cfg["sm.consolidation.total_buffer_size"] = "1048576";
   Context ctx(cfg);
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -1404,6 +1404,7 @@ TEST_CASE_METHOD(
   // fully removed for overlapping ranges, this test case can be deleted.
   tiledb::Config cfg;
   cfg.set("sm.merge_overlapping_ranges_experimental", "false");
+  cfg["sm.consolidation.total_buffer_size"] = "1048576";
   ctx_ = Context(cfg);
   sm_ = ctx_.ptr().get()->storage_manager();
   vfs_ = VFS(ctx_);

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -120,7 +120,9 @@ TEST_CASE(
   remove_array(array_name);
 
   // Create array
-  Context ctx;
+  tiledb::Config cfg;
+  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+  Context ctx(cfg);
   Domain domain(ctx);
   auto d = Dimension::create<int>(ctx, "d1", {{10, 110}}, 50);
   domain.add_dimensions(d);

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -879,6 +879,7 @@ TEST_CASE(
     // Consolidate fragments
     Config config;
     config["sm.consolidation.mode"] = "fragments";
+    config["sm.consolidation.total_buffer_size"] = "1048576";
     Array::consolidate(ctx, array_name, &config);
 
     // Load fragment info

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -1974,6 +1974,7 @@ TEST_CASE(
   Config config;
   config["sm.consolidation.mode"] = "fragments";
   config["sm.vacuum.mode"] = "fragments";
+  config["sm.consolidation.total_buffer_size"] = "1048576";
   CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
   CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
   auto contents = vfs.ls(get_fragment_dir(array_name));

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -243,6 +243,7 @@ struct CPPMaxFragmentSizeFx {
       uint64_t max_fragment_size = std::numeric_limits<uint64_t>::max()) {
     auto config = ctx_.config();
     config["sm.consolidation.max_fragment_size"] = max_fragment_size;
+    config["sm.consolidation.total_buffer_size"] = "1048576";
     Array::consolidate(ctx_, array_name, &config);
   }
 

--- a/test/src/unit-duplicates.cc
+++ b/test/src/unit-duplicates.cc
@@ -334,11 +334,23 @@ TEST_CASE_METHOD(
                         !std::memcmp(data_c_2, data_r, data_r_size);
   CHECK(data_c_matches);
 
+  // Consolidate fragments
+  tiledb_config_t* config = nullptr;
+  tiledb_error_t* error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  rc = tiledb_config_set(
+      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
   // Consolidate
-  rc = tiledb_array_consolidate(ctx_, array_name_.c_str(), nullptr);
+  rc = tiledb_array_consolidate(ctx_, array_name_.c_str(), config);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_array_vacuum(ctx_, array_name_.c_str(), nullptr);
   REQUIRE(rc == TILEDB_OK);
+  tiledb_config_free(&config);
 
   // Open array for reading - #2
   rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);


### PR DESCRIPTION
Update some consolidation tests to run faster after the consolidation setting change.

---
TYPE: NO_HISTORY
DESC: Make consolidation tests fater.
