### PR TITLE
Expose VFSExperimental and relocate CallbackWrapperCPP.

### DIFF
--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -651,61 +651,42 @@ TEST_CASE("CPP API: Throwing filter", "[cppapi][vfs][ls-recursive]") {
 TEST_CASE(
     "CPP API: CallbackWrapperCPP construction validation",
     "[ls-recursive][callback][wrapper]") {
-  tiledb::test::LocalFsTest local_fs({1});
-  tiledb::test::vfs_config cfg;
-  tiledb::Context ctx(tiledb::Config(&cfg.config));
-  tiledb::VFS vfs(ctx);
-
   tiledb::VFSExperimental::LsObjects data;
-  auto path = local_fs.temp_dir_.to_string();
   auto cb = [&](std::string_view, uint64_t) -> bool { return true; };
   SECTION("Null callback") {
-    CHECK_THROWS(
-        tiledb::VFSExperimental::ls_recursive(ctx, vfs, path, nullptr));
+    CHECK_THROWS(tiledb::VFSExperimental::CallbackWrapperCPP(nullptr));
   }
   SECTION("Valid callback") {
-    CHECK_NOTHROW(tiledb::VFSExperimental::ls_recursive(ctx, vfs, path, cb));
+    CHECK_NOTHROW(tiledb::VFSExperimental::CallbackWrapperCPP(cb));
   }
 }
 
 TEST_CASE(
     "CPP API: CallbackWrapperCPP operator() validation",
     "[ls-recursive][callback][wrapper]") {
-  tiledb::test::LocalFsTest local_fs({1});
-  tiledb::test::vfs_config cfg;
-  tiledb::Context ctx(tiledb::Config(&cfg.config));
-  tiledb::VFS vfs(ctx);
-
   tiledb::VFSExperimental::LsObjects data;
   auto cb = [&](std::string_view path, uint64_t object_size) -> bool {
-    if (object_size > 10) {
+    if (object_size > 100) {
       // Throw if object size is greater than 100 bytes.
       throw std::runtime_error("Throwing callback");
-    } else if (!path.ends_with("test_file_1")) {
+    } else if (!path.ends_with(".txt")) {
+      // Reject non-txt files.
       return false;
     }
     data.emplace_back(path, object_size);
     return true;
   };
+  tiledb::VFSExperimental::CallbackWrapperCPP wrapper(cb);
 
-  auto path = local_fs.temp_dir_.to_string();
   SECTION("Callback return true accepts object") {
-    CHECK_NOTHROW(tiledb::VFSExperimental::ls_recursive(
-        ctx, vfs, path + "/subdir_1", cb));
+    CHECK(wrapper("file.txt", 10) == true);
     CHECK(data.size() == 1);
   }
   SECTION("Callback return false rejects object") {
-    CHECK_NOTHROW(tiledb::VFSExperimental::ls_recursive(ctx, vfs, path, cb));
+    CHECK(wrapper("some/dir/", 0) == false);
     CHECK(data.empty());
   }
   SECTION("Callback exception is propagated") {
-    auto large_file = local_fs.temp_dir_.join_path("/subdir_1/test_file_1");
-    std::string file_data(11, 'a');
-    local_fs.vfs_.open_file(large_file, tiledb::sm::VFSMode::VFS_WRITE).ok();
-    local_fs.vfs_.write(large_file, file_data.data(), file_data.size()).ok();
-    local_fs.vfs_.close_file(large_file).ok();
-    CHECK_THROWS_WITH(
-        tiledb::VFSExperimental::ls_recursive(ctx, vfs, path + "/subdir_1", cb),
-        Catch::Matchers::ContainsSubstring("Throwing callback"));
+    CHECK_THROWS_WITH(wrapper("path", 101) == 0, "Throwing callback");
   }
 }

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -123,6 +123,7 @@ if (TILEDB_CPP_API)
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/utils.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/version.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/vfs.h
+    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/vfs_experimental.h
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/arrowio
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/arrow_io_impl.h
   )

--- a/tiledb/sm/cpp_api/tiledb_experimental
+++ b/tiledb/sm/cpp_api/tiledb_experimental
@@ -45,5 +45,6 @@
 #include "query_condition_experimental.h"
 #include "query_experimental.h"
 #include "subarray_experimental.h"
+#include "vfs_experimental.h"
 
 #endif  // TILEDB_EXPERIMENTAL_CPP_H

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -117,7 +117,7 @@ class VFSExperimental {
       const VFS& vfs,
       const std::string& uri,
       LsCallback cb) {
-    tiledb::sm::CallbackWrapperCPP wrapper(cb);
+    CallbackWrapperCPP wrapper(cb);
     ctx.handle_error(tiledb_vfs_ls_recursive(
         ctx.ptr().get(),
         vfs.ptr().get(),
@@ -195,10 +195,38 @@ class VFSExperimental {
    */
   static int32_t ls_callback_wrapper(
       const char* path, size_t path_len, uint64_t object_size, void* data) {
-    tiledb::sm::CallbackWrapperCPP* cb =
-        static_cast<tiledb::sm::CallbackWrapperCPP*>(data);
+    CallbackWrapperCPP* cb = static_cast<CallbackWrapperCPP*>(data);
     return (*cb)({path, path_len}, object_size);
   }
+
+  /** Class to wrap C++ FilePredicate for passing to the C API. */
+  class CallbackWrapperCPP {
+   public:
+    /** Default constructor is deleted */
+    CallbackWrapperCPP() = delete;
+
+    /** Constructor */
+    CallbackWrapperCPP(LsCallback cb)
+        : cb_(cb) {
+      if (cb_ == nullptr) {
+        throw std::logic_error("ls_recursive callback function cannot be null");
+      }
+    }
+
+    /**
+     * Operator to wrap the FilePredicate used in the C++ API.
+     *
+     * @param path The path of the object.
+     * @param size The size of the object in bytes.
+     * @return True if the object should be included, False otherwise.
+     */
+    bool operator()(std::string_view path, uint64_t size) {
+      return cb_(path, size);
+    }
+
+   private:
+    LsCallback cb_;
+  };
 };
 }  // namespace tiledb
 

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -82,6 +82,35 @@ class VFSExperimental {
    */
   using LsObjects = std::vector<std::pair<std::string, uint64_t>>;
 
+  /** Class to wrap C++ FilePredicate for passing to the C API. */
+  class CallbackWrapperCPP {
+   public:
+    /** Default constructor is deleted */
+    CallbackWrapperCPP() = delete;
+
+    /** Constructor */
+    CallbackWrapperCPP(LsCallback cb)
+        : cb_(cb) {
+      if (cb_ == nullptr) {
+        throw std::logic_error("ls_recursive callback function cannot be null");
+      }
+    }
+
+    /**
+     * Operator to wrap the FilePredicate used in the C++ API.
+     *
+     * @param path The path of the object.
+     * @param size The size of the object in bytes.
+     * @return True if the object should be included, False otherwise.
+     */
+    bool operator()(std::string_view path, uint64_t size) {
+      return cb_(path, size);
+    }
+
+   private:
+    LsCallback cb_;
+  };
+
   /* ********************************* */
   /*       PUBLIC STATIC METHODS       */
   /* ********************************* */
@@ -198,35 +227,6 @@ class VFSExperimental {
     CallbackWrapperCPP* cb = static_cast<CallbackWrapperCPP*>(data);
     return (*cb)({path, path_len}, object_size);
   }
-
-  /** Class to wrap C++ FilePredicate for passing to the C API. */
-  class CallbackWrapperCPP {
-   public:
-    /** Default constructor is deleted */
-    CallbackWrapperCPP() = delete;
-
-    /** Constructor */
-    CallbackWrapperCPP(LsCallback cb)
-        : cb_(cb) {
-      if (cb_ == nullptr) {
-        throw std::logic_error("ls_recursive callback function cannot be null");
-      }
-    }
-
-    /**
-     * Operator to wrap the FilePredicate used in the C++ API.
-     *
-     * @param path The path of the object.
-     * @param size The size of the object in bytes.
-     * @return True if the object should be included, False otherwise.
-     */
-    bool operator()(std::string_view path, uint64_t size) {
-      return cb_(path, size);
-    }
-
-   private:
-    LsCallback cb_;
-  };
 };
 }  // namespace tiledb
 

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -316,45 +316,6 @@ class CallbackWrapperCAPI {
   void* data_;
 };
 
-/** Class to wrap C++ FilePredicate for passing to the C API. */
-class CallbackWrapperCPP {
- public:
-  /**
-   * Typedef for ls callback function used to check if a single
-   * result should be included in the final results returned from ls_recursive.
-   *
-   * @param path The path of a visited object for the relative filesystem.
-   * @param size The size of the current object in bytes.
-   * @return True if the result should be included, else false.
-   */
-  using LsCallback = std::function<bool(std::string_view, uint64_t)>;
-
-  /** Default constructor is deleted */
-  CallbackWrapperCPP() = delete;
-
-  /** Constructor */
-  CallbackWrapperCPP(LsCallback cb)
-      : cb_(cb) {
-    if (cb_ == nullptr) {
-      throw LsScanException("ls_recursive callback function cannot be null");
-    }
-  }
-
-  /**
-   * Operator to wrap the FilePredicate used in the C++ API.
-   *
-   * @param path The path of the object.
-   * @param size The size of the object in bytes.
-   * @return True if the object should be included, False otherwise.
-   */
-  bool operator()(std::string_view path, uint64_t size) {
-    return cb_(path, size);
-  }
-
- private:
-  LsCallback cb_;
-};
-
 /**
  * Implements the `ls_filtered` function for `std::filesystem` which can be used
  * for Posix and Win32


### PR DESCRIPTION
@kounelisagis reported issues working on [SC-43316](https://app.shortcut.com/tiledb-inc/story/43316/add-wrapping-for-ls-recursive) and found that #4625 did not expose VFSExperimental. This exposes the VFS experimental C++ APIs and relocates CallbackWrapperCPP to fix build errors from using `tiledb::sm` in an external header.

The C APIs were exposed in #4615.

---
TYPE: BUG
DESC: Expose VFSExperimental and relocate CallbackWrapperCPP.
