### PR TITLE
Support specifying GCP account credentials as a config option.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -690,8 +690,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.read_logging_mode"] = "";
   all_param_values["vfs.gcs.endpoint"] = "";
   all_param_values["vfs.gcs.project_id"] = "";
-  all_param_values["vfs.gcs.service_account_credentials"] = "";
-  all_param_values["vfs.gcs.external_account_credentials"] = "";
+  all_param_values["vfs.gcs.service_account_key"] = "";
+  all_param_values["vfs.gcs.workload_identity_configuration"] = "";
   all_param_values["vfs.gcs.impersonate_service_account"] = "";
   all_param_values["vfs.gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -763,8 +763,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["read_logging_mode"] = "";
   vfs_param_values["gcs.endpoint"] = "";
   vfs_param_values["gcs.project_id"] = "";
-  vfs_param_values["gcs.service_account_credentials"] = "";
-  vfs_param_values["gcs.external_account_credentials"] = "";
+  vfs_param_values["gcs.service_account_key"] = "";
+  vfs_param_values["gcs.workload_identity_configuration"] = "";
   vfs_param_values["gcs.impersonate_service_account"] = "";
   vfs_param_values["gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -829,8 +829,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   std::map<std::string, std::string> gcs_param_values;
   gcs_param_values["endpoint"] = "";
   gcs_param_values["project_id"] = "";
-  gcs_param_values["service_account_credentials"] = "";
-  gcs_param_values["external_account_credentials"] = "";
+  gcs_param_values["service_account_key"] = "";
+  gcs_param_values["workload_identity_configuration"] = "";
   gcs_param_values["impersonate_service_account"] = "";
   gcs_param_values["max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -690,6 +690,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.read_logging_mode"] = "";
   all_param_values["vfs.gcs.endpoint"] = "";
   all_param_values["vfs.gcs.project_id"] = "";
+  all_param_values["vfs.gcs.service_account_credentials"] = "";
+  all_param_values["vfs.gcs.external_account_credentials"] = "";
   all_param_values["vfs.gcs.impersonate_service_account"] = "";
   all_param_values["vfs.gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -761,6 +763,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["read_logging_mode"] = "";
   vfs_param_values["gcs.endpoint"] = "";
   vfs_param_values["gcs.project_id"] = "";
+  vfs_param_values["gcs.service_account_credentials"] = "";
+  vfs_param_values["gcs.external_account_credentials"] = "";
   vfs_param_values["gcs.impersonate_service_account"] = "";
   vfs_param_values["gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -825,6 +829,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   std::map<std::string, std::string> gcs_param_values;
   gcs_param_values["endpoint"] = "";
   gcs_param_values["project_id"] = "";
+  gcs_param_values["service_account_credentials"] = "";
+  gcs_param_values["external_account_credentials"] = "";
   gcs_param_values["impersonate_service_account"] = "";
   gcs_param_values["max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 66);
+  CHECK(names.size() == 68);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -812,10 +812,10 @@ TEST_CASE(
   GCS gcs;
   // The content of the credentials does not matter; it does not get parsed
   // until it is used in an API request, which we are not doing.
-  std::string service_account_credentials = "{\"foo\": \"bar\"}";
+  std::string service_account_key = "{\"foo\": \"bar\"}";
 
-  require_tiledb_ok(cfg.set(
-      "vfs.gcs.service_account_credentials", service_account_credentials));
+  require_tiledb_ok(
+      cfg.set("vfs.gcs.service_account_key", service_account_key));
 
   require_tiledb_ok(gcs.init(cfg, &thread_pool));
 
@@ -827,7 +827,7 @@ TEST_CASE(
           credentials.get());
 
   REQUIRE(service_account != nullptr);
-  REQUIRE(service_account->json_object() == service_account_credentials);
+  REQUIRE(service_account->json_object() == service_account_key);
 }
 
 TEST_CASE(
@@ -838,11 +838,11 @@ TEST_CASE(
   GCS gcs;
   // The content of the credentials does not matter; it does not get parsed
   // until it is used in an API request, which we are not doing.
-  std::string service_account_credentials = "{\"foo\": \"bar\"}";
+  std::string service_account_key = "{\"foo\": \"bar\"}";
   std::string impersonate_service_account = "account1,account2,account3";
 
-  require_tiledb_ok(cfg.set(
-      "vfs.gcs.service_account_credentials", service_account_credentials));
+  require_tiledb_ok(
+      cfg.set("vfs.gcs.service_account_key", service_account_key));
   require_tiledb_ok(cfg.set(
       "vfs.gcs.impersonate_service_account", impersonate_service_account));
 
@@ -865,7 +865,7 @@ TEST_CASE(
           impersonate_credentials->base_credentials().get());
 
   REQUIRE(inner_service_account != nullptr);
-  REQUIRE(inner_service_account->json_object() == service_account_credentials);
+  REQUIRE(inner_service_account->json_object() == service_account_key);
 }
 
 TEST_CASE(
@@ -876,10 +876,11 @@ TEST_CASE(
   GCS gcs;
   // The content of the credentials does not matter; it does not get parsed
   // until it is used in an API request, which we are not doing.
-  std::string external_account_credentials = "{\"foo\": \"bar\"}";
+  std::string workload_identity_configuration = "{\"foo\": \"bar\"}";
 
   require_tiledb_ok(cfg.set(
-      "vfs.gcs.external_account_credentials", external_account_credentials));
+      "vfs.gcs.workload_identity_configuration",
+      workload_identity_configuration));
 
   require_tiledb_ok(gcs.init(cfg, &thread_pool));
 
@@ -891,6 +892,6 @@ TEST_CASE(
           credentials.get());
 
   REQUIRE(external_account != nullptr);
-  REQUIRE(external_account->json_object() == external_account_credentials);
+  REQUIRE(external_account->json_object() == workload_identity_configuration);
 }
 #endif

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -758,7 +758,8 @@ TEST_CASE("Validate vfs.s3.custom_headers.*", "[s3][custom-headers]") {
 
 #ifdef HAVE_GCS
 TEST_CASE(
-    "Validate GCS service account impersonation", "[gcs][impersonation]") {
+    "Validate GCS service account impersonation",
+    "[gcs][credentials][impersonation]") {
   ThreadPool thread_pool(2);
   Config cfg = set_config_params(true);
   GCS gcs;
@@ -801,5 +802,95 @@ TEST_CASE(
       impersonate_credentials->target_service_account() ==
       target_service_account);
   REQUIRE(impersonate_credentials->delegates() == delegates);
+}
+
+TEST_CASE(
+    "Validate GCS service account credentials",
+    "[gcs][credentials][service-account]") {
+  ThreadPool thread_pool(2);
+  Config cfg = set_config_params(true);
+  GCS gcs;
+  // The content of the credentials does not matter; it does not get parsed
+  // until it is used in an API request, which we are not doing.
+  std::string service_account_credentials = "{\"foo\": \"bar\"}";
+
+  require_tiledb_ok(cfg.set(
+      "vfs.gcs.service_account_credentials", service_account_credentials));
+
+  require_tiledb_ok(gcs.init(cfg, &thread_pool));
+
+  auto credentials = gcs.make_credentials({});
+
+  // We are using an internal class only for inspection purposes.
+  auto service_account =
+      dynamic_cast<google::cloud::internal::ServiceAccountConfig*>(
+          credentials.get());
+
+  REQUIRE(service_account != nullptr);
+  REQUIRE(service_account->json_object() == service_account_credentials);
+}
+
+TEST_CASE(
+    "Validate GCS service account credentials with impersonation",
+    "[gcs][credentials][service-account-and-impersonation]") {
+  ThreadPool thread_pool(2);
+  Config cfg = set_config_params(true);
+  GCS gcs;
+  // The content of the credentials does not matter; it does not get parsed
+  // until it is used in an API request, which we are not doing.
+  std::string service_account_credentials = "{\"foo\": \"bar\"}";
+  std::string impersonate_service_account = "account1,account2,account3";
+
+  require_tiledb_ok(cfg.set(
+      "vfs.gcs.service_account_credentials", service_account_credentials));
+  require_tiledb_ok(cfg.set(
+      "vfs.gcs.impersonate_service_account", impersonate_service_account));
+
+  require_tiledb_ok(gcs.init(cfg, &thread_pool));
+
+  auto credentials = gcs.make_credentials({});
+
+  // We are using an internal class only for inspection purposes.
+  auto impersonate_credentials =
+      dynamic_cast<google::cloud::internal::ImpersonateServiceAccountConfig*>(
+          credentials.get());
+  REQUIRE(impersonate_credentials != nullptr);
+  REQUIRE(impersonate_credentials->target_service_account() == "account3");
+  REQUIRE(
+      impersonate_credentials->delegates() ==
+      std::vector<std::string>{"account1", "account2"});
+
+  auto inner_service_account =
+      dynamic_cast<google::cloud::internal::ServiceAccountConfig*>(
+          impersonate_credentials->base_credentials().get());
+
+  REQUIRE(inner_service_account != nullptr);
+  REQUIRE(inner_service_account->json_object() == service_account_credentials);
+}
+
+TEST_CASE(
+    "Validate GCS external account credentials",
+    "[gcs][credentials][external-account]") {
+  ThreadPool thread_pool(2);
+  Config cfg = set_config_params(true);
+  GCS gcs;
+  // The content of the credentials does not matter; it does not get parsed
+  // until it is used in an API request, which we are not doing.
+  std::string external_account_credentials = "{\"foo\": \"bar\"}";
+
+  require_tiledb_ok(cfg.set(
+      "vfs.gcs.external_account_credentials", external_account_credentials));
+
+  require_tiledb_ok(gcs.init(cfg, &thread_pool));
+
+  auto credentials = gcs.make_credentials({});
+
+  // We are using an internal class only for inspection purposes.
+  auto external_account =
+      dynamic_cast<google::cloud::internal::ExternalAccountConfig*>(
+          credentials.get());
+
+  REQUIRE(external_account != nullptr);
+  REQUIRE(external_account->json_object() == external_account_credentials);
 }
 #endif

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -391,6 +391,17 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `vfs.gcs.project_id` <br>
  *    Set the GCS project id. <br>
  *    **Default**: ""
+ * - `vfs.gcs.service_account_credentials` <br>
+ *    Set the JSON string with GCS service account credentials. Takes precedence
+ *    over `vfs.gcs.external_account_credentials` if both are specified. If neither
+ *    is specified, Application Default Credentials will be used. <br>
+ *    **Default**: ""
+ * - `vfs.gcs.external_account_credentials` <br>
+ *    Set the JSON string with GCS external account credentials, used for Workload
+ *    Identity Federation. `vfs.gcs.service_account_credentials` takes precedence
+ *    over this if both are specified. If neither is specified, Application Default
+ *    Credentials will be used. <br>
+ *    **Default**: ""
  * - `vfs.gcs.impersonate_service_account` <br>
  *    Set the GCS service account to impersonate. A chain of impersonated
  *    accounts can be formed by specifying many service accounts, separated by a

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -397,7 +397,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    neither is specified, Application Default Credentials will be used. <br>
  *    **Default**: ""
  * - `vfs.gcs.workload_identity_configuration` <br>
- *    Set the JSON string with Workload Identity Federation credentials.
+ *    Set the JSON string with Workload Identity Federation configuration.
  *    `vfs.gcs.service_account_key` takes precedence over this if both are
  *    specified. If neither is specified, Application Default Credentials will
  *    be used. <br>

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -391,16 +391,16 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `vfs.gcs.project_id` <br>
  *    Set the GCS project id. <br>
  *    **Default**: ""
- * - `vfs.gcs.service_account_credentials` <br>
- *    Set the JSON string with GCS service account credentials. Takes precedence
- *    over `vfs.gcs.external_account_credentials` if both are specified. If
+ * - `vfs.gcs.service_account_key` <br>
+ *    Set the JSON string with GCS service account key. Takes precedence
+ *    over `vfs.gcs.workload_identity_configuration` if both are specified. If
  *    neither is specified, Application Default Credentials will be used. <br>
  *    **Default**: ""
- * - `vfs.gcs.external_account_credentials` <br>
- *    Set the JSON string with GCS external account credentials, used for
- *    Workload Identity Federation. `vfs.gcs.service_account_credentials` takes
- *    precedence over this if both are specified. If neither is specified,
- *    Application Default Credentials will be used. <br>
+ * - `vfs.gcs.workload_identity_configuration` <br>
+ *    Set the JSON string with Workload Identity Federation credentials.
+ *    `vfs.gcs.service_account_key` takes precedence over this if both are
+ *    specified. If neither is specified, Application Default Credentials will
+ *    be used. <br>
  *    **Default**: ""
  * - `vfs.gcs.impersonate_service_account` <br>
  *    Set the GCS service account to impersonate. A chain of impersonated

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -393,14 +393,14 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: ""
  * - `vfs.gcs.service_account_credentials` <br>
  *    Set the JSON string with GCS service account credentials. Takes precedence
- *    over `vfs.gcs.external_account_credentials` if both are specified. If neither
- *    is specified, Application Default Credentials will be used. <br>
+ *    over `vfs.gcs.external_account_credentials` if both are specified. If
+ *    neither is specified, Application Default Credentials will be used. <br>
  *    **Default**: ""
  * - `vfs.gcs.external_account_credentials` <br>
- *    Set the JSON string with GCS external account credentials, used for Workload
- *    Identity Federation. `vfs.gcs.service_account_credentials` takes precedence
- *    over this if both are specified. If neither is specified, Application Default
- *    Credentials will be used. <br>
+ *    Set the JSON string with GCS external account credentials, used for
+ *    Workload Identity Federation. `vfs.gcs.service_account_credentials` takes
+ *    precedence over this if both are specified. If neither is specified,
+ *    Application Default Credentials will be used. <br>
  *    **Default**: ""
  * - `vfs.gcs.impersonate_service_account` <br>
  *    Set the GCS service account to impersonate. A chain of impersonated

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -185,6 +185,8 @@ const std::string Config::VFS_AZURE_RETRY_DELAY_MS = "800";
 const std::string Config::VFS_AZURE_MAX_RETRY_DELAY_MS = "60000";
 const std::string Config::VFS_GCS_ENDPOINT = "";
 const std::string Config::VFS_GCS_PROJECT_ID = "";
+const std::string Config::VFS_GCS_SERVICE_ACCOUNT_CREDENTIALS = "";
+const std::string Config::VFS_GCS_EXTERNAL_ACCOUNT_CREDENTIALS = "";
 const std::string Config::VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT = "";
 const std::string Config::VFS_GCS_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
@@ -422,6 +424,12 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair("vfs.gcs.endpoint", Config::VFS_GCS_ENDPOINT),
     std::make_pair("vfs.gcs.project_id", Config::VFS_GCS_PROJECT_ID),
     std::make_pair(
+        "vfs.gcs.service_account_credentials",
+        Config::VFS_GCS_SERVICE_ACCOUNT_CREDENTIALS),
+    std::make_pair(
+        "vfs.gcs.external_account_credentials",
+        Config::VFS_GCS_EXTERNAL_ACCOUNT_CREDENTIALS),
+    std::make_pair(
         "vfs.gcs.impersonate_service_account",
         Config::VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT),
     std::make_pair(
@@ -513,6 +521,8 @@ const std::set<std::string> Config::unserialized_params_ = {
     "vfs.s3.aws_external_id",
     "vfs.s3.aws_load_frequency",
     "vfs.s3.aws_session_name",
+    "vfs.gcs.service_account_credentials",
+    "vfs.gcs.external_account_credentials",
     "vfs.gcs.impersonate_service_account",
     "rest.username",
     "rest.password",

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -185,8 +185,8 @@ const std::string Config::VFS_AZURE_RETRY_DELAY_MS = "800";
 const std::string Config::VFS_AZURE_MAX_RETRY_DELAY_MS = "60000";
 const std::string Config::VFS_GCS_ENDPOINT = "";
 const std::string Config::VFS_GCS_PROJECT_ID = "";
-const std::string Config::VFS_GCS_SERVICE_ACCOUNT_CREDENTIALS = "";
-const std::string Config::VFS_GCS_EXTERNAL_ACCOUNT_CREDENTIALS = "";
+const std::string Config::VFS_GCS_SERVICE_ACCOUNT_KEY = "";
+const std::string Config::VFS_GCS_WORKLOAD_IDENTITY_CONFIGURATION = "";
 const std::string Config::VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT = "";
 const std::string Config::VFS_GCS_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
@@ -424,11 +424,10 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair("vfs.gcs.endpoint", Config::VFS_GCS_ENDPOINT),
     std::make_pair("vfs.gcs.project_id", Config::VFS_GCS_PROJECT_ID),
     std::make_pair(
-        "vfs.gcs.service_account_credentials",
-        Config::VFS_GCS_SERVICE_ACCOUNT_CREDENTIALS),
+        "vfs.gcs.service_account_key", Config::VFS_GCS_SERVICE_ACCOUNT_KEY),
     std::make_pair(
-        "vfs.gcs.external_account_credentials",
-        Config::VFS_GCS_EXTERNAL_ACCOUNT_CREDENTIALS),
+        "vfs.gcs.workload_identity_configuration",
+        Config::VFS_GCS_WORKLOAD_IDENTITY_CONFIGURATION),
     std::make_pair(
         "vfs.gcs.impersonate_service_account",
         Config::VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT),
@@ -521,8 +520,8 @@ const std::set<std::string> Config::unserialized_params_ = {
     "vfs.s3.aws_external_id",
     "vfs.s3.aws_load_frequency",
     "vfs.s3.aws_session_name",
-    "vfs.gcs.service_account_credentials",
-    "vfs.gcs.external_account_credentials",
+    "vfs.gcs.service_account_key",
+    "vfs.gcs.workload_identity_configuration",
     "vfs.gcs.impersonate_service_account",
     "rest.username",
     "rest.password",

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -460,11 +460,11 @@ class Config {
   /** GCS service account(s) to impersonate. */
   static const std::string VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT;
 
-  /** GCS service account credentials JSON string. */
-  static const std::string VFS_GCS_SERVICE_ACCOUNT_CREDENTIALS;
+  /** GCS service account key JSON string. */
+  static const std::string VFS_GCS_SERVICE_ACCOUNT_KEY;
 
   /** GCS external account credentials JSON string. */
-  static const std::string VFS_GCS_EXTERNAL_ACCOUNT_CREDENTIALS;
+  static const std::string VFS_GCS_WORKLOAD_IDENTITY_CONFIGURATION;
 
   /** GCS max parallel ops. */
   static const std::string VFS_GCS_MAX_PARALLEL_OPS;

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -460,6 +460,12 @@ class Config {
   /** GCS service account(s) to impersonate. */
   static const std::string VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT;
 
+  /** GCS service account credentials JSON string. */
+  static const std::string VFS_GCS_SERVICE_ACCOUNT_CREDENTIALS;
+
+  /** GCS external account credentials JSON string. */
+  static const std::string VFS_GCS_EXTERNAL_ACCOUNT_CREDENTIALS;
+
   /** GCS max parallel ops. */
   static const std::string VFS_GCS_MAX_PARALLEL_OPS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -575,7 +575,7 @@ class Config {
    *    neither is specified, Application Default Credentials will be used. <br>
    *    **Default**: ""
    * - `vfs.gcs.workload_identity_configuration` <br>
-   *    Set the JSON string with Workload Identity Federation credentials.
+   *    Set the JSON string with Workload Identity Federation configuration.
    *    `vfs.gcs.service_account_key` takes precedence over this if both are
    *    specified. If neither is specified, Application Default Credentials will
    *    be used. <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -569,6 +569,18 @@ class Config {
    * - `vfs.gcs.project_id` <br>
    *    Set the GCS project id. <br>
    *    **Default**: ""
+   * - `vfs.gcs.service_account_credentials` <br>
+   *    Set the JSON string with GCS service account credentials. Takes
+   *    precedence over `vfs.gcs.external_account_credentials` if both are
+   *    specified. If neither is specified, Application Default Credentials will
+   *    be used. <br>
+   *    **Default**: ""
+   * - `vfs.gcs.external_account_credentials` <br>
+   *    Set the JSON string with GCS external account credentials, used for
+   *    Workload Identity Federation. `vfs.gcs.service_account_credentials`
+   *    takes precedence over this if both are specified. If neither is
+   *    specified, Application Default Credentials will be used. <br>
+   *    **Default**: ""
    * - `vfs.gcs.impersonate_service_account` <br>
    *    Set the GCS service account to impersonate. A chain of impersonated
    *    accounts can be formed by specifying many service accounts, separated by

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -569,17 +569,16 @@ class Config {
    * - `vfs.gcs.project_id` <br>
    *    Set the GCS project id. <br>
    *    **Default**: ""
-   * - `vfs.gcs.service_account_credentials` <br>
-   *    Set the JSON string with GCS service account credentials. Takes
-   *    precedence over `vfs.gcs.external_account_credentials` if both are
+   * - `vfs.gcs.service_account_key` <br>
+   *    Set the JSON string with GCS service account key. Takes precedence
+   *    over `vfs.gcs.workload_identity_configuration` if both are specified. If
+   *    neither is specified, Application Default Credentials will be used. <br>
+   *    **Default**: ""
+   * - `vfs.gcs.workload_identity_configuration` <br>
+   *    Set the JSON string with Workload Identity Federation credentials.
+   *    `vfs.gcs.service_account_key` takes precedence over this if both are
    *    specified. If neither is specified, Application Default Credentials will
    *    be used. <br>
-   *    **Default**: ""
-   * - `vfs.gcs.external_account_credentials` <br>
-   *    Set the JSON string with GCS external account credentials, used for
-   *    Workload Identity Federation. `vfs.gcs.service_account_credentials`
-   *    takes precedence over this if both are specified. If neither is
-   *    specified, Application Default Credentials will be used. <br>
    *    **Default**: ""
    * - `vfs.gcs.impersonate_service_account` <br>
    *    Set the GCS service account to impersonate. A chain of impersonated

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -195,8 +195,8 @@ std::shared_ptr<google::cloud::Credentials> GCS::make_credentials(
   if (!service_account_key_.empty()) {
     if (!workload_identity_configuration_.empty()) {
       LOG_WARN(
-          "Both GCS service account credentials and external account "
-          "credentials were specified; picking the former");
+          "Both GCS service account key and workload identity configuration "
+          "were specified; picking the former");
     }
     creds = google::cloud::MakeServiceAccountCredentials(
         service_account_key_, options);

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -193,9 +193,7 @@ static shared_ptr<google::cloud::Credentials> apply_impersonation(
 std::shared_ptr<google::cloud::Credentials> GCS::make_credentials(
     const google::cloud::Options& options) const {
   shared_ptr<google::cloud::Credentials> creds = nullptr;
-  if (!endpoint_.empty() || getenv("CLOUD_STORAGE_EMULATOR_ENDPOINT")) {
-    creds = google::cloud::MakeInsecureCredentials();
-  } else if (!service_account_credentials_.empty()) {
+  if (!service_account_credentials_.empty()) {
     if (!external_account_credentials_.empty()) {
       LOG_WARN(
           "Both GCS service account credentials and external account "
@@ -206,6 +204,8 @@ std::shared_ptr<google::cloud::Credentials> GCS::make_credentials(
   } else if (!external_account_credentials_.empty()) {
     creds = google::cloud::MakeExternalAccountCredentials(
         external_account_credentials_, options);
+  } else if (!endpoint_.empty() || getenv("CLOUD_STORAGE_EMULATOR_ENDPOINT")) {
+    creds = google::cloud::MakeInsecureCredentials();
   } else {
     creds = google::cloud::MakeGoogleDefaultCredentials(options);
   }

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -443,6 +443,12 @@ class GCS {
   // The GCS project id.
   std::string project_id_;
 
+  // The GCS service account credentials JSON string.
+  std::string service_account_credentials_;
+
+  // The GCS external account credentials JSON string.
+  std::string external_account_credentials_;
+
   // A comma-separated list with the GCS service accounts to impersonate.
   std::string impersonate_service_account_;
 

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -444,10 +444,10 @@ class GCS {
   std::string project_id_;
 
   // The GCS service account credentials JSON string.
-  std::string service_account_credentials_;
+  std::string service_account_key_;
 
   // The GCS external account credentials JSON string.
-  std::string external_account_credentials_;
+  std::string workload_identity_configuration_;
 
   // A comma-separated list with the GCS service accounts to impersonate.
   std::string impersonate_service_account_;


### PR DESCRIPTION
[SC-44515](https://app.shortcut.com/tiledb-inc/story/44515/support-specifying-gcp-account-credentials-as-a-config-option)

---
TYPE: CONFIG
DESC: Add `vfs.gcs.service_account_credential` config option that specifies a Google Cloud service account credential JSON string.

---
TYPE: CONFIG
DESC: Add `vfs.gcs.external_account_credential` config option that specifies a Google Cloud Workload Identity Federation credential JSON string.