### PR TITLE
Don't use non empty domain on empty array.

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -119,8 +119,6 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
   auto timer_se = stats_->start_timer("dowork");
   stats_->add_counter("loop_num", 1);
 
-  subarray_.reset_default_ranges();
-
   // Check that the query condition is valid.
   if (condition_.has_value()) {
     throw_if_not_ok(condition_->check(array_schema_));
@@ -136,6 +134,8 @@ Status SparseGlobalOrderReader<BitmapType>::dowork() {
     read_state_.set_done_adding_result_tiles(true);
     return Status::Ok();
   }
+
+  subarray_.reset_default_ranges();
 
   // Load initial data, if not loaded already.
   throw_if_not_ok(load_initial_data());

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -125,10 +125,6 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
   auto timer_se = stats_->start_timer("dowork");
   stats_->add_counter("loop_num", 1);
 
-  // Subarray is not known to be explicitly set until buffers are deserialized
-  subarray_.reset_default_ranges();
-  include_coords_ = subarray_.is_set();
-
   // Make sure user didn't request delete timestamps.
   if (buffers_.count(constants::delete_timestamps) != 0) {
     return logger_->status(Status_SparseUnorderedWithDupsReaderError(
@@ -153,6 +149,10 @@ Status SparseUnorderedWithDupsReader<BitmapType>::dowork() {
     read_state_.set_done_adding_result_tiles(true);
     return Status::Ok();
   }
+
+  // Subarray is not known to be explicitly set until buffers are deserialized
+  subarray_.reset_default_ranges();
+  include_coords_ = subarray_.is_set();
 
   // Load initial data, if not loaded already. Coords are only included if the
   // subarray is set.


### PR DESCRIPTION
This was introduced in https://github.com/TileDB-Inc/TileDB/pull/4710. In that PR, we could try to use the non empty domain of an array with no fragments, which is empty. This should fix python and R nightlies.

---
TYPE: NO_HISTORY
DESC: Don't use non empty domain on empty array.
