### PR TITLE
Prevent bugs in memory_type_to_str

### DIFF
--- a/tiledb/common/memory_tracker.cc
+++ b/tiledb/common/memory_tracker.cc
@@ -84,9 +84,6 @@ std::string memory_type_to_str(MemoryType type) {
       return "TileWriterData";
     case MemoryType::METADATA:
       return "Metadata";
-    default:
-      auto val = std::to_string(static_cast<uint32_t>(type));
-      throw std::logic_error("Invalid memory type: " + val);
   }
 
   auto val = std::to_string(static_cast<uint32_t>(type));
@@ -123,9 +120,6 @@ std::string memory_tracker_type_to_str(MemoryTrackerType type) {
       return "SchemaEvolution";
     case MemoryTrackerType::GROUP:
       return "Group";
-    default:
-      auto val = std::to_string(static_cast<uint32_t>(type));
-      throw std::logic_error("Invalid memory tracker type: " + val);
   }
 
   auto val = std::to_string(static_cast<uint32_t>(type));


### PR DESCRIPTION
My first PR for this either had a weird merge conflict or I totally whiffed on the commit. Regardless, the point was to remove the default switch case so that the compiler will enforce a switch case for every MemoryType and MemoryTrackerType.

---
TYPE: NO_HISTORY
DESC: Actually fix missing memory_tracker_type_to_str