### PR TITLE
Remove dead code from FragmentInfo and FragmentMetadata

### DIFF
--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -51,11 +51,6 @@ namespace tiledb::sm {
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-FragmentInfo::FragmentInfo()
-    : resources_(nullptr)
-    , unconsolidated_metadata_num_(0) {
-}
-
 FragmentInfo::FragmentInfo(const URI& array_uri, ContextResources& resources)
     : array_uri_(array_uri)
     , config_(resources.config())
@@ -64,28 +59,6 @@ FragmentInfo::FragmentInfo(const URI& array_uri, ContextResources& resources)
 }
 
 FragmentInfo::~FragmentInfo() = default;
-
-FragmentInfo::FragmentInfo(const FragmentInfo& fragment_info)
-    : FragmentInfo() {
-  auto clone = fragment_info.clone();
-  swap(clone);
-}
-
-FragmentInfo::FragmentInfo(FragmentInfo&& fragment_info)
-    : FragmentInfo() {
-  swap(fragment_info);
-}
-
-FragmentInfo& FragmentInfo::operator=(const FragmentInfo& fragment_info) {
-  auto clone = fragment_info.clone();
-  swap(clone);
-  return *this;
-}
-
-FragmentInfo& FragmentInfo::operator=(FragmentInfo&& fragment_info) {
-  swap(fragment_info);
-  return *this;
-}
 
 /* ********************************* */
 /*                API                */
