### PR TITLE
Vac files should only be removed if paths removal was fully successful

### DIFF
--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -7139,8 +7139,11 @@ TEST_CASE_METHOD(
   if constexpr (tiledb::platform::is_os_windows) {
     return;
   }
-
   if (!vfs_test_setup_.is_local()) {
+    return;
+  }
+  char* manylinux_var = getenv("TILEDB_MANYLINUX");
+  if (manylinux_var && strlen(manylinux_var) > 0) {
     return;
   }
 
@@ -7240,8 +7243,11 @@ TEST_CASE_METHOD(
   if constexpr (tiledb::platform::is_os_windows) {
     return;
   }
-
   if (!vfs_test_setup_.is_local()) {
+    return;
+  }
+  char* manylinux_var = getenv("TILEDB_MANYLINUX");
+  if (manylinux_var && strlen(manylinux_var) > 0) {
     return;
   }
 
@@ -7324,7 +7330,7 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test vacuuming resumes fine in case of error deleting fragment",
     "[capi][vacuuming][resume][frag]") {
-  bool dense_test;
+  bool dense_test = true;
   std::string array_uri;
   std::string commits_uri;
 
@@ -7407,7 +7413,7 @@ TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test vacuuming resumes fine in case of error deleting commit file",
     "[capi][vacuuming][resume][wrt]") {
-  bool dense_test;
+  bool dense_test = true;
   std::string array_uri;
   std::string commits_uri;
 

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -446,16 +446,17 @@ void FragmentConsolidator::vacuum(const char* array_name) {
     array_dir.write_commit_ignore_file(commit_uris_to_ignore);
   }
 
-  // Delete the vacuum files.
   auto vfs = storage_manager_->vfs();
   auto compute_tp = storage_manager_->compute_tp();
-  vfs->remove_files(
-      compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
 
   // Delete fragment directories
   throw_if_not_ok(parallel_for(
       compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs->remove_dir(fragment_uris_to_vacuum[i]));
+        bool is_dir = false;
+        RETURN_NOT_OK(vfs->is_dir(fragment_uris_to_vacuum[i], &is_dir));
+        if (is_dir) {
+          RETURN_NOT_OK(vfs->remove_dir(fragment_uris_to_vacuum[i]));
+        }
 
         // Remove the commit file, if present.
         auto commit_uri = array_dir.get_commit_uri(fragment_uris_to_vacuum[i]);
@@ -467,6 +468,10 @@ void FragmentConsolidator::vacuum(const char* array_name) {
 
         return Status::Ok();
       }));
+
+  // Delete the vacuum files.
+  vfs->remove_files(
+      compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -452,18 +452,18 @@ void FragmentConsolidator::vacuum(const char* array_name) {
   // Delete fragment directories
   throw_if_not_ok(parallel_for(
       compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
-        bool is_dir = false;
-        RETURN_NOT_OK(vfs->is_dir(fragment_uris_to_vacuum[i], &is_dir));
-        if (is_dir) {
-          RETURN_NOT_OK(vfs->remove_dir(fragment_uris_to_vacuum[i]));
-        }
-
         // Remove the commit file, if present.
         auto commit_uri = array_dir.get_commit_uri(fragment_uris_to_vacuum[i]);
         bool is_file = false;
         RETURN_NOT_OK(vfs->is_file(commit_uri, &is_file));
         if (is_file) {
           RETURN_NOT_OK(vfs->remove_file(commit_uri));
+        }
+
+        bool is_dir = false;
+        RETURN_NOT_OK(vfs->is_dir(fragment_uris_to_vacuum[i], &is_dir));
+        if (is_dir) {
+          RETURN_NOT_OK(vfs->remove_dir(fragment_uris_to_vacuum[i]));
         }
 
         return Status::Ok();


### PR DESCRIPTION
- Vacuum files are only removed on a fully successful vacuum.
- The presence of the vacuum files will allow to open any array where a vacuum failed.
- The presence of the vacuum files will allow to resume and complete any vacuum that could have previously failed.
- Test coverage for the scenarios above: dense/sparse, failure points at frag dir removal and commits file removal.

Followups for extending test coverage further:
https://app.shortcut.com/tiledb-inc/story/45564
https://app.shortcut.com/tiledb-inc/story/45565

---
TYPE: BUG
DESC: Vac files should only be removed if paths removal was fully successful
