### PR TITLE
Support dimension labels in `tiledb_query_get_field`.

### DIFF
--- a/tiledb/api/c_api/query_field/query_field_api.cc
+++ b/tiledb/api/c_api/query_field/query_field_api.cc
@@ -35,6 +35,7 @@
 #include "tiledb/api/c_api/datatype/datatype_api_external.h"
 #include "tiledb/api/c_api/query/query_api_internal.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
+#include "tiledb/sm/array_schema/dimension_label.h"
 #include "tiledb/sm/misc/constants.h"
 
 tiledb_field_origin_t FieldFromDimension::origin() {
@@ -47,6 +48,10 @@ tiledb_field_origin_t FieldFromAttribute::origin() {
 
 tiledb_field_origin_t FieldFromAggregate::origin() {
   return TILEDB_AGGREGATE_FIELD;
+}
+
+tiledb_field_origin_t FieldFromDimensionLabel::origin() {
+  return TILEDB_DIMENSION_LABEL_FIELD;
 }
 
 tiledb_query_field_handle_t::tiledb_query_field_handle_t(
@@ -71,6 +76,12 @@ tiledb_query_field_handle_t::tiledb_query_field_handle_t(
     type_ = query_->array_schema().dimension_ptr(field_name_)->type();
     cell_val_num_ =
         query_->array_schema().dimension_ptr(field_name_)->cell_val_num();
+  } else if (query_->array_schema().is_dim_label(field_name_)) {
+    field_origin_ = std::make_shared<FieldFromDimensionLabel>();
+    type_ = query_->array_schema().dimension_label(field_name_).label_type();
+    cell_val_num_ = query_->array_schema()
+                        .dimension_label(field_name_)
+                        .label_cell_val_num();
   } else if (query_->is_aggregate(field_name_)) {
     field_origin_ = std::make_shared<FieldFromAggregate>();
     auto aggregate = query_->get_aggregate(field_name_).value();

--- a/tiledb/api/c_api/query_field/query_field_api_external_experimental.h
+++ b/tiledb/api/c_api/query_field/query_field_api_external_experimental.h
@@ -48,7 +48,8 @@ typedef struct tiledb_query_field_handle_t tiledb_query_field_t;
 typedef enum {
   TILEDB_ATTRIBUTE_FIELD = 0,
   TILEDB_DIMENSION_FIELD,
-  TILEDB_AGGREGATE_FIELD
+  TILEDB_AGGREGATE_FIELD,
+  TILEDB_DIMENSION_LABEL_FIELD
 } tiledb_field_origin_t;
 
 /**

--- a/tiledb/api/c_api/query_field/query_field_api_internal.h
+++ b/tiledb/api/c_api/query_field/query_field_api_internal.h
@@ -60,6 +60,11 @@ class FieldFromAggregate : public FieldOrigin {
   virtual tiledb_field_origin_t origin() override;
 };
 
+class FieldFromDimensionLabel : public FieldOrigin {
+ public:
+  virtual tiledb_field_origin_t origin() override;
+};
+
 struct tiledb_query_field_handle_t
     : public tiledb::api::CAPIHandle<tiledb_query_field_handle_t> {
   /**

--- a/tiledb/api/c_api/query_field/test/unit_capi_query_field.cc
+++ b/tiledb/api/c_api/query_field/test/unit_capi_query_field.cc
@@ -160,6 +160,13 @@ void QueryFieldFx::create_sparse_array(const std::string& array_name) {
       tiledb_array_schema_add_attribute(ctx, array_schema, c));
   throw_if_setup_failed(
       tiledb_array_schema_add_attribute(ctx, array_schema, d));
+  throw_if_setup_failed(tiledb_array_schema_add_dimension_label(
+      ctx,
+      array_schema,
+      0,
+      "d1_label",
+      TILEDB_INCREASING_DATA,
+      TILEDB_STRING_ASCII));
 
   // check array schema
   throw_if_setup_failed(tiledb_array_schema_check(ctx, array_schema));
@@ -360,6 +367,16 @@ TEST_CASE_METHOD(
   CHECK(origin == TILEDB_AGGREGATE_FIELD);
   REQUIRE(tiledb_field_cell_val_num(ctx, field, &cell_val_num) == TILEDB_OK);
   CHECK(cell_val_num == 1);
+  CHECK(tiledb_query_field_free(ctx, &field) == TILEDB_OK);
+
+  // Check field api works on dimension label field
+  REQUIRE(tiledb_query_get_field(ctx, query, "d1_label", &field) == TILEDB_OK);
+  REQUIRE(tiledb_field_datatype(ctx, field, &type) == TILEDB_OK);
+  CHECK(type == TILEDB_STRING_ASCII);
+  REQUIRE(tiledb_field_origin(ctx, field, &origin) == TILEDB_OK);
+  CHECK(origin == TILEDB_DIMENSION_LABEL_FIELD);
+  REQUIRE(tiledb_field_cell_val_num(ctx, field, &cell_val_num) == TILEDB_OK);
+  CHECK(cell_val_num == TILEDB_VAR_NUM);
   CHECK(tiledb_query_field_free(ctx, &field) == TILEDB_OK);
 
   // Clean up


### PR DESCRIPTION
[SC-39110](https://app.shortcut.com/tiledb-inc/story/39110/tiledb-query-get-field-does-not-consider-dimension-labels)

---
TYPE: BUG
DESC: Fix dimension labels not being recognized by `tiledb_query_get_field`.
TYPE: C_API
DESC: Add a new field type `TILEDB_DIMENSION_LABEL_FIELD`.