### PR TITLE
Deprecate sm.consolidation.total_buffer_size.

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -164,11 +164,12 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    (since the resulting fragment is dense). <br>
  *    **Default**: 1.0
  * - `sm.consolidation.buffer_size` <br>
- *    Deprecated. Prefer `sm.consolidation.total_buffer_size` instead.
+ *    **Deprecated**
  *    The size (in bytes) of the attribute buffers used during
  *    consolidation. <br>
  *    **Default**: 50,000,000
  * - `sm.consolidation.total_buffer_size` <br>
+ *    **Deprecated**
  *    The size (in bytes) of all attribute buffers used during
  *    consolidation. <br>
  *    **Default**: 2,147,483,648

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -340,11 +340,12 @@ class Config {
    *    (since the resulting fragments is dense). <br>
    *    **Default**: 1.0
    * - `sm.consolidation.buffer_size` <br>
-   *    Deprecated. Prefer `sm.consolidation.total_buffer_size` instead.
+   *    **Deprecated**
    *    The size (in bytes) of the attribute buffers used during
    *    consolidation. <br>
    *    **Default**: 50,000,000
    * - `sm.consolidation.total_buffer_size` <br>
+   *    **Deprecated**
    *    The size (in bytes) of all attribute buffers used during
    *    consolidation. <br>
    *    **Default**: 2,147,483,648


### PR DESCRIPTION
We are going to use sm.mem.total_bugdet to allocate consolidation buffers.

---
TYPE: NO_HISTORY
DESC: Deprecate sm.consolidation.total_buffer_size.
