### PR TITLE
[Backport release-2.18] Free some disk space before downloading the backwards compatibility test arrays. (#4700)

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -74,6 +74,16 @@ jobs:
       - name: Update tiledb_unit permissions
         run: chmod +x $GITHUB_WORKSPACE/build/tiledb/test/tiledb_unit
 
+      - name: Free disk space
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: 'Test backward compatibility'
         id: test
         env:


### PR DESCRIPTION
Free some disk space before downloading the backwards compatibility test arrays.

Fixes #4900

---
TYPE: NO_HISTORY
