### PR TITLE
Fix crash getting file size on non existent blob on Azure.

### DIFF
--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -445,7 +445,11 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   // Getting file_size on a nonexistent blob shouldn't crash on Azure
   uint64_t nbytes = 0;
   URI non_existent = URI(path.to_string() + "non_existent");
-  CHECK(!vfs.file_size(non_existent, &nbytes).ok());
+  if (path.is_file()) {
+    CHECK_THROWS(vfs.file_size(non_existent, &nbytes));
+  } else {
+    CHECK(!vfs.file_size(non_existent, &nbytes).ok());
+  }
 
   // Set up
   bool exists = false;

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -442,6 +442,11 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   Config config = set_config_params(disable_multipart, max_parallel_ops);
   VFS vfs{&g_helper_stats, &compute_tp, &io_tp, config};
 
+  // Getting file_size on a nonexistent blob shouldn't crash on Azure
+  uint64_t nbytes = 0;
+  URI non_existent = URI(path.to_string() + "non_existent");
+  require_tiledb_ok(vfs.file_size(non_existent, &nbytes));
+
   // Set up
   bool exists = false;
   if (path.is_gcs() || path.is_s3() || path.is_azure()) {
@@ -494,7 +499,6 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   CHECK(exists);
 
   // Get file sizes
-  uint64_t nbytes = 0;
   require_tiledb_ok(vfs.file_size(largefile, &nbytes));
   CHECK(nbytes == (buffer_size));
   require_tiledb_ok(vfs.file_size(smallfile, &nbytes));

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -445,7 +445,7 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   // Getting file_size on a nonexistent blob shouldn't crash on Azure
   uint64_t nbytes = 0;
   URI non_existent = URI(path.to_string() + "non_existent");
-  require_tiledb_ok(vfs.file_size(non_existent, &nbytes));
+  CHECK(!vfs.file_size(non_existent, &nbytes).ok());
 
   // Set up
   bool exists = false;

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -446,7 +446,11 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   uint64_t nbytes = 0;
   URI non_existent = URI(path.to_string() + "non_existent");
   if (path.is_file()) {
+#ifdef _WIN32
+    CHECK(!vfs.file_size(non_existent, &nbytes).ok());
+#else
     CHECK_THROWS(vfs.file_size(non_existent, &nbytes));
+#endif
   } else {
     CHECK(!vfs.file_size(non_existent, &nbytes).ok());
   }

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -700,9 +700,9 @@ Status Azure::blob_size(const URI& uri, uint64_t* const nbytes) const {
 
     if (response.Blobs.empty()) {
       error_message = "Blob does not exist.";
+    } else {
+      *nbytes = static_cast<uint64_t>(response.Blobs[0].BlobSize);
     }
-
-    *nbytes = static_cast<uint64_t>(response.Blobs[0].BlobSize);
   } catch (const ::Azure::Storage::StorageException& e) {
     error_message = e.Message;
   }


### PR DESCRIPTION
This fixes getting a file size on azure when the blob is non existent. We would end up not getting an error and trying to read an empty array.

---
TYPE: BUG
DESC: Fix crash getting file size on non existent blob on Azure.
