### PR TITLE
Migrate Array APIs out of StorageManager: non_empty_domain_*_from_index.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -1133,9 +1133,10 @@ void Array::non_empty_domain_from_index(
   auto& array_domain{array_schema.domain()};
 
   // Sanity checks
-  if (idx >= array_schema.dim_num())
+  if (idx >= array_schema.dim_num()) {
     throw ArrayException(
         "Cannot get non-empty domain; Invalid dimension index");
+  }
   if (array_domain.dimension_ptr(idx)->var_size()) {
     throw ArrayException(
         "Cannot get non-empty domain; Dimension '" +
@@ -1143,10 +1144,10 @@ void Array::non_empty_domain_from_index(
   }
 
   NDRange dom;
-  throw_if_not_ok(
-      storage_manager_->array_get_non_empty_domain(this, &dom, is_empty));
-  if (*is_empty)
+  non_empty_domain(&dom, is_empty);
+  if (*is_empty) {
     return;
+  }
 
   std::memcpy(domain, dom[idx].data(), dom[idx].size());
 }
@@ -1158,9 +1159,10 @@ void Array::non_empty_domain_var_size_from_index(
   auto& array_domain{array_schema.domain()};
 
   // Sanity checks
-  if (idx >= array_schema.dim_num())
+  if (idx >= array_schema.dim_num()) {
     throw ArrayException(
         "Cannot get non-empty domain; Invalid dimension index");
+  }
   if (!array_domain.dimension_ptr(idx)->var_size()) {
     throw ArrayException(
         "Cannot get non-empty domain; Dimension '" +
@@ -1168,8 +1170,7 @@ void Array::non_empty_domain_var_size_from_index(
   }
 
   NDRange dom;
-  throw_if_not_ok(
-      storage_manager_->array_get_non_empty_domain(this, &dom, is_empty));
+  non_empty_domain(&dom, is_empty);
   if (*is_empty) {
     *start_size = 0;
     *end_size = 0;
@@ -1187,9 +1188,10 @@ void Array::non_empty_domain_var_from_index(
   auto& array_domain{array_schema.domain()};
 
   // Sanity checks
-  if (idx >= array_schema.dim_num())
+  if (idx >= array_schema.dim_num()) {
     throw ArrayException(
         "Cannot get non-empty domain; Invalid dimension index");
+  }
   if (!array_domain.dimension_ptr(idx)->var_size()) {
     throw ArrayException(
         "Cannot get non-empty domain; Dimension '" +
@@ -1197,10 +1199,10 @@ void Array::non_empty_domain_var_from_index(
   }
 
   NDRange dom;
-  throw_if_not_ok(
-      storage_manager_->array_get_non_empty_domain(this, &dom, is_empty));
-  if (*is_empty)
+  non_empty_domain(&dom, is_empty);
+  if (*is_empty) {
     return;
+  }
 
   auto start_str = dom[idx].start_str();
   std::memcpy(start, start_str.data(), start_str.size());

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -779,6 +779,42 @@ class Array {
   void non_empty_domain(void* domain, bool* is_empty);
 
   /**
+   * Returns the non-empty domain of the opened array on the given dimension.
+   * This is the union of the non-empty domains of the array fragments.
+   *
+   * @param idx The dimension index.
+   * @param domain The domain to be retrieved.
+   * @param is_empty `true` if the non-empty domain (and array) is empty.
+   */
+  void non_empty_domain_from_index(unsigned idx, void* domain, bool* is_empty);
+
+  /**
+   * Returns the non-empty domain size of the opened array on the given
+   * dimension. This is the union of the non-empty domains of the array
+   * fragments. Applicable only to var-sized dimensions.
+   *
+   * @param idx The dimension index.
+   * @param start_size The size in bytes of the range start.
+   * @param end_size The size in bytes of the range end.
+   * @param is_empty `true` if the non-empty domain (and array) is empty.
+   */
+  void non_empty_domain_var_size_from_index(
+      unsigned idx, uint64_t* start_size, uint64_t* end_size, bool* is_empty);
+
+  /**
+   * Returns the non-empty domain of the opened array on the given dimension.
+   * This is the union of the non-empty domains of the array fragments.
+   * Applicable only to var-sized dimensions.
+   *
+   * @param idx The dimension index.
+   * @param start The domain range start to set.
+   * @param end The domain range end to set.
+   * @param is_empty `true` if the non-empty domain (and array) is empty.
+   */
+  void non_empty_domain_var_from_index(
+      unsigned idx, void* start, void* end, bool* is_empty);
+
+  /**
    * Retrieves the array metadata object that is already loaded. If it's not yet
    * loaded it will be empty.
    */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2811,10 +2811,7 @@ int32_t tiledb_array_get_non_empty_domain_from_index(
     return TILEDB_ERR;
 
   bool is_empty_b;
-
-  throw_if_not_ok(ctx->storage_manager()->array_get_non_empty_domain_from_index(
-      array->array_.get(), idx, domain, &is_empty_b));
-
+  array->array_->non_empty_domain_from_index(idx, domain, &is_empty_b);
   *is_empty = (int32_t)is_empty_b;
 
   return TILEDB_OK;
@@ -2850,11 +2847,8 @@ int32_t tiledb_array_get_non_empty_domain_var_size_from_index(
     return TILEDB_ERR;
 
   bool is_empty_b = true;
-
-  throw_if_not_ok(
-      ctx->storage_manager()->array_get_non_empty_domain_var_size_from_index(
-          array->array_.get(), idx, start_size, end_size, &is_empty_b));
-
+  array->array_->non_empty_domain_var_size_from_index(
+      idx, start_size, end_size, &is_empty_b);
   *is_empty = (int32_t)is_empty_b;
 
   return TILEDB_OK;
@@ -2892,11 +2886,7 @@ int32_t tiledb_array_get_non_empty_domain_var_from_index(
     return TILEDB_ERR;
 
   bool is_empty_b = true;
-
-  throw_if_not_ok(
-      ctx->storage_manager()->array_get_non_empty_domain_var_from_index(
-          array->array_.get(), idx, start, end, &is_empty_b));
-
+  array->array_->non_empty_domain_var_from_index(idx, start, end, &is_empty_b);
   *is_empty = (int32_t)is_empty_b;
 
   return TILEDB_OK;

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2807,8 +2807,10 @@ int32_t tiledb_array_get_non_empty_domain_from_index(
     uint32_t idx,
     void* domain,
     int32_t* is_empty) {
-  if (sanity_check(ctx, array) == TILEDB_ERR)
+  if (sanity_check(ctx, array) == TILEDB_ERR) {
     return TILEDB_ERR;
+  }
+  ensure_output_pointer_is_valid(is_empty);
 
   bool is_empty_b;
   array->array_->non_empty_domain_from_index(idx, domain, &is_empty_b);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2845,8 +2845,12 @@ int32_t tiledb_array_get_non_empty_domain_var_size_from_index(
     uint64_t* start_size,
     uint64_t* end_size,
     int32_t* is_empty) {
-  if (sanity_check(ctx, array) == TILEDB_ERR)
+  if (sanity_check(ctx, array) == TILEDB_ERR) {
     return TILEDB_ERR;
+  }
+  ensure_output_pointer_is_valid(start_size);
+  ensure_output_pointer_is_valid(end_size);
+  ensure_output_pointer_is_valid(is_empty);
 
   bool is_empty_b = true;
   array->array_->non_empty_domain_var_size_from_index(
@@ -2884,8 +2888,12 @@ int32_t tiledb_array_get_non_empty_domain_var_from_index(
     void* start,
     void* end,
     int32_t* is_empty) {
-  if (sanity_check(ctx, array) == TILEDB_ERR)
+  if (sanity_check(ctx, array) == TILEDB_ERR) {
     return TILEDB_ERR;
+  }
+  ensure_output_pointer_is_valid(start);
+  ensure_output_pointer_is_valid(end);
+  ensure_output_pointer_is_valid(is_empty);
 
   bool is_empty_b = true;
   array->array_->non_empty_domain_var_from_index(idx, start, end, &is_empty_b);

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -247,20 +247,6 @@ class StorageManagerCanonical {
    * This is the union of the non-empty domains of the array fragments.
    *
    * @param array An open array object (must be already open).
-   * @param idx The dimension index.
-   * @param domain The domain to be retrieved.
-   * @param is_empty `ture` if the non-empty domain is empty (the array
-   *     is empty).
-   * @return Status
-   */
-  Status array_get_non_empty_domain_from_index(
-      Array* array, unsigned idx, void* domain, bool* is_empty);
-
-  /**
-   * Retrieves the non-empty domain from an array on the given dimension.
-   * This is the union of the non-empty domains of the array fragments.
-   *
-   * @param array An open array object (must be already open).
    * @param name The dimension name.
    * @param domain The domain to be retrieved.
    * @param is_empty `ture` if the non-empty domain is empty (the array
@@ -269,26 +255,6 @@ class StorageManagerCanonical {
    */
   Status array_get_non_empty_domain_from_name(
       Array* array, const char* name, void* domain, bool* is_empty);
-
-  /**
-   * Retrieves the non-empty domain size from an array on the given dimension.
-   * This is the union of the non-empty domains of the array fragments.
-   * Applicable only to var-sized dimensions.
-   *
-   * @param array An open array object (must be already open).
-   * @param idx The dimension index.
-   * @param start_size The size in bytes of the range start.
-   * @param end_size The size in bytes of the range end.
-   * @param is_empty `ture` if the non-empty domain is empty (the array
-   *     is empty).
-   * @return Status
-   */
-  Status array_get_non_empty_domain_var_size_from_index(
-      Array* array,
-      unsigned idx,
-      uint64_t* start_size,
-      uint64_t* end_size,
-      bool* is_empty);
 
   /**
    * Retrieves the non-empty domain size from an array on the given dimension.
@@ -309,22 +275,6 @@ class StorageManagerCanonical {
       uint64_t* start_size,
       uint64_t* end_size,
       bool* is_empty);
-
-  /**
-   * Retrieves the non-empty domain from an array on the given dimension.
-   * This is the union of the non-empty domains of the array fragments.
-   * Applicable only to var-sized dimensions.
-   *
-   * @param array An open array object (must be already open).
-   * @param idx The dimension index.
-   * @param start The domain range start to set.
-   * @param end The domain range end to set.
-   * @param is_empty `ture` if the non-empty domain is empty (the array
-   *     is empty).
-   * @return Status
-   */
-  Status array_get_non_empty_domain_var_from_index(
-      Array* array, unsigned idx, void* start, void* end, bool* is_empty);
 
   /**
    * Retrieves the non-empty domain from an array on the given dimension.


### PR DESCRIPTION
Migrate `Array` APIs out of `StorageManager`: `non_empty_domain_*_from_index`.

This includes 3 separate APIs:
* `non_empty_domain_from_index`
* `non_empty_domain_var_size_from_index`
* `non_empty_domain_var_from_index`

---
[sc-44989]
[sc-44991]
[sc-44993]

---
TYPE: NO_HISTORY
DESC: Migrate Array APIs out of StorageManager: non_empty_domain_*_from_index.
