### PR TITLE
Add memory tracking for RTree.

### DIFF
--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1578,7 +1578,7 @@ const NDRange& FragmentMetadata::mbr(uint64_t tile_idx) const {
   return rtree_.leaf(tile_idx);
 }
 
-const std::vector<NDRange>& FragmentMetadata::mbrs() const {
+const tdb::pmr::vector<NDRange>& FragmentMetadata::mbrs() const {
   return rtree_.leaves();
 }
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -81,7 +81,7 @@ FragmentMetadata::FragmentMetadata(
     ContextResources* resources, shared_ptr<MemoryTracker> memory_tracker)
     : resources_(resources)
     , memory_tracker_(memory_tracker)
-    , rtree_(RTree(memory_tracker_, nullptr, constants::rtree_fanout))
+    , rtree_(RTree(nullptr, constants::rtree_fanout, memory_tracker_))
     , tile_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
     , tile_var_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
     , tile_var_sizes_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
@@ -121,7 +121,7 @@ FragmentMetadata::FragmentMetadata(
     , sparse_tile_num_(0)
     , meta_file_size_(0)
     , rtree_(RTree(
-          memory_tracker_, &array_schema_->domain(), constants::rtree_fanout))
+          &array_schema_->domain(), constants::rtree_fanout, memory_tracker_))
     , tile_index_base_(0)
     , tile_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
     , tile_var_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -81,6 +81,7 @@ FragmentMetadata::FragmentMetadata(
     ContextResources* resources, shared_ptr<MemoryTracker> memory_tracker)
     : resources_(resources)
     , memory_tracker_(memory_tracker)
+    , rtree_(RTree(memory_tracker_, nullptr, constants::rtree_fanout))
     , tile_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
     , tile_var_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
     , tile_var_sizes_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
@@ -119,7 +120,8 @@ FragmentMetadata::FragmentMetadata(
     , has_delete_meta_(has_deletes_meta)
     , sparse_tile_num_(0)
     , meta_file_size_(0)
-    , rtree_(RTree(&array_schema_->domain(), constants::rtree_fanout))
+    , rtree_(RTree(
+          memory_tracker_, &array_schema_->domain(), constants::rtree_fanout))
     , tile_index_base_(0)
     , tile_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))
     , tile_var_offsets_(memory_tracker_->get_resource(MemoryType::TILE_OFFSETS))

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1229,6 +1229,11 @@ class FragmentMetadata {
     return gt_offsets_;
   }
 
