### PR TITLE
Fix consolidation plan to print relative paths in output

### DIFF
--- a/test/src/test-cppapi-consolidation-plan.cc
+++ b/test/src/test-cppapi-consolidation-plan.cc
@@ -37,6 +37,7 @@
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/cpp_api/tiledb_experimental"
 #include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/serialization/consolidation.h"
 
 #include <test/support/tdb_catch.h>
@@ -170,7 +171,7 @@ std::string CppConsolidationPlanFx::write_sparse(
   // Close array.
   array->close();
 
-  return query.fragment_uri(0);
+  return tiledb::sm::URI(query.fragment_uri(0)).last_path_part();
 }
 
 void CppConsolidationPlanFx::remove_array(const std::string& array_name) {

--- a/tiledb/sm/consolidation_plan/consolidation_plan.h
+++ b/tiledb/sm/consolidation_plan/consolidation_plan.h
@@ -198,8 +198,10 @@ class ConsolidationPlan {
       std::vector<std::string> ret;
       ret.reserve(fragment_indexes_.size());
       for (auto& idx : fragment_indexes_) {
-        ret.emplace_back(
-            array_->fragment_metadata()[idx]->fragment_uri().c_str());
+        ret.emplace_back(array_->fragment_metadata()[idx]
+                             ->fragment_uri()
+                             .last_path_part()
+                             .c_str());
       }
 
       return ret;


### PR DESCRIPTION
This issue was found by @anastasop while testing Cloud support for Consolidation plan. So far consolidation plan would print full URIs for fragments. However, for remote arrays we should be only printing out relative URIs. So, this fix replaces full with relative URIs for any type of array consolidation plan.


---
TYPE: IMPROVEMENT
DESC: Fix consolidation plan to print relative paths in output
