### PR TITLE
[Backport release-2.22] Support specifying GCP account credentials as a config option.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -690,6 +690,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.read_logging_mode"] = "";
   all_param_values["vfs.gcs.endpoint"] = "";
   all_param_values["vfs.gcs.project_id"] = "";
+  all_param_values["vfs.gcs.service_account_key"] = "";
+  all_param_values["vfs.gcs.workload_identity_configuration"] = "";
   all_param_values["vfs.gcs.impersonate_service_account"] = "";
   all_param_values["vfs.gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -761,6 +763,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["read_logging_mode"] = "";
   vfs_param_values["gcs.endpoint"] = "";
   vfs_param_values["gcs.project_id"] = "";
+  vfs_param_values["gcs.service_account_key"] = "";
+  vfs_param_values["gcs.workload_identity_configuration"] = "";
   vfs_param_values["gcs.impersonate_service_account"] = "";
   vfs_param_values["gcs.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -825,6 +829,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   std::map<std::string, std::string> gcs_param_values;
   gcs_param_values["endpoint"] = "";
   gcs_param_values["project_id"] = "";
+  gcs_param_values["service_account_key"] = "";
+  gcs_param_values["workload_identity_configuration"] = "";
   gcs_param_values["impersonate_service_account"] = "";
   gcs_param_values["max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -60,7 +60,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 66);
+  CHECK(names.size() == 68);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -391,6 +391,17 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `vfs.gcs.project_id` <br>
  *    Set the GCS project id. <br>
  *    **Default**: ""
+ * - `vfs.gcs.service_account_key` <br>
+ *    Set the JSON string with GCS service account key. Takes precedence
+ *    over `vfs.gcs.workload_identity_configuration` if both are specified. If
+ *    neither is specified, Application Default Credentials will be used. <br>
+ *    **Default**: ""
+ * - `vfs.gcs.workload_identity_configuration` <br>
+ *    Set the JSON string with Workload Identity Federation configuration.
+ *    `vfs.gcs.service_account_key` takes precedence over this if both are
+ *    specified. If neither is specified, Application Default Credentials will
+ *    be used. <br>
+ *    **Default**: ""
  * - `vfs.gcs.impersonate_service_account` <br>
  *    Set the GCS service account to impersonate. A chain of impersonated
  *    accounts can be formed by specifying many service accounts, separated by a

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -185,6 +185,8 @@ const std::string Config::VFS_AZURE_RETRY_DELAY_MS = "800";
 const std::string Config::VFS_AZURE_MAX_RETRY_DELAY_MS = "60000";
 const std::string Config::VFS_GCS_ENDPOINT = "";
 const std::string Config::VFS_GCS_PROJECT_ID = "";
+const std::string Config::VFS_GCS_SERVICE_ACCOUNT_KEY = "";
+const std::string Config::VFS_GCS_WORKLOAD_IDENTITY_CONFIGURATION = "";
 const std::string Config::VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT = "";
 const std::string Config::VFS_GCS_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
@@ -422,6 +424,11 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair("vfs.gcs.endpoint", Config::VFS_GCS_ENDPOINT),
     std::make_pair("vfs.gcs.project_id", Config::VFS_GCS_PROJECT_ID),
     std::make_pair(
+        "vfs.gcs.service_account_key", Config::VFS_GCS_SERVICE_ACCOUNT_KEY),
+    std::make_pair(
+        "vfs.gcs.workload_identity_configuration",
+        Config::VFS_GCS_WORKLOAD_IDENTITY_CONFIGURATION),
+    std::make_pair(
         "vfs.gcs.impersonate_service_account",
         Config::VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT),
     std::make_pair(
@@ -513,6 +520,8 @@ const std::set<std::string> Config::unserialized_params_ = {
     "vfs.s3.aws_external_id",
     "vfs.s3.aws_load_frequency",
     "vfs.s3.aws_session_name",
+    "vfs.gcs.service_account_key",
+    "vfs.gcs.workload_identity_configuration",
     "vfs.gcs.impersonate_service_account",
     "rest.username",
     "rest.password",

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -460,6 +460,12 @@ class Config {
   /** GCS service account(s) to impersonate. */
   static const std::string VFS_GCS_IMPERSONATE_SERVICE_ACCOUNT;
 
+  /** GCS service account key JSON string. */
+  static const std::string VFS_GCS_SERVICE_ACCOUNT_KEY;
+
+  /** GCS external account credentials JSON string. */
+  static const std::string VFS_GCS_WORKLOAD_IDENTITY_CONFIGURATION;
+
   /** GCS max parallel ops. */
   static const std::string VFS_GCS_MAX_PARALLEL_OPS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -569,6 +569,17 @@ class Config {
    * - `vfs.gcs.project_id` <br>
    *    Set the GCS project id. <br>
    *    **Default**: ""
+   * - `vfs.gcs.service_account_key` <br>
+   *    Set the JSON string with GCS service account key. Takes precedence
+   *    over `vfs.gcs.workload_identity_configuration` if both are specified. If
+   *    neither is specified, Application Default Credentials will be used. <br>
+   *    **Default**: ""
+   * - `vfs.gcs.workload_identity_configuration` <br>
+   *    Set the JSON string with Workload Identity Federation configuration.
+   *    `vfs.gcs.service_account_key` takes precedence over this if both are
+   *    specified. If neither is specified, Application Default Credentials will
+   *    be used. <br>
+   *    **Default**: ""
    * - `vfs.gcs.impersonate_service_account` <br>
    *    Set the GCS service account to impersonate. A chain of impersonated
    *    accounts can be formed by specifying many service accounts, separated by

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -102,6 +102,11 @@ Status GCS::init(const Config& config, ThreadPool* const thread_pool) {
   }
   project_id_ = config.get("vfs.gcs.project_id", &found);
   assert(found);
+  service_account_key_ = config.get("vfs.gcs.service_account_key", &found);
+  assert(found);
+  workload_identity_configuration_ =
+      config.get("vfs.gcs.workload_identity_configuration", &found);
+  assert(found);
   impersonate_service_account_ =
       config.get("vfs.gcs.impersonate_service_account", &found);
   assert(found);
@@ -187,7 +192,18 @@ static shared_ptr<google::cloud::Credentials> apply_impersonation(
 std::shared_ptr<google::cloud::Credentials> GCS::make_credentials(
     const google::cloud::Options& options) const {
   shared_ptr<google::cloud::Credentials> creds = nullptr;
-  if (!endpoint_.empty() || getenv("CLOUD_STORAGE_EMULATOR_ENDPOINT")) {
+  if (!service_account_key_.empty()) {
+    if (!workload_identity_configuration_.empty()) {
+      LOG_WARN(
+          "Both GCS service account key and workload identity configuration "
+          "were specified; picking the former");
+    }
+    creds = google::cloud::MakeServiceAccountCredentials(
+        service_account_key_, options);
+  } else if (!workload_identity_configuration_.empty()) {
+    creds = google::cloud::MakeExternalAccountCredentials(
+        workload_identity_configuration_, options);
+  } else if (!endpoint_.empty() || getenv("CLOUD_STORAGE_EMULATOR_ENDPOINT")) {
     creds = google::cloud::MakeInsecureCredentials();
   } else {
     creds = google::cloud::MakeGoogleDefaultCredentials(options);

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -443,6 +443,12 @@ class GCS {
   // The GCS project id.
   std::string project_id_;
 
+  // The GCS service account credentials JSON string.
+  std::string service_account_key_;
+
+  // The GCS external account credentials JSON string.
+  std::string workload_identity_configuration_;
+
   // A comma-separated list with the GCS service accounts to impersonate.
   std::string impersonate_service_account_;
 


### PR DESCRIPTION
Backport 0ae11e2014d5bf059f6cb8adf5e59ae08887f3b7 from #4855.

---
TYPE: CONFIG
DESC: Add `vfs.gcs.impersonate_service_account` option that specifies a service account to impersonate, or a comma-separated list for delegated impersonation.

---
TYPE: IMPROVEMENT
DESC: Stop using deprecated Google Cloud SDK APIs.