### PR TITLE
Fix segfault in ArraySchema::check

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1454,6 +1454,18 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
+    "ArraySchema - No Segfault on Check",
+    "[enumeration][array-scehma][size-check]") {
+  create_array();
+  auto array = get_array(QueryType::READ);
+  auto schema = array->array_schema_latest_ptr();
+  // Schema has unloaded enumerations at this point. Make sure that check
+  // doesn't segfault.
+  REQUIRE_NOTHROW(schema->check(cfg_));
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
     "ArraySchema - Many Large Enumerations",
     "[enumeration][array-scehma][size-check]") {
   auto schema = create_schema();

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -586,6 +586,12 @@ void ArraySchema::check_enumerations(const Config& cfg) const {
 
   uint64_t total_size = 0;
   for (const auto& pair : enumeration_map_) {
+    if (!pair.second) {
+      // We don't have an Array instance at this point so the best we can do
+      // is just avoid segfaulting when we attempt to check with unloaded
+      // enumerations.
+      continue;
+    }
     uint64_t size = pair.second->data().size() + pair.second->offsets().size();
     if (size > max_size.value()) {
       throw ArraySchemaException(


### PR DESCRIPTION
Previously we weren't accounting for when enumerations weren't loaded and a check was performed. This lead to attempts to dereference the nullptr when the enumeration hadn't been loaded.

Given that enumerations are only unloaded when reading an array, that means these checks were already run when the schema was written so ignoring them here is fine since they're just enforcing a maximum size constraint.

---
TYPE: BUG
DESC: Fix segfault in ArraySchema::check