### PR TITLE
Pin MINIO to verison before delete behavior change for release-2.18

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -48,6 +48,7 @@ env:
   bootstrap_args: "--enable-ccache ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
+  MINIO_VERSION: "RELEASE.2024-02-09T21-25-16Z"
 
 jobs:
   build:

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -26,6 +26,9 @@
 
 # Installs dependencies for minio.
 
+# Define MINIO_VERSION to default if not set
+MINIO_VERSION=${MINIO_VERSION:="RELEASE.2024-02-09T21-25-16Z"}
+
 die() {
   echo "$@" 1>&2 ; popd 2>/dev/null; exit 1
 }
@@ -50,7 +53,7 @@ install_brew_pkgs() {
   #brew install minio/stable/minio
 
   # Use direct installation due to failed download from homebrew
-  curl -O https://dl.min.io/server/minio/release/darwin-amd64/minio
+  curl --output minio https://dl.min.io/server/minio/release/darwin-amd64/archive/minio.${MINIO_VERSION}
   chmod +x ./minio
   sudo mv ./minio /usr/local/bin/
 }

--- a/scripts/run-minio.sh
+++ b/scripts/run-minio.sh
@@ -27,6 +27,9 @@
 # Starts a minio server and exports credentials to the environment
 # ('source' this script instead of executing).
 
+# Define MINIO_VERSION to default if not set
+MINIO_VERSION=${MINIO_VERSION:="RELEASE.2024-02-09T21-25-16Z"}
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 if [[ "$BASH_SOURCE" = $0 ]]; then
@@ -50,7 +53,7 @@ run_docker_minio() {
   docker run -v /tmp/minio-data:/tmp/minio-data \
        -e MINIO_ROOT_USER=minio -e MINIO_ROOT_PASSWORD=miniosecretkey \
        -d -p 9999:9000 \
-       minio/minio server -S /tmp/minio-data/test_certs \
+       minio/minio:${MINIO_VERSION} server -S /tmp/minio-data/test_certs \
          /tmp/minio-data || die "could not run docker minio"
 }
 


### PR DESCRIPTION
The [new MinIO behavior](https://github.com/minio/minio/pull/19034) was accounted for in dev/2.20 and newer. Instead of backporting the new S3 behavior we are pinning MinIO.

The mentioned update took place in https://github.com/TileDB-Inc/TileDB/pull/4725


---
TYPE: NO_HISTORY
DESC: Change CI to use a pinned version of MinIO before breaking behavior on deletes was introduced.
