### PR TITLE
Add a test for concurrent array metadata writes.

### DIFF
--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -338,13 +338,12 @@ TEST_CASE_METHOD(
     "[!mayfail][capi][metadata][concurrent_writes]") {
   int32_t one = 1;
   int32_t two = 2;
-  int fail_count = 0;
   const void* v_r = nullptr;
   tiledb_datatype_t v_type;
   uint32_t v_num;
 
-  // Run the test body 1000 times
-  for (int i = 0; i < 1000; i++) {
+  // Run the test body 20 times
+  for (int i = 0; i < 20; i++) {
     // Create and open array in write mode
     create_default_array_1d();
     tiledb_array_t* array;
@@ -377,21 +376,13 @@ TEST_CASE_METHOD(
     CHECK(rc == TILEDB_OK);
     CHECK(v_type == TILEDB_INT32);
     CHECK(v_num == 1);
-    if ((*((const int32_t*)v_r)) != 2) {
-      fail_count++;
-    } else {
-      CHECK(*((const int32_t*)v_r) == 2);
-    }
+    CHECK(*((const int32_t*)v_r) == 2);
 
     // Cleanup
     rc = tiledb_array_close(ctx_, array);
     REQUIRE(rc == TILEDB_OK);
     tiledb_array_free(&array);
     remove_dir(array_name_, ctx_, vfs_);
-  }
-
-  if (fail_count != 0) {
-    std::cerr << "Rate of failure: " << (float)fail_count / 10 << std::endl;
   }
 }
 

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -342,8 +342,8 @@ TEST_CASE_METHOD(
   tiledb_datatype_t v_type;
   uint32_t v_num;
 
-  // Run the test body 20 times
-  for (int i = 0; i < 20; i++) {
+  // Run the test body 100 times
+  for (int i = 0; i < 100; i++) {
     // Create and open array in write mode
     create_default_array_1d();
     tiledb_array_t* array;

--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -334,8 +334,8 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     CMetadataFx,
-    "C API: Metadata, concurrent writes",
-    "[!mayfail][capi][metadata][concurrent_writes]") {
+    "C API: Metadata, sub-millisecond writes",
+    "[!mayfail][capi][metadata][sub-millisecond]") {
   int32_t one = 1;
   int32_t two = 2;
   const void* v_r = nullptr;


### PR DESCRIPTION
Add a test for concurrent array metadata writes. With the fragment name generation, this test is tagged as `[!mayfail]`, because there's no means of sorting fragments which are written within the same millisecond. Once sub millisecond temporal disambiguation is implemented, this test should serve as a regression case. 

---
TYPE: NO_HISTORY
DESC: Add a test for concurrent array metadata writes. 
