### PR TITLE
Update back compat arrays after delta filter addition.

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -59,7 +59,7 @@ jobs:
           - ubuntu-20.04
         # Note: v2_1_0 arrays were never created so its currently skipped
         # Note: This matrix is used to set the value of TILEDB_COMPATIBILITY_VERSION
-        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1", "v2_10_0", "v2_11_0", "v2_12_0", "v2_13_0", "v2_14_0", "v2_15_0", "v2_16_0", "v2_17_3", "v2_18_1"]
+        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1", "v2_10_0", "v2_11_0", "v2_12_3", "v2_13_2", "v2_14_0", "v2_15_0", "v2_16_3", "v2_17_5", "v2_18_3"]
     timeout-minutes: 30
     name: ${{ matrix.tiledb_version }}
     steps:

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -826,7 +826,7 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
       array_uri_,
       key->encryption_type(),
       key->key().data(),
-      key->key().size(),
+      static_cast<uint32_t>(key->key().size()),
       this->timestamp_start(),
       timestamp_end_opened_at(),
       is_remote());


### PR DESCRIPTION
This switches the tests to the new versions of the backwards compatibility arrays for 2.16, 2.17 and 2.18 that include the delta filter. Older branches will still use the old arrays... Once we get a few releases done, we should remove the old arrays.

---
TYPE: NO_HISTORY
DESC: Update back compat arrays after delta filter addition.
