### PR TITLE
Fix documentation of `Subarray::set_config` to match `tiledb_subarray_set_config`.

### DIFF
--- a/tiledb/sm/cpp_api/subarray.h
+++ b/tiledb/sm/cpp_api/subarray.h
@@ -331,16 +331,7 @@ class Subarray {
    * Setting configuration with this function overrides the following
    * Subarray-level parameters only:
    *
-   * - `sm.memory_budget`
-   * - `sm.memory_budget_var`
-   * - `sm.sub_partitioner_memory_budget`
-   * - `sm.var_offsets.mode`
-   * - `sm.var_offsets.extra_element`
-   * - `sm.var_offsets.bitsize`
-   * - `sm.check_coord_dups`
-   * - `sm.check_coord_oob`
-   * - `sm.check_global_order`
-   * - `sm.dedup_coords`
+   * - `sm.read_range_oob`
    */
   Subarray& set_config(const Config& config) {
     auto ctx = ctx_.get();


### PR DESCRIPTION
See https://github.com/TileDB-Inc/TileDB/blob/1ea150f531e0da288594e410e2d1d986741dfcf2/tiledb/sm/c_api/tiledb.h#L2364-L2375

---
TYPE: BUG
DESC: Fix documentation of `Subarray::set_config` to match `tiledb_subarray_set_config`.