+  /** memory_tracker_ accessor */
+  inline shared_ptr<MemoryTracker> memory_tracker() {
+    return memory_tracker_;
+  }
+
   /** set the CR pointer during deserialization*/
   void set_context_resources(ContextResources* cr) {
     resources_ = cr;

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -783,7 +783,7 @@ class FragmentMetadata {
   const NDRange& mbr(uint64_t tile_idx) const;
 
   /** Returns all the MBRs of all tiles in the fragment. */
-  const std::vector<NDRange>& mbrs() const;
+  const tdb::pmr::vector<NDRange>& mbrs() const;
 
   /**
    * Retrieves the size of the tile when it is persisted (e.g. the size of the

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -1229,11 +1229,6 @@ class FragmentMetadata {
     return gt_offsets_;
   }
 
-  /** memory_tracker_ accessor */
-  inline shared_ptr<MemoryTracker> memory_tracker() {
-    return memory_tracker_;
-  }
-
   /** set the CR pointer during deserialization*/
   void set_context_resources(ContextResources* cr) {
     resources_ = cr;

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -55,9 +55,9 @@ namespace sm {
 /* ****************************** */
 
 RTree::RTree(
-    shared_ptr<MemoryTracker> memory_tracker,
     const Domain* domain,
-    unsigned fanout)
+    unsigned fanout,
+    shared_ptr<MemoryTracker> memory_tracker)
     : memory_tracker_(memory_tracker)
     , domain_(domain)
     , fanout_(fanout)

--- a/tiledb/sm/rtree/rtree.h
+++ b/tiledb/sm/rtree/rtree.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -119,7 +119,7 @@ class RTree {
   const NDRange& leaf(uint64_t leaf_idx) const;
 
   /** Returns the leaves of the tree. */
-  const std::vector<NDRange>& leaves() const;
+  const tdb::pmr::vector<NDRange>& leaves() const;
 
   /**
    * Returns the number of leaves that are stored in a (full) subtree
@@ -152,7 +152,7 @@ class RTree {
    * Sets the input MBRs as leaves. This will destroy the existing
    * RTree.
    */
-  Status set_leaves(const std::vector<NDRange>& mbrs);
+  Status set_leaves(const tdb::pmr::vector<NDRange>& mbrs);
 
   /**
    * Resizes the leaf level. It destroys the upper levels
@@ -169,6 +169,14 @@ class RTree {
    */
   void deserialize(
       Deserializer& deserializer, const Domain* domain, uint32_t version);
+
+  /**
+   * Resets the RTree with the input domain and fanout.
+   *
+   * @param domain The domain to use for the RTree.
+   * @param fanout The fanout of the RTree.
+   */
+  void reset(const Domain* domain, unsigned fanout);
 
  private:
   /* ********************************* */
@@ -197,7 +205,7 @@ class RTree {
    * `levels_`, where the first level is the root. This is how
    * we can infer which tree level each `Level` object corresponds to.
    */
-  typedef std::vector<NDRange> Level;
+  typedef tdb::pmr::vector<NDRange> Level;
 
   /**
    * Defines an R-Tree level entry, which corresponds to a node

--- a/tiledb/sm/rtree/rtree.h
+++ b/tiledb/sm/rtree/rtree.h
@@ -68,9 +68,9 @@ class RTree {
 
   /** Constructor. */
   RTree(
-      shared_ptr<MemoryTracker> memory_tracker,
       const Domain* domain,
-      unsigned fanout);
+      unsigned fanout,
+      shared_ptr<MemoryTracker> memory_tracker);
 
   /** Destructor. */
   ~RTree();

--- a/tiledb/sm/rtree/test/CMakeLists.txt
+++ b/tiledb/sm/rtree/test/CMakeLists.txt
@@ -28,11 +28,6 @@ include(unit_test)
 
 commence(unit_test rtree)
     this_target_sources(main.cc unit_rtree.cc)
-    if (NOT MSVC)
-        target_compile_options(unit_rtree PRIVATE -Wno-deprecated-declarations)
-    endif()
-    target_include_directories(unit_rtree PRIVATE
-        "$<TARGET_PROPERTY:TILEDB_CORE_OBJECTS,INCLUDE_DIRECTORIES>")
     this_target_link_libraries(tiledb_test_support_lib)
     this_target_object_libraries(rtree)
 conclude(unit_test)

--- a/tiledb/sm/rtree/test/CMakeLists.txt
+++ b/tiledb/sm/rtree/test/CMakeLists.txt
@@ -28,5 +28,11 @@ include(unit_test)
 
 commence(unit_test rtree)
     this_target_sources(main.cc unit_rtree.cc)
+    if (NOT MSVC)
+        target_compile_options(unit_rtree PRIVATE -Wno-deprecated-declarations)
+    endif()
+    target_include_directories(unit_rtree PRIVATE
+        "$<TARGET_PROPERTY:TILEDB_CORE_OBJECTS,INCLUDE_DIRECTORIES>")
+    this_target_link_libraries(tiledb_test_support_lib)
     this_target_object_libraries(rtree)
 conclude(unit_test)

--- a/tiledb/sm/rtree/test/compile_rtree_main.cc
+++ b/tiledb/sm/rtree/test/compile_rtree_main.cc
@@ -29,6 +29,6 @@
 #include "../rtree.h"
 
 int main() {
-  (void)sizeof(tiledb::sm::RTree);
+  tiledb::sm::RTree x{nullptr, nullptr, 0};
   return 0;
 }

--- a/tiledb/sm/rtree/test/compile_rtree_main.cc
+++ b/tiledb/sm/rtree/test/compile_rtree_main.cc
@@ -29,6 +29,6 @@
 #include "../rtree.h"
 
 int main() {
-  tiledb::sm::RTree x{nullptr, nullptr, 0};
+  tiledb::sm::RTree x{nullptr, 0, nullptr};
   return 0;
 }

--- a/tiledb/sm/rtree/test/compile_rtree_main.cc
+++ b/tiledb/sm/rtree/test/compile_rtree_main.cc
@@ -29,6 +29,6 @@
 #include "../rtree.h"
 
 int main() {
-  tiledb::sm::RTree x{};
+  (void)sizeof(tiledb::sm::RTree);
   return 0;
 }

--- a/tiledb/sm/rtree/test/unit_rtree.cc
+++ b/tiledb/sm/rtree/test/unit_rtree.cc
@@ -30,6 +30,7 @@
  * Tests the `RTree` class.
  */
 
+#include "test/support/src/helpers.h"
 #include "tiledb/common/common.h"
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -41,6 +42,7 @@
 #include <iostream>
 
 using namespace tiledb::sm;
+using tiledb::test::create_test_memory_tracker;
 
 // `mbrs` contains a flattened vector of values (low, high)
 // per dimension per MBR
@@ -119,7 +121,7 @@ Domain create_domain(
 
 TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   // Empty tree
-  RTree rtree0(make_shared<MemoryTracker>(HERE()), nullptr, 0);
+  RTree rtree0(create_test_memory_tracker(), nullptr, 0);
   CHECK(rtree0.height() == 0);
   CHECK(rtree0.dim_num() == 0);
   CHECK(rtree0.domain() == nullptr);
@@ -134,7 +136,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs_1d = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
   const Domain d1{dom1};
-  RTree rtree1(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree1(create_test_memory_tracker(), &d1, 3);
   CHECK(!rtree1.set_leaf(0, mbrs_1d[0]).ok());
   CHECK(rtree1.set_leaf_num(mbrs_1d.size()).ok());
   for (size_t m = 0; m < mbrs_1d.size(); ++m)
@@ -195,7 +197,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   std::vector<NDRange> mbrs_2d =
       create_mbrs<int64_t, 2>({1, 3, 5, 10, 20, 22, 24, 25, 11, 15, 30, 31});
   const Domain d2{dom2};
-  RTree rtree2(make_shared<MemoryTracker>(HERE()), &d2, 5);
+  RTree rtree2(create_test_memory_tracker(), &d2, 5);
   CHECK(rtree2.set_leaves(mbrs_2d).ok());
   rtree2.build_tree();
   CHECK(rtree2.height() == 2);
@@ -234,7 +236,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   Domain dom2f =
       create_domain({"d"}, {Datatype::FLOAT32}, {dim_dom_f}, {&dim_extent_f});
   const Domain d2f{dom2f};
-  RTree rtreef(make_shared<MemoryTracker>(HERE()), &d2f, 5);
+  RTree rtreef(create_test_memory_tracker(), &d2f, 5);
   CHECK(rtreef.set_leaves(mbrs_f).ok());
   rtreef.build_tree();
 
@@ -277,7 +279,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 2", "[rtree][1d][2h]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
   const Domain d1{dom1};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -324,7 +326,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   const Domain d1(dom1);
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -393,7 +395,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 2", "[rtree][2d][2h]") {
   std::vector<NDRange> mbrs =
       create_mbrs<int32_t, 2>({1, 3, 2, 4, 5, 7, 6, 9, 10, 12, 10, 15});
   const Domain d2{dom2};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d2, 3);
+  RTree rtree(create_test_memory_tracker(), &d2, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -447,7 +449,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
       {1,  3,  2,  4,  5,  7,  6,  9,  10, 12, 10, 15, 11, 15, 20, 22, 16, 16,
        23, 23, 19, 20, 24, 26, 25, 28, 30, 32, 30, 35, 35, 37, 40, 42, 40, 42});
   const Domain d2{dom2};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d2, 3);
+  RTree rtree(create_test_memory_tracker(), &d2, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -525,7 +527,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5}, {5, 6, 7, 9});
   const Domain d1{dom};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 5);
+  RTree rtree(create_test_memory_tracker(), &d1, 5);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -581,7 +583,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_mbrs<uint64_t, float>({0, 1, 3, 5}, {.5f, .6f, .7f, .9f});
   const Domain d1{dom};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 5);
+  RTree rtree(create_test_memory_tracker(), &d1, 5);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -637,7 +639,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5, 11, 20}, {5, 6, 7, 9, 11, 30});
   const Domain d1{dom};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -706,7 +708,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs = create_mbrs<uint8_t, int32_t>(
       {0, 1, 3, 5, 11, 20, 21, 26}, {5, 6, 7, 9, 11, 30, 31, 40});
   const Domain d1{dom};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 2);
