### PR TITLE
Always use Ninja on Windows CI.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -60,22 +60,8 @@ jobs:
       TILEDB_ARROW_TESTS: ${{ matrix.TILEDB_ARROW_TESTS }}
       TILEDB_WEBP: ${{ matrix.TILEDB_WEBP }}
       TILEDB_CMAKE_BUILD_TYPE: 'Release'
-      # On windows-2019 we are using the Visual Studio generator, which is multi-config and places the build artifacts in a subdirectory
-      CONFIG_PATH_FIXUP: ${{ matrix.os == 'windows-2019' && 'Release' || '' }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
     steps:
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
-      - name: Setup MSVC toolset (VS 2022)
-        uses: TheMrMilchmann/setup-msvc-dev@v3
-        if: matrix.os == 'windows-2022'
-        with:
-          arch: x64
-          toolset: 14.39
-      - name: Install Ninja (VS 2022)
-        uses: seanmiddleditch/gha-setup-ninja@v4
-        if: matrix.os == 'windows-2022'
       - name: 'tiledb env prep'
         run: |
           $env:BUILD_BUILDDIRECTORY = $env:GITHUB_WORKSPACE.replace("TileDB\TileDB","tdbbd") # 't'ile'db' 'b'uild 'd'ir
@@ -141,6 +127,18 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+      # By default Visual Studio chooses the earliest installed toolset version
+      # for the main build and vcpkg chooses the latest. Force it to use the
+      # latest (14.39 currently).
+      - name: Setup MSVC toolset (VS 2022)
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        if: matrix.os == 'windows-2022'
+        with:
+          arch: x64
+          toolset: 14.39
+      # This must happen after checkout, because checkout would remove the directory.
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Prevent vcpkg from building debug variants
         run: python $env:GITHUB_WORKSPACE/scripts/ci/patch_vcpkg_triplets.py
 
@@ -155,7 +153,7 @@ jobs:
           # allow double-checking path
           cmd /c "echo $PATH"
 
-          $bootstrapOptions = $env:TILEDB_BASE_BOOTSTRAP_OPTIONS + " -CMakeGenerator ${{ matrix.os == 'windows-2022' && 'Ninja' || '`"Visual Studio 16 2019`"' }}"
+          $bootstrapOptions = $env:TILEDB_BASE_BOOTSTRAP_OPTIONS + " -CMakeGenerator Ninja"
           if ($env:TILEDB_S3 -eq "ON") {
             $bootstrapOptions = "-EnableS3 " + $bootstrapOptions
           }
@@ -284,7 +282,7 @@ jobs:
 
           # Actually run tests
 
-          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\$env:CONFIG_PATH_FIXUP\tiledb_unit.exe -d=yes"
+          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\tiledb_unit.exe -d=yes"
           Write-Host "cmds: '$cmds'"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
@@ -292,7 +290,7 @@ jobs:
              $host.SetShouldExit($LastExitCode)
           }
           
-          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\tiledb\sm\filesystem\test\$env:CONFIG_PATH_FIXUP\unit_vfs -d=yes"
+          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\tiledb\sm\filesystem\test\unit_vfs -d=yes"
           Write-Host "cmds: '$cmds'"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
@@ -300,7 +298,7 @@ jobs:
              $host.SetShouldExit($LastExitCode)
           }
 
-          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\ci\$env:CONFIG_PATH_FIXUP\test_assert.exe -d=yes"
+          $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\test\ci\test_assert.exe -d=yes"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
              Write-Host "Tests failed. test_assert exit status: " $LastExitCocde
@@ -322,7 +320,7 @@ jobs:
 
           $TestAppDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api")
           $TestAppDataDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api\test_app_data")
-          Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api\$env:CONFIG_PATH_FIXUP\") -Filter *.exe |
+          Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\c_api\") -Filter *.exe |
           Foreach-Object {
             try {
               Set-Location -path $TestAppDir
@@ -355,7 +353,7 @@ jobs:
 
           $TestAppDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api")
           $TestAppDataDir = (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api\test_app_data")
-          Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api\$env:CONFIG_PATH_FIXUP\") -Filter *.exe |
+          Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "tiledb\examples\cpp_api\") -Filter *.exe |
           Foreach-Object {
             try {
               Set-Location -path $TestAppDir
@@ -400,12 +398,12 @@ jobs:
           cd build
 
           # Build zip artifact
-          cmake ${{ matrix.os != 'windows-2019' && '-G Ninja' || '' }} -DCMAKE_BUILD_TYPE="$CMakeBuildType" -DCMAKE_PREFIX_PATH="$env:BUILD_BUILDDIRECTORY\dist;$env:BUILD_BUILDDIRECTORY\vcpkg_installed\x64-windows" ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE="$CMakeBuildType" -DCMAKE_PREFIX_PATH="$env:BUILD_BUILDDIRECTORY\dist;$env:BUILD_BUILDDIRECTORY\vcpkg_installed\x64-windows" ..
 
           cmake --build . --config $CMakeBuildType -v
 
-          #.\$env:CONFIG_PATH_FIXUP\ExampleExe.exe
-          $cmd = ".\$env:CONFIG_PATH_FIXUP\ExampleExe.exe"
+          #.\ExampleExe.exe
+          $cmd = ".\ExampleExe.exe"
           Write-Host "cmd: '$cmd'"
           Invoke-Expression $cmd
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -127,15 +127,14 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
-      - name: Setup MSVC toolset (VS 2022)
+      - name: Setup MSVC toolset
         uses: TheMrMilchmann/setup-msvc-dev@v3
-        if: matrix.os == 'windows-2022'
         with:
           arch: x64
-          toolset: 14.39
+          # By default Visual Studio 2022 chooses the earliest installed toolset
+          # version for the main build and vcpkg chooses the latest. Force it to
+          # use the latest (14.39 currently).
+          toolset: ${{ matrix.os == 'windows-2022' && '14.39' || '' }}
       # This must happen after checkout, because checkout would remove the directory.
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@v4


### PR DESCRIPTION
[SC-44745](https://app.shortcut.com/tiledb-inc/story/44745/remove-ninja-workaround-for-windows-builds)

In #4759, I switched the VS2022 builds to use Ninja due to errors caused by MSVC toolset version mismatch but could not make the VS2019 builds use Ninja as well and resorted to some conditional logic to support both Ninja and MSBuild.

I subsequently found out what the problem with VS2019 was (the action to install Ninja was running before the checkout action, and the latter deleted the downloaded Ninja), and this PR enables Ninja on all Visual Studio versions and deletes the conditional logic, simplifying the workflow.

Ninja is preferred to MSBuild because of the superior parallelization capabilities. For coverage, MSBuild is still being used on nightly builds.

---
TYPE: NO_HISTORY