### PR TITLE
Add CPP byte-type datatype checks.

### DIFF
--- a/test/src/unit-cppapi-type.cc
+++ b/test/src/unit-cppapi-type.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,8 @@
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
 
+using namespace tiledb;
+
 struct MyData {
   int a;
   float b;
@@ -40,7 +42,6 @@ struct MyData {
 };
 
 TEST_CASE("C++ API: Types", "[cppapi][types]") {
-  using namespace tiledb;
   Context ctx;
 
   CHECK(
@@ -122,6 +123,12 @@ TEST_CASE("C++ API: Types", "[cppapi][types]") {
       impl::type_check<std::vector<char>>(TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
   CHECK_NOTHROW(impl::type_check<std::array<char, 1>>(
       TILEDB_STRING_ASCII, TILEDB_VAR_NUM));
+
+  // Validate byte datatypes
+  CHECK_NOTHROW(impl::type_check<std::byte>(TILEDB_BLOB));
+  CHECK_NOTHROW(impl::type_check<std::byte>(TILEDB_GEOM_WKB));
+  CHECK_NOTHROW(impl::type_check<std::byte>(TILEDB_GEOM_WKT));
+  CHECK_THROWS(impl::type_check<std::byte>(TILEDB_BOOL));
 
   auto a1 = Attribute::create<int>(ctx, "a1");
   auto a2 = Attribute::create<float>(ctx, "a2");

--- a/test/src/unit-enum-helpers.cc
+++ b/test/src/unit-enum-helpers.cc
@@ -63,3 +63,11 @@ TEST_CASE(
   REQUIRE_THROWS(datatype_max_integral_value(Datatype::FLOAT64));
   REQUIRE_THROWS(datatype_max_integral_value(Datatype::STRING_ASCII));
 }
+
+TEST_CASE("Test datatype_is_byte", "[enums][datatype][datatype_is_byte]") {
+  auto datatype =
+      GENERATE(Datatype::BLOB, Datatype::GEOM_WKB, Datatype::GEOM_WKT);
+
+  CHECK(datatype_is_byte(datatype));
+  CHECK(!datatype_is_byte(Datatype::BOOL));
+}

--- a/tiledb/sm/cpp_api/exception.h
+++ b/tiledb/sm/cpp_api/exception.h
@@ -7,7 +7,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -89,6 +89,12 @@ inline void type_check(tiledb_datatype_t type, unsigned num = 0) {
           ") does not match expected container type STRING_ASCII for tiledb "
           "type (" +
           impl::type_to_str(type) + ")");
+    }
+  } else if (tiledb_byte_type(type)) {
+    if (!std::is_same<T, std::byte>::value) {
+      throw TypeError(
+          "Static type does not match expected container type std::byte for "
+          "tiledb byte type");
     }
   } else if (tiledb_datetime_type(type)) {
     if (!std::is_same<T, int64_t>::value) {

--- a/tiledb/sm/cpp_api/type.h
+++ b/tiledb/sm/cpp_api/type.h
@@ -7,7 +7,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -288,6 +288,17 @@ inline bool tiledb_string_type(tiledb_datatype_t type) {
     case TILEDB_STRING_UTF32:
     case TILEDB_STRING_UCS2:
     case TILEDB_STRING_UCS4:
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline bool tiledb_byte_type(tiledb_datatype_t type) {
+  switch (type) {
+    case TILEDB_BLOB:
+    case TILEDB_GEOM_WKB:
+    case TILEDB_GEOM_WKT:
       return true;
     default:
       return false;

--- a/tiledb/sm/enums/datatype.h
+++ b/tiledb/sm/enums/datatype.h
@@ -410,7 +410,7 @@ inline bool datatype_is_time(Datatype type) {
 /** Returns true if the input datatype is a std::byte type. */
 inline bool datatype_is_byte(Datatype type) {
   return (
-      type == Datatype::BOOL || type == Datatype::GEOM_WKB ||
+      type == Datatype::BLOB || type == Datatype::GEOM_WKB ||
       type == Datatype::GEOM_WKT);
 }
 


### PR DESCRIPTION
Fix `datatype_is_byte` to appropriately validate `std::byte` Datatypes. Also add a C++ byte-type check and add the byte case to `typeError`.

----

TYPE: IMPROVEMENT
DESC: Add CPP byte-type checks.
