### PR TITLE
Fix stats bug in StorageManager

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -1376,7 +1376,7 @@ Status StorageManagerCanonical::store_metadata(
   Serializer serializer(tile.data(), tile.size());
   metadata->serialize(serializer);
 
-  stats()->add_counter("write_meta_size", serializer.size());
+  stats()->add_counter("write_meta_size", size_computation_serializer.size());
 
   // Create a metadata file name
   URI metadata_uri = metadata->get_uri(uri);


### PR DESCRIPTION
I just stumbled across the fact that Serializer::size() returns semantically different values depending on whether its in size computing mode vs serialization mode. In size computing mode, it returns the number of bytes "written" which is the required buffer size. In actual serializing stuff mode, it returns how much of the buffer is left to be written, so generally should return 0 after a complete serialization.

Just to see if anyone was misusing that I moved size() to the size computing serializer and lo and behold, there was a single case where we had buggy behavior. Fix is to just record the size calculated by the size computing serializer.

---
TYPE: BUG
DESC: Fix stats bug in StorageManager
