### PR TITLE
Update nightly workflow to account for `macos-latest` meaning macOS in Apple Silicon.

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -16,7 +16,7 @@ jobs:
           - os: macos-latest
           - os: macos-latest # ASAN build
             sanitizer: "address"
-            base_triplet: "x64-osx"
+            base_triplet: "arm64-osx"
           - os: macos-latest
             experimental: ON
           - os: windows-latest


### PR DESCRIPTION
[SC-46173](https://app.shortcut.com/tiledb-inc/story/46173)

Since yesterday, the `macos-latest` images mean macOS in Apple SIlicon. This PR updates the nightly workflow to account for that.

Should fix macOS failures with ASAN.

---
TYPE: NO_HISTORY