### PR TITLE
Increase HDFS timeout in nightlies.

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -72,7 +72,7 @@ jobs:
       matrix_image: ubuntu-22.04
       matrix_compiler_cc: 'gcc-13'
       matrix_compiler_cxx: 'g++-13'
-      timeout: 180
+      timeout: 300
       bootstrap_args: '--enable-hdfs --enable-static-tiledb --disable-werror'
 
   create_issue_on_fail:


### PR DESCRIPTION
We added more tests to REST, which ends up increasing the number of tests running against HDFS.

---
TYPE: NO_HISTORY
DESC: Increase HDFS timeout in nightlies.
