### PR TITLE
Fix throwing exception on remote incomplete queries with aggregates.

### DIFF
--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -1551,9 +1551,9 @@ Status query_to_capnp(
   // that has aggregates on it, this behavior is currently not supported.
   if (!client_side && query.status() == QueryStatus::INCOMPLETE &&
       query.has_aggregates()) {
-    throw Status_SerializationError(
+    throw StatusException(Status_SerializationError(
         "Aggregates are not currently supported in incomplete remote "
-        "queries");
+        "queries"));
   }
   query_channels_to_capnp(query, query_builder);
 


### PR DESCRIPTION
[SC-42786](https://app.shortcut.com/tiledb-inc/story/42786/remote-incomplete-queries-with-aggregates-fail-with-a-vague-message)

Validated with a locally built REST server.

Before: `[TileDB::REST] Error: Error submitting query to REST; server returned no data. Curl error: Error in libcurl POST operation: libcurl error message 'CURLE_OK'; HTTP code 400; server response data '{"code":2208,"message":"Error serializing query: C API: unknown exception type; no further information","request_id":"a0f026a8-8507-4c54-b592-5166c7d4f0b6"}'.`

After: `[TileDB::REST] Error: Error submitting query to REST; server returned no data. Curl error: Error in libcurl POST operation: libcurl error message 'CURLE_OK'; HTTP code 400; server response data '{"code":2208,"message":"Error serializing query: [TileDB::Serialization] Error: Cannot serialize; exception: [TileDB::Serialization] Error: Aggregates are not currently supported in incomplete remote queries","request_id":"c6638565-d80d-4c0c-88a6-52c1a748df1a"}'.`

---
TYPE: BUG
DESC: Provide a clear exception message when performing remote incomplete queries with aggregates