### PR TITLE
Improve diagnostics when an Azure endpoint is not configured.

### DIFF
--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -70,7 +70,13 @@ namespace sm {
 struct AzureParameters {
   AzureParameters() = delete;
 
-  AzureParameters(const Config& config);
+  /**
+   * Creates an AzureParameters object.
+   *
+   * @return AzureParameters or nullopt if config does not have
+   * a storage account or blob endpoint set.
+   */
+  static std::optional<AzureParameters> create(const Config& config);
 
   /**  The maximum number of parallel requests. */
   uint64_t max_parallel_ops_;
@@ -107,6 +113,12 @@ struct AzureParameters {
 
   /** Whether the config specifies a SAS token. */
   bool has_sas_token_;
+
+ private:
+  AzureParameters(
+      const Config& config,
+      const std::string& account_name,
+      const std::string& blob_endpoint);
 };
 
 class Azure {
@@ -362,7 +374,21 @@ class Azure {
    * use of the BlobServiceClient.
    */
   const ::Azure::Storage::Blobs::BlobServiceClient& client() const {
-    assert(azure_params_);
+    // This branch can be entered in two circumstances:
+    // 1. The init method has not been called yet.
+    // 2. The init method has been called, but the config (or environment
+    //    variables) do not contain enough information to get the Azure
+    //    endpoint.
+    // We don't distinguish between the two, because only the latter can
+    // happen under normal circumstances, and the former is a C.41 issue
+    // that will go away once the class is C.41 compliant.
+    if (!azure_params_) {
+      throw StatusException(Status_AzureError(
+          "Azure VFS is not configured. Please set the "
+          "'vfs.azure.storage_account_name' and/or "
+          "'vfs.azure.blob_endpoint' configuration options."));
+    }
+
     return client_singleton_.get(*azure_params_);
   }
 


### PR DESCRIPTION
[SC-43870](https://app.shortcut.com/tiledb-inc/story/43870/remove-azure-warning-when-not-using-azure-credentials)

This PR changes the Azure VFS to fail with an explicit error if an operation on the Azure VFS was attempted, but an endpoint to Azure Blob Storage could not be determined based on the `vfs.azure.storage_account_name` and `vfs.azure.blob_endpoint` configuration options. The previous behavior was to emit a warning, which happened at the initialization of the VFS class if Azure is enabled, regardless of whether Azure is being actually used. That warning is no longer emitted.

---
TYPE: IMPROVEMENT
DESC: Improve diagnostics when an Azure endpoint is not configured.