### PR TITLE
Move common strategy parameters to class.

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -163,9 +163,7 @@ TEST_CASE_METHOD(
             .ok());
   Subarray subarray(&array, &g_helper_stats, g_helper_logger());
   DefaultChannelAggregates default_channel_aggregates;
-  Reader reader(
-      &g_helper_stats,
-      g_helper_logger(),
+  auto params = StrategyParams(
       context.storage_manager(),
       &array,
       config,
@@ -174,7 +172,9 @@ TEST_CASE_METHOD(
       subarray,
       Layout::ROW_MAJOR,
       condition,
-      default_channel_aggregates);
+      default_channel_aggregates,
+      false);
+  Reader reader(&g_helper_stats, g_helper_logger(), params);
   unsigned dim_num = 2;
   auto size = 2 * sizeof(int32_t);
   int32_t domain_vec[] = {1, 10, 1, 15};

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -57,25 +57,10 @@ class DeleteAndUpdateStatusException : public StatusException {
 DeletesAndUpdates::DeletesAndUpdates(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    Subarray& subarray,
-    Layout layout,
-    std::optional<QueryCondition>& condition,
-    std::vector<UpdateValue>& update_values,
-    bool skip_checks_serialization)
-    : StrategyBase(
-          stats,
-          logger->clone("Deletes", ++logger_id_),
-          storage_manager,
-          array,
-          config,
-          buffers,
-          subarray,
-          layout)
-    , condition_(condition)
+    StrategyParams& params,
+    std::vector<UpdateValue>& update_values)
+    : StrategyBase(stats, logger->clone("Deletes", ++logger_id_), params)
+    , condition_(params.condition())
     , update_values_(update_values) {
   // Sanity checks
   if (storage_manager_ == nullptr) {
@@ -98,7 +83,7 @@ DeletesAndUpdates::DeletesAndUpdates(
         "Cannot initialize deletes; Subarrays are not supported");
   }
 
-  if (!skip_checks_serialization && !condition_.has_value()) {
+  if (!params.skip_checks_serialization() && !condition_.has_value()) {
     throw DeleteAndUpdateStatusException(
         "Cannot initialize deletes; One condition is needed");
   }

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.h
@@ -54,15 +54,8 @@ class DeletesAndUpdates : public StrategyBase, public IQueryStrategy {
   DeletesAndUpdates(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      std::vector<UpdateValue>& update_values,
-      bool skip_checks_serialization = false);
+      StrategyParams& params,
+      std::vector<UpdateValue>& update_values);
 
   /** Destructor. */
   ~DeletesAndUpdates();

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -67,16 +67,7 @@ class Reader : public ReaderBase, public IQueryStrategy {
   Reader(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates,
-      bool skip_checks_serialization = false,
+      StrategyParams& params,
       bool remote_query = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1789,6 +1789,17 @@ bool Query::is_aggregate(std::string output_field_name) const {
 /* ****************************** */
 
 Status Query::create_strategy(bool skip_checks_serialization) {
+  auto params = StrategyParams(
+      storage_manager_,
+      array_,
+      config_,
+      buffers_,
+      aggregate_buffers_,
+      subarray_,
+      layout_,
+      condition_,
+      default_channel_aggregates_,
+      skip_checks_serialization);
   if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
     if (layout_ == Layout::COL_MAJOR || layout_ == Layout::ROW_MAJOR) {
       if (!array_schema_->dense()) {
@@ -1800,17 +1811,11 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           OrderedWriter,
           stats_->create_child("Writer"),
           logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
+          params,
           written_fragment_info_,
           coords_info_,
           remote_query_,
-          fragment_name_,
-          skip_checks_serialization));
+          fragment_name_));
     } else if (layout_ == Layout::UNORDERED) {
       if (array_schema_->dense()) {
         return Status_QueryError(
@@ -1821,37 +1826,25 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           UnorderedWriter,
           stats_->create_child("Writer"),
           logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
+          params,
           written_fragment_info_,
           coords_info_,
           written_buffers_,
           remote_query_,
-          fragment_name_,
-          skip_checks_serialization));
+          fragment_name_));
     } else if (layout_ == Layout::GLOBAL_ORDER) {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           GlobalOrderWriter,
           stats_->create_child("Writer"),
           logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          subarray_,
-          layout_,
+          params,
           fragment_size_,
           written_fragment_info_,
           disable_checks_consolidation_,
           processed_conditions_,
           coords_info_,
           remote_query_,
-          fragment_name_,
-          skip_checks_serialization));
+          fragment_name_));
     } else {
       return Status_QueryError(
           "Cannot create strategy; unsupported layout " + layout_str(layout_));
@@ -1867,17 +1860,8 @@ Status Query::create_strategy(bool skip_checks_serialization) {
           OrderedDimLabelReader,
           stats_->create_child("Reader"),
           logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          aggregate_buffers_,
-          subarray_,
-          layout_,
-          condition_,
-          default_channel_aggregates_,
-          dimension_label_increasing_,
-          skip_checks_serialization));
+          params,
+          dimension_label_increasing_));
     } else if (use_refactored_sparse_unordered_with_dups_reader(
                    layout_, *array_schema_)) {
       auto&& [st, non_overlapping_ranges]{Query::non_overlapping_ranges()};
@@ -1889,31 +1873,13 @@ Status Query::create_strategy(bool skip_checks_serialization) {
             SparseUnorderedWithDupsReader<uint8_t>,
             stats_->create_child("Reader"),
             logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            aggregate_buffers_,
-            subarray_,
-            layout_,
-            condition_,
-            default_channel_aggregates_,
-            skip_checks_serialization));
+            params));
       } else {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseUnorderedWithDupsReader<uint64_t>,
             stats_->create_child("Reader"),
             logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            aggregate_buffers_,
-            subarray_,
-            layout_,
-            condition_,
-            default_channel_aggregates_,
-            skip_checks_serialization));
+            params));
       }
     } else if (
         use_refactored_sparse_global_order_reader(layout_, *array_schema_) &&
@@ -1929,65 +1895,29 @@ Status Query::create_strategy(bool skip_checks_serialization) {
             SparseGlobalOrderReader<uint8_t>,
             stats_->create_child("Reader"),
             logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            aggregate_buffers_,
-            subarray_,
-            layout_,
-            condition_,
-            default_channel_aggregates_,
-            consolidation_with_timestamps_,
-            skip_checks_serialization));
+            params,
+            consolidation_with_timestamps_));
       } else {
         strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
             SparseGlobalOrderReader<uint64_t>,
             stats_->create_child("Reader"),
             logger_,
-            storage_manager_,
-            array_,
-            config_,
-            buffers_,
-            aggregate_buffers_,
-            subarray_,
-            layout_,
-            condition_,
-            default_channel_aggregates_,
-            consolidation_with_timestamps_,
-            skip_checks_serialization));
+            params,
+            consolidation_with_timestamps_));
       }
     } else if (use_refactored_dense_reader(*array_schema_, all_dense)) {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           DenseReader,
           stats_->create_child("Reader"),
           logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          aggregate_buffers_,
-          subarray_,
-          layout_,
-          condition_,
-          default_channel_aggregates_,
-          skip_checks_serialization,
+          params,
           remote_query_));
     } else {
       strategy_ = tdb_unique_ptr<IQueryStrategy>(tdb_new(
           Reader,
           stats_->create_child("Reader"),
           logger_,
-          storage_manager_,
-          array_,
-          config_,
-          buffers_,
-          aggregate_buffers_,
-          subarray_,
-          layout_,
-          condition_,
-          default_channel_aggregates_,
-          skip_checks_serialization,
+          params,
           remote_query_));
     }
   } else if (type_ == QueryType::DELETE || type_ == QueryType::UPDATE) {
@@ -1995,15 +1925,8 @@ Status Query::create_strategy(bool skip_checks_serialization) {
         DeletesAndUpdates,
         stats_->create_child("Deletes"),
         logger_,
-        storage_manager_,
-        array_,
-        config_,
-        buffers_,
-        subarray_,
-        layout_,
-        condition_,
-        update_values_,
-        skip_checks_serialization));
+        params,
+        update_values_));
   } else {
     return logger_->status(
         Status_QueryError("Cannot create strategy; unsupported query type"));

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -71,30 +71,10 @@ class DenseReaderStatusException : public StatusException {
 DenseReader::DenseReader(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-    Subarray& subarray,
-    Layout layout,
-    std::optional<QueryCondition>& condition,
-    DefaultChannelAggregates& default_channel_aggregates,
-    bool skip_checks_serialization,
+    StrategyParams& params,
     bool remote_query)
-    : ReaderBase(
-          stats,
-          logger->clone("DenseReader", ++logger_id_),
-          storage_manager,
-          array,
-          config,
-          buffers,
-          aggregate_buffers,
-          subarray,
-          layout,
-          condition,
-          default_channel_aggregates)
-    , array_memory_tracker_(array->memory_tracker()) {
+    : ReaderBase(stats, logger->clone("DenseReader", ++logger_id_), params)
+    , array_memory_tracker_(params.array()->memory_tracker()) {
   elements_mode_ = false;
 
   // Sanity checks.
@@ -103,13 +83,13 @@ DenseReader::DenseReader(
         "Cannot initialize dense reader; Storage manager not set");
   }
 
-  if (!skip_checks_serialization && buffers_.empty() &&
+  if (!params.skip_checks_serialization() && buffers_.empty() &&
       aggregate_buffers_.empty()) {
     throw DenseReaderStatusException(
         "Cannot initialize dense reader; Buffers not set");
   }
 
-  if (!skip_checks_serialization && !subarray_.is_set()) {
+  if (!params.skip_checks_serialization() && !subarray_.is_set()) {
     throw DenseReaderStatusException(
         "Cannot initialize reader; Dense reads must have a subarray set");
   }

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -90,16 +90,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
   DenseReader(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates,
-      bool skip_checks_serialization = false,
+      StrategyParams& params,
       bool remote_query = false);
 
   /** Destructor. */

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -252,17 +252,8 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
   OrderedDimLabelReader(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates,
-      bool increasing_order,
-      bool skip_checks_serialization);
+      StrategyParams& params,
+      bool increasing_order);
 
   /** Destructor. */
   ~OrderedDimLabelReader() = default;

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -72,46 +72,28 @@ class ReaderBaseStatusException : public StatusException {
 /* ****************************** */
 
 ReaderBase::ReaderBase(
-    stats::Stats* stats,
-    shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-    Subarray& subarray,
-    Layout layout,
-    std::optional<QueryCondition>& condition,
-    DefaultChannelAggregates& default_channel_aggregates)
-    : StrategyBase(
-          stats,
-          logger,
-          storage_manager,
-          array,
-          config,
-          buffers,
-          subarray,
-          layout)
-    , condition_(condition)
+    stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
+    : StrategyBase(stats, logger, params)
+    , condition_(params.condition())
     , user_requested_timestamps_(false)
     , use_timestamps_(false)
     , initial_data_loaded_(false)
-    , max_batch_size_(config.get<uint64_t>("vfs.max_batch_size").value())
-    , min_batch_gap_(config.get<uint64_t>("vfs.min_batch_gap").value())
-    , min_batch_size_(config.get<uint64_t>("vfs.min_batch_size").value())
-    , aggregate_buffers_(aggregate_buffers) {
-  if (array != nullptr)
-    fragment_metadata_ = array->fragment_metadata();
+    , max_batch_size_(config_.get<uint64_t>("vfs.max_batch_size").value())
+    , min_batch_gap_(config_.get<uint64_t>("vfs.min_batch_gap").value())
+    , min_batch_size_(config_.get<uint64_t>("vfs.min_batch_size").value())
+    , aggregate_buffers_(params.aggregate_buffers()) {
+  if (params.array() != nullptr)
+    fragment_metadata_ = params.array()->fragment_metadata();
   timestamps_needed_for_deletes_and_updates_.resize(fragment_metadata_.size());
 
-  if (layout_ == Layout::GLOBAL_ORDER && subarray.range_num() > 1) {
+  if (layout_ == Layout::GLOBAL_ORDER && subarray_.range_num() > 1) {
     throw ReaderBaseStatusException(
         "Cannot initialize reader; Multi-range reads are not supported on a "
         "global order query.");
   }
 
   // Validate the aggregates and store the requested aggregates by field name.
-  for (auto& aggregate : default_channel_aggregates) {
+  for (auto& aggregate : params.default_channel_aggregates()) {
     aggregate.second->validate_output_buffer(
         aggregate.first, aggregate_buffers_);
     aggregates_[aggregate.second->field_name()].emplace_back(aggregate.second);

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -165,17 +165,7 @@ class ReaderBase : public StrategyBase {
 
   /** Constructor. */
   ReaderBase(
-      stats::Stats* stats,
-      shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates);
+      stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params);
 
   /** Destructor. */
   ~ReaderBase() = default;

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -71,36 +71,18 @@ template <class BitmapType>
 SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-    Subarray& subarray,
-    Layout layout,
-    std::optional<QueryCondition>& condition,
-    DefaultChannelAggregates& default_channel_aggregates,
-    bool consolidation_with_timestamps,
-    bool skip_checks_serialization)
+    StrategyParams& params,
+    bool consolidation_with_timestamps)
     : SparseIndexReaderBase(
           "sparse_global_order",
           stats,
-          logger->clone("SparseGlobalOrderReader", ++logger_id_),
-          storage_manager,
-          array,
-          config,
-          buffers,
-          aggregate_buffers,
-          subarray,
-          layout,
-          condition,
-          default_channel_aggregates,
-          skip_checks_serialization,
+          logger->clone("SparseUnorderedWithDupsReader", ++logger_id_),
+          params,
           true)
-    , result_tiles_leftover_(array->fragment_metadata().size())
-    , memory_used_for_coords_(array->fragment_metadata().size())
+    , result_tiles_leftover_(array_->fragment_metadata().size())
+    , memory_used_for_coords_(array_->fragment_metadata().size())
     , consolidation_with_timestamps_(consolidation_with_timestamps)
-    , last_cells_(array->fragment_metadata().size())
+    , last_cells_(array_->fragment_metadata().size())
     , tile_offsets_loaded_(false) {
   // Initialize memory budget variables.
   refresh_config();
@@ -2234,33 +2216,9 @@ void SparseGlobalOrderReader<BitmapType>::end_iteration(
 
 // Explicit template instantiations
 template SparseGlobalOrderReader<uint8_t>::SparseGlobalOrderReader(
-    stats::Stats*,
-    shared_ptr<Logger>,
-    StorageManager*,
-    Array*,
-    Config&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    Subarray&,
-    Layout,
-    std::optional<QueryCondition>&,
-    DefaultChannelAggregates&,
-    bool,
-    bool);
+    stats::Stats*, shared_ptr<Logger>, StrategyParams&, bool);
 template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
-    stats::Stats*,
-    shared_ptr<Logger>,
-    StorageManager*,
-    Array*,
-    Config&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    Subarray&,
-    Layout,
-    std::optional<QueryCondition>&,
-    DefaultChannelAggregates&,
-    bool,
-    bool);
+    stats::Stats*, shared_ptr<Logger>, StrategyParams&, bool);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -71,17 +71,8 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   SparseGlobalOrderReader(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates,
-      bool consolidation_with_timestamps,
-      bool skip_checks_serialization = false);
+      StrategyParams& params,
+      bool consolidation_with_timestamps);
 
   /** Destructor. */
   ~SparseGlobalOrderReader() = default;

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -67,33 +67,13 @@ SparseIndexReaderBase::SparseIndexReaderBase(
     std::string reader_string,
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-    Subarray& subarray,
-    Layout layout,
-    std::optional<QueryCondition>& condition,
-    DefaultChannelAggregates& default_channel_aggregates,
-    bool skip_checks_serialization,
+    StrategyParams& params,
     bool include_coords)
-    : ReaderBase(
-          stats,
-          logger,
-          storage_manager,
-          array,
-          config,
-          buffers,
-          aggregate_buffers,
-          subarray,
-          layout,
-          condition,
-          default_channel_aggregates)
-    , tmp_read_state_(array->fragment_metadata().size())
-    , memory_budget_(config, reader_string)
+    : ReaderBase(stats, logger, params)
+    , tmp_read_state_(array_->fragment_metadata().size())
+    , memory_budget_(config_, reader_string)
     , include_coords_(include_coords)
-    , array_memory_tracker_(array->memory_tracker())
+    , array_memory_tracker_(params.array()->memory_tracker())
     , memory_used_for_coords_total_(0)
     , deletes_consolidation_no_purge_(
           buffers_.count(constants::delete_timestamps) != 0)
@@ -104,7 +84,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
         "Cannot initialize reader; Storage manager not set");
   }
 
-  if (!skip_checks_serialization && buffers_.empty() &&
+  if (!params.skip_checks_serialization() && buffers_.empty() &&
       aggregate_buffers_.empty()) {
     throw SparseIndexReaderBaseStatusException(
         "Cannot initialize reader; Buffers not set");

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -493,16 +493,7 @@ class SparseIndexReaderBase : public ReaderBase {
       std::string reader_string,
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates,
-      bool skip_checks_serialization,
+      StrategyParams& params,
       bool include_coords);
 
   /** Destructor. */

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -67,40 +67,16 @@ class SparseUnorderedWithDupsReaderStatusException : public StatusException {
 
 template <class BitmapType>
 SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
-    stats::Stats* stats,
-    shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-    Subarray& subarray,
-    Layout layout,
-    std::optional<QueryCondition>& condition,
-    DefaultChannelAggregates& default_channel_aggregates,
-    bool skip_checks_serialization)
+    stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
     : SparseIndexReaderBase(
-          "sparse_unordered_with_dups",
-          stats,
-          logger->clone("SparseUnorderedWithDupsReader", ++logger_id_),
-          storage_manager,
-          array,
-          config,
-          buffers,
-          aggregate_buffers,
-          subarray,
-          layout,
-          condition,
-          default_channel_aggregates,
-          skip_checks_serialization,
-          false)
+          "sparse_unordered_with_dups", stats, logger, params, false)
     , tile_offsets_min_frag_idx_(std::numeric_limits<unsigned>::max())
     , tile_offsets_max_frag_idx_(0) {
   // Initialize memory budget variables.
   refresh_config();
 
-  // Get the setting that allows to partially load tile offsets. This is done
-  // for this reader only for now.
+  // Get the setting that allows to partially load tile offsets. This is
+  // done for this reader only for now.
   bool found = false;
   if (!config_
            .get<bool>(
@@ -2050,31 +2026,9 @@ void SparseUnorderedWithDupsReader<BitmapType>::end_iteration(
 
 // Explicit template instantiations
 template SparseUnorderedWithDupsReader<uint8_t>::SparseUnorderedWithDupsReader(
-    stats::Stats*,
-    shared_ptr<Logger>,
-    StorageManager*,
-    Array*,
-    Config&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    Subarray&,
-    Layout,
-    std::optional<QueryCondition>&,
-    DefaultChannelAggregates&,
-    bool);
+    stats::Stats*, shared_ptr<Logger>, StrategyParams&);
 template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
-    stats::Stats*,
-    shared_ptr<Logger>,
-    StorageManager*,
-    Array*,
-    Config&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    std::unordered_map<std::string, QueryBuffer>&,
-    Subarray&,
-    Layout,
-    std::optional<QueryCondition>&,
-    DefaultChannelAggregates&,
-    bool);
+    stats::Stats*, shared_ptr<Logger>, StrategyParams&);
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -68,18 +68,7 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
 
   /** Constructor. */
   SparseUnorderedWithDupsReader(
-      stats::Stats* stats,
-      shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
-      Subarray& subarray,
-      Layout layout,
-      std::optional<QueryCondition>& condition,
-      DefaultChannelAggregates& default_channel_aggregates,
-      bool skip_checks_serialization = false);
+      stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params);
 
   /** Destructor. */
   ~SparseUnorderedWithDupsReader() = default;

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -46,23 +46,16 @@ namespace sm {
 /* ****************************** */
 
 StrategyBase::StrategyBase(
-    stats::Stats* stats,
-    shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    Subarray& subarray,
-    Layout layout)
+    stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
     : stats_(stats)
     , logger_(logger)
-    , array_(array)
-    , array_schema_(array->array_schema_latest())
-    , config_(config)
-    , buffers_(buffers)
-    , layout_(layout)
-    , storage_manager_(storage_manager)
-    , subarray_(subarray)
+    , array_(params.array())
+    , array_schema_(params.array()->array_schema_latest())
+    , config_(params.config())
+    , buffers_(params.buffers())
+    , layout_(params.layout())
+    , storage_manager_(params.storage_manager())
+    , subarray_(params.subarray())
     , offsets_format_mode_(Config::SM_OFFSETS_FORMAT_MODE)
     , offsets_extra_element_(false)
     , offsets_bitsize_(constants::cell_var_offset_size * 8) {

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -45,9 +45,137 @@ namespace sm {
 
 class Array;
 class ArraySchema;
+class IAggregator;
 enum class Layout : uint8_t;
 class Subarray;
 class QueryBuffer;
+class QueryCondition;
+
+typedef std::unordered_map<std::string, shared_ptr<IAggregator>>
+    DefaultChannelAggregates;
+
+/**
+ * Class used to pass in common parameters to strategies. This will make it
+ * easier to change parameters moving fowards.
+ */
+class StrategyParams {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  StrategyParams(
+      StorageManager* storage_manager,
+      Array* array,
+      Config& config,
+      std::unordered_map<std::string, QueryBuffer>& buffers,
+      std::unordered_map<std::string, QueryBuffer>& aggregate_buffers,
+      Subarray& subarray,
+      Layout layout,
+      std::optional<QueryCondition>& condition,
+      DefaultChannelAggregates& default_channel_aggregates,
+      bool skip_checks_serialization)
+      : storage_manager_(storage_manager)
+      , array_(array)
+      , config_(config)
+      , buffers_(buffers)
+      , aggregate_buffers_(aggregate_buffers)
+      , subarray_(subarray)
+      , layout_(layout)
+      , condition_(condition)
+      , default_channel_aggregates_(default_channel_aggregates)
+      , skip_checks_serialization_(skip_checks_serialization) {
+  }
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /** Return the storage manager. */
+  inline StorageManager* storage_manager() {
+    return storage_manager_;
+  };
+
+  /** Return the array. */
+  inline Array* array() {
+    return array_;
+  };
+
+  /** Return the config. */
+  inline Config& config() {
+    return config_;
+  };
+
+  /** Return the buffers. */
+  inline std::unordered_map<std::string, QueryBuffer>& buffers() {
+    return buffers_;
+  };
+
+  /** Return the aggregate buffers. */
+  inline std::unordered_map<std::string, QueryBuffer>& aggregate_buffers() {
+    return aggregate_buffers_;
+  };
+
+  /** Return the subarray. */
+  inline Subarray& subarray() {
+    return subarray_;
+  };
+
+  /** Return the layout. */
+  inline Layout layout() {
+    return layout_;
+  };
+
+  /** Return the condition. */
+  inline std::optional<QueryCondition>& condition() {
+    return condition_;
+  }
+
+  /** Return the default channel aggregates. */
+  inline DefaultChannelAggregates& default_channel_aggregates() {
+    return default_channel_aggregates_;
+  }
+
+  /** Return if we should skip checks for serialization. */
+  inline bool skip_checks_serialization() {
+    return skip_checks_serialization_;
+  }
+
+ private:
+  /* ********************************* */
+  /*        PRIVATE ATTRIBUTES         */
+  /* ********************************* */
+
+  /** Storage manager. */
+  StorageManager* storage_manager_;
+
+  /** Array. */
+  Array* array_;
+
+  /** Config for query-level parameters only. */
+  Config& config_;
+
+  /** Buffers. */
+  std::unordered_map<std::string, QueryBuffer>& buffers_;
+
+  /** Aggregate buffers. */
+  std::unordered_map<std::string, QueryBuffer>& aggregate_buffers_;
+
+  /** Query subarray (initially the whole domain by default). */
+  Subarray& subarray_;
+
+  /** Layout of the cells in the result of the subarray. */
+  Layout layout_;
+
+  /** Query condition. */
+  std::optional<QueryCondition>& condition_;
+
+  /** Default channel aggregates. */
+  DefaultChannelAggregates& default_channel_aggregates_;
+
+  /** Skip checks for serialization. */
+  bool skip_checks_serialization_;
+};
 
 /** Processes read or write queries. */
 class StrategyBase {
@@ -58,14 +186,7 @@ class StrategyBase {
 
   /** Constructor. */
   StrategyBase(
-      stats::Stats* stats,
-      shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      Subarray& subarray,
-      Layout layout);
+      stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params);
 
   /** Destructor. */
   ~StrategyBase() = default;
@@ -119,7 +240,7 @@ class StrategyBase {
    * Maps attribute/dimension names to their buffers.
    * `TILEDB_COORDS` may be used for the special zipped coordinates
    * buffer.
-   * */
+   */
   std::unordered_map<std::string, QueryBuffer>& buffers_;
 
   /** The layout of the cells in the result of the subarray. */

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -73,43 +73,31 @@ class GlobalOrderWriterStatusException : public StatusException {
 GlobalOrderWriter::GlobalOrderWriter(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    Subarray& subarray,
-    Layout layout,
+    StrategyParams& params,
     uint64_t fragment_size,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     bool disable_checks_consolidation,
     std::vector<std::string>& processed_conditions,
     Query::CoordsInfo& coords_info,
     bool remote_query,
-    optional<std::string> fragment_name,
-    bool skip_checks_serialization)
+    optional<std::string> fragment_name)
     : WriterBase(
           stats,
           logger,
-          storage_manager,
-          array,
-          config,
-          buffers,
-          subarray,
-          layout,
+          params,
           written_fragment_info,
           disable_checks_consolidation,
           coords_info,
           remote_query,
-          fragment_name,
-          skip_checks_serialization)
+          fragment_name)
     , processed_conditions_(processed_conditions)
     , fragment_size_(fragment_size)
     , current_fragment_size_(0) {
   // Check the layout is global order.
-  if (layout != Layout::GLOBAL_ORDER) {
+  if (layout_ != Layout::GLOBAL_ORDER) {
     throw GlobalOrderWriterStatusException(
         "Failed to initialize global order writer. Layout " +
-        layout_str(layout) + " is not global order.");
+        layout_str(layout_) + " is not global order.");
   }
 
   // Check no ordered attributes.

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -108,20 +108,14 @@ class GlobalOrderWriter : public WriterBase {
   GlobalOrderWriter(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      Subarray& subarray,
-      Layout layout,
+      StrategyParams& params,
       uint64_t fragment_size,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       bool disable_checks_consolidation,
       std::vector<std::string>& processed_conditions,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
-      optional<std::string> fragment_name = nullopt,
-      bool skip_checks_serialization = false);
+      optional<std::string> fragment_name = nullopt);
 
   /** Destructor. */
   ~GlobalOrderWriter();

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -67,38 +67,26 @@ namespace tiledb::sm {
 OrderedWriter::OrderedWriter(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    Subarray& subarray,
-    Layout layout,
+    StrategyParams& params,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
     bool remote_query,
-    optional<std::string> fragment_name,
-    bool skip_checks_serialization)
+    optional<std::string> fragment_name)
     : WriterBase(
           stats,
           logger,
-          storage_manager,
-          array,
-          config,
-          buffers,
-          subarray,
-          layout,
+          params,
           written_fragment_info,
           false,
           coords_info,
           remote_query,
-          fragment_name,
-          skip_checks_serialization)
+          fragment_name)
     , frag_uri_(std::nullopt) {
-  if (layout != Layout::ROW_MAJOR && layout != Layout::COL_MAJOR) {
+  if (layout_ != Layout::ROW_MAJOR && layout_ != Layout::COL_MAJOR) {
     throw StatusException(Status_WriterError(
         "Failed to initialize OrderedWriter; The ordered writer does not "
         "support layout " +
-        layout_str(layout)));
+        layout_str(layout_)));
   }
 
   if (!array_schema_.dense()) {

--- a/tiledb/sm/query/writers/ordered_writer.h
+++ b/tiledb/sm/query/writers/ordered_writer.h
@@ -55,17 +55,11 @@ class OrderedWriter : public WriterBase {
   OrderedWriter(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      Subarray& subarray,
-      Layout layout,
+      StrategyParams& params,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
-      optional<std::string> fragment_name = nullopt,
-      bool skip_checks_serialization = false);
+      optional<std::string> fragment_name = nullopt);
 
   /** Destructor. */
   ~OrderedWriter();

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -73,42 +73,30 @@ class UnorderWriterException : public StatusException {
 UnorderedWriter::UnorderedWriter(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    Subarray& subarray,
-    Layout layout,
+    StrategyParams& params,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     Query::CoordsInfo& coords_info,
     std::unordered_set<std::string>& written_buffers,
     bool remote_query,
-    optional<std::string> fragment_name,
-    bool skip_checks_serialization)
+    optional<std::string> fragment_name)
     : WriterBase(
           stats,
           logger,
-          storage_manager,
-          array,
-          config,
-          buffers,
-          subarray,
-          layout,
+          params,
           written_fragment_info,
           false,
           coords_info,
           remote_query,
-          fragment_name,
-          skip_checks_serialization)
+          fragment_name)
     , frag_uri_(std::nullopt)
     , written_buffers_(written_buffers)
     , is_coords_pass_(true) {
   // Check the layout is unordered.
-  if (layout != Layout::UNORDERED) {
+  if (layout_ != Layout::UNORDERED) {
     throw UnorderWriterException(
         "Failed to initialize UnorderedWriter; The unordered writer does not "
         "support layout " +
-        layout_str(layout));
+        layout_str(layout_));
   }
 
   // Check the array is sparse.

--- a/tiledb/sm/query/writers/unordered_writer.h
+++ b/tiledb/sm/query/writers/unordered_writer.h
@@ -55,18 +55,12 @@ class UnorderedWriter : public WriterBase {
   UnorderedWriter(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      Subarray& subarray,
-      Layout layout,
+      StrategyParams& params,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       Query::CoordsInfo& coords_info,
       std::unordered_set<std::string>& written_buffers,
       bool remote_query,
-      optional<std::string> fragment_name = nullopt,
-      bool skip_checks_serialization = false);
+      optional<std::string> fragment_name = nullopt);
 
   /** Destructor. */
   ~UnorderedWriter();

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -75,27 +75,13 @@ class WriterBaseStatusException : public StatusException {
 WriterBase::WriterBase(
     stats::Stats* stats,
     shared_ptr<Logger> logger,
-    StorageManager* storage_manager,
-    Array* array,
-    Config& config,
-    std::unordered_map<std::string, QueryBuffer>& buffers,
-    Subarray& subarray,
-    Layout layout,
+    StrategyParams& params,
     std::vector<WrittenFragmentInfo>& written_fragment_info,
     bool disable_checks_consolidation,
     Query::CoordsInfo& coords_info,
     bool remote_query,
-    optional<std::string> fragment_name,
-    bool skip_checks_serialization)
-    : StrategyBase(
-          stats,
-          logger->clone("Writer", ++logger_id_),
-          storage_manager,
-          array,
-          config,
-          buffers,
-          subarray,
-          layout)
+    optional<std::string> fragment_name)
+    : StrategyBase(stats, logger->clone("Writer", ++logger_id_), params)
     , disable_checks_consolidation_(disable_checks_consolidation)
     , coords_info_(coords_info)
     , check_coord_dups_(false)
@@ -110,7 +96,7 @@ WriterBase::WriterBase(
         "Cannot initialize query; Storage manager not set");
   }
 
-  if (!skip_checks_serialization && buffers_.empty()) {
+  if (!params.skip_checks_serialization() && buffers_.empty()) {
     throw WriterBaseStatusException(
         "Cannot initialize writer; Buffers not set");
   }
@@ -202,7 +188,7 @@ WriterBase::WriterBase(
     check_extra_element();
   }
 
-  if (!skip_checks_serialization) {
+  if (!params.skip_checks_serialization()) {
     // Consolidation might set a subarray that is not tile aligned.
     if (!disable_checks_consolidation) {
       check_subarray();

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -70,18 +70,12 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   WriterBase(
       stats::Stats* stats,
       shared_ptr<Logger> logger,
-      StorageManager* storage_manager,
-      Array* array,
-      Config& config,
-      std::unordered_map<std::string, QueryBuffer>& buffers,
-      Subarray& subarray,
-      Layout layout,
+      StrategyParams& params,
       std::vector<WrittenFragmentInfo>& written_fragment_info,
       bool disable_checks_consolidation,
       Query::CoordsInfo& coords_info_,
       bool remote_query,
-      optional<std::string> fragment_name = nullopt,
-      bool skip_checks_serialization = false);
+      optional<std::string> fragment_name = nullopt);
 
   /** Destructor. */
   ~WriterBase();


### PR DESCRIPTION
This moves common strategy parameters to a class so that adding/updating parameters is easier moving forward.

Note that this doesn't move the stats and logger as those get modified in many places down the construction chain so that will require a later change that can be done with more care.

---
TYPE: NO_HISTORY
DESC: Move common strategy parameters to class.
