### PR TITLE
Improve pattern recognizing release artifacts

### DIFF
--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Render template
         run: |
-          PATTERN="tiledb-([^-]+)-([^-]+)(-noavx2)?-([^-]+)-([^-]+).(tar.gz|zip)$"
+          PATTERN="tiledb-([^-]+)-([^-]+)(-noavx2)?-(.+)\.(tar\.gz|zip)$"
           RELLIST="output/releases.csv"
           MODULE="output/DownloadPrebuiltTileDB.cmake"
           cp cmake/inputs/DownloadPrebuiltTileDB.cmake $MODULE


### PR DESCRIPTION
After changing release artifact names the `releases.csv` file generator logic broke since the REGEX matcher expected different input. This PR changes the matcher REGEX to match everything after all required fields:

![1710495096_grim](https://github.com/TileDB-Inc/TileDB/assets/5787996/397d7947-e4a0-4bb0-9748-e36cbb0f3d5a)

example release: https://github.com/dudoslav/TileDB/releases/tag/t15.0.1-rc1

---
TYPE: NO_HISTORY
DESC: Change regex matching release artifacts
