### PR TITLE
Lazily initialize the Azure SDK client.

### DIFF
--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -160,7 +160,7 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
 /* ********************************* */
 
 const ::Azure::Storage::Blobs::BlobServiceClient&
-Azure::LazyClientHolder::get_or_create_client(const Azure& azure) {
+Azure::AzureClientSingleton::get(const Azure& azure) {
   // Initialize logging from the Azure SDK.
   static std::once_flag azure_log_sentinel;
   std::call_once(azure_log_sentinel, []() {

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -61,11 +61,11 @@ namespace sm {
 /* ********************************* */
 
 Azure::Azure(const Config& config, ThreadPool* thread_pool)
-    : write_cache_max_size_(0)
+    : thread_pool_(thread_pool)
+    , write_cache_max_size_(0)
     , max_parallel_ops_(1)
     , block_list_block_size_(0)
     , use_block_list_upload_(false)
-    , thread_pool_(thread_pool)
     , ssl_cfg_(config) {
   if (thread_pool == nullptr) {
     throw std::invalid_argument("Can't initialize with null thread pool.");
@@ -1131,7 +1131,7 @@ std::shared_ptr<::Azure::Core::Http::HttpTransport> create_transport(
 #else
 #include <azure/core/http/curl_transport.hpp>
 std::shared_ptr<::Azure::Core::Http::HttpTransport> create_transport(
-    tiledb::sm::SSLConfig& ssl_cfg) {
+    const tiledb::sm::SSLConfig& ssl_cfg) {
   ::Azure::Core::Http::CurlTransportOptions transport_opts;
 
   if (!ssl_cfg.ca_file().empty()) {

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -134,6 +134,8 @@ Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
     blob_endpoint_ += sas_token;
   }
 
+  ssl_cfg_ = SSLConfig(config);
+
   max_parallel_ops_ =
       config.get<uint64_t>("vfs.azure.max_parallel_ops", Config::must_find);
   block_list_block_size_ = config.get<uint64_t>(

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -60,16 +60,26 @@ namespace sm {
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
 
-Azure::Azure(const Config& config, ThreadPool* thread_pool)
-    : thread_pool_(thread_pool)
-    , write_cache_max_size_(0)
+Azure::Azure()
+    : write_cache_max_size_(0)
     , max_parallel_ops_(1)
     , block_list_block_size_(0)
-    , use_block_list_upload_(false)
-    , ssl_cfg_(config) {
+    , use_block_list_upload_(false) {
+}
+
+Azure::~Azure() {
+}
+
+/* ********************************* */
+/*                 API               */
+/* ********************************* */
+
+Status Azure::init(const Config& config, ThreadPool* const thread_pool) {
   if (thread_pool == nullptr) {
-    throw std::invalid_argument("Can't initialize with null thread pool.");
+    return LOG_STATUS(
+        Status_AzureError("Can't initialize with null thread pool."));
   }
+  thread_pool_ = thread_pool;
   char* tmp = nullptr;
 
   account_name_ = config.get<std::string>(
@@ -139,9 +149,8 @@ Azure::Azure(const Config& config, ThreadPool* thread_pool)
       config.get<uint64_t>("vfs.azure.retry_delay_ms", Config::must_find)};
 
   write_cache_max_size_ = max_parallel_ops_ * block_list_block_size_;
-}
 
-Azure::~Azure() {
+  return Status::Ok();
 }
 
 /* ********************************* */

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -413,8 +413,7 @@ class Azure {
    *
    * This class ensures that:
    * * Callers access the client in an initialized state.
-   * * The client gets initialized only once in the face
-   *   of concurrent accesses.
+   * * The client gets initialized only once even for concurrent accesses.
    */
   class AzureClientSingleton {
    public:
@@ -451,7 +450,8 @@ class Azure {
   /** Protects 'write_cache_map_'. */
   std::mutex write_cache_map_lock_;
 
-  /** Contains options to configure connection to Azure.
+  /**
+   * Contains options to configure connection to Azure.
    * After the class becomes C.41 compliant, remove the std::optional.
    */
   std::optional<AzureParameters> azure_params_;

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -369,7 +369,7 @@ class Azure {
   ThreadPool* thread_pool_;
 
   /** The Azure blob service client. */
-  tdb_unique_ptr<::Azure::Storage::Blobs::BlobServiceClient> client_;
+  mutable tdb_unique_ptr<::Azure::Storage::Blobs::BlobServiceClient> client_;
 
   /** Maps a blob URI to a write cache buffer. */
   std::unordered_map<std::string, Buffer> write_cache_map_;
@@ -418,7 +418,7 @@ class Azure {
   std::mutex block_list_upload_states_lock_;
 
   /** Protects 'client()'. */
-  std::mutex client_init_lock_;
+  mutable std::mutex client_init_lock_;
 
   /* ********************************* */
   /*          PRIVATE METHODS          */
@@ -485,7 +485,6 @@ class Azure {
    * @param length The length of `buffer`.
    * @param block_id A base64-encoded string that is unique to this block
    * within the blob.
-   * @param result The returned future to fetch the async upload result from.
    * @return Status
    */
   Status upload_block(

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -70,15 +70,8 @@ class Azure {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Default constructor is deleted. */
-  Azure() = delete;
-
-  /** Constructor.
-   *
-   * @param config Configuration parameters.
-   * @param thread_pool The parent VFS thread pool.
-   */
-  Azure(const Config& config, ThreadPool* thread_pool);
+  /** Constructor. */
+  Azure();
 
   /** Destructor. */
   ~Azure();
@@ -86,6 +79,15 @@ class Azure {
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
+
+  /**
+   * Initializes and connects an Azure client.
+   *
+   * @param config Configuration parameters.
+   * @param thread_pool The parent VFS thread pool.
+   * @return Status
+   */
+  Status init(const Config& config, ThreadPool* thread_pool);
 
   /**
    * Creates a container.

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -317,7 +317,7 @@ class Azure {
    * use of the BlobServiceClient.
    */
   const ::Azure::Storage::Blobs::BlobServiceClient& client() const {
-    return client_holder_.get_or_create_client(*this);
+    return client_singleton_.get(*this);
   }
 
  private:
@@ -373,7 +373,7 @@ class Azure {
    * * The client gets initialized only once in the face
    *   of concurrent accesses.
    */
-  class LazyClientHolder {
+  class AzureClientSingleton {
    public:
     /**
      * Gets a reference to the Azure BlobServiceClient, and initializes it if it
@@ -381,7 +381,7 @@ class Azure {
      *
      * @param azure A reference to the parent Azure VFS object.
      */
-    const ::Azure::Storage::Blobs::BlobServiceClient& get_or_create_client(
+    const ::Azure::Storage::Blobs::BlobServiceClient& get(
         const Azure& azure);
 
    private:
@@ -400,7 +400,7 @@ class Azure {
   ThreadPool* thread_pool_;
 
   /** A holder for the Azure blob service client. */
-  mutable LazyClientHolder client_holder_;
+  mutable AzureClientSingleton client_singleton_;
 
   /** Maps a blob URI to a write cache buffer. */
   std::unordered_map<std::string, Buffer> write_cache_map_;

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -64,9 +64,6 @@ VFS::VFS(
     const Config& config)
     : VFSBase(parent_stats)
     , S3_within_VFS(stats_, io_tp, config)
-#ifdef HAVE_AZURE
-    , azure_(config, io_tp)
-#endif
     , config_(config)
     , compute_tp_(compute_tp)
     , io_tp_(io_tp)
@@ -92,9 +89,13 @@ VFS::VFS(
     supported_fs_.insert(Filesystem::S3);
   }
 
-  if constexpr (azure_enabled) {
-    supported_fs_.insert(Filesystem::AZURE);
+#ifdef HAVE_AZURE
+  supported_fs_.insert(Filesystem::AZURE);
+  st = azure_.init(config_, io_tp_);
+  if (!st.ok()) {
+    throw VFSException("Failed to initialize Azure backend.");
   }
+#endif
 
 #ifdef HAVE_GCS
   supported_fs_.insert(Filesystem::GCS);

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -64,6 +64,9 @@ VFS::VFS(
     const Config& config)
     : VFSBase(parent_stats)
     , S3_within_VFS(stats_, io_tp, config)
+#ifdef HAVE_AZURE
+    , azure_(config, io_tp)
+#endif
     , config_(config)
     , compute_tp_(compute_tp)
     , io_tp_(io_tp)
@@ -89,13 +92,9 @@ VFS::VFS(
     supported_fs_.insert(Filesystem::S3);
   }
 
-#ifdef HAVE_AZURE
-  supported_fs_.insert(Filesystem::AZURE);
-  st = azure_.init(config_, io_tp_);
-  if (!st.ok()) {
-    throw VFSException("Failed to initialize Azure backend.");
+  if constexpr (azure_enabled) {
+    supported_fs_.insert(Filesystem::AZURE);
   }
-#endif
 
 #ifdef HAVE_GCS
   supported_fs_.insert(Filesystem::GCS);


### PR DESCRIPTION
[SC-40555](https://app.shortcut.com/tiledb-inc/story/40555/lazily-initialize-the-azure-sdk)

The other two cloud VFSes already lazily initialize their SDK client, this PR does it for Azure as well.

Validated by locally running the Azure tests in Azurite.

---
TYPE: IMPROVEMENT
DESC: Lazily initialize the Azure SDK client.