### PR TITLE
Ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ examples/obj/*
 scripts/deps-staging/*
 .idea
 *.DS_Store
+compile_commands.json
 doc/venv
 doc/source/__pycache__
 doc/source/_build


### PR DESCRIPTION
This is just a quality of life so that developers can symlink compile_commands.json to wherever they place their build directory. The reaoning for this is that a number of editor extensions use this file to configure their LSP interface for improved editor support.

---
TYPE: NO_HISTORY
DESC: Ignore compile_commands.json