### PR TITLE
Finalize should error out for remote global order writes

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -475,7 +475,7 @@ QueryBuffer Query::buffer(const std::string& name) const {
 
 Status Query::finalize() {
   if (status_ == QueryStatus::UNINITIALIZED ||
-      status_ == QueryStatus::INITIALIZED) {
+      (status_ == QueryStatus::INITIALIZED && !array_->is_remote())) {
     return Status::Ok();
   }
 


### PR DESCRIPTION
Calling finalize() was allowed as noop in remote global order writes, but it should have been treated as incorrect usage.

---
TYPE: BUG
DESC: Finalize should error out for remote global order writes
