### PR TITLE
Move the GCS client header files to `gcs.cc`.

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -35,6 +35,17 @@
 #include <sstream>
 #include <unordered_set>
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+// One abseil file has a warning that fails on Windows when compiling with
+// warnings as errors.
+#pragma warning(disable : 4127)  // conditional expression is constant
+#endif
+#include <google/cloud/storage/client.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 #include "tiledb/common/common.h"
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/logger.h"
@@ -171,15 +182,11 @@ Status GCS::init_client() const {
     if (!endpoint_.empty()) {
       client_options.set_endpoint(endpoint_);
     }
-    auto client = google::cloud::storage::Client(
+    client_ = tdb_unique_ptr<google::cloud::storage::Client>(tdb_new(
+        google::cloud::storage::Client,
         client_options,
         google::cloud::storage::LimitedTimeRetryPolicy(
-            std::chrono::milliseconds(request_timeout_ms_)));
-    client_ = google::cloud::StatusOr<google::cloud::storage::Client>(client);
-    if (!client_) {
-      return LOG_STATUS(Status_GCSError(
-          "Failed to initialize GCS Client; " + client_.status().message()));
-    }
+            std::chrono::milliseconds(request_timeout_ms_))));
   } catch (const std::exception& e) {
     return LOG_STATUS(
         Status_GCSError("Failed to initialize GCS: " + std::string(e.what())));

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -35,16 +35,7 @@
 
 #ifdef HAVE_GCS
 
-#if defined(_MSC_VER)
-#pragma warning(push)
-// One abseil file has a warning that fails on Windows when compiling with
-// warnings as errors.
-#pragma warning(disable : 4127)  // conditional expression is constant
-#endif
-#include <google/cloud/storage/client.h>
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
+#include <google/cloud/version.h>
 
 #include "tiledb/common/rwlock.h"
 #include "tiledb/common/status.h"
@@ -57,6 +48,12 @@
 #include "uri.h"
 
 using namespace tiledb::common;
+
+namespace google::cloud::storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class Client;
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::storage
 
 namespace tiledb {
 
@@ -430,7 +427,7 @@ class GCS {
   std::string project_id_;
 
   // The GCS REST client.
-  mutable google::cloud::StatusOr<google::cloud::storage::Client> client_;
+  mutable tdb_unique_ptr<google::cloud::storage::Client> client_;
 
   /** Maps a object URI to an write cache buffer. */
   std::unordered_map<std::string, Buffer> write_cache_map_;


### PR DESCRIPTION
This PR moves including `google/cloud/storage/client.h` from `gcs.h` to the `gcs.cc` implementation file. Due to the current structure of the code, `gcs.h` is included by `vfs.h`, which is included by many files, resulting in the GCS SDK code being needlessly compiled.

On my machine, the time to do a clean build with 8 CPU cores and only GCS enabled dropped from 104.22 to 75.4 seconds, a 27.6% improvement.

This PR did the minimal necessary changes to the GCS VFS. Other VFSes that are susceptible to leaking headers are HDFS, whose header is relatively small, and S3, that requires more extensive moving of code.

---
TYPE: BUILD
DESC: Improve build performance when GCS is enabled.