### PR TITLE
[Backport release-2.21] Fix crash getting file size on non existent blob on Azure. (#4836)

### DIFF
--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -643,9 +643,9 @@ Status Azure::blob_size(const URI& uri, uint64_t* const nbytes) const {
 
     if (response.Blobs.empty()) {
       error_message = "Blob does not exist.";
+    } else {
+      *nbytes = static_cast<uint64_t>(response.Blobs[0].BlobSize);
     }
-
-    *nbytes = static_cast<uint64_t>(response.Blobs[0].BlobSize);
   } catch (const ::Azure::Storage::StorageException& e) {
     error_message = e.Message;
   }


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/0c50eeb227fae51ad2d2697bfe3fbc3628e9fb9b from https://github.com/TileDB-Inc/TileDB/pull/4836.

---
TYPE: BUG
DESC: Fix crash getting file size on non existent blob on Azure.
