### PR TITLE
Pass AWS client config when creating `STSAssumeRoleCredentialsProvider`.

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -51,6 +51,7 @@
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
+#include <aws/sts/STSClient.h>
 #include <boost/interprocess/streams/bufferstream.hpp>
 #include <fstream>
 #include <iostream>
@@ -1307,8 +1308,7 @@ Status S3::init_client() const {
   // check for client configuration on create, which can be slow if aws is not
   // configured on a users systems due to ec2 metadata check
 
-  client_config_ = tdb_unique_ptr<Aws::Client::ClientConfiguration>(
-      tdb_new(Aws::Client::ClientConfiguration));
+  client_config_ = make_shared<Aws::Client::ClientConfiguration>(HERE());
 
   s3_tp_executor_ = make_shared<S3ThreadPoolExecutor>(HERE(), vfs_thread_pool_);
 
@@ -1403,7 +1403,7 @@ Status S3::init_client() const {
                 session_name,
                 external_id,
                 load_frequency,
-                nullptr);
+                make_shared<Aws::STS::STSClient>(HERE(), client_config));
         break;
       }
       case 7: {

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -1240,7 +1240,7 @@ class S3 {
   mutable std::mutex client_init_mtx_;
 
   /** Configuration object used to initialize the client. */
-  mutable tdb_unique_ptr<Aws::Client::ClientConfiguration> client_config_;
+  mutable shared_ptr<Aws::Client::ClientConfiguration> client_config_;
 
   /** The executor used by 'client_'. */
   mutable shared_ptr<S3ThreadPoolExecutor> s3_tp_executor_;


### PR DESCRIPTION
This fixes an issue with assume role where the client configuration was not getting passed to the `STSAssumeRoleCredentialsProvider`, which resulted in options like the CA path not being honored when the AWS SDK was making HTTP requests for assume role.

---
TYPE: BUG
DESC: Fix HTTP requests for AWS assume role not honoring config options.