### PR TITLE
Fix memory budget tests on ASAN nightlies.

### DIFF
--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -763,7 +763,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "10200");
+  cfg.set("sm.mem.total_budget", "11000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.4");
   ctx_ = Context(cfg);
 
@@ -822,7 +822,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "10200");
+  cfg.set("sm.mem.total_budget", "11000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.4");
   ctx_ = Context(cfg);
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -777,7 +777,7 @@ TEST_CASE_METHOD(
 
   // Two result tile (2 * (~1200 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "10500";
+  total_budget_ = "12000";
   ratio_coords_ = "0.30";
   update_config();
 
@@ -1348,7 +1348,7 @@ TEST_CASE_METHOD(
 
   // Two result tile (2 * (~1200 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "10500";
+  total_budget_ = "12000";
   ratio_coords_ = "0.30";
   update_config();
 


### PR DESCRIPTION
Some objects are larger on the ASAN debug build and causes us to load less tiles in memory, failing some memory budget verifications. Making the budget slightly larger fixes the tests.

---
TYPE: NO_HISTORY
DESC: Fix memory budget tests on ASAN nightlies.
