### PR TITLE
Config serialization should take into account environment variables

### DIFF
--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -918,6 +918,17 @@ const char* Config::get_from_config_or_env(
   return *found ? value_config : "";
 }
 
+const std::map<std::string, std::string>
+Config::get_all_params_from_config_or_env() const {
+  std::map<std::string, std::string> values;
+  bool found = false;
+  for (const auto& [key, value] : param_values_) {
+    std::string val = get_from_config_or_env(key, &found);
+    values.emplace(key, val);
+  }
+  return values;
+}
+
 template <class T, bool must_find_>
 optional<T> Config::get_internal(const std::string& key) const {
   auto value = get_internal_string<must_find_>(key);

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -61,6 +61,8 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
+class WhiteboxConfig;
+
 /**
  * This class manages the TileDB configuration options.
  * It is implemented as a simple map from string to string.
@@ -68,6 +70,10 @@ namespace tiledb::sm {
  */
 class Config {
   friend class ConfigIter;
+  /**
+   * WhiteboxConfig makes available internals of Config for testing.
+   */
+  friend class WhiteboxConfig;
 
  public:
   /* ****************************** */

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -67,6 +67,8 @@ namespace tiledb::sm {
  * Parsing to appropriate types happens on demand.
  */
 class Config {
+  friend class ConfigIter;
+
  public:
   /* ****************************** */
   /*        CONFIG DEFAULTS         */
@@ -689,9 +691,6 @@ class Config {
   Status get_vector(
       const std::string& param, std::vector<T>* value, bool* found) const;
 
-  /** Returns the param -> value map. */
-  const std::map<std::string, std::string>& param_values() const;
-
   /** Gets the set parameters. */
   const std::set<std::string>& set_params() const;
 
@@ -705,6 +704,10 @@ class Config {
 
   /** Compares configs for equality. */
   bool operator==(const Config& rhs) const;
+
+  /** Get all config params taking into account environment variables */
+  const std::map<std::string, std::string> get_all_params_from_config_or_env()
+      const;
 
  private:
   /* ********************************* */
@@ -782,6 +785,9 @@ class Config {
 
   template <bool must_find_>
   optional<std::string> get_internal_string(const std::string& key) const;
+
+  /** Returns the param -> value map. */
+  const std::map<std::string, std::string>& param_values() const;
 };
 
 /**

--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -61,9 +61,10 @@ namespace serialization {
 
 Status config_to_capnp(
     const Config& config, capnp::Config::Builder* config_builder) {
-  auto entries = config_builder->initEntries(config.param_values().size());
+  auto config_params = config.get_all_params_from_config_or_env();
+  auto entries = config_builder->initEntries(config_params.size());
   uint64_t i = 0;
-  for (const auto& kv : config.param_values()) {
+  for (const auto& kv : config_params) {
     entries[i].setKey(kv.first);
     entries[i].setValue(kv.second);
     ++i;


### PR DESCRIPTION
sc-44928
We were getting failures while testing Query v3 , and specifically when setting up the REST-CI environment for it, because the `rest.use_refactored_array_open_and_query_submit` config we were setting was not getting propagated to the REST server.

After debugging it seems that Config serialization code was calling `param_values()` method to get the config variables to set in Cap'n'proto, which is not taking into account environment variables.

This PR also moves `param_values()` to private to prevent other classes from similar mistakes. `ConfiIter` is the only class that still uses it and I only saw that class being used in `S3Parameters::load_headers`. It's worth investigating further if that's a problem or not.

---
TYPE: BUG
DESC: Config serialization should take into account environment variables
