### PR TITLE
Subarray Rework B: FieldDataSize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode*
 *.sw?
 build/*
+build-*/*
 dist/*
 cmake-build-*/*
 core/bin/*

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -775,7 +775,8 @@ bool ArraySchema::is_dim_label(const std::string& name) const {
 }
 
 bool ArraySchema::is_field(const std::string& name) const {
-  return is_attr(name) || is_dim(name) || is_special_attribute(name);
+  return is_attr(name) || is_dim(name) || is_dim_label(name) ||
+         is_special_attribute(name);
 }
 
 bool ArraySchema::is_nullable(const std::string& name) const {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1541,11 +1541,17 @@ int32_t tiledb_query_get_est_result_size(
     const tiledb_query_t* query,
     const char* name,
     uint64_t* size) {
-  if (sanity_check(ctx, query) == TILEDB_ERR)
+  if (sanity_check(ctx, query) == TILEDB_ERR) {
     return TILEDB_ERR;
-
-  throw_if_not_ok(query->query_->get_est_result_size(name, size));
-
+  }
+  if (name == nullptr) {
+    throw CAPIStatusException("Pointer to field name may not be NULL");
+  }
+  if (size == nullptr) {
+    throw CAPIStatusException("Pointer to size may not be NULL");
+  }
+  auto est_size{query->query_->get_est_result_size_fixed_nonnull(name)};
+  *size = est_size.fixed_;
   return TILEDB_OK;
 }
 
@@ -1555,10 +1561,22 @@ int32_t tiledb_query_get_est_result_size_var(
     const char* name,
     uint64_t* size_off,
     uint64_t* size_val) {
-  if (sanity_check(ctx, query) == TILEDB_ERR)
+  if (sanity_check(ctx, query) == TILEDB_ERR) {
     return TILEDB_ERR;
+  }
+  if (name == nullptr) {
+    throw CAPIStatusException("Pointer to field name may not be NULL");
+  }
+  if (size_off == nullptr) {
+    throw CAPIStatusException("Pointer to offset size may not be NULL");
+  }
+  if (size_val == nullptr) {
+    throw CAPIStatusException("Pointer to value size may not be NULL");
+  }
 
-  throw_if_not_ok(query->query_->get_est_result_size(name, size_off, size_val));
+  auto est_size{query->query_->get_est_result_size_variable_nonnull(name)};
+  *size_off = est_size.fixed_;
+  *size_val = est_size.variable_;
 
   return TILEDB_OK;
 }
@@ -1569,12 +1587,22 @@ int32_t tiledb_query_get_est_result_size_nullable(
     const char* name,
     uint64_t* size_val,
     uint64_t* size_validity) {
-  if (sanity_check(ctx, query) == TILEDB_ERR)
+  if (sanity_check(ctx, query) == TILEDB_ERR) {
     return TILEDB_ERR;
+  }
+  if (name == nullptr) {
+    throw CAPIStatusException("Pointer to field name may not be NULL");
+  }
+  if (size_val == nullptr) {
+    throw CAPIStatusException("Pointer to value size may not be NULL");
+  }
+  if (size_validity == nullptr) {
+    throw CAPIStatusException("Pointer to validity size may not be NULL");
+  }
 
-  throw_if_not_ok(query->query_->get_est_result_size_nullable(
-      name, size_val, size_validity));
-
+  auto est_size{query->query_->get_est_result_size_fixed_nullable(name)};
+  *size_val = est_size.fixed_;
+  *size_validity = est_size.validity_;
   return TILEDB_OK;
 }
 
@@ -1585,12 +1613,25 @@ int32_t tiledb_query_get_est_result_size_var_nullable(
     uint64_t* size_off,
     uint64_t* size_val,
     uint64_t* size_validity) {
-  if (sanity_check(ctx, query) == TILEDB_ERR)
+  if (sanity_check(ctx, query) == TILEDB_ERR) {
     return TILEDB_ERR;
-
-  throw_if_not_ok(query->query_->get_est_result_size_nullable(
-      name, size_off, size_val, size_validity));
-
+  }
+  if (name == nullptr) {
+    throw CAPIStatusException("Pointer to field name may not be NULL");
+  }
+  if (size_off == nullptr) {
+    throw CAPIStatusException("Pointer to offset size may not be NULL");
+  }
+  if (size_val == nullptr) {
+    throw CAPIStatusException("Pointer to value size may not be NULL");
+  }
+  if (size_validity == nullptr) {
+    throw CAPIStatusException("Pointer to validity size may not be NULL");
+  }
+  auto est_size{query->query_->get_est_result_size_variable_nullable(name)};
+  *size_off = est_size.fixed_;
+  *size_val = est_size.variable_;
+  *size_validity = est_size.validity_;
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -257,8 +257,8 @@ class Query {
    * @return estimated result size
    */
   FieldDataSize internal_est_result_size(const char* name);
