### PR TITLE
Move the Hadoop header files to `hdfs_filesystem.cc`.

### DIFF
--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -49,6 +49,8 @@
 #include "tiledb/sm/misc/utils.h"
 #include "uri.h"
 
+#include "hadoop/hdfs.h"
+
 #include <dlfcn.h>
 #include <cassert>
 #include <climits>

--- a/tiledb/sm/filesystem/hdfs_filesystem.h
+++ b/tiledb/sm/filesystem/hdfs_filesystem.h
@@ -41,9 +41,12 @@
 
 #include "tiledb/common/status.h"
 
-#include "hadoop/hdfs.h"
-
 using namespace tiledb::common;
+
+// Declarations copied from hadoop/hdfs.h
+// We do not include it here to avoid leaking it to consuming code.
+struct hdfs_internal;
+typedef struct hdfs_internal* hdfsFS;
 
 namespace tiledb {
 


### PR DESCRIPTION
[SC-42734](https://app.shortcut.com/tiledb-inc/story/42734)

This PR moves including `hadoop/hdfs.h` from `hdfs_filesystem.h` to the `hdfs_filesystem.cc` implementation file. Due to the current structure of the code, `hdfs_filesystem.h` is included by `vfs.h`, which is included by many files, resulting in having to specify the path to `hadoop/hdfs.h` in all dependents, such as unit tests. A similar change was recently made for the GCS SDK in #4777.

Thanks to @rroelke for finding this issue. Validated by successfully building all unit tests touched by #4793 with HDFS enabled.

---
TYPE: BUILD
DESC: Fix compiling unit tests when HDFS is enabled.