### PR TITLE
Fix crash in aggregates on dimensions

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -61,6 +61,7 @@ struct CppAggregatesFx {
   bool allow_dups_;
   bool set_ranges_;
   bool set_qc_;
+  bool use_dim_;
   tiledb_layout_t layout_;
   std::vector<bool> set_qc_values_;
   std::vector<tiledb_layout_t> layout_values_;
@@ -161,6 +162,7 @@ void CppAggregatesFx<T>::generate_test_params() {
     allow_dups_ = false;
     set_qc_values_ = {true, false};
     layout_values_ = {TILEDB_ROW_MAJOR, TILEDB_COL_MAJOR, TILEDB_GLOBAL_ORDER};
+    use_dim_ = false;
   }
 
   SECTION("sparse") {
@@ -169,6 +171,8 @@ void CppAggregatesFx<T>::generate_test_params() {
     allow_dups_ = GENERATE(true, false);
     set_qc_values_ = {false};
     layout_values_ = {TILEDB_UNORDERED};
+    use_dim_ =
+        GENERATE(false, true) && !nullable_ && std::is_same<T, uint64_t>::value;
   }
 }
 
@@ -1431,6 +1435,7 @@ TEST_CASE_METHOD(
 
   for (bool set_ranges : {true, false}) {
     set_ranges_ = set_ranges;
+    use_dim_ = use_dim_ && !set_ranges;
     for (bool request_data : {true, false}) {
       request_data_ = request_data;
       for (bool set_qc : set_qc_values_) {
@@ -1472,7 +1477,10 @@ TEST_CASE_METHOD(
 
           // Check the results.
           uint64_t expected_count;
-          if (dense_) {
+
+          if (use_dim_) {
+            expected_count = 999;
+          } else if (dense_) {
             expected_count = set_ranges ? 24 : 36;
           } else {
             if (set_ranges) {
@@ -1526,6 +1534,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
 
   for (bool set_ranges : {true, false}) {
     CppAggregatesFx<T>::set_ranges_ = set_ranges;
+    CppAggregatesFx<T>::use_dim_ = CppAggregatesFx<T>::use_dim_ && !set_ranges;
     for (bool request_data : {true, false}) {
       CppAggregatesFx<T>::request_data_ = request_data;
       for (bool set_qc : CppAggregatesFx<T>::set_qc_values_) {
@@ -1539,7 +1548,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
               QueryExperimental::get_default_channel(query);
           ChannelOperation operation =
               QueryExperimental::create_unary_aggregate<SumOperator>(
-                  query, "a1");
+                  query, CppAggregatesFx<T>::use_dim_ ? "d1" : "a1");
           default_channel.apply_aggregate("Sum", operation);
 
           CppAggregatesFx<T>::set_ranges_and_condition_if_needed(
@@ -1575,7 +1584,9 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
 
           // Check the results.
           typename tiledb::sm::sum_type_data<T>::sum_type expected_sum;
-          if (CppAggregatesFx<T>::dense_) {
+          if (CppAggregatesFx<T>::use_dim_) {
+            expected_sum = 499500;
+          } else if (CppAggregatesFx<T>::dense_) {
             if (CppAggregatesFx<T>::nullable_) {
               if (set_ranges) {
                 expected_sum = set_qc ? 197 : 201;
@@ -1650,6 +1661,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
 
   for (bool set_ranges : {true, false}) {
     CppAggregatesFx<T>::set_ranges_ = set_ranges;
+    CppAggregatesFx<T>::use_dim_ = CppAggregatesFx<T>::use_dim_ && !set_ranges;
     for (bool request_data : {true, false}) {
       CppAggregatesFx<T>::request_data_ = request_data;
       for (bool set_qc : CppAggregatesFx<T>::set_qc_values_) {
@@ -1662,7 +1674,7 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
               QueryExperimental::get_default_channel(query);
           ChannelOperation operation =
               QueryExperimental::create_unary_aggregate<MeanOperator>(
-                  query, "a1");
+                  query, CppAggregatesFx<T>::use_dim_ ? "d1" : "a1");
           default_channel.apply_aggregate("Mean", operation);
 
           CppAggregatesFx<T>::set_ranges_and_condition_if_needed(
@@ -1698,7 +1710,9 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
 
           // Check the results.
           double expected_mean;
-          if (CppAggregatesFx<T>::dense_) {
+          if (CppAggregatesFx<T>::use_dim_) {
+            expected_mean = 500;
+          } else if (CppAggregatesFx<T>::dense_) {
             if (CppAggregatesFx<T>::nullable_) {
               if (set_ranges) {
                 expected_mean = set_qc ? (197.0 / 11.0) : (201.0 / 12.0);
@@ -1789,6 +1803,7 @@ TEMPLATE_LIST_TEST_CASE(
 
   for (bool set_ranges : {true, false}) {
     fx.set_ranges_ = set_ranges;
+    fx.use_dim_ = fx.use_dim_ && !set_ranges;
     for (bool request_data : {true, false}) {
       fx.request_data_ = request_data;
       for (bool set_qc : fx.set_qc_values_) {
@@ -1801,7 +1816,8 @@ TEMPLATE_LIST_TEST_CASE(
           QueryChannel default_channel =
               QueryExperimental::get_default_channel(query);
           ChannelOperation operation =
-              QueryExperimental::create_unary_aggregate<AGG>(query, "a1");
+              QueryExperimental::create_unary_aggregate<AGG>(
+                  query, fx.use_dim_ ? "d1" : "a1");
           default_channel.apply_aggregate("MinMax", operation);
 
           fx.set_ranges_and_condition_if_needed(array, query, false);
@@ -1848,7 +1864,9 @@ TEMPLATE_LIST_TEST_CASE(
 
           // Check the results.
           std::vector<uint8_t> expected_min_max;
-          if (fx.dense_) {
+          if (fx.use_dim_) {
+            expected_min_max = fx.make_data_buff({min ? 1 : 999});
+          } else if (fx.dense_) {
             if (fx.nullable_) {
               if (set_ranges) {
                 expected_min_max =

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -388,6 +388,14 @@ Status SparseIndexReaderBase::load_initial_data() {
         memory_budget_.ratio_tile_ranges() * memory_budget_.total_budget())
       return logger_->status(
           Status_ReaderError("Exceeded memory budget for result tile ranges"));
+  } else {
+    for (const auto& [name, _] : aggregates_) {
+      if (array_schema_.is_dim(name)) {
+        throw_if_not_ok(subarray_.load_relevant_fragment_rtrees(
+            storage_manager_->compute_tp()));
+        break;
+      }
+    }
   }
 
   // Compute tile offsets to load and var size to load for attributes.

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -1325,6 +1325,9 @@ class Subarray {
    */
   void reset_default_ranges();
 
+  /** Loads the R-Trees of all relevant fragments in parallel. */
+  Status load_relevant_fragment_rtrees(ThreadPool* compute_tp) const;
+
  private:
   /* ********************************* */
   /*        PRIVATE DATA TYPES         */
@@ -1595,9 +1598,6 @@ class Subarray {
    * given subarray.
    */
   void swap(Subarray& subarray);
-
-  /** Loads the R-Trees of all relevant fragments in parallel. */
-  Status load_relevant_fragment_rtrees(ThreadPool* compute_tp) const;
 
   /**
    * Computes the tile overlap for each range and relevant fragment.


### PR DESCRIPTION
RTREE wasn't loaded when processing aggregates on dimensions. We use the RTREE when we aggregate full tiles so the fix is to load the rtree for cases where we don't have ranges and we have aggregates on dimensions.

---
TYPE: BUG
DESC: Fix crash in aggregates on dimensions
