### PR TITLE
[Backport release-2.19] Free some disk space before downloading the back compat test arrays. (#4700)

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -59,7 +59,7 @@ jobs:
           - ubuntu-20.04
         # Note: v2_1_0 arrays were never created so its currently skipped
         # Note: This matrix is used to set the value of TILEDB_COMPATIBILITY_VERSION
-        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1", "v2_10_0", "v2_11_0", "v2_12_0", "v2_13_0", "v2_14_0", "v2_15_0", "v2_16_0", "v2_17_3", "v2_18_1"]
+        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1", "v2_10_0", "v2_11_0", "v2_12_3", "v2_13_2", "v2_14_0", "v2_15_0", "v2_16_3", "v2_17_5", "v2_18_3"]
     timeout-minutes: 30
     name: ${{ matrix.tiledb_version }}
     steps:
@@ -73,6 +73,16 @@ jobs:
 
       - name: Update tiledb_unit permissions
         run: chmod +x $GITHUB_WORKSPACE/build/tiledb/test/tiledb_unit
+
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: 'Test backward compatibility'
         id: test


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/4c6d530b7147baabede0e68bdb6ecc831cc2983e from https://github.com/TileDB-Inc/TileDB/pull/4700.

---
TYPE: NO_HISTORY