+  RTree rtree(create_test_memory_tracker(), &d1, 2);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -843,7 +845,7 @@ TEST_CASE(
       create_str_mbrs<1>({"aa", "b", "eee", "g", "gggg", "ii"});
 
   const Domain d1{dom1};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -932,7 +934,7 @@ TEST_CASE(
        "oop"});
 
   const Domain d1{dom1};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -1027,7 +1029,7 @@ TEST_CASE(
        "qqq"});
 
   const Domain d1{dom};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -1133,7 +1135,7 @@ TEST_CASE(
       {"aa", "b", "eee", "g", "gggg", "ii"}, {1, 5, 7, 8, 10, 14});
 
   const Domain d1{dom};
-  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
+  RTree rtree(create_test_memory_tracker(), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);

--- a/tiledb/sm/rtree/test/unit_rtree.cc
+++ b/tiledb/sm/rtree/test/unit_rtree.cc
@@ -31,6 +31,7 @@
  */
 
 #include "tiledb/common/common.h"
+#include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/layout.h"
@@ -118,7 +119,7 @@ Domain create_domain(
 
 TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   // Empty tree
-  RTree rtree0;
+  RTree rtree0(make_shared<MemoryTracker>(HERE()), nullptr, 0);
   CHECK(rtree0.height() == 0);
   CHECK(rtree0.dim_num() == 0);
   CHECK(rtree0.domain() == nullptr);
@@ -133,7 +134,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs_1d = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
   const Domain d1{dom1};
-  RTree rtree1(&d1, 3);
+  RTree rtree1(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(!rtree1.set_leaf(0, mbrs_1d[0]).ok());
   CHECK(rtree1.set_leaf_num(mbrs_1d.size()).ok());
   for (size_t m = 0; m < mbrs_1d.size(); ++m)
@@ -194,7 +195,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   std::vector<NDRange> mbrs_2d =
       create_mbrs<int64_t, 2>({1, 3, 5, 10, 20, 22, 24, 25, 11, 15, 30, 31});
   const Domain d2{dom2};
-  RTree rtree2(&d2, 5);
+  RTree rtree2(make_shared<MemoryTracker>(HERE()), &d2, 5);
   CHECK(rtree2.set_leaves(mbrs_2d).ok());
   rtree2.build_tree();
   CHECK(rtree2.height() == 2);
@@ -233,7 +234,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   Domain dom2f =
       create_domain({"d"}, {Datatype::FLOAT32}, {dim_dom_f}, {&dim_extent_f});
   const Domain d2f{dom2f};
-  RTree rtreef(&d2f, 5);
+  RTree rtreef(make_shared<MemoryTracker>(HERE()), &d2f, 5);
   CHECK(rtreef.set_leaves(mbrs_f).ok());
   rtreef.build_tree();
 
@@ -276,7 +277,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 2", "[rtree][1d][2h]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   std::vector<NDRange> mbrs = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22});
   const Domain d1{dom1};
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -323,7 +324,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   const Domain d1(dom1);
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -392,7 +393,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 2", "[rtree][2d][2h]") {
   std::vector<NDRange> mbrs =
       create_mbrs<int32_t, 2>({1, 3, 2, 4, 5, 7, 6, 9, 10, 12, 10, 15});
   const Domain d2{dom2};
