### PR TITLE
Make Group load_metadata not depend on StorageManager

### DIFF
--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -62,11 +62,10 @@ class Group {
  public:
   /**
    * Constructs a Group object given a uri and a ContextResources reference.
-   * This is a transitional constructor in the sense that we are working
-   * on removing the dependency of the Group class on StorageManager. For
-   * now we still need to keep the storage_manager argument, but once the
-   * dependency is gone the signature will be
-   * Group(ContextResources&, const URI&).
+   * This is a transitional constructor in the sense that we are working on
+   * removing the dependency of the Group class on StorageManager. For now we
+   * still need to keep the storage_manager argument, but once the dependency is
+   * gone the signature will be Group(ContextResources&, const URI&).
    *
    * @param resources A ContextResources reference
    * @param group_uri The location of the group


### PR DESCRIPTION
A good starting point for eliminating the dependency of Group on StorageManager
is to move StorageManager load_group_metadata into Group.

---
TYPE: IMPROVEMENT
DESC: Make Group load_metadata not depend on StorageManager
