### PR TITLE
Return a fresh handle from `tiledb_field_channel`.

### DIFF
--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -165,7 +165,7 @@ capi_return_t tiledb_query_get_default_channel(
   // We don't have an internal representation of a channel,
   // the default channel is currently just a hashmap, so only pass the query
   // to the channel constructor to be carried until next the api call.
-  *channel = tiledb_query_channel_handle_t::make_handle(query);
+  *channel = tiledb_query_channel_handle_t::make_handle(query->query_);
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api_internal.h
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api_internal.h
@@ -90,8 +90,8 @@ struct tiledb_query_channel_handle_t
    * Ordinary constructor.
    * @param query The query object that owns the channel
    */
-  tiledb_query_channel_handle_t(tiledb_query_t* query)
-      : query_(query->query_) {
+  tiledb_query_channel_handle_t(tiledb::sm::Query* query)
+      : query_(query) {
   }
 
   inline void add_aggregate(

--- a/tiledb/api/c_api/query_field/query_field_api.cc
+++ b/tiledb/api/c_api/query_field/query_field_api.cc
@@ -80,8 +80,6 @@ tiledb_query_field_handle_t::tiledb_query_field_handle_t(
   } else {
     throw tiledb::api::CAPIStatusException("There is no field " + field_name_);
   }
-
-  channel_ = tiledb_query_channel_handle_t::make_handle(query);
 }
 
 namespace tiledb::api {

--- a/tiledb/api/c_api/query_field/query_field_api_internal.h
+++ b/tiledb/api/c_api/query_field/query_field_api_internal.h
@@ -73,7 +73,6 @@ struct tiledb_query_field_handle_t
   std::shared_ptr<FieldOrigin> field_origin_;
   tiledb::sm::Datatype type_;
   uint32_t cell_val_num_;
-  tiledb_query_channel_handle_t* channel_;
 
  public:
   /**
@@ -87,9 +86,7 @@ struct tiledb_query_field_handle_t
    */
   tiledb_query_field_handle_t(tiledb_query_t* query, const char* field_name);
 
-  ~tiledb_query_field_handle_t() {
-    tiledb_query_channel_handle_t::break_handle(channel_);
-  }
+  ~tiledb_query_field_handle_t() = default;
 
   tiledb_field_origin_t origin() {
     return field_origin_->origin();
@@ -101,7 +98,7 @@ struct tiledb_query_field_handle_t
     return cell_val_num_;
   }
   tiledb_query_channel_handle_t* channel() {
-    return channel_;
+    return tiledb_query_channel_t::make_handle(query_);
   }
 };
 


### PR DESCRIPTION
[SC-39123](https://app.shortcut.com/tiledb-inc/story/39123/tiledb-field-channel-returns-the-same-handle-and-is-prone-to-double-freeing)

`tiledb_field_channel` was always returning the same channel for a field and freed it when the field itself was freed, resulting in double freeing if the user also freed that handle, as the expectation for managing handles is. This PR changes the function to always create a different handle.

Validated by successfully running `unit_capi_query_field` on Windows in Debug mode (it was failing previously with a segfault because of the aforementioned double freeing).

---
TYPE: BUG
DESC: Return a fresh handle from `tiledb_field_channel`, preventing double freeing.