### PR TITLE
Fix aggregate leak when field doesn't exist.

### DIFF
--- a/tiledb/api/c_api/query_field/query_field_api.cc
+++ b/tiledb/api/c_api/query_field/query_field_api.cc
@@ -52,8 +52,7 @@ tiledb_field_origin_t FieldFromAggregate::origin() {
 tiledb_query_field_handle_t::tiledb_query_field_handle_t(
     tiledb_query_t* query, const char* field_name)
     : query_(query->query_)
-    , field_name_(field_name)
-    , channel_(tiledb_query_channel_handle_t::make_handle(query)) {
+    , field_name_(field_name) {
   if (field_name_ == tiledb::sm::constants::coords) {
     field_origin_ = std::make_shared<FieldFromDimension>();
     type_ = query_->array_schema().domain().dimension_ptr(0)->type();
@@ -81,6 +80,8 @@ tiledb_query_field_handle_t::tiledb_query_field_handle_t(
   } else {
     throw tiledb::api::CAPIStatusException("There is no field " + field_name_);
   }
+
+  channel_ = tiledb_query_channel_handle_t::make_handle(query);
 }
 
 namespace tiledb::api {


### PR DESCRIPTION
When a field didn't exist, we would throw on the creation of the query field handle after making a handle for the channel. This handle wouldn't get broken after we throw. This solves the issue by creating the handle for the channel after we validated that the field exists.

---
TYPE: BUG
DESC: Fix aggregate leak when field doesn't exist.
