### PR TITLE
Keep opened array resources alive until query ends.

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -165,7 +165,7 @@ TEST_CASE_METHOD(
   DefaultChannelAggregates default_channel_aggregates;
   auto params = StrategyParams(
       context.storage_manager(),
-      &array,
+      array.opened_array(),
       config,
       buffers,
       aggregate_buffers,
@@ -173,7 +173,8 @@ TEST_CASE_METHOD(
       Layout::ROW_MAJOR,
       condition,
       default_channel_aggregates,
-      false);
+      false,
+      array.memory_tracker());
   Reader reader(&g_helper_stats, g_helper_logger(), params);
   unsigned dim_num = 2;
   auto size = 2 * sizeof(int32_t);

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2337,7 +2337,7 @@ TEST_CASE_METHOD(
 
   // Check the retrieved non empty domain
   auto non_empty_domain = new_array->array_->loaded_non_empty_domain();
-  CHECK(non_empty_domain->empty() == false);
+  CHECK(non_empty_domain.empty() == false);
 
   // Check the retrieved metadata
   Datatype type;

--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -1279,6 +1279,8 @@ TEST_CASE(
   rc = tiledb_array_consolidate(ctx, array_name.c_str(), config);
   CHECK(rc == TILEDB_OK);
 
+  tiledb_config_free(&config);
+
   // Load fragment info
   rc = tiledb_fragment_info_load(ctx, fragment_info);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -2088,3 +2088,50 @@ TEST_CASE(
   vfs.remove_dir(get_commit_dir(array_read.uri()));
   vfs.remove_dir(array_read.uri() + "/__schema");
 }
+
+TEST_CASE(
+    "C++ API: Close array with running query", "[cppapi][close-before-read]") {
+  const std::string array_name = "cpp_unit_array";
+  Context ctx;
+  VFS vfs(ctx);
+
+  if (vfs.is_dir(array_name))
+    vfs.remove_dir(array_name);
+
+  // Create
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<int>(ctx, "rows", {{0, 3}}, 4))
+      .add_dimension(Dimension::create<int>(ctx, "cols", {{0, 3}}, 4));
+  ArraySchema schema(ctx, TILEDB_DENSE);
+  schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+  Array::create(array_name, schema);
+
+  // Write
+  std::vector<int> data_w = {
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  Array array_w(ctx, array_name, TILEDB_WRITE);
+  Query query_w(ctx, array_w);
+  query_w.set_subarray(Subarray(ctx, array_w).set_subarray({0, 3, 0, 3}))
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("a", data_w);
+  query_w.submit();
+  array_w.close();
+
+  // Open for read.
+  Array array(ctx, array_name, TILEDB_READ);
+  std::vector<int> subarray_read = {0, 3, 0, 3};
+  std::vector<int> a_read(16);
+
+  Query query(ctx, array);
+  query.set_subarray(subarray_read)
+      .set_layout(TILEDB_ROW_MAJOR)
+      .set_data_buffer("a", a_read);
+  query.submit_async();
+  array.close();
+
+  while (query.query_status() != Query::Status::COMPLETE) {
+  }
+
+  std::cout << "done";
+}

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -2130,8 +2130,10 @@ TEST_CASE(
   query.submit_async();
   array.close();
 
+  uint64_t i = 0;
   while (query.query_status() != Query::Status::COMPLETE) {
+    i++;
   }
 
-  std::cout << "done";
+  CHECK(i > 0);
 }

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -458,7 +458,7 @@ void DeletesFx::check_delete_conditions(
 
   // Load delete conditions.
   auto&& [st, delete_conditions, update_values] =
-      sm_->load_delete_and_update_conditions(*array_ptr);
+      sm_->load_delete_and_update_conditions(*(array_ptr->opened_array()));
   REQUIRE(st.ok());
   REQUIRE(delete_conditions->size() == qcs.size());
 

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -415,32 +415,6 @@ TEST_CASE("C++ API: Test subarray (dense)", "[cppapi][dense][subarray]") {
     // default expected to err.
     REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
     tiledb::Config config;
-    // The config option should be ignored but we set anyway.
-    config.set("sm.read_range_oob", "error");
-    subarray.set_config(config);
-    REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
-  }
-
-  SECTION("- set_subarray Write ranges oob warn - Subarray-query") {
-    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
-    tiledb::Query query(ctx, array);
-    // default (dense) WRITE should always err/throw on oob
-    REQUIRE_THROWS(query.set_subarray({1, 4, -1, 3}));
-    tiledb::Config config;
-    config.set("sm.read_range_oob", "warn");
-    query.set_config(config);
-    // (dense) WRITE should ignore sm.read_range_oob config option
-    // and err/throw on oob
-    REQUIRE_THROWS(query.set_subarray({1, 4, -1, 3}));
-  }
-
-  SECTION("- set_subarray Write ranges oob warn - Subarray-cppapi") {
-    tiledb::Array array(ctx, array_name, TILEDB_WRITE);
-    tiledb::Subarray subarray(ctx, array);
-    REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
-    tiledb::Config config;
-    config.set("sm.read_range_oob", "warn");
-    subarray.set_config(config);
     REQUIRE_THROWS(subarray.set_subarray({1, 4, -1, 3}));
   }
 

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -203,7 +203,7 @@ void UpdatesFx::check_update_conditions(
 
   // Load delete conditions.
   auto&& [st, conditions, update_values] =
-      sm_->load_delete_and_update_conditions(*array_ptr);
+      sm_->load_delete_and_update_conditions(*(array_ptr->opened_array()));
   REQUIRE(st.ok());
   REQUIRE(conditions->size() == qcs.size());
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -84,11 +84,8 @@ Array::Array(
     const URI& array_uri,
     StorageManager* storage_manager,
     ConsistencyController& cc)
-    : array_schema_latest_(nullptr)
-    , array_uri_(array_uri)
-    , array_dir_(storage_manager->resources(), array_uri)
+    : array_uri_(array_uri)
     , array_uri_serialized_(array_uri)
-    , encryption_key_(make_shared<EncryptionKey>(HERE()))
     , is_open_(false)
     , is_opening_or_closing_(false)
     , array_dir_timestamp_start_(0)
@@ -99,9 +96,6 @@ Array::Array(
     , resources_(storage_manager_->resources())
     , config_(resources_.config())
     , remote_(array_uri.is_tiledb())
-    , metadata_()
-    , metadata_loaded_(false)
-    , non_empty_domain_computed_(false)
     , consistency_controller_(cc)
     , consistency_sentry_(nullopt) {
 }
@@ -110,30 +104,8 @@ Array::Array(
 /*                API                */
 /* ********************************* */
 
-void Array::set_array_schema_latest(
-    const shared_ptr<ArraySchema>& array_schema) {
-  array_schema_latest_ = array_schema;
-}
-
-const ArraySchema& Array::array_schema_latest() const {
-  return *(array_schema_latest_.get());
-}
-
-shared_ptr<const ArraySchema> Array::array_schema_latest_ptr() const {
-  return array_schema_latest_;
-}
-
-void Array::set_array_schemas_all(
-    std::unordered_map<std::string, shared_ptr<ArraySchema>>& all_schemas) {
-  array_schemas_all_ = all_schemas;
-}
-
 const URI& Array::array_uri() const {
   return array_uri_;
-}
-
-const ArrayDirectory& Array::array_directory() const {
-  return array_dir_;
 }
 
 const URI& Array::array_uri_serialized() const {
@@ -141,7 +113,7 @@ const URI& Array::array_uri_serialized() const {
 }
 
 const EncryptionKey* Array::encryption_key() const {
-  return encryption_key_.get();
+  return opened_array_->encryption_key();
 }
 
 // Used in Consolidator
@@ -162,9 +134,14 @@ Status Array::open_without_fragments(
                           "remote arrays are not supported."));
   }
 
-  metadata_.clear();
-  metadata_loaded_ = false;
-  non_empty_domain_computed_ = false;
+  opened_array_ = make_shared<OpenedArray>(
+      HERE(),
+      encryption_type,
+      encryption_key,
+      key_length,
+      timestamp_start(),
+      timestamp_end_opened_at(),
+      is_remote());
 
   /* Note: query_type_ MUST be set before calling set_array_open()
     because it will be examined by the ConsistencyController. */
@@ -174,12 +151,6 @@ Status Array::open_without_fragments(
    * opening process, it will throw and the array will be set as closed. */
   try {
     set_array_open(query_type_);
-
-    // Copy the key bytes.
-    st = encryption_key_->set_key(encryption_type, encryption_key, key_length);
-    if (!st.ok()) {
-      throw StatusException(st);
-    }
 
     if (remote_) {
       auto rest_client = resources_.rest_client();
@@ -195,7 +166,7 @@ Status Array::open_without_fragments(
         if (!st.ok()) {
           throw StatusException(st);
         }
-        array_schema_latest_ = array_schema_latest.value();
+        set_array_schema_latest(array_schema_latest.value());
       } else {
         auto st = rest_client->post_array_from_rest(
             array_uri_, storage_manager_, this);
@@ -207,11 +178,13 @@ Status Array::open_without_fragments(
       {
         auto timer_se = resources_.stats().start_timer(
             "array_open_without_fragments_load_directory");
-        array_dir_ = ArrayDirectory(
-            resources_, array_uri_, 0, UINT64_MAX, ArrayDirectoryMode::READ);
+        set_array_directory(ArrayDirectory(
+            resources_, array_uri_, 0, UINT64_MAX, ArrayDirectoryMode::READ));
       }
-      std::tie(array_schema_latest_, array_schemas_all_) =
+      auto&& [array_schema_latest, array_schemas_all] =
           open_for_reads_without_fragments();
+      set_array_schema_latest(array_schema_latest);
+      set_array_schemas_all(std::move(array_schemas_all));
     }
   } catch (...) {
     set_array_closed();
@@ -229,14 +202,14 @@ void Array::load_fragments(
 
   // Load the fragment metadata
   std::unordered_map<std::string, std::pair<Tile*, uint64_t>> offsets;
-  fragment_metadata_ = FragmentMetadata::load(
+  set_fragment_metadata(FragmentMetadata::load(
       resources_,
       memory_tracker(),
-      array_schema_latest_ptr(),
+      opened_array_->array_schema_latest_ptr(),
       array_schemas_all(),
       *encryption_key(),
       fragments_to_load,
-      offsets);
+      offsets));
 }
 
 Status Array::open(
@@ -269,9 +242,6 @@ Status Array::open(
         Status_ArrayError("Cannot open array; Array already open."));
   }
 
-  metadata_.clear();
-  metadata_loaded_ = false;
-  non_empty_domain_computed_ = false;
   query_type_ = query_type;
 
   set_timestamps(
@@ -334,11 +304,14 @@ Status Array::open(
           "Cannot open array; encrypted remote arrays are not supported.");
     }
 
-    // Copy the key bytes.
-    st = encryption_key_->set_key(encryption_type, encryption_key, key_length);
-    if (!st.ok()) {
-      throw StatusException(st);
-    }
+    opened_array_ = make_shared<OpenedArray>(
+        HERE(),
+        encryption_type,
+        encryption_key,
+        key_length,
+        this->timestamp_start(),
+        timestamp_end_opened_at(),
+        is_remote());
 
     if (remote_) {
       auto rest_client = resources_.rest_client();
@@ -350,7 +323,7 @@ Status Array::open(
         auto&& [st, array_schema_latest] =
             rest_client->get_array_schema_from_rest(array_uri_);
         throw_if_not_ok(st);
-        array_schema_latest_ = array_schema_latest.value();
+        set_array_schema_latest(array_schema_latest.value());
       } else {
         auto st = rest_client->post_array_from_rest(
             array_uri_, storage_manager_, this);
@@ -362,57 +335,59 @@ Status Array::open(
       {
         auto timer_se =
             resources_.stats().start_timer("array_open_read_load_directory");
-        array_dir_ = ArrayDirectory(
+        set_array_directory(ArrayDirectory(
             resources_,
             array_uri_,
             array_dir_timestamp_start_,
-            array_dir_timestamp_end_);
+            array_dir_timestamp_end_));
       }
-      std::tie(array_schema_latest_, array_schemas_all_, fragment_metadata_) =
+      auto&& [array_schema_latest, array_schemas_all, fragment_metadata] =
           open_for_reads();
+      set_array_schema_latest(array_schema_latest);
+      set_array_schemas_all(std::move(array_schemas_all));
+      set_fragment_metadata(std::move(fragment_metadata));
     } else if (
         query_type == QueryType::WRITE ||
         query_type == QueryType::MODIFY_EXCLUSIVE) {
       {
         auto timer_se =
             resources_.stats().start_timer("array_open_write_load_directory");
-        array_dir_ = ArrayDirectory(
+        set_array_directory(ArrayDirectory(
             resources_,
             array_uri_,
             array_dir_timestamp_start_,
             array_dir_timestamp_end_,
-            ArrayDirectoryMode::SCHEMA_ONLY);
+            ArrayDirectoryMode::SCHEMA_ONLY));
       }
       auto&& [st, array_schema_latest, array_schemas] = open_for_writes();
       throw_if_not_ok(st);
 
       // Set schemas
-      array_schema_latest_ = array_schema_latest.value();
-      array_schemas_all_ = array_schemas.value();
+      set_array_schema_latest(array_schema_latest.value());
+      set_array_schemas_all(std::move(array_schemas.value()));
 
       // Set the timestamp
-      metadata_.reset(timestamp_for_new_component());
-
+      opened_array_->metadata().reset(timestamp_for_new_component());
     } else if (
         query_type == QueryType::DELETE || query_type == QueryType::UPDATE) {
       {
         auto timer_se = resources_.stats().start_timer(
             "array_open_delete_or_update_load_directory");
-        array_dir_ = ArrayDirectory(
+        set_array_directory(ArrayDirectory(
             resources_,
             array_uri_,
             array_dir_timestamp_start_,
             array_dir_timestamp_end_,
-            ArrayDirectoryMode::READ);
+            ArrayDirectoryMode::READ));
       }
-      auto&& [st, array_schema_latest, array_schemas] = open_for_writes();
+      auto&& [st, latest, array_schemas] = open_for_writes();
       throw_if_not_ok(st);
 
       // Set schemas
-      array_schema_latest_ = array_schema_latest.value();
-      array_schemas_all_ = array_schemas.value();
+      set_array_schema_latest(latest.value());
+      set_array_schemas_all(std::move(array_schemas.value()));
 
-      auto version = array_schema_latest_->version();
+      auto version = array_schema_latest().version();
       if (query_type == QueryType::DELETE &&
           version < constants::deletes_min_version) {
         std::stringstream err;
@@ -433,7 +408,7 @@ Status Array::open(
       }
 
       // Updates the timestamp to use for metadata.
-      metadata_.reset(timestamp_for_new_component());
+      opened_array_->metadata().reset(timestamp_for_new_component());
     } else {
       throw ArrayException("Cannot open array; Unsupported query type.");
     }
@@ -455,10 +430,7 @@ Status Array::close() {
     return Status::Ok();
   }
 
-  non_empty_domain_.clear();
-  non_empty_domain_computed_ = false;
   clear_last_max_buffer_sizes();
-  fragment_metadata_.clear();
 
   try {
     set_array_closed();
@@ -468,10 +440,10 @@ Status Array::close() {
       // user
       if ((query_type_ == QueryType::WRITE ||
            query_type_ == QueryType::MODIFY_EXCLUSIVE) &&
-          metadata_.num() > 0) {
+          opened_array_->metadata().num() > 0) {
         // Set metadata loaded to be true so when serialization fetchs the
         // metadata it won't trigger a deadlock
-        metadata_loaded_ = true;
+        set_metadata_loaded(true);
         auto rest_client = resources_.rest_client();
         if (rest_client == nullptr) {
           throw Status_ArrayError(
@@ -483,15 +455,11 @@ Status Array::close() {
             array_dir_timestamp_end_,
             this));
       }
-
-      // Storage manager does not own the array schema for remote arrays.
-      array_schema_latest_.reset();
     } else {
-      array_schema_latest_.reset();
       if (query_type_ == QueryType::WRITE ||
           query_type_ == QueryType::MODIFY_EXCLUSIVE) {
         st = storage_manager_->store_metadata(
-            array_uri_, *encryption_key_.get(), &metadata_);
+            array_uri_, *encryption_key(), &opened_array_->metadata());
         if (!st.ok()) {
           throw StatusException(st);
         }
@@ -502,9 +470,7 @@ Status Array::close() {
       }
     }
 
-    array_schemas_all_.clear();
-    metadata_.clear();
-    metadata_loaded_ = false;
+    opened_array_.reset();
   } catch (std::exception& e) {
     is_opening_or_closing_ = false;
     throw Status_ArrayError(e.what());
@@ -587,7 +553,7 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
   // Dedupe requested names and filter out anything already loaded.
   std::unordered_set<std::string> enmrs_to_load;
   for (auto& enmr_name : enumeration_names) {
-    if (array_schema_latest_->is_enumeration_loaded(enmr_name)) {
+    if (array_schema_latest().is_enumeration_loaded(enmr_name)) {
       continue;
     }
     enmrs_to_load.insert(enmr_name);
@@ -620,25 +586,25 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
       // Create a vector of paths to be loaded.
       std::vector<std::string> paths_to_load;
       for (auto& enmr_name : enmrs_to_load) {
-        auto path = array_schema_latest_->get_enumeration_path_name(enmr_name);
+        auto path = array_schema_latest().get_enumeration_path_name(enmr_name);
         paths_to_load.push_back(path);
       }
 
       // Load the enumerations from storage
-      loaded = array_dir_.load_enumerations_from_paths(
-          paths_to_load, get_encryption_key(), memory_tracker_);
+      loaded = array_directory().load_enumerations_from_paths(
+          paths_to_load, *encryption_key(), memory_tracker_);
     }
 
     // Store the loaded enumerations in the schema
     for (auto& enmr : loaded) {
-      array_schema_latest_->store_enumeration(enmr);
+      opened_array_->array_schema_latest_ptr()->store_enumeration(enmr);
     }
   }
 
   // Return the requested list of enumerations
   std::vector<shared_ptr<const Enumeration>> ret(enumeration_names.size());
   for (size_t i = 0; i < enumeration_names.size(); i++) {
-    ret[i] = array_schema_latest_->get_enumeration(enumeration_names[i]);
+    ret[i] = array_schema_latest().get_enumeration(enumeration_names[i]);
   }
   return ret;
 }
@@ -648,11 +614,11 @@ void Array::load_all_enumerations() {
     throw ArrayException("Unable to load all enumerations; Array is not open.");
   }
   // Load all enumerations, discarding the returned list of loaded enumerations.
-  get_enumerations(array_schema_latest_->get_enumeration_names());
+  get_enumerations(array_schema_latest().get_enumeration_names());
 }
 
 bool Array::is_empty() const {
-  return fragment_metadata_.empty();
+  return opened_array_->fragment_metadata().empty();
 }
 
 bool Array::is_open() {
@@ -664,10 +630,6 @@ bool Array::is_remote() const {
   return remote_;
 }
 
-std::vector<shared_ptr<FragmentMetadata>> Array::fragment_metadata() const {
-  return fragment_metadata_;
-}
-
 tuple<Status, optional<shared_ptr<ArraySchema>>> Array::get_array_schema()
     const {
   // Error if the array is not open
@@ -677,7 +639,7 @@ tuple<Status, optional<shared_ptr<ArraySchema>>> Array::get_array_schema()
             Status_ArrayError("Cannot get array schema; Array is not open")),
         nullopt};
 
-  return {Status::Ok(), array_schema_latest_};
+  return {Status::Ok(), opened_array_->array_schema_latest_ptr()};
 }
 
 QueryType Array::get_query_type() const {
@@ -706,22 +668,22 @@ Status Array::get_max_buffer_size(
   }
 
   // Not applicable to heterogeneous domains
-  if (!array_schema_latest_->domain().all_dims_same_type()) {
+  if (!array_schema_latest().domain().all_dims_same_type()) {
     return LOG_STATUS(
         Status_ArrayError("Cannot get max buffer size; Function not "
                           "applicable to heterogeneous domains"));
   }
 
   // Not applicable to variable-sized dimensions
-  if (!array_schema_latest_->domain().all_dims_fixed()) {
+  if (!array_schema_latest().domain().all_dims_fixed()) {
     return LOG_STATUS(Status_ArrayError(
         "Cannot get max buffer size; Function not "
         "applicable to domains with variable-sized dimensions"));
   }
 
   // Check if name is attribute or dimension
-  bool is_dim = array_schema_latest_->is_dim(name);
-  bool is_attr = array_schema_latest_->is_attr(name);
+  bool is_dim = array_schema_latest().is_dim(name);
+  bool is_attr = array_schema_latest().is_attr(name);
 
   // Check if attribute/dimension exists
   if (name != constants::coords && !is_dim && !is_attr) {
@@ -731,7 +693,7 @@ Status Array::get_max_buffer_size(
   }
 
   // Check if attribute/dimension is fixed sized
-  if (array_schema_latest_->var_size(name)) {
+  if (array_schema_latest().var_size(name)) {
     return LOG_STATUS(Status_ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' is var-sized"));
@@ -772,14 +734,14 @@ Status Array::get_max_buffer_size(
   }
 
   // Not applicable to heterogeneous domains
-  if (!array_schema_latest_->domain().all_dims_same_type()) {
+  if (!array_schema_latest().domain().all_dims_same_type()) {
     return LOG_STATUS(
         Status_ArrayError("Cannot get max buffer size; Function not "
                           "applicable to heterogeneous domains"));
   }
 
   // Not applicable to variable-sized dimensions
-  if (!array_schema_latest_->domain().all_dims_fixed()) {
+  if (!array_schema_latest().domain().all_dims_fixed()) {
     return LOG_STATUS(Status_ArrayError(
         "Cannot get max buffer size; Function not "
         "applicable to domains with variable-sized dimensions"));
@@ -796,7 +758,7 @@ Status Array::get_max_buffer_size(
   }
 
   // Check if attribute/dimension is var-sized
-  if (!array_schema_latest_->var_size(name)) {
+  if (!array_schema_latest().var_size(name)) {
     return LOG_STATUS(Status_ArrayError(
         std::string("Cannot get max buffer size; Attribute/Dimension '") +
         name + "' is fixed-sized"));
@@ -807,10 +769,6 @@ Status Array::get_max_buffer_size(
   *buffer_val_size = it->second.second;
 
   return Status::Ok();
-}
-
-const EncryptionKey& Array::get_encryption_key() const {
-  return *encryption_key_;
 }
 
 Status Array::reopen() {
@@ -857,13 +815,15 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   clear_last_max_buffer_sizes();
 
   // Reopen metadata.
-  fragment_metadata_.clear();
-  metadata_.clear();
-  metadata_loaded_ = false;
-
-  // Reset the non-empty domain - may be different.
-  non_empty_domain_.clear();
-  non_empty_domain_computed_ = false;
+  auto key = opened_array_->encryption_key();
+  opened_array_ = make_shared<OpenedArray>(
+      HERE(),
+      key->encryption_type(),
+      key->key().data(),
+      key->key().size(),
+      this->timestamp_start(),
+      timestamp_end_opened_at(),
+      is_remote());
 
   // Use open to reopen a remote array.
   if (remote_) {
@@ -877,30 +837,33 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
 
     return open(
         query_type_,
-        encryption_key_->encryption_type(),
-        encryption_key_->key().data(),
-        encryption_key_->key().size());
+        encryption_key()->encryption_type(),
+        encryption_key()->key().data(),
+        encryption_key()->key().size());
   }
 
   // Reload the array directory in READ mode (reopen only supports reads).
   try {
     {
       auto timer_se = resources_.stats().start_timer("array_reopen_directory");
-      array_dir_ = ArrayDirectory(
+      set_array_directory(ArrayDirectory(
           resources_,
           array_uri_,
           array_dir_timestamp_start_,
           array_dir_timestamp_end_,
           query_type_ == QueryType::READ ? ArrayDirectoryMode::READ :
-                                           ArrayDirectoryMode::SCHEMA_ONLY);
+                                           ArrayDirectoryMode::SCHEMA_ONLY));
     }
   } catch (const std::logic_error& le) {
     return LOG_STATUS(Status_ArrayDirectoryError(le.what()));
   }
 
   // Reopen the array and update private variables.
-  std::tie(array_schema_latest_, array_schemas_all_, fragment_metadata_) =
+  auto&& [array_schema_latest, array_schemas_all, fragment_metadata] =
       open_for_reads();
+  set_array_schema_latest(array_schema_latest);
+  set_array_schemas_all(std::move(array_schemas_all));
+  set_fragment_metadata(std::move(fragment_metadata));
 
   return Status::Ok();
 }
@@ -931,7 +894,7 @@ void Array::delete_metadata(const char* key) {
     throw ArrayException("Cannot delete metadata. Key cannot be null");
   }
 
-  metadata_.del(key);
+  opened_array_->metadata().del(key);
 }
 
 void Array::put_metadata(
@@ -962,7 +925,7 @@ void Array::put_metadata(
     throw ArrayException("Cannot put metadata; Value type cannot be ANY");
   }
 
-  metadata_.put(key, value_type, value_num, value);
+  opened_array_->metadata().put(key, value_type, value_num, value);
 }
 
 void Array::get_metadata(
@@ -987,11 +950,11 @@ void Array::get_metadata(
   }
 
   // Load array metadata, if not loaded yet
-  if (!metadata_loaded_) {
+  if (!metadata_loaded()) {
     throw_if_not_ok(load_metadata());
   }
 
-  metadata_.get(key, value_type, value_num, value);
+  opened_array_->metadata().get(key, value_type, value_num, value);
 }
 
 void Array::get_metadata(
@@ -1013,11 +976,12 @@ void Array::get_metadata(
   }
 
   // Load array metadata, if not loaded yet
-  if (!metadata_loaded_) {
+  if (!metadata_loaded()) {
     throw_if_not_ok(load_metadata());
   }
 
-  metadata_.get(index, key, key_len, value_type, value_num, value);
+  opened_array_->metadata().get(
+      index, key, key_len, value_type, value_num, value);
 }
 
 uint64_t Array::metadata_num() {
@@ -1033,11 +997,11 @@ uint64_t Array::metadata_num() {
   }
 
   // Load array metadata, if not loaded yet
-  if (!metadata_loaded_) {
+  if (!metadata_loaded()) {
     throw_if_not_ok(load_metadata());
   }
 
-  return metadata_.num();
+  return opened_array_->metadata().num();
 }
 
 std::optional<Datatype> Array::metadata_type(const char* key) {
@@ -1058,43 +1022,35 @@ std::optional<Datatype> Array::metadata_type(const char* key) {
   }
 
   // Load array metadata, if not loaded yet
-  if (!metadata_loaded_) {
+  if (!metadata_loaded()) {
     throw_if_not_ok(load_metadata());
   }
 
-  return metadata_.metadata_type(key);
+  return opened_array_->metadata().metadata_type(key);
 }
 
 Metadata* Array::unsafe_metadata() {
-  return &metadata_;
+  return &opened_array_->metadata();
 }
 
 Status Array::metadata(Metadata** metadata) {
   // Load array metadata for array opened for reads, if not loaded yet
-  if (query_type_ == QueryType::READ && !metadata_loaded_) {
+  if (query_type_ == QueryType::READ && !metadata_loaded()) {
     RETURN_NOT_OK(load_metadata());
   }
 
-  *metadata = &metadata_;
+  *metadata = &opened_array_->metadata();
 
   return Status::Ok();
 }
 
-NDRange* Array::loaded_non_empty_domain() {
-  return &non_empty_domain_;
-}
-
-tuple<Status, optional<const NDRange>> Array::non_empty_domain() {
-  if (!non_empty_domain_computed_) {
+const NDRange Array::non_empty_domain() {
+  if (!non_empty_domain_computed()) {
     // Compute non-empty domain
-    RETURN_NOT_OK_TUPLE(compute_non_empty_domain(), nullopt);
+    throw_if_not_ok(compute_non_empty_domain());
   }
 
-  return {Status::Ok(), non_empty_domain_};
-}
-
-void Array::set_non_empty_domain(const NDRange& non_empty_domain) {
-  non_empty_domain_ = non_empty_domain;
+  return loaded_non_empty_domain();
 }
 
 MemoryTracker* Array::memory_tracker() {
@@ -1194,12 +1150,16 @@ std::unordered_map<std::string, uint64_t> Array::get_average_var_cell_sizes()
     const {
   std::unordered_map<std::string, uint64_t> ret;
 
+  // Keep the current opened array alive for the duration of this call.
+  auto opened_array = opened_array_;
+  auto fragment_metadata = opened_array->fragment_metadata();
+
   // Find the names of the var-sized dimensions or attributes.
   std::vector<std::string> var_names;
 
   // Start with dimensions.
-  for (unsigned d = 0; d < array_schema_latest_->dim_num(); d++) {
-    auto dim = array_schema_latest_->dimension_ptr(d);
+  for (unsigned d = 0; d < array_schema_latest().dim_num(); d++) {
+    auto dim = array_schema_latest().dimension_ptr(d);
     if (dim->var_size()) {
       var_names.emplace_back(dim->name());
       ret.emplace(dim->name(), 0);
@@ -1207,7 +1167,7 @@ std::unordered_map<std::string, uint64_t> Array::get_average_var_cell_sizes()
   }
 
   // Now attributes.
-  for (auto& attr : array_schema_latest_->attributes()) {
+  for (auto& attr : array_schema_latest().attributes()) {
     if (attr->var_size()) {
       var_names.emplace_back(attr->name());
       ret.emplace(attr->name(), 0);
@@ -1219,17 +1179,17 @@ std::unordered_map<std::string, uint64_t> Array::get_average_var_cell_sizes()
     throw_if_not_ok(parallel_for(
         &resources_.compute_tp(),
         0,
-        fragment_metadata_.size(),
+        fragment_metadata.size(),
         [&](const unsigned f) {
           // Gracefully skip loading tile sizes for attributes added in schema
           // evolution that do not exists in this fragment.
-          const auto& schema = fragment_metadata_[f]->array_schema();
+          const auto& schema = fragment_metadata[f]->array_schema();
           if (!schema->is_field(var_name)) {
             return Status::Ok();
           }
 
-          fragment_metadata_[f]->load_tile_var_sizes(
-              *encryption_key_, var_name);
+          fragment_metadata[f]->load_tile_var_sizes(
+              *encryption_key(), var_name);
           return Status::Ok();
         }));
   }
@@ -1242,18 +1202,18 @@ std::unordered_map<std::string, uint64_t> Array::get_average_var_cell_sizes()
         auto& var_name = var_names[n];
 
         // Sum the total tile size and cell num for each fragments.
-        for (unsigned f = 0; f < fragment_metadata_.size(); f++) {
+        for (unsigned f = 0; f < fragment_metadata.size(); f++) {
           // Skip computation for fields that don't exist for a particular
           // fragment.
-          const auto& schema = fragment_metadata_[f]->array_schema();
+          const auto& schema = fragment_metadata[f]->array_schema();
           if (!schema->is_field(var_name)) {
             continue;
           }
 
           // Go through all tiles.
-          for (uint64_t t = 0; t < fragment_metadata_[f]->tile_num(); t++) {
-            total_size += fragment_metadata_[f]->tile_var_size(var_name, t);
-            cell_num += fragment_metadata_[f]->cell_num(t);
+          for (uint64_t t = 0; t < fragment_metadata[f]->tile_num(); t++) {
+            total_size += fragment_metadata[f]->tile_var_size(var_name, t);
+            cell_num += fragment_metadata[f]->cell_num(t);
           }
         }
 
@@ -1294,7 +1254,7 @@ Array::open_for_reads_without_fragments() {
       "array_open_read_without_fragments_load_schemas");
 
   // Load array schemas
-  auto result = array_dir_.load_array_schemas(*encryption_key());
+  auto result = array_directory().load_array_schemas(*encryption_key());
 
   auto version = std::get<0>(result)->version();
   ensure_supported_schema_version_for_read(version);
@@ -1319,7 +1279,7 @@ Array::open_for_writes() {
 
   // Load array schemas
   auto&& [array_schema_latest, array_schemas_all] =
-      array_dir_.load_array_schemas(*encryption_key_);
+      array_directory().load_array_schemas(*encryption_key());
 
   // If building experimentally, this library should not be able to
   // write to newer-versioned or older-versioned arrays
@@ -1363,16 +1323,16 @@ void Array::clear_last_max_buffer_sizes() {
 
 Status Array::compute_max_buffer_sizes(const void* subarray) {
   // Applicable only to domains where all dimensions have the same type
-  if (!array_schema_latest_->domain().all_dims_same_type()) {
+  if (!array_schema_latest().domain().all_dims_same_type()) {
     return LOG_STATUS(
         Status_ArrayError("Cannot compute max buffer sizes; Inapplicable when "
                           "dimension domains have different types"));
   }
 
   // Allocate space for max buffer sizes subarray
-  auto dim_num = array_schema_latest_->dim_num();
+  auto dim_num = array_schema_latest().dim_num();
   auto coord_size{
-      array_schema_latest_->domain().dimension_ptr(0)->coord_size()};
+      array_schema_latest().domain().dimension_ptr(0)->coord_size()};
   auto subarray_size = 2 * dim_num * coord_size;
   last_max_buffer_sizes_subarray_.resize(subarray_size);
 
@@ -1383,7 +1343,7 @@ Status Array::compute_max_buffer_sizes(const void* subarray) {
     last_max_buffer_sizes_.clear();
 
     // Get all attributes and coordinates
-    auto attributes = array_schema_latest_->attributes();
+    auto attributes = array_schema_latest().attributes();
     last_max_buffer_sizes_.clear();
     for (const auto& attr : attributes)
       last_max_buffer_sizes_[attr->name()] =
@@ -1392,7 +1352,7 @@ Status Array::compute_max_buffer_sizes(const void* subarray) {
         std::pair<uint64_t, uint64_t>(0, 0);
     for (unsigned d = 0; d < dim_num; ++d)
       last_max_buffer_sizes_
-          [array_schema_latest_->domain().dimension_ptr(d)->name()] =
+          [array_schema_latest().domain().dimension_ptr(d)->name()] =
               std::pair<uint64_t, uint64_t>(0, 0);
 
     RETURN_NOT_OK(compute_max_buffer_sizes(subarray, &last_max_buffer_sizes_));
@@ -1416,64 +1376,68 @@ Status Array::compute_max_buffer_sizes(
     }
 
     return rest_client->get_array_max_buffer_sizes(
-        array_uri_, *(array_schema_latest_.get()), subarray, buffer_sizes);
+        array_uri_, array_schema_latest(), subarray, buffer_sizes);
   }
 
+  // Keep the current opened array alive for the duration of this call.
+  auto opened_array = opened_array_;
+  auto fragment_metadata = opened_array->fragment_metadata();
+
   // Return if there are no metadata
-  if (fragment_metadata_.empty()) {
+  if (fragment_metadata.empty()) {
     return Status::Ok();
   }
 
   // First we calculate a rough upper bound. Especially for dense
   // arrays, this will not be accurate, as it accounts only for the
   // non-empty regions of the subarray.
-  for (auto& meta : fragment_metadata_) {
-    meta->add_max_buffer_sizes(*encryption_key_, subarray, buffer_sizes);
+  for (auto& meta : fragment_metadata) {
+    meta->add_max_buffer_sizes(*encryption_key(), subarray, buffer_sizes);
   }
 
   // Prepare an NDRange for the subarray
-  auto dim_num = array_schema_latest_->dim_num();
+  auto dim_num = array_schema_latest().dim_num();
   NDRange sub(dim_num);
   auto sub_ptr = (const unsigned char*)subarray;
   uint64_t offset = 0;
   for (unsigned d = 0; d < dim_num; ++d) {
-    auto r_size{2 * array_schema_latest_->dimension_ptr(d)->coord_size()};
+    auto r_size{2 * array_schema_latest().dimension_ptr(d)->coord_size()};
     sub[d] = Range(&sub_ptr[offset], r_size);
     offset += r_size;
   }
 
   // Rectify bound for dense arrays
-  if (array_schema_latest_->dense()) {
-    auto cell_num = array_schema_latest_->domain().cell_num(sub);
+  if (array_schema_latest().dense()) {
+    auto cell_num = array_schema_latest().domain().cell_num(sub);
     // `cell_num` becomes 0 when `subarray` is huge, leading to a
     // `uint64_t` overflow.
     if (cell_num != 0) {
       for (auto& it : *buffer_sizes) {
-        if (array_schema_latest_->var_size(it.first)) {
+        if (array_schema_latest().var_size(it.first)) {
           it.second.first = cell_num * constants::cell_var_offset_size;
           it.second.second +=
-              cell_num * datatype_size(array_schema_latest_->type(it.first));
+              cell_num * datatype_size(array_schema_latest().type(it.first));
         } else {
           it.second.first =
-              cell_num * array_schema_latest_->cell_size(it.first);
+              cell_num * array_schema_latest().cell_size(it.first);
         }
       }
     }
   }
 
   // Rectify bound for sparse arrays with integer domain, without duplicates
-  if (!array_schema_latest_->dense() && !array_schema_latest_->allows_dups() &&
-      array_schema_latest_->domain().all_dims_int()) {
-    auto cell_num = array_schema_latest_->domain().cell_num(sub);
+  if (!array_schema_latest().dense() && !array_schema_latest().allows_dups() &&
+      array_schema_latest().domain().all_dims_int()) {
+    auto cell_num = array_schema_latest().domain().cell_num(sub);
     // `cell_num` becomes 0 when `subarray` is huge, leading to a
     // `uint64_t` overflow.
     if (cell_num != 0) {
       for (auto& it : *buffer_sizes) {
-        if (!array_schema_latest_->var_size(it.first)) {
+        if (!array_schema_latest().var_size(it.first)) {
           // Check for overflow
           uint64_t new_size =
-              cell_num * array_schema_latest_->cell_size(it.first);
-          if (new_size / array_schema_latest_->cell_size((it.first)) !=
+              cell_num * array_schema_latest().cell_size(it.first);
+          if (new_size / array_schema_latest().cell_size((it.first)) !=
               cell_num) {
             continue;
           }
@@ -1489,14 +1453,14 @@ Status Array::compute_max_buffer_sizes(
 }
 
 void Array::do_load_metadata() {
-  if (!array_dir_.loaded()) {
+  if (!array_directory().loaded()) {
     throw ArrayException(
         "Cannot load metadata; array directory is not loaded.");
   }
   auto timer_se = resources_.stats().start_timer("sm_load_array_metadata");
 
   // Determine which array metadata to load
-  const auto& array_metadata_to_load = array_dir_.array_meta_uris();
+  const auto& array_metadata_to_load = array_directory().array_meta_uris();
 
   auto metadata_num = array_metadata_to_load.size();
   std::vector<shared_ptr<Tile>> metadata_tiles(metadata_num);
@@ -1504,7 +1468,8 @@ void Array::do_load_metadata() {
       parallel_for(&resources_.compute_tp(), 0, metadata_num, [&](size_t m) {
         const auto& uri = array_metadata_to_load[m].uri_;
 
-        auto&& tile = GenericTileIO::load(resources_, uri, 0, *encryption_key_);
+        auto&& tile =
+            GenericTileIO::load(resources_, uri, 0, *encryption_key());
         metadata_tiles[m] = tdb::make_shared<Tile>(HERE(), std::move(tile));
 
         return Status::Ok();
@@ -1517,10 +1482,10 @@ void Array::do_load_metadata() {
   }
   resources_.stats().add_counter("read_array_meta_size", meta_size);
 
-  metadata_ = Metadata::deserialize(metadata_tiles);
+  opened_array_->metadata() = Metadata::deserialize(metadata_tiles);
 
   // Sets the loaded metadata URIs
-  metadata_.set_loaded_metadata_uris(array_metadata_to_load);
+  opened_array_->metadata().set_loaded_metadata_uris(array_metadata_to_load);
 }
 
 Status Array::load_metadata() {
@@ -1538,7 +1503,7 @@ Status Array::load_metadata() {
   } else {
     do_load_metadata();
   }
-  metadata_loaded_ = true;
+  set_metadata_loaded(true);
   return Status::Ok();
 }
 
@@ -1551,14 +1516,14 @@ Status Array::load_remote_non_empty_domain() {
     }
     RETURN_NOT_OK(rest_client->get_array_non_empty_domain(
         this, array_dir_timestamp_start_, timestamp_end_opened_at()));
-    non_empty_domain_computed_ = true;
+    set_non_empty_domain_computed(true);
   }
   return Status::Ok();
 }
 
-ArrayDirectory& Array::load_array_directory() {
-  if (array_dir_.loaded()) {
-    return array_dir_;
+const ArrayDirectory& Array::load_array_directory() {
+  if (array_directory().loaded()) {
+    return array_directory();
   }
 
   if (remote_) {
@@ -1571,45 +1536,49 @@ ArrayDirectory& Array::load_array_directory() {
                   ArrayDirectoryMode::SCHEMA_ONLY :
                   ArrayDirectoryMode::READ;
 
-  array_dir_ = ArrayDirectory(
+  set_array_directory(ArrayDirectory(
       resources_,
       array_uri_,
       array_dir_timestamp_start_,
       array_dir_timestamp_end_,
-      mode);
+      mode));
 
-  return array_dir_;
+  return array_directory();
 }
 
 Status Array::compute_non_empty_domain() {
+  // Keep the current opened array alive for the duration of this call.
+  auto opened_array = opened_array_;
+  auto fragment_metadata = opened_array->fragment_metadata();
+
   if (remote_) {
     RETURN_NOT_OK(load_remote_non_empty_domain());
-  } else if (!fragment_metadata_.empty()) {
-    const auto& frag0_dom = fragment_metadata_[0]->non_empty_domain();
-    non_empty_domain_.assign(frag0_dom.begin(), frag0_dom.end());
+  } else if (!fragment_metadata.empty()) {
+    const auto& frag0_dom = fragment_metadata[0]->non_empty_domain();
+    loaded_non_empty_domain().assign(frag0_dom.begin(), frag0_dom.end());
 
-    auto metadata_num = fragment_metadata_.size();
+    auto metadata_num = fragment_metadata.size();
     for (size_t j = 1; j < metadata_num; ++j) {
-      const auto& meta_dom = fragment_metadata_[j]->non_empty_domain();
+      const auto& meta_dom = fragment_metadata[j]->non_empty_domain();
       // Validate that this fragment's non-empty domain is set
       // It should _always_ be set, however we've seen cases where disk
       // corruption or other out-of-band activity can cause the fragment to be
       // corrupt for these cases we want to check to prevent any segfaults
       // later.
       if (!meta_dom.empty()) {
-        array_schema_latest_->domain().expand_ndrange(
-            meta_dom, &non_empty_domain_);
+        array_schema_latest().domain().expand_ndrange(
+            meta_dom, &loaded_non_empty_domain());
       } else {
         // If the fragment's non-empty domain is indeed empty, lets log it so
         // the user gets a message warning that this fragment might be corrupt
         // Note: LOG_STATUS only prints if TileDB is built in verbose mode.
         LOG_STATUS_NO_RETURN_VALUE(Status_ArrayError(
             "Non empty domain unexpectedly empty for fragment: " +
-            fragment_metadata_[j]->fragment_uri().to_string()));
+            fragment_metadata[j]->fragment_uri().to_string()));
       }
     }
   }
-  non_empty_domain_computed_ = true;
+  set_non_empty_domain_computed(true);
   return Status::Ok();
 }
 
@@ -1629,6 +1598,19 @@ void Array::set_array_open(const QueryType& query_type) {
   consistency_sentry_.emplace(
       consistency_controller_.make_sentry(array_uri_, *this, query_type));
   is_open_ = true;
+}
+
+void Array::set_serialized_array_open() {
+  is_open_ = true;
+
+  opened_array_ = make_shared<OpenedArray>(
+      HERE(),
+      EncryptionType::NO_ENCRYPTION,
+      nullptr,
+      0,
+      timestamp_start(),
+      timestamp_end_opened_at(),
+      array_uri_.is_tiledb());
 }
 
 void Array::set_array_closed() {

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -136,6 +136,8 @@ Status Array::open_without_fragments(
 
   opened_array_ = make_shared<OpenedArray>(
       HERE(),
+      resources_,
+      array_uri_,
       encryption_type,
       encryption_key,
       key_length,
@@ -306,6 +308,8 @@ Status Array::open(
 
     opened_array_ = make_shared<OpenedArray>(
         HERE(),
+        resources_,
+        array_uri_,
         encryption_type,
         encryption_key,
         key_length,
@@ -818,6 +822,8 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   auto key = opened_array_->encryption_key();
   opened_array_ = make_shared<OpenedArray>(
       HERE(),
+      resources_,
+      array_uri_,
       key->encryption_type(),
       key->key().data(),
       key->key().size(),
@@ -1605,6 +1611,8 @@ void Array::set_serialized_array_open() {
 
   opened_array_ = make_shared<OpenedArray>(
       HERE(),
+      resources_,
+      array_uri_,
       EncryptionType::NO_ENCRYPTION,
       nullptr,
       0,

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -80,6 +80,8 @@ class OpenedArray {
   /**
    * Construct a new Opened Array object.
    *
+   * @param resources The context resources to use.
+   * @param array_uri The URI of the array.
    * @param encryption_type Encryption type.
    * @param key_bytes Encryption key data.
    * @param key_length Encryption key length.
@@ -88,13 +90,16 @@ class OpenedArray {
    * @param is_remote Is the array remote?
    */
   OpenedArray(
+      ContextResources& resources,
+      const URI& array_uri,
       EncryptionType encryption_type,
       const void* key_bytes,
       uint32_t key_length,
       uint64_t timestamp_start,
       uint64_t timestamp_end_opened_at,
       bool is_remote)
-      : array_schema_latest_(nullptr)
+      : array_dir_(ArrayDirectory(resources, array_uri))
+      , array_schema_latest_(nullptr)
       , metadata_()
       , metadata_loaded_(false)
       , non_empty_domain_computed_(false)

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -59,6 +59,195 @@ class FragmentMetadata;
 enum class QueryType : uint8_t;
 
 /**
+ * Class to store opened array resources. The class is not C.41 compliant as the
+ * serialization code doesn't allow it. It needs to be refactored. This object
+ * will not change after the array as been opened though (see note below for the
+ * consolidation exception), so eventually we can make this object C.41
+ * compliant. That object allows queries or subarrays can take a reference to
+ * the resources which is going to be stored in a shared pointer and guarantee
+ * that the resources will be kept alive for the whole duration of the query.
+ *
+ * For consolidation, the opened array resources will be changed after the array
+ * is opened. The consolidator does load fragments separately once it figured
+ * out what it wants to consolidate. This is not an issue as we control the
+ * consolidator code and that code is built around that functionality.
+ */
+class OpenedArray {
+ public:
+  /* No default constructor. */
+  OpenedArray() = delete;
+
+  /**
+   * Construct a new Opened Array object.
+   *
+   * @param encryption_type Encryption type.
+   * @param key_bytes Encryption key data.
+   * @param key_length Encryption key length.
+   * @param timestamp_start Start timestamp used to load the array directory.
+   * @param timestamp_end_opened_at Timestamp at which the array was opened.
+   * @param is_remote Is the array remote?
+   */
+  OpenedArray(
+      EncryptionType encryption_type,
+      const void* key_bytes,
+      uint32_t key_length,
+      uint64_t timestamp_start,
+      uint64_t timestamp_end_opened_at,
+      bool is_remote)
+      : array_schema_latest_(nullptr)
+      , metadata_()
+      , metadata_loaded_(false)
+      , non_empty_domain_computed_(false)
+      , encryption_key_(make_shared<EncryptionKey>(HERE()))
+      , timestamp_start_(timestamp_start)
+      , timestamp_end_opened_at_(timestamp_end_opened_at)
+      , is_remote_(is_remote) {
+    throw_if_not_ok(
+        encryption_key_->set_key(encryption_type, key_bytes, key_length));
+  }
+
+  /** Returns the array directory object. */
+  inline const ArrayDirectory& array_directory() const {
+    return array_dir_.value();
+  }
+
+  /** Sets the array directory. */
+  inline void set_array_directory(const ArrayDirectory&& dir) {
+    array_dir_ = dir;
+  }
+
+  /** Returns the latest array schema. */
+  inline const ArraySchema& array_schema_latest() const {
+    return *(array_schema_latest_.get());
+  }
+
+  /** Returns the latest array schema as a shared pointer. */
+  inline shared_ptr<ArraySchema> array_schema_latest_ptr() const {
+    return array_schema_latest_;
+  }
+
+  /** Sets the latest array schema. */
+  inline void set_array_schema_latest(
+      const shared_ptr<ArraySchema>& array_schema) {
+    array_schema_latest_ = array_schema;
+  }
+
+  /** Returns all array schemas. */
+  inline const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
+  array_schemas_all() const {
+    return array_schemas_all_;
+  }
+
+  /** Sets all array schema. */
+  inline void set_array_schemas_all(
+      std::unordered_map<std::string, shared_ptr<ArraySchema>>&& all_schemas) {
+    array_schemas_all_ = std::move(all_schemas);
+  }
+
+  /** Gets a reference to the metadata. */
+  inline Metadata& metadata() {
+    return metadata_;
+  }
+
+  /** Get a reference to the `metadata_loaded_` value. */
+  inline bool& metadata_loaded() {
+    return metadata_loaded_;
+  }
+
+  /** Get a reference to the `non_empty_domain_computed_` value. */
+  inline bool& non_empty_domain_computed() {
+    return non_empty_domain_computed_;
+  }
+
+  /** Gets a reference to the non empty domain. */
+  inline NDRange& non_empty_domain() {
+    return non_empty_domain_;
+  }
+
+  /** Gets a reference to the fragment metadata. */
+  inline std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata() {
+    return fragment_metadata_;
+  }
+
+  /** Returns a constant pointer to the encryption key. */
+  inline const EncryptionKey* encryption_key() const {
+    return encryption_key_.get();
+  }
+
+  /**
+   * Returns a reference to the private encryption key.
+   */
+  inline const EncryptionKey& get_encryption_key() const {
+    return *encryption_key_;
+  }
+
+  /** Returns the start timestamp used to load the array directory. */
+  inline uint64_t timestamp_start() const {
+    return timestamp_start_;
+  }
+
+  /**
+   * Returns the timestamp at which the array was opened.
+   *
+   * WARNING: This is a legacy function that is needed to support the current
+   * API and REST calls. Do not use in new code.
+   */
+  inline uint64_t timestamp_end_opened_at() const {
+    return timestamp_end_opened_at_;
+  }
+
+  /** Returns if the array is remote or not. */
+  inline bool is_remote() const {
+    return is_remote_;
+  }
+
+ private:
+  /** The array directory object for listing URIs. */
+  optional<ArrayDirectory> array_dir_;
+
+  /** The latest array schema. */
+  shared_ptr<ArraySchema> array_schema_latest_;
+
+  /**
+   * A map of all array_schemas_all
+   */
+  std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas_all_;
+
+  /** The array metadata. */
+  Metadata metadata_;
+
+  /** True if the array metadata is loaded. */
+  bool metadata_loaded_;
+
+  /** True if the non_empty_domain has been computed */
+  bool non_empty_domain_computed_;
+
+  /** The non-empty domain of the array. */
+  NDRange non_empty_domain_;
+
+  /** The metadata of the fragments the array was opened with. */
+  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata_;
+
+  /**
+   * The private encryption key used to encrypt the array.
+   *
+   * Note: This is the only place in TileDB where the user's private key
+   * bytes should be stored. Whenever a key is needed, a pointer to this
+   * memory region should be passed instead of a copy of the bytes.
+   */
+  shared_ptr<EncryptionKey> encryption_key_;
+
+  /** The start timestamp used to load the array directory. */
+  uint64_t timestamp_start_;
+
+  /** The timestamp at which the array was opened. */
+  uint64_t timestamp_end_opened_at_;
+
+  /** Is this a remote array? */
+  bool is_remote_;
+};
+
+/**
  * Free function that returns a reference to the ConsistencyController object.
  */
 ConsistencyController& controller();
@@ -103,37 +292,53 @@ class Array {
   /*                API                */
   /* ********************************* */
 
+  /** Returns the opened array. */
+  inline const shared_ptr<OpenedArray> opened_array() const {
+    return opened_array_;
+  };
+
   /** Returns the array directory object. */
-  const ArrayDirectory& array_directory() const;
+  inline const ArrayDirectory& array_directory() const {
+    return opened_array_->array_directory();
+  }
 
   /** Set the array directory. */
-  void set_array_directory(const ArrayDirectory& dir) {
-    array_dir_ = dir;
+  inline void set_array_directory(const ArrayDirectory&& dir) {
+    opened_array_->set_array_directory(std::move(dir));
   }
 
   /** Sets the latest array schema.
    * @param array_schema The array schema to set.
    */
-  void set_array_schema_latest(const shared_ptr<ArraySchema>& array_schema);
+  inline void set_array_schema_latest(
+      const shared_ptr<ArraySchema>& array_schema) {
+    opened_array_->set_array_schema_latest(array_schema);
+  }
 
   /** Returns the latest array schema. */
-  const ArraySchema& array_schema_latest() const;
+  inline const ArraySchema& array_schema_latest() const {
+    return opened_array_->array_schema_latest();
+  }
 
   /** Returns the latest array schema as a shared pointer. */
-  shared_ptr<const ArraySchema> array_schema_latest_ptr() const;
+  inline shared_ptr<const ArraySchema> array_schema_latest_ptr() const {
+    return opened_array_->array_schema_latest_ptr();
+  }
 
   /** Returns array schemas map. */
   inline const std::unordered_map<std::string, shared_ptr<ArraySchema>>&
   array_schemas_all() const {
-    return array_schemas_all_;
+    return opened_array_->array_schemas_all();
   }
 
   /**
    * Sets all array schemas.
    * @param all_schemas The array schemas to set.
    */
-  void set_array_schemas_all(
-      std::unordered_map<std::string, shared_ptr<ArraySchema>>& all_schemas);
+  inline void set_array_schemas_all(
+      std::unordered_map<std::string, shared_ptr<ArraySchema>>&& all_schemas) {
+    opened_array_->set_array_schemas_all(std::move(all_schemas));
+  }
 
   /** Returns the array URI. */
   const URI& array_uri() const;
@@ -242,16 +447,19 @@ class Array {
   const EncryptionKey* encryption_key() const;
 
   /**
-   * Returns the fragment metadata of the array. If the array is not open,
-   * an empty vector is returned.
-   */
-  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata() const;
-
-  /**
    * Accessor to the fragment metadata of the array.
    */
   inline std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata() {
-    return fragment_metadata_;
+    return opened_array_->fragment_metadata();
+  }
+
+  /**
+   * Sets fragment metadata.
+   * @param fragment_metadata The fragment metadata.
+   */
+  inline void set_fragment_metadata(
+      std::vector<shared_ptr<FragmentMetadata>>&& fragment_metadata) {
+    opened_array_->fragment_metadata() = fragment_metadata;
   }
 
   /**
@@ -321,7 +529,9 @@ class Array {
   /**
    * Returns a reference to the private encryption key.
    */
-  const EncryptionKey& get_encryption_key() const;
+  inline const EncryptionKey& get_encryption_key() const {
+    return opened_array_->get_encryption_key();
+  }
 
   /**
    * Re-opens the array. This effectively updates the "view" of the array,
@@ -531,37 +741,40 @@ class Array {
 
   /** Set if array metadata is loaded already for this array or not */
   inline void set_metadata_loaded(const bool is_loaded) {
-    metadata_loaded_ = is_loaded;
+    opened_array_->metadata_loaded() = is_loaded;
   }
 
   /** Check if array metadata is loaded already for this array or not */
-  inline bool& metadata_loaded() {
-    return metadata_loaded_;
+  inline bool metadata_loaded() {
+    return opened_array_->metadata_loaded();
   }
 
   /** Check if non emtpy domain is loaded already for this array or not */
-  inline bool& non_empty_domain_computed() {
-    return non_empty_domain_computed_;
+  inline bool non_empty_domain_computed() {
+    return opened_array_->non_empty_domain_computed();
   }
 
-  /** Returns the non-empty domain of the opened array.
-   *  If the non_empty_domain has not been computed or loaded
-   *  it will be loaded first
-   * */
-  tuple<Status, optional<const NDRange>> non_empty_domain();
-
   /**
-   * Retrieves the array metadata object that is already loadad.
-   * If it's not yet loaded it will be empty.
+   * Returns the non-empty domain of the opened array. If the non_empty_domain
+   * has not been computed or loaded it will be loaded first
    */
-  NDRange* loaded_non_empty_domain();
+  const NDRange non_empty_domain();
+  /**
+   * Retrieves the array metadata object that is already loaded. If it's not yet
+   * loaded it will be empty.
+   */
+  inline NDRange& loaded_non_empty_domain() {
+    return opened_array_->non_empty_domain();
+  }
 
   /** Returns the non-empty domain of the opened array. */
-  void set_non_empty_domain(const NDRange& non_empty_domain);
+  inline void set_non_empty_domain(const NDRange& non_empty_domain) {
+    opened_array_->non_empty_domain() = non_empty_domain;
+  }
 
   /** Set if the non_empty_domain is computed already for this array or not */
   inline void set_non_empty_domain_computed(const bool is_computed) {
-    non_empty_domain_computed_ = is_computed;
+    opened_array_->non_empty_domain_computed() = is_computed;
   }
 
   /** Returns the memory tracker. */
@@ -569,7 +782,8 @@ class Array {
 
   /**
    * Checks the config to see if non empty domain should be serialized on array
-   * open. */
+   * open.
+   */
   bool serialize_non_empty_domain() const;
 
   /**
@@ -598,9 +812,7 @@ class Array {
   /**
    * Sets the array state as open, used in serialization
    */
-  inline void set_serialized_array_open() {
-    is_open_ = true;
-  }
+  void set_serialized_array_open();
 
   /** Set the query type to open the array for. */
   inline void set_query_type(QueryType query_type) {
@@ -619,26 +831,18 @@ class Array {
   std::unordered_map<std::string, uint64_t> get_average_var_cell_sizes() const;
 
   /** Load array directory for non-remote arrays */
-  ArrayDirectory& load_array_directory();
+  const ArrayDirectory& load_array_directory();
 
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
-  /** The latest array schema. */
-  shared_ptr<ArraySchema> array_schema_latest_;
-
-  /**
-   * A map of all array_schemas_all
-   */
-  std::unordered_map<std::string, shared_ptr<ArraySchema>> array_schemas_all_;
+  /** The opened array that can be used by queries. */
+  shared_ptr<OpenedArray> opened_array_;
 
   /** The array URI. */
   URI array_uri_;
-
-  /** The array directory object for listing URIs. */
-  ArrayDirectory array_dir_;
 
   /** This is a backwards compatible URI from serialization
    *  In TileDB 2.5 we removed sending the URI but 2.4 and older were
@@ -647,18 +851,6 @@ class Array {
    * clients.
    */
   URI array_uri_serialized_;
-
-  /**
-   * The private encryption key used to encrypt the array.
-   *
-   * Note: This is the only place in TileDB where the user's private key
-   * bytes should be stored. Whenever a key is needed, a pointer to this
-   * memory region should be passed instead of a copy of the bytes.
-   */
-  shared_ptr<EncryptionKey> encryption_key_;
-
-  /** The metadata of the fragments the array was opened with. */
-  std::vector<shared_ptr<FragmentMetadata>> fragment_metadata_;
 
   /** `True` if the array has been opened. */
   std::atomic<bool> is_open_;
@@ -726,18 +918,6 @@ class Array {
 
   /** True if the array is remote (has `tiledb://` URI scheme). */
   bool remote_;
-
-  /** The array metadata. */
-  Metadata metadata_;
-
-  /** True if the array metadata is loaded. */
-  bool metadata_loaded_;
-
-  /** True if the non_empty_domain has been computed */
-  bool non_empty_domain_computed_;
-
-  /** The non-empty domain of the array. */
-  NDRange non_empty_domain_;
 
   /** Memory tracker for the array. */
   MemoryTracker memory_tracker_;

--- a/tiledb/sm/array/array_directory.h
+++ b/tiledb/sm/array/array_directory.h
@@ -286,7 +286,7 @@ class ArrayDirectory {
   /* ********************************* */
 
   /**
-   * Constructor.
+   * Constructor. Needed for serialization.
    *
    * @param resources A reference to a ContextResources instance
    * @param uri The URI of the array directory

--- a/tiledb/sm/array/test/CMakeLists.txt
+++ b/tiledb/sm/array/test/CMakeLists.txt
@@ -27,6 +27,7 @@
 include(unit_test)
 
 commence(unit_test array)
+    this_target_compile_definitions(-DTILEDB_TEST_INPUTS_DIR="${CMAKE_SOURCE_DIR}/test/inputs/")
     this_target_sources(main.cc unit_array_directory.cc)
     this_target_link_libraries(array context_resources)
 conclude(unit_test)

--- a/tiledb/sm/array/test/unit_array_directory.cc
+++ b/tiledb/sm/array/test/unit_array_directory.cc
@@ -40,6 +40,9 @@
 using namespace tiledb::common;
 using namespace tiledb::sm;
 
+static const std::string arrays_dir =
+    std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays";
+
 namespace tiledb::sm {
 class WhiteboxArrayDirectory {
  public:
@@ -49,12 +52,6 @@ class WhiteboxArrayDirectory {
       const bool consolidation_with_timestamps) const {
     return array_directory.timestamps_overlap(
         fragment_timestamp_range, consolidation_with_timestamps);
-  }
-
-  void set_open_timestamps(
-      ArrayDirectory& array_directory, uint64_t start, uint64_t end) const {
-    array_directory.timestamp_start_ = start;
-    array_directory.timestamp_end_ = end;
   }
 };
 }  // namespace tiledb::sm
@@ -66,8 +63,12 @@ TEST_CASE(
   Config cfg;
   auto logger = make_shared<Logger>(HERE(), "foo");
   ContextResources resources{cfg, logger, 1, 1, ""};
-  ArrayDirectory array_dir(resources, URI());
-  wb_array_dir.set_open_timestamps(array_dir, 2, 4);
+  ArrayDirectory array_dir(
+      resources,
+      URI(arrays_dir + "/dense_array_v1_3_0"),
+      2,
+      4,
+      ArrayDirectoryMode::READ);
 
   // Only full overlap should be included for regular fragments.
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -495,9 +495,9 @@ int32_t tiledb_array_schema_load(
     auto storage_manager{ctx->storage_manager()};
 
     // Load URIs from the array directory
-    tiledb::sm::ArrayDirectory array_dir(storage_manager->resources(), uri);
+    optional<tiledb::sm::ArrayDirectory> array_dir;
     try {
-      array_dir = tiledb::sm::ArrayDirectory(
+      array_dir.emplace(
           storage_manager->resources(),
           uri,
           0,
@@ -512,7 +512,7 @@ int32_t tiledb_array_schema_load(
     }
 
     // Load latest array schema
-    auto&& array_schema_latest = array_dir.load_array_schema_latest(key);
+    auto&& array_schema_latest = array_dir->load_array_schema_latest(key);
     (*array_schema)->array_schema_ = array_schema_latest;
   }
   return TILEDB_OK;
@@ -586,9 +586,9 @@ int32_t tiledb_array_schema_load_with_key(
     auto storage_manager{ctx->storage_manager()};
 
     // Load URIs from the array directory
-    tiledb::sm::ArrayDirectory array_dir(storage_manager->resources(), uri);
+    optional<tiledb::sm::ArrayDirectory> array_dir;
     try {
-      array_dir = tiledb::sm::ArrayDirectory(
+      array_dir.emplace(
           storage_manager->resources(),
           uri,
           0,
@@ -603,7 +603,7 @@ int32_t tiledb_array_schema_load_with_key(
     }
 
     // Load latest array schema
-    auto&& array_schema_latest = array_dir.load_array_schema_latest(key);
+    auto&& array_schema_latest = array_dir->load_array_schema_latest(key);
     (*array_schema)->array_schema_ = array_schema_latest;
   }
   return TILEDB_OK;
@@ -1719,7 +1719,8 @@ int32_t tiledb_subarray_set_config(
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
   api::ensure_config_is_valid(config);
-  subarray->subarray_->set_config(config->config());
+  subarray->subarray_->set_config(
+      tiledb::sm::QueryType::READ, config->config());
   return TILEDB_OK;
 }
 
@@ -2929,9 +2930,9 @@ int32_t tiledb_array_encryption_type(
   auto uri = tiledb::sm::URI(array_uri);
 
   // Load URIs from the array directory
-  tiledb::sm::ArrayDirectory array_dir(storage_manager->resources(), uri);
+  optional<tiledb::sm::ArrayDirectory> array_dir;
   try {
-    array_dir = tiledb::sm::ArrayDirectory(
+    array_dir.emplace(
         storage_manager->resources(),
         uri,
         0,
@@ -2947,7 +2948,7 @@ int32_t tiledb_array_encryption_type(
   // Get encryption type
   tiledb::sm::EncryptionType enc;
   throw_if_not_ok(
-      ctx->storage_manager()->array_get_encryption(array_dir, &enc));
+      ctx->storage_manager()->array_get_encryption(array_dir.value(), &enc));
 
   *encryption_type = static_cast<tiledb_encryption_type_t>(enc);
 

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -111,6 +111,14 @@ Status ArrayMetaConsolidator::consolidate(
   // Get the new URI name for consolidated metadata
   URI new_uri = metadata_w->get_uri(array_uri);
 
+  // Write vac files relative to the array URI. This was fixed for reads in
+  // version 19 so only do this for arrays starting with version 19.
+  size_t base_uri_size = 0;
+  if (array_for_reads.array_schema_latest_ptr() == nullptr ||
+      array_for_reads.array_schema_latest().write_version() >= 19) {
+    base_uri_size = array_for_reads.array_uri().to_string().size();
+  }
+
   // Close arrays
   RETURN_NOT_OK_ELSE(
       array_for_reads.close(), throw_if_not_ok(array_for_writes.close()));
@@ -118,15 +126,6 @@ Status ArrayMetaConsolidator::consolidate(
 
   // Write vacuum file
   URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
-
-  size_t base_uri_size = 0;
-
-  // Write vac files relative to the array URI. This was fixed for reads in
-  // version 19 so only do this for arrays starting with version 19.
-  if (array_for_reads.array_schema_latest_ptr() == nullptr ||
-      array_for_reads.array_schema_latest().write_version() >= 19) {
-    base_uri_size = array_for_reads.array_uri().to_string().size();
-  }
 
   std::stringstream ss;
   for (const auto& uri : to_vacuum) {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -129,7 +129,7 @@ Query::Query(
     config_ = storage_manager->config();
 
   // Set initial subarray configuration
-  subarray_.set_config(config_);
+  subarray_.set_config(type_, config_);
 
   rest_scratch_ = make_shared<Buffer>(HERE());
 }
@@ -983,7 +983,7 @@ void Query::set_config(const Config& config) {
   // Set subarray's config for backwards compatibility
   // Users expect the query config to effect the subarray based on existing
   // behavior before subarray was exposed directly
-  subarray_.set_config(config_);
+  subarray_.set_config(type_, config_);
 }
 
 Status Query::set_coords_buffer(void* buffer, uint64_t* buffer_size) {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -84,6 +84,7 @@ Query::Query(
     optional<std::string> fragment_name)
     : array_shared_(array)
     , array_(array_shared_.get())
+    , opened_array_(array->opened_array())
     , array_schema_(array->array_schema_latest_ptr())
     , type_(array_->get_query_type())
     , layout_(
@@ -1791,7 +1792,7 @@ bool Query::is_aggregate(std::string output_field_name) const {
 Status Query::create_strategy(bool skip_checks_serialization) {
   auto params = StrategyParams(
       storage_manager_,
-      array_,
+      opened_array_,
       config_,
       buffers_,
       aggregate_buffers_,
@@ -1799,7 +1800,8 @@ Status Query::create_strategy(bool skip_checks_serialization) {
       layout_,
       condition_,
       default_channel_aggregates_,
-      skip_checks_serialization);
+      skip_checks_serialization,
+      array_->memory_tracker());
   if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
     if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
       if (!array_schema_->dense()) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -784,9 +784,14 @@ class Query {
    * Ensures that the Array object exists as long as the Query object exists. */
   shared_ptr<Array> array_shared_;
 
-  /** The array the query is associated with.
-   * Cached copy of array_shared_.get(). */
+  /**
+   * The array the query is associated with.
+   * Cached copy of array_shared_.get().
+   */
   Array* array_;
+
+  /** Keeps a copy of the opened array object at construction. */
+  shared_ptr<OpenedArray> opened_array_;
 
   /** The array schema. */
   shared_ptr<const ArraySchema> array_schema_;

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -74,7 +74,7 @@ DenseReader::DenseReader(
     StrategyParams& params,
     bool remote_query)
     : ReaderBase(stats, logger->clone("DenseReader", ++logger_id_), params)
-    , array_memory_tracker_(params.array()->memory_tracker()) {
+    , array_memory_tracker_(params.memory_tracker()) {
   elements_mode_ = false;
 
   // Sanity checks.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -73,7 +73,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
     , tmp_read_state_(array_->fragment_metadata().size())
     , memory_budget_(config_, reader_string)
     , include_coords_(include_coords)
-    , array_memory_tracker_(params.array()->memory_tracker())
+    , array_memory_tracker_(params.memory_tracker())
     , memory_used_for_coords_total_(0)
     , deletes_consolidation_no_purge_(
           buffers_.count(constants::delete_timestamps) != 0)

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -49,7 +49,7 @@ StrategyBase::StrategyBase(
     stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
     : stats_(stats)
     , logger_(logger)
-    , array_(params.array()->opened_array())
+    , array_(params.array())
     , array_schema_(params.array()->array_schema_latest())
     , config_(params.config())
     , buffers_(params.buffers())

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -49,7 +49,7 @@ StrategyBase::StrategyBase(
     stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
     : stats_(stats)
     , logger_(logger)
-    , array_(params.array())
+    , array_(params.array()->opened_array())
     , array_schema_(params.array()->array_schema_latest())
     , config_(params.config())
     , buffers_(params.buffers())

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -43,17 +43,17 @@
 namespace tiledb {
 namespace sm {
 
-class Array;
 class OpenedArray;
 class ArraySchema;
 class IAggregator;
 enum class Layout : uint8_t;
+class MemoryTracker;
 class Subarray;
 class QueryBuffer;
 class QueryCondition;
 
-typedef std::unordered_map<std::string, shared_ptr<IAggregator>>
-    DefaultChannelAggregates;
+using DefaultChannelAggregates =
+    std::unordered_map<std::string, shared_ptr<IAggregator>>;
 
 /**
  * Class used to pass in common parameters to strategies. This will make it
@@ -67,7 +67,7 @@ class StrategyParams {
 
   StrategyParams(
       StorageManager* storage_manager,
-      Array* array,
+      shared_ptr<OpenedArray> array,
       Config& config,
       std::unordered_map<std::string, QueryBuffer>& buffers,
       std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
@@ -75,7 +75,8 @@ class StrategyParams {
       Layout layout,
       std::optional<QueryCondition>& condition,
       DefaultChannelAggregates& default_channel_aggregates,
-      bool skip_checks_serialization)
+      bool skip_checks_serialization,
+      MemoryTracker* memory_tracker)
       : storage_manager_(storage_manager)
       , array_(array)
       , config_(config)
@@ -85,7 +86,8 @@ class StrategyParams {
       , layout_(layout)
       , condition_(condition)
       , default_channel_aggregates_(default_channel_aggregates)
-      , skip_checks_serialization_(skip_checks_serialization) {
+      , skip_checks_serialization_(skip_checks_serialization)
+      , memory_tracker_(memory_tracker) {
   }
 
   /* ********************************* */
@@ -98,7 +100,7 @@ class StrategyParams {
   };
 
   /** Return the array. */
-  inline Array* array() {
+  inline shared_ptr<OpenedArray> array() {
     return array_;
   };
 
@@ -142,6 +144,10 @@ class StrategyParams {
     return skip_checks_serialization_;
   }
 
+  inline MemoryTracker* memory_tracker() {
+    return memory_tracker_;
+  }
+
  private:
   /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */
@@ -151,7 +157,7 @@ class StrategyParams {
   StorageManager* storage_manager_;
 
   /** Array. */
-  Array* array_;
+  shared_ptr<OpenedArray> array_;
 
   /** Config for query-level parameters only. */
   Config& config_;
@@ -176,6 +182,9 @@ class StrategyParams {
 
   /** Skip checks for serialization. */
   bool skip_checks_serialization_;
+
+  /** Memory tracker. */
+  MemoryTracker* memory_tracker_;
 };
 
 /** Processes read or write queries. */

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -44,6 +44,7 @@ namespace tiledb {
 namespace sm {
 
 class Array;
+class OpenedArray;
 class ArraySchema;
 class IAggregator;
 enum class Layout : uint8_t;
@@ -227,8 +228,11 @@ class StrategyBase {
   /** The class logger. */
   shared_ptr<Logger> logger_;
 
-  /** The array. */
-  const Array* array_;
+  /**
+   * A shared pointer to the opened array which ensures that the query can
+   * still access it even after the array is closed.
+   */
+  shared_ptr<OpenedArray> array_;
 
   /** The array schema. */
   const ArraySchema& array_schema_;

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -484,14 +484,10 @@ Status serialize_non_empty_domain_rv(
  */
 template <typename CapnpT>
 Status serialize_non_empty_domain(CapnpT& builder, tiledb::sm::Array* array) {
-  auto&& [st, nonEmptyDomain_opt] = array->non_empty_domain();
-  RETURN_NOT_OK(st);
-  if (nonEmptyDomain_opt.has_value()) {
-    return serialize_non_empty_domain_rv(
-        builder,
-        nonEmptyDomain_opt.value(),
-        array->array_schema_latest().dim_num());
-  }
+  return serialize_non_empty_domain_rv(
+      builder,
+      array->non_empty_domain(),
+      array->array_schema_latest().dim_num());
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -66,6 +66,7 @@ namespace tiledb {
 namespace sm {
 
 class Array;
+class OpenedArray;
 class ArrayDirectory;
 class ArraySchema;
 class ArraySchemaEvolution;
@@ -597,14 +598,14 @@ class StorageManagerCanonical {
   /**
    * Loads the delete and update conditions from storage.
    *
-   * @param array The array.
+   * @param opened_array The opened array.
    * @return Status, vector of the conditions, vector of the update values.
    */
   tuple<
       Status,
       optional<std::vector<QueryCondition>>,
       optional<std::vector<std::vector<UpdateValue>>>>
-  load_delete_and_update_conditions(const Array& array);
+  load_delete_and_update_conditions(const OpenedArray& opened_array);
 
   /** Removes a TileDB object (group, array). */
   Status object_remove(const char* path) const;

--- a/tiledb/sm/subarray/relevant_fragment_generator.h
+++ b/tiledb/sm/subarray/relevant_fragment_generator.h
@@ -43,7 +43,7 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
-class Array;
+class OpenedArray;
 class RelevantFragments;
 class Subarray;
 class SubarrayTileOverlap;
@@ -72,7 +72,9 @@ class RelevantFragmentGenerator {
 
   /** Constructor a generator. */
   RelevantFragmentGenerator(
-      const Array& array, const Subarray& subarray, stats::Stats* stats);
+      const shared_ptr<OpenedArray> opened_array,
+      const Subarray& subarray,
+      stats::Stats* stats);
 
   /* ********************************* */
   /*                API                */
@@ -144,8 +146,8 @@ class RelevantFragmentGenerator {
   /** The class stats. */
   stats::Stats* stats_;
 
-  /** Reference to the opened array. */
-  const Array& array_;
+  /** Reference to the opened opened array. */
+  const shared_ptr<OpenedArray> array_;
 
   /** Reference to the subarray. */
   const Subarray& subarray_;

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -69,6 +69,7 @@ namespace sm {
 
 class Array;
 class ArraySchema;
+class OpenedArray;
 class DimensionLabel;
 class EncryptionKey;
 class FragIdx;
@@ -248,6 +249,26 @@ class Subarray {
       StorageManager* storage_manager = nullptr);
 
   /**
+   * Constructor.
+   *
+   * @param opened_array The opened array the subarray is associated with.
+   * @param layout The layout of the values of the subarray (of the results
+   *     if the subarray is used for reads, or of the values provided
+   *     by the user for writes).
+   * @param parent_stats The parent stats to inherit from.
+   * @param logger The parent logger to clone and use for logging
+   * @param coalesce_ranges When enabled, ranges will attempt to coalesce
+   *     with existing ranges as they are added.
+   */
+  Subarray(
+      const shared_ptr<OpenedArray> opened_array,
+      Layout layout,
+      stats::Stats* parent_stats,
+      shared_ptr<Logger> logger,
+      bool coalesce_ranges = true,
+      StorageManager* storage_manager = nullptr);
+
+  /**
    * Copy constructor. This performs a deep copy (including memcpy of
    * underlying buffers).
    */
@@ -273,7 +294,7 @@ class Subarray {
   /* ********************************* */
 
   /** Sets config for query-level parameters only. */
-  void set_config(const Config& config);
+  void set_config(const QueryType query_type, const Config& config);
 
   /**
    * Get the config of the writer
@@ -593,8 +614,8 @@ class Subarray {
       void* start,
       void* end) const;
 
-  /** Returns the array the subarray is associated with. */
-  const Array* array() const;
+  /** Returns the opened array the subarray is associated with. */
+  const shared_ptr<OpenedArray> array() const;
 
   /**
    * Returns the number of cells in the subarray.
@@ -1388,7 +1409,7 @@ class Subarray {
   shared_ptr<Logger> logger_;
 
   /** The array the subarray object is associated with. */
-  const Array* array_;
+  shared_ptr<OpenedArray> array_;
 
   /** Stores the estimated result size for each array attribute/dimension. */
   std::unordered_map<std::string, ResultSize> est_result_size_;

--- a/tiledb/sm/subarray/test/unit_add_ranges_list.cc
+++ b/tiledb/sm/subarray/test/unit_add_ranges_list.cc
@@ -71,12 +71,9 @@ TEST_CASE("Subarray::add_ranges_list", "[subarray]") {
       make_shared<tiledb::sm::ArraySchema>(HERE());
   CHECK(sp_as->set_domain(sp_dom).ok());
   CHECK(sp_as->add_attribute(sp_attrib).ok());
-  // sp_as->add_dimension();
   tiledb::sm::Config cfg;
   tiledb::sm::Context ctx(cfg);
   tiledb::sm::Array a(tiledb::sm::URI{"mem://junk"}, ctx.storage_manager());
-  a.set_array_schema_latest(sp_as);
-  // a.create();
   tiledb::sm::EncryptionKey ek;
   CHECK(ek.set_key(tiledb::sm::EncryptionType::NO_ENCRYPTION, nullptr, 0).ok());
   CHECK(ctx.storage_manager()->array_create(a.array_uri(), sp_as, ek).ok());


### PR DESCRIPTION
This change moves all the opened array resources used in strategies to a class so that they can be acquired as a shared pointer when the strategy begins and kept alive until the strategy is done.

[sc-38872]

---
TYPE: IMPROVEMENT
DESC: Keep opened array resources alive until query ends.
