### PR TITLE
Rr/sc 42004 ls recursive posix

### DIFF
--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -73,6 +73,9 @@ class LsStopTraversal : public LsScanException {
 };
 
 using FileFilter = std::function<bool(const std::string_view&, uint64_t)>;
+[[maybe_unused]] static bool accept_all_files(const std::string_view&, uint64_t) {
+  return true;
+}
 
 using DirectoryFilter = std::function<bool(const std::string_view&)>;
 /** Static DirectoryFilter used as default argument. */

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -382,9 +382,12 @@ tuple<Status, optional<LsObjects>> Posix::ls_filtered(const URI& parent,
       const auto abspath = entry.path().native();
       if (entry.is_directory()) {
           if (directory_filter(abspath)) {
+              if (std::filesystem::is_empty(entry.path()) || !recursive) {
+                  /* non-empty directories are leaves, so always include them in result set */
+                  qualifyingPaths.push_back(std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
+              }
               if (!recursive) {
                   iter.disable_recursion_pending();
-                  qualifyingPaths.push_back(std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
               }
           } else {
               /* do not descend into directories which don't qualify */

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -379,11 +379,12 @@ tuple<Status, optional<LsObjects>> Posix::ls_filtered(const URI& parent,
   auto iter = std::filesystem::recursive_directory_iterator(parentstr);
   for (const std::filesystem::directory_entry &entry : iter)
   {
+      const auto abspath = entry.path().native();
       if (entry.is_directory()) {
-          if (directory_filter(entry.path().native())) {
+          if (directory_filter(abspath)) {
               if (!recursive) {
                   iter.disable_recursion_pending();
-                  qualifyingPaths.push_back(std::make_pair(entry.path(), 0));
+                  qualifyingPaths.push_back(std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
               }
           } else {
               /* do not descend into directories which don't qualify */
@@ -394,10 +395,8 @@ tuple<Status, optional<LsObjects>> Posix::ls_filtered(const URI& parent,
            * A leaf of the filesystem
            * (or symbolic link - split to a separate case if we want to descend into them)
            */
-          const auto pathstr = entry.path().native();
-          if (file_filter(pathstr, entry.file_size())) {
-              /* TODO: URI in result set instead */
-              qualifyingPaths.push_back(std::make_pair(pathstr, entry.file_size()));
+          if (file_filter(abspath, entry.file_size())) {
+              qualifyingPaths.push_back(std::make_pair(tiledb::sm::URI(abspath).to_string(), entry.file_size()));
           }
       }
   }

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -275,11 +275,14 @@ class Posix : public FilesystemBase {
    *    pruning. This is currently unused, but is kept here for future support.
    * @param recursive Whether to recursively list subdirectories.
    *
-   * Note: the return type LsObjects does not match the other "ls" methods so as to
-   * match the S3 equivalent API.
+   * Note: the return type LsObjects does not match the other "ls" methods so as
+   * to match the S3 equivalent API.
    */
   template <FilePredicate F, DirectoryPredicate D>
-  tuple<Status, optional<LsObjects>> ls_filtered(const URI& parent, F f, D d = accept_all_dirs,
+  tuple<Status, optional<LsObjects>> ls_filtered(
+      const URI& parent,
+      F f,
+      D d = accept_all_dirs,
       bool recursive = false) const;
 
   /**
@@ -362,51 +365,55 @@ class Posix : public FilesystemBase {
   uint32_t file_permissions_, directory_permissions_;
 };
 
-
 template <FilePredicate F, DirectoryPredicate D>
-tuple<Status, optional<LsObjects>> Posix::ls_filtered(const URI& parent,
-    F file_filter, D directory_filter, bool recursive) const
-{
+tuple<Status, optional<LsObjects>> Posix::ls_filtered(
+    const URI& parent,
+    F file_filter,
+    D directory_filter,
+    bool recursive) const {
   /*
    * The input URI was useful to the top-level VFS to identify this is a
    * regular filesystem path, but we don't need the "file://" qualifier
-   * anymore and can reason with unqualified strings for the rest of the function.
+   * anymore and can reason with unqualified strings for the rest of the
+   * function.
    */
   const auto parentstr = parent.to_path();
 
   LsObjects qualifyingPaths;
 
   auto iter = std::filesystem::recursive_directory_iterator(parentstr);
-  for (const std::filesystem::directory_entry &entry : iter)
-  {
-      const auto abspath = entry.path().native();
-      if (entry.is_directory()) {
-          if (directory_filter(abspath)) {
-              if (std::filesystem::is_empty(entry.path()) || !recursive) {
-                  /* non-empty directories are leaves, so always include them in result set */
-                  qualifyingPaths.push_back(std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
-              }
-              if (!recursive) {
-                  iter.disable_recursion_pending();
-              }
-          } else {
-              /* do not descend into directories which don't qualify */
-              iter.disable_recursion_pending();
-          }
+  for (const std::filesystem::directory_entry& entry : iter) {
+    const auto abspath = entry.path().native();
+    if (entry.is_directory()) {
+      if (directory_filter(abspath)) {
+        if (std::filesystem::is_empty(entry.path()) || !recursive) {
+          /* non-empty directories are leaves, so always include them in result
+           * set */
+          qualifyingPaths.push_back(
+              std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
+        }
+        if (!recursive) {
+          iter.disable_recursion_pending();
+        }
       } else {
-          /*
-           * A leaf of the filesystem
-           * (or symbolic link - split to a separate case if we want to descend into them)
-           */
-          if (file_filter(abspath, entry.file_size())) {
-              qualifyingPaths.push_back(std::make_pair(tiledb::sm::URI(abspath).to_string(), entry.file_size()));
-          }
+        /* do not descend into directories which don't qualify */
+        iter.disable_recursion_pending();
       }
+    } else {
+      /*
+       * A leaf of the filesystem
+       * (or symbolic link - split to a separate case if we want to descend into
+       * them)
+       */
+      if (file_filter(abspath, entry.file_size())) {
+        qualifyingPaths.push_back(std::make_pair(
+            tiledb::sm::URI(abspath).to_string(), entry.file_size()));
+      }
+    }
   }
 
   return {Status::Ok(), qualifyingPaths};
 }
-
 
 }  // namespace sm
 }  // namespace tiledb

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -169,7 +169,7 @@ struct TestPath {
    * to appear in the ls_recursive output
    */
   std::string lsresult() const {
-    return abspath.native(); /* TODO: this shoudl be URI */
+    return tiledb::sm::URI(abspath.native()).to_string();
   }
 
   bool matches(const std::pair<std::string, uint64_t>& lsout) const {

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -297,18 +297,18 @@ TEST_CASE(
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
         tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
-    REQUIRE(ls.size() == testpaths.size());
+    CHECK(ls.size() == testpaths.size());
     REQUIRE(testpaths.size() >= 9); /* avoid invalid access below */
 
-    CHECK(testpaths[0].matches(ls[0]));
-    CHECK(testpaths[1].matches(ls[1]));
-    CHECK(testpaths[5].matches(ls[2]));
-    CHECK(testpaths[7].matches(ls[3]));
-    CHECK(testpaths[8].matches(ls[4]));
-    CHECK(testpaths[6].matches(ls[5]));
-    CHECK(testpaths[4].matches(ls[6]));
-    CHECK(testpaths[2].matches(ls[7]));
-    CHECK(testpaths[3].matches(ls[8]));
+    if (ls.size() >= 1) { CHECK(testpaths[0].matches(ls[0])); }
+    if (ls.size() >= 2) { CHECK(testpaths[1].matches(ls[1])); }
+    if (ls.size() >= 3) { CHECK(testpaths[5].matches(ls[2])); }
+    if (ls.size() >= 4) { CHECK(testpaths[7].matches(ls[3])); }
+    if (ls.size() >= 5) { CHECK(testpaths[8].matches(ls[4])); }
+    if (ls.size() >= 6) { CHECK(testpaths[6].matches(ls[5])); }
+    if (ls.size() >= 7) { CHECK(testpaths[4].matches(ls[6])); }
+    if (ls.size() >= 8) { CHECK(testpaths[2].matches(ls[7])); }
+    if (ls.size() >= 9) { CHECK(testpaths[3].matches(ls[8])); }
   }
 
   /* all tests must close all the files that they opened, in normal use of the API */

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -231,44 +231,44 @@ TEST_CASE(
   }
 
   SECTION("Empty subdirectory") {
-    TestPath(vfs_test, "d1").mkdir();
+    auto d1 = TestPath(vfs_test, "d1");
+    d1.mkdir();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
         tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
 
-    /*
-     * TODO with reviewer feedback: should this be empty or list `d1`?
-     */
-    REQUIRE(ls.empty());
+    CHECK(ls.size() == 1);
+    if (ls.size() >= 1) { CHECK(d1.matches(ls[0])); }
   }
 
   SECTION("Empty subdirectory and files") {
     testpaths[0].touch();
     testpaths[1].touch();
-    TestPath(vfs_test, "d1").mkdir();
+    auto d1 = TestPath(vfs_test, "d1");
+    d1.mkdir();
     testpaths[2].touch();
     testpaths[3].touch();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
         tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
-    REQUIRE(ls.size() == 4);
-    CHECK(testpaths[0].matches(ls[0]));
-    CHECK(testpaths[1].matches(ls[1]));
-    CHECK(testpaths[2].matches(ls[2]));
-    CHECK(testpaths[3].matches(ls[3]));
+    CHECK(ls.size() == 5);
+    if (ls.size() >= 1) { CHECK(testpaths[0].matches(ls[0])); }
+    if (ls.size() >= 2) { CHECK(testpaths[1].matches(ls[1])); }
+    if (ls.size() >= 3) { CHECK(d1.matches(ls[2])); }
+    if (ls.size() >= 4) { CHECK(testpaths[2].matches(ls[3])); }
+    if (ls.size() >= 5) { CHECK(testpaths[3].matches(ls[4])); }
   }
 
   SECTION("Empty sub-subdirectory") {
     TestPath(vfs_test, "d1").mkdir();
-    TestPath(vfs_test, "d1/d1sub1").mkdir();
+    auto d1sub1 = TestPath(vfs_test, "d1/d1sub1");
+    d1sub1.mkdir();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
         tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
 
-    /*
-     * TODO with reviewer feedback: should this be empty or list `d1`?
-     */
-    REQUIRE(ls.empty());
+    CHECK(ls.size() == 1);
+    if (ls.size() >= 1) { CHECK(d1sub1.matches(ls[0])); }
   }
 
   SECTION("Deeply-nested files") {

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -115,19 +115,6 @@ class VFSTest {
   tiledb::sm::LsObjects expected_results_;
 };
 
-
-static constexpr const char *PATH_DELIM = "/";
-
-template <typename T>
-T pathjoin(T t) {
-  return t;
-}
-
-template <typename T, typename... Args>
-T pathjoin(T t, Args... args) {
-  return t + PATH_DELIM + pathjoin<Args...>(args...);
-}
-
 /**
  * Represents a path used in the test.
  * Encapsulates absolute and relative paths, and can be extended for URI
@@ -135,21 +122,21 @@ T pathjoin(T t, Args... args) {
  */
 struct TestPath {
   VFSTest    &vfs_test;
-  std::string abspath;
-  std::string relpath;
+  std::filesystem::path relpath;
+  std::filesystem::path abspath;
   uint64_t    size;
 
   TestPath(VFSTest &vfs_test, std::string_view relpath, uint64_t size = 0) :
     vfs_test(vfs_test),
-    abspath(pathjoin(vfs_test.temp_dir_.to_path(), std::string(relpath))),
     relpath(relpath),
+    abspath(std::filesystem::path(vfs_test.temp_dir_.to_path()).append(relpath)),
     size(size)
   {}
 
   TestPath(const TestPath &copy) :
     vfs_test(copy.vfs_test),
-    abspath(copy.abspath),
     relpath(copy.relpath),
+    abspath(copy.abspath),
     size(copy.size)
   {}
 
@@ -181,8 +168,8 @@ struct TestPath {
    * @return a string containing the way this is expected
    * to appear in the ls_recursive output
    */
-  std::string_view lsresult() const {
-    return abspath; /* TODO: this shoudl be URI */
+  std::string lsresult() const {
+    return abspath.native(); /* TODO: this shoudl be URI */
   }
 
   bool matches(const std::pair<std::string, uint64_t>& lsout) const {

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -52,7 +52,9 @@ class VFSTest {
       , vfs_(&stats_, &io_, &compute_, tiledb::sm::Config())
       , test_tree_(test_tree)
       , prefix_(prefix)
-      , temp_dir_(prefix_) {
+      , temp_dir_(prefix_)
+      , init_open_files_(count_open_files())
+  {
   }
 
   virtual ~VFSTest() {
@@ -63,10 +65,40 @@ class VFSTest {
     }
   }
 
-  /** FilePredicate for passing to ls_filtered that accepts all files. */
-  static bool accept_all_files(const std::string_view&, uint64_t) {
-    return true;
+  Status mkdir() const {
+    return vfs_.create_dir(temp_dir_);
   }
+
+#ifdef __windows__
+  std::optional<uint64_t> count_open_files() const {
+    return std::nullopt;
+  }
+#else
+  std::optional<uint64_t> count_open_files() const {
+    const std::string fddir = "/proc/" + std::to_string(getpid()) + "/fd";
+
+    std::vector<tiledb::sm::URI> ls;
+    const auto st = vfs_.ls(tiledb::sm::URI(fddir), &ls);
+    REQUIRE(st.ok());
+    return ls.size();
+  }
+#endif
+
+  /**
+   * @return true if the number of open files is the same
+   * as it was when we started the test
+   */
+  bool check_open_files() const {
+    const auto maybe_updated_open_files = count_open_files();
+    if (maybe_updated_open_files) {
+      const uint64_t updated_open_files = *maybe_updated_open_files;
+      return (updated_open_files == init_open_files_);
+    } else {
+      /* not enough information to say otherwise */
+      return true;
+    }
+  }
+
 
   /** Resources needed to construct VFS */
   tiledb::sm::stats::Stats stats_;
@@ -77,40 +109,438 @@ class VFSTest {
   std::string prefix_;
   tiledb::sm::URI temp_dir_;
 
+  std::optional<uint64_t> init_open_files_;
+
  private:
   tiledb::sm::LsObjects expected_results_;
 };
 
-// TODO: Disable shouldfail when file:// or mem:// support is added.
+
+static constexpr const char *PATH_DELIM = "/";
+
+template <typename T>
+T pathjoin(T t) {
+  return t;
+}
+
+template <typename T, typename... Args>
+T pathjoin(T t, Args... args) {
+  return t + PATH_DELIM + pathjoin<Args...>(args...);
+}
+
+/**
+ * Represents a path used in the test.
+ * Encapsulates absolute and relative paths, and can be extended for URI
+ * if we determine that `ls_recursive` should output that instead.
+ */
+struct TestPath {
+  VFSTest    &vfs_test;
+  std::string abspath;
+  std::string relpath;
+  uint64_t    size;
+
+  TestPath(VFSTest &vfs_test, std::string_view relpath, uint64_t size = 0) :
+    vfs_test(vfs_test),
+    abspath(pathjoin(vfs_test.temp_dir_.to_path(), std::string(relpath))),
+    relpath(relpath),
+    size(size)
+  {}
+
+  TestPath(const TestPath &copy) :
+    vfs_test(copy.vfs_test),
+    abspath(copy.abspath),
+    relpath(copy.relpath),
+    size(copy.size)
+  {}
+
+  void touch(bool mkdirs = false) {
+    if (mkdirs) {
+      std::vector<tiledb::sm::URI> parents;
+
+      tiledb::sm::URI absuri(abspath);
+      do {
+        absuri = absuri.parent_path();
+        parents.push_back(absuri);
+      } while (absuri != vfs_test.temp_dir_);
+
+      parents.pop_back(); /* temp_dir_ */
+      while (!parents.empty()) {
+        REQUIRE(vfs_test.vfs_.create_dir(parents.back()).ok());
+        parents.pop_back();
+      }
+    }
+    REQUIRE(vfs_test.vfs_.touch(tiledb::sm::URI(abspath)).ok());
+    std::filesystem::resize_file(abspath, size);
+  }
+
+  void mkdir() {
+    REQUIRE(vfs_test.vfs_.create_dir(tiledb::sm::URI(abspath)).ok());
+  }
+
+  /**
+   * @return a string containing the way this is expected
+   * to appear in the ls_recursive output
+   */
+  std::string_view lsresult() const {
+    return abspath; /* TODO: this shoudl be URI */
+  }
+
+  bool matches(const std::pair<std::string, uint64_t>& lsout) const {
+    return (lsresult() == lsout.first && size == lsout.second);
+  }
+};
+
+tiledb::sm::LsObjects sort_by_name(const tiledb::sm::LsObjects &in_objs) {
+  tiledb::sm::LsObjects out_objs(in_objs);
+  std::sort(out_objs.begin(), out_objs.end(), [](const auto &f1, const auto &f2) {
+      return f1.first < f2.first;
+      });
+  return out_objs;
+}
+
+
+TEST_CASE(
+    "VFS: ls_recursive unfiltered",
+    "[vfs][ls_recursive]")
+{
+  std::string prefix = GENERATE("file://");
+  prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
+
+  VFSTest vfs_test({0}, prefix);
+  const auto mkst = vfs_test.mkdir();
+  REQUIRE(mkst.ok());
+
+  std::vector<TestPath> testpaths = {
+    TestPath(vfs_test, "a1.txt", 30),
+    TestPath(vfs_test, "a2.txt", 40),
+    TestPath(vfs_test, "f1.txt", 10),
+    TestPath(vfs_test, "f2.txt", 20),
+    TestPath(vfs_test, "d1/f1.txt", 45),
+    TestPath(vfs_test, "d1/c1.txt", 55),
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/g1.txt", 33),
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1/b1.txt", 12),
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1/h1.txt", 33),
+  };
+
+  SECTION("Empty directory") {
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    CHECK(ls.empty());
+  }
+
+  SECTION("Files only") {
+    testpaths[0].touch();
+    testpaths[1].touch();
+    testpaths[2].touch();
+    testpaths[3].touch();
+
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    REQUIRE(ls.size() == 4);
+    CHECK(testpaths[0].matches(ls[0]));
+    CHECK(testpaths[1].matches(ls[1]));
+    CHECK(testpaths[2].matches(ls[2]));
+    CHECK(testpaths[3].matches(ls[3]));
+  }
+
+  SECTION("Empty subdirectory") {
+    TestPath(vfs_test, "d1").mkdir();
+
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+
+    /*
+     * TODO with reviewer feedback: should this be empty or list `d1`?
+     */
+    REQUIRE(ls.empty());
+  }
+
+  SECTION("Empty subdirectory and files") {
+    testpaths[0].touch();
+    testpaths[1].touch();
+    TestPath(vfs_test, "d1").mkdir();
+    testpaths[2].touch();
+    testpaths[3].touch();
+
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    REQUIRE(ls.size() == 4);
+    CHECK(testpaths[0].matches(ls[0]));
+    CHECK(testpaths[1].matches(ls[1]));
+    CHECK(testpaths[2].matches(ls[2]));
+    CHECK(testpaths[3].matches(ls[3]));
+  }
+
+  SECTION("Empty sub-subdirectory") {
+    TestPath(vfs_test, "d1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1").mkdir();
+
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+
+    /*
+     * TODO with reviewer feedback: should this be empty or list `d1`?
+     */
+    REQUIRE(ls.empty());
+  }
+
+  SECTION("Deeply-nested files") {
+    TestPath(vfs_test, "d1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1").mkdir();
+    testpaths[7].touch();
+
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    REQUIRE(ls.size() == 1);
+
+    CHECK(testpaths[7].matches(ls[0]));
+  }
+
+  SECTION("Recursion") {
+    TestPath(vfs_test, "d1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1").mkdir();
+    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1").mkdir();
+    for (unsigned i = 0; i < testpaths.size(); i++) {
+      testpaths[i].touch();
+    }
+
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    REQUIRE(ls.size() == testpaths.size());
+    REQUIRE(testpaths.size() >= 9); /* avoid invalid access below */
+
+    CHECK(testpaths[0].matches(ls[0]));
+    CHECK(testpaths[1].matches(ls[1]));
+    CHECK(testpaths[5].matches(ls[2]));
+    CHECK(testpaths[7].matches(ls[3]));
+    CHECK(testpaths[8].matches(ls[4]));
+    CHECK(testpaths[6].matches(ls[5]));
+    CHECK(testpaths[4].matches(ls[6]));
+    CHECK(testpaths[2].matches(ls[7]));
+    CHECK(testpaths[3].matches(ls[8]));
+  }
+
+  /* all tests must close all the files that they opened, in normal use of the API */
+  REQUIRE(vfs_test.check_open_files());
+}
+
+TEST_CASE(
+    "VFS: ls_recursive file filter",
+    "[vfs][ls_recursive]") {
+  std::string prefix = GENERATE("file://");
+  prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
+
+  VFSTest vfs_test({0}, prefix);
+  const auto mkst = vfs_test.mkdir();
+  REQUIRE(mkst.ok());
+
+  std::vector<TestPath> testpaths = {
+    TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
+    TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
+    TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
+    TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
+    TestPath(vfs_test, "year=2021/month=9/day=27/log1.txt", 50),
+    TestPath(vfs_test, "year=2021/month=9/day=27/log2.txt", 51),
+    TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 60),
+    TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 61),
+    TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
+    TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
+    TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
+    TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
+    TestPath(vfs_test, "year=2022/month=9/day=27/log1.txt", 90),
+    TestPath(vfs_test, "year=2022/month=9/day=27/log2.txt", 91),
+    TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 20),
+    TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 21),
+  };
+
+  SECTION("File predicate returning false is discarded from results") {
+    for (auto &testpath : testpaths) {
+      testpath.touch(true);
+    }
+
+    /*
+     * This also shows us that the file filter is only called on the leaves,
+     * since "log1.txt" only appears in the basename component of the test paths.
+     */
+    auto log_is_1 = [](const std::string_view& path, uint64_t) -> bool {
+      return (path.find("log1.txt") != std::string::npos);
+    };
+
+    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        log_is_1, tiledb::sm::accept_all_dirs);
+    CHECK(ls.size() == testpaths.size() / 2);
+
+    ls = sort_by_name(ls);  /* ensure order matches the testpaths order */
+
+    for (uint64_t i = 0; i < testpaths.size(); i += 2) {
+      CHECK(testpaths[i].matches(ls[i / 2]));
+    }
+  }
+}
+
+TEST_CASE(
+    "VFS: ls_recursive directory filter",
+    "[vfs][ls_recursive]") {
+  std::string prefix = GENERATE("file://");
+  prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
+
+  VFSTest vfs_test({0}, prefix);
+  const auto mkst = vfs_test.mkdir();
+  REQUIRE(mkst.ok());
+
+  std::vector<TestPath> testpaths = {
+    TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
+    TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
+    TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
+    TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
+    TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 50),
+    TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 51),
+    TestPath(vfs_test, "year=2021/month=9/day=29/log1.txt", 60),
+    TestPath(vfs_test, "year=2021/month=9/day=29/log2.txt", 61),
+    TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
+    TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
+    TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
+    TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
+    TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 90),
+    TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 91),
+    TestPath(vfs_test, "year=2022/month=9/day=29/log1.txt", 20),
+    TestPath(vfs_test, "year=2022/month=9/day=29/log2.txt", 21),
+  };
+
+  /* create all files and dirs */
+  for (auto &testpath : testpaths) {
+    testpath.touch(true);
+  }
+
+  SECTION("Directory predicate returning true is filtered from results") {
+    auto month_is_august = [](std::string_view dirname) -> bool {
+      if (dirname.find("month") == std::string::npos) {
+        /* haven't descended far enough yet */
+        return true;
+      } else if (dirname.find("month=8") == std::string::npos) {
+        /* not august */
+        return false;
+      } else {
+        return true;
+      }
+    };
+
+    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files, month_is_august);
+    CHECK(ls.size() == testpaths.size() / 2);
+
+    ls = sort_by_name(ls);  /* ensure order matches the testpaths order */
+
+    CHECK(ls.size() == 8);
+    if (ls.size() >= 1) { testpaths[0].matches(ls[0]); }
+    if (ls.size() >= 2) { testpaths[1].matches(ls[1]); }
+    if (ls.size() >= 3) { testpaths[2].matches(ls[2]); }
+    if (ls.size() >= 4) { testpaths[3].matches(ls[3]); }
+    if (ls.size() >= 5) { testpaths[8].matches(ls[4]); }
+    if (ls.size() >= 6) { testpaths[9].matches(ls[5]); }
+    if (ls.size() >= 7) { testpaths[10].matches(ls[6]); }
+    if (ls.size() >= 8) { testpaths[11].matches(ls[7]); }
+  }
+
+  /* note: this should be true for POSIX but is not for S3 without hierarchical list API */
+  SECTION("Directory predicate returning true does not descend into directory") {
+    /*
+     * In the test data we only find "day=29" beneath "month=9",
+     * so the `ls` should throw with this directory filter if and only if
+     * we descend into directories with "month=9".
+     */
+    std::string monthstr = "month=9";
+    auto throw_if_day_is_29 = [&monthstr](std::string_view dirname) -> bool {
+      if (dirname.find("month") == std::string::npos) {
+        /* haven't descended far enough yet */
+        return true;
+      } else if (dirname.find(monthstr) == std::string::npos) {
+        /* not august */
+        return false;
+      } else if (dirname.find("day=29") == std::string::npos) {
+        /* not the 29th */
+        return true;
+      } else {
+        /* it is the 29th, throw */
+        throw std::logic_error("Throwing FileFilter: day=29");
+      }
+    };
+
+    CHECK_THROWS_AS(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29),
+        std::logic_error);
+    CHECK_THROWS_WITH(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29),
+        Catch::Matchers::ContainsSubstring("Throwing FileFilter: day=29"));
+
+    monthstr = "month=8";
+
+    /* now the result should be the same as the first section */
+    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29);
+    CHECK(ls.size() == testpaths.size() / 2);
+
+    ls = sort_by_name(ls);  /* ensure order matches the testpaths order */
+
+    CHECK(ls.size() == 8);
+    if (ls.size() >= 1) { testpaths[0].matches(ls[0]); }
+    if (ls.size() >= 2) { testpaths[1].matches(ls[1]); }
+    if (ls.size() >= 3) { testpaths[2].matches(ls[2]); }
+    if (ls.size() >= 4) { testpaths[3].matches(ls[3]); }
+    if (ls.size() >= 5) { testpaths[8].matches(ls[4]); }
+    if (ls.size() >= 6) { testpaths[9].matches(ls[5]); }
+    if (ls.size() >= 7) { testpaths[10].matches(ls[6]); }
+    if (ls.size() >= 8) { testpaths[11].matches(ls[7]); }
+  }
+
+  /*
+   * Note that since we throw in the previous section, this check
+   * demonstrates that all directories are closed whether or not we return
+   * from ls_recursive normally
+   */
+  REQUIRE(vfs_test.check_open_files());
+}
+
 TEST_CASE(
     "VFS: Throwing FileFilter ls_recursive",
-    "[vfs][ls_recursive][!shouldfail]") {
-  std::string prefix = GENERATE("file://", "mem://");
+    "[vfs][ls_recursive]") {
+  std::string prefix = GENERATE("file://");
   prefix += std::filesystem::current_path().string() + "/ls_filtered_test";
 
   VFSTest vfs_test({0}, prefix);
-  auto file_filter = [](const std::string_view&, uint64_t) -> bool {
+  const auto mkst = vfs_test.mkdir();
+  REQUIRE(mkst.ok());
+
+  auto always_throw_filter = [](const std::string_view&, uint64_t) -> bool {
     throw std::logic_error("Throwing FileFilter");
   };
   SECTION("Throwing FileFilter with 0 objects should not throw") {
     CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, file_filter, tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, always_throw_filter, tiledb::sm::accept_all_dirs));
+  }
+  SECTION("Throwing FileFilter will not throw if ls_recursive only visits directories") {
   }
   SECTION("Throwing FileFilter with N objects should throw") {
     vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")).ok();
     CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, always_throw_filter),
         std::logic_error);
     CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, always_throw_filter),
         Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
   }
+
+  /* all tests must close all the files that they opened, regardless of exception behavior */
+  REQUIRE(vfs_test.check_open_files());
 }
 
 TEST_CASE(
     "VFS: ls_recursive throws for unsupported filesystems",
     "[vfs][ls_recursive]") {
-  std::string prefix = GENERATE("file://", "mem://");
+  std::string prefix = GENERATE("mem://");
   prefix += std::filesystem::current_path().string() + "/ls_filtered_test";
 
   VFSTest vfs_test({1}, prefix);
@@ -118,7 +548,9 @@ TEST_CASE(
   DYNAMIC_SECTION(backend << " unsupported backend should throw") {
     CHECK_THROWS_WITH(
         vfs_test.vfs_.ls_recursive(
-            vfs_test.temp_dir_, VFSTest::accept_all_files),
+            vfs_test.temp_dir_, tiledb::sm::accept_all_files),
         Catch::Matchers::ContainsSubstring("storage backend is not supported"));
   }
+
+  REQUIRE(vfs_test.check_open_files());
 }

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -53,8 +53,7 @@ class VFSTest {
       , test_tree_(test_tree)
       , prefix_(prefix)
       , temp_dir_(prefix_)
-      , init_open_files_(count_open_files())
-  {
+      , init_open_files_(count_open_files()) {
   }
 
   virtual ~VFSTest() {
@@ -99,7 +98,6 @@ class VFSTest {
     }
   }
 
-
   /** Resources needed to construct VFS */
   tiledb::sm::stats::Stats stats_;
   ThreadPool io_, compute_;
@@ -121,24 +119,25 @@ class VFSTest {
  * if we determine that `ls_recursive` should output that instead.
  */
 struct TestPath {
-  VFSTest    &vfs_test;
+  VFSTest& vfs_test;
   std::filesystem::path relpath;
   std::filesystem::path abspath;
-  uint64_t    size;
+  uint64_t size;
 
-  TestPath(VFSTest &vfs_test, std::string_view relpath, uint64_t size = 0) :
-    vfs_test(vfs_test),
-    relpath(relpath),
-    abspath(std::filesystem::path(vfs_test.temp_dir_.to_path()).append(relpath)),
-    size(size)
-  {}
+  TestPath(VFSTest& vfs_test, std::string_view relpath, uint64_t size = 0)
+      : vfs_test(vfs_test)
+      , relpath(relpath)
+      , abspath(
+            std::filesystem::path(vfs_test.temp_dir_.to_path()).append(relpath))
+      , size(size) {
+  }
 
-  TestPath(const TestPath &copy) :
-    vfs_test(copy.vfs_test),
-    relpath(copy.relpath),
-    abspath(copy.abspath),
-    size(copy.size)
-  {}
+  TestPath(const TestPath& copy)
+      : vfs_test(copy.vfs_test)
+      , relpath(copy.relpath)
+      , abspath(copy.abspath)
+      , size(copy.size) {
+  }
 
   void touch(bool mkdirs = false) {
     if (mkdirs) {
@@ -177,19 +176,16 @@ struct TestPath {
   }
 };
 
-tiledb::sm::LsObjects sort_by_name(const tiledb::sm::LsObjects &in_objs) {
+tiledb::sm::LsObjects sort_by_name(const tiledb::sm::LsObjects& in_objs) {
   tiledb::sm::LsObjects out_objs(in_objs);
-  std::sort(out_objs.begin(), out_objs.end(), [](const auto &f1, const auto &f2) {
-      return f1.first < f2.first;
+  std::sort(
+      out_objs.begin(), out_objs.end(), [](const auto& f1, const auto& f2) {
+        return f1.first < f2.first;
       });
   return out_objs;
 }
 
-
-TEST_CASE(
-    "VFS: ls_recursive unfiltered",
-    "[vfs][ls_recursive]")
-{
+TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("file://");
   prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
 
@@ -198,20 +194,22 @@ TEST_CASE(
   REQUIRE(mkst.ok());
 
   std::vector<TestPath> testpaths = {
-    TestPath(vfs_test, "a1.txt", 30),
-    TestPath(vfs_test, "a2.txt", 40),
-    TestPath(vfs_test, "f1.txt", 10),
-    TestPath(vfs_test, "f2.txt", 20),
-    TestPath(vfs_test, "d1/f1.txt", 45),
-    TestPath(vfs_test, "d1/c1.txt", 55),
-    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/g1.txt", 33),
-    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1/b1.txt", 12),
-    TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1/h1.txt", 33),
+      TestPath(vfs_test, "a1.txt", 30),
+      TestPath(vfs_test, "a2.txt", 40),
+      TestPath(vfs_test, "f1.txt", 10),
+      TestPath(vfs_test, "f2.txt", 20),
+      TestPath(vfs_test, "d1/f1.txt", 45),
+      TestPath(vfs_test, "d1/c1.txt", 55),
+      TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/g1.txt", 33),
+      TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1/b1.txt", 12),
+      TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1/h1.txt", 33),
   };
 
   SECTION("Empty directory") {
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
     CHECK(ls.empty());
   }
 
@@ -221,8 +219,10 @@ TEST_CASE(
     testpaths[2].touch();
     testpaths[3].touch();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
     REQUIRE(ls.size() == 4);
     CHECK(testpaths[0].matches(ls[0]));
     CHECK(testpaths[1].matches(ls[1]));
@@ -234,11 +234,15 @@ TEST_CASE(
     auto d1 = TestPath(vfs_test, "d1");
     d1.mkdir();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
 
     CHECK(ls.size() == 1);
-    if (ls.size() >= 1) { CHECK(d1.matches(ls[0])); }
+    if (ls.size() >= 1) {
+      CHECK(d1.matches(ls[0]));
+    }
   }
 
   SECTION("Empty subdirectory and files") {
@@ -249,14 +253,26 @@ TEST_CASE(
     testpaths[2].touch();
     testpaths[3].touch();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
     CHECK(ls.size() == 5);
-    if (ls.size() >= 1) { CHECK(testpaths[0].matches(ls[0])); }
-    if (ls.size() >= 2) { CHECK(testpaths[1].matches(ls[1])); }
-    if (ls.size() >= 3) { CHECK(d1.matches(ls[2])); }
-    if (ls.size() >= 4) { CHECK(testpaths[2].matches(ls[3])); }
-    if (ls.size() >= 5) { CHECK(testpaths[3].matches(ls[4])); }
+    if (ls.size() >= 1) {
+      CHECK(testpaths[0].matches(ls[0]));
+    }
+    if (ls.size() >= 2) {
+      CHECK(testpaths[1].matches(ls[1]));
+    }
+    if (ls.size() >= 3) {
+      CHECK(d1.matches(ls[2]));
+    }
+    if (ls.size() >= 4) {
+      CHECK(testpaths[2].matches(ls[3]));
+    }
+    if (ls.size() >= 5) {
+      CHECK(testpaths[3].matches(ls[4]));
+    }
   }
 
   SECTION("Empty sub-subdirectory") {
@@ -264,11 +280,15 @@ TEST_CASE(
     auto d1sub1 = TestPath(vfs_test, "d1/d1sub1");
     d1sub1.mkdir();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
 
     CHECK(ls.size() == 1);
-    if (ls.size() >= 1) { CHECK(d1sub1.matches(ls[0])); }
+    if (ls.size() >= 1) {
+      CHECK(d1sub1.matches(ls[0]));
+    }
   }
 
   SECTION("Deeply-nested files") {
@@ -278,8 +298,10 @@ TEST_CASE(
     TestPath(vfs_test, "d1/d1sub1/d1sub1sub1/d1sub1sub1sub1").mkdir();
     testpaths[7].touch();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
     REQUIRE(ls.size() == 1);
 
     CHECK(testpaths[7].matches(ls[0]));
@@ -295,29 +317,48 @@ TEST_CASE(
       testpaths[i].touch();
     }
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, tiledb::sm::accept_all_dirs));
+    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_,
+        tiledb::sm::accept_all_files,
+        tiledb::sm::accept_all_dirs));
     CHECK(ls.size() == testpaths.size());
     REQUIRE(testpaths.size() >= 9); /* avoid invalid access below */
 
-    if (ls.size() >= 1) { CHECK(testpaths[0].matches(ls[0])); }
-    if (ls.size() >= 2) { CHECK(testpaths[1].matches(ls[1])); }
-    if (ls.size() >= 3) { CHECK(testpaths[5].matches(ls[2])); }
-    if (ls.size() >= 4) { CHECK(testpaths[7].matches(ls[3])); }
-    if (ls.size() >= 5) { CHECK(testpaths[8].matches(ls[4])); }
-    if (ls.size() >= 6) { CHECK(testpaths[6].matches(ls[5])); }
-    if (ls.size() >= 7) { CHECK(testpaths[4].matches(ls[6])); }
-    if (ls.size() >= 8) { CHECK(testpaths[2].matches(ls[7])); }
-    if (ls.size() >= 9) { CHECK(testpaths[3].matches(ls[8])); }
+    if (ls.size() >= 1) {
+      CHECK(testpaths[0].matches(ls[0]));
+    }
+    if (ls.size() >= 2) {
+      CHECK(testpaths[1].matches(ls[1]));
+    }
+    if (ls.size() >= 3) {
+      CHECK(testpaths[5].matches(ls[2]));
+    }
+    if (ls.size() >= 4) {
+      CHECK(testpaths[7].matches(ls[3]));
+    }
+    if (ls.size() >= 5) {
+      CHECK(testpaths[8].matches(ls[4]));
+    }
+    if (ls.size() >= 6) {
+      CHECK(testpaths[6].matches(ls[5]));
+    }
+    if (ls.size() >= 7) {
+      CHECK(testpaths[4].matches(ls[6]));
+    }
+    if (ls.size() >= 8) {
+      CHECK(testpaths[2].matches(ls[7]));
+    }
+    if (ls.size() >= 9) {
+      CHECK(testpaths[3].matches(ls[8]));
+    }
   }
 
-  /* all tests must close all the files that they opened, in normal use of the API */
+  /* all tests must close all the files that they opened, in normal use of the
+   * API */
   REQUIRE(vfs_test.check_open_files());
 }
 
-TEST_CASE(
-    "VFS: ls_recursive file filter",
-    "[vfs][ls_recursive]") {
+TEST_CASE("VFS: ls_recursive file filter", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("file://");
   prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
 
@@ -326,42 +367,43 @@ TEST_CASE(
   REQUIRE(mkst.ok());
 
   std::vector<TestPath> testpaths = {
-    TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
-    TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
-    TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
-    TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
-    TestPath(vfs_test, "year=2021/month=9/day=27/log1.txt", 50),
-    TestPath(vfs_test, "year=2021/month=9/day=27/log2.txt", 51),
-    TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 60),
-    TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 61),
-    TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
-    TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
-    TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
-    TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
-    TestPath(vfs_test, "year=2022/month=9/day=27/log1.txt", 90),
-    TestPath(vfs_test, "year=2022/month=9/day=27/log2.txt", 91),
-    TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 20),
-    TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 21),
+      TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
+      TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
+      TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
+      TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
+      TestPath(vfs_test, "year=2021/month=9/day=27/log1.txt", 50),
+      TestPath(vfs_test, "year=2021/month=9/day=27/log2.txt", 51),
+      TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 60),
+      TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 61),
+      TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
+      TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
+      TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
+      TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
+      TestPath(vfs_test, "year=2022/month=9/day=27/log1.txt", 90),
+      TestPath(vfs_test, "year=2022/month=9/day=27/log2.txt", 91),
+      TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 20),
+      TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 21),
   };
 
   SECTION("File predicate returning false is discarded from results") {
-    for (auto &testpath : testpaths) {
+    for (auto& testpath : testpaths) {
       testpath.touch(true);
     }
 
     /*
      * This also shows us that the file filter is only called on the leaves,
-     * since "log1.txt" only appears in the basename component of the test paths.
+     * since "log1.txt" only appears in the basename component of the test
+     * paths.
      */
     auto log_is_1 = [](const std::string_view& path, uint64_t) -> bool {
       return (path.find("log1.txt") != std::string::npos);
     };
 
-    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        log_is_1, tiledb::sm::accept_all_dirs);
+    auto ls = vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_, log_is_1, tiledb::sm::accept_all_dirs);
     CHECK(ls.size() == testpaths.size() / 2);
 
-    ls = sort_by_name(ls);  /* ensure order matches the testpaths order */
+    ls = sort_by_name(ls); /* ensure order matches the testpaths order */
 
     for (uint64_t i = 0; i < testpaths.size(); i += 2) {
       CHECK(testpaths[i].matches(ls[i / 2]));
@@ -369,9 +411,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "VFS: ls_recursive directory filter",
-    "[vfs][ls_recursive]") {
+TEST_CASE("VFS: ls_recursive directory filter", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("file://");
   prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
 
@@ -380,26 +420,26 @@ TEST_CASE(
   REQUIRE(mkst.ok());
 
   std::vector<TestPath> testpaths = {
-    TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
-    TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
-    TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
-    TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
-    TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 50),
-    TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 51),
-    TestPath(vfs_test, "year=2021/month=9/day=29/log1.txt", 60),
-    TestPath(vfs_test, "year=2021/month=9/day=29/log2.txt", 61),
-    TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
-    TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
-    TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
-    TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
-    TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 90),
-    TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 91),
-    TestPath(vfs_test, "year=2022/month=9/day=29/log1.txt", 20),
-    TestPath(vfs_test, "year=2022/month=9/day=29/log2.txt", 21),
+      TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
+      TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
+      TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
+      TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
+      TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 50),
+      TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 51),
+      TestPath(vfs_test, "year=2021/month=9/day=29/log1.txt", 60),
+      TestPath(vfs_test, "year=2021/month=9/day=29/log2.txt", 61),
+      TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
+      TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
+      TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
+      TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
+      TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 90),
+      TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 91),
+      TestPath(vfs_test, "year=2022/month=9/day=29/log1.txt", 20),
+      TestPath(vfs_test, "year=2022/month=9/day=29/log2.txt", 21),
   };
 
   /* create all files and dirs */
-  for (auto &testpath : testpaths) {
+  for (auto& testpath : testpaths) {
     testpath.touch(true);
   }
 
@@ -416,25 +456,43 @@ TEST_CASE(
       }
     };
 
-    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files, month_is_august);
+    auto ls = vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files, month_is_august);
     CHECK(ls.size() == testpaths.size() / 2);
 
-    ls = sort_by_name(ls);  /* ensure order matches the testpaths order */
+    ls = sort_by_name(ls); /* ensure order matches the testpaths order */
 
     CHECK(ls.size() == 8);
-    if (ls.size() >= 1) { testpaths[0].matches(ls[0]); }
-    if (ls.size() >= 2) { testpaths[1].matches(ls[1]); }
-    if (ls.size() >= 3) { testpaths[2].matches(ls[2]); }
-    if (ls.size() >= 4) { testpaths[3].matches(ls[3]); }
-    if (ls.size() >= 5) { testpaths[8].matches(ls[4]); }
-    if (ls.size() >= 6) { testpaths[9].matches(ls[5]); }
-    if (ls.size() >= 7) { testpaths[10].matches(ls[6]); }
-    if (ls.size() >= 8) { testpaths[11].matches(ls[7]); }
+    if (ls.size() >= 1) {
+      testpaths[0].matches(ls[0]);
+    }
+    if (ls.size() >= 2) {
+      testpaths[1].matches(ls[1]);
+    }
+    if (ls.size() >= 3) {
+      testpaths[2].matches(ls[2]);
+    }
+    if (ls.size() >= 4) {
+      testpaths[3].matches(ls[3]);
+    }
+    if (ls.size() >= 5) {
+      testpaths[8].matches(ls[4]);
+    }
+    if (ls.size() >= 6) {
+      testpaths[9].matches(ls[5]);
+    }
+    if (ls.size() >= 7) {
+      testpaths[10].matches(ls[6]);
+    }
+    if (ls.size() >= 8) {
+      testpaths[11].matches(ls[7]);
+    }
   }
 
-  /* note: this should be true for POSIX but is not for S3 without hierarchical list API */
-  SECTION("Directory predicate returning true does not descend into directory") {
+  /* note: this should be true for POSIX but is not for S3 without hierarchical
+   * list API */
+  SECTION(
+      "Directory predicate returning true does not descend into directory") {
     /*
      * In the test data we only find "day=29" beneath "month=9",
      * so the `ls` should throw with this directory filter if and only if
@@ -458,29 +516,52 @@ TEST_CASE(
     };
 
     CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29),
+        vfs_test.vfs_.ls_recursive(
+            vfs_test.temp_dir_,
+            tiledb::sm::accept_all_files,
+            throw_if_day_is_29),
         std::logic_error);
     CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29),
+        vfs_test.vfs_.ls_recursive(
+            vfs_test.temp_dir_,
+            tiledb::sm::accept_all_files,
+            throw_if_day_is_29),
         Catch::Matchers::ContainsSubstring("Throwing FileFilter: day=29"));
 
     monthstr = "month=8";
 
     /* now the result should be the same as the first section */
-    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29);
+    auto ls = vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files, throw_if_day_is_29);
     CHECK(ls.size() == testpaths.size() / 2);
 
-    ls = sort_by_name(ls);  /* ensure order matches the testpaths order */
+    ls = sort_by_name(ls); /* ensure order matches the testpaths order */
 
     CHECK(ls.size() == 8);
-    if (ls.size() >= 1) { testpaths[0].matches(ls[0]); }
-    if (ls.size() >= 2) { testpaths[1].matches(ls[1]); }
-    if (ls.size() >= 3) { testpaths[2].matches(ls[2]); }
-    if (ls.size() >= 4) { testpaths[3].matches(ls[3]); }
-    if (ls.size() >= 5) { testpaths[8].matches(ls[4]); }
-    if (ls.size() >= 6) { testpaths[9].matches(ls[5]); }
-    if (ls.size() >= 7) { testpaths[10].matches(ls[6]); }
-    if (ls.size() >= 8) { testpaths[11].matches(ls[7]); }
+    if (ls.size() >= 1) {
+      testpaths[0].matches(ls[0]);
+    }
+    if (ls.size() >= 2) {
+      testpaths[1].matches(ls[1]);
+    }
+    if (ls.size() >= 3) {
+      testpaths[2].matches(ls[2]);
+    }
+    if (ls.size() >= 4) {
+      testpaths[3].matches(ls[3]);
+    }
+    if (ls.size() >= 5) {
+      testpaths[8].matches(ls[4]);
+    }
+    if (ls.size() >= 6) {
+      testpaths[9].matches(ls[5]);
+    }
+    if (ls.size() >= 7) {
+      testpaths[10].matches(ls[6]);
+    }
+    if (ls.size() >= 8) {
+      testpaths[11].matches(ls[7]);
+    }
   }
 
   /*
@@ -491,9 +572,7 @@ TEST_CASE(
   REQUIRE(vfs_test.check_open_files());
 }
 
-TEST_CASE(
-    "VFS: Throwing FileFilter ls_recursive",
-    "[vfs][ls_recursive]") {
+TEST_CASE("VFS: Throwing FileFilter ls_recursive", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("file://");
   prefix += std::filesystem::current_path().string() + "/ls_filtered_test";
 
@@ -508,7 +587,9 @@ TEST_CASE(
     CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
         vfs_test.temp_dir_, always_throw_filter, tiledb::sm::accept_all_dirs));
   }
-  SECTION("Throwing FileFilter will not throw if ls_recursive only visits directories") {
+  SECTION(
+      "Throwing FileFilter will not throw if ls_recursive only visits "
+      "directories") {
   }
   SECTION("Throwing FileFilter with N objects should throw") {
     vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")).ok();
@@ -520,7 +601,8 @@ TEST_CASE(
         Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
   }
 
-  /* all tests must close all the files that they opened, regardless of exception behavior */
+  /* all tests must close all the files that they opened, regardless of
+   * exception behavior */
   REQUIRE(vfs_test.check_open_files());
 }
 


### PR DESCRIPTION
@shaunrd0 previously added `ls_recursive` support for the S3 file system.  This pull request implements it for Posix, in a hopefully-portable way (`std::filesystem::recursive_directory_iterator`) which can be recycled for Windows.

Some notes about input/output:
- while `LsObjects` has a `std::string` component, the string is a URI.
- for posix, we include empty directories in the result set.

The recursion is implemented so that if a directory does not pass the directory filter, then we do not descend into that directory.  I have added a unit test to check this behavior.  Something like this could be useful for S3 as well if the "list objects" request is done in hierarchical mode.

---
TYPE: FEATURE
DESC: Support VFS `ls_recursive` API for posix filesystem
