### PR TITLE
[Backport release-2.22] Mark the newly introduced GCS configuration options as experimental. (#4872)

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -392,17 +392,20 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Set the GCS project id. <br>
  *    **Default**: ""
  * - `vfs.gcs.service_account_key` <br>
+ *    **Experimental** <br>
  *    Set the JSON string with GCS service account key. Takes precedence
  *    over `vfs.gcs.workload_identity_configuration` if both are specified. If
  *    neither is specified, Application Default Credentials will be used. <br>
  *    **Default**: ""
  * - `vfs.gcs.workload_identity_configuration` <br>
+ *    **Experimental** <br>
  *    Set the JSON string with Workload Identity Federation configuration.
  *    `vfs.gcs.service_account_key` takes precedence over this if both are
  *    specified. If neither is specified, Application Default Credentials will
  *    be used. <br>
  *    **Default**: ""
  * - `vfs.gcs.impersonate_service_account` <br>
+ *    **Experimental** <br>
  *    Set the GCS service account to impersonate. A chain of impersonated
  *    accounts can be formed by specifying many service accounts, separated by a
  *    comma. <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -570,17 +570,20 @@ class Config {
    *    Set the GCS project id. <br>
    *    **Default**: ""
    * - `vfs.gcs.service_account_key` <br>
+   *    **Experimental** <br>
    *    Set the JSON string with GCS service account key. Takes precedence
    *    over `vfs.gcs.workload_identity_configuration` if both are specified. If
    *    neither is specified, Application Default Credentials will be used. <br>
    *    **Default**: ""
    * - `vfs.gcs.workload_identity_configuration` <br>
+   *    **Experimental** <br>
    *    Set the JSON string with Workload Identity Federation configuration.
    *    `vfs.gcs.service_account_key` takes precedence over this if both are
    *    specified. If neither is specified, Application Default Credentials will
    *    be used. <br>
    *    **Default**: ""
    * - `vfs.gcs.impersonate_service_account` <br>
+   *    **Experimental** <br>
    *    Set the GCS service account to impersonate. A chain of impersonated
    *    accounts can be formed by specifying many service accounts, separated by
    *    a comma. <br>


### PR DESCRIPTION
Backport commit d7b798bf12b166081177ffb0c07f020f609681cb from #4872.

---
TYPE: NO_HISTORY