### PR TITLE
Remove serialization non C.41 constructors from index_read_state_from_capnp.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -94,7 +94,7 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
 
 template <class BitmapType>
 bool SparseGlobalOrderReader<BitmapType>::incomplete() const {
-  return !read_state_.done_adding_result_tiles_ ||
+  return !read_state_.done_adding_result_tiles() ||
          memory_used_for_coords_total_ != 0;
 }
 
@@ -131,7 +131,7 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
 
   // Handle empty array.
   if (fragment_metadata_.empty()) {
-    read_state_.done_adding_result_tiles_ = true;
+    read_state_.done_adding_result_tiles() = true;
     return Status::Ok();
   }
 
@@ -416,7 +416,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles(
           auto tile_num = fragment_metadata_[f]->tile_num();
 
           // Figure out the start index.
-          auto start = read_state_.frag_idx_[f].tile_idx_;
+          auto start = read_state_.frag_idx()[f].tile_idx_;
           if (!result_tiles[f].empty()) {
             start = std::max(start, result_tiles[f].back().tile_idx() + 1);
           }
@@ -470,7 +470,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles(
     logger_->debug("All result tiles loaded");
   }
 
-  read_state_.done_adding_result_tiles_ = done_adding_result_tiles;
+  read_state_.done_adding_result_tiles() = done_adding_result_tiles;
 
   // Return the list of tiles added.
   std::vector<ResultTile*> created_tiles;
@@ -789,8 +789,8 @@ bool SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
       // Increment the tile index, which should clear all tiles in
       // end_iteration.
       if (!result_tiles[frag_idx].empty()) {
-        read_state_.frag_idx_[frag_idx].tile_idx_++;
-        read_state_.frag_idx_[frag_idx].cell_idx_ = 0;
+        read_state_.frag_idx()[frag_idx].tile_idx_++;
+        read_state_.frag_idx()[frag_idx].cell_idx_ = 0;
       }
 
       // This fragment has more tiles potentially.
@@ -876,7 +876,7 @@ void SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
 template <class BitmapType>
 void SparseGlobalOrderReader<BitmapType>::update_frag_idx(
     GlobalOrderResultTile<BitmapType>* tile, uint64_t c) {
-  auto& frag_idx = read_state_.frag_idx_[tile->frag_idx()];
+  auto& frag_idx = read_state_.frag_idx()[tile->frag_idx()];
   auto t = tile->tile_idx();
   if ((t == frag_idx.tile_idx_ && c > frag_idx.cell_idx_) ||
       t > frag_idx.tile_idx_) {
@@ -932,8 +932,8 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
 
           // Add the tile to the queue.
           uint64_t cell_idx =
-              read_state_.frag_idx_[f].tile_idx_ == rt_it[f]->tile_idx() ?
-                  read_state_.frag_idx_[f].cell_idx_ :
+              read_state_.frag_idx()[f].tile_idx_ == rt_it[f]->tile_idx() ?
+                  read_state_.frag_idx()[f].cell_idx_ :
                   0;
           GlobalOrderResultCoords rc(&*(rt_it[f]), cell_idx);
           bool res = add_next_cell_to_queue(
@@ -1716,7 +1716,7 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
   while (result_cell_slabs.size() > max_cs_idx) {
     // Revert progress for this slab in read state, and pop it.
     auto& last_rcs = result_cell_slabs.back();
-    read_state_.frag_idx_[last_rcs.tile_->frag_idx()] =
+    read_state_.frag_idx()[last_rcs.tile_->frag_idx()] =
         FragIdx(last_rcs.tile_->tile_idx(), last_rcs.start_);
     result_cell_slabs.pop_back();
   }
@@ -1758,7 +1758,7 @@ SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
     while (query_buffer.original_buffer_var_size_ < new_var_buffer_size) {
       // Revert progress for this slab in read state, and pop it.
       auto& last_rcs = result_cell_slabs.back();
-      read_state_.frag_idx_[last_rcs.tile_->frag_idx()] =
+      read_state_.frag_idx()[last_rcs.tile_->frag_idx()] =
           FragIdx(last_rcs.tile_->tile_idx(), last_rcs.start_);
       result_cell_slabs.pop_back();
 
@@ -1787,7 +1787,7 @@ SparseGlobalOrderReader<BitmapType>::compute_var_size_offsets(
     new_var_buffer_size = ((OffType*)query_buffer.buffer_)[total_cells];
 
     // Update the cell progress.
-    read_state_.frag_idx_[last_rcs.tile_->frag_idx()] =
+    read_state_.frag_idx()[last_rcs.tile_->frag_idx()] =
         FragIdx(last_rcs.tile_->tile_idx(), last_rcs.start_ + last_rcs.length_);
 
     // Remove empty cell slab.
@@ -2192,7 +2192,7 @@ void SparseGlobalOrderReader<BitmapType>::end_iteration(
       storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
         while (!result_tiles[f].empty() &&
                result_tiles[f].front().tile_idx() <
-                   read_state_.frag_idx_[f].tile_idx_) {
+                   read_state_.frag_idx()[f].tile_idx_) {
           remove_result_tile(f, result_tiles[f].begin(), result_tiles);
         }
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -70,6 +70,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
     StrategyParams& params,
     bool include_coords)
     : ReaderBase(stats, logger, params)
+    , read_state_(array_->fragment_metadata().size())
     , tmp_read_state_(array_->fragment_metadata().size())
     , memory_budget_(config_, reader_string)
     , include_coords_(include_coords)
@@ -131,13 +132,13 @@ SparseIndexReaderBase::SparseIndexReaderBase(
 /*        PROTECTED METHODS       */
 /* ****************************** */
 
-const typename SparseIndexReaderBase::ReadState*
+const typename SparseIndexReaderBase::ReadState&
 SparseIndexReaderBase::read_state() const {
-  return &read_state_;
+  return read_state_;
 }
 
-typename SparseIndexReaderBase::ReadState* SparseIndexReaderBase::read_state() {
-  return &read_state_;
+typename SparseIndexReaderBase::ReadState& SparseIndexReaderBase::read_state() {
+  return read_state_;
 }
 
 uint64_t SparseIndexReaderBase::available_memory() {
@@ -319,11 +320,10 @@ Status SparseIndexReaderBase::load_initial_data() {
   }
 
   auto timer_se = stats_->start_timer("load_initial_data");
-  read_state_.done_adding_result_tiles_ = false;
+  read_state_.done_adding_result_tiles() = false;
 
   // For easy reference.
   const auto dim_num = array_schema_.dim_num();
-  auto fragment_num = fragment_metadata_.size();
 
   // Load delete conditions.
   auto&& [st, conditions, update_values] =
@@ -366,9 +366,6 @@ Status SparseIndexReaderBase::load_initial_data() {
     }
   }
 
-  // Make sure there is enough space for tiles data.
-  read_state_.frag_idx_.resize(fragment_num);
-
   // Calculate ranges of tiles in the subarray, if set.
   if (subarray_.is_set()) {
     // At this point, full memory budget is available.
@@ -385,7 +382,7 @@ Status SparseIndexReaderBase::load_initial_data() {
     // below.
     RETURN_NOT_OK(subarray_.precompute_all_ranges_tile_overlap(
         storage_manager_->compute_tp(),
-        read_state_.frag_idx_,
+        read_state_.frag_idx(),
         &tmp_read_state_));
 
     if (tmp_read_state_.memory_used_tile_ranges() >

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -137,8 +137,8 @@ SparseIndexReaderBase::read_state() const {
   return read_state_;
 }
 
-typename SparseIndexReaderBase::ReadState& SparseIndexReaderBase::read_state() {
-  return read_state_;
+void SparseIndexReaderBase::set_read_state(ReadState read_state) {
+  read_state_ = std::move(read_state);
 }
 
 uint64_t SparseIndexReaderBase::available_memory() {
@@ -320,7 +320,7 @@ Status SparseIndexReaderBase::load_initial_data() {
   }
 
   auto timer_se = stats_->start_timer("load_initial_data");
-  read_state_.done_adding_result_tiles() = false;
+  read_state_.set_done_adding_result_tiles(false);
 
   // For easy reference.
   const auto dim_num = array_schema_.dim_num();

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -572,7 +572,7 @@ class SparseIndexReaderBase : public ReaderBase {
   const ReadState& read_state() const;
 
   /**
-   * Sets the new read state.
+   * Sets the new read state. Used only for deserialization.
    *
    * @param read_state New read_state value.
    * @return void

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -296,20 +296,49 @@ class SparseIndexReaderBase : public ReaderBase {
    * it is really required to determine if a query is incomplete from the client
    * side of a cloud request.
    */
-  struct ReadState {
-    /** The tile index inside of each fragments. */
-    std::vector<FragIdx> frag_idx_;
+  class ReadState {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
 
-    /** Is the reader done with the query. */
-    bool done_adding_result_tiles_;
+    ReadState() = delete;
 
-    ReadState() {
+    ReadState(size_t frag_idxs_len)
+        : frag_idx_(frag_idxs_len) {
     }
 
     ReadState(std::vector<FragIdx>&& frag_idx, bool done_adding_result_tiles)
         : frag_idx_(std::move(frag_idx))
         , done_adding_result_tiles_(done_adding_result_tiles) {
     }
+
+    /* ********************************* */
+    /*              GETTERS              */
+    /* ********************************* */
+
+    const bool& done_adding_result_tiles() const {
+      return done_adding_result_tiles_;
+    }
+
+    bool& done_adding_result_tiles() {
+      return done_adding_result_tiles_;
+    }
+
+    std::vector<FragIdx>& frag_idx() {
+      return frag_idx_;
+    }
+
+    const std::vector<FragIdx>& frag_idx() const {
+      return frag_idx_;
+    }
+
+   private:
+    /** The tile index inside of each fragments. */
+    std::vector<FragIdx> frag_idx_;
+
+    /** Is the reader done with the query. */
+    bool done_adding_result_tiles_;
   };
 
   /**
@@ -514,16 +543,16 @@ class SparseIndexReaderBase : public ReaderBase {
   /**
    * Returns the current read state.
    *
-   * @return pointer to the read state.
+   * @return reference to the read state.
    */
-  const ReadState* read_state() const;
+  const ReadState& read_state() const;
 
   /**
    * Returns the current read state.
    *
-   * @return pointer to the read state.
+   * @return reference to the read state.
    */
-  ReadState* read_state();
+  ReadState& read_state();
 
  protected:
   /* ********************************* */

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -339,7 +339,6 @@ class SparseIndexReaderBase : public ReaderBase {
      * Sets a value in the fragment index vector.
      * @param idx The index of the vector.
      * @param val The value to set frag_idx[idx] to.
-     * @return void
      */
     inline void set_frag_idx(uint64_t idx, FragIdx val) {
       if (idx >= frag_idx_.size()) {

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -302,12 +302,17 @@ class SparseIndexReaderBase : public ReaderBase {
     /*     CONSTRUCTORS & DESTRUCTORS    */
     /* ********************************* */
 
+    /** Delete default constructor. */
     ReadState() = delete;
 
+    /** Constructor.
+     * @param frag_idxs_len The length of the fragment index vector.
+     */
     ReadState(size_t frag_idxs_len)
         : frag_idx_(frag_idxs_len) {
     }
 
+    /** Constructor used in deserialization. */
     ReadState(std::vector<FragIdx>&& frag_idx, bool done_adding_result_tiles)
         : frag_idx_(std::move(frag_idx))
         , done_adding_result_tiles_(done_adding_result_tiles) {
@@ -321,7 +326,7 @@ class SparseIndexReaderBase : public ReaderBase {
      * Return whether the tiles that will be processed are loaded in memory.
      * @return Done adding result tiles.
      */
-    const bool& done_adding_result_tiles() const {
+    inline bool done_adding_result_tiles() const {
       return done_adding_result_tiles_;
     }
 
@@ -329,7 +334,6 @@ class SparseIndexReaderBase : public ReaderBase {
      * Sets the flag that determines whether the tiles that will be processed
      * are loaded in memory.
      * @param done_adding_result_tiles Done adding result tiles.
-     * @return void
      */
     inline void set_done_adding_result_tiles(bool done_adding_result_tiles) {
       done_adding_result_tiles_ = done_adding_result_tiles;
@@ -355,6 +359,10 @@ class SparseIndexReaderBase : public ReaderBase {
     const std::vector<FragIdx>& frag_idx() const {
       return frag_idx_;
     }
+
+    /* ********************************* */
+    /*         PRIVATE ATTRIBUTES        */
+    /* ********************************* */
 
    private:
     /** The tile index inside of each fragments. */
@@ -574,7 +582,6 @@ class SparseIndexReaderBase : public ReaderBase {
    * Sets the new read state. Used only for deserialization.
    *
    * @param read_state New read_state value.
-   * @return void
    */
   void set_read_state(ReadState read_state);
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -302,6 +302,14 @@ class SparseIndexReaderBase : public ReaderBase {
 
     /** Is the reader done with the query. */
     bool done_adding_result_tiles_;
+
+    ReadState() {
+    }
+
+    ReadState(std::vector<FragIdx>&& frag_idx, bool done_adding_result_tiles)
+        : frag_idx_(std::move(frag_idx))
+        , done_adding_result_tiles_(done_adding_result_tiles) {
+    }
   };
 
   /**

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -314,21 +314,45 @@ class SparseIndexReaderBase : public ReaderBase {
     }
 
     /* ********************************* */
-    /*              GETTERS              */
+    /*                API                */
     /* ********************************* */
 
+    /**
+     * Return whether the tiles that will be processed are loaded in memory.
+     * @return Done adding result tiles.
+     */
     const bool& done_adding_result_tiles() const {
       return done_adding_result_tiles_;
     }
 
-    bool& done_adding_result_tiles() {
-      return done_adding_result_tiles_;
+    /**
+     * Sets the flag that determines whether the tiles that will be processed
+     * are loaded in memory.
+     * @param done_adding_result_tiles Done adding result tiles.
+     * @return void
+     */
+    inline void set_done_adding_result_tiles(bool done_adding_result_tiles) {
+      done_adding_result_tiles_ = done_adding_result_tiles;
     }
 
-    std::vector<FragIdx>& frag_idx() {
-      return frag_idx_;
+    /**
+     * Sets a value in the fragment index vector.
+     * @param idx The index of the vector.
+     * @param val The value to set frag_idx[idx] to.
+     * @return void
+     */
+    inline void set_frag_idx(uint64_t idx, FragIdx val) {
+      if (idx >= frag_idx_.size()) {
+        throw std::runtime_error(
+            "ReadState::set_frag_idx: idx greater than frag_idx_'s size.");
+      }
+      frag_idx_[idx] = std::move(val);
     }
 
+    /**
+     * Returns a read-only version of the fragment index vector.
+     * @return The fragment index vector.
+     */
     const std::vector<FragIdx>& frag_idx() const {
       return frag_idx_;
     }
@@ -337,7 +361,7 @@ class SparseIndexReaderBase : public ReaderBase {
     /** The tile index inside of each fragments. */
     std::vector<FragIdx> frag_idx_;
 
-    /** Is the reader done with the query. */
+    /** Have all tiles to be processed been loaded in memory? */
     bool done_adding_result_tiles_;
   };
 
@@ -543,16 +567,17 @@ class SparseIndexReaderBase : public ReaderBase {
   /**
    * Returns the current read state.
    *
-   * @return reference to the read state.
+   * @return const reference to the read state.
    */
   const ReadState& read_state() const;
 
   /**
-   * Returns the current read state.
+   * Sets the new read state.
    *
-   * @return reference to the read state.
+   * @param read_state New read_state value.
+   * @return void
    */
-  ReadState& read_state();
+  void set_read_state(ReadState read_state);
 
  protected:
   /* ********************************* */

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -149,7 +149,7 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
 
   // Handle empty array.
   if (fragment_metadata_.empty()) {
-    read_state_.done_adding_result_tiles() = true;
+    read_state_.set_done_adding_result_tiles(true);
     return Status::Ok();
   }
 
@@ -502,7 +502,7 @@ SparseUnorderedWithDupsReader<BitmapType>::create_result_tiles() {
     logger_->debug("All result tiles loaded");
   }
 
-  read_state_.done_adding_result_tiles() = done_adding_result_tiles;
+  read_state_.set_done_adding_result_tiles(done_adding_result_tiles);
 
   return result_tiles;
 }
@@ -1724,18 +1724,20 @@ bool SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
 
   // Adjust tile index.
   for (auto rt : result_tiles) {
-    read_state_.frag_idx()[rt->frag_idx()] = FragIdx(rt->tile_idx() + 1, 0);
+    read_state_.set_frag_idx(rt->frag_idx(), FragIdx(rt->tile_idx() + 1, 0));
   }
 
   // If the last tile is not fully copied, save the cell index.
   if (result_tiles.size() > 0) {
     auto last_tile =
         (UnorderedWithDupsResultTile<BitmapType>*)result_tiles.back();
-    auto& frag_tile_idx = read_state_.frag_idx()[last_tile->frag_idx()];
     if (last_tile->result_num() != last_tile_cells_copied) {
-      frag_tile_idx.tile_idx_ = last_tile->tile_idx();
-      frag_tile_idx.cell_idx_ =
-          last_tile->pos_with_given_result_sum(0, last_tile_cells_copied) + 1;
+      read_state_.set_frag_idx(
+          last_tile->frag_idx(),
+          FragIdx(
+              last_tile->tile_idx(),
+              last_tile->pos_with_given_result_sum(0, last_tile_cells_copied) +
+                  1));
     }
   }
 

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -663,10 +663,9 @@ Status read_state_from_capnp(
   return Status::Ok();
 }
 
-Status index_read_state_from_capnp(
+tiledb::sm::SparseIndexReaderBase::ReadState index_read_state_from_capnp(
     const ArraySchema& schema,
-    const capnp::ReadStateIndex::Reader& read_state_reader,
-    SparseIndexReaderBase* reader) {
+    const capnp::ReadStateIndex::Reader& read_state_reader) {
   bool done_reading = read_state_reader.getDoneAddingResultTiles();
   assert(read_state_reader.hasFragTileIdx());
   std::vector<FragIdx> fragment_indexes;
@@ -677,9 +676,8 @@ Status index_read_state_from_capnp(
     fragment_indexes.emplace_back(tile_idx, cell_idx);
   }
 
-  reader->read_state() = tiledb::sm::SparseIndexReaderBase::ReadState(
+  return tiledb::sm::SparseIndexReaderBase::ReadState(
       std::move(fragment_indexes), done_reading);
-  return Status::Ok();
 }
 
 Status dense_read_state_from_capnp(
@@ -1177,8 +1175,8 @@ Status index_reader_from_capnp(
 
   // Read state
   if (reader_reader.hasReadState())
-    RETURN_NOT_OK(index_read_state_from_capnp(
-        schema, reader_reader.getReadState(), reader));
+    reader->set_read_state(
+        index_read_state_from_capnp(schema, reader_reader.getReadState()));
 
   // Query condition
   if (reader_reader.hasCondition()) {

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -596,18 +596,18 @@ Status read_state_to_capnp(
 }
 
 Status index_read_state_to_capnp(
-    const SparseIndexReaderBase::ReadState* read_state,
+    const SparseIndexReaderBase::ReadState& read_state,
     capnp::ReaderIndex::Builder* builder) {
   auto read_state_builder = builder->initReadState();
 
   read_state_builder.setDoneAddingResultTiles(
-      read_state->done_adding_result_tiles_);
+      read_state.done_adding_result_tiles());
 
   auto frag_tile_idx_builder =
-      read_state_builder.initFragTileIdx(read_state->frag_idx_.size());
-  for (size_t i = 0; i < read_state->frag_idx_.size(); ++i) {
-    frag_tile_idx_builder[i].setTileIdx(read_state->frag_idx_[i].tile_idx_);
-    frag_tile_idx_builder[i].setCellIdx(read_state->frag_idx_[i].cell_idx_);
+      read_state_builder.initFragTileIdx(read_state.frag_idx().size());
+  for (size_t i = 0; i < read_state.frag_idx().size(); ++i) {
+    frag_tile_idx_builder[i].setTileIdx(read_state.frag_idx()[i].tile_idx_);
+    frag_tile_idx_builder[i].setCellIdx(read_state.frag_idx()[i].cell_idx_);
   }
 
   return Status::Ok();
@@ -677,13 +677,7 @@ Status index_read_state_from_capnp(
     fragment_indexes.emplace_back(tile_idx, cell_idx);
   }
 
-  auto read_state = reader->read_state();
-  if (read_state == nullptr) {
-    throw std::runtime_error(
-        "index_read_state_from_capnp: read_state within SparseIndexReaderBase "
-        "object is null.");
-  }
-  *read_state = tiledb::sm::SparseIndexReaderBase::ReadState(
+  reader->read_state() = tiledb::sm::SparseIndexReaderBase::ReadState(
       std::move(fragment_indexes), done_reading);
   return Status::Ok();
 }

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -2640,7 +2640,7 @@ Status Subarray::precompute_tile_overlap(
 
 Status Subarray::precompute_all_ranges_tile_overlap(
     ThreadPool* const compute_tp,
-    std::vector<FragIdx>& frag_tile_idx,
+    const std::vector<FragIdx>& frag_tile_idx,
     ITileRange* tile_ranges) {
   auto timer_se = stats_->start_timer("read_compute_simple_tile_overlap");
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -707,7 +707,7 @@ class Subarray {
    */
   Status precompute_all_ranges_tile_overlap(
       ThreadPool* const compute_tp,
-      std::vector<FragIdx>& frag_tile_idx,
+      const std::vector<FragIdx>& frag_tile_idx,
       ITileRange* tile_ranges);
 
   /**


### PR DESCRIPTION
Made index_read_state_from_capnp C41 compliant. 
---
TYPE: NO_HISTORY
DESC: Remove serialization non C.41 constructors from index_read_state_from_capnp