-  RTree rtree(&d2, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d2, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -446,7 +447,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
       {1,  3,  2,  4,  5,  7,  6,  9,  10, 12, 10, 15, 11, 15, 20, 22, 16, 16,
        23, 23, 19, 20, 24, 26, 25, 28, 30, 32, 30, 35, 35, 37, 40, 42, 40, 42});
   const Domain d2{dom2};
-  RTree rtree(&d2, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d2, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -524,7 +525,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5}, {5, 6, 7, 9});
   const Domain d1{dom};
-  RTree rtree(&d1, 5);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 5);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -580,7 +581,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_mbrs<uint64_t, float>({0, 1, 3, 5}, {.5f, .6f, .7f, .9f});
   const Domain d1{dom};
-  RTree rtree(&d1, 5);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 5);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -636,7 +637,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5, 11, 20}, {5, 6, 7, 9, 11, 30});
   const Domain d1{dom};
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -705,7 +706,7 @@ TEST_CASE(
   std::vector<NDRange> mbrs = create_mbrs<uint8_t, int32_t>(
       {0, 1, 3, 5, 11, 20, 21, 26}, {5, 6, 7, 9, 11, 30, 31, 40});
   const Domain d1{dom};
-  RTree rtree(&d1, 2);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 2);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -842,7 +843,7 @@ TEST_CASE(
       create_str_mbrs<1>({"aa", "b", "eee", "g", "gggg", "ii"});
 
   const Domain d1{dom1};
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -931,7 +932,7 @@ TEST_CASE(
        "oop"});
 
   const Domain d1{dom1};
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -1026,7 +1027,7 @@ TEST_CASE(
        "qqq"});
 
   const Domain d1{dom};
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -1132,7 +1133,7 @@ TEST_CASE(
       {"aa", "b", "eee", "g", "gggg", "ii"}, {1, 5, 7, 8, 10, 14});
 
   const Domain d1{dom};
