### PR TITLE
Instrument Metadata class for memory measurement.

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2289,8 +2289,8 @@ TEST_CASE_METHOD(
   // in array open v1 but with separate requests, so we simulate
   // this here by forcing metadata loading
   if (!array_v2) {
-    Metadata* metadata = nullptr;
-    CHECK(array->array_->metadata(&metadata).ok());
+    auto metadata = &array->array_->metadata();
+    CHECK(metadata != nullptr);
     array->array_->non_empty_domain();
   }
 
@@ -2340,7 +2340,7 @@ TEST_CASE_METHOD(
   Datatype type;
   const void* v_r;
   uint32_t v_num;
-  auto new_metadata = new_array->array_->unsafe_metadata();
+  auto new_metadata = &new_array->array_->metadata();
   new_metadata->get("aaa", &type, &v_num, &v_r);
   CHECK(static_cast<tiledb_datatype_t>(type) == TILEDB_INT32);
   CHECK(v_num == 1);

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -540,14 +540,9 @@ capi_return_t tiledb_serialize_group_metadata(
   auto buf = tiledb_buffer_handle_t::make_handle();
 
   // Get metadata to serialize, this will load it if it does not exist
-  tiledb::sm::Metadata* metadata;
-  auto st = group->group().metadata(&metadata);
-  if (!st.ok()) {
-    tiledb_buffer_handle_t::break_handle(buf);
-    throw StatusException(st);
-  }
+  auto metadata = group->group().metadata();
 
-  st = tiledb::sm::serialization::metadata_serialize(
+  auto st = tiledb::sm::serialization::metadata_serialize(
       metadata,
       static_cast<tiledb::sm::SerializationType>(serialize_type),
       &(buf->buffer()));

--- a/tiledb/common/memory_tracker.cc
+++ b/tiledb/common/memory_tracker.cc
@@ -80,8 +80,6 @@ std::string memory_type_to_str(MemoryType type) {
       return "TileSums";
     case MemoryType::TILE_WRITER_DATA:
       return "TileWriterData";
-    case MemoryType::ENUMERATION:
-      return "Enumeration";
     case MemoryType::METADATA:
       return "Metadata";
     default:

--- a/tiledb/common/memory_tracker.cc
+++ b/tiledb/common/memory_tracker.cc
@@ -80,6 +80,10 @@ std::string memory_type_to_str(MemoryType type) {
       return "TileSums";
     case MemoryType::TILE_WRITER_DATA:
       return "TileWriterData";
+    case MemoryType::ENUMERATION:
+      return "Enumeration";
+    case MemoryType::METADATA:
+      return "Metadata";
     default:
       auto val = std::to_string(static_cast<uint32_t>(type));
       throw std::logic_error("Invalid memory type: " + val);
@@ -112,6 +116,8 @@ std::string memory_tracker_type_to_str(MemoryTrackerType type) {
       return "Ephemeral";
     case MemoryTrackerType::SCHEMA_EVOLUTION:
       return "SchemaEvolution";
+    case MemoryTrackerType::GROUP:
+      return "Group";
     default:
       auto val = std::to_string(static_cast<uint32_t>(type));
       throw std::logic_error("Invalid memory tracker type: " + val);

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -97,8 +97,7 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/config/config.h"
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 //** The type of memory to track. */
 enum class MemoryType {
@@ -115,6 +114,7 @@ enum class MemoryType {
   ATTRIBUTES,
   DIMENSION_LABELS,
   DIMENSIONS,
+  METADATA,
   TILE_SUMS,
   TILE_WRITER_DATA
 };
@@ -132,6 +132,7 @@ enum class MemoryTrackerType {
   QUERY_WRITE,
   CONSOLIDATOR,
   REST_CLIENT,
+  GROUP,
   EPHEMERAL,
   SCHEMA_EVOLUTION
 };
@@ -431,7 +432,6 @@ class MemoryTrackerReporter {
   bool stop_;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_OPEN_ARRAY_MEMORY_TRACKER_H

--- a/tiledb/common/pmr.h
+++ b/tiledb/common/pmr.h
@@ -34,6 +34,7 @@
 #ifndef TILEDB_COMMON_PMR_H
 #define TILEDB_COMMON_PMR_H
 
+#include <map>
 #include <unordered_map>
 #include <vector>
 
@@ -251,9 +252,14 @@ class unordered_map : public pmr_unordered_map<Key, T, Hash, KeyEqual> {
   using insert_return_type =
       typename pmr_unordered_map<Key, T, Hash, KeyEqual>::insert_return_type;
 
+  // Delete all default constructors because they don't require an allocator
   constexpr unordered_map() = delete;
   constexpr unordered_map(const unordered_map& other) = delete;
   constexpr unordered_map(unordered_map&& other) = delete;
+
+  // Delete non-allocator aware copy and move assign.
+  constexpr unordered_map& operator=(const unordered_map& other) = delete;
+  constexpr unordered_map& operator=(unordered_map&& other) noexcept = delete;
 
   constexpr explicit unordered_map(
       size_type bucket_count,
@@ -347,6 +353,96 @@ class unordered_map : public pmr_unordered_map<Key, T, Hash, KeyEqual> {
       : pmr_unordered_map<Key, T, Hash, KeyEqual>(
             init, bucket_count, hash, KeyEqual(), alloc) {
   }
+};
+
+/* ********************************* */
+/*         PMR MAP DECLARATION       */
+/* ********************************* */
+template <class Key, class T, class Compare = std::less<Key>>
+using pmr_map =
+    std::map<Key, T, Compare, polymorphic_allocator<std::pair<const Key, T>>>;
+
+template <class Key, class T, class Compare = std::less<Key>>
+class map : public pmr_map<Key, T, Compare> {
+ public:
+  // Type declarations.
+  using key_type = typename pmr_map<Key, T, Compare>::key_type;
+  using mapped_type = typename pmr_map<Key, T, Compare>::mapped_type;
+  using value_type = typename pmr_map<Key, T, Compare>::value_type;
+  using size_type = typename pmr_map<Key, T, Compare>::size_type;
+  using difference_type = typename pmr_map<Key, T, Compare>::difference_type;
+  using key_compare = typename pmr_map<Key, T, Compare>::key_compare;
+  using allocator_type = typename pmr_map<Key, T, Compare>::allocator_type;
+  using reference = typename pmr_map<Key, T, Compare>::reference;
+  using const_reference = typename pmr_map<Key, T, Compare>::const_reference;
+  using pointer = typename pmr_map<Key, T, Compare>::pointer;
+  using const_pointer = typename pmr_map<Key, T, Compare>::const_pointer;
+  using iterator = typename pmr_map<Key, T, Compare>::iterator;
+  using const_iterator = typename pmr_map<Key, T, Compare>::const_iterator;
+  using reverse_iterator = typename pmr_map<Key, T, Compare>::reverse_iterator;
+  using const_reverse_iterator =
+      typename pmr_map<Key, T, Compare>::const_reverse_iterator;
+  using node_type = typename pmr_map<Key, T, Compare>::node_type;
+  using insert_return_type =
+      typename pmr_map<Key, T, Compare>::insert_return_type;
+
+  // Delete all default constructors because they don't require an allocator
+  constexpr map() = delete;
+  constexpr map(const map& other) = delete;
+  constexpr map(map&& other) = delete;
+
+  // Delete non-allocator aware copy and move assign.
+  constexpr map& operator=(const map& other) = delete;
+  constexpr map& operator=(map&& other) noexcept = delete;
+
+  constexpr explicit map(const Compare& comp, const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(comp, alloc) {
+  }
+
+  constexpr explicit map(const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(alloc) {
+  }
+
+  template <class InputIt>
+  constexpr map(
+      InputIt first,
+      InputIt last,
+      const Compare& comp,
+      const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(first, last, comp, alloc) {
+  }
+
+  template <class InputIt>
+  constexpr map(InputIt first, InputIt last, const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(first, last, Compare(), alloc) {
+  }
+
+  constexpr map(const map& other, const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(other, alloc) {
+  }
+
+  constexpr map(map&& other, const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(other, alloc) {
+  }
+
+  constexpr map(
+      std::initializer_list<value_type> init,
+      const Compare& comp,
+      const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(init, comp, alloc) {
+  }
+
+  constexpr map(
+      std::initializer_list<value_type> init, const allocator_type& alloc)
+      : pmr_map<Key, T, Compare>(init, Compare(), alloc) {
+  }
+
+  // Declare member class value_compare.
+  class value_compare : public pmr_map<Key, T, Compare>::value_compare {
+   public:
+    constexpr bool operator()(
+        const value_type& lhs, const value_type& rhs) const;
+  };
 };
 
 }  // namespace tiledb::common::pmr

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -60,8 +60,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class ArrayException : public StatusException {
  public:
@@ -139,6 +138,7 @@ Status Array::open_without_fragments(
   opened_array_ = make_shared<OpenedArray>(
       HERE(),
       resources_,
+      memory_tracker_,
       array_uri_,
       encryption_type,
       encryption_key,
@@ -317,6 +317,7 @@ Status Array::open(
     opened_array_ = make_shared<OpenedArray>(
         HERE(),
         resources_,
+        memory_tracker_,
         array_uri_,
         encryption_type,
         encryption_key,
@@ -832,6 +833,7 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   opened_array_ = make_shared<OpenedArray>(
       HERE(),
       resources_,
+      memory_tracker_,
       array_uri_,
       key->encryption_type(),
       key->key().data(),
@@ -1048,15 +1050,13 @@ Metadata* Array::unsafe_metadata() {
   return &opened_array_->metadata();
 }
 
-Status Array::metadata(Metadata** metadata) {
+Metadata& Array::metadata() {
   // Load array metadata for array opened for reads, if not loaded yet
   if (query_type_ == QueryType::READ && !metadata_loaded()) {
-    RETURN_NOT_OK(load_metadata());
+    throw_if_not_ok(load_metadata());
   }
 
-  *metadata = &opened_array_->metadata();
-
-  return Status::Ok();
+  return opened_array_->metadata();
 }
 
 const NDRange Array::non_empty_domain() {
@@ -1620,6 +1620,7 @@ void Array::set_serialized_array_open() {
   opened_array_ = make_shared<OpenedArray>(
       HERE(),
       resources_,
+      memory_tracker_,
       array_uri_,
       EncryptionType::NO_ENCRYPTION,
       nullptr,
@@ -1691,5 +1692,4 @@ void ensure_supported_schema_version_for_read(format_version_t version) {
   }
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,8 +49,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class ArraySchema;
 class SchemaEvolution;
@@ -81,6 +80,7 @@ class OpenedArray {
    * Construct a new Opened Array object.
    *
    * @param resources The context resources to use.
+   * @param memory_tracker The array's MemoryTracker.
    * @param array_uri The URI of the array.
    * @param encryption_type Encryption type.
    * @param key_bytes Encryption key data.
@@ -91,6 +91,7 @@ class OpenedArray {
    */
   OpenedArray(
       ContextResources& resources,
+      shared_ptr<MemoryTracker> memory_tracker,
       const URI& array_uri,
       EncryptionType encryption_type,
       const void* key_bytes,
@@ -100,7 +101,7 @@ class OpenedArray {
       bool is_remote)
       : array_dir_(ArrayDirectory(resources, array_uri))
       , array_schema_latest_(nullptr)
-      , metadata_()
+      , metadata_(memory_tracker)
       , metadata_loaded_(false)
       , non_empty_domain_computed_(false)
       , encryption_key_(make_shared<EncryptionKey>(HERE()))
@@ -730,7 +731,7 @@ class Array {
   std::optional<Datatype> metadata_type(const char* key);
 
   /** Retrieves the array metadata object. */
-  Status metadata(Metadata** metadata);
+  Metadata& metadata();
 
   /**
    * Retrieves the array metadata object.
@@ -1050,7 +1051,6 @@ class Array {
   void set_array_closed();
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_ARRAY_H

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -4030,9 +4030,13 @@ int32_t tiledb_serialize_array_metadata(
   auto buf = tiledb_buffer_handle_t::make_handle();
 
   // Get metadata to serialize, this will load it if it does not exist
-  tiledb::sm::Metadata* metadata;
-  if (SAVE_ERROR_CATCH(ctx, array->array_->metadata(&metadata))) {
-    tiledb_buffer_handle_t::break_handle(buf);
+  sm::Metadata* metadata = nullptr;
+  try {
+    metadata = &array->array_->metadata();
+  } catch (StatusException& e) {
+    auto st = Status_Error(e.what());
+    LOG_STATUS_NO_RETURN_VALUE(st);
+    save_error(ctx, st);
     return TILEDB_ERR;
   }
 

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,30 +86,13 @@ Status ArrayMetaConsolidator::consolidate(
           QueryType::WRITE, encryption_type, encryption_key, key_length),
       throw_if_not_ok(array_for_reads.close()));
 
-  // Swap the in-memory metadata between the two arrays.
+  // "Swap" the in-memory metadata between the two arrays.
   // After that, the array for writes will store the (consolidated by
   // the way metadata loading works) metadata of the array for reads
-  Metadata* metadata_r;
-  auto st = array_for_reads.metadata(&metadata_r);
-  if (!st.ok()) {
-    throw_if_not_ok(array_for_reads.close());
-    throw_if_not_ok(array_for_writes.close());
-    return st;
-  }
-  Metadata* metadata_w;
-  st = array_for_writes.metadata(&metadata_w);
-  if (!st.ok()) {
-    throw_if_not_ok(array_for_reads.close());
-    throw_if_not_ok(array_for_writes.close());
-    return st;
-  }
-  metadata_r->swap(metadata_w);
-
-  // Metadata uris to delete
-  const auto to_vacuum = metadata_w->loaded_metadata_uris();
-
-  // Get the new URI name for consolidated metadata
-  URI new_uri = metadata_w->get_uri(array_uri);
+  auto& metadata_r = array_for_reads.metadata();
+  array_for_writes.opened_array()->metadata() = metadata_r;
+  URI new_uri = metadata_r.get_uri(array_uri);
+  const auto& to_vacuum = metadata_r.loaded_metadata_uris();
 
   // Write vac files relative to the array URI. This was fixed for reads in
   // version 19 so only do this for arrays starting with version 19.
@@ -119,23 +102,20 @@ Status ArrayMetaConsolidator::consolidate(
     base_uri_size = array_for_reads.array_uri().to_string().size();
   }
 
-  // Close arrays
-  RETURN_NOT_OK_ELSE(
-      array_for_reads.close(), throw_if_not_ok(array_for_writes.close()));
-  throw_if_not_ok(array_for_writes.close());
-
   // Write vacuum file
   URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
-
   std::stringstream ss;
   for (const auto& uri : to_vacuum) {
     ss << uri.to_string().substr(base_uri_size) << "\n";
   }
-
   auto data = ss.str();
   RETURN_NOT_OK(
       storage_manager_->vfs()->write(vac_uri, data.c_str(), data.size()));
   RETURN_NOT_OK(storage_manager_->vfs()->close_file(vac_uri));
+
+  // Close arrays
+  throw_if_not_ok(array_for_reads.close());
+  throw_if_not_ok(array_for_writes.close());
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -64,7 +64,6 @@ GroupMetaConsolidator::GroupMetaConsolidator(
 Status GroupMetaConsolidator::consolidate(
     const char* group_name, EncryptionType, const void*, uint32_t) {
   auto timer_se = stats_->start_timer("consolidate_group_meta");
-
   check_array_uri(group_name);
 
   // Open group for reading
@@ -81,28 +80,28 @@ Status GroupMetaConsolidator::consolidate(
       group_for_writes.open(QueryType::WRITE),
       throw_if_not_ok(group_for_reads.close()));
 
-  // "Swap" the in-memory metadata between the two groups.
-  // After that, the group for writes will store the (consolidated by
-  // the way metadata loading works) metadata of the group for reads
+  // Copy-assign the read metadata into the metadata of the group for writes
   auto metadata_r = group_for_reads.metadata();
   *(group_for_writes.metadata()) = *metadata_r;
   URI new_uri = metadata_r->get_uri(group_uri);
   const auto& to_vacuum = metadata_r->loaded_metadata_uris();
 
-  // Write vacuum file
+  // Prepare vacuum file
   URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
   std::stringstream ss;
   for (const auto& uri : to_vacuum) {
     ss << uri.to_string() << "\n";
   }
   auto data = ss.str();
+
+  // Close groups
+  throw_if_not_ok(group_for_reads.close());
+  throw_if_not_ok(group_for_writes.close());
+
+  // Write vacuum file
   RETURN_NOT_OK(
       storage_manager_->vfs()->write(vac_uri, data.c_str(), data.size()));
   RETURN_NOT_OK(storage_manager_->vfs()->close_file(vac_uri));
-
-  // Close groups
-  RETURN_NOT_OK(group_for_reads.close());
-  RETURN_NOT_OK(group_for_writes.close());
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,47 +81,28 @@ Status GroupMetaConsolidator::consolidate(
       group_for_writes.open(QueryType::WRITE),
       throw_if_not_ok(group_for_reads.close()));
 
-  // Swap the in-memory metadata between the two groups.
+  // "Swap" the in-memory metadata between the two groups.
   // After that, the group for writes will store the (consolidated by
   // the way metadata loading works) metadata of the group for reads
-  Metadata* metadata_r;
-  auto st = group_for_reads.metadata(&metadata_r);
-  if (!st.ok()) {
-    throw_if_not_ok(group_for_reads.close());
-    throw_if_not_ok(group_for_writes.close());
-    return st;
-  }
-  Metadata* metadata_w;
-  st = group_for_writes.metadata(&metadata_w);
-  if (!st.ok()) {
-    throw_if_not_ok(group_for_reads.close());
-    throw_if_not_ok(group_for_writes.close());
-    return st;
-  }
-  metadata_r->swap(metadata_w);
-
-  // Metadata uris to delete
-  const auto to_vacuum = metadata_w->loaded_metadata_uris();
-
-  // Get the new URI name for consolidated metadata
-  URI new_uri = metadata_w->get_uri(group_uri);
-
-  // Close groups
-  RETURN_NOT_OK_ELSE(
-      group_for_reads.close(), throw_if_not_ok(group_for_writes.close()));
-  RETURN_NOT_OK(group_for_writes.close());
+  auto metadata_r = group_for_reads.metadata();
+  *(group_for_writes.metadata()) = *metadata_r;
+  URI new_uri = metadata_r->get_uri(group_uri);
+  const auto& to_vacuum = metadata_r->loaded_metadata_uris();
 
   // Write vacuum file
   URI vac_uri = URI(new_uri.to_string() + constants::vacuum_file_suffix);
-
   std::stringstream ss;
-  for (const auto& uri : to_vacuum)
+  for (const auto& uri : to_vacuum) {
     ss << uri.to_string() << "\n";
-
+  }
   auto data = ss.str();
   RETURN_NOT_OK(
       storage_manager_->vfs()->write(vac_uri, data.c_str(), data.size()));
   RETURN_NOT_OK(storage_manager_->vfs()->close_file(vac_uri));
+
+  // Close groups
+  RETURN_NOT_OK(group_for_reads.close());
+  RETURN_NOT_OK(group_for_writes.close());
 
   return Status::Ok();
 }

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -381,11 +381,6 @@ class Group {
    */
   const shared_ptr<GroupDetails> group_details() const;
 
-  /** Returns the memory tracker. */
-  inline shared_ptr<MemoryTracker> memory_tracker() {
-    return memory_tracker_;
-  }
-
  protected:
   /* ********************************* */
   /*       PROTECTED ATTRIBUTES        */

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -195,7 +195,7 @@ class Group {
   std::optional<Datatype> metadata_type(const char* key);
 
   /** Retrieves the group metadata object. */
-  Status metadata(Metadata** metadata);
+  Metadata* metadata();
 
   /**
    * Retrieves the group metadata object.
@@ -208,7 +208,6 @@ class Group {
    * REST. A lock should already by taken before load_metadata is called.
    */
   Metadata* unsafe_metadata();
-  const Metadata* metadata() const;
 
   /**
    * Set metadata loaded
@@ -382,10 +381,18 @@ class Group {
    */
   const shared_ptr<GroupDetails> group_details() const;
 
+  /** Returns the memory tracker. */
+  inline shared_ptr<MemoryTracker> memory_tracker() {
+    return memory_tracker_;
+  }
+
  protected:
   /* ********************************* */
   /*       PROTECTED ATTRIBUTES        */
   /* ********************************* */
+  /** Memory tracker for the group. */
+  shared_ptr<MemoryTracker> memory_tracker_;
+
   /** The group URI. */
   URI group_uri_;
 
@@ -460,8 +467,7 @@ class Group {
    */
   void load_metadata_from_storage(
       const shared_ptr<GroupDirectory>& group_dir,
-      const EncryptionKey& encryption_key,
-      Metadata* metadata);
+      const EncryptionKey& encryption_key);
 
   /** Opens an group for reads. */
   void group_open_for_reads();

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -56,20 +56,9 @@ class MetadataException : public StatusException {
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
-
 Metadata::Metadata(shared_ptr<MemoryTracker> memory_tracker)
-    : Metadata(
-          tdb::pmr::map<std::string, MetadataValue>(
-              memory_tracker->get_resource(MemoryType::METADATA)),
-          memory_tracker) {
-}
-
-Metadata::Metadata(
-    const tdb::pmr::map<std::string, MetadataValue>& metadata_map,
-    shared_ptr<MemoryTracker> memory_tracker)
     : memory_tracker_(memory_tracker)
-    , metadata_map_(
-          metadata_map, memory_tracker_->get_resource(MemoryType::METADATA))
+    , metadata_map_(memory_tracker_->get_resource(MemoryType::METADATA))
     , metadata_index_(memory_tracker_->get_resource(MemoryType::METADATA))
     , timestamp_range_([]() -> std::pair<uint64_t, uint64_t> {
       auto t = utils::time::timestamp_now_ms();

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@
 #include "tiledb/sm/metadata/metadata.h"
 #include "tiledb/common/exception/exception.h"
 #include "tiledb/common/logger.h"
+#include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/tdb_time.h"
@@ -56,35 +57,27 @@ class MetadataException : public StatusException {
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
 
-Metadata::Metadata()
-    : Metadata(std::map<std::string, MetadataValue>()) {
+Metadata::Metadata(shared_ptr<MemoryTracker> memory_tracker)
+    : Metadata(
+          tdb::pmr::map<std::string, MetadataValue>(
+              memory_tracker->get_resource(MemoryType::METADATA)),
+          memory_tracker) {
 }
 
-Metadata::Metadata(const std::map<std::string, MetadataValue>& metadata_map)
-    : metadata_map_(metadata_map)
+Metadata::Metadata(
+    const tdb::pmr::map<std::string, MetadataValue>& metadata_map,
+    shared_ptr<MemoryTracker> memory_tracker)
+    : memory_tracker_(memory_tracker)
+    , metadata_map_(
+          metadata_map, memory_tracker_->get_resource(MemoryType::METADATA))
+    , metadata_index_(memory_tracker_->get_resource(MemoryType::METADATA))
     , timestamp_range_([]() -> std::pair<uint64_t, uint64_t> {
       auto t = utils::time::timestamp_now_ms();
       return std::make_pair(t, t);
-    }()) {
+    }())
+    , loaded_metadata_uris_(
+          memory_tracker_->get_resource(MemoryType::METADATA)) {
   build_metadata_index();
-}
-
-Metadata::Metadata(const Metadata& rhs)
-    : metadata_map_(rhs.metadata_map_)
-    , timestamp_range_(rhs.timestamp_range_)
-    , loaded_metadata_uris_(rhs.loaded_metadata_uris_)
-    , uri_(rhs.uri_) {
-  if (!rhs.metadata_index_.empty())
-    build_metadata_index();
-}
-
-Metadata& Metadata::operator=(const Metadata& other) {
-  metadata_map_ = other.metadata_map_;
-  timestamp_range_ = other.timestamp_range_;
-  loaded_metadata_uris_ = other.loaded_metadata_uris_;
-  uri_ = other.uri_;
-  build_metadata_index();
-  return *this;
 }
 
 Metadata::~Metadata() = default;
@@ -92,6 +85,35 @@ Metadata::~Metadata() = default;
 /* ********************************* */
 /*                API                */
 /* ********************************* */
+
+Metadata& Metadata::operator=(Metadata& other) {
+  clear();
+  for (auto& [k, v] : other.metadata_map_) {
+    metadata_map_.emplace(k, v);
+  }
+
+  timestamp_range_ = other.timestamp_range_;
+
+  for (auto& uri : other.loaded_metadata_uris_) {
+    loaded_metadata_uris_.emplace_back(uri);
+  }
+
+  build_metadata_index();
+
+  return *this;
+}
+
+Metadata& Metadata::operator=(
+    std::map<std::string, Metadata::MetadataValue>&& md_map) {
+  clear();
+  for (auto& [k, v] : md_map) {
+    metadata_map_.emplace(k, v);
+  }
+
+  build_metadata_index();
+
+  return *this;
+}
 
 void Metadata::clear() {
   metadata_map_.clear();
@@ -115,11 +137,8 @@ void Metadata::generate_uri(const URI& array_uri) {
              .join_path(ts_name);
 }
 
-Metadata Metadata::deserialize(
+std::map<std::string, Metadata::MetadataValue> Metadata::deserialize(
     const std::vector<shared_ptr<Tile>>& metadata_tiles) {
-  if (metadata_tiles.empty()) {
-    return Metadata();
-  }
   std::map<std::string, MetadataValue> metadata_map;
 
   Status st;
@@ -157,7 +176,7 @@ Metadata Metadata::deserialize(
     }
   }
 
-  return Metadata(metadata_map);
+  return metadata_map;
 }
 
 void Metadata::serialize(Serializer& serializer) const {
@@ -313,15 +332,8 @@ void Metadata::set_loaded_metadata_uris(
   timestamp_range_.second = loaded_metadata_uris.back().timestamp_range_.second;
 }
 
-const std::vector<URI>& Metadata::loaded_metadata_uris() const {
+const tdb::pmr::vector<URI>& Metadata::loaded_metadata_uris() const {
   return loaded_metadata_uris_;
-}
-
-void Metadata::swap(Metadata* metadata) {
-  std::swap(metadata_map_, metadata->metadata_map_);
-  std::swap(metadata_index_, metadata->metadata_index_);
-  std::swap(timestamp_range_, metadata->timestamp_range_);
-  std::swap(loaded_metadata_uris_, metadata->loaded_metadata_uris_);
 }
 
 void Metadata::reset(uint64_t timestamp) {

--- a/tiledb/sm/metadata/metadata.cc
+++ b/tiledb/sm/metadata/metadata.cc
@@ -80,8 +80,6 @@ Metadata::Metadata(
   build_metadata_index();
 }
 
-Metadata::~Metadata() = default;
-
 /* ********************************* */
 /*                API                */
 /* ********************************* */
@@ -139,9 +137,11 @@ void Metadata::generate_uri(const URI& array_uri) {
 
 std::map<std::string, Metadata::MetadataValue> Metadata::deserialize(
     const std::vector<shared_ptr<Tile>>& metadata_tiles) {
-  std::map<std::string, MetadataValue> metadata_map;
+  if (metadata_tiles.empty()) {
+    return {};
+  }
 
-  Status st;
+  std::map<std::string, MetadataValue> metadata_map;
   uint32_t key_len;
   char del;
   size_t value_len;

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@
 
 #include "tiledb/common/common.h"
 #include "tiledb/common/heap_memory.h"
+#include "tiledb/common/pmr.h"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/tile/tile.h"
 #include "tiledb/storage_format/serialization/serializers.h"
@@ -50,6 +51,7 @@ namespace tiledb::sm {
 
 class Buffer;
 class ConstBuffer;
+class MemoryTracker;
 enum class Datatype : uint8_t;
 
 /**
@@ -81,23 +83,25 @@ class Metadata {
   };
 
   /** Iterator type for iterating over metadata values. */
-  typedef std::map<std::string, MetadataValue>::const_iterator iterator;
+  typedef tdb::pmr::map<std::string, MetadataValue>::const_iterator iterator;
 
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Constructor. */
-  explicit Metadata();
+  /** Default constructor is deleted. */
+  Metadata() = delete;
 
   /** Constructor. */
-  Metadata(const std::map<std::string, MetadataValue>& metadata_map);
+  Metadata(shared_ptr<MemoryTracker> memory_tracker);
 
-  /** Copy constructor. */
-  Metadata(const Metadata& rhs);
+  /** Constructor. */
+  Metadata(
+      const tdb::pmr::map<std::string, MetadataValue>& metadata_map,
+      shared_ptr<MemoryTracker> memory_tracker);
 
-  /** Copy assignment. */
-  Metadata& operator=(const Metadata& other);
+  DISABLE_COPY(Metadata);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(Metadata);
 
   /** Destructor. */
   ~Metadata();
@@ -105,6 +109,17 @@ class Metadata {
   /* ********************************* */
   /*                API                */
   /* ********************************* */
+
+  /** Copy assignment. */
+  Metadata& operator=(Metadata& other);
+
+  /** Assignment via std::map. */
+  Metadata& operator=(std::map<std::string, MetadataValue>&& md_map);
+
+  /** Returns the memory tracker. */
+  inline shared_ptr<MemoryTracker> memory_tracker() {
+    return memory_tracker_;
+  }
 
   /** Clears the metadata. */
   void clear();
@@ -120,7 +135,7 @@ class Metadata {
    * assumed to be sorted on time. The function will take care of any
    * deleted or overwritten metadata items considering the order.
    */
-  static Metadata deserialize(
+  static std::map<std::string, MetadataValue> deserialize(
       const std::vector<shared_ptr<Tile>>& metadata_tiles);
 
   /** Serializes all key-value metadata items into the input buffer. */
@@ -204,10 +219,7 @@ class Metadata {
    * Returns the URIs of the metadata files that have been loaded
    * to this object.
    */
-  const std::vector<URI>& loaded_metadata_uris() const;
-
-  /** Swaps the contents between the object and the input. */
-  void swap(Metadata* metadata);
+  const tdb::pmr::vector<URI>& loaded_metadata_uris() const;
 
   /**
    * Clears the metadata and assigns the input timestamp to
@@ -233,15 +245,19 @@ class Metadata {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
+  /** The memory tracker. */
+  shared_ptr<MemoryTracker> memory_tracker_;
+
   /** A map from metadata key to metadata value. */
-  std::map<std::string, MetadataValue> metadata_map_;
+  tdb::pmr::map<std::string, MetadataValue> metadata_map_;
 
   /**
    * A vector pointing to all the values in `metadata_map_`. It facilitates
    * searching metadata from index. Used only for reading metadata (inapplicable
    * when writing metadata).
    */
-  std::vector<std::pair<const std::string*, MetadataValue*>> metadata_index_;
+  tdb::pmr::vector<std::pair<const std::string*, MetadataValue*>>
+      metadata_index_;
 
   /** Mutex for thread-safety. */
   mutable std::mutex mtx_;
@@ -256,7 +272,7 @@ class Metadata {
    * The URIs of the metadata files that have been loaded to this object.
    * This is needed to know which files to delete upon consolidation.
    */
-  std::vector<URI> loaded_metadata_uris_;
+  tdb::pmr::vector<URI> loaded_metadata_uris_;
 
   /** The URI of the array metadata file. */
   URI uri_;

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -104,7 +104,7 @@ class Metadata {
   DISABLE_MOVE_AND_MOVE_ASSIGN(Metadata);
 
   /** Destructor. */
-  ~Metadata();
+  ~Metadata() = default;
 
   /* ********************************* */
   /*                API                */

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -95,11 +95,6 @@ class Metadata {
   /** Constructor. */
   Metadata(shared_ptr<MemoryTracker> memory_tracker);
 
-  /** Constructor. */
-  Metadata(
-      const tdb::pmr::map<std::string, MetadataValue>& metadata_map,
-      shared_ptr<MemoryTracker> memory_tracker);
-
   DISABLE_COPY(Metadata);
   DISABLE_MOVE_AND_MOVE_ASSIGN(Metadata);
 

--- a/tiledb/sm/metadata/test/CMakeLists.txt
+++ b/tiledb/sm/metadata/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2022 TileDB, Inc.
+# Copyright (c) 2022-2024 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,5 +29,6 @@ commence(unit_test metadata)
     this_target_object_libraries(metadata mem_helpers)	
     # The dependency on the `tile` object library is suspect, but here for now.	
     this_target_object_libraries(tile)
+    this_target_link_libraries(tiledb_test_support_lib)
     this_target_sources(main.cc unit_metadata.cc)
 conclude(unit_test)

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -57,12 +57,6 @@ TEST_CASE("Metadata: Constructor validation", "[metadata][constructor]") {
   SECTION("memory_tracker") {
     REQUIRE_NOTHROW(Metadata(tracker));
   }
-
-  SECTION("map, memory_tracker") {
-    tdb::pmr::map<std::string, Metadata::MetadataValue> map(
-        tracker->get_resource(MemoryType::METADATA));
-    REQUIRE_NOTHROW(Metadata(map, tracker));
-  }
 }
 
 TEST_CASE(
@@ -92,8 +86,8 @@ TEST_CASE(
 
   SizeComputationSerializer size_computation_serializer1;
   metadata_to_serialize1.serialize(size_computation_serializer1);
-  WriterTile tile1{WriterTile::from_generic(
-      size_computation_serializer1.size(), memory_tracker)};
+  WriterTile tile1{
+      WriterTile::from_generic(size_computation_serializer1.size(), tracker)};
 
   Serializer serializer1(tile1.data(), tile1.size());
   metadata_to_serialize1.serialize(serializer1);
@@ -102,8 +96,8 @@ TEST_CASE(
 
   SizeComputationSerializer size_computation_serializer2;
   metadata_to_serialize2.serialize(size_computation_serializer2);
-  WriterTile tile2{WriterTile::from_generic(
-      size_computation_serializer2.size(), memory_tracker)};
+  WriterTile tile2{
+      WriterTile::from_generic(size_computation_serializer2.size(), tracker)};
 
   Serializer serializer2(tile2.data(), tile2.size());
   metadata_to_serialize2.serialize(serializer2);
@@ -113,8 +107,8 @@ TEST_CASE(
 
   SizeComputationSerializer size_computation_serializer3;
   metadata_to_serialize3.serialize(size_computation_serializer3);
-  WriterTile tile3{WriterTile::from_generic(
-      size_computation_serializer3.size(), memory_tracker)};
+  WriterTile tile3{
+      WriterTile::from_generic(size_computation_serializer3.size(), tracker)};
 
   Serializer serializer3(tile3.data(), tile3.size());
   metadata_to_serialize3.serialize(serializer3);
@@ -129,7 +123,7 @@ TEST_CASE(
       tile1.size(),
       tile1.filtered_buffer().data(),
       tile1.filtered_buffer().size(),
-      memory_tracker);
+      tracker);
   memcpy(metadata_tiles[0]->data(), tile1.data(), tile1.size());
 
   metadata_tiles[1] = tdb::make_shared<Tile>(
@@ -141,7 +135,7 @@ TEST_CASE(
       tile2.size(),
       tile2.filtered_buffer().data(),
       tile2.filtered_buffer().size(),
-      memory_tracker);
+      tracker);
   memcpy(metadata_tiles[1]->data(), tile2.data(), tile2.size());
 
   metadata_tiles[2] = tdb::make_shared<Tile>(
@@ -153,7 +147,7 @@ TEST_CASE(
       tile3.size(),
       tile3.filtered_buffer().data(),
       tile3.filtered_buffer().size(),
-      memory_tracker);
+      tracker);
   memcpy(metadata_tiles[2]->data(), tile3.data(), tile3.size());
 
   meta = Metadata::deserialize(metadata_tiles);

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,9 +55,7 @@
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
 
-namespace tiledb {
-namespace sm {
-namespace serialization {
+namespace tiledb::sm::serialization {
 
 class ArraySerializationException : public StatusException {
  public:
@@ -206,10 +204,8 @@ Status array_to_capnp(
       // If this is the Cloud server, it should load and serialize metadata
       // If this is the client, it should have previously received the array
       // metadata from the Cloud server, so it should just serialize it
-      Metadata* metadata = nullptr;
-      // Get metadata. If not loaded, load it first.
-      RETURN_NOT_OK(array->metadata(&metadata));
-      RETURN_NOT_OK(metadata_to_capnp(metadata, &array_metadata_builder));
+      auto& metadata = array->metadata();
+      RETURN_NOT_OK(metadata_to_capnp(&metadata, &array_metadata_builder));
     }
   } else {
     if (array->non_empty_domain_computed()) {
@@ -741,6 +737,4 @@ Status metadata_deserialize(Metadata*, SerializationType, const Buffer&) {
 
 #endif  // TILEDB_SERIALIZATION
 
-}  // namespace serialization
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::serialization

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -58,9 +58,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
-namespace serialization {
+namespace tiledb::sm::serialization {
 
 #ifdef TILEDB_SERIALIZATION
 
@@ -72,13 +70,7 @@ Status group_metadata_to_capnp(
   auto config_builder = group_metadata_builder->initConfig();
   RETURN_NOT_OK(config_to_capnp(group->config(), &config_builder));
 
-  Metadata* metadata;
-  if (load) {
-    RETURN_NOT_OK(group->metadata(&metadata));
-  } else {
-    metadata = const_cast<Metadata*>(group->metadata());
-  }
-
+  auto metadata = group->metadata();
   if (metadata->num()) {
     auto metadata_builder = group_metadata_builder->initMetadata();
     RETURN_NOT_OK(metadata_to_capnp(metadata, &metadata_builder));
@@ -165,13 +157,7 @@ Status group_details_to_capnp(
     }
   }
 
-  Metadata* metadata;
-  if (group->group_uri().is_tiledb()) {
-    metadata = const_cast<Metadata*>(group->metadata());
-  } else {
-    RETURN_NOT_OK(group->metadata(&metadata));
-  }
-
+  auto metadata = group->metadata();
   if (metadata->num()) {
     auto group_metadata_builder = group_details_builder->initMetadata();
     RETURN_NOT_OK(metadata_to_capnp(metadata, &group_metadata_builder));
@@ -831,6 +817,4 @@ Status group_metadata_serialize(Group*, SerializationType, Buffer*, bool) {
 
 #endif  // TILEDB_SERIALIZATION
 
-}  // namespace serialization
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::serialization


### PR DESCRIPTION
Add `tdb::pmr::map` wrapper as an alias for `std::map`. Migrate class `Metadata` to use scoped allocators for memory tracking. 

---
TYPE: NO_HISTORY
DESC: Instrument Metadata class for memory measurement. Addition of tdb::pmr::map wrapper. 
