### PR TITLE
Enable vcpkg binary caching for the `build-docs` workflow.

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     name: Build Docs
+    env:
+      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
     steps:
       - uses: actions/checkout@v3
       - name: 'Print env'
@@ -40,6 +42,13 @@ jobs:
           echo "uname -v: " $(uname -v)
           printenv
         shell: bash
+
+      - name: Set environment variables for vcpkg binary caching
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
---
TYPE: NO_HISTORY