-  RTree rtree(&d1, 3);
+  RTree rtree(make_shared<MemoryTracker>(HERE()), &d1, 3);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);

--- a/tiledb/sm/rtree/test/unit_rtree.cc
+++ b/tiledb/sm/rtree/test/unit_rtree.cc
@@ -30,7 +30,7 @@
  * Tests the `RTree` class.
  */
 
-#include "test/support/src/helpers.h"
+#include "test/support/src/mem_helpers.h"
 #include "tiledb/common/common.h"
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/array_schema/dimension.h"
@@ -142,7 +142,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   auto mbrs_1d = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22}, tracker);
   const Domain d1{dom1};
-  RTree rtree1(create_test_memory_tracker(), &d1, 3);
+  RTree rtree1(tracker, &d1, 3);
   CHECK(!rtree1.set_leaf(0, mbrs_1d[0]).ok());
   CHECK(rtree1.set_leaf_num(mbrs_1d.size()).ok());
   for (size_t m = 0; m < mbrs_1d.size(); ++m)
@@ -203,7 +203,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   auto mbrs_2d = create_mbrs<int64_t, 2>(
       {1, 3, 5, 10, 20, 22, 24, 25, 11, 15, 30, 31}, tracker);
   const Domain d2{dom2};
-  RTree rtree2(create_test_memory_tracker(), &d2, 5);
+  RTree rtree2(tracker, &d2, 5);
   CHECK(rtree2.set_leaves(mbrs_2d).ok());
   rtree2.build_tree();
   CHECK(rtree2.height() == 2);
