### PR TITLE
Update GitHub Actions to use Node 20

### DIFF
--- a/.github/workflows/build-dockerfile.yml
+++ b/.github/workflows/build-dockerfile.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
             submodules: true
             fetch-depth: 0

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 90
     name: Build Docs
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"
@@ -42,7 +42,7 @@ jobs:
         shell: bash
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
 
       - name: Install Doxygen
         run: |

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Prepare git
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Get vcpkg commit to checkout
@@ -25,7 +25,7 @@ jobs:
       # We clone vcpkg ourselves because having FetchContent do it inside
       # the build directory causes compilation errors due to long paths.
       - name: Checkout vcpkg repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: microsoft/vcpkg
           path: vcpkg
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -53,7 +53,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
       - name: "Upload binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mingw-w64-${{ matrix.msystem }}-tiledb
           path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*

--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -17,14 +17,14 @@ jobs:
     timeout-minutes: 120
     name: Build tiledb_unit
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Print env'
         run: ./scripts/ci/posix/print-env.sh
         shell: bash
 
       # Need this for virtualenv and arrow tests if enabled
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - run: |
@@ -43,7 +43,7 @@ jobs:
 
       # Save the tiledb_unit binary for use in the next step
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tiledb_unit
           path: ${{ github.workspace }}/build/tiledb/test/tiledb_unit
