### PR TITLE
Pass AWS client configuration to `STSProfileWithWebIdentityCredentialsProvider`.

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1421,7 +1421,14 @@ Status S3::init_client() const {
       }
       case 16: {
         credentials_provider_ = make_shared<
-            Aws::Auth::STSProfileWithWebIdentityCredentialsProvider>(HERE());
+            Aws::Auth::STSProfileWithWebIdentityCredentialsProvider>(
+            HERE(),
+            Aws::Auth::GetConfigProfileName(),
+            std::chrono::minutes(60),
+            [client_config](const auto& credentials) {
+              return make_shared<Aws::STS::STSClient>(
+                  HERE(), credentials, client_config);
+            });
         break;
       }
       default: {

--- a/tiledb/sm/filesystem/s3/STSProfileWithWebIdentityCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/STSProfileWithWebIdentityCredentialsProvider.h
@@ -97,8 +97,8 @@ class /* AWS_IDENTITY_MANAGEMENT_API */
   STSProfileWithWebIdentityCredentialsProvider(
       const Aws::String& profileName,
       std::chrono::minutes duration,
-      const std::function<Aws::STS::STSClient*(const AWSCredentials&)>&
-          stsClientFactory);
+      const std::function<std::shared_ptr<Aws::STS::STSClient>(
+          const AWSCredentials&)>& stsClientFactory);
 
   /**
    * Fetches the credentials set from STS following the rules defined in the
@@ -132,11 +132,15 @@ class /* AWS_IDENTITY_MANAGEMENT_API */
       const Aws::String& externalID,
       Aws::STS::STSClient* client);
 
+  AWSCredentials GetCredentialsFromWebIdentityInternal(
+      const Config::Profile& profile, Aws::STS::STSClient* client);
+
   Aws::String m_profileName;
   AWSCredentials m_credentials;
   const std::chrono::minutes m_duration;
   const std::chrono::milliseconds m_reloadFrequency;
-  std::function<Aws::STS::STSClient*(const AWSCredentials&)> m_stsClientFactory;
+  std::function<std::shared_ptr<Aws::STS::STSClient>(const AWSCredentials&)>
+      m_stsClientFactory;
 };
 }  // namespace Auth
 }  // namespace Aws


### PR DESCRIPTION
This PR applies a similar fix to #4616 but for `STSProfileWithWebIdentityCredentialsProvider`. That class was also adjusted to prevent a memory leak, to use the user-provided `STSClient` if available, and to use public APIs.

The issue has been validated to be fixed.

---
TYPE: BUG
DESC: Fix HTTP requests for AWS assume role with web identity not honoring config options.