### PR TITLE
[Backport release-2.19] Use 7-digit commit hashes in release artifacts. (#4599)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set variables
         id: get-values
         run: |
-          release_hash=$( echo ${{ github.sha }} | cut -c-8 - )
+          release_hash=$( echo ${{ github.sha }} | cut -c-7 - )
           ref=${{ github.head_ref || github.ref_name }}
           echo "release_hash=$release_hash" >> $GITHUB_OUTPUT
           echo "archive_name=tiledb-${{ matrix.platform }}-${ref##*/}-$release_hash" >> $GITHUB_OUTPUT
@@ -126,8 +126,24 @@ jobs:
           source $GITHUB_WORKSPACE/scripts/ci/print_logs.sh
         if: failure() # only run this job if the build step failed
 
-  Publish-Release:
+  Test-Release-Artifacts:
     needs: Build-Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: tiledb-dist
+          path: dist
+      - name: Test names of release artifacts
+        run: |
+          if [ ls dist/ | grep -Ev -- '^tiledb-(linux|macos|windows)+-(x86_64|arm64)(-noavx2)?-.+-[0-9a-f]{7}\.(zip|tar\.gz)$' ]; then
+            echo "Some release artifact names do not match expected pattern"
+            exit 1
+          fi
+
+  Publish-Release:
+    needs: Test-Release-Artifacts
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/31500c5a26b224843113589875f36f78f0be8fbf from https://github.com/TileDB-Inc/TileDB/pull/4599.

---
TYPE: BUILD
DESC: Fix regression where release artifacts had 8-digit commit hashes.
