### PR TITLE
Deprecate C++ APIs that rely on deprecated APIs.

### DIFF
--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -661,6 +661,7 @@ class Array {
    * @param config Configuration parameters for the consolidation.
    */
   // clang-format on
+  TILEDB_DEPRECATED
   static void consolidate(
       const Context& ctx,
       const std::string& uri,
@@ -819,6 +820,7 @@ class Array {
    * @param encryption_key The encryption key to use.
    */
   // clang-format on
+  TILEDB_DEPRECATED
   static void create(
       const std::string& uri,
       const ArraySchema& schema,
@@ -1176,6 +1178,7 @@ class Array {
    * @param config Configuration parameters for the consolidation.
    */
   // clang-format on
+  TILEDB_DEPRECATED
   static void consolidate_metadata(
       const Context& ctx,
       const std::string& uri,

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -179,6 +179,7 @@ class ArraySchema : public Schema {
    * @param encryption_type The encryption type to use.
    * @param encryption_key The encryption key to use.
    */
+  TILEDB_DEPRECATED
   ArraySchema(
       const Context& ctx,
       const std::string& uri,

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -303,6 +303,8 @@ class Query {
   /**
    * Submit an async query, with callback. Call returns immediately.
    *
+   * Deprecated, call `submit()` on another thread instead.
+   *
    * @note Same notes apply as `Query::submit()`.
    *
    * **Example:**
@@ -316,7 +318,7 @@ class Query {
    * @param callback Callback function.
    */
   template <typename Fn>
-  void submit_async(const Fn& callback) {
+  TILEDB_DEPRECATED void submit_async(const Fn& callback) {
     std::function<void(void*)> wrapper = [&](void*) { callback(); };
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb::impl::tiledb_query_submit_async_func(
@@ -325,6 +327,8 @@ class Query {
 
   /**
    * Submit an async query, with no callback. Call returns immediately.
+   *
+   * Deprecated, call `submit()` on another thread instead.
    *
    * @note Same notes apply as `Query::submit()`.
    *
@@ -336,7 +340,7 @@ class Query {
    * query.submit_async();
    * @endcode
    */
-  void submit_async() {
+  TILEDB_DEPRECATED void submit_async() {
     submit_async([]() {});
   }
 


### PR DESCRIPTION
As part of removing the deprecated APIs, we discovered that there are some non-deprecated C++ APIs that are calling deprecated C APIs and would break once the latter get removed. This PR marks these C++ APIs as deprecated, to be removed alongside the C APIs.

---
TYPE: CPP_API
DESC: `Query::submit_async` is deprecated. Call `Query::submit()` on another thread instead.

---
TYPE: CPP_API
DESC: Overloads of methods and constructors in `Array` and `ArraySchema` that accept encryption keys are deprecated. Specify the encryption key with the `sm.encryption_type` and `sm.encryption_key` config options instead.