### PR TITLE
Remove `Status` from `class Subarray`

### DIFF
--- a/test/src/unit-CellSlabIter.cc
+++ b/test/src/unit-CellSlabIter.cc
@@ -314,7 +314,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{5, 15, 3, 5, 11, 14}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   uint64_t tile_coords_0[] = {0};
   uint64_t tile_coords_1[] = {1};
@@ -434,7 +434,7 @@ TEST_CASE_METHOD(
       {1, 2, 5, 8},
   };
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   check_iter<uint64_t>(subarray, c_cell_slabs);
 

--- a/test/src/unit-DenseTiler.cc
+++ b/test/src/unit-DenseTiler.cc
@@ -150,7 +150,8 @@ void DenseTilerFx::add_ranges(
     uint64_t range_size,
     tiledb::sm::Subarray* subarray) {
   for (size_t i = 0; i < ranges.size(); ++i)
-    CHECK(subarray->add_range((uint32_t)i, Range(ranges[i], range_size)).ok());
+    CHECK_NOTHROW(
+        subarray->add_range((uint32_t)i, Range(ranges[i], range_size)));
 }
 
 void DenseTilerFx::open_array(

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -247,7 +247,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{5, 15}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice = {1, 100};
@@ -321,7 +321,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{5, 15}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice = {20, 30};
@@ -395,7 +395,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{5, 15, 3, 5, 11, 14}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice_1 = {5, 12};
@@ -480,7 +480,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{3, 15, 18, 20}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice = {3, 12};
@@ -704,7 +704,7 @@ TEST_CASE_METHOD(
   Subarray subarray;
   SubarrayRanges<uint64_t> ranges = {{2, 3}, {2, 6}};
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice = {1, 6, 1, 6};
@@ -890,7 +890,7 @@ TEST_CASE_METHOD(
   Subarray subarray;
   SubarrayRanges<uint64_t> ranges = {{2, 3}, {2, 6}};
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice = {6, 6, 6, 6};
@@ -1089,7 +1089,7 @@ TEST_CASE_METHOD(
   Subarray subarray;
   SubarrayRanges<uint64_t> ranges = {{2, 3}, {2, 6}};
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice = {3, 6, 5, 6};
@@ -1332,7 +1332,7 @@ TEST_CASE_METHOD(
   Subarray subarray;
   SubarrayRanges<uint64_t> ranges = {{3, 5}, {2, 4, 5, 6}};
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Create result space tiles
   std::vector<uint64_t> slice_1 = {3, 5, 2, 4};

--- a/test/src/unit-Subarray.cc
+++ b/test/src/unit-Subarray.cc
@@ -125,7 +125,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{5, 7, 6, 15, 33, 43}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   // Prepare correct tile coordinates
   std::vector<std::vector<uint8_t>> c_tile_coords;
@@ -248,7 +248,7 @@ TEST_CASE_METHOD(
   SubarrayRanges<uint64_t> ranges = {{2, 2, 6, 10}, {2, 6, 5, 10}};
   Layout subarray_layout = Layout::ROW_MAJOR;
   create_subarray(array_->array_, ranges, subarray_layout, &subarray);
-  CHECK(subarray.compute_tile_coords<uint64_t>().ok());
+  CHECK_NOTHROW(subarray.compute_tile_coords<uint64_t>());
 
   auto tile_coords = subarray.tile_coords();
   CHECK(tile_coords == c_tile_coords);
@@ -310,11 +310,11 @@ TEST_CASE_METHOD(
       subarray.crop_to_tile(&tile_coords[0], Layout::ROW_MAJOR);
   const Range* range = nullptr;
   CHECK(cropped_subarray.range_num() == 2);
-  CHECK(cropped_subarray.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(cropped_subarray.get_range(0, 0, &range));
   CHECK(!memcmp(range->data(), &c_range_0_0[0], 2 * sizeof(uint64_t)));
-  CHECK(cropped_subarray.get_range(1, 0, &range).ok());
+  CHECK_NOTHROW(cropped_subarray.get_range(1, 0, &range));
   CHECK(!memcmp(range->data(), &c_range_1_0[0], 2 * sizeof(uint64_t)));
-  CHECK(cropped_subarray.get_range(1, 1, &range).ok());
+  CHECK_NOTHROW(cropped_subarray.get_range(1, 1, &range));
   CHECK(!memcmp(range->data(), &c_range_1_1[0], 2 * sizeof(uint64_t)));
 
   close_array(ctx_, array_);

--- a/test/src/unit-SubarrayPartitioner-sparse.cc
+++ b/test/src/unit-SubarrayPartitioner-sparse.cc
@@ -2287,7 +2287,7 @@ TEST_CASE_METHOD(
   // Check unsplittable
   tiledb::sm::Subarray subarray(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  CHECK(subarray.add_range(0, Range("bb", "bb"), true).ok());
+  CHECK_NOTHROW(subarray.add_range(0, Range("bb", "bb"), true));
   ThreadPool tp(4);
   Config config;
   SubarrayPartitioner partitioner(
@@ -2315,7 +2315,7 @@ TEST_CASE_METHOD(
   auto partition = partitioner.current();
   CHECK(partition.range_num() == 1);
   const Range* range = nullptr;
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("bb", 2));
   CHECK(range->end_str() == std::string("bb", 2));
@@ -2323,7 +2323,7 @@ TEST_CASE_METHOD(
   // Check full
   tiledb::sm::Subarray subarray_full(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  CHECK(subarray_full.add_range(0, Range("a", "bb"), true).ok());
+  CHECK_NOTHROW(subarray_full.add_range(0, Range("a", "bb"), true));
   SubarrayPartitioner partitioner_full(
       &config,
       subarray_full,
@@ -2342,7 +2342,7 @@ TEST_CASE_METHOD(
   CHECK(!unsplittable);
   partition = partitioner_full.current();
   CHECK(partition.range_num() == 1);
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("a", 1));
   CHECK(range->end_str() == std::string("bb", 2));
@@ -2350,7 +2350,7 @@ TEST_CASE_METHOD(
   // Check split
   tiledb::sm::Subarray subarray_split(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  CHECK(subarray_split.add_range(0, Range("a", "bb"), true).ok());
+  CHECK_NOTHROW(subarray_split.add_range(0, Range("a", "bb"), true));
   SubarrayPartitioner partitioner_split(
       &config,
       subarray_split,
@@ -2370,7 +2370,7 @@ TEST_CASE_METHOD(
   CHECK(!unsplittable);
   partition = partitioner_split.current();
   CHECK(partition.range_num() == 1);
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("a", 1));
   CHECK(range->end_str() == std::string("a\x7F", 2));
@@ -2378,7 +2378,7 @@ TEST_CASE_METHOD(
   CHECK(!unsplittable);
   partition = partitioner_split.current();
   CHECK(partition.range_num() == 1);
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("b", 1));
   CHECK(range->end_str() == std::string("bb", 2));
@@ -2387,7 +2387,7 @@ TEST_CASE_METHOD(
   // Check no split 2 MBRs
   tiledb::sm::Subarray subarray_no_split(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  CHECK(subarray_no_split.add_range(0, Range("bb", "cc"), true).ok());
+  CHECK_NOTHROW(subarray_no_split.add_range(0, Range("bb", "cc"), true));
   SubarrayPartitioner partitioner_no_split(
       &config,
       subarray_no_split,
@@ -2408,7 +2408,7 @@ TEST_CASE_METHOD(
   CHECK(!unsplittable);
   partition = partitioner_no_split.current();
   CHECK(partition.range_num() == 1);
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("bb", 2));
   CHECK(range->end_str() == std::string("cc", 2));
@@ -2416,7 +2416,7 @@ TEST_CASE_METHOD(
   // Check split 2 MBRs
   tiledb::sm::Subarray subarray_split_2(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  CHECK(subarray_split_2.add_range(0, Range("bb", "cc"), true).ok());
+  CHECK_NOTHROW(subarray_split_2.add_range(0, Range("bb", "cc"), true));
   SubarrayPartitioner partitioner_split_2(
       &config,
       subarray_split_2,
@@ -2437,7 +2437,7 @@ TEST_CASE_METHOD(
   CHECK(!unsplittable);
   partition = partitioner_split_2.current();
   CHECK(partition.range_num() == 1);
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("bb", 2));
   CHECK(range->end_str() == std::string("b\x7F", 2));
@@ -2445,7 +2445,7 @@ TEST_CASE_METHOD(
   CHECK(!unsplittable);
   partition = partitioner_split_2.current();
   CHECK(partition.range_num() == 1);
-  CHECK(partition.get_range(0, 0, &range).ok());
+  CHECK_NOTHROW(partition.get_range(0, 0, &range));
   CHECK(range != nullptr);
   CHECK(range->start_str() == std::string("c", 1));
   CHECK(range->end_str() == std::string("cc", 2));
@@ -2554,7 +2554,7 @@ TEST_CASE_METHOD(
 
   tiledb::sm::Subarray subarray(
       array->array_.get(), layout, &g_helper_stats, g_helper_logger());
-  CHECK(subarray.add_range(0, Range("cc", "ccd"), true).ok());
+  CHECK_NOTHROW(subarray.add_range(0, Range("cc", "ccd"), true));
   ThreadPool tp(4);
   Config config;
   SubarrayPartitioner partitioner(

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -467,29 +467,29 @@ TEST_CASE(
   SECTION("- Upper bound OOB") {
     int range[] = {0, 100};
     auto r = Range(&range[0], &range[1], sizeof(int));
-    CHECK(subarray.ptr().get()->subarray_->add_range_unsafe(0, r).ok());
+    CHECK_NOTHROW(subarray.ptr().get()->subarray_->add_range_unsafe(0, r));
   }
 
   SECTION("- Lower bound OOB") {
     int range[] = {-1, 2};
     auto r = Range(&range[0], &range[1], sizeof(int));
-    CHECK(subarray.ptr().get()->subarray_->add_range_unsafe(0, r).ok());
+    CHECK_NOTHROW(subarray.ptr().get()->subarray_->add_range_unsafe(0, r));
   }
 
   SECTION("- Second range OOB") {
     int range[] = {1, 4};
     auto r = Range(&range[0], &range[1], sizeof(int));
-    CHECK(subarray.ptr().get()->subarray_->add_range_unsafe(0, r).ok());
+    CHECK_NOTHROW(subarray.ptr().get()->subarray_->add_range_unsafe(0, r));
     int range2[] = {10, 20};
     auto r2 = Range(&range2[0], &range2[1], sizeof(int));
-    CHECK(subarray.ptr().get()->subarray_->add_range_unsafe(1, r2).ok());
+    CHECK_NOTHROW(subarray.ptr().get()->subarray_->add_range_unsafe(1, r2));
   }
 
   SECTION("- Valid ranges") {
     int range[] = {0, 1};
     auto r = Range(&range[0], &range[1], sizeof(int));
-    CHECK(subarray.ptr().get()->subarray_->add_range_unsafe(0, r).ok());
-    CHECK(subarray.ptr().get()->subarray_->add_range_unsafe(1, r).ok());
+    CHECK_NOTHROW(subarray.ptr().get()->subarray_->add_range_unsafe(0, r));
+    CHECK_NOTHROW(subarray.ptr().get()->subarray_->add_range_unsafe(1, r));
     expected = TILEDB_OK;
   }
 

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -252,10 +252,6 @@ void check_subarray(
     tiledb::Subarray& subarray, const SubarrayRanges<T>& ranges);
 
 template <class T>
-void check_subarray_equiv(
-    tiledb::sm::Subarray& subarray1, tiledb::sm::Subarray& subarray2);
-
-template <class T>
 bool subarray_equiv(
     tiledb::sm::Subarray& subarray1, tiledb::sm::Subarray& subarray2);
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1753,10 +1753,7 @@ int32_t tiledb_subarray_set_coalesce_ranges(
   // Sanity check
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(
-      subarray->subarray_->set_coalesce_ranges(coalesce_ranges != 0));
-
+  subarray->subarray_->set_coalesce_ranges(coalesce_ranges != 0);
   return TILEDB_OK;
 }
 
@@ -1767,7 +1764,7 @@ int32_t tiledb_subarray_set_subarray(
   if (sanity_check(ctx, subarray_obj) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  throw_if_not_ok(subarray_obj->subarray_->set_subarray(subarray_vals));
+  subarray_obj->subarray_->set_subarray(subarray_vals);
 
   return TILEDB_OK;
 }
@@ -1782,7 +1779,7 @@ int32_t tiledb_subarray_add_range(
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
 
-  throw_if_not_ok(subarray->subarray_->add_range(dim_idx, start, end, stride));
+  subarray->subarray_->add_range(dim_idx, start, end, stride);
 
   return TILEDB_OK;
 }
@@ -1795,9 +1792,7 @@ int32_t tiledb_subarray_add_point_ranges(
     uint64_t count) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->add_point_ranges(dim_idx, start, count));
-
+  subarray->subarray_->add_point_ranges(dim_idx, start, count);
   return TILEDB_OK;
 }
 
@@ -1810,10 +1805,7 @@ int32_t tiledb_subarray_add_range_by_name(
     const void* stride) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(
-      subarray->subarray_->add_range_by_name(dim_name, start, end, stride));
-
+  subarray->subarray_->add_range_by_name(dim_name, start, end, stride);
   return TILEDB_OK;
 }
 
@@ -1827,10 +1819,7 @@ int32_t tiledb_subarray_add_range_var(
     uint64_t end_size) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->add_range_var(
-      dim_idx, start, start_size, end, end_size));
-
+  subarray->subarray_->add_range_var(dim_idx, start, start_size, end, end_size);
   return TILEDB_OK;
 }
 
@@ -1844,10 +1833,8 @@ int32_t tiledb_subarray_add_range_var_by_name(
     uint64_t end_size) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->add_range_var_by_name(
-      dim_name, start, start_size, end, end_size));
-
+  subarray->subarray_->add_range_var_by_name(
+      dim_name, start, start_size, end, end_size);
   return TILEDB_OK;
 }
 
@@ -1858,9 +1845,7 @@ int32_t tiledb_subarray_get_range_num(
     uint64_t* range_num) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->get_range_num(dim_idx, range_num));
-
+  subarray->subarray_->get_range_num(dim_idx, range_num);
   return TILEDB_OK;
 }
 
@@ -1871,10 +1856,7 @@ int32_t tiledb_subarray_get_range_num_from_name(
     uint64_t* range_num) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(
-      subarray->subarray_->get_range_num_from_name(dim_name, range_num));
-
+  subarray->subarray_->get_range_num_from_name(dim_name, range_num);
   return TILEDB_OK;
 }
 
@@ -1888,10 +1870,7 @@ int32_t tiledb_subarray_get_range(
     const void** stride) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(
-      subarray->subarray_->get_range(dim_idx, range_idx, start, end, stride));
-
+  subarray->subarray_->get_range(dim_idx, range_idx, start, end, stride);
   return TILEDB_OK;
 }
 
@@ -1904,10 +1883,8 @@ int32_t tiledb_subarray_get_range_var_size(
     uint64_t* end_size) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->get_range_var_size(
-      dim_idx, range_idx, start_size, end_size));
-
+  subarray->subarray_->get_range_var_size(
+      dim_idx, range_idx, start_size, end_size);
   return TILEDB_OK;
 }
 
@@ -1921,10 +1898,8 @@ int32_t tiledb_subarray_get_range_from_name(
     const void** stride) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->get_range_from_name(
-      dim_name, range_idx, start, end, stride));
-
+  subarray->subarray_->get_range_from_name(
+      dim_name, range_idx, start, end, stride);
   return TILEDB_OK;
 }
 
@@ -1937,10 +1912,8 @@ int32_t tiledb_subarray_get_range_var_size_from_name(
     uint64_t* end_size) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->get_range_var_size_from_name(
-      dim_name, range_idx, start_size, end_size));
-
+  subarray->subarray_->get_range_var_size_from_name(
+      dim_name, range_idx, start_size, end_size);
   return TILEDB_OK;
 }
 
@@ -1953,10 +1926,7 @@ int32_t tiledb_subarray_get_range_var(
     void* end) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(
-      subarray->subarray_->get_range_var(dim_idx, range_idx, start, end));
-
+  subarray->subarray_->get_range_var(dim_idx, range_idx, start, end);
   return TILEDB_OK;
 }
 
@@ -1969,10 +1939,7 @@ int32_t tiledb_subarray_get_range_var_from_name(
     void* end) {
   if (sanity_check(ctx, subarray) == TILEDB_ERR)
     return TILEDB_ERR;
-
-  throw_if_not_ok(subarray->subarray_->get_range_var_from_name(
-      dim_name, range_idx, start, end));
-
+  subarray->subarray_->get_range_var_from_name(dim_name, range_idx, start, end);
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -296,7 +296,7 @@ int32_t tiledb_filestore_uri_import(
   uint64_t range_arr[] = {static_cast<uint64_t>(0), last_space_tile_boundary};
   tiledb::type::Range subarray_range(
       static_cast<void*>(range_arr), sizeof(uint64_t) * 2);
-  throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+  subarray.add_range(0, std::move(subarray_range));
   query.set_subarray(subarray);
 
   auto tiledb_cloud_fix = [&](uint64_t start, uint64_t end) {
@@ -312,8 +312,7 @@ int32_t tiledb_filestore_uri_import(
     uint64_t cloud_fix_range_arr[] = {start, end};
     tiledb::type::Range subarray_range_cloud_fix(
         static_cast<void*>(cloud_fix_range_arr), sizeof(uint64_t) * 2);
-    throw_if_not_ok(
-        subarray_cloud_fix.add_range(0, std::move(subarray_range_cloud_fix)));
+    subarray_cloud_fix.add_range(0, std::move(subarray_range_cloud_fix));
     query.set_subarray(subarray_cloud_fix);
     uint64_t data_buff_len = end - start + 1;
     throw_if_not_ok(query.set_data_buffer(
@@ -440,7 +439,7 @@ int32_t tiledb_filestore_uri_export(
     uint64_t subarray_range_arr[] = {start_range, end_range};
     tiledb::type::Range subarray_range(
         static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
-    throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+    subarray.add_range(0, std::move(subarray_range));
 
     tiledb::sm::Query query(context.storage_manager(), array);
     throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
@@ -558,7 +557,7 @@ int32_t tiledb_filestore_buffer_import(
       static_cast<uint64_t>(0), static_cast<uint64_t>(size - 1)};
   tiledb::type::Range subarray_range(
       static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
-  throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+  subarray.add_range(0, std::move(subarray_range));
 
   query.set_subarray(subarray);
   uint64_t size_tmp = size;
@@ -620,7 +619,7 @@ int32_t tiledb_filestore_buffer_export(
       static_cast<uint64_t>(offset), static_cast<uint64_t>(offset + size - 1)};
   tiledb::type::Range subarray_range(
       static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
-  throw_if_not_ok(subarray.add_range(0, std::move(subarray_range)));
+  subarray.add_range(0, std::move(subarray_range));
 
   tiledb::sm::Query query(context.storage_manager(), array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -167,8 +167,7 @@ void DimensionLabelQuery::initialize_read_labels_query(
   if (!parent_subarray.is_default(dim_idx) &&
       !parent_subarray.has_label_ranges(dim_idx)) {
     Subarray subarray{*this->subarray()};
-    throw_if_not_ok(subarray.set_ranges_for_dim(
-        0, parent_subarray.ranges_for_dim(dim_idx)));
+    subarray.set_ranges_for_dim(0, parent_subarray.ranges_for_dim(dim_idx));
     set_subarray(subarray);
   }
 
@@ -193,8 +192,7 @@ void DimensionLabelQuery::initialize_ordered_write_query(
     // Set the subarray if it has index ranges added to it.
     if (!parent_subarray.is_default(dim_idx)) {
       Subarray subarray{*this->subarray()};
-      throw_if_not_ok(subarray.set_ranges_for_dim(
-          0, parent_subarray.ranges_for_dim(dim_idx)));
+      subarray.set_ranges_for_dim(0, parent_subarray.ranges_for_dim(dim_idx));
       if (subarray.range_num() > 1) {
         throw DimensionLabelQueryStatusException(
             "Dimension label writes can only be set for a single range.");
@@ -209,8 +207,8 @@ void DimensionLabelQuery::initialize_ordered_write_query(
     uint64_t count = *index_buffer.buffer_size_ /
                      datatype_size(array_schema().dimension_ptr(0)->type());
     Subarray subarray{*this->subarray()};
-    throw_if_not_ok(subarray.set_coalesce_ranges(true));
-    throw_if_not_ok(subarray.add_point_ranges(0, index_buffer.buffer_, count));
+    subarray.set_coalesce_ranges(true);
+    subarray.add_point_ranges(0, index_buffer.buffer_, count);
     if (subarray.range_num() > 1) {
       throw DimensionLabelQueryStatusException(
           "The dimension data must contain consecutive points when writing to "

--- a/tiledb/sm/query/legacy/cell_slab_iter.cc
+++ b/tiledb/sm/query/legacy/cell_slab_iter.cc
@@ -252,12 +252,12 @@ Status CellSlabIter<T>::init_ranges() {
   ranges_.resize(dim_num);
   for (unsigned d = 0; d < dim_num; ++d) {
     auto dim_dom = (const T*)array_domain[d].data();
-    RETURN_NOT_OK(subarray_->get_range_num(d, &range_num));
+    subarray_->get_range_num(d, &range_num);
     ranges_[d].reserve(range_num);
     tile_extent = *(const T*)array_schema.domain().tile_extent(d).data();
     dim_domain_start = dim_dom[0];
     for (uint64_t j = 0; j < range_num; ++j) {
-      RETURN_NOT_OK(subarray_->get_range(d, j, &r));
+      subarray_->get_range(d, j, &r);
       create_ranges(
           (const T*)(*r).data(), tile_extent, dim_domain_start, &ranges_[d]);
     }

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -1571,7 +1571,7 @@ Status Reader::compute_result_cell_slabs_global(
     tile_subarrays.emplace_back(
         subarray.crop_to_tile((const T*)&tc[0], cell_order));
     auto& tile_subarray = tile_subarrays.back();
-    throw_if_not_ok(tile_subarray.template compute_tile_coords<T>());
+    tile_subarray.template compute_tile_coords<T>();
 
     RETURN_NOT_OK(compute_result_cell_slabs_row_col<T>(
         tile_subarray,
@@ -1738,7 +1738,7 @@ Status Reader::dense_read() {
   std::vector<ResultTile*> result_tiles;
   auto& subarray = read_state_.partitioner_.current();
 
-  RETURN_NOT_OK(subarray.compute_tile_coords<T>());
+  subarray.compute_tile_coords<T>();
   RETURN_NOT_OK(compute_result_cell_slabs<T>(
       subarray,
       result_space_tiles,

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -688,7 +688,7 @@ class Query {
       Layout layout, const ArraySchema& array_schema);
 
   /** Returns if all ranges for this query are non overlapping. */
-  tuple<Status, optional<bool>> non_overlapping_ranges();
+  bool non_overlapping_ranges();
 
   /** Returns true if this is a dense query */
   bool is_dense() const;

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -230,7 +230,7 @@ Status DenseReader::dense_read() {
   // For easy reference.
   const auto dim_num = array_schema_.dim_num();
   auto& subarray = read_state_.partitioner_.current();
-  RETURN_NOT_OK(subarray.compute_tile_coords<DimType>());
+  subarray.compute_tile_coords<DimType>();
   const auto& domain{array_schema_.domain()};
 
   // Cache tile extents.

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -379,10 +379,10 @@ Status SparseIndexReaderBase::load_initial_data() {
     // Tile ranges computation will not stop if it exceeds memory budget.
     // This is ok as it is a soft limit and will be taken into consideration
     // below.
-    RETURN_NOT_OK(subarray_.precompute_all_ranges_tile_overlap(
+    subarray_.precompute_all_ranges_tile_overlap(
         storage_manager_->compute_tp(),
         read_state_.frag_idx(),
-        &tmp_read_state_));
+        &tmp_read_state_);
 
     if (tmp_read_state_.memory_used_tile_ranges() >
         memory_budget_.ratio_tile_ranges() * memory_budget_.total_budget())
@@ -391,8 +391,7 @@ Status SparseIndexReaderBase::load_initial_data() {
   } else {
     for (const auto& [name, _] : aggregates_) {
       if (array_schema_.is_dim(name)) {
-        throw_if_not_ok(subarray_.load_relevant_fragment_rtrees(
-            storage_manager_->compute_tp()));
+        subarray_.load_relevant_fragment_rtrees(storage_manager_->compute_tp());
         break;
       }
     }

--- a/tiledb/sm/query_plan/test/unit_query_plan.cc
+++ b/tiledb/sm/query_plan/test/unit_query_plan.cc
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(QueryPlanFx, "Query plan dump_json", "[query_plan][dump]") {
   stats::Stats stats("foo");
   Subarray subarray(array_shared.get(), &stats, logger_);
   uint64_t r[2]{0, 1};
-  REQUIRE(subarray.add_range(0, r, r + 1, nullptr).ok());
+  subarray.add_range(0, r, r + 1, nullptr);
   query.set_subarray(subarray);
 
   std::vector<uint64_t> data(2);

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -263,7 +263,7 @@ Status subarray_to_capnp(
 
 Status subarray_from_capnp(
     const capnp::Subarray::Reader& reader, Subarray* subarray) {
-  RETURN_NOT_OK(subarray->set_coalesce_ranges(reader.getCoalesceRanges()));
+  subarray->set_coalesce_ranges(reader.getCoalesceRanges());
   auto ranges_reader = reader.getRanges();
   uint32_t dim_num = ranges_reader.size();
   for (uint32_t i = 0; i < dim_num; i++) {
@@ -273,14 +273,14 @@ Status subarray_from_capnp(
     auto data_ptr = data.asBytes();
     if (range_reader.hasBufferSizes()) {
       auto ranges = range_buffers_from_capnp(range_reader);
-      RETURN_NOT_OK(subarray->set_ranges_for_dim(i, ranges));
+      subarray->set_ranges_for_dim(i, ranges);
 
       // Set default indicator
       subarray->set_is_default(i, range_reader.getHasDefaultRange());
     } else {
       // Handle 1.7 style ranges where there is a single range with no sizes
       Range range(data_ptr.begin(), data.size());
-      RETURN_NOT_OK(subarray->set_ranges_for_dim(i, {range}));
+      subarray->set_ranges_for_dim(i, {range});
       subarray->set_is_default(i, range_reader.getHasDefaultRange());
     }
   }
@@ -514,12 +514,12 @@ Status subarray_partitioner_from_capnp(
         partition_info_reader.getSubarray(), &partition_info->partition_));
 
     if (compute_current_tile_overlap) {
-      throw_if_not_ok(partition_info->partition_.precompute_tile_overlap(
+      partition_info->partition_.precompute_tile_overlap(
           partition_info->start_,
           partition_info->end_,
           &config,
           compute_tp,
-          true));
+          true);
     }
   }
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -64,8 +64,7 @@ namespace tiledb::type {
 class Range;
 }
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 class ArraySchema;
@@ -363,9 +362,8 @@ class Subarray {
    * This is only valid for arrays with homogenous dimension data types.
    *
    * @param subarray A pointer to the range data to use.
-   * @returns Status error
    */
-  Status set_subarray(const void* subarray);
+  void set_subarray(const void* subarray);
 
   /**
    * Sets the subarray using a pointer to raw range data that stores one range
@@ -441,7 +439,7 @@ class Subarray {
       uint64_t end_size);
 
   /** Adds a range along the dimension with the given index. */
-  Status add_range(
+  void add_range(
       uint32_t dim_idx, Range&& range, const bool read_range_oob_error = true);
 
   /**
@@ -450,7 +448,7 @@ class Subarray {
    * The range components must be of the same type as the domain type of the
    * underlying array.
    */
-  Status add_range(
+  void add_range(
       unsigned dim_idx, const void* start, const void* end, const void* stride);
 
   /**
@@ -462,9 +460,8 @@ class Subarray {
    * @param check_for_label If ``true``, verify no label ranges set on this
    *   dimension. This should check for labels unless being called by
    *   ``add_index_ranges_from_label`` to update label ranges with index values.
-   * @return Status
    */
-  Status add_point_ranges(
+  void add_point_ranges(
       unsigned dim_idx,
       const void* start,
       uint64_t count,
@@ -480,12 +477,11 @@ class Subarray {
    * @param check_for_label If ``true``, verify no label ranges set on this
    *   dimension. This should check for labels unless being called by
    *   ``add_index_ranges_from_label`` to update label ranges with index values.
-   * @return Status
    * @note The pairs list is logically { {begin1,end1}, {begin2,end2}, ...} but
    * because of typing considerations from the C api is simply presented as
    * a linear list of individual items, though they should be multiple of 2
    */
-  Status add_ranges_list(
+  void add_ranges_list(
       unsigned dim_idx,
       const void* start,
       uint64_t count,
@@ -495,7 +491,7 @@ class Subarray {
    * Adds a variable-sized range to the (read/write) query on the input
    * dimension by index, in the form of (start, end).
    */
-  Status add_range_var(
+  void add_range_var(
       unsigned dim_idx,
       const void* start,
       uint64_t start_size,
@@ -506,7 +502,7 @@ class Subarray {
    * Adds a range along the dimension with the given index, without
    * performing any error checks.
    */
-  Status add_range_unsafe(uint32_t dim_idx, const Range& range);
+  void add_range_unsafe(uint32_t dim_idx, const Range& range);
 
   /**
    * Adds a range to the (read/write) query on the input dimension by name,
@@ -514,7 +510,7 @@ class Subarray {
    * The range components must be of the same type as the domain type of the
    * underlying array.
    */
-  Status add_range_by_name(
+  void add_range_by_name(
       const std::string& dim_name,
       const void* start,
       const void* end,
@@ -524,7 +520,7 @@ class Subarray {
    * Adds a variable-sized range to the (read/write) query on the input
    * dimension by name, in the form of (start, end).
    */
-  Status add_range_var_by_name(
+  void add_range_var_by_name(
       const std::string& dim_name,
       const void* start,
       uint64_t start_size,
@@ -617,7 +613,7 @@ class Subarray {
    * Retrieves the number of ranges of the subarray for the given dimension
    * name.
    */
-  Status get_range_num_from_name(
+  void get_range_num_from_name(
       const std::string& dim_name, uint64_t* range_num) const;
 
   /**
@@ -628,9 +624,8 @@ class Subarray {
    * @param start The range start to retrieve.
    * @param end The range end to retrieve.
    * @param stride The range stride to retrieve.
-   * @return Status
    */
-  Status get_range_from_name(
+  void get_range_from_name(
       const std::string& dim_name,
       uint64_t range_idx,
       const void** start,
@@ -644,9 +639,8 @@ class Subarray {
    * @param range_idx The id of the range to retrieve.
    * @param start_size range start size in bytes
    * @param end_size range end size in bytes
-   * @return Status
    */
-  Status get_range_var_size_from_name(
+  void get_range_var_size_from_name(
       const std::string& dim_name,
       uint64_t range_idx,
       uint64_t* start_size,
@@ -660,9 +654,8 @@ class Subarray {
    * @param range_idx The id of the range to retrieve.
    * @param start The range start to retrieve.
    * @param end The range end to retrieve.
-   * @return Status
    */
-  Status get_range_var_from_name(
+  void get_range_var_from_name(
       const std::string& dim_name,
       uint64_t range_idx,
       void* start,
@@ -745,7 +738,7 @@ class Subarray {
    * @param override_memory_constraint When true, this forces the
    *    routine to compute tile overlap for all ranges.
    */
-  Status precompute_tile_overlap(
+  void precompute_tile_overlap(
       uint64_t start_range_idx,
       uint64_t end_range_idx,
       const Config* config,
@@ -759,8 +752,8 @@ class Subarray {
    * @param frag_tile_idx The current tile index, per fragment.
    * @param tile_ranges The resulting tile ranges.
    */
-  Status precompute_all_ranges_tile_overlap(
-      ThreadPool* const compute_tp,
+  void precompute_all_ranges_tile_overlap(
+      ThreadPool* compute_tp,
       const std::vector<FragIdx>& frag_tile_idx,
       ITileRange* tile_ranges);
 
@@ -785,9 +778,8 @@ class Subarray {
    * @param result_sizes The result sizes to be retrieved for all given names.
    * @param frag_tiles The set of unique (fragment id, tile id) pairs across
    *   all ranges, which is update by this function in a thread-safe manner.
-   * @return Status
    */
-  Status compute_relevant_fragment_est_result_sizes(
+  void compute_relevant_fragment_est_result_sizes(
       const ArraySchema& array_schema,
       bool all_dims_same_type,
       bool all_dims_fixed,
@@ -839,7 +831,7 @@ class Subarray {
    *     Subarray::add_range() is called after this function. In that case,
    *     make sure to make a copy in the caller function.
    */
-  Status get_range(
+  void get_range(
       uint32_t dim_idx, uint64_t range_idx, const Range** range) const;
 
   /**
@@ -850,7 +842,7 @@ class Subarray {
    *     Subarray::add_range() is called after this function. In that case,
    *     make sure to make a copy in the caller function.
    */
-  Status get_range(
+  void get_range(
       uint32_t dim_idx,
       uint64_t range_idx,
       const void** start,
@@ -865,9 +857,8 @@ class Subarray {
    * @param range_idx The id of the range to retrieve.
    * @param start_size range start size in bytes
    * @param end_size range end size in bytes
-   * @return Status
    */
-  Status get_range_var_size(
+  void get_range_var_size(
       uint32_t dim_idx,
       uint64_t range_idx,
       uint64_t* start_size,
@@ -881,13 +872,12 @@ class Subarray {
    * @param range_idx The id of the range to retrieve.
    * @param start The range start to retrieve.
    * @param end The range end to retrieve.
-   * @return Status
    */
-  Status get_range_var(
+  void get_range_var(
       unsigned dim_idx, uint64_t range_idx, void* start, void* end) const;
 
   /** Retrieves the number of ranges on the given dimension index. */
-  Status get_range_num(uint32_t dim_idx, uint64_t* range_num) const;
+  void get_range_num(uint32_t dim_idx, uint64_t* range_num) const;
 
   /**
    * Retrieves a range from a dimension index in the form (start, end, stride).
@@ -897,9 +887,8 @@ class Subarray {
    * @param start The range start to retrieve.
    * @param end The range end to retrieve.
    * @param stride The range stride to retrieve.
-   * @return Status
    */
-  Status get_range(
+  void get_range(
       unsigned dim_idx,
       uint64_t range_idx,
       const void** start,
@@ -931,16 +920,10 @@ class Subarray {
   bool is_unary() const;
 
   /**
-   * Returns ``true`` if the subarray range with the input id is unary
-   * (i.e., consisting of a single point in the 1D domain).
-   */
-  bool is_unary(uint64_t range_idx) const;
-
-  /**
    * Gets the estimated result size (in bytes) for the input fixed-sized
    * attribute/dimension.
    */
-  Status get_est_result_size_internal(
+  void get_est_result_size_internal(
       const char* name,
       uint64_t* size,
       const Config* config,
@@ -950,7 +933,7 @@ class Subarray {
    * Gets the estimated result size (in bytes) for the input var-sized
    * attribute/dimension.
    */
-  Status get_est_result_size(
+  void get_est_result_size(
       const char* name,
       uint64_t* size_off,
       uint64_t* size_val,
@@ -961,7 +944,7 @@ class Subarray {
    * Gets the estimated result size (in bytes) for the input fixed-sized,
    * nullable attribute.
    */
-  Status get_est_result_size_nullable(
+  void get_est_result_size_nullable(
       const char* name,
       uint64_t* size,
       uint64_t* size_validity,
@@ -972,7 +955,7 @@ class Subarray {
    * Gets the estimated result size (in bytes) for the input var-sized,
    * nullable attribute.
    */
-  Status get_est_result_size_nullable(
+  void get_est_result_size_nullable(
       const char* name,
       uint64_t* size_off,
       uint64_t* size_val,
@@ -987,7 +970,7 @@ class Subarray {
    * Gets the maximum memory required to produce the result (in bytes)
    * for the input fixed-sized attribute/dimension.
    */
-  Status get_max_memory_size(
+  void get_max_memory_size(
       const char* name,
       uint64_t* size,
       const Config* config,
@@ -997,7 +980,7 @@ class Subarray {
    * Gets the maximum memory required to produce the result (in bytes)
    * for the input var-sized attribute/dimension.
    */
-  Status get_max_memory_size(
+  void get_max_memory_size(
       const char* name,
       uint64_t* size_off,
       uint64_t* size_val,
@@ -1008,7 +991,7 @@ class Subarray {
    * Gets the maximum memory required to produce the result (in bytes)
    * for the input fixed-sized, nullable attribute.
    */
-  Status get_max_memory_size_nullable(
+  void get_max_memory_size_nullable(
       const char* name,
       uint64_t* size,
       uint64_t* size_validity,
@@ -1019,7 +1002,7 @@ class Subarray {
    * Gets the maximum memory required to produce the result (in bytes)
    * for the input var-sized, nullable attribute.
    */
-  Status get_max_memory_size_nullable(
+  void get_max_memory_size_nullable(
       const char* name,
       uint64_t* size_off,
       uint64_t* size_val,
@@ -1085,13 +1068,15 @@ class Subarray {
    * default coalesc-ranges=true semantics of internal class constructor, but
    * giving capi clients ability to turn off if desired.
    */
-  Status set_coalesce_ranges(bool coalesce_ranges = true);
+  void set_coalesce_ranges(bool coalesce_ranges = true);
 
   /**
    * Flattens the subarray ranges in a byte vector. Errors out
    * if the subarray is not unary.
+   *
+   * @note Only used in test helper `subarray_equiv`; keep it that way.
    */
-  Status to_byte_vec(std::vector<uint8_t>* byte_vec) const;
+  void to_byte_vec(std::vector<uint8_t>* byte_vec) const;
 
   /** Returns the subarray layout. */
   Layout layout() const;
@@ -1162,11 +1147,10 @@ class Subarray {
    *
    * @param dim_idx Index of dimension to set
    * @param ranges `Range` vector that will be copied and set
-   * @return Status
    *
    * @note Intended for serialization only
    */
-  Status set_ranges_for_dim(uint32_t dim_idx, const std::vector<Range>& ranges);
+  void set_ranges_for_dim(uint32_t dim_idx, const std::vector<Range>& ranges);
 
   /**
    * Directly sets the dimension label ranges for the given dimension index,
@@ -1175,7 +1159,6 @@ class Subarray {
    * @param dim_idx Index of dimension to set
    * @param name Name of the dimension label to set
    * @param ranges `Range` vector that will be copied and set
-   * @return Status
    *
    * @note Intended for serialization only
    */
@@ -1188,7 +1171,7 @@ class Subarray {
    * Splits the subarray along the splitting dimension and value into
    * two new subarrays `r1` and `r2`.
    */
-  Status split(
+  void split(
       unsigned splitting_dim,
       const ByteVecValue& splitting_value,
       Subarray* r1,
@@ -1198,7 +1181,7 @@ class Subarray {
    * Splits the subarray along the splitting range, dimension and value
    * into two new subarrays `r1` and `r2`.
    */
-  Status split(
+  void split(
       uint64_t splitting_range,
       unsigned splitting_dim,
       const ByteVecValue& splitting_value,
@@ -1252,10 +1235,9 @@ class Subarray {
    * be sorted on the array tile order.
    *
    * @tparam T The subarray datatype.
-   * @return Status
    */
   template <class T>
-  Status compute_tile_coords();
+  void compute_tile_coords();
 
   /**
    * Computes the estimated result sizes for the input attribute/dimension
@@ -1270,7 +1252,7 @@ class Subarray {
    * the maximum memory size for all ranges (i.e., based on whether
    * it overlaps a unique tile versus all previous ranges in the vector).
    */
-  Status compute_relevant_fragment_est_result_sizes(
+  void compute_relevant_fragment_est_result_sizes(
       const std::vector<std::string>& names,
       uint64_t range_start,
       uint64_t range_end,
@@ -1283,9 +1265,8 @@ class Subarray {
    *
    * @param est_result_size map to set
    * @param max_mem_size map to set
-   * @return Status
    */
-  Status set_est_result_size(
+  void set_est_result_size(
       std::unordered_map<std::string, ResultSize>& est_result_size,
       std::unordered_map<std::string, MemorySize>& max_mem_size);
 
@@ -1352,8 +1333,7 @@ class Subarray {
   void sort_and_merge_ranges(ThreadPool* const compute_tp);
 
   /** Returns if all ranges for this subarray are non overlapping. */
-  tuple<Status, optional<bool>> non_overlapping_ranges(
-      ThreadPool* const compute_tp);
+  bool non_overlapping_ranges(ThreadPool* const compute_tp);
 
   /** Returns if ranges will be coalesced as they are added. */
   inline bool coalesce_ranges() const {
@@ -1380,7 +1360,7 @@ class Subarray {
   void reset_default_ranges();
 
   /** Loads the R-Trees of all relevant fragments in parallel. */
-  Status load_relevant_fragment_rtrees(ThreadPool* compute_tp) const;
+  void load_relevant_fragment_rtrees(ThreadPool* compute_tp) const;
 
  private:
   /* ********************************* */
@@ -1560,27 +1540,25 @@ class Subarray {
   void add_default_ranges();
 
   /** Computes the estimated result size for all attributes/dimensions. */
-  Status compute_est_result_size(const Config* config, ThreadPool* compute_tp);
+  void compute_est_result_size(const Config* config, ThreadPool* compute_tp);
 
   /**
    * Compute `tile_coords_` and `tile_coords_map_`. The coordinates will
    * be sorted on col-major tile order.
    *
    * @tparam T The subarray datatype.
-   * @return Status
    */
   template <class T>
-  Status compute_tile_coords_col();
+  void compute_tile_coords_col();
 
   /**
    * Compute `tile_coords_` and `tile_coords_map_`. The coordinates will
    * be sorted on row-major tile order.
    *
    * @tparam T The subarray datatype.
-   * @return Status
    */
   template <class T>
-  Status compute_tile_coords_row();
+  void compute_tile_coords_row();
 
   /** Returns a deep copy of this Subarray. */
   Subarray clone() const;
@@ -1621,7 +1599,7 @@ class Subarray {
    * @param fn_ctx An opaque context object to be used between successive
    * invocations.
    */
-  Status compute_relevant_fragment_tile_overlap(
+  void compute_relevant_fragment_tile_overlap(
       ThreadPool* compute_tp,
       SubarrayTileOverlap* tile_overlap,
       ComputeRelevantTileOverlapCtx* fn_ctx);
@@ -1636,9 +1614,8 @@ class Subarray {
    * @param tile_overlap Mutated to store the computed tile overlap.
    * @param fn_ctx An opaque context object to be used between successive
    * invocations.
-   * @return Status
    */
-  Status compute_relevant_fragment_tile_overlap(
+  void compute_relevant_fragment_tile_overlap(
       shared_ptr<FragmentMetadata> meta,
       unsigned frag_idx,
       bool dense,
@@ -1650,7 +1627,7 @@ class Subarray {
    * Load the var-sized tile sizes for the input names and from the
    * relevant fragments.
    */
-  Status load_relevant_fragment_tile_var_sizes(
+  void load_relevant_fragment_tile_var_sizes(
       const std::vector<std::string>& names, ThreadPool* compute_tp) const;
 
   /**
@@ -1659,8 +1636,7 @@ class Subarray {
    * @param dim_idx dimension index.
    * @return true if the ranges are non overlapping, false otherwise.
    */
-  tuple<Status, optional<bool>> non_overlapping_ranges_for_dim(
-      const uint64_t dim_idx);
+  bool non_overlapping_ranges_for_dim(uint64_t dim_idx);
 
   /**
    * Returns a cropped version of the subarray, constrained in the
@@ -1671,7 +1647,6 @@ class Subarray {
   void crop_to_tile_impl(const T* tile_coords, Subarray& ret) const;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_SUBARRAY_H

--- a/tiledb/sm/subarray/test/unit_add_ranges_list.cc
+++ b/tiledb/sm/subarray/test/unit_add_ranges_list.cc
@@ -113,17 +113,17 @@ TEST_CASE("Subarray::add_ranges_list", "[subarray]") {
   // underneath add_ranges_list to determine the size of the values being
   // iterated over.
   uint64_t ranges[] = {1, 2, 4, 5, 7, 8, 10, 11};
-  CHECK(sa.add_ranges_list(0, ranges, 8).ok());
-  CHECK(sa.add_ranges_list(1, ranges, 8).ok());
+  CHECK_NOTHROW(sa.add_ranges_list(0, ranges, 8));
+  CHECK_NOTHROW(sa.add_ranges_list(1, ranges, 8));
   uint64_t range_num;
-  CHECK(sa.get_range_num(0, &range_num).ok());
+  CHECK_NOTHROW(sa.get_range_num(0, &range_num));
   CHECK(range_num == 4);
 
   // Check ranges
   for (uint32_t dim_idx = 0; dim_idx < 1; dim_idx++) {
     for (uint32_t idx = 0; idx < range_num; idx++) {
       const void *start, *end;
-      CHECK(sa.get_range(dim_idx, idx, &start, &end).ok());
+      CHECK_NOTHROW(sa.get_range(dim_idx, idx, &start, &end));
       CHECK(*(uint64_t*)start == ranges[idx * 2]);
       CHECK(*(uint64_t*)end == ranges[idx * 2 + 1]);
     }

--- a/tiledb/sm/subarray/tile_cell_slab_iter.cc
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.cc
@@ -296,10 +296,10 @@ Status TileCellSlabIter<T>::init_ranges(const Subarray& subarray) {
   const tiledb::type::Range* r;
   ranges_.resize(dim_num_);
   for (int d = 0; d < dim_num_; ++d) {
-    RETURN_NOT_OK(subarray.get_range_num(d, &range_num));
+    subarray.get_range_num(d, &range_num);
     ranges_[d].reserve(range_num);
     for (uint64_t j = 0; j < range_num; ++j) {
-      RETURN_NOT_OK(subarray.get_range(d, j, &r));
+      subarray.get_range(d, j, &r);
       auto range = (const T*)(*r).data();
       ranges_[d].emplace_back(range[0], range[1]);
     }


### PR DESCRIPTION
This PR removes `Status` from all member functions of `class Subarray`. It also removes all occurrence of `Status` from `subarray/subarray.cc` except for the ones necessary to use `parallel_for`. There are a handful of changes that tagged along, although these were minimized to alleviate review. These other changes include (1) adding blocks to `if` statements without them, (2) removal of some inconsequential `const` declarations, (3) removal of some dead code.

In almost all cases, follow-on changes were not pursued. One exception is `Query::non_overlapping_ranges`, which is proxy for a subarray function; this PR changes its signature. Another was in the test helper `subarray_equiv`, which requires more rewriting that the rest of the call sites.

---
TYPE: NO_HISTORY
DESC: Remove `Status` from `class Subarray`
