### PR TITLE
Remove mayfail from temporal regression test.

### DIFF
--- a/test/src/unit-capi-metadata.cc
+++ b/test/src/unit-capi-metadata.cc
@@ -335,7 +335,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     CMetadataFx,
     "C API: Metadata, sub-millisecond writes",
-    "[!mayfail][capi][metadata][sub-millisecond]") {
+    "[capi][metadata][sub-millisecond]") {
   int32_t one = 1;
   int32_t two = 2;
   const void* v_r = nullptr;


### PR DESCRIPTION
Remove `[!mayfail]` from the temporal regression test.

---
TYPE: NO_HISTORY
DESC: Remove mayfail from sub-millisecond temporal regression test.
