### PR TITLE
Remove serialization non C.41 constructors from query condition.

### DIFF
--- a/test/src/unit-QueryCondition-serialization.cc
+++ b/test/src/unit-QueryCondition-serialization.cc
@@ -272,7 +272,7 @@ TEST_CASE(
               query_condition, &condition_builder)
               .ok());
   REQUIRE(tiledb::sm::serialization::condition_from_capnp(
-              condition_builder, &query_condition_clone)
+              condition_builder, query_condition_clone)
               .ok());
   REQUIRE(tiledb::test::ast_equal(
       query_condition.ast(), query_condition_clone.ast()));

--- a/test/src/unit-QueryCondition-serialization.cc
+++ b/test/src/unit-QueryCondition-serialization.cc
@@ -51,7 +51,6 @@ TEST_CASE(
     "QueryCondition serialization: Test serialization",
     "[QueryCondition][serialization]") {
   QueryCondition query_condition;
-  QueryCondition query_condition_clone;
 
   SECTION("Test serialization, basic") {
     std::string field_name = "x";
@@ -271,7 +270,7 @@ TEST_CASE(
   REQUIRE(tiledb::sm::serialization::condition_to_capnp(
               query_condition, &condition_builder)
               .ok());
-  query_condition_clone =
+  auto query_condition_clone =
       tiledb::sm::serialization::condition_from_capnp(condition_builder);
   REQUIRE(tiledb::test::ast_equal(
       query_condition.ast(), query_condition_clone.ast()));

--- a/test/src/unit-QueryCondition-serialization.cc
+++ b/test/src/unit-QueryCondition-serialization.cc
@@ -271,9 +271,8 @@ TEST_CASE(
   REQUIRE(tiledb::sm::serialization::condition_to_capnp(
               query_condition, &condition_builder)
               .ok());
-  REQUIRE(tiledb::sm::serialization::condition_from_capnp(
-              condition_builder, query_condition_clone)
-              .ok());
+  query_condition_clone =
+      tiledb::sm::serialization::condition_from_capnp(condition_builder);
   REQUIRE(tiledb::test::ast_equal(
       query_condition.ast(), query_condition_clone.ast()));
 }

--- a/test/src/unit-cppapi-query-condition-sets.cc
+++ b/test/src/unit-cppapi-query-condition-sets.cc
@@ -924,7 +924,7 @@ QueryCondition CPPQueryConditionFx::serialize_deserialize_qc(
   throw_if_not_ok(condition_to_capnp(*qc_ptr, &builder));
 
   // Deserialize the query condition.
-  throw_if_not_ok(condition_from_capnp(builder, ret_ptr));
+  throw_if_not_ok(condition_from_capnp(builder, *ret_ptr));
   REQUIRE(tiledb::test::ast_equal(ret_ptr->ast(), qc_ptr->ast()));
 
   return ret;

--- a/test/src/unit-cppapi-query-condition-sets.cc
+++ b/test/src/unit-cppapi-query-condition-sets.cc
@@ -924,7 +924,7 @@ QueryCondition CPPQueryConditionFx::serialize_deserialize_qc(
   throw_if_not_ok(condition_to_capnp(*qc_ptr, &builder));
 
   // Deserialize the query condition.
-  throw_if_not_ok(condition_from_capnp(builder, *ret_ptr));
+  *ret_ptr = condition_from_capnp(builder);
   REQUIRE(tiledb::test::ast_equal(ret_ptr->ast(), qc_ptr->ast()));
 
   return ret;

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -2757,10 +2757,6 @@ uint64_t QueryCondition::condition_index() const {
   return condition_index_;
 }
 
-void QueryCondition::set_ast(tdb_unique_ptr<ASTNode>&& ast) {
-  tree_ = std::move(ast);
-}
-
 // Explicit template instantiations.
 template Status QueryCondition::apply_sparse<uint8_t>(
     const ArraySchema& array_schema, ResultTile&, std::vector<uint8_t>&);

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -248,12 +248,6 @@ class QueryCondition {
   QueryCondition negated_condition();
 
   /**
-   * Sets the AST. This is internal state to only be used in
-   * the serialization path.
-   */
-  void set_ast(tdb_unique_ptr<ASTNode>&& ast);
-
-  /**
    * Returns the AST object. This is internal state to only be used in testing
    * and the serialization path.
    */

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -59,10 +59,10 @@ class QueryCondition {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Default constructor. */
+  /** Default constructor. Should be used only in the C API. */
   QueryCondition();
 
-  /** Constructor for a set membership QueryCondition */
+  /** Constructor for a set membership QueryCondition. */
   QueryCondition(
       const std::string& field_name,
       const void* data,

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -239,9 +239,8 @@ Status unordered_write_state_from_capnp(
     UnorderedWriter* runordered_writer,
     SerializationContext context);
 
-Status condition_from_capnp(
-    const capnp::Condition::Reader& condition_reader,
-    QueryCondition& condition);
+QueryCondition condition_from_capnp(
+    const capnp::Condition::Reader& condition_reader);
 
 Status condition_to_capnp(
     const QueryCondition& condition,

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -241,7 +241,7 @@ Status unordered_write_state_from_capnp(
 
 Status condition_from_capnp(
     const capnp::Condition::Reader& condition_reader,
-    QueryCondition* const condition);
+    QueryCondition& condition);
 
 Status condition_to_capnp(
     const QueryCondition& condition,


### PR DESCRIPTION
This change removes non C.41 constructors from condition_from_capnp.

---
TYPE: NO_HISTORY
DESC: Remove serialization non C.41 constructors from query condition.
