### PR TITLE
Add the query_memory_tracker

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -69,12 +69,15 @@ struct ReaderFx {
   const char* ARRAY_NAME = "reader";
   tiledb_array_t* array_ = nullptr;
 
+  shared_ptr<MemoryTracker> tracker_;
+
   ReaderFx();
   ~ReaderFx();
 };
 
 ReaderFx::ReaderFx()
-    : fs_vec_(vfs_test_get_fs_vec()) {
+    : fs_vec_(vfs_test_get_fs_vec())
+    , tracker_(tiledb::test::create_test_memory_tracker()) {
   // Initialize vfs test
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
 
@@ -166,6 +169,7 @@ TEST_CASE_METHOD(
   DefaultChannelAggregates default_channel_aggregates;
   auto params = StrategyParams(
       array.memory_tracker(),
+      tracker_,
       context.storage_manager(),
       array.opened_array(),
       config,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1807,6 +1807,7 @@ bool Query::is_aggregate(std::string output_field_name) const {
 Status Query::create_strategy(bool skip_checks_serialization) {
   auto params = StrategyParams(
       array_->memory_tracker(),
+      query_memory_tracker_,
       storage_manager_,
       opened_array_,
       config_,

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -48,6 +48,7 @@ namespace sm {
 StrategyBase::StrategyBase(
     stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
     : array_memory_tracker_(params.array_memory_tracker())
+    , query_memory_tracker_(params.query_memory_tracker())
     , stats_(stats)
     , logger_(logger)
     , array_(params.array())

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -67,6 +67,7 @@ class StrategyParams {
 
   StrategyParams(
       shared_ptr<MemoryTracker> array_memory_tracker,
+      shared_ptr<MemoryTracker> query_memory_tracker,
       StorageManager* storage_manager,
       shared_ptr<OpenedArray> array,
       Config& config,
@@ -78,6 +79,7 @@ class StrategyParams {
       DefaultChannelAggregates& default_channel_aggregates,
       bool skip_checks_serialization)
       : array_memory_tracker_(array_memory_tracker)
+      , query_memory_tracker_(query_memory_tracker)
       , storage_manager_(storage_manager)
       , array_(array)
       , config_(config)
@@ -97,6 +99,10 @@ class StrategyParams {
   /** Return the array memory tracker. */
   inline shared_ptr<MemoryTracker> array_memory_tracker() {
     return array_memory_tracker_;
+  }
+
+  inline shared_ptr<MemoryTracker> query_memory_tracker() {
+    return query_memory_tracker_;
   }
 
   /** Return the storage manager. */
@@ -156,6 +162,9 @@ class StrategyParams {
 
   /** Array Memory tracker. */
   shared_ptr<MemoryTracker> array_memory_tracker_;
+
+  /** Query Memory tracker. */
+  shared_ptr<MemoryTracker> query_memory_tracker_;
 
   /** Storage manager. */
   StorageManager* storage_manager_;
@@ -242,8 +251,11 @@ class StrategyBase {
   /*        PROTECTED ATTRIBUTES       */
   /* ********************************* */
 
-  /** The memory tracker. */
+  /** The array memory tracker. */
   shared_ptr<MemoryTracker> array_memory_tracker_;
+
+  /** The query memory tracker. */
+  shared_ptr<MemoryTracker> query_memory_tracker_;
 
   /** The class stats. */
   stats::Stats* stats_;


### PR DESCRIPTION
This allows easy access for readers and writers to the query memory tracker. Originally written as part of the Tile instrumentation PR, this is just an extraction so that it can unblock other work in adding other measurements.

---
TYPE: NO_HISTORY
DESC: Add the query_memory_tracker
