### PR TITLE
Throw error when an upload fails due to bad state.

### DIFF
--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 multiupload abort path", "[s3]") {
     CHECK(!exists);
 
     // Flush the file
-    CHECK(s3_.flush_object(URI(largefile)).ok());
+    CHECK(!s3_.flush_object(URI(largefile)).ok());
 
     // After flushing, the file does not exist
     CHECK(s3_.is_object(URI(largefile), &exists).ok());

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -633,13 +633,11 @@ Status S3::disconnect() {
             Aws::S3::Model::AbortMultipartUploadRequest abort_request =
                 make_multipart_abort_request(*state);
             auto outcome = client_->AbortMultipartUpload(abort_request);
-            if (!outcome.IsSuccess()) {
-              const Status st = LOG_STATUS(Status_S3Error(
-                  std::string("Failed to disconnect and flush S3 objects. ") +
-                  outcome_error_message(outcome)));
-              if (!st.ok()) {
-                ret_st = st;
-              }
+            const Status st = LOG_STATUS(Status_S3Error(
+                std::string("Failed to disconnect and flush S3 objects. ") +
+                outcome_error_message(outcome)));
+            if (!st.ok()) {
+              ret_st = st;
             }
           }
           return Status::Ok();
@@ -714,7 +712,7 @@ Status S3::flush_object(const URI& uri) {
 
     throw_if_not_ok(wait_for_object_to_propagate(move(bucket), move(key)));
 
-    return finish_flush_object(std::move(outcome), uri, buff);
+    return finish_flush_object(std::move(outcome), uri, buff, false);
   } else {
     Aws::S3::Model::AbortMultipartUploadRequest abort_request =
         make_multipart_abort_request(*state);
@@ -723,7 +721,7 @@ Status S3::flush_object(const URI& uri) {
 
     state_lck.unlock();
 
-    return finish_flush_object(std::move(outcome), uri, buff);
+    return finish_flush_object(std::move(outcome), uri, buff, true);
   }
 }
 
@@ -799,11 +797,9 @@ void S3::finalize_and_flush_object(const URI& uri) {
         make_multipart_abort_request(state);
 
     auto outcome = client_->AbortMultipartUpload(abort_request);
-    if (!outcome.IsSuccess()) {
-      throw S3Exception{
-          std::string("Failed to flush S3 object ") + uri.c_str() +
-          outcome_error_message(outcome)};
-    }
+    throw S3Exception{
+        std::string("Failed to flush S3 object ") + uri.c_str() +
+        outcome_error_message(outcome)};
   }
 
   // Remove intermediate chunk files if any
@@ -1689,7 +1685,8 @@ template <typename R, typename E>
 Status S3::finish_flush_object(
     const Aws::Utils::Outcome<R, E>& outcome,
     const URI& uri,
-    Buffer* const buff) {
+    Buffer* const buff,
+    bool is_abort) {
   Aws::Http::URI aws_uri = uri.c_str();
 
   UniqueWriteLock unique_wl(&multipart_upload_rwlock_);
@@ -1701,7 +1698,7 @@ Status S3::finish_flush_object(
   file_buffers_lck.unlock();
   tdb_delete(buff);
 
-  if (!outcome.IsSuccess()) {
+  if (!outcome.IsSuccess() || is_abort) {
     return LOG_STATUS(Status_S3Error(
         std::string("Failed to flush S3 object ") + uri.c_str() +
         outcome_error_message(outcome)));

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -1509,7 +1509,7 @@ class S3 : FilesystemBase {
    * @param outcome The returned outcome from the complete or abort request.
    * @param uri The URI of the S3 file to be written to.
    * @param buff The file buffer associated with 'uri'.
-   * @param abort Should be true only when this is an abort request.
+   * @param is_abort Should be true only when this is an abort request.
    * @return Status
    */
   template <typename R, typename E>

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -1509,13 +1509,15 @@ class S3 : FilesystemBase {
    * @param outcome The returned outcome from the complete or abort request.
    * @param uri The URI of the S3 file to be written to.
    * @param buff The file buffer associated with 'uri'.
+   * @param abort Should be true only when this is an abort request.
    * @return Status
    */
   template <typename R, typename E>
   Status finish_flush_object(
       const Aws::Utils::Outcome<R, E>& outcome,
       const URI& uri,
-      Buffer* const buff);
+      Buffer* const buff,
+      bool is_abort);
 
   /**
    * Writes the input buffer to a file by issuing one PutObject


### PR DESCRIPTION
This PR will throw an error if the state when uploading files to s3 is not ok. More details can be found in the shortcut story. The gist is that we are returning an OK status even if the upload is unsuccessful. 

Below you can see my reproduction. Thanks to @gspowley. 

1. I created a valid VCF dataset in s3:
```dist/bin/tiledbvcf create --uri s3://tiledb-dstara/my_dataset```
2. After ingesting some vcf files into a valid dataset we can see 21 files
```
dimitrisstaratzis@iMac TileDB-VCF % aws s3 ls s3://tiledb-dstara/my_dataset/data/__fragments/__1710345309063_1710345309063_59cf338875644cd28114f95923a018e3_21/                                          
2024-03-13 17:55:22      12164 __fragment_metadata.tdb
2024-03-13 17:55:14        177 a0.tdb
2024-03-13 17:55:20        177 a1.tdb
2024-03-13 17:55:13        143 a2.tdb
2024-03-13 17:55:13        179 a3.tdb
2024-03-13 17:55:14        161 a3_var.tdb
2024-03-13 17:55:14        179 a4.tdb
2024-03-13 17:55:15        141 a4_var.tdb
2024-03-13 17:55:21        179 a5.tdb
2024-03-13 17:55:13        166 a5_var.tdb
2024-03-13 17:55:14        182 a6.tdb
2024-03-13 17:55:15        196 a6_var.tdb
2024-03-13 17:55:13        179 a7.tdb
2024-03-13 17:55:14        191 a7_var.tdb
2024-03-13 17:55:14        179 a8.tdb
2024-03-13 17:55:15        147 a8_var.tdb
2024-03-13 17:55:13          8 d0.tdb
2024-03-13 17:55:14         45 d0_var.tdb
2024-03-13 17:55:14        191 d1.tdb
2024-03-13 17:55:13          8 d2.tdb
2024-03-13 17:55:13        102 d2_var.tdb
```

3. I am now using an env variable to inject a random error in the state. (See in shortcut story)

```
dimitrisstaratzis@iMac TileDB-VCF % export TILEDB_S3_INJECT_ERROR=1
dimitrisstaratzis@iMac TileDB-VCF % dist/bin/tiledbvcf store --uri s3://tiledb-dstara/my_dataset small.vcf.gz

[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
```

and I get 16 files instead of the correct 21. So the user does not know something is wrong:

```
dimitrisstaratzis@iMac TileDB-VCF % aws s3 ls s3://tiledb-dstara/my_dataset/data/__fragments/__1710347463937_1710347463937_97d481ba63664dcca766d91b20e029b2_21/
2024-03-13 18:31:24      12164 __fragment_metadata.tdb
2024-03-13 18:31:15        143 a2.tdb
2024-03-13 18:31:15        179 a3.tdb
2024-03-13 18:31:16        161 a3_var.tdb
2024-03-13 18:31:15        179 a4.tdb
2024-03-13 18:31:16        141 a4_var.tdb
2024-03-13 18:31:15        179 a5.tdb
2024-03-13 18:31:21        182 a6.tdb
2024-03-13 18:31:15        179 a7.tdb
2024-03-13 18:31:15        191 a7_var.tdb
2024-03-13 18:31:14        179 a8.tdb
2024-03-13 18:31:15          8 d0.tdb
2024-03-13 18:31:16         45 d0_var.tdb
2024-03-13 18:31:15        191 d1.tdb
2024-03-13 18:31:15          8 d2.tdb
2024-03-13 18:31:15        102 d2_var.tdb
```

4. With my fix an error is thrown so the user is aware and can retry
```
dimitrisstaratzis@iMac TileDB-VCF % dist/bin/tiledbvcf store --uri s3://tiledb-dstara/my_dataset small.vcf.gz                                              

[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 0
[S3::flush_object] error = 1
[S3::flush_object] Aborting multipart upload
[S3::flush_object] error = 0
[2024-03-13 19:10:54.265] [tiledb-vcf] [Process: 96652] [Thread: 76198470] [critical] Exception: TileDB internal: [GlobalOrderWriter::dowork]  ([TileDB::S3] Error: Failed to flush S3 object s3://tiledb-dstara/my_dataset_error_fix/variant_stats/__fragments/__1710349852046_1710349852046_0ccf455080ac435a9da6e10bd5b48f20_21/d1.tdbSuccess)
```

[sc-42315]

---
TYPE: BUG
DESC: Throw error when an upload fails due to bad state.
