### PR TITLE
Support triggering REST CI workflow on a specific ref

### DIFF
--- a/.github/workflows/ci-rest.yml
+++ b/.github/workflows/ci-rest.yml
@@ -3,6 +3,10 @@ name: REST CI
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        required: false
 
   push:
     branches:
@@ -35,5 +39,5 @@ jobs:
           token: ${{ secrets.TILEDB_REST_CI_PAT }}
           # Pass TileDB core ref to test against REST.
           # github.head_ref will only be set for PRs, so fallback to github.ref_name if triggered via push event.
-          inputs: '{ "tiledb_ref": "${{ github.head_ref || github.ref_name }}"}'
+          inputs: '{ "tiledb_ref": "${{ github.event.inputs.ref || github.head_ref || github.ref_name }}"}'
           wait-for-completion-timeout: 90m


### PR DESCRIPTION
Support triggering REST CI workflow on a specific ref (commit/tag). This adds an input option on the manual trigger button for this workflow; the existing dropdown _only_ supports branches and tags.

<img width="324" alt="image" src="https://github.com/TileDB-Inc/TileDB/assets/327706/ef8b6f8a-a733-4c1b-a33d-cd7d4fc3b06f">

---
TYPE: NO_HISTORY
DESC: Support triggering REST CI workflow on a specific ref
