### PR TITLE
Update the download/upload artifact actions to version 4.

### DIFF
--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -53,7 +53,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
       - name: "Upload binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mingw-w64-${{ matrix.msystem }}-tiledb
           path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*

--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Save the tiledb_unit binary for use in the next step
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tiledb_unit
           path: ${{ github.workspace }}/build/tiledb/test/tiledb_unit
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tiledb_unit
           path: ${{ github.workspace }}/build/tiledb/test/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -408,7 +408,7 @@ jobs:
 
       - name: 'upload dumpfile artifacts' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ always() == true && startsWith(matrix.os, 'windows-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{matrix.environ}}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -228,20 +228,20 @@ jobs:
 
       - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
-          name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
+          name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{ inputs.ci_backend }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
           if-no-files-found: warn # 'ignore', 'warn' or 'error' are available, defaults to `warn`
           path: |
             /var/lib/apport/coredump/
 
       - name: 'Upload failure artifacts (macOS)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ failure() == true && startsWith(matrix.os, 'macos-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
-          name: "${{ matrix.os }}.coredumps.${{ github.job }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
+          name: "${{ matrix.os }}.${{ inputs.ci_backend }}.coredumps.${{ github.job }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
           if-no-files-found: warn # 'ignore', 'warn' or 'error' are available, defaults to `warn`
           path: |
             /cores/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,17 +107,17 @@ jobs:
           Compress-Archive -Path dist\* -DestinationPath ${{ steps.get-values.outputs.archive_name }}.zip
         shell: pwsh
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tiledb-dist
+          name: tiledb-dist-${{ matrix.platform }}
           path: ${{ steps.get-values.outputs.archive_name }}.*
       - name: Archive build directory
         run: |
           tar -czf build-${{ matrix.platform }}.tar.gz -C build .
       - name: Upload build directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tiledb-build
+          name: tiledb-build-${{ matrix.platform }}
           path: build-${{ matrix.platform }}.tar.gz
       - name: "Print log files (failed build only)"
         run: |
@@ -129,9 +129,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: tiledb-dist
+          pattern: tiledb-dist-*
+          merge-multiple: true
           path: dist
       - name: Test names of release artifacts
         run: |
@@ -146,9 +147,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
-          name: tiledb-dist
+          pattern: tiledb-dist-*
+          merge-multiple: true
           path: dist
       - name: Publish release artifacts
         uses: actions/github-script@v6


### PR DESCRIPTION
Artifacts are now immutable and we can't upload many times to the same one as we do in the Release workflow, but what we can do is upload to many artifacts with a common prefix, and download all of them with a pattern.

---
TYPE: NO_HISTORY