### PR TITLE
Refactor fragment consolidation with `class FragmentConsolidationWorkspace`

### DIFF
--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -125,6 +125,18 @@ class Consolidator {
    */
   virtual void vacuum(const char* array_name);
 
+  /* ********************************* */
+  /*           TYPE DEFINITIONS        */
+  /* ********************************* */
+
+  /** Consolidation configuration parameters. */
+  struct ConsolidationConfigBase {
+    /** Start time for consolidation. */
+    uint64_t timestamp_start_;
+    /** End time for consolidation. */
+    uint64_t timestamp_end_;
+  };
+
  protected:
   /* ********************************* */
   /*         PROTECTED METHODS         */
@@ -143,18 +155,6 @@ class Consolidator {
    * @param array_name Name of the array to check.
    */
   void check_array_uri(const char* array_name);
-
-  /* ********************************* */
-  /*           TYPE DEFINITIONS        */
-  /* ********************************* */
-
-  /** Consolidation configuration parameters. */
-  struct ConsolidationConfigBase {
-    /** Start time for consolidation. */
-    uint64_t timestamp_start_;
-    /** End time for consolidation. */
-    uint64_t timestamp_end_;
-  };
 
   /* ********************************* */
   /*       PROTECTED ATTRIBUTES        */

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -419,7 +419,8 @@ Status FragmentConsolidator::consolidate_internal(
 
   // Prepare buffers
   auto average_var_cell_sizes = array_for_reads->get_average_var_cell_sizes();
-  FragmentConsolidationWorkspace cw{create_buffers(stats_, config_, array_schema, average_var_cell_sizes)};
+  FragmentConsolidationWorkspace cw{
+      create_buffers(stats_, config_, array_schema, average_var_cell_sizes)};
 
   // Create queries
   auto query_r = (Query*)nullptr;

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -528,7 +528,7 @@ void FragmentConsolidator::copy_array(
   } while (query_r->status() == QueryStatus::INCOMPLETE);
 }
 
-FragmentConsolidationWorkspace&& FragmentConsolidator::create_buffers(
+FragmentConsolidationWorkspace FragmentConsolidator::create_buffers(
     stats::Stats* stats,
     const FragmentConsolidationConfig& config,
     const ArraySchema& array_schema,
@@ -620,7 +620,7 @@ FragmentConsolidationWorkspace&& FragmentConsolidator::create_buffers(
   }
 
   // Success
-  return std::move(cw);
+  return cw;
 }
 
 Status FragmentConsolidator::create_queries(

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -51,9 +51,9 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
-class FragmentConsolidatorStatusException : public StatusException {
+class FragmentConsolidatorException : public StatusException {
  public:
-  explicit FragmentConsolidatorStatusException(const std::string& message)
+  explicit FragmentConsolidatorException(const std::string& message)
       : StatusException("FragmentConsolidator", message) {
   }
 };
@@ -293,7 +293,7 @@ Status FragmentConsolidator::consolidate_fragments(
 
 void FragmentConsolidator::vacuum(const char* array_name) {
   if (array_name == nullptr) {
-    throw Status_StorageManagerError(
+    throw FragmentConsolidatorException(
         "Cannot vacuum fragments; Array name cannot be null");
   }
 
@@ -348,7 +348,7 @@ bool FragmentConsolidator::are_consolidatable(
     size_t start,
     size_t end,
     const NDRange& union_non_empty_domains) const {
-  auto anterior_ndrange = fragment_info.anterior_ndrange();
+  const auto& anterior_ndrange = fragment_info.anterior_ndrange();
   if (anterior_ndrange.size() != 0 &&
       domain.overlap(union_non_empty_domains, anterior_ndrange))
     return false;
@@ -419,8 +419,7 @@ Status FragmentConsolidator::consolidate_internal(
 
   // Prepare buffers
   auto average_var_cell_sizes = array_for_reads->get_average_var_cell_sizes();
-  auto&& [buffers, buffer_sizes] =
-      create_buffers(stats_, config_, array_schema, average_var_cell_sizes);
+  FragmentConsolidationWorkspace cw{create_buffers(stats_, config_, array_schema, average_var_cell_sizes)};
 
   // Create queries
   auto query_r = (Query*)nullptr;
@@ -451,12 +450,13 @@ Status FragmentConsolidator::consolidate_internal(
   }
 
   // Read from one array and write to the other
-  st = copy_array(query_r, query_w, &buffers, &buffer_sizes);
-  if (!st.ok()) {
+  try {
+    copy_array(query_r, query_w, cw);
+  } catch (...) {
     tdb_delete(query_r);
     tdb_delete(query_w);
-    return st;
-  }
+    throw;
+  };
 
   // Finalize write query
   st = query_w->finalize();
@@ -495,47 +495,41 @@ Status FragmentConsolidator::consolidate_internal(
   return st;
 }
 
-Status FragmentConsolidator::copy_array(
-    Query* query_r,
-    Query* query_w,
-    std::vector<ByteVec>* buffers,
-    std::vector<uint64_t>* buffer_sizes) {
+void FragmentConsolidator::copy_array(
+    Query* query_r, Query* query_w, FragmentConsolidationWorkspace& cw) {
   auto timer_se = stats_->start_timer("consolidate_copy_array");
 
   // Set the read query buffers outside the repeated submissions.
   // The Reader will reset the query buffer sizes to the original
   // sizes, not the potentially smaller sizes of the results after
   // the query submission.
-  RETURN_NOT_OK(set_query_buffers(query_r, buffers, buffer_sizes));
+  set_query_buffers(query_r, cw);
 
   do {
     // READ
-    RETURN_NOT_OK(query_r->submit());
+    throw_if_not_ok(query_r->submit());
 
     // If Consolidation cannot make any progress, throw. The first buffer will
-    // always contain fixed size data, wether it is tile offsets for var size
+    // always contain fixed size data, whether it is tile offsets for var size
     // attribute/dimension or the actual fixed size data so we can use its size
     // to know if any cells were written or not.
-    if (buffer_sizes->at(0) == 0) {
-      throw FragmentConsolidatorStatusException(
+    if (cw.sizes().at(0) == 0) {
+      throw FragmentConsolidatorException(
           "Consolidation read 0 cells, no progress can be made");
     }
 
     // Set explicitly the write query buffers, as the sizes may have
     // been altered by the read query.
-    RETURN_NOT_OK(set_query_buffers(query_w, buffers, buffer_sizes));
+    set_query_buffers(query_w, cw);
 
     // WRITE
-    RETURN_NOT_OK(query_w->submit());
+    throw_if_not_ok(query_w->submit());
   } while (query_r->status() == QueryStatus::INCOMPLETE);
-
-  return Status::Ok();
 }
 
-tuple<std::vector<ByteVec>, std::vector<uint64_t>>
-FragmentConsolidator::create_buffers(
+FragmentConsolidationWorkspace&& FragmentConsolidator::create_buffers(
     stats::Stats* stats,
-    const ConsolidationConfig& config,
+    const FragmentConsolidationConfig& config,
     const ArraySchema& array_schema,
     std::unordered_map<std::string, uint64_t>& avg_cell_sizes) {
   auto timer_se = stats->start_timer("consolidate_create_buffers");
@@ -610,10 +604,11 @@ FragmentConsolidator::create_buffers(
   }
 
   // Create buffers.
-  std::vector<ByteVec> buffers(buffer_num);
-  std::vector<uint64_t> buffer_sizes(buffer_num);
-  auto total_weights =
-      std::accumulate(buffer_weights.begin(), buffer_weights.end(), 0);
+  FragmentConsolidationWorkspace cw{buffer_num};
+  std::vector<ByteVec>& buffers{cw.buffers()};
+  std::vector<uint64_t>& buffer_sizes{cw.sizes()};
+  auto total_weights = std::accumulate(
+      buffer_weights.begin(), buffer_weights.end(), static_cast<size_t>(0));
 
   // Allocate space for each buffer.
   uint64_t adjusted_budget = total_budget / total_weights * total_weights;
@@ -624,7 +619,7 @@ FragmentConsolidator::create_buffers(
   }
 
   // Success
-  return {buffers, buffer_sizes};
+  return std::move(cw);
 }
 
 Status FragmentConsolidator::create_queries(
@@ -810,10 +805,11 @@ Status FragmentConsolidator::compute_next_to_consolidate(
   return Status::Ok();
 }
 
-Status FragmentConsolidator::set_query_buffers(
-    Query* query,
-    std::vector<ByteVec>* buffers,
-    std::vector<uint64_t>* buffer_sizes) const {
+void FragmentConsolidator::set_query_buffers(
+    Query* query, FragmentConsolidationWorkspace& cw) const {
+  std::vector<ByteVec>* buffers{&cw.buffers()};
+  std::vector<uint64_t>* buffer_sizes{&cw.sizes()};
+
   const auto& array_schema = query->array_schema();
   auto dim_num = array_schema.dim_num();
   auto dense = array_schema.dense();
@@ -892,8 +888,6 @@ Status FragmentConsolidator::set_query_buffers(
         &(*buffer_sizes)[bid]));
     ++bid;
   }
-
-  return Status::Ok();
 }
 
 Status FragmentConsolidator::set_config(const Config& config) {

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -60,21 +60,21 @@ class URI;
 /** Consolidation configuration parameters. */
 struct FragmentConsolidationConfig : Consolidator::ConsolidationConfigBase {
   /**
-     * Include timestamps in the consolidated fragment or not.
+   * Include timestamps in the consolidated fragment or not.
    */
   bool with_timestamps_;
   /**
-     * Include delete metadata in the consolidated fragment or not.
+   * Include delete metadata in the consolidated fragment or not.
    */
   bool with_delete_meta_;
   /**
-     * The factor by which the size of the dense fragment resulting
-     * from consolidating a set of fragments (containing at least one
-     * dense fragment) can be amplified. This is important when
-     * the union of the non-empty domains of the fragments to be
-     * consolidated have a lot of empty cells, which the consolidated
-     * fragment will have to fill with the special fill value
-     * (since the resulting fragments is dense).
+   * The factor by which the size of the dense fragment resulting
+   * from consolidating a set of fragments (containing at least one
+   * dense fragment) can be amplified. This is important when
+   * the union of the non-empty domains of the fragments to be
+   * consolidated have a lot of empty cells, which the consolidated
+   * fragment will have to fill with the special fill value
+   * (since the resulting fragments is dense).
    */
   float amplification_;
   /** Attribute buffer size. */
@@ -84,8 +84,8 @@ struct FragmentConsolidationConfig : Consolidator::ConsolidationConfigBase {
   /** Max fragment size. */
   uint64_t max_fragment_size_;
   /**
-     * Number of consolidation steps performed in a single
-     * consolidation invocation.
+   * Number of consolidation steps performed in a single
+   * consolidation invocation.
    */
   uint32_t steps_;
   /** Minimum number of fragments to consolidate in a single step. */
@@ -93,8 +93,8 @@ struct FragmentConsolidationConfig : Consolidator::ConsolidationConfigBase {
   /** Maximum number of fragments to consolidate in a single step. */
   uint32_t max_frags_;
   /**
-     * Minimum size ratio for two fragments to be considered for
-     * consolidation.
+   * Minimum size ratio for two fragments to be considered for
+   * consolidation.
    */
   float size_ratio_;
   /** Is the refactored reader in use or not */
@@ -119,7 +119,8 @@ class FragmentConsolidationWorkspace {
   /**
    * Copy constructor is deleted to avoid copying large amounts of memory
    */
-  FragmentConsolidationWorkspace(const FragmentConsolidationWorkspace&) = delete;
+  FragmentConsolidationWorkspace(const FragmentConsolidationWorkspace&) =
+      delete;
 
   /**
    * Move constructor
@@ -129,8 +130,8 @@ class FragmentConsolidationWorkspace {
   /**
    * Copy assignment is deleted to avoid copying large amounts of memory
    */
-  const FragmentConsolidationWorkspace& operator=(const FragmentConsolidationWorkspace&) =
-      delete;
+  const FragmentConsolidationWorkspace& operator=(
+      const FragmentConsolidationWorkspace&) = delete;
 
   /**
    * Move assignment is deleted for convenience
@@ -291,7 +292,8 @@ class FragmentConsolidator : public Consolidator {
    * @param query_w The write query.
    * @param cw A workspace containing buffers for the queries
    */
-  void copy_array(Query* query_r, Query* query_w, FragmentConsolidationWorkspace& cw);
+  void copy_array(
+      Query* query_r, Query* query_w, FragmentConsolidationWorkspace& cw);
 
   /**
    * Creates the buffers that will be used upon reading the input fragments and

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -306,7 +306,7 @@ class FragmentConsolidator : public Consolidator {
    * @param avg_cell_sizes The average cell sizes.
    * @return a consolidation workspace containing the buffers
    */
-  static FragmentConsolidationWorkspace&& create_buffers(
+  static FragmentConsolidationWorkspace create_buffers(
       stats::Stats* stats,
       const FragmentConsolidationConfig& config,
       const ArraySchema& array_schema,

--- a/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
@@ -43,7 +43,7 @@ using namespace tiledb::sm;
 namespace tiledb::sm {
 class WhiteboxFragmentConsolidator {
  public:
-  static FragmentConsolidationWorkspace&& create_buffers(
+  static FragmentConsolidationWorkspace create_buffers(
       stats::Stats* stats,
       const bool with_timestamps,
       const bool with_delete_meta,

--- a/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
@@ -232,13 +232,14 @@ TEST_CASE(
   }
 
   // Create buffers.
-  FragmentConsolidationWorkspace cw{WhiteboxFragmentConsolidator::create_buffers(
-      &statistics,
-      with_timestamps,
-      with_delete_meta,
-      1000,
-      *schema,
-      avg_cell_sizes)};
+  FragmentConsolidationWorkspace cw{
+      WhiteboxFragmentConsolidator::create_buffers(
+          &statistics,
+          with_timestamps,
+          with_delete_meta,
+          1000,
+          *schema,
+          avg_cell_sizes)};
   std::vector<ByteVec>& buffers{cw.buffers()};
   std::vector<uint64_t>& buffer_sizes{cw.sizes()};
 

--- a/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
@@ -43,7 +43,7 @@ using namespace tiledb::sm;
 namespace tiledb::sm {
 class WhiteboxFragmentConsolidator {
  public:
-  static tuple<std::vector<ByteVec>, std::vector<uint64_t>> create_buffers(
+  static FragmentConsolidationWorkspace&& create_buffers(
       stats::Stats* stats,
       const bool with_timestamps,
       const bool with_delete_meta,
@@ -51,7 +51,7 @@ class WhiteboxFragmentConsolidator {
       const ArraySchema& schema,
       std::unordered_map<std::string, uint64_t>& avg_cell_sizes) {
     // Create config.
-    FragmentConsolidator::ConsolidationConfig cfg;
+    FragmentConsolidationConfig cfg;
     cfg.with_timestamps_ = with_timestamps;
     cfg.with_delete_meta_ = with_delete_meta;
     cfg.buffer_size_ = buffer_size;
@@ -232,13 +232,15 @@ TEST_CASE(
   }
 
   // Create buffers.
-  auto&& [buffers, buffer_sizes] = WhiteboxFragmentConsolidator::create_buffers(
+  FragmentConsolidationWorkspace cw{WhiteboxFragmentConsolidator::create_buffers(
       &statistics,
       with_timestamps,
       with_delete_meta,
       1000,
       *schema,
-      avg_cell_sizes);
+      avg_cell_sizes)};
+  std::vector<ByteVec>& buffers{cw.buffers()};
+  std::vector<uint64_t>& buffer_sizes{cw.sizes()};
 
   // Validate.
   CHECK(buffers.size() == expected_sizes.size());


### PR DESCRIPTION
This PR puts the query buffers used inside the fragment consolidator into their own class. This class deletes its copy constructor but provides a move constructor. This avoids copying the buffers in the `return` statement of `create_buffers`, which not only doubles the instantaneous memory consumption during that statement, but does a bunch of spurious copying of empty buffers.

In addition, this change prepares for memory as a managed resource, providing a single location for the allocators of the containers for these buffers to be specified.

---
TYPE: NO_HISTORY
DESC:  `class FragmentConsolidationWorkspace`
