### PR TITLE
Only run Github Actions REST CI job on dev/release/tag branches

### DIFF
--- a/.github/workflows/ci-rest.yml
+++ b/.github/workflows/ci-rest.yml
@@ -4,6 +4,12 @@ on:
   - workflow_call
   - workflow_dispatch
 
+  push:
+    branches:
+      - dev
+      - release-*
+      - refs/tags/*
+
 jobs:
   rest-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -138,10 +138,6 @@ jobs:
   ci_docker:
     uses: ./.github/workflows/build-dockerfile.yml
 
-  ci_rest:
-    uses: ./.github/workflows/ci-rest.yml
-    secrets: inherit
-
   # dummy job for branch protection check
   full_ci_passed:
     needs: [


### PR DESCRIPTION
Now that we have this job on Gitlab, let's reduce the usage by only running the GHA pipeline on dev/release/tag branches. We'll run this in parallel for a while to catch any discrepancies, and aim to remove the GHA version entirely in a few weeks.

---
TYPE: NO_HISTORY