### PR TITLE
[release-2.18] Update backwards compatibility arrays for newer versions

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -59,7 +59,7 @@ jobs:
           - ubuntu-20.04
         # Note: v2_1_0 arrays were never created so its currently skipped
         # Note: This matrix is used to set the value of TILEDB_COMPATIBILITY_VERSION
-        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1", "v2_10_0", "v2_11_0", "v2_12_0", "v2_13_0", "v2_14_0", "v2_15_0", "v2_16_0"]
+        tiledb_version: ["v1_4_0", "v1_5_0", "v1_6_0", "v1_7_0", "v2_0_0", "v2_2_0", "v2_2_3", "v2_3_0", "v2_4_0", "v2_5_0", "v2_6_0", "v2_7_0", "v2_8_3", "v2_9_1", "v2_10_0", "v2_11_0", "v2_12_3", "v2_13_2", "v2_14_0", "v2_15_0", "v2_16_3", "v2_17_5", "v2_18_3"]
     timeout-minutes: 30
     name: ${{ matrix.tiledb_version }}
     steps:


### PR DESCRIPTION
This updates the list of backwards compatibility arrays for the current supported lists. Namely the following were updated based on this commit being for `release-2.18` branch:

| old verison | new version |
| ----------- | ----------- |
|  `v2.12.0`  |  `v2.12.3`  |
|  `v2.13.0`  |  `v2.13.2`  |
|  `v2.16.0`  |  `v2.16.3`  |
|     N/A     |  `v2.17.5`  |
|     N/A     |  `v2.18.3`  |


---
TYPE: IMPROVEMENT
DESC: Update backwards compatibility arrays for latest versions to include additional delta filter tests