- public:
 
+ public:
   /** Retrieves the number of written fragments. */
   Status get_written_fragment_num(uint32_t* num) const;
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -64,12 +64,13 @@ namespace tiledb {
 namespace sm {
 
 /** Class for query status exceptions. */
-class QueryStatusException : public StatusException {
+class QueryException : public StatusException {
  public:
-  explicit QueryStatusException(const std::string& msg)
+  explicit QueryException(const std::string& msg)
       : StatusException("Query", msg) {
   }
 };
+using QueryStatusException = QueryException;
 
 class Array;
 class ArrayDimensionLabelQueries;
@@ -172,34 +173,91 @@ class Query {
   /* ********************************* */
 
   /**
+   * Require that a name be that of a fixed-size field from the source array.
+   *
+   * Validate these conditions and throw if any are not met.
+   * - The name is that of a field in the array
+   * - The field is fixed-sized
+   *
+   * @param origin The name of the operation that this validation is a part of
+   * @param name The name of a field
+   */
+  void field_require_array_fixed(
+      const std::string_view origin, const char* name);
+
+  /**
+   * Require that a name be that of a variable-size field from the source array.
+   *
+   * Validate these conditions and throw if any are not met.
+   * - The name is that of a field in the array
+   * - The field is variable-sized
+   *
+   * @param origin The name of the operation that this validation is a part of
+   * @param name The name of a field
+   */
+  void field_require_array_variable(
+      const std::string_view origin, const char* name);
+
+  /**
+   * Require that a field be a nullable field from the source array.
+   *
+   * Validate these conditions and throw if any are not met.
+   * - The name is that of an attribute of the source array
+   * - The attribute is nullable
+   *
+   * @param origin The name of the operation that this validation is a part of
+   * @param name The name of a field
+   */
+  void field_require_array_nullable(
+      const std::string_view origin, const char* name);
+
+  /**
+   * Require that a field be a nonnull field from the source array.
+   *
+   * Validate these conditions and throw if any are not met.
+   * - The name is that of a field in the array
+   * - The field is not nullable
+   *
+   * @param origin The name of the operation that this validation is a part of.
+   * @param name The name of a field
+   */
+  void field_require_array_nonnull(
+      const std::string_view origin, const char* name);
+
+  /**
    * Gets the estimated result size (in bytes) for the input fixed-sized
    * attribute/dimension.
    */
-  Status get_est_result_size(const char* name, uint64_t* size);
+  FieldDataSize get_est_result_size_fixed_nonnull(const char* name);
 
   /**
    * Gets the estimated result size (in bytes) for the input var-sized
    * attribute/dimension.
    */
-  Status get_est_result_size(
-      const char* name, uint64_t* size_off, uint64_t* size_val);
+  FieldDataSize get_est_result_size_variable_nonnull(const char* name);
 
   /**
    * Gets the estimated result size (in bytes) for the input fixed-sized,
    * nullable attribute.
    */
-  Status get_est_result_size_nullable(
-      const char* name, uint64_t* size_val, uint64_t* size_validity);
+  FieldDataSize get_est_result_size_fixed_nullable(const char* name);
 
   /**
    * Gets the estimated result size (in bytes) for the input var-sized,
    * nullable attribute.
    */
-  Status get_est_result_size_nullable(
-      const char* name,
-      uint64_t* size_off,
-      uint64_t* size_val,
-      uint64_t* size_validity);
+  FieldDataSize get_est_result_size_variable_nullable(const char* name);
+
+ private:
+  /**
+   * Common part of all `est_result_size_*` functions, called after argument
+   * validation.
+   *
+   * @param name The name of a field
+   * @return estimated result size
+   */
+  FieldDataSize internal_est_result_size(const char* name);
+ public:
 
   /** Retrieves the number of written fragments. */
   Status get_written_fragment_num(uint32_t* num) const;

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1124,7 +1124,7 @@ FieldDataSize Subarray::get_est_result_size(
   }
 
   bool is_variable_sized{
-      array_schema.var_size(name) || name == constants::coords};
+      name != constants::coords && array_schema.var_size(name)};
   bool is_nullable{array_schema.is_nullable(name)};
 
   // Compute tile overlap for each fragment
@@ -1202,7 +1202,7 @@ FieldDataSize Subarray::get_max_memory_size(
   }
 
   bool is_variable_sized{
-      array_schema.var_size(name) || name == constants::coords};
+      name != constants::coords && array_schema.var_size(name)};
   bool is_nullable{array_schema.is_nullable(name)};
 
   // Compute tile overlap for each fragment

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1142,7 +1142,7 @@ FieldDataSize Subarray::get_est_result_size(
    * Special fix-ups may be necessary if data is empty or very short.
    */
   if (is_variable_sized) {
-    if (r.variable_ == 0 ) {
+    if (r.variable_ == 0) {
       // Assert: no variable data for a variable-sized field
       // Ensure that there are no offsets.
       r.fixed_ = 0;
@@ -1171,7 +1171,7 @@ FieldDataSize Subarray::get_est_result_size(
      * least one cell.
      */
     const auto cell_size = array_schema.cell_size(name);
-    if ( 0 < r.fixed_ && r.fixed_ < cell_size) {
+    if (0 < r.fixed_ && r.fixed_ < cell_size) {
       r.fixed_ = cell_size;
       if (is_nullable) {
         r.validity_ = 1;

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -1103,22 +1103,12 @@ Layout Subarray::layout() const {
   return layout_;
 }
 
-void Subarray::get_est_result_size_internal(
-    const char* name,
-    uint64_t* size,
-    const Config* config,
-    ThreadPool* compute_tp) {
+FieldDataSize Subarray::get_est_result_size(
+    const char* name, const Config* config, ThreadPool* compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr) {
     throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension name cannot be null");
-  }
-
-  // Check size pointer
-  if (size == nullptr) {
-    throw SubarrayException(
-        "Cannot get estimated result size; Input size cannot be null");
+        "Cannot get estimated result size; field name cannot be null");
   }
 
   // Check if name is attribute or dimension
@@ -1129,242 +1119,74 @@ void Subarray::get_est_result_size_internal(
   // Check if attribute/dimension exists
   if (!ArraySchema::is_special_attribute(name) && !is_dim && !is_attr) {
     throw SubarrayException(
-        std::string("Cannot get estimated result size; Attribute/Dimension '") +
-        name + "' does not exist");
+        std::string("Cannot get estimated result size; ") +
+        "there is no field named '" + name + "'");
   }
 
-  // Check if the attribute/dimension is fixed-sized
-  if (array_schema.var_size(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must be fixed-sized");
-  }
-
-  // Check if attribute/dimension is nullable
-  if (array_schema.is_nullable(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable");
-  }
+  bool is_variable_sized{
+      array_schema.var_size(name) || name == constants::coords};
+  bool is_nullable{array_schema.is_nullable(name)};
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
-  *size = static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
 
-  // If the size is non-zero, ensure it is large enough to
-  // contain at least one cell.
-  const auto cell_size = array_schema.cell_size(name);
-  if (*size > 0 && *size < cell_size)
-    *size = cell_size;
+  FieldDataSize r{
+      static_cast<size_t>(std::ceil(est_result_size_[name].size_fixed_)),
+      is_variable_sized ?
+          static_cast<size_t>(std::ceil(est_result_size_[name].size_var_)) :
+          0,
+      is_nullable ? static_cast<size_t>(
+                        std::ceil(est_result_size_[name].size_validity_)) :
+                    0};
+  /*
+   * Special fix-ups may be necessary if data is empty or very short.
+   */
+  if (is_variable_sized) {
+    if (r.variable_ == 0 ) {
+      // Assert: no variable data for a variable-sized field
+      // Ensure that there are no offsets.
+      r.fixed_ = 0;
+      r.validity_ = 0;
+    } else {
+      // Ensure that there's space for at least one offset value.
+      const auto off_cell_size = constants::cell_var_offset_size;
+      if (r.fixed_ < off_cell_size) {
+        r.fixed_ = off_cell_size;
+      }
+      // Ensure that there's space for at least one data value.
+      const auto val_cell_size = datatype_size(array_schema.type(name));
+      if (r.variable_ < val_cell_size) {
+        r.variable_ = val_cell_size;
+      }
+      if (is_nullable) {
+        const auto validity_cell_size = constants::cell_validity_size;
+        if (r.validity_ < validity_cell_size) {
+          r.validity_ = validity_cell_size;
+        }
+      }
+    }
+  } else {
+    /*
+     * If the fixed data is not empty, ensure it is large enough to contain at
+     * least one cell.
+     */
+    const auto cell_size = array_schema.cell_size(name);
+    if ( 0 < r.fixed_ && r.fixed_ < cell_size) {
+      r.fixed_ = cell_size;
+      if (is_nullable) {
+        r.validity_ = 1;
+      }
+    }
+  }
+  return r;
 }
 
-void Subarray::get_est_result_size(
-    const char* name,
-    uint64_t* size_off,
-    uint64_t* size_val,
-    const Config* config,
-    ThreadPool* compute_tp) {
+FieldDataSize Subarray::get_max_memory_size(
+    const char* name, const Config* config, ThreadPool* compute_tp) {
   // Check attribute/dimension name
   if (name == nullptr) {
     throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension name cannot be null");
-  }
-
-  // Check size pointer
-  if (size_off == nullptr || size_val == nullptr) {
-    throw SubarrayException(
-        "Cannot get estimated result size; Input sizes cannot be null");
-  }
-
-  // Check if name is attribute or dimension
-  const auto& array_schema = array_->array_schema_latest();
-  const bool is_dim = array_schema.is_dim(name);
-  const bool is_attr = array_schema.is_attr(name);
-
-  // Check if attribute/dimension exists
-  if (!ArraySchema::is_special_attribute(name) && !is_dim && !is_attr) {
-    throw SubarrayException(
-        std::string("Cannot get estimated result size; Attribute/Dimension '") +
-        name + "' does not exist");
-  }
-
-  // Check if the attribute/dimension is var-sized
-  if (!array_schema.var_size(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must be var-sized");
-  }
-
-  // Check if attribute/dimension is nullable
-  if (array_schema.is_nullable(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable");
-  }
-
-  // Compute tile overlap for each fragment
-  compute_est_result_size(config, compute_tp);
-  *size_off =
-      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
-  *size_val =
-      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_var_));
-
-  // If the value size is non-zero, ensure both it and the offset size
-  // are large enough to contain at least one cell. Otherwise, ensure
-  // the offset size is also zero.
-  if (*size_val > 0) {
-    const auto off_cell_size = constants::cell_var_offset_size;
-    if (*size_off < off_cell_size)
-      *size_off = off_cell_size;
-
-    const uint64_t val_cell_size = datatype_size(array_schema.type(name));
-    if (*size_val < val_cell_size)
-      *size_val = val_cell_size;
-  } else {
-    *size_off = 0;
-  }
-}
-
-void Subarray::get_est_result_size_nullable(
-    const char* name,
-    uint64_t* size,
-    uint64_t* size_validity,
-    const Config* config,
-    ThreadPool* compute_tp) {
-  // Check attribute/dimension name
-  if (name == nullptr)
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute name cannot be null");
-
-  // Check size pointer
-  if (size == nullptr || size_validity == nullptr)
-    throw SubarrayException(
-        "Cannot get estimated result size; Input sizes cannot be null");
-
-  // Check if name is attribute
-  const auto& array_schema = array_->array_schema_latest();
-  const bool is_attr = array_schema.is_attr(name);
-
-  // Check if attribute exists
-  if (!is_attr)
-    throw SubarrayException(
-        std::string("Cannot get estimated result size; Attribute '") + name +
-        "' does not exist");
-
-  // Check if the attribute is fixed-sized
-  if (array_schema.var_size(name))
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute must be fixed-sized");
-
-  // Check if attribute is nullable
-  if (!array_schema.is_nullable(name))
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute must be nullable");
-
-  // Compute tile overlap for each fragment
-  compute_est_result_size(config, compute_tp);
-  *size = static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
-  *size_validity =
-      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_validity_));
-
-  // If the size is non-zero, ensure it is large enough to
-  // contain at least one cell.
-  const auto cell_size = array_schema.cell_size(name);
-  if (*size > 0 && *size < cell_size) {
-    *size = cell_size;
-    *size_validity = 1;
-  }
-}
-
-void Subarray::get_est_result_size_nullable(
-    const char* name,
-    uint64_t* size_off,
-    uint64_t* size_val,
-    uint64_t* size_validity,
-    const Config* config,
-    ThreadPool* compute_tp) {
-  // Check attribute/dimension name
-  if (name == nullptr)
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute name cannot be null");
-
-  // Check size pointer
-  if (size_off == nullptr || size_val == nullptr || size_validity == nullptr)
-    throw SubarrayException(
-        "Cannot get estimated result size; Input sizes cannot be null");
-
-  // Check if name is attribute
-  const auto& array_schema = array_->array_schema_latest();
-  const bool is_attr = array_schema.is_attr(name);
-
-  // Check if attribute exists
-  if (!is_attr)
-    throw SubarrayException(
-        std::string("Cannot get estimated result size; Attribute '") + name +
-        "' does not exist");
-
-  // Check if the attribute is var-sized
-  if (!array_schema.var_size(name))
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute must be var-sized");
-
-  // Check if attribute is nullable
-  if (!array_schema.is_nullable(name))
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute must be nullable");
-
-  // Compute tile overlap for each fragment
-  compute_est_result_size(config, compute_tp);
-  *size_off =
-      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_fixed_));
-  *size_val =
-      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_var_));
-  *size_validity =
-      static_cast<uint64_t>(std::ceil(est_result_size_[name].size_validity_));
-
-  // If the value size is non-zero, ensure both it and the offset and
-  // validity sizes are large enough to contain at least one cell. Otherwise,
-  // ensure the offset and validity sizes are also zero.
-  if (*size_val > 0) {
-    const uint64_t off_cell_size = constants::cell_var_offset_size;
-    if (*size_off < off_cell_size)
-      *size_off = off_cell_size;
-
-    const uint64_t val_cell_size = datatype_size(array_schema.type(name));
-    if (*size_val < val_cell_size)
-      *size_val = val_cell_size;
-
-    const uint64_t validity_cell_size = constants::cell_validity_size;
-    if (*size_validity < validity_cell_size)
-      *size_validity = validity_cell_size;
-  } else {
-    *size_off = 0;
-    *size_validity = 0;
-  }
-}
-
-void Subarray::get_max_memory_size(
-    const char* name,
-    uint64_t* size,
-    const Config* config,
-    ThreadPool* compute_tp) {
-  // Check attribute/dimension name
-  if (name == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute/Dimension cannot be null");
-  }
-
-  // Check size pointer
-  if (size == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Input size cannot be null");
+        "Cannot get max memory size; field name cannot be null");
   }
 
   // Check if name is attribute or dimension
@@ -1375,170 +1197,20 @@ void Subarray::get_max_memory_size(
   // Check if attribute/dimension exists
   if (!ArraySchema::is_special_attribute(name) && !is_dim && !is_attr) {
     throw SubarrayException(
-        std::string("Cannot get max memory size; Attribute/Dimension '") +
-        name + "' does not exist");
+        std::string("Cannot get max memory size; ") +
+        "there is no field named '" + name + "'");
   }
 
-  // Check if the attribute/dimension is fixed-sized
-  if (name != constants::coords && array_schema.var_size(name)) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute/Dimension must be fixed-sized");
-  }
-
-  // Check if attribute/dimension is nullable
-  if (array_schema.is_nullable(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable");
-  }
+  bool is_variable_sized{
+      array_schema.var_size(name) || name == constants::coords};
+  bool is_nullable{array_schema.is_nullable(name)};
 
   // Compute tile overlap for each fragment
   compute_est_result_size(config, compute_tp);
-  *size = max_mem_size_[name].size_fixed_;
-}
-
-void Subarray::get_max_memory_size(
-    const char* name,
-    uint64_t* size_off,
-    uint64_t* size_val,
-    const Config* config,
-    ThreadPool* compute_tp) {
-  // Check attribute/dimension name
-  if (name == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute/Dimension cannot be null");
-  }
-
-  // Check size pointer
-  if (size_off == nullptr || size_val == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Input sizes cannot be null");
-  }
-
-  // Check if name is attribute or dimension
-  const auto& array_schema = array_->array_schema_latest();
-  bool is_dim = array_schema.is_dim(name);
-  bool is_attr = array_schema.is_attr(name);
-
-  // Check if attribute/dimension exists
-  if (!ArraySchema::is_special_attribute(name) && !is_dim && !is_attr) {
-    throw SubarrayException(
-        std::string("Cannot get max memory size; Attribute/Dimension '") +
-        name + "' does not exist");
-  }
-
-  // Check if the attribute/dimension is var-sized
-  if (!array_schema.var_size(name)) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute/Dimension must be var-sized");
-  }
-
-  // Check if attribute/dimension is nullable
-  if (array_schema.is_nullable(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute/Dimension must not be nullable");
-  }
-
-  // Compute tile overlap for each fragment
-  compute_est_result_size(config, compute_tp);
-  *size_off = max_mem_size_[name].size_fixed_;
-  *size_val = max_mem_size_[name].size_var_;
-}
-
-void Subarray::get_max_memory_size_nullable(
-    const char* name,
-    uint64_t* size,
-    uint64_t* size_validity,
-    const Config* config,
-    ThreadPool* compute_tp) {
-  // Check attribute name
-  if (name == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute cannot be null");
-  }
-  // Check size pointer
-  if (size == nullptr || size_validity == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Input sizes cannot be null");
-  }
-  // Check if name is attribute
-  const auto& array_schema = array_->array_schema_latest();
-  bool is_attr = array_schema.is_attr(name);
-
-  // Check if attribute exists
-  if (!is_attr) {
-    throw SubarrayException(
-        std::string("Cannot get max memory size; Attribute '") + name +
-        "' does not exist");
-  }
-
-  // Check if the attribute is fixed-sized
-  if (array_schema.var_size(name)) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute must be fixed-sized");
-  }
-
-  // Check if attribute is nullable
-  if (!array_schema.is_nullable(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute must be nullable");
-  }
-
-  // Compute tile overlap for each fragment
-  compute_est_result_size(config, compute_tp);
-  *size = max_mem_size_[name].size_fixed_;
-  *size_validity = max_mem_size_[name].size_validity_;
-}
-
-void Subarray::get_max_memory_size_nullable(
-    const char* name,
-    uint64_t* size_off,
-    uint64_t* size_val,
-    uint64_t* size_validity,
-    const Config* config,
-    ThreadPool* compute_tp) {
-  // Check attribute/dimension name
-  if (name == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute/Dimension cannot be null");
-  }
-
-  // Check size pointer
-  if (size_off == nullptr || size_val == nullptr || size_validity == nullptr) {
-    throw SubarrayException(
-        "Cannot get max memory size; Input sizes cannot be null");
-  }
-  // Check if name is attribute or dimension
-  const auto& array_schema = array_->array_schema_latest();
-  bool is_attr = array_schema.is_attr(name);
-
-  // Check if attribute exists
-  if (!is_attr) {
-    throw SubarrayException(
-        std::string("Cannot get max memory size; Attribute '") + name +
-        "' does not exist");
-  }
-
-  // Check if the attribute is var-sized
-  if (!array_schema.var_size(name)) {
-    throw SubarrayException(
-        "Cannot get max memory size; Attribute/Dimension must be var-sized");
-  }
-
-  // Check if attribute is nullable
-  if (!array_schema.is_nullable(name)) {
-    throw SubarrayException(
-        "Cannot get estimated result size; "
-        "Attribute must be nullable");
-  }
-
-  // Compute tile overlap for each fragment
-  compute_est_result_size(config, compute_tp);
-  *size_off = max_mem_size_[name].size_fixed_;
-  *size_val = max_mem_size_[name].size_var_;
-  *size_validity = max_mem_size_[name].size_validity_;
+  return {
+      max_mem_size_[name].size_fixed_,
+      is_variable_sized ? max_mem_size_[name].size_var_ : 0,
+      is_nullable ? max_mem_size_[name].size_validity_ : 0};
 }
 
 std::vector<uint64_t> Subarray::get_range_coords(uint64_t range_idx) const {
@@ -1573,36 +1245,6 @@ std::vector<uint64_t> Subarray::get_range_coords(uint64_t range_idx) const {
   }
 
   return ret;
-}
-
-void Subarray::get_next_range_coords(
-    std::vector<uint64_t>* range_coords) const {
-  auto dim_num = array_->array_schema_latest().dim_num();
-  auto layout =
-      (layout_ == Layout::UNORDERED) ?
-          ((cell_order_ == Layout::HILBERT) ? Layout::ROW_MAJOR : cell_order_) :
-          layout_;
-
-  if (layout == Layout::ROW_MAJOR) {
-    auto d = dim_num - 1;
-    ++(*range_coords)[d];
-    while ((*range_coords)[d] >= range_subset_[d].num_ranges() && d != 0) {
-      (*range_coords)[d] = 0;
-      --d;
-      ++(*range_coords)[d];
-    }
-  } else if (layout == Layout::COL_MAJOR) {
-    auto d = (unsigned)0;
-    ++(*range_coords)[d];
-    while ((*range_coords)[d] >= range_subset_[d].num_ranges() &&
-           d != dim_num - 1) {
-      (*range_coords)[d] = 0;
-      ++d;
-      ++(*range_coords)[d];
-    }
-  } else {
-    // Global order - noop
-  }
 }
 
 uint64_t Subarray::range_idx(const std::vector<uint64_t>& range_coords) const {

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -66,6 +66,23 @@ class Range;
 
 namespace tiledb::sm {
 
+struct FieldDataSize {
+  /**
+   * The size of fixed-length field data in bytes.
+   */
+  size_t fixed_;
+
+  /**
+   * The size of variable-length field data in bytes.
+   */
+  size_t variable_;
+
+  /**
+   * The size of validity data in bytes.
+   */
+  size_t validity_;
+};
+
 class Array;
 class ArraySchema;
 class OpenedArray;
@@ -919,96 +936,28 @@ class Subarray {
    */
   bool is_unary() const;
 
-  /**
-   * Gets the estimated result size (in bytes) for the input fixed-sized
-   * attribute/dimension.
-   */
-  void get_est_result_size_internal(
-      const char* name,
-      uint64_t* size,
-      const Config* config,
-      ThreadPool* compute_tp);
-
-  /**
-   * Gets the estimated result size (in bytes) for the input var-sized
-   * attribute/dimension.
-   */
-  void get_est_result_size(
-      const char* name,
-      uint64_t* size_off,
-      uint64_t* size_val,
-      const Config* config,
-      ThreadPool* compute_tp);
-
-  /**
-   * Gets the estimated result size (in bytes) for the input fixed-sized,
-   * nullable attribute.
-   */
-  void get_est_result_size_nullable(
-      const char* name,
-      uint64_t* size,
-      uint64_t* size_validity,
-      const Config* config,
-      ThreadPool* compute_tp);
-
-  /**
-   * Gets the estimated result size (in bytes) for the input var-sized,
-   * nullable attribute.
-   */
-  void get_est_result_size_nullable(
-      const char* name,
-      uint64_t* size_off,
-      uint64_t* size_val,
-      uint64_t* size_validity,
-      const Config* config,
-      ThreadPool* compute_tp);
-
   /** Returns whether the estimated result size has been computed or not. */
   bool est_result_size_computed();
 
-  /*
-   * Gets the maximum memory required to produce the result (in bytes)
-   * for the input fixed-sized attribute/dimension.
+  /**
+   * The estimated result size in bytes for a field.
+   *
+   * This function handles all fields. The field may be a dimension or
+   * attribute, fixed-length or variable, nullable or not. If a particular
+   * size is not relevant to the field type, then it's returned as zero.
    */
-  void get_max_memory_size(
-      const char* name,
-      uint64_t* size,
-      const Config* config,
-      ThreadPool* compute_tp);
+  FieldDataSize get_est_result_size(
+      const char* name, const Config* config, ThreadPool* compute_tp);
 
   /**
-   * Gets the maximum memory required to produce the result (in bytes)
-   * for the input var-sized attribute/dimension.
+   * The maximum memory in bytes required for a field.
+   *
+   * This function handles all fields. The field may be a dimension or
+   * attribute, fixed-length or variable, nullable or not. If a particular
+   * size is not relevant to the field type, then it's returned as zero.
    */
-  void get_max_memory_size(
-      const char* name,
-      uint64_t* size_off,
-      uint64_t* size_val,
-      const Config* config,
-      ThreadPool* compute_tp);
-
-  /*
-   * Gets the maximum memory required to produce the result (in bytes)
-   * for the input fixed-sized, nullable attribute.
-   */
-  void get_max_memory_size_nullable(
-      const char* name,
-      uint64_t* size,
-      uint64_t* size_validity,
-      const Config* config,
-      ThreadPool* compute_tp);
-
-  /**
-   * Gets the maximum memory required to produce the result (in bytes)
-   * for the input var-sized, nullable attribute.
-   */
-  void get_max_memory_size_nullable(
-      const char* name,
-      uint64_t* size_off,
-      uint64_t* size_val,
-      uint64_t* size_validity,
-      const Config* config,
-      ThreadPool* compute_tp);
+  FieldDataSize get_max_memory_size(
+      const char* name, const Config* config, ThreadPool* compute_tp);
 
   /**
    * Returns the range coordinates (for all dimensions) given a flattened
@@ -1017,12 +966,6 @@ class Subarray {
    * subarray range.
    */
   std::vector<uint64_t> get_range_coords(uint64_t range_idx) const;
-
-  /**
-   * Advances the input range coords to the next coords along the
-   * subarray range layout.
-   */
-  void get_next_range_coords(std::vector<uint64_t>* range_coords) const;
 
   /**
    * Returns a subarray consisting of the dimension ranges specified by


### PR DESCRIPTION
Add `struct FieldDataSize`. There are already two incorrect versions of this within `class Subarray`, one which uses `double` (??!) and one which uses `uint64_t`. The correct type for sizes of objects held within program memory is `size_t`, per the C++ standard.

Change return type of `get_max_memory_size` to `FieldDataSize` and remove output arguments. Combine all four `get_max_memory_size*` functions into a single one, thus removing both copypasta and extraneous checks.

Change return type of `Subarray::get_est_result_size` to `FieldDataView` and remove output arguments. Combine all four `get_est_result_size*` functions into a single one, thus again removing both copypasta and extraneous checks. Rework the `Query::get_est_result_size_*` functions that directly serve the C API. Rationalize their names. Move validation for `Query::get_est_result_size_*` to separate functions, which yet again removes a large amount of copypasta. Add null pointer checks to C API functions `tiledb_query_est_result_size*`. Previous null checks were not exhaustive and did not happen in the C API implementation function.

Fix defect in `ArraySchema::is_field`, which did not consider a dimension label as a field.

Removed unused function `get_next_range_coords`.

Added another item to `.gitignore` to cope with an increase requirement from AWS for short lengths in the build directory prefix.

<long description>

---
TYPE: NO_HISTORY
DESC: Subarray Rework B: FieldDataSize
