### PR TITLE
Fix defects with query channels

### DIFF
--- a/tiledb/api/c_api/query/query_api_internal.h
+++ b/tiledb/api/c_api/query/query_api_internal.h
@@ -57,8 +57,8 @@ inline void ensure_query_is_valid(tiledb_query_t* query) {
  *
  * @param query A sm::Query pointer
  */
-inline void ensure_query_is_not_initialized(const tiledb::sm::Query* query) {
-  if (query->status() != sm::QueryStatus::UNINITIALIZED) {
+inline void ensure_query_is_not_initialized(const tiledb::sm::Query& query) {
+  if (query.status() != sm::QueryStatus::UNINITIALIZED) {
     throw CAPIStatusException(
         "argument `query` is at a too late state of its lifetime");
   }
@@ -72,7 +72,8 @@ inline void ensure_query_is_not_initialized(const tiledb::sm::Query* query) {
  */
 inline void ensure_query_is_not_initialized(tiledb_query_t* query) {
   ensure_query_is_valid(query);
-  ensure_query_is_not_initialized(query->query_);
+  // Indirection safe because previous statement will throw otherwise
+  ensure_query_is_not_initialized(*query->query_);
 }
 
 }  // namespace tiledb::api

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -162,7 +162,7 @@ capi_return_t tiledb_query_get_default_channel(
   ensure_query_is_valid(query);
   ensure_output_pointer_is_valid(channel);
   *channel = tiledb_query_channel_handle_t::make_handle(
-      query->query_->actual_default_channel());
+      query->query_->default_channel());
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api.cc
@@ -161,11 +161,8 @@ capi_return_t tiledb_query_get_default_channel(
     tiledb_ctx_t*, tiledb_query_t* query, tiledb_query_channel_t** channel) {
   ensure_query_is_valid(query);
   ensure_output_pointer_is_valid(channel);
-
-  // We don't have an internal representation of a channel,
-  // the default channel is currently just a hashmap, so only pass the query
-  // to the channel constructor to be carried until next the api call.
-  *channel = tiledb_query_channel_handle_t::make_handle(query);
+  *channel = tiledb_query_channel_handle_t::make_handle(
+      query->query_->actual_default_channel());
 
   return TILEDB_OK;
 }
@@ -209,7 +206,7 @@ capi_return_t tiledb_channel_apply_aggregate(
     const char* output_field_name,
     const tiledb_channel_operation_t* operation) {
   ensure_query_channel_is_valid(channel);
-  ensure_query_is_not_initialized(channel->query_);
+  ensure_query_is_not_initialized(channel->query());
   ensure_output_field_is_valid(output_field_name);
   ensure_operation_is_valid(operation);
   channel->add_aggregate(output_field_name, operation);

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api_internal.h
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api_internal.h
@@ -39,6 +39,7 @@
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/query/readers/aggregators/operation.h"
+#include "tiledb/sm/query/readers/aggregators/query_channel.h"
 
 struct tiledb_channel_operation_handle_t
     : public tiledb::api::CAPIHandle<tiledb_channel_operation_handle_t> {
@@ -71,6 +72,11 @@ struct tiledb_channel_operation_handle_t
   }
 };
 
+/* Forward declaration */
+namespace tiledb::sm {
+class Query;
+}
+
 struct tiledb_query_channel_handle_t
     : public tiledb::api::CAPIHandle<tiledb_query_channel_handle_t> {
   /**
@@ -78,9 +84,10 @@ struct tiledb_query_channel_handle_t
    */
   static constexpr std::string_view object_type_name{"tiledb_query_channel_t"};
 
- public:
-  tiledb::sm::Query* query_;
+ private:
+  std::shared_ptr<class tiledb::sm::QueryChannelActual> channel_;
 
+ public:
   /**
    * Default constructor doesn't make sense
    */
@@ -90,14 +97,16 @@ struct tiledb_query_channel_handle_t
    * Ordinary constructor.
    * @param query The query object that owns the channel
    */
-  tiledb_query_channel_handle_t(tiledb_query_t* query)
-      : query_(query->query_) {
+  tiledb_query_channel_handle_t(
+      std::shared_ptr<class tiledb::sm::QueryChannelActual> channel)
+      : channel_(channel) {
   }
 
   inline void add_aggregate(
       const char* output_field,
       const tiledb_channel_operation_handle_t* operation) {
-    if (query_->is_aggregate(output_field)) {
+    auto& query{channel_->query()};
+    if (query.is_aggregate(output_field)) {
       throw tiledb::api::CAPIStatusException(
           "An aggregate operation for output field: " +
           std::string(output_field) + " already exists.");
@@ -105,8 +114,12 @@ struct tiledb_query_channel_handle_t
 
     // Add the aggregator the the default channel as this is the only channel
     // type we currently support
-    query_->add_aggregator_to_default_channel(
+    query.add_aggregator_to_default_channel(
         output_field, operation->aggregator());
+  }
+
+  inline tiledb::sm::Query& query() {
+    return channel_->query();
   }
 };
 

--- a/tiledb/api/c_api/query_aggregate/query_aggregate_api_internal.h
+++ b/tiledb/api/c_api/query_aggregate/query_aggregate_api_internal.h
@@ -85,7 +85,7 @@ struct tiledb_query_channel_handle_t
   static constexpr std::string_view object_type_name{"tiledb_query_channel_t"};
 
  private:
-  std::shared_ptr<class tiledb::sm::QueryChannelActual> channel_;
+  std::shared_ptr<class tiledb::sm::QueryChannel> channel_;
 
  public:
   /**
@@ -98,7 +98,7 @@ struct tiledb_query_channel_handle_t
    * @param query The query object that owns the channel
    */
   tiledb_query_channel_handle_t(
-      std::shared_ptr<class tiledb::sm::QueryChannelActual> channel)
+      std::shared_ptr<class tiledb::sm::QueryChannel> channel)
       : channel_(channel) {
   }
 

--- a/tiledb/api/c_api/query_field/query_field_api.cc
+++ b/tiledb/api/c_api/query_field/query_field_api.cc
@@ -88,9 +88,9 @@ tiledb_query_field_handle_t::tiledb_query_field_handle_t(
    * responsibility for.
    */
   if (is_aggregate) {
-    channel_ = query_->actual_aggegate_channel();
+    channel_ = query_->aggegate_channel();
   } else {
-    channel_ = query_->actual_default_channel();
+    channel_ = query_->default_channel();
   }
 }
 

--- a/tiledb/api/c_api/query_field/query_field_api_internal.h
+++ b/tiledb/api/c_api/query_field/query_field_api_internal.h
@@ -73,7 +73,7 @@ struct tiledb_query_field_handle_t
   std::shared_ptr<FieldOrigin> field_origin_;
   tiledb::sm::Datatype type_;
   uint32_t cell_val_num_;
-  tiledb_query_channel_handle_t* channel_;
+  std::shared_ptr<tiledb::sm::QueryChannelActual> channel_;
 
  public:
   /**
@@ -87,10 +87,6 @@ struct tiledb_query_field_handle_t
    */
   tiledb_query_field_handle_t(tiledb_query_t* query, const char* field_name);
 
-  ~tiledb_query_field_handle_t() {
-    tiledb_query_channel_handle_t::break_handle(channel_);
-  }
-
   tiledb_field_origin_t origin() {
     return field_origin_->origin();
   }
@@ -101,7 +97,7 @@ struct tiledb_query_field_handle_t
     return cell_val_num_;
   }
   tiledb_query_channel_handle_t* channel() {
-    return channel_;
+    return tiledb_query_channel_handle_t::make_handle(channel_);
   }
 };
 

--- a/tiledb/api/c_api/query_field/query_field_api_internal.h
+++ b/tiledb/api/c_api/query_field/query_field_api_internal.h
@@ -73,7 +73,7 @@ struct tiledb_query_field_handle_t
   std::shared_ptr<FieldOrigin> field_origin_;
   tiledb::sm::Datatype type_;
   uint32_t cell_val_num_;
-  std::shared_ptr<tiledb::sm::QueryChannelActual> channel_;
+  std::shared_ptr<tiledb::sm::QueryChannel> channel_;
 
  public:
   /**

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -106,8 +106,7 @@ Query::Query(
     , dimension_label_increasing_(true)
     , fragment_size_(std::numeric_limits<uint64_t>::max())
     , query_remote_buffer_storage_(std::nullopt)
-    , default_channel_actual_{
-          make_shared<QueryChannelActual>(HERE(), *this, 0)} {
+    , default_channel_{make_shared<QueryChannel>(HERE(), *this, 0)} {
   assert(array->is_open());
 
   if (array->get_query_type() == QueryType::READ) {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -67,14 +67,6 @@ using namespace tiledb::sm::stats;
 namespace tiledb {
 namespace sm {
 
-/** Class for query status exceptions. */
-class QueryStatusException : public StatusException {
- public:
-  explicit QueryStatusException(const std::string& msg)
-      : StatusException("Query", msg) {
-  }
-};
-
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -113,7 +105,9 @@ Query::Query(
     , is_dimension_label_ordered_read_(false)
     , dimension_label_increasing_(true)
     , fragment_size_(std::numeric_limits<uint64_t>::max())
-    , query_remote_buffer_storage_(std::nullopt) {
+    , query_remote_buffer_storage_(std::nullopt)
+    , default_channel_actual_{
+          make_shared<QueryChannelActual>(HERE(), *this, 0)} {
   assert(array->is_open());
 
   if (array->get_query_type() == QueryType::READ) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -62,6 +62,14 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+/** Class for query status exceptions. */
+class QueryStatusException : public StatusException {
+ public:
+  explicit QueryStatusException(const std::string& msg)
+      : StatusException("Query", msg) {
+  }
+};
+
 class Array;
 class ArrayDimensionLabelQueries;
 
@@ -740,6 +748,22 @@ class Query {
   /** Returns true if the output field is an aggregate. */
   bool is_aggregate(std::string output_field_name) const;
 
+ private:
+  /**
+   * Create the aggregate channel object. This is split out because it's not
+   * at construction time, but on demand, and in two different situations.
+   */
+  void create_actual_aggregate_channel() {
+    /*
+     * Because we have an extremely simple way of choosing channel identifiers,
+     * we can get away with hard-coding `1` here as the identifier for the
+     * aggregate channel.
+     */
+    aggregate_channel_actual_ =
+        make_shared<QueryChannelActual>(HERE(), *this, 1);
+  }
+
+ public:
   /**
    * Adds an aggregator to the default channel.
    *
@@ -748,6 +772,15 @@ class Query {
    */
   void add_aggregator_to_default_channel(
       std::string output_field_name, shared_ptr<IAggregator> aggregator) {
+    if (default_channel_aggregates_.empty()) {
+      /*
+       * Assert: this is the first aggregate added.
+       *
+       * We create the actual aggregate channel on demand, and this is when
+       * we need to do it.
+       */
+      create_actual_aggregate_channel();
+    }
     default_channel_aggregates_.emplace(output_field_name, aggregator);
   }
 
@@ -764,14 +797,18 @@ class Query {
   }
 
   /**
-   * Add a channel to the query
+   * Add a channel to the query. Used only by capnp serialization to initialize
+   * the aggregates list.
    */
   void add_channel(const QueryChannel& channel) {
     if (channel.is_default()) {
       default_channel_aggregates_ = channel.aggregates();
+      if (!default_channel_aggregates_.empty()) {
+        create_actual_aggregate_channel();
+      }
       return;
     }
-    throw std::logic_error(
+    throw QueryStatusException(
         "We currently only support a default channel for queries");
   }
 
@@ -780,7 +817,36 @@ class Query {
    */
   bool has_aggregates() {
     // We only need to check the default channel for now
-    return default_channel_aggregates_.empty();
+    return !default_channel_aggregates_.empty();
+  }
+
+  /**
+   * Returns the number of actual channels. "Actual channels" is the replacement
+   * for the current channel class.
+   *
+   * Responsibility for choosing channel identifiers is the responsibility of
+   * this class. At the present time the policy is very simple, since all
+   * queries only draw from a single array.
+   *   - Channel 0: All rows from the query. Always non-segmented, that is,
+   *       without any grouping.
+   *   - Channel 1: (optional) Simple aggregates, if any exist.
+   */
+  inline size_t number_of_actual_channels() {
+    return has_aggregates() ? 1 : 0;
+  };
+
+  /**
+   * The default channel is initialized at construction and always exists.
+   */
+  inline std::shared_ptr<QueryChannelActual> actual_default_channel() {
+    return default_channel_actual_;
+  }
+
+  inline std::shared_ptr<QueryChannelActual> actual_aggegate_channel() {
+    if (!has_aggregates()) {
+      throw QueryStatusException("Aggregate channel does not exist");
+    }
+    return aggregate_channel_actual_;
   }
 
  private:
@@ -967,6 +1033,24 @@ class Query {
   /** Aggregates for the default channel, by output field name. */
   std::unordered_map<std::string, shared_ptr<IAggregator>>
       default_channel_aggregates_;
+
+  /*
+   * Handles to channels use shared pointers, so the channels are allocated here
+   * for ease of implementation.
+   *
+   * At present there's only one possible non-default channel, so we keep track
+   * of it in its own variable. A fully C.41 class might simply store these in
+   * a constant vector.
+   */
+  /**
+   * The default channel is allocated in the constructor for simplicity.
+   */
+  std::shared_ptr<QueryChannelActual> default_channel_actual_;
+  /**
+   * The aggegregate channel is optional, so we initialize it as empty with it
+   * default constructor.
+   */
+  std::shared_ptr<QueryChannelActual> aggregate_channel_actual_{};
 
   /* ********************************* */
   /*           PRIVATE METHODS         */

--- a/tiledb/sm/query/readers/aggregators/query_channel.h
+++ b/tiledb/sm/query/readers/aggregators/query_channel.h
@@ -43,7 +43,7 @@ namespace tiledb::sm {
  * Original class is only used for capnp (de)serialization. `class Query` uses
  * its own container to hold aggregates.
  */
-class QueryChannel {
+class LegacyQueryAggregatesOverDefault {
  public:
   using ChannelAggregates =
       std::unordered_map<std::string, shared_ptr<IAggregator>>;
@@ -58,7 +58,8 @@ class QueryChannel {
    * @param is_default If true, this is the default query channel
    * @param aggregates A map of aggregators by output field name
    */
-  QueryChannel(bool is_default, const ChannelAggregates& aggregates)
+  LegacyQueryAggregatesOverDefault(
+      bool is_default, const ChannelAggregates& aggregates)
       : default_(is_default)
       , aggregates_{aggregates} {
   }
@@ -99,7 +100,7 @@ class Query;
  * Responsibility for choosing channel identifiers is the responsibility of
  * `class Query`; this class merely carries the resulting identifier.
  */
-class QueryChannelActual {
+class QueryChannel {
   std::reference_wrapper<Query> query_;
   size_t id_;
 
@@ -107,11 +108,11 @@ class QueryChannelActual {
   /**
    * Default constructor is deleted. A channel makes no sense without a query.
    */
-  QueryChannelActual() = delete;
+  QueryChannel() = delete;
   /*
    * Ordinary constructor.
    */
-  QueryChannelActual(Query& q, size_t id)
+  QueryChannel(Query& q, size_t id)
       : query_(q)
       , id_(id) {
     (void)id_;
@@ -119,19 +120,19 @@ class QueryChannelActual {
   /**
    * Copy constructor is the default.
    */
-  QueryChannelActual(const QueryChannelActual&) = default;
+  QueryChannel(const QueryChannel&) = default;
   /**
    * Move constructor is the default.
    */
-  QueryChannelActual(QueryChannelActual&&) = default;
+  QueryChannel(QueryChannel&&) = default;
   /**
    * Copy assignment is the default.
    */
-  QueryChannelActual& operator=(const QueryChannelActual&) = default;
+  QueryChannel& operator=(const QueryChannel&) = default;
   /**
    * Move assignment is the default.
    */
-  QueryChannelActual& operator=(QueryChannelActual&&) = default;
+  QueryChannel& operator=(QueryChannel&&) = default;
 
   /**
    * Accessor for query member

--- a/tiledb/sm/query/readers/aggregators/query_channel.h
+++ b/tiledb/sm/query/readers/aggregators/query_channel.h
@@ -114,6 +114,7 @@ class QueryChannelActual {
   QueryChannelActual(Query& q, size_t id)
       : query_(q)
       , id_(id) {
+    (void)id_;
   }
   /**
    * Copy constructor is the default.

--- a/tiledb/sm/query/readers/aggregators/query_channel.h
+++ b/tiledb/sm/query/readers/aggregators/query_channel.h
@@ -39,6 +39,10 @@
 
 namespace tiledb::sm {
 
+/**
+ * Original class is only used for capnp (de)serialization. `class Query` uses
+ * its own container to hold aggregates.
+ */
 class QueryChannel {
  public:
   using ChannelAggregates =
@@ -83,6 +87,57 @@ class QueryChannel {
   /* ********************************* */
   bool default_;
   ChannelAggregates aggregates_;
+};
+
+/* forward declaration */
+class Query;
+
+/**
+ * Replacement for the current QueryChannel, which does not work for more than
+ * the initial case with a default channel and only simple aggregates.
+ *
+ * Responsibility for choosing channel identifiers is the responsibility of
+ * `class Query`; this class merely carries the resulting identifier.
+ */
+class QueryChannelActual {
+  std::reference_wrapper<Query> query_;
+  size_t id_;
+
+ public:
+  /**
+   * Default constructor is deleted. A channel makes no sense without a query.
+   */
+  QueryChannelActual() = delete;
+  /*
+   * Ordinary constructor.
+   */
+  QueryChannelActual(Query& q, size_t id)
+      : query_(q)
+      , id_(id) {
+  }
+  /**
+   * Copy constructor is the default.
+   */
+  QueryChannelActual(const QueryChannelActual&) = default;
+  /**
+   * Move constructor is the default.
+   */
+  QueryChannelActual(QueryChannelActual&&) = default;
+  /**
+   * Copy assignment is the default.
+   */
+  QueryChannelActual& operator=(const QueryChannelActual&) = default;
+  /**
+   * Move assignment is the default.
+   */
+  QueryChannelActual& operator=(QueryChannelActual&&) = default;
+
+  /**
+   * Accessor for query member
+   */
+  inline Query& query() {
+    return query_;
+  }
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1550,7 +1550,7 @@ Status query_to_capnp(
   // The server should throw if it's about to serialize an incomplete query
   // that has aggregates on it, this behavior is currently not supported.
   if (!client_side && query.status() == QueryStatus::INCOMPLETE &&
-      !query.has_aggregates()) {
+      query.has_aggregates()) {
     throw Status_SerializationError(
         "Aggregates are not currently supported in incomplete remote "
         "queries");

--- a/tiledb/sm/serialization/query_aggregates.cc
+++ b/tiledb/sm/serialization/query_aggregates.cc
@@ -87,7 +87,7 @@ void query_channels_from_capnp(
       auto channel_reader = channels_reader[i];
 
       if (channel_reader.hasAggregates()) {
-        QueryChannel::ChannelAggregates aggregates;
+        LegacyQueryAggregatesOverDefault::ChannelAggregates aggregates;
 
         auto aggregates_reader = channel_reader.getAggregates();
         for (const auto& aggregate : aggregates_reader) {
@@ -119,8 +119,8 @@ void query_channels_from_capnp(
           }
         }
         if (!aggregates.empty()) {
-          query->add_channel(
-              QueryChannel{channel_reader.getDefault(), aggregates});
+          query->add_channel(LegacyQueryAggregatesOverDefault{
+              channel_reader.getDefault(), aggregates});
         }
       }
     }


### PR DESCRIPTION
New `class QueryChannelActual` to replace the previous class that was not actually a channel. Added methods in `class Query` for it, and rewrote the channel C API handle class to use it. Correctly initialize the underlying channel object within the query field C API handle class, and return a channel handle with the right lifespan. (This fixes the defect reported.)

Reworked test fixture to use `TemporaryLocalDirectory`. Reworked tests for isolation with SECTION. Rewrote the two tests with aggegrates to use correct calling sequence.

Changed `ensure_query_is_not_initialized` to take a reference. Changed `tiledb_query_get_default_channel` to return an actual channel handle rather than a stub for one.

Reference:
https://app.shortcut.com/tiledb-inc/story/39123/tiledb-field-channel-returns-the-same-handle-and-is-prone-to-double-freeing

[sc-39123]

---
TYPE: BUG
DESC: Fix defects with query channels