@@ -63,10 +63,10 @@ jobs:
     timeout-minutes: 30
     name: ${{ matrix.tiledb_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tiledb_unit
           path: ${{ github.workspace }}/build/tiledb/test/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,7 +79,7 @@ jobs:
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -122,7 +122,7 @@ jobs:
       - name: Prepare git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -408,7 +408,7 @@ jobs:
 
       - name: 'upload dumpfile artifacts' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ always() == true && startsWith(matrix.os, 'windows-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{matrix.environ}}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 90
     name: Check Clang Format
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"

--- a/.github/workflows/check-heap-memory-api-violations.yml
+++ b/.github/workflows/check-heap-memory-api-violations.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 90
     name: Check Heap Memory Violations
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: 'Print env'
         run: |
           echo "'uname -s' is:"

--- a/.github/workflows/check-pr-body.yml
+++ b/.github/workflows/check-pr-body.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run PR body checker
         run: |
           cat <<'EOF' | scripts/parse_pr.py

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -80,14 +80,29 @@ jobs:
     timeout-minutes: ${{ inputs.timeout || 90 }}
     name: ${{matrix.os}} - ${{ inputs.ci_backend }}${{ inputs.ci_option }}
     steps:
+      # v4 uses node 20 which is incompatible with the libc version of the manylinux image
+      - uses: actions/checkout@v3
+        if: inputs.manylinux
+        with:
+            submodules: true
+            fetch-depth: 0
       - uses: actions/checkout@v4
+        if: ${{ !inputs.manylinux }}
         with:
             submodules: true
             fetch-depth: 0
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
+      # v7 uses node 20 which is incompatible with the libc version of the manylinux image
+      - uses: actions/github-script@v6
+        if: inputs.manylinux
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - uses: actions/github-script@v7
+        if: ${{ !inputs.manylinux }}
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -226,8 +241,19 @@ jobs:
         run: du --exclude _deps -h $GITHUB_WORKSPACE/build
         if: ${{ failure() }}
 
+      # v4 uses node 20 which is incompatible with the libc version of the manylinux image
       - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
-        if: ${{ startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
+        if: ${{ inputs.manylinux && startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
+        uses: actions/upload-artifact@v3
+        with:
+          retention-days: 10
+          name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
+          if-no-files-found: warn # 'ignore', 'warn' or 'error' are available, defaults to `warn`
+          path: |
+            /var/lib/apport/coredump/
+
+      - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
+        if: ${{ !inputs.manylinux && startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
         uses: actions/upload-artifact@v4
         with:
           retention-days: 10

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -80,14 +80,14 @@ jobs:
     timeout-minutes: ${{ inputs.timeout || 90 }}
     name: ${{matrix.os}} - ${{ inputs.ci_backend }}${{ inputs.ci_option }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
             submodules: true
             fetch-depth: 0
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -113,7 +113,7 @@ jobs:
 
       # Need this for virtualenv and arrow tests if enabled
       - name: 'Install Python'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         if: ${{ !inputs.manylinux }}
         with:
           python-version: '3.8'
@@ -228,7 +228,7 @@ jobs:
 
       - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
@@ -238,7 +238,7 @@ jobs:
 
       - name: 'Upload failure artifacts (macOS)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ failure() == true && startsWith(matrix.os, 'macos-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "${{ matrix.os }}.coredumps.${{ github.job }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/nightly-dockerfile.yml
+++ b/.github/workflows/nightly-dockerfile.yml
@@ -18,7 +18,7 @@ jobs:
     name: ${{ matrix.dockerfile }}
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -38,7 +38,7 @@ jobs:
         run: printenv
 
       - name: Checkout TileDB `dev`
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure TileDB CMake (not-Windows)
         if: ${{ ! contains(matrix.os, 'windows') }}
@@ -73,7 +73,7 @@ jobs:
     if: failure() || cancelled()
     steps:
       - name: Checkout TileDB `dev`
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/quarto-render.yml
+++ b/.github/workflows/quarto-render.yml
@@ -26,7 +26,7 @@ jobs:
   quarto-render-and-deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Quarto
       uses: quarto-dev/quarto-actions/setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,12 @@ jobs:
     steps:
       - name: Checkout TileDB
         # v4 uses node 20 which is incompatible with the libc version of the manylinux image
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
         if: ${{ startsWith(matrix.os, 'macos-') == true }}  
       - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -110,7 +110,7 @@ jobs:
           Compress-Archive -Path dist\* -DestinationPath ${{ steps.get-values.outputs.archive_name }}.zip
         shell: pwsh
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tiledb-dist
           path: ${{ steps.get-values.outputs.archive_name }}.*
@@ -118,7 +118,7 @@ jobs:
         run: |
           tar -czf build-${{ matrix.platform }}.tar.gz -C build .
       - name: Upload build directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tiledb-build
           path: build-${{ matrix.platform }}.tar.gz
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: tiledb-dist
           path: dist
@@ -149,12 +149,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: tiledb-dist
           path: dist
       - name: Publish release artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,14 +53,27 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
+      # v4 uses node 20 which is incompatible with the libc version of the manylinux image
+      - name: Checkout TileDB (Node 16)
+        uses: actions/checkout@v3
+        if: matrix.manylinux
       - name: Checkout TileDB
-        # v4 uses node 20 which is incompatible with the libc version of the manylinux image
         uses: actions/checkout@v4
+        if: ${{ !matrix.manylinux }}
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
-        if: ${{ startsWith(matrix.os, 'macos-') == true }}  
+        if: ${{ startsWith(matrix.os, 'macos-') == true }}
+      # v7 uses node 20 which is incompatible with the libc version of the manylinux image
+      - name: Export GitHub Actions cache variables (Node 16)
+        uses: actions/github-script@v6
+        if: matrix.manylinux
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v7
+        if: ${{ !matrix.manylinux }}
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
@@ -109,16 +122,32 @@ jobs:
         run: |
           Compress-Archive -Path dist\* -DestinationPath ${{ steps.get-values.outputs.archive_name }}.zip
         shell: pwsh
+      # v4 uses node 20 which is incompatible with the libc version of the manylinux image
+      - name: Upload release artifacts (Node 16)
+        uses: actions/upload-artifact@v3
+        if: matrix.manylinux
+        with:
+          name: tiledb-dist
+          path: ${{ steps.get-values.outputs.archive_name }}.*
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
+        if: ${{ !matrix.manylinux }}
         with:
           name: tiledb-dist
           path: ${{ steps.get-values.outputs.archive_name }}.*
       - name: Archive build directory
         run: |
           tar -czf build-${{ matrix.platform }}.tar.gz -C build .
+      # v4 uses node 20 which is incompatible with the libc version of the manylinux image
+      - name: Upload build directory (Node 16)
+        uses: actions/upload-artifact@v3
+        if: matrix.manylinux
+        with:
+          name: tiledb-build
+          path: build-${{ matrix.platform }}.tar.gz
       - name: Upload build directory
         uses: actions/upload-artifact@v4
+        if: ${{ !matrix.manylinux }}
         with:
           name: tiledb-build
           path: build-${{ matrix.platform }}.tar.gz

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
     name: Build - ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
@@ -29,7 +29,7 @@ jobs:
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');


### PR DESCRIPTION
GitHub plans to deprecate Node 16 in Spring 2024

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

I updated all the obvious actions from GitHub to their latest Node 20 supported version:

https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400
https://github.com/actions/github-script#v7
https://github.com/actions/upload-artifact#v4---whats-new
https://github.com/actions/download-artifact#v4---whats-new
https://github.com/actions/setup-python/releases/tag/v5.0.0

---
TYPE: NO_HISTORY
DESC: Update GitHub Actions to use Node 20
