### PR TITLE
Stabilize REST CI

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -320,6 +320,11 @@ struct TestParams {
 TEST_CASE(
     "Testing read query with empty QC, with no range.",
     "[query][query-condition][empty][rest]") {
+  // Generate test parameters.
+  TestParams params = GENERATE(
+      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
+      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
+      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
   // Initial setup.
   std::srand(static_cast<uint32_t>(time(0)));
   test::VFSTestSetup vfs_test_setup;
@@ -337,12 +342,6 @@ TEST_CASE(
   // condition specified above.
   std::vector<int> a_data_read_2(num_rows * num_rows);
   std::vector<float> b_data_read_2(num_rows * num_rows);
-
-  // Generate test parameters.
-  TestParams params = GENERATE(
-      TestParams(TILEDB_SPARSE, TILEDB_GLOBAL_ORDER, false, true),
-      TestParams(TILEDB_SPARSE, TILEDB_UNORDERED, true, false),
-      TestParams(TILEDB_DENSE, TILEDB_ROW_MAJOR, false, false));
 
   // Setup by creating buffers to store all elements of the original array.
   create_array(

--- a/test/src/unit-cppapi-string-dims.cc
+++ b/test/src/unit-cppapi-string-dims.cc
@@ -1497,6 +1497,7 @@ void read_and_check_sparse_array_string_dim(
 TEST_CASE(
     "C++ API: Test filtering of string dimensions on sparse arrays",
     "[cppapi][string-dims][rle-strings][dict-strings][sparse][rest]") {
+  auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
   // Create data buffer to use
   std::stringstream repetitions;
   size_t repetition_num = 100;
@@ -1519,7 +1520,6 @@ TEST_CASE(
   auto dim =
       Dimension::create(ctx, "dim1", TILEDB_STRING_ASCII, nullptr, nullptr);
 
-  auto f = GENERATE(TILEDB_FILTER_RLE, TILEDB_FILTER_DICTIONARY);
   // Create compressor as a filter
   Filter filter(ctx, f);
   // Create filter list


### PR DESCRIPTION
Moves generators in the beginning of tests. Flow of execution and clean up can get unclear/messy when GENERATORS and SECTIONs are interleaved.

Testing: I re-ran the REST-CI 3 times and it passed all of them. Not sure the problem is fixed, but for sure it didn't make it worse. 

sc-42190

---
TYPE: NO_HISTORY
DESC: Stabilize REST CI