### PR TITLE
Migrate Array APIs out of StorageManager: get_non_empty_domain.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1067,35 +1067,51 @@ const NDRange Array::non_empty_domain() {
 }
 
 void Array::non_empty_domain(NDRange* domain, bool* is_empty) {
-  if (domain == nullptr)
-    throw ArrayException("[non_empty_domain] Domain object is null");
+  if (domain == nullptr) {
+    throw std::invalid_argument("[non_empty_domain] Domain object is null");
+  }
+  if (is_empty == nullptr) {
+    throw std::invalid_argument("[non_empty_domain] is_empty* is null");
+  }
 
-  if (!is_open())
+  if (!is_open()) {
     throw ArrayException("[non_empty_domain] Array is not open");
+  }
 
   QueryType query_type{get_query_type()};
-  if (query_type != QueryType::READ)
+  if (query_type != QueryType::READ) {
     throw ArrayException("[non_empty_domain] Array not opened for reads");
+  }
 
   *domain = non_empty_domain();
   *is_empty = domain->empty();
 }
 
 void Array::non_empty_domain(void* domain, bool* is_empty) {
-  if (!array_schema_latest().domain().all_dims_same_type())
+  if (domain == nullptr) {
+    throw std::invalid_argument("[non_empty_domain] Domain object is null");
+  }
+  if (is_empty == nullptr) {
+    throw std::invalid_argument("[non_empty_domain] is_empty* is null");
+  }
+
+  if (!array_schema_latest().domain().all_dims_same_type()) {
     throw ArrayException(
         "[non_empty_domain] Function non-applicable to arrays with "
         "heterogenous dimensions");
+  }
 
-  if (!array_schema_latest().domain().all_dims_fixed())
+  if (!array_schema_latest().domain().all_dims_fixed()) {
     throw ArrayException(
         "[non_empty_domain] Function non-applicable to arrays with "
         "variable-sized dimensions");
+  }
 
   NDRange dom;
   non_empty_domain(&dom, is_empty);
-  if (*is_empty)
+  if (*is_empty) {
     return;
+  }
 
   const auto& array_schema = array_schema_latest();
   auto dim_num = array_schema.dim_num();

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1061,11 +1061,50 @@ Metadata& Array::metadata() {
 
 const NDRange Array::non_empty_domain() {
   if (!non_empty_domain_computed()) {
-    // Compute non-empty domain
     throw_if_not_ok(compute_non_empty_domain());
   }
-
   return loaded_non_empty_domain();
+}
+
+void Array::non_empty_domain(NDRange* domain, bool* is_empty) {
+  if (domain == nullptr)
+    throw ArrayException("[non_empty_domain] Domain object is null");
+
+  if (!is_open())
+    throw ArrayException("[non_empty_domain] Array is not open");
+
+  QueryType query_type{get_query_type()};
+  if (query_type != QueryType::READ)
+    throw ArrayException("[non_empty_domain] Array not opened for reads");
+
+  *domain = non_empty_domain();
+  *is_empty = domain->empty();
+}
+
+void Array::non_empty_domain(void* domain, bool* is_empty) {
+  if (!array_schema_latest().domain().all_dims_same_type())
+    throw ArrayException(
+        "[non_empty_domain] Function non-applicable to arrays with "
+        "heterogenous dimensions");
+
+  if (!array_schema_latest().domain().all_dims_fixed())
+    throw ArrayException(
+        "[non_empty_domain] Function non-applicable to arrays with "
+        "variable-sized dimensions");
+
+  NDRange dom;
+  non_empty_domain(&dom, is_empty);
+  if (*is_empty)
+    return;
+
+  const auto& array_schema = array_schema_latest();
+  auto dim_num = array_schema.dim_num();
+  auto domain_c = (unsigned char*)domain;
+  uint64_t offset = 0;
+  for (unsigned d = 0; d < dim_num; ++d) {
+    std::memcpy(&domain_c[offset], dom[d].data(), dom[d].size());
+    offset += dom[d].size();
+  }
 }
 
 bool Array::serialize_non_empty_domain() const {

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -754,9 +754,29 @@ class Array {
 
   /**
    * Returns the non-empty domain of the opened array. If the non_empty_domain
-   * has not been computed or loaded it will be loaded first
+   * has not been computed or loaded it will be loaded first.
    */
   const NDRange non_empty_domain();
+
+  /**
+   * Retrieves the non-empty domain from the opened array.
+   * This is the union of the non-empty domains of the array fragments.
+   *
+   * @param domain The domain to be retrieved.
+   * @param is_empty `true` if the non-empty domain (and array) is empty.
+   */
+  void non_empty_domain(NDRange* domain, bool* is_empty);
+
+  /**
+   * Retrieves the non-empty domain from the opened array.
+   * This is the union of the non-empty domains of the array fragments.
+   *
+   * @pre The array dimensions are numeric and of the same type.
+   *
+   * @param domain The domain to be retrieved.
+   * @param is_empty `true` if the non-empty domain (and array) is empty.
+   */
+  void non_empty_domain(void* domain, bool* is_empty);
 
   /**
    * Retrieves the array metadata object that is already loaded. If it's not yet

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2754,10 +2754,7 @@ int32_t tiledb_array_get_non_empty_domain(
     return TILEDB_ERR;
 
   bool is_empty_b;
-
-  throw_if_not_ok(ctx->storage_manager()->array_get_non_empty_domain(
-      array->array_.get(), domain, &is_empty_b));
-
+  array->array_->non_empty_domain(domain, &is_empty_b);
   *is_empty = (int32_t)is_empty_b;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -83,13 +83,6 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
-class StorageManagerException : public StatusException {
- public:
-  explicit StorageManagerException(const std::string& message)
-      : StatusException("StorageManager", message) {
-  }
-};
-
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -82,6 +82,13 @@
 using namespace tiledb::common;
 
 namespace tiledb::sm {
+
+class StorageManagerException : public StatusException {
+ public:
+  explicit StorageManagerException(const std::string& message)
+      : StatusException("StorageManager", message) {
+  }
+};
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -497,64 +504,6 @@ Status StorageManagerCanonical::array_upgrade_version(
   return Status::Ok();
 }
 
-Status StorageManagerCanonical::array_get_non_empty_domain(
-    Array* array, NDRange* domain, bool* is_empty) {
-  if (domain == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Domain object is null"));
-
-  if (array == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Array object is null"));
-
-  if (!array->is_open())
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Array is not open"));
-
-  QueryType query_type{array->get_query_type()};
-  if (query_type != QueryType::READ)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Array not opened for reads"));
-
-  *domain = array->non_empty_domain();
-  *is_empty = domain->empty();
-
-  return Status::Ok();
-}
-
-Status StorageManagerCanonical::array_get_non_empty_domain(
-    Array* array, void* domain, bool* is_empty) {
-  if (array == nullptr)
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Array object is null"));
-
-  if (!array->array_schema_latest().domain().all_dims_same_type())
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Function non-applicable to arrays with "
-        "heterogenous dimensions"));
-
-  if (!array->array_schema_latest().domain().all_dims_fixed())
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get non-empty domain; Function non-applicable to arrays with "
-        "variable-sized dimensions"));
-
-  NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
-  if (*is_empty)
-    return Status::Ok();
-
-  const auto& array_schema = array->array_schema_latest();
-  auto dim_num = array_schema.dim_num();
-  auto domain_c = (unsigned char*)domain;
-  uint64_t offset = 0;
-  for (unsigned d = 0; d < dim_num; ++d) {
-    std::memcpy(&domain_c[offset], dom[d].data(), dom[d].size());
-    offset += dom[d].size();
-  }
-
-  return Status::Ok();
-}
-
 Status StorageManagerCanonical::array_get_non_empty_domain_from_index(
     Array* array, unsigned idx, void* domain, bool* is_empty) {
   // Check if array is open - must be open for reads
@@ -578,7 +527,7 @@ Status StorageManagerCanonical::array_get_non_empty_domain_from_index(
   }
 
   NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
+  array->non_empty_domain(&dom, is_empty);
   if (*is_empty)
     return Status::Ok();
 
@@ -599,7 +548,7 @@ Status StorageManagerCanonical::array_get_non_empty_domain_from_name(
         "Cannot get non-empty domain; Array is not open"));
 
   NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
+  array->non_empty_domain(&dom, is_empty);
 
   const auto& array_schema = array->array_schema_latest();
   auto& array_domain{array_schema.domain()};
@@ -647,7 +596,7 @@ Status StorageManagerCanonical::array_get_non_empty_domain_var_size_from_index(
   }
 
   NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
+  array->non_empty_domain(&dom, is_empty);
   if (*is_empty) {
     *start_size = 0;
     *end_size = 0;
@@ -672,7 +621,7 @@ Status StorageManagerCanonical::array_get_non_empty_domain_var_size_from_name(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
+  array->non_empty_domain(&dom, is_empty);
 
   const auto& array_schema = array->array_schema_latest();
   auto& array_domain{array_schema.domain()};
@@ -722,7 +671,7 @@ Status StorageManagerCanonical::array_get_non_empty_domain_var_from_index(
   }
 
   NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
+  array->non_empty_domain(&dom, is_empty);
 
   if (*is_empty)
     return Status::Ok();
@@ -743,7 +692,7 @@ Status StorageManagerCanonical::array_get_non_empty_domain_var_from_name(
         "Cannot get non-empty domain; Invalid dimension name"));
 
   NDRange dom;
-  RETURN_NOT_OK(array_get_non_empty_domain(array, &dom, is_empty));
+  array->non_empty_domain(&dom, is_empty);
 
   const auto& array_schema = array->array_schema_latest();
   auto& array_domain{array_schema.domain()};

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -62,8 +62,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 class OpenedArray;
@@ -243,31 +242,6 @@ class StorageManagerCanonical {
    * @return Status
    */
   Status array_upgrade_version(const URI& uri, const Config& config);
-
-  /**
-   * Retrieves the non-empty domain from an array. This is the union of the
-   * non-empty domains of the array fragments.
-   *
-   * @param array An open array object (must be already open).
-   * @param domain The domain to be retrieved.
-   * @param is_empty `true` if the non-empty domain is empty (the array
-   *     is empty).
-   * @return Status
-   */
-  Status array_get_non_empty_domain(
-      Array* array, NDRange* domain, bool* is_empty);
-
-  /**
-   * Retrieves the non-empty domain from an array. This is the union of the
-   * non-empty domains of the array fragments.
-   *
-   * @param array An open array object (must be already open).
-   * @param domain The domain to be retrieved.
-   * @param is_empty `ture` if the non-empty domain is empty (the array
-   *     is empty).
-   * @return Status
-   */
-  Status array_get_non_empty_domain(Array* array, void* domain, bool* is_empty);
 
   /**
    * Retrieves the non-empty domain from an array on the given dimension.
@@ -720,7 +694,6 @@ class StorageManagerCanonical {
   Status set_default_tags();
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_STORAGE_MANAGER_CANONICAL_H


### PR DESCRIPTION
Migrate `Array` APIs out of `StorageManager`: `array_get_non_empty_domain`.

---
[sc-44988]

---
TYPE: NO_HISTORY
DESC: Migrate Array APIs out of StorageManager: array_get_non_empty_domain.
