### PR TITLE
feature: trigger ci job in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,4 +18,5 @@ trigger_pipeline:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
   trigger:
     project: tiledb-inc/tiledb-rest-ci
+    ref: dt/sc-40467/increase-limits
     strategy: depend    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,6 @@ trigger_pipeline:
   variables:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
   trigger:
-    project: tiledb-inc/tiledb-rest-ci
+    project: tiledb-inc/tiledb-internal
     branch: dt/sc-40467/increase-limits
     strategy: depend    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,5 +18,5 @@ trigger_pipeline:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
   trigger:
     project: tiledb-inc/tiledb-rest-ci
-    ref: dt/sc-40467/increase-limits
+    branch: dt/sc-40467/increase-limits
     strategy: depend    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,5 +18,4 @@ trigger_pipeline:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
   trigger:
     project: tiledb-inc/tiledb-internal
-    branch: dt/sc-40467/increase-limits
     strategy: depend    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+stages: 
+  - test
+ 
+trigger_pipeline:
+  stage: test
+  rules: 
+    - if: $CI_COMMIT_BRANCH =~ /^dev|^release-.*/ || $CI_COMMIT_TAG != "" # only/except rules are no longer actively developed. Please use `rules` instead.
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+      changes: 
+        - "!.github/workflows/quarto-render.yml"
+        - "!_quarto.yml"
+        - "!quarto-materials/*"
+        - "!**/.md"
+        - "!tiledb/doxygen/source/*"
+        - "!tiledb/sm/c_api/tiledb_version.h"
+
+  variables:
+    TILEDB_REF: ${CI_COMMIT_REF_NAME}
+  trigger:
+    project: tiledb-inc/tiledb-rest-ci
+    strategy: depend    


### PR DESCRIPTION
Runs TIleDB-REST-CI on gitlab, from the TileDB repository. 

This ensures the result of this pipeline is displayed as a status check on PRs and `dev/release` branches. 

**Test plan**

Triggers successfully when running a similar, albiet simpler workflow on a test project. 

https://gitlab.com/TileDB-Inc/dave-ci-test/-/pipelines/1179801941

TYPE: NO_HISTORY
