### PR TITLE
Remove Status from datatype_enum.

### DIFF
--- a/tiledb/api/c_api/datatype/datatype_api.cc
+++ b/tiledb/api/c_api/datatype/datatype_api.cc
@@ -45,11 +45,7 @@ capi_return_t tiledb_datatype_to_str(
 
 capi_return_t tiledb_datatype_from_str(
     const char* str, tiledb_datatype_t* datatype) {
-  tiledb::sm::Datatype val = tiledb::sm::Datatype::UINT8;
-  if (!tiledb::sm::datatype_enum(str, &val).ok()) {
-    return TILEDB_ERR;
-  }
-  *datatype = (tiledb_datatype_t)val;
+  *datatype = (tiledb_datatype_t)tiledb::sm::datatype_enum(str);
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -235,100 +235,99 @@ inline const std::string& datatype_str(Datatype type) {
 }
 
 /** Returns the datatype given a string representation. */
-inline Status datatype_enum(
-    const std::string& datatype_str, Datatype* datatype) {
+inline Datatype datatype_enum(const std::string& datatype_str) {
   if (datatype_str == constants::int32_str)
-    *datatype = Datatype::INT32;
+    return Datatype::INT32;
   else if (datatype_str == constants::int64_str)
-    *datatype = Datatype::INT64;
+    return Datatype::INT64;
   else if (datatype_str == constants::float32_str)
-    *datatype = Datatype::FLOAT32;
+    return Datatype::FLOAT32;
   else if (datatype_str == constants::float64_str)
-    *datatype = Datatype::FLOAT64;
+    return Datatype::FLOAT64;
   else if (datatype_str == constants::char_str)
-    *datatype = Datatype::CHAR;
+    return Datatype::CHAR;
   else if (datatype_str == constants::blob_str)
-    *datatype = Datatype::BLOB;
+    return Datatype::BLOB;
   else if (datatype_str == constants::geom_wkb_str)
-    *datatype = Datatype::GEOM_WKB;
+    return Datatype::GEOM_WKB;
   else if (datatype_str == constants::geom_wkt_str)
-    *datatype = Datatype::GEOM_WKT;
+    return Datatype::GEOM_WKT;
   else if (datatype_str == constants::bool_str)
-    *datatype = Datatype::BOOL;
+    return Datatype::BOOL;
   else if (datatype_str == constants::int8_str)
-    *datatype = Datatype::INT8;
+    return Datatype::INT8;
   else if (datatype_str == constants::uint8_str)
-    *datatype = Datatype::UINT8;
+    return Datatype::UINT8;
   else if (datatype_str == constants::int16_str)
-    *datatype = Datatype::INT16;
+    return Datatype::INT16;
   else if (datatype_str == constants::uint16_str)
-    *datatype = Datatype::UINT16;
+    return Datatype::UINT16;
   else if (datatype_str == constants::uint32_str)
-    *datatype = Datatype::UINT32;
+    return Datatype::UINT32;
   else if (datatype_str == constants::uint64_str)
-    *datatype = Datatype::UINT64;
+    return Datatype::UINT64;
   else if (datatype_str == constants::string_ascii_str)
-    *datatype = Datatype::STRING_ASCII;
+    return Datatype::STRING_ASCII;
   else if (datatype_str == constants::string_utf8_str)
-    *datatype = Datatype::STRING_UTF8;
+    return Datatype::STRING_UTF8;
   else if (datatype_str == constants::string_utf16_str)
-    *datatype = Datatype::STRING_UTF16;
+    return Datatype::STRING_UTF16;
   else if (datatype_str == constants::string_utf32_str)
-    *datatype = Datatype::STRING_UTF32;
+    return Datatype::STRING_UTF32;
   else if (datatype_str == constants::string_ucs2_str)
-    *datatype = Datatype::STRING_UCS2;
+    return Datatype::STRING_UCS2;
   else if (datatype_str == constants::string_ucs4_str)
-    *datatype = Datatype::STRING_UCS4;
+    return Datatype::STRING_UCS4;
   else if (datatype_str == constants::any_str)
-    *datatype = Datatype::ANY;
+    return Datatype::ANY;
   else if (datatype_str == constants::datetime_year_str)
-    *datatype = Datatype::DATETIME_YEAR;
+    return Datatype::DATETIME_YEAR;
   else if (datatype_str == constants::datetime_month_str)
-    *datatype = Datatype::DATETIME_MONTH;
+    return Datatype::DATETIME_MONTH;
   else if (datatype_str == constants::datetime_week_str)
-    *datatype = Datatype::DATETIME_WEEK;
+    return Datatype::DATETIME_WEEK;
   else if (datatype_str == constants::datetime_day_str)
-    *datatype = Datatype::DATETIME_DAY;
+    return Datatype::DATETIME_DAY;
   else if (datatype_str == constants::datetime_hr_str)
-    *datatype = Datatype::DATETIME_HR;
+    return Datatype::DATETIME_HR;
   else if (datatype_str == constants::datetime_min_str)
-    *datatype = Datatype::DATETIME_MIN;
+    return Datatype::DATETIME_MIN;
   else if (datatype_str == constants::datetime_sec_str)
-    *datatype = Datatype::DATETIME_SEC;
+    return Datatype::DATETIME_SEC;
   else if (datatype_str == constants::datetime_ms_str)
-    *datatype = Datatype::DATETIME_MS;
+    return Datatype::DATETIME_MS;
   else if (datatype_str == constants::datetime_us_str)
-    *datatype = Datatype::DATETIME_US;
+    return Datatype::DATETIME_US;
   else if (datatype_str == constants::datetime_ns_str)
-    *datatype = Datatype::DATETIME_NS;
+    return Datatype::DATETIME_NS;
   else if (datatype_str == constants::datetime_ps_str)
-    *datatype = Datatype::DATETIME_PS;
+    return Datatype::DATETIME_PS;
   else if (datatype_str == constants::datetime_fs_str)
-    *datatype = Datatype::DATETIME_FS;
+    return Datatype::DATETIME_FS;
   else if (datatype_str == constants::datetime_as_str)
-    *datatype = Datatype::DATETIME_AS;
+    return Datatype::DATETIME_AS;
   else if (datatype_str == constants::time_hr_str)
-    *datatype = Datatype::TIME_HR;
+    return Datatype::TIME_HR;
   else if (datatype_str == constants::time_min_str)
-    *datatype = Datatype::TIME_MIN;
+    return Datatype::TIME_MIN;
   else if (datatype_str == constants::time_sec_str)
-    *datatype = Datatype::TIME_SEC;
+    return Datatype::TIME_SEC;
   else if (datatype_str == constants::time_ms_str)
-    *datatype = Datatype::TIME_MS;
+    return Datatype::TIME_MS;
   else if (datatype_str == constants::time_us_str)
-    *datatype = Datatype::TIME_US;
+    return Datatype::TIME_US;
   else if (datatype_str == constants::time_ns_str)
-    *datatype = Datatype::TIME_NS;
+    return Datatype::TIME_NS;
   else if (datatype_str == constants::time_ps_str)
-    *datatype = Datatype::TIME_PS;
+    return Datatype::TIME_PS;
   else if (datatype_str == constants::time_fs_str)
-    *datatype = Datatype::TIME_FS;
+    return Datatype::TIME_FS;
   else if (datatype_str == constants::time_as_str)
-    *datatype = Datatype::TIME_AS;
+    return Datatype::TIME_AS;
   else {
-    return Status_Error("Invalid Datatype " + datatype_str);
+    throw std::runtime_error(
+        "Invalid Datatype string (\"" + datatype_str + "\")");
   }
-  return Status::Ok();
 }
 
 /** Returns true if the input datatype is a string type. */
@@ -440,12 +439,7 @@ inline void ensure_datatype_is_valid(Datatype type) {
  * the datatype string's enum is not between 0 and 43.
  **/
 inline void ensure_datatype_is_valid(const std::string& datatype_str) {
-  Datatype datatype_type;
-  Status st{datatype_enum(datatype_str, &datatype_type)};
-  if (!st.ok()) {
-    throw std::runtime_error(
-        "Invalid Datatype string (\"" + datatype_str + "\")");
-  }
+  Datatype datatype_type = datatype_enum(datatype_str);
   ensure_datatype_is_valid(datatype_type);
 }
 

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -102,8 +102,7 @@ Status metadata_from_capnp(
     auto entry_reader = entries_reader[i];
     auto key = std::string{std::string_view{
         entry_reader.getKey().cStr(), entry_reader.getKey().size()}};
-    Datatype type = Datatype::UINT8;
-    RETURN_NOT_OK(datatype_enum(entry_reader.getType(), &type));
+    Datatype type = datatype_enum(entry_reader.getType());
     uint32_t value_num = entry_reader.getValueNum();
 
     auto value_ptr = entry_reader.getValue();

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -400,8 +400,7 @@ void attribute_to_capnp(
 shared_ptr<Attribute> attribute_from_capnp(
     const capnp::Attribute::Reader& attribute_reader) {
   // Get datatype
-  Datatype datatype = Datatype::ANY;
-  throw_if_not_ok(datatype_enum(attribute_reader.getType(), &datatype));
+  Datatype datatype = datatype_enum(attribute_reader.getType());
 
   // Set nullable
   const bool nullable = attribute_reader.getNullable();
@@ -614,8 +613,7 @@ shared_ptr<Dimension> dimension_from_capnp(
   Status st;
 
   // Deserialize datatype
-  Datatype dim_type;
-  st = datatype_enum(dimension_reader.getType().cStr(), &dim_type);
+  Datatype dim_type = datatype_enum(dimension_reader.getType().cStr());
   if (!st.ok()) {
     throw std::runtime_error(
         "[Deserialization::dimension_from_capnp] " +
@@ -783,8 +781,7 @@ shared_ptr<DimensionLabel> dimension_label_from_capnp(
     const capnp::DimensionLabel::Reader& dim_label_reader,
     shared_ptr<MemoryTracker> memory_tracker) {
   // Get datatype
-  Datatype datatype = Datatype::ANY;
-  throw_if_not_ok(datatype_enum(dim_label_reader.getType(), &datatype));
+  Datatype datatype = datatype_enum(dim_label_reader.getType());
 
   shared_ptr<ArraySchema> schema{nullptr};
   if (dim_label_reader.hasSchema()) {

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -75,8 +75,7 @@ shared_ptr<const Enumeration> enumeration_from_capnp(
     shared_ptr<MemoryTracker> memory_tracker) {
   auto name = reader.getName();
   auto path_name = reader.getPathName();
-  Datatype datatype = Datatype::ANY;
-  throw_if_not_ok(datatype_enum(reader.getType(), &datatype));
+  Datatype datatype = datatype_enum(reader.getType());
 
   const void* data = nullptr;
   uint64_t data_size = 0;

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -268,8 +268,6 @@ Status subarray_from_capnp(
   uint32_t dim_num = ranges_reader.size();
   for (uint32_t i = 0; i < dim_num; i++) {
     auto range_reader = ranges_reader[i];
-    Datatype type = Datatype::UINT8;
-    RETURN_NOT_OK(datatype_enum(range_reader.getType(), &type));
 
     auto data = range_reader.getBuffer();
     auto data_ptr = data.asBytes();

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -205,6 +205,60 @@ class Subarray {
     uint64_t size_validity_;
   };
 
+  /**
+   * Wrapper for optional<tuple<std::string, RangeSetAndSuperset>> for
+   * cleaner data access.
+   */
+  struct LabelRangeSubset {
+   public:
+    /**
+     * Default constructor is not C.41.
+     **/
+    LabelRangeSubset() = delete;
+
+    /**
+     * Constructor
+     *
+     * @param ref Dimension label the ranges will be set on.
+     * @param coalesce_ranges Set if ranges should be combined when adjacent.
+     */
+    LabelRangeSubset(const DimensionLabel& ref, bool coalesce_ranges = true);
+
+    /**
+     * Constructor
+     *
+     * @param name The name of the dimension label the ranges will be set on.
+     * @param type The type of the label the ranges will be set on.
+     * @param coalesce_ranges Set if ranges should be combined when adjacent.
+     */
+    LabelRangeSubset(
+        const std::string& name, Datatype type, bool coalesce_ranges = true);
+
+    /**
+     * Constructor
+     *
+     * @param name The name of the dimension label the ranges will be set on.
+     * @param type The type of the label the ranges will be set on.
+     * @param ranges The range subset for the dimension label.
+     * @param coalesce_ranges Set if ranges should be combined when adjacent.
+     */
+    LabelRangeSubset(
+        const std::string& name,
+        Datatype type,
+        std::vector<Range> ranges,
+        bool coalesce_ranges = true);
+
+    inline const std::vector<Range>& get_ranges() const {
+      return ranges_.ranges();
+    }
+
+    /** Name of the dimension label. */
+    std::string name_;
+
+    /** The ranges set on the dimension label. */
+    RangeSetAndSuperset ranges_;
+  };
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
@@ -1349,46 +1403,6 @@ class Subarray {
 
     /** The number of ranges. */
     uint64_t range_len_;
-  };
-
-  /**
-   * Wrapper for optional<tuple<std::string, RangeSetAndSuperset>> for
-   * cleaner data access.
-   */
-  struct LabelRangeSubset {
-   public:
-    /**
-     * Default constructor is not C.41.
-     **/
-    LabelRangeSubset() = delete;
-
-    /**
-     * Constructor
-     *
-     * @param ref Dimension label the ranges will be set on.
-     * @param coalesce_ranges Set if ranges should be combined when adjacent.
-     */
-    LabelRangeSubset(const DimensionLabel& ref, bool coalesce_ranges = true);
-
-    /**
-     * Constructor
-     *
-     * @param name The name of the dimension label the ranges will be set on.
-     * @param type The type of the label the ranges will be set on.
-     * @param coalesce_ranges Set if ranges should be combined when adjacent.
-     */
-    LabelRangeSubset(
-        const std::string& name, Datatype type, bool coalesce_ranges = true);
-
-    inline const std::vector<Range>& get_ranges() const {
-      return ranges_.ranges();
-    }
-
-    /** Name of the dimension label. */
-    std::string name_;
-
-    /** The ranges set on the dimension label. */
-    RangeSetAndSuperset ranges_;
   };
 
   /**


### PR DESCRIPTION
Removes Status from datatype_enum, returning `Datatype` instead. This also relocates `Subarray::LabelRangeSubset` to be public for use in #4685.

---
TYPE: NO_HISTORY
DESC: Remove Status from datatype_enum.
