### PR TITLE
Fix C query condition examples

### DIFF
--- a/examples/c_api/query_condition_dense.c
+++ b/examples/c_api/query_condition_dense.c
@@ -308,7 +308,6 @@ int main() {
   const char* eve = "eve";
   tiledb_query_condition_init(ctx, qc1, "b", eve, strlen(eve), TILEDB_LT);
   read_array_with_qc(ctx, qc1);
-  tiledb_query_condition_free(&qc1);
   printf("\n");
 
   // Execute a read query with query condition `c >= 1`.
@@ -338,7 +337,6 @@ int main() {
   read_array_with_qc(ctx, qc5);
   tiledb_query_condition_free(&qc3);
   tiledb_query_condition_free(&qc4);
-  tiledb_query_condition_free(&qc5);
   printf("\n");
 
   // Execute a read query with query condition `3.0f <= d AND d <= 4.0f AND a !=
@@ -356,6 +354,8 @@ int main() {
   tiledb_query_condition_alloc(ctx, &qc8);
   tiledb_query_condition_combine(ctx, qc7, qc1, TILEDB_AND, &qc8);
   read_array_with_qc(ctx, qc8);
+  tiledb_query_condition_free(&qc1);
+  tiledb_query_condition_free(&qc5);
   tiledb_query_condition_free(&qc6);
   tiledb_query_condition_free(&qc7);
   tiledb_query_condition_free(&qc8);

--- a/examples/c_api/query_condition_sparse.c
+++ b/examples/c_api/query_condition_sparse.c
@@ -298,7 +298,6 @@ int main() {
   const char* eve = "eve";
   tiledb_query_condition_init(ctx, qc1, "b", eve, strlen(eve), TILEDB_LT);
   read_array_with_qc(ctx, qc1);
-  tiledb_query_condition_free(&qc1);
   printf("\n");
 
   // Execute a read query with query condition `c >= 1`.
@@ -328,7 +327,6 @@ int main() {
   read_array_with_qc(ctx, qc5);
   tiledb_query_condition_free(&qc3);
   tiledb_query_condition_free(&qc4);
-  tiledb_query_condition_free(&qc5);
   printf("\n");
 
   // Execute a read query with query condition `3.0f <= d AND d <= 4.0f AND a !=
@@ -346,6 +344,8 @@ int main() {
   tiledb_query_condition_alloc(ctx, &qc8);
   tiledb_query_condition_combine(ctx, qc7, qc1, TILEDB_AND, &qc8);
   read_array_with_qc(ctx, qc8);
+  tiledb_query_condition_free(&qc1);
+  tiledb_query_condition_free(&qc5);
   tiledb_query_condition_free(&qc6);
   tiledb_query_condition_free(&qc7);
   tiledb_query_condition_free(&qc8);


### PR DESCRIPTION
The examples were attempting to use query conditions that were already destroyed in the last example which led to erroneous output.

Shoutout to @rroelke who was the one that noticed the disparity.

[sc-46017]

---
TYPE: BUG
DESC: Fix C query condition examples