### PR TITLE
Fix yaml syntax error in ci-rest job

### DIFF
--- a/.github/workflows/ci-rest.yml
+++ b/.github/workflows/ci-rest.yml
@@ -1,8 +1,8 @@
 name: REST CI
 
 on:
-  - workflow_call
-  - workflow_dispatch
+  workflow_call:
+  workflow_dispatch:
 
   push:
     branches:


### PR DESCRIPTION
Fix yaml syntax error in ci-rest job.

---
TYPE: NO_HISTORY
