### PR TITLE
[Backport release-2.18]  Fix doxygen build step. (#4639)

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -560,7 +560,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    When set to `true`, the S3 SDK uses a handler that ignores SIGPIPE
  *    signals.
  *    **Default**: "true"
- * - `vfs.hdfs.name_node_uri"` <br>
+ * - `vfs.hdfs.name_node_uri` <br>
  *    Name node for HDFS. <br>
  *    **Default**: ""
  * - `vfs.hdfs.username` <br>

--- a/tiledb/doxygen/local-build.sh
+++ b/tiledb/doxygen/local-build.sh
@@ -92,7 +92,7 @@ build_site() {
     # Note:
     #  -E disables the build cache (slower builds).
     #  -W enables warnings as errors.
-    sphinx-build -E -W -T -b html -d ${build_dir}/doctrees -D language=en ${source_dir} ${build_dir}/html ${BUILD_DIR_ARG:-} || \
+    sphinx-build -E -W -T -b html -d ${build_dir}/doctrees ${source_dir} ${build_dir}/html ${BUILD_DIR_ARG:-} || \
         die "could not build sphinx site"
 }
 

--- a/tiledb/doxygen/source/conf.py
+++ b/tiledb/doxygen/source/conf.py
@@ -107,7 +107,7 @@ c_id_attributes = ['TILEDB_EXPORT', 'TILEDB_NOEXCEPT', 'TILEDB_DEPRECATED_EXPORT
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/tiledb/doxygen/source/requirements.txt
+++ b/tiledb/doxygen/source/requirements.txt
@@ -1,6 +1,6 @@
-breathe==4.26.1
-sphinxcontrib-contentui==0.2.5
-sphinx_rtd_theme==0.5.0
-docutils < 0.18 # pin pending https://github.com/sphinx-doc/sphinx/issues/9777
-cmake>=3.21
-jinja2<3.1 # pinned due to incompatibility with sphinx 3.4
+breathe
+cmake
+docutils
+jinja2
+sphinx_rtd_theme
+sphinxcontrib-contentui


### PR DESCRIPTION
Backport https://github.com/TileDB-Inc/TileDB/commit/8594341a444ca475705babf6c000e183107f52d3 from https://github.com/TileDB-Inc/TileDB/pull/4639.

---
TYPE: NO_HISTORY
DESC: Fix doxygen build step.