### PR TITLE
Make closing a group that is not open a no-op

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -217,7 +217,7 @@ Status Group::open(QueryType query_type) {
 Status Group::close() {
   // Check if group is open
   if (!is_open_)
-    return Status_GroupError("Cannot close group; Group not open.");
+    return Status::Ok();
 
   if (remote_) {
     // Update group metadata for write queries if metadata was written by the


### PR DESCRIPTION
Issue reported from Cloud team: When attempting to close a TileDB group that is not open an error is raised polluting the server log. On the other hand, attempting to close a TileDB Array does not result to any error log (as per https://github.com/TileDB-Inc/TileDB/pull/2889). 

This PR unifies the behavior between closing and Array and a Group. Another solution would have been to check if the group is open on the server side but this would mean special casing for Groups, when I don't see the benefit of it.

[sc-46186]

---
TYPE: IMPROVEMENT
DESC: Make closing a group that is not open a no-op
