### PR TITLE
Create issue if release workflow fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     needs: Publish-Release
-    if: failure() || cancelled()
+    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
     steps:
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,8 +178,6 @@ jobs:
     needs: Publish-Release
     if: failure() || cancelled()
     steps:
-      - name: Checkout TileDB `dev`
-        uses: actions/checkout@v3
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Checkout TileDB
         # v4 uses node 20 which is incompatible with the libc version of the manylinux image
         uses: actions/checkout@v3
-      - run: exit 1
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
         if: ${{ startsWith(matrix.os, 'macos-') == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,5 +185,5 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: Release failed
-          label: release
+          label: bug
           assignee: KiterLuc,teo-tsirpanis,davisp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,3 +170,19 @@ jobs:
                 data: fs.readFileSync(file)
               });
             }
+
+  Create-Issue-On-Fail:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: Publish-Release
+    if: failure() || cancelled()
+    steps:
+      - name: Checkout TileDB `dev`
+        uses: actions/checkout@v3
+      - name: Create Issue if Build Fails
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: Release failed
+          label: release
+          assignee: KiterLuc,teo-tsirpanis,davisp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Checkout TileDB
         # v4 uses node 20 which is incompatible with the libc version of the manylinux image
         uses: actions/checkout@v3
+      - run: exit 1
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
         if: ${{ startsWith(matrix.os, 'macos-') == true }}


### PR DESCRIPTION
This PR adds functionality to create issue when release workflow fails.

This is how the issue will look:
https://github.com/dudoslav/TileDB/issues/1

---
TYPE: NO_HISTORY
DESC: Create issue if release workflow fails
