### PR TITLE
`class BudgetUnavailable`

### DIFF
--- a/tiledb/api/c_api/api_external_common.h
+++ b/tiledb/api/c_api/api_external_common.h
@@ -156,6 +156,10 @@ TILEDB_EXPORT capi_status_t tiledb_status_code(capi_return_t x);
  * Invalid error argument would prevent errors from being reported correctly.
  */
 #define TILEDB_INVALID_ERROR (-4)
+/**
+ * Invalid error argument would prevent errors from being reported correctly.
+ */
+#define TILEDB_BUDGET_UNAVAILABLE (-5)
 /**@}*/
 
 #ifdef __cplusplus

--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -605,6 +605,11 @@ class CAPIFunction<f, H, A> {
       if constexpr (!std::same_as<R, void>) {
         return TILEDB_INVALID_CONTEXT;
       }
+    } catch (const BudgetUnavailable& e) {
+      h.action(e);
+      if constexpr (!std::same_as<R, void>) {
+        return TILEDB_BUDGET_UNAVAILABLE;
+      }
     } catch (const detail::InvalidErrorException& e) {
       h.action(e);
       if constexpr (!std::same_as<R, void>) {

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_exception_wrapper.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_exception_wrapper.cc
@@ -289,3 +289,19 @@ TEST_CASE("api_entry_error - throw") {
   CHECK(error->message() == "Test: error");
   tiledb_error_free(&error);
 }
+
+capi_return_t tf_budget_never_available() {
+  throw BudgetUnavailable("Test", "budget unavailable");
+}
+TEST_CASE("BudgetUnavailable - special return value from CAPIFunction") {
+  auto rc{tiledb::api::api_entry_plain<tf_budget_never_available>()};
+  CHECK(tiledb_status(rc) == TILEDB_BUDGET_UNAVAILABLE);
+}
+
+capi_return_t tf_budget_exceeded() {
+  throw BudgetExceeded("Test", "budget exceeded");
+}
+TEST_CASE("BudgetExceeded - ordinary return value from CAPIFunction") {
+  auto rc{tiledb::api::api_entry_plain<tf_budget_exceeded>()};
+  CHECK(tiledb_status(rc) == TILEDB_ERR);
+}

--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -186,8 +186,9 @@ inline void throw_if_not_ok(const Status& st) {
 }
 
 /**
- * An exception that refuses to start an operation because the estimate of resources
- * to complete the operation exceeds the available budget for those resources.
+ * An exception that refuses to start an operation because the estimate of
+ * resources to complete the operation exceeds the available budget for those
+ * resources.
  *
  * This exception should only be thrown _before_ an operation commences. Once an
  * operation starts, if (for whatever reason) the budget estimate was wrong, the
@@ -229,7 +230,6 @@ class BudgetExceeded : public StatusException {
       : StatusException(origin, message) {
   }
 };
-
 
 }  // namespace tiledb::common
 

--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -185,6 +185,52 @@ inline void throw_if_not_ok(const Status& st) {
   }
 }
 
+/**
+ * An exception that refuses to start an operation because the estimate of resources
+ * to complete the operation exceeds the available budget for those resources.
+ *
+ * This exception should only be thrown _before_ an operation commences. Once an
+ * operation starts, if (for whatever reason) the budget estimate was wrong, the
+ * proper exception to throw is `BudgetExceeded`. The reason for this is that
+ * the exception wrapper catches this exception in a specific `catch` clause,
+ * whereupon it returns the special value `TILEDB_BUDGET_UNAVAILABLE` to the C
+ * API caller. `BudgetExceeded`, by contrast, is an ordinary exception that will
+ * terminate an in-progress operation like any other fatal error would.
+ *
+ * @section Maturity Notes
+ *
+ * This exception makes no attempt to state what kind of budget was unavailable.
+ * In order to do this in the exception itself there would need to be data
+ * structures available that formalized what budget categories existed, what the
+ * limits are, what the request would have required, etc. The constructor for
+ * this exception might eventually take additional constructor arguments for
+ * this purpose.
+ */
+class BudgetUnavailable : public StatusException {
+ public:
+  /**
+   * Ordinary constructor has same signature as `BudgetExceeded`.
+   */
+  BudgetUnavailable(const std::string origin, const std::string message)
+      : StatusException(origin, message) {
+  }
+};
+
+/**
+ * An exception that terminates an already-started operation because there is
+ * not enough budget of some resource to complete the operation.
+ */
+class BudgetExceeded : public StatusException {
+ public:
+  /**
+   * Ordinary constructor has same signature as `BudgetUnavailable`.
+   */
+  BudgetExceeded(const std::string origin, const std::string message)
+      : StatusException(origin, message) {
+  }
+};
+
+
 }  // namespace tiledb::common
 
 #endif  // TILEDB_COMMON_EXCEPTION_H


### PR DESCRIPTION
Added new exception classes for resource budgeting. `class BudgetUnavailable` translates to a special C API return code.

---
TYPE: NO_HISTORY
DESC: <short description>