@@ -1219,38 +1192,6 @@ Status FragmentInfo::replace(
   (void)old_fragment_num;  // When running in release mode, this is not used
 
   return Status::Ok();
-}
-
-FragmentInfo FragmentInfo::clone() const {
-  FragmentInfo clone;
-  clone.array_uri_ = array_uri_;
-  clone.array_schema_latest_ = array_schema_latest_;
-  clone.array_schemas_all_ = array_schemas_all_;
-  clone.config_ = config_;
-  clone.single_fragment_info_vec_ = single_fragment_info_vec_;
-  clone.resources_ = resources_;
-  clone.to_vacuum_ = to_vacuum_;
-  clone.unconsolidated_metadata_num_ = unconsolidated_metadata_num_;
-  clone.anterior_ndrange_ = anterior_ndrange_;
-  clone.timestamp_start_ = timestamp_start_;
-  clone.timestamp_end_ = timestamp_end_;
-
-  return clone;
-}
-
-void FragmentInfo::swap(FragmentInfo& fragment_info) {
-  std::swap(array_uri_, fragment_info.array_uri_);
-  std::swap(array_schema_latest_, fragment_info.array_schema_latest_);
-  std::swap(array_schemas_all_, fragment_info.array_schemas_all_);
-  std::swap(config_, fragment_info.config_);
-  std::swap(single_fragment_info_vec_, fragment_info.single_fragment_info_vec_);
-  std::swap(resources_, fragment_info.resources_);
-  std::swap(to_vacuum_, fragment_info.to_vacuum_);
-  std::swap(
-      unconsolidated_metadata_num_, fragment_info.unconsolidated_metadata_num_);
-  std::swap(anterior_ndrange_, fragment_info.anterior_ndrange_);
-  std::swap(timestamp_start_, fragment_info.timestamp_start_);
-  std::swap(timestamp_end_, fragment_info.timestamp_end_);
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/fragment/fragment_info.h
+++ b/tiledb/sm/fragment/fragment_info.h
@@ -54,8 +54,7 @@ class FragmentInfo {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Constructor. */
-  FragmentInfo();
+  FragmentInfo() = delete;
 
   /** Constructor. */
   FragmentInfo(const URI& array_uri, ContextResources& resources);
@@ -63,17 +62,8 @@ class FragmentInfo {
   /** Destructor. */
   ~FragmentInfo();
 
-  /** Copy constructor. */
-  FragmentInfo(const FragmentInfo& fragment_info);
-
-  /** Move constructor. */
-  FragmentInfo(FragmentInfo&& fragment_info);
-
-  /** Copy-assign operator. */
-  FragmentInfo& operator=(const FragmentInfo& fragment_info);
-
-  /** Move-assign operator. */
-  FragmentInfo& operator=(FragmentInfo&& fragment_info);
+  DISABLE_COPY_AND_COPY_ASSIGN(FragmentInfo);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(FragmentInfo);
 
   /* ********************************* */
   /*                API                */
@@ -484,15 +474,6 @@ class FragmentInfo {
   Status replace(
       const SingleFragmentInfo& new_single_fragment_info,
       const std::vector<TimestampedURI>& to_replace);
-
-  /** Returns a copy of this object. */
-  FragmentInfo clone() const;
-
-  /**
-   * Swaps the contents (all field values) of this object with the
-   * given object.
-   */
-  void swap(FragmentInfo& fragment_info);
 };
 
 }  // namespace sm

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -113,51 +113,6 @@ FragmentMetadata::FragmentMetadata(
 
 FragmentMetadata::~FragmentMetadata() = default;
 
-// Copy initialization
-FragmentMetadata::FragmentMetadata(const FragmentMetadata& other) {
-  resources_ = other.resources_;
-  array_schema_ = other.array_schema_;
-  dense_ = other.dense_;
-  fragment_uri_ = other.fragment_uri_;
-  timestamp_range_ = other.timestamp_range_;
-  has_consolidated_footer_ = other.has_consolidated_footer_;
-  rtree_ = other.rtree_;
-  meta_file_size_ = other.meta_file_size_;
-  version_ = other.version_;
-  tile_index_base_ = other.tile_index_base_;
-  has_timestamps_ = other.has_timestamps_;
-  has_delete_meta_ = other.has_delete_meta_;
-  sparse_tile_num_ = other.sparse_tile_num_;
-  footer_size_ = other.footer_size_;
-  footer_offset_ = other.footer_offset_;
-  idx_map_ = other.idx_map_;
-  array_schema_name_ = other.array_schema_name_;
-  array_uri_ = other.array_uri_;
-}
-
-FragmentMetadata& FragmentMetadata::operator=(const FragmentMetadata& other) {
-  resources_ = other.resources_;
-  array_schema_ = other.array_schema_;
-  dense_ = other.dense_;
-  fragment_uri_ = other.fragment_uri_;
-  timestamp_range_ = other.timestamp_range_;
-  has_consolidated_footer_ = other.has_consolidated_footer_;
-  rtree_ = other.rtree_;
-  meta_file_size_ = other.meta_file_size_;
-  version_ = other.version_;
-  tile_index_base_ = other.tile_index_base_;
-  has_timestamps_ = other.has_timestamps_;
-  has_delete_meta_ = other.has_delete_meta_;
-  sparse_tile_num_ = other.sparse_tile_num_;
-  footer_size_ = other.footer_size_;
-  footer_offset_ = other.footer_offset_;
-  idx_map_ = other.idx_map_;
-  array_schema_name_ = other.array_schema_name_;
-  array_uri_ = other.array_uri_;
-
-  return *this;
-}
-
 /* ****************************** */
 /*                API             */
 /* ****************************** */

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -100,10 +100,8 @@ class FragmentMetadata {
   /** Destructor. */
   ~FragmentMetadata();
 
-  // Copy initialization
-  FragmentMetadata(const FragmentMetadata& other);
-
-  FragmentMetadata& operator=(const FragmentMetadata& other);
+  DISABLE_COPY_AND_COPY_ASSIGN(FragmentMetadata);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(FragmentMetadata);
 
   /* ********************************* */
   /*          TYPE DEFINITIONS         */


### PR DESCRIPTION
This just removes some unused constructor and assignment operators that are no longer used now that these classes are almost exclusively used with shared pointers.

---
TYPE: NO_HISTORY
DESC: Remove dead code from FragmentInfo and FragmentMetadata
