### PR TITLE
Fix narrowing integer error in number of cells per tile computation 

### DIFF
--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -823,9 +823,9 @@ void Domain::compute_cell_num_per_tile() {
 
   cell_num_per_tile_ = 1;
   for (unsigned d = 0; d < dim_num_; ++d) {
-    auto tile_extent = *(const T*)this->tile_extent(d).data();
-    cell_num_per_tile_ =
-        Dimension::tile_extent_mult<T>(cell_num_per_tile_, tile_extent);
+    auto tile_extent =
+        static_cast<uint64_t>(this->tile_extent(d).rvalue_as<T>());
+    cell_num_per_tile_ *= tile_extent;
   }
 }
 

--- a/tiledb/sm/array_schema/test/CMakeLists.txt
+++ b/tiledb/sm/array_schema/test/CMakeLists.txt
@@ -35,6 +35,7 @@ commence(unit_test array_schema)
         unit_array_schema.cc
         unit_dimension.cc
         unit_dimension_label.cc
+        unit_domain.cc
         unit_domain_data.cc
         unit_tile_domain.cc
     )

--- a/tiledb/sm/array_schema/test/unit_domain.cc
+++ b/tiledb/sm/array_schema/test/unit_domain.cc
@@ -111,9 +111,11 @@ TEST_CASE("Domain: Test deserialization", "[domain][deserialize]") {
   dom_buffer_offset<uint64_t, 63>(p) = domain_size2;
   dom_buffer_offset<uint8_t, 71>(p) = null_tile_extent2;
 
+  FilterPipeline coords_filters{};
+
   Deserializer deserializer(&serialized_buffer, sizeof(serialized_buffer));
   auto dom{Domain::deserialize(
-      deserializer, 10, Layout::ROW_MAJOR, Layout::ROW_MAJOR)};
+      deserializer, 10, Layout::ROW_MAJOR, Layout::ROW_MAJOR, coords_filters)};
   CHECK(dom->dim_num() == dim_num);
 
   auto dim1{dom->dimension_ptr("d1")};

--- a/tiledb/sm/array_schema/test/unit_domain.cc
+++ b/tiledb/sm/array_schema/test/unit_domain.cc
@@ -130,3 +130,41 @@ TEST_CASE("Domain: Test deserialization", "[domain][deserialize]") {
   CHECK(dim2->cell_val_num() == cell_val_num2);
   CHECK(dim2->filters().size() == num_filters2);
 }
+
+TEST_CASE("Domain: Cells per tile larger than dimension type", "[domain]") {
+  Status rc{};
+
+  // Create dim1.
+  auto dim1 = make_shared<Dimension>(HERE(), "dim1", Datatype::UINT8);
+  uint8_t dim1_tile_extent{17};
+  uint8_t dim1_domain[2]{1, 35};
+  rc = dim1->set_domain(&dim1_domain);
+  REQUIRE(rc.ok());
+  rc = dim1->set_tile_extent(&dim1_tile_extent);
+  REQUIRE(rc.ok());
+
+  // Create dim2.
+  auto dim2 = make_shared<Dimension>(HERE(), "dim2", Datatype::UINT8);
+  uint8_t dim2_tile_extent{19};
+  uint8_t dim2_domain[2]{1, 39};
+  rc = dim2->set_domain(&dim2_domain);
+  REQUIRE(rc.ok());
+  rc = dim2->set_tile_extent(&dim2_tile_extent);
+  REQUIRE(rc.ok());
+
+  // Create dim3.
+  auto dim3 = make_shared<Dimension>(HERE(), "dim3", Datatype::UINT8);
+  uint8_t dim3_tile_extent{3};
+  uint8_t dim3_domain[2]{1, 3};
+  rc = dim3->set_domain(&dim3_domain);
+  REQUIRE(rc.ok());
+  rc = dim3->set_tile_extent(&dim3_tile_extent);
+  REQUIRE(rc.ok());
+
+  // Create the domain.
+  Domain domain{Layout::ROW_MAJOR, {dim1, dim2, dim3}, Layout::ROW_MAJOR};
+
+  // Check the number of cells per tile.
+  uint64_t expected_cell_num_per_tile{17 * 19 * 3};
+  CHECK(domain.cell_num_per_tile() == expected_cell_num_per_tile);
+}

--- a/tiledb/sm/misc/types.cc
+++ b/tiledb/sm/misc/types.cc
@@ -53,7 +53,7 @@ template int8_t ByteVecValue::rvalue_as<int8_t>() const;
 template uint8_t ByteVecValue::rvalue_as<uint8_t>() const;
 template int16_t ByteVecValue::rvalue_as<int16_t>() const;
 template uint16_t ByteVecValue::rvalue_as<uint16_t>() const;
-template int ByteVecValue::rvalue_as<int>() const;
+template int32_t ByteVecValue::rvalue_as<int32_t>() const;
 template uint32_t ByteVecValue::rvalue_as<uint32_t>() const;
 template int64_t ByteVecValue::rvalue_as<int64_t>() const;
 template uint64_t ByteVecValue::rvalue_as<uint64_t>() const;


### PR DESCRIPTION
This PR fixes a bug in the templated `Domain::compute_cell_num_per_tile` function.

Previously,  the `cell_num_per_tile_` (type `uint64_t`) would be converted to a smaller value when being passed into `Dimension::tile_extent_mult` if the maximum values of the datatype of the dimension was smaller than the current `cell_num_per_tile_` value.

---
TYPE: BUG 
DESC: Fix narrowing integer error in number of cells per tile computation 
