### PR TITLE
Move consolidation calls out of StorageManager.

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2708,7 +2708,7 @@ int32_t tiledb_array_consolidate(
       tiledb::sm::EncryptionType::NO_ENCRYPTION,
       nullptr,
       0,
-      (config == nullptr) ? ctx->resources().config() : config->config(),
+      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
       ctx->storage_manager());
   return TILEDB_OK;
 }
@@ -2727,7 +2727,7 @@ int32_t tiledb_array_consolidate_with_key(
       static_cast<tiledb::sm::EncryptionType>(encryption_type),
       encryption_key,
       key_length,
-      (config == nullptr) ? ctx->resources().config() : config->config(),
+      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
       ctx->storage_manager());
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2748,14 +2748,14 @@ int32_t tiledb_array_consolidate_fragments(
     uris.emplace_back(fragment_uris[i]);
   }
 
-  throw_if_not_ok(ctx->storage_manager()->fragments_consolidate(
+  tiledb::sm::Consolidator::fragments_consolidate(
       array_uri,
       tiledb::sm::EncryptionType::NO_ENCRYPTION,
       nullptr,
       0,
       uris,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
+      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
+      ctx->storage_manager());
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2762,10 +2762,10 @@ int32_t tiledb_array_consolidate_fragments(
 
 int32_t tiledb_array_vacuum(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
-  ctx->storage_manager()->array_vacuum(
+  tiledb::sm::Consolidator::array_vacuum(
       array_uri,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config());
+      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
+      ctx->storage_manager());
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -58,6 +58,7 @@
 #include "tiledb/sm/c_api/api_argument_validator.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/config/config_iter.h"
+#include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/sm/cpp_api/core_interface.h"
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/encryption_type.h"
@@ -2702,13 +2703,13 @@ int32_t tiledb_array_create_with_key(
 int32_t tiledb_array_consolidate(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
   api::ensure_config_is_valid_if_present(config);
-  throw_if_not_ok(ctx->storage_manager()->array_consolidate(
+  tiledb::sm::Consolidator::array_consolidate(
       array_uri,
       tiledb::sm::EncryptionType::NO_ENCRYPTION,
       nullptr,
       0,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
+      (config == nullptr) ? ctx->resources().config() : config->config(),
+      ctx->storage_manager());
   return TILEDB_OK;
 }
 
@@ -2721,13 +2722,13 @@ int32_t tiledb_array_consolidate_with_key(
     tiledb_config_t* config) {
   // Sanity checks
 
-  throw_if_not_ok(ctx->storage_manager()->array_consolidate(
+  tiledb::sm::Consolidator::array_consolidate(
       array_uri,
       static_cast<tiledb::sm::EncryptionType>(encryption_type),
       encryption_key,
       key_length,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
+      (config == nullptr) ? ctx->resources().config() : config->config(),
+      ctx->storage_manager());
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/consolidator/array_meta_consolidator.h
+++ b/tiledb/sm/consolidator/array_meta_consolidator.h
@@ -85,14 +85,14 @@ class ArrayMetaConsolidator : public Consolidator {
       const char* array_name,
       EncryptionType encryption_type,
       const void* encryption_key,
-      uint32_t key_length);
+      uint32_t key_length) override;
 
   /**
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to consolidate.
    */
-  void vacuum(const char* array_name);
+  void vacuum(const char* array_name) override;
 
  private:
   /* ********************************* */

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -95,8 +95,8 @@ Status CommitsConsolidator::consolidate(
 
   // Get the file name.
   auto& to_consolidate = array_dir.commit_uris_to_consolidate();
-  storage_manager_->write_consolidated_commits_file(
-      write_version, array_dir, to_consolidate);
+  Consolidator::write_consolidated_commits_file(
+      write_version, array_dir, to_consolidate, storage_manager_);
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/commits_consolidator.h
+++ b/tiledb/sm/consolidator/commits_consolidator.h
@@ -83,14 +83,14 @@ class CommitsConsolidator : public Consolidator {
       const char* array_name,
       EncryptionType encryption_type,
       const void* encryption_key,
-      uint32_t key_length);
+      uint32_t key_length) override;
 
   /**
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to consolidate.
    */
-  void vacuum(const char* array_name);
+  void vacuum(const char* array_name) override;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -306,6 +306,22 @@ void Consolidator::write_consolidated_commits_file(
   throw_if_not_ok(storage_manager->vfs()->close_file(consolidated_commits_uri));
 }
 
+void Consolidator::array_vacuum(
+    const char* array_name,
+    const Config& config,
+    StorageManager* storage_manager) {
+  URI array_uri(array_name);
+  if (array_uri.is_tiledb()) {
+    throw_if_not_ok(
+        storage_manager->rest_client()->post_vacuum_to_rest(array_uri, config));
+    return;
+  }
+
+  auto mode = Consolidator::mode_from_config(config, true);
+  auto consolidator = Consolidator::create(mode, config, storage_manager);
+  consolidator->vacuum(array_name);
+}
+
 void Consolidator::check_array_uri(const char* array_name) {
   if (URI(array_name).is_tiledb()) {
     throw ConsolidatorException(

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -123,7 +123,7 @@ Status Consolidator::consolidate(
 }
 
 void Consolidator::vacuum([[maybe_unused]] const char* array_name) {
-  throw Status_ConsolidatorError("Cannot vacuum; Invalid object");
+  throw ConsolidatorException("Cannot vacuum; Invalid object");
 }
 
 void Consolidator::array_consolidate(
@@ -136,8 +136,7 @@ void Consolidator::array_consolidate(
   // Check array URI
   URI array_uri(array_name);
   if (array_uri.is_invalid()) {
-    throw StatusException(
-        Status_ConsolidatorError("Cannot consolidate array; Invalid URI"));
+    throw ConsolidatorException("Cannot consolidate array; Invalid URI");
   }
 
   // Check if array exists
@@ -145,8 +144,8 @@ void Consolidator::array_consolidate(
   throw_if_not_ok(storage_manager->object_type(array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
-    throw StatusException(Status_ConsolidatorError(
-        "Cannot consolidate array; Array does not exist"));
+    throw ConsolidatorException(
+        "Cannot consolidate array; Array does not exist");
   }
 
   if (array_uri.is_tiledb()) {
@@ -190,7 +189,8 @@ void Consolidator::array_consolidate(
 
 void Consolidator::check_array_uri(const char* array_name) {
   if (URI(array_name).is_tiledb()) {
-    throw std::logic_error("Consolidation is not supported for remote arrays.");
+    throw ConsolidatorException(
+        "Consolidation is not supported for remote arrays.");
   }
 }
 

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -32,6 +32,7 @@
 
 #include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/common/logger.h"
+#include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/consolidator/array_meta_consolidator.h"
 #include "tiledb/sm/consolidator/commits_consolidator.h"
 #include "tiledb/sm/consolidator/fragment_consolidator.h"
@@ -40,6 +41,7 @@
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
+#include "tiledb/storage_format/uri/generate_uri.h"
 
 using namespace tiledb::common;
 
@@ -244,6 +246,64 @@ void Consolidator::fragments_consolidate(
       dynamic_cast<FragmentConsolidator*>(consolidator.get());
   throw_if_not_ok(fragment_consolidator->consolidate_fragments(
       array_name, encryption_type, encryption_key, key_length, fragment_uris));
+}
+
+void Consolidator::write_consolidated_commits_file(
+    format_version_t write_version,
+    ArrayDirectory array_dir,
+    const std::vector<URI>& commit_uris,
+    StorageManager* storage_manager) {
+  // Compute the file name.
+  auto name = storage_format::generate_consolidated_fragment_name(
+      commit_uris.front(), commit_uris.back(), write_version);
+
+  // Compute size of consolidated file. Save the sizes of the files to re-use
+  // below.
+  storage_size_t total_size = 0;
+  const auto base_uri_size = array_dir.uri().to_string().size();
+  std::vector<storage_size_t> file_sizes(commit_uris.size());
+  for (uint64_t i = 0; i < commit_uris.size(); i++) {
+    const auto& uri = commit_uris[i];
+    total_size += uri.to_string().size() - base_uri_size + 1;
+
+    // If the file is a delete, add the file size to the count and the size of
+    // the size variable.
+    if (stdx::string::ends_with(
+            uri.to_string(), constants::delete_file_suffix)) {
+      throw_if_not_ok(storage_manager->vfs()->file_size(uri, &file_sizes[i]));
+      total_size += file_sizes[i];
+      total_size += sizeof(storage_size_t);
+    }
+  }
+
+  // Write consolidated file, URIs are relative to the array URI.
+  std::vector<uint8_t> data(total_size);
+  storage_size_t file_index = 0;
+  for (uint64_t i = 0; i < commit_uris.size(); i++) {
+    // Add the uri.
+    const auto& uri = commit_uris[i];
+    std::string relative_uri = uri.to_string().substr(base_uri_size) + "\n";
+    memcpy(&data[file_index], relative_uri.data(), relative_uri.size());
+    file_index += relative_uri.size();
+
+    // For deletes, read the delete condition to the output file.
+    if (stdx::string::ends_with(
+            uri.to_string(), constants::delete_file_suffix)) {
+      memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
+      file_index += sizeof(storage_size_t);
+      throw_if_not_ok(storage_manager->vfs()->read(
+          uri, 0, &data[file_index], file_sizes[i]));
+      file_index += file_sizes[i];
+    }
+  }
+
+  // Write the file to storage.
+  URI consolidated_commits_uri =
+      array_dir.get_commits_dir(write_version)
+          .join_path(name + constants::con_commits_file_suffix);
+  throw_if_not_ok(storage_manager->vfs()->write(
+      consolidated_commits_uri, data.data(), data.size()));
+  throw_if_not_ok(storage_manager->vfs()->close_file(consolidated_commits_uri));
 }
 
 void Consolidator::check_array_uri(const char* array_name) {

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -187,6 +187,65 @@ void Consolidator::array_consolidate(
   }
 }
 
+void Consolidator::fragments_consolidate(
+    const char* array_name,
+    EncryptionType encryption_type,
+    const void* encryption_key,
+    uint32_t key_length,
+    const std::vector<std::string> fragment_uris,
+    const Config& config,
+    StorageManager* storage_manager) {
+  // Check array URI
+  URI array_uri(array_name);
+  if (array_uri.is_invalid()) {
+    throw ConsolidatorException("Cannot consolidate array; Invalid URI");
+  }
+
+  // Check if array exists
+  ObjectType obj_type;
+  throw_if_not_ok(storage_manager->object_type(array_uri, &obj_type));
+
+  if (obj_type != ObjectType::ARRAY) {
+    throw ConsolidatorException(
+        "Cannot consolidate array; Array does not exist");
+  }
+
+  // Get encryption key from config
+  std::string encryption_key_from_cfg;
+  if (!encryption_key) {
+    bool found = false;
+    encryption_key_from_cfg = config.get("sm.encryption_key", &found);
+    assert(found);
+  }
+
+  if (!encryption_key_from_cfg.empty()) {
+    encryption_key = encryption_key_from_cfg.c_str();
+    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
+    std::string encryption_type_from_cfg;
+    bool found = false;
+    encryption_type_from_cfg = config.get("sm.encryption_type", &found);
+    assert(found);
+    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
+    throw_if_not_ok(st);
+    encryption_type = et.value();
+
+    if (!EncryptionKey::is_valid_key_length(
+            encryption_type,
+            static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
+      encryption_key = nullptr;
+      key_length = 0;
+    }
+  }
+
+  // Consolidate
+  auto consolidator = Consolidator::create(
+      ConsolidationMode::FRAGMENT, config, storage_manager);
+  auto fragment_consolidator =
+      dynamic_cast<FragmentConsolidator*>(consolidator.get());
+  throw_if_not_ok(fragment_consolidator->consolidate_fragments(
+      array_name, encryption_type, encryption_key, key_length, fragment_uris));
+}
+
 void Consolidator::check_array_uri(const char* array_name) {
   if (URI(array_name).is_tiledb()) {
     throw ConsolidatorException(

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -125,6 +125,26 @@ class Consolidator {
    */
   virtual void vacuum(const char* array_name);
 
+  /**
+   * Consolidates the fragments of an array into a single one.
+   *
+   * @param array_name The name of the array to be consolidated.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @param config Configuration parameters for the consolidation
+   *     (`nullptr` means default, which will use the config associated with
+   *      this instance).
+   */
+  static void array_consolidate(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length,
+      const Config& config,
+      StorageManager* storage_manager);
+
   /* ********************************* */
   /*           TYPE DEFINITIONS        */
   /* ********************************* */
@@ -148,6 +168,13 @@ class Consolidator {
    * @param storage_manager Storage manager.
    */
   explicit Consolidator(StorageManager* storage_manager);
+
+  /**
+   * Constructor.
+   *
+   * @param resources ContextResources.
+   */
+  explicit Consolidator(ContextResources& resources);
 
   /**
    * Checks if the array is remote.

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -153,6 +153,29 @@ class Consolidator {
       const Config& config,
       StorageManager* storage_manager);
 
+  /**
+   * Consolidates the fragments of an array into a single one.
+   *
+   * @param array_name The name of the array to be consolidated.
+   * @param encryption_type The encryption type of the array
+   * @param encryption_key If the array is encrypted, the private encryption
+   *    key. For unencrypted arrays, pass `nullptr`.
+   * @param key_length The length in bytes of the encryption key.
+   * @param fragment_uris URIs of the fragments to consolidate.
+   * @param config Configuration parameters for the consolidation
+   *     (`nullptr` means default, which will use the config associated with
+   *      this instance).
+   * @param storage_manager The storage manager.
+   */
+  static void fragments_consolidate(
+      const char* array_name,
+      EncryptionType encryption_type,
+      const void* encryption_key,
+      uint32_t key_length,
+      const std::vector<std::string> fragment_uris,
+      const Config& config,
+      StorageManager* storage_manager);
+
   /* ********************************* */
   /*           TYPE DEFINITIONS        */
   /* ********************************* */

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -190,6 +190,20 @@ class Consolidator {
       const std::vector<URI>& commit_uris,
       StorageManager* storage_manager);
 
+  /**
+   * Cleans up the array, such as its consolidated fragments and array
+   * metadata. Note that this will coarsen the granularity of time traveling
+   * (see docs for more information).
+   *
+   * @param array_name The name of the array to be vacuumed.
+   * @param config Configuration parameters for vacuuming.
+   * @param storage_manager The storage manager.
+   */
+  static void array_vacuum(
+      const char* array_name,
+      const Config& config,
+      StorageManager* storage_manager);
+
   /* ********************************* */
   /*           TYPE DEFINITIONS        */
   /* ********************************* */

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -176,6 +176,20 @@ class Consolidator {
       const Config& config,
       StorageManager* storage_manager);
 
+  /**
+   * Writes a consolidated commits file.
+   *
+   * @param write_version Write version.
+   * @param array_dir ArrayDirectory where the data is stored.
+   * @param commit_uris Commit files to include.
+   * @param storage_manager The storage manager.
+   */
+  static void write_consolidated_commits_file(
+      format_version_t write_version,
+      ArrayDirectory array_dir,
+      const std::vector<URI>& commit_uris,
+      StorageManager* storage_manager);
+
   /* ********************************* */
   /*           TYPE DEFINITIONS        */
   /* ********************************* */

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -46,6 +46,13 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
+class ConsolidatorException : public StatusException {
+ public:
+  explicit ConsolidatorException(const std::string& msg)
+      : StatusException("Consolidator", msg) {
+  }
+};
+
 class ArraySchema;
 class Config;
 class Query;
@@ -136,6 +143,7 @@ class Consolidator {
    * @param config Configuration parameters for the consolidation
    *     (`nullptr` means default, which will use the config associated with
    *      this instance).
+   * @param storage_manager The storage manager.
    */
   static void array_consolidate(
       const char* array_name,
@@ -168,13 +176,6 @@ class Consolidator {
    * @param storage_manager Storage manager.
    */
   explicit Consolidator(StorageManager* storage_manager);
-
-  /**
-   * Constructor.
-   *
-   * @param resources ContextResources.
-   */
-  explicit Consolidator(ContextResources& resources);
 
   /**
    * Checks if the array is remote.

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -184,7 +184,7 @@ FragmentConsolidator::FragmentConsolidator(
     : Consolidator(storage_manager) {
   auto st = set_config(config);
   if (!st.ok()) {
-    throw std::logic_error(st.message());
+    throw FragmentConsolidatorException(st.message());
   }
 }
 

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -199,7 +199,7 @@ class FragmentConsolidator : public Consolidator {
       const char* array_name,
       EncryptionType encryption_type,
       const void* encryption_key,
-      uint32_t key_length);
+      uint32_t key_length) override;
 
   /**
    * Consolidates only the fragments of the input array using a list of
@@ -229,7 +229,7 @@ class FragmentConsolidator : public Consolidator {
    *
    * @param array_name URI of array to vacuum.
    */
-  void vacuum(const char* array_name);
+  void vacuum(const char* array_name) override;
 
  private:
   /* ********************************* */

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.h
@@ -83,14 +83,14 @@ class FragmentMetaConsolidator : public Consolidator {
       const char* array_name,
       EncryptionType encryption_type,
       const void* encryption_key,
-      uint32_t key_length);
+      uint32_t key_length) override;
 
   /**
    * Performs the vacuuming operation.
    *
    * @param array_name URI of array to consolidate.
    */
-  void vacuum(const char* array_name);
+  void vacuum(const char* array_name) override;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/group_meta_consolidator.h
+++ b/tiledb/sm/consolidator/group_meta_consolidator.h
@@ -83,14 +83,14 @@ class GroupMetaConsolidator : public Consolidator {
       const char* group_name,
       EncryptionType encryption_type,
       const void* encryption_key,
-      uint32_t key_length);
+      uint32_t key_length) override;
 
   /**
    * Performs the vacuuming operation.
    *
    * @param group_name URI of group to consolidate.
    */
-  void vacuum(const char* group_name);
+  void vacuum(const char* group_name) override;
 
  private:
   /* ********************************* */

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -37,6 +37,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
+#include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/comparators.h"
 #include "tiledb/sm/misc/hilbert.h"
@@ -713,8 +714,11 @@ Status GlobalOrderWriter::finalize_global_write_state() {
     commit_uris.emplace_back(commit_uri);
 
     auto write_version = array_->array_schema_latest().write_version();
-    storage_manager_->write_consolidated_commits_file(
-        write_version, array_->array_directory(), commit_uris);
+    Consolidator::write_consolidated_commits_file(
+        write_version,
+        array_->array_directory(),
+        commit_uris,
+        storage_manager_);
   }
 
   // Delete global write state

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -267,19 +267,6 @@ void StorageManagerCanonical::delete_group(const char* group_name) {
   vfs()->remove_dirs(compute_tp(), dirs);
 }
 
-void StorageManagerCanonical::array_vacuum(
-    const char* array_name, const Config& config) {
-  URI array_uri(array_name);
-  if (array_uri.is_tiledb()) {
-    throw_if_not_ok(rest_client()->post_vacuum_to_rest(array_uri, config));
-    return;
-  }
-
-  auto mode = Consolidator::mode_from_config(config, true);
-  auto consolidator = Consolidator::create(mode, config, this);
-  consolidator->vacuum(array_name);
-}
-
 Status StorageManagerCanonical::array_create(
     const URI& array_uri,
     const shared_ptr<ArraySchema>& array_schema,

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -167,66 +167,6 @@ Status StorageManagerCanonical::group_close_for_writes(Group* group) {
   return Status::Ok();
 }
 
-Status StorageManagerCanonical::array_consolidate(
-    const char* array_name,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    const Config& config) {
-  // Check array URI
-  URI array_uri(array_name);
-  if (array_uri.is_invalid()) {
-    return logger_->status(
-        Status_StorageManagerError("Cannot consolidate array; Invalid URI"));
-  }
-
-  // Check if array exists
-  ObjectType obj_type;
-  RETURN_NOT_OK(object_type(array_uri, &obj_type));
-
-  if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot consolidate array; Array does not exist"));
-  }
-
-  if (array_uri.is_tiledb()) {
-    return rest_client()->post_consolidation_to_rest(array_uri, config);
-  }
-
-  // Get encryption key from config
-  std::string encryption_key_from_cfg;
-  if (!encryption_key) {
-    bool found = false;
-    encryption_key_from_cfg = config.get("sm.encryption_key", &found);
-    assert(found);
-  }
-
-  if (!encryption_key_from_cfg.empty()) {
-    encryption_key = encryption_key_from_cfg.c_str();
-    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-    std::string encryption_type_from_cfg;
-    bool found = false;
-    encryption_type_from_cfg = config.get("sm.encryption_type", &found);
-    assert(found);
-    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
-    RETURN_NOT_OK(st);
-    encryption_type = et.value();
-
-    if (!EncryptionKey::is_valid_key_length(
-            encryption_type,
-            static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      encryption_key = nullptr;
-      key_length = 0;
-    }
-  }
-
-  // Consolidate
-  auto mode = Consolidator::mode_from_config(config);
-  auto consolidator = Consolidator::create(mode, config, this);
-  return consolidator->consolidate(
-      array_name, encryption_type, encryption_key, key_length);
-}
-
 Status StorageManagerCanonical::fragments_consolidate(
     const char* array_name,
     EncryptionType encryption_type,

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -167,65 +167,6 @@ Status StorageManagerCanonical::group_close_for_writes(Group* group) {
   return Status::Ok();
 }
 
-Status StorageManagerCanonical::fragments_consolidate(
-    const char* array_name,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    const std::vector<std::string> fragment_uris,
-    const Config& config) {
-  // Check array URI
-  URI array_uri(array_name);
-  if (array_uri.is_invalid()) {
-    return logger_->status(
-        Status_StorageManagerError("Cannot consolidate array; Invalid URI"));
-  }
-
-  // Check if array exists
-  ObjectType obj_type;
-  RETURN_NOT_OK(object_type(array_uri, &obj_type));
-
-  if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot consolidate array; Array does not exist"));
-  }
-
-  // Get encryption key from config
-  std::string encryption_key_from_cfg;
-  if (!encryption_key) {
-    bool found = false;
-    encryption_key_from_cfg = config.get("sm.encryption_key", &found);
-    assert(found);
-  }
-
-  if (!encryption_key_from_cfg.empty()) {
-    encryption_key = encryption_key_from_cfg.c_str();
-    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-    std::string encryption_type_from_cfg;
-    bool found = false;
-    encryption_type_from_cfg = config.get("sm.encryption_type", &found);
-    assert(found);
-    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
-    RETURN_NOT_OK(st);
-    encryption_type = et.value();
-
-    if (!EncryptionKey::is_valid_key_length(
-            encryption_type,
-            static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      encryption_key = nullptr;
-      key_length = 0;
-    }
-  }
-
-  // Consolidate
-  auto consolidator =
-      Consolidator::create(ConsolidationMode::FRAGMENT, config, this);
-  auto fragment_consolidator =
-      dynamic_cast<FragmentConsolidator*>(consolidator.get());
-  return fragment_consolidator->consolidate_fragments(
-      array_name, encryption_type, encryption_key, key_length, fragment_uris);
-}
-
 void StorageManagerCanonical::write_consolidated_commits_file(
     format_version_t write_version,
     ArrayDirectory array_dir,

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -280,65 +280,6 @@ void StorageManagerCanonical::array_vacuum(
   consolidator->vacuum(array_name);
 }
 
-Status StorageManagerCanonical::array_metadata_consolidate(
-    const char* array_name,
-    EncryptionType encryption_type,
-    const void* encryption_key,
-    uint32_t key_length,
-    const Config& config) {
-  // Check array URI
-  URI array_uri(array_name);
-  if (array_uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot consolidate array metadata; Invalid URI"));
-  }
-  // Check if array exists
-  ObjectType obj_type;
-  RETURN_NOT_OK(object_type(array_uri, &obj_type));
-
-  if (obj_type != ObjectType::ARRAY) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot consolidate array metadata; Array does not exist"));
-  }
-
-  if (array_uri.is_tiledb()) {
-    return rest_client()->post_consolidation_to_rest(array_uri, config);
-  }
-
-  // Get encryption key from config
-  std::string encryption_key_from_cfg;
-  if (!encryption_key) {
-    bool found = false;
-    encryption_key_from_cfg = config.get("sm.encryption_key", &found);
-    assert(found);
-  }
-
-  if (!encryption_key_from_cfg.empty()) {
-    encryption_key = encryption_key_from_cfg.c_str();
-    key_length = static_cast<uint32_t>(encryption_key_from_cfg.size());
-    std::string encryption_type_from_cfg;
-    bool found = false;
-    encryption_type_from_cfg = config.get("sm.encryption_type", &found);
-    assert(found);
-    auto [st, et] = encryption_type_enum(encryption_type_from_cfg);
-    RETURN_NOT_OK(st);
-    encryption_type = et.value();
-
-    if (!EncryptionKey::is_valid_key_length(
-            encryption_type,
-            static_cast<uint32_t>(encryption_key_from_cfg.size()))) {
-      encryption_key = nullptr;
-      key_length = 0;
-    }
-  }
-
-  // Consolidate
-  auto consolidator =
-      Consolidator::create(ConsolidationMode::ARRAY_META, config, this);
-  return consolidator->consolidate(
-      array_name, encryption_type, encryption_key, key_length);
-}
-
 Status StorageManagerCanonical::array_create(
     const URI& array_uri,
     const shared_ptr<ArraySchema>& array_schema,

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -167,62 +167,6 @@ Status StorageManagerCanonical::group_close_for_writes(Group* group) {
   return Status::Ok();
 }
 
-void StorageManagerCanonical::write_consolidated_commits_file(
-    format_version_t write_version,
-    ArrayDirectory array_dir,
-    const std::vector<URI>& commit_uris) {
-  // Compute the file name.
-  auto name = storage_format::generate_consolidated_fragment_name(
-      commit_uris.front(), commit_uris.back(), write_version);
-
-  // Compute size of consolidated file. Save the sizes of the files to re-use
-  // below.
-  storage_size_t total_size = 0;
-  const auto base_uri_size = array_dir.uri().to_string().size();
-  std::vector<storage_size_t> file_sizes(commit_uris.size());
-  for (uint64_t i = 0; i < commit_uris.size(); i++) {
-    const auto& uri = commit_uris[i];
-    total_size += uri.to_string().size() - base_uri_size + 1;
-
-    // If the file is a delete, add the file size to the count and the size of
-    // the size variable.
-    if (stdx::string::ends_with(
-            uri.to_string(), constants::delete_file_suffix)) {
-      throw_if_not_ok(vfs()->file_size(uri, &file_sizes[i]));
-      total_size += file_sizes[i];
-      total_size += sizeof(storage_size_t);
-    }
-  }
-
-  // Write consolidated file, URIs are relative to the array URI.
-  std::vector<uint8_t> data(total_size);
-  storage_size_t file_index = 0;
-  for (uint64_t i = 0; i < commit_uris.size(); i++) {
-    // Add the uri.
-    const auto& uri = commit_uris[i];
-    std::string relative_uri = uri.to_string().substr(base_uri_size) + "\n";
-    memcpy(&data[file_index], relative_uri.data(), relative_uri.size());
-    file_index += relative_uri.size();
-
-    // For deletes, read the delete condition to the output file.
-    if (stdx::string::ends_with(
-            uri.to_string(), constants::delete_file_suffix)) {
-      memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
-      file_index += sizeof(storage_size_t);
-      throw_if_not_ok(vfs()->read(uri, 0, &data[file_index], file_sizes[i]));
-      file_index += file_sizes[i];
-    }
-  }
-
-  // Write the file to storage.
-  URI consolidated_commits_uri =
-      array_dir.get_commits_dir(write_version)
-          .join_path(name + constants::con_commits_file_suffix);
-  throw_if_not_ok(
-      vfs()->write(consolidated_commits_uri, data.data(), data.size()));
-  throw_if_not_ok(vfs()->close_file(consolidated_commits_uri));
-}
-
 void StorageManagerCanonical::delete_array(const char* array_name) {
   if (array_name == nullptr) {
     throw std::invalid_argument("[delete_array] Array name cannot be null");

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -282,27 +282,6 @@ class StorageManagerCanonical {
   void array_vacuum(const char* array_name, const Config& config);
 
   /**
-   * Consolidates the metadata of an array into a single file.
-   *
-   * @param array_name The name of the array whose metadata will be
-   *     consolidated.
-   * @param encryption_type The encryption type of the array
-   * @param encryption_key If the array is encrypted, the private encryption
-   *    key. For unencrypted arrays, pass `nullptr`.
-   * @param key_length The length in bytes of the encryption key.
-   * @param config Configuration parameters for the consolidation
-   *     (`nullptr` means default, which will use the config associated with
-   *      this instance).
-   * @return Status
-   */
-  Status array_metadata_consolidate(
-      const char* array_name,
-      EncryptionType encryption_type,
-      const void* encryption_key,
-      uint32_t key_length,
-      const Config& config);
-
-  /**
    * Creates a TileDB array storing its schema.
    *
    * @param array_uri The URI of the array to be created.

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -248,28 +248,6 @@ class StorageManagerCanonical {
   group_open_for_writes(Group* group);
 
   /**
-   * Consolidates the fragments of an array into a single one.
-   *
-   * @param array_name The name of the array to be consolidated.
-   * @param encryption_type The encryption type of the array
-   * @param encryption_key If the array is encrypted, the private encryption
-   *    key. For unencrypted arrays, pass `nullptr`.
-   * @param key_length The length in bytes of the encryption key.
-   * @param fragment_uris URIs of the fragments to consolidate.
-   * @param config Configuration parameters for the consolidation
-   *     (`nullptr` means default, which will use the config associated with
-   *      this instance).
-   * @return Status
-   */
-  Status fragments_consolidate(
-      const char* array_name,
-      EncryptionType encryption_type,
-      const void* encryption_key,
-      uint32_t key_length,
-      const std::vector<std::string> fragment_uris,
-      const Config& config);
-
-  /**
    * Writes a consolidated commits file.
    *
    * @param write_version Write version.

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -272,16 +272,6 @@ class StorageManagerCanonical {
   void delete_group(const char* group_name);
 
   /**
-   * Cleans up the array, such as its consolidated fragments and array
-   * metadata. Note that this will coarsen the granularity of time traveling
-   * (see docs for more information).
-   *
-   * @param array_name The name of the array to be vacuumed.
-   * @param config Configuration parameters for vacuuming.
-   */
-  void array_vacuum(const char* array_name, const Config& config);
-
-  /**
    * Creates a TileDB array storing its schema.
    *
    * @param array_uri The URI of the array to be created.

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -248,18 +248,6 @@ class StorageManagerCanonical {
   group_open_for_writes(Group* group);
 
   /**
-   * Writes a consolidated commits file.
-   *
-   * @param write_version Write version.
-   * @param array_dir ArrayDirectory where the data is stored.
-   * @param commit_uris Commit files to include.
-   */
-  void write_consolidated_commits_file(
-      format_version_t write_version,
-      ArrayDirectory array_dir,
-      const std::vector<URI>& commit_uris);
-
-  /**
    * Cleans up the array data.
    *
    * @param array_name The name of the array whose data is to be deleted.

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -255,26 +255,6 @@ class StorageManagerCanonical {
    * @param encryption_key If the array is encrypted, the private encryption
    *    key. For unencrypted arrays, pass `nullptr`.
    * @param key_length The length in bytes of the encryption key.
-   * @param config Configuration parameters for the consolidation
-   *     (`nullptr` means default, which will use the config associated with
-   *      this instance).
-   * @return Status
-   */
-  Status array_consolidate(
-      const char* array_name,
-      EncryptionType encryption_type,
-      const void* encryption_key,
-      uint32_t key_length,
-      const Config& config);
-
-  /**
-   * Consolidates the fragments of an array into a single one.
-   *
-   * @param array_name The name of the array to be consolidated.
-   * @param encryption_type The encryption type of the array
-   * @param encryption_key If the array is encrypted, the private encryption
-   *    key. For unencrypted arrays, pass `nullptr`.
-   * @param key_length The length in bytes of the encryption key.
    * @param fragment_uris URIs of the fragments to consolidate.
    * @param config Configuration parameters for the consolidation
    *     (`nullptr` means default, which will use the config associated with


### PR DESCRIPTION
This moves consolidation out of StorageManager using static methods in `tiledb::sm::Consolidator`. The subclasses that derive from Consolidator will still need access to the StorageManager for opening the arrays and groups in the `consolidate` and `vacuum` overrides.

---
TYPE: NO_HISTORY
DESC: Move consolidation calls out of StorageManager.