@@ -242,7 +242,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   Domain dom2f =
       create_domain({"d"}, {Datatype::FLOAT32}, {dim_dom_f}, {&dim_extent_f});
   const Domain d2f{dom2f};
-  RTree rtreef(create_test_memory_tracker(), &d2f, 5);
+  RTree rtreef(tracker, &d2f, 5);
   CHECK(rtreef.set_leaves(mbrs_f).ok());
   rtreef.build_tree();
 
@@ -847,10 +847,6 @@ tdb::pmr::vector<NDRange> create_str_int32_mbrs(
   }
 
   return {ret, tracker->get_resource(MemoryType::RTREE)};
-}
-
-std::pair<std::string, std::string> range_to_str(const Range& r) {
-  return std::pair<std::string, std::string>(r.start_str(), r.end_str());
 }
 
 TEST_CASE(

--- a/tiledb/sm/rtree/test/unit_rtree.cc
+++ b/tiledb/sm/rtree/test/unit_rtree.cc
@@ -127,7 +127,7 @@ Domain create_domain(
 TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   // Empty tree
   auto tracker = create_test_memory_tracker();
-  RTree rtree0(tracker, nullptr, 0);
+  RTree rtree0(nullptr, 0, tracker);
   CHECK(rtree0.height() == 0);
   CHECK(rtree0.dim_num() == 0);
   CHECK(rtree0.domain() == nullptr);
@@ -142,7 +142,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   auto mbrs_1d = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22}, tracker);
   const Domain d1{dom1};
-  RTree rtree1(tracker, &d1, 3);
+  RTree rtree1(&d1, 3, tracker);
   CHECK(!rtree1.set_leaf(0, mbrs_1d[0]).ok());
   CHECK(rtree1.set_leaf_num(mbrs_1d.size()).ok());
   for (size_t m = 0; m < mbrs_1d.size(); ++m)
@@ -203,7 +203,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   auto mbrs_2d = create_mbrs<int64_t, 2>(
       {1, 3, 5, 10, 20, 22, 24, 25, 11, 15, 30, 31}, tracker);
   const Domain d2{dom2};
-  RTree rtree2(tracker, &d2, 5);
+  RTree rtree2(&d2, 5, tracker);
   CHECK(rtree2.set_leaves(mbrs_2d).ok());
   rtree2.build_tree();
   CHECK(rtree2.height() == 2);
@@ -242,7 +242,7 @@ TEST_CASE("RTree: Test R-Tree, basic functions", "[rtree][basic]") {
   Domain dom2f =
       create_domain({"d"}, {Datatype::FLOAT32}, {dim_dom_f}, {&dim_extent_f});
   const Domain d2f{dom2f};
-  RTree rtreef(tracker, &d2f, 5);
+  RTree rtreef(&d2f, 5, tracker);
   CHECK(rtreef.set_leaves(mbrs_f).ok());
   rtreef.build_tree();
 
@@ -286,7 +286,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 2", "[rtree][1d][2h]") {
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   auto mbrs = create_mbrs<int32_t, 1>({1, 3, 5, 10, 20, 22}, tracker);
   const Domain d1{dom1};
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -334,7 +334,7 @@ TEST_CASE("RTree: Test 1D R-tree, height 3", "[rtree][1d][3h]") {
   Domain dom1 =
       create_domain({"d"}, {Datatype::INT32}, {dim_dom}, {&dim_extent});
   const Domain d1(dom1);
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -404,7 +404,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 2", "[rtree][2d][2h]") {
   auto mbrs = create_mbrs<int32_t, 2>(
       {1, 3, 2, 4, 5, 7, 6, 9, 10, 12, 10, 15}, tracker);
   const Domain d2{dom2};
-  RTree rtree(tracker, &d2, 3);
+  RTree rtree(&d2, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -460,7 +460,7 @@ TEST_CASE("RTree: Test 2D R-tree, height 3", "[rtree][2d][3h]") {
        23, 23, 19, 20, 24, 26, 25, 28, 30, 32, 30, 35, 35, 37, 40, 42, 40, 42},
       tracker);
   const Domain d2{dom2};
-  RTree rtree(tracker, &d2, 3);
+  RTree rtree(&d2, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -539,7 +539,7 @@ TEST_CASE(
   auto mbrs =
       create_mbrs<uint8_t, int32_t>({0, 1, 3, 5}, {5, 6, 7, 9}, tracker);
   const Domain d1{dom};
-  RTree rtree(tracker, &d1, 5);
+  RTree rtree(&d1, 5, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -596,7 +596,7 @@ TEST_CASE(
   auto mbrs =
       create_mbrs<uint64_t, float>({0, 1, 3, 5}, {.5f, .6f, .7f, .9f}, tracker);
   const Domain d1{dom};
-  RTree rtree(tracker, &d1, 5);
+  RTree rtree(&d1, 5, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -653,7 +653,7 @@ TEST_CASE(
   auto mbrs = create_mbrs<uint8_t, int32_t>(
       {0, 1, 3, 5, 11, 20}, {5, 6, 7, 9, 11, 30}, tracker);
   const Domain d1{dom};
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -723,7 +723,7 @@ TEST_CASE(
   auto mbrs = create_mbrs<uint8_t, int32_t>(
       {0, 1, 3, 5, 11, 20, 21, 26}, {5, 6, 7, 9, 11, 30, 31, 40}, tracker);
   const Domain d1{dom};
-  RTree rtree(tracker, &d1, 2);
+  RTree rtree(&d1, 2, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -861,7 +861,7 @@ TEST_CASE(
       create_str_mbrs<1>({"aa", "b", "eee", "g", "gggg", "ii"}, tracker);
 
   const Domain d1{dom1};
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -952,7 +952,7 @@ TEST_CASE(
       tracker);
 
   const Domain d1{dom1};
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 3);
@@ -1038,7 +1038,7 @@ TEST_CASE(
       tracker);
 
   const Domain d1{dom};
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);
@@ -1145,7 +1145,7 @@ TEST_CASE(
       {"aa", "b", "eee", "g", "gggg", "ii"}, {1, 5, 7, 8, 10, 14}, tracker);
 
   const Domain d1{dom};
-  RTree rtree(tracker, &d1, 3);
+  RTree rtree(&d1, 3, tracker);
   CHECK(rtree.set_leaves(mbrs).ok());
   rtree.build_tree();
   CHECK(rtree.height() == 2);

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -358,7 +358,7 @@ Status fragment_metadata_from_capnp(
     auto data = frag_meta_reader.getRtree();
     auto& domain = array_schema->domain();
     // If there are no levels, we still need domain_ properly initialized
-    RETURN_NOT_OK(frag_meta->rtree().set_domain(&domain));
+    frag_meta->rtree().reset(&domain, constants::rtree_fanout);
     Deserializer deserializer(data.begin(), data.size());
     // What we actually deserialize is not something written on disk in a
     // possibly historical format, but what has been serialized in

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -358,7 +358,7 @@ Status fragment_metadata_from_capnp(
     auto data = frag_meta_reader.getRtree();
     auto& domain = array_schema->domain();
     // If there are no levels, we still need domain_ properly initialized
-    frag_meta->rtree() = RTree(&domain, constants::rtree_fanout);
+    RETURN_NOT_OK(frag_meta->rtree().set_domain(&domain));
     Deserializer deserializer(data.begin(), data.size());
     // What we actually deserialize is not something written on disk in a
     // possibly historical format, but what has been serialized in


### PR DESCRIPTION
Add MemoryTracker to RTree using `tdb::pmr` containers.

---
TYPE: NO_HISTORY
DESC: Add memory tracking for RTree.