### PR TITLE
Run standalone unit tests on Windows.

### DIFF
--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: 'Run standalone unit tests'
         run: |
-          ctest --test-dir build/tiledb -R '^unit_' -R 'test_assert' -U --no-tests=error
+          ctest --test-dir build/tiledb -R '(^unit_|test_assert)' --no-tests=error
           ctest --test-dir build/tiledb -R 'test_ci_asserts'
 
       - name: "Print log files (failed build only)"

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -9,7 +9,6 @@ env:
   TILEDB_AZURE: OFF
   TILEDB_GCS: OFF
   TILEDB_SERIALIZATION: ON
-  TILEDB_TOOLS: ON
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 jobs:
@@ -17,15 +16,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     name: Build - ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
 
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
-        if: ${{ startsWith(matrix.os, 'macos-') == true }}
+        if: ${{ startsWith(matrix.os, 'macos-') }}
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v4
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
@@ -45,28 +50,27 @@ jobs:
           echo "uname -v: " $(uname -v)
           printenv
         shell: bash
+        if: ${{ !startsWith(matrix.os, 'windows-') }}
 
-      - name: 'Build and run standalone unit tests'
-        id: test
+      - name: 'Build standalone unit tests'
         run: |
-
-          mkdir -p $GITHUB_WORKSPACE/build
-          pushd $GITHUB_WORKSPACE/build
-
-          cmake .. \
+          cmake -S . \
+            -B build \
+            -G Ninja \
             -DTILEDB_AZURE=${TILEDB_AZURE}\
             -DTILEDB_GCS=${TILEDB_GCS} \
             -DTILEDB_S3=${TILEDB_S3} \
             -DTILEDB_SERIALIZATION=${TILEDB_SERIALIZATION} \
             -DTILEDB_ASSERTIONS=${TILEDB_ASSERTIONS}
-          make -j4
+          cmake --build build -j4
           # Build all unit tests
-          make -C tiledb tests -j4
-          # Run all unit tests
-          make -C tiledb test ARGS="-R '^unit_'" -R "test_assert"
-          make -C tiledb test ARGS="-R 'test_ci_asserts'"
+          cmake --build build/tiledb --target tests -j4
 
-          popd
+      - name: 'Run standalone unit tests'
+        run: |
+          ctest -C build/tiledb -R '^unit_' -R 'test_assert'
+          ctest -C build/tiledb -R 'test_ci_asserts'
+
       - name: "Print log files (failed build only)"
         run: |
           source $GITHUB_WORKSPACE/scripts/ci/print_logs.sh

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -32,6 +32,16 @@ jobs:
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@v4
 
+      - name: Setup MSVC toolset
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        with:
+          arch: x64
+          # By default Visual Studio 2022 chooses the earliest installed toolset
+          # version for the main build and vcpkg chooses the latest. Force it to
+          # use the latest (14.39 currently).
+          toolset: '14.39'
+
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache
       - uses: actions/github-script@v6

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -3,12 +3,6 @@ on:
   workflow_call:
 
 env:
-  BACKWARDS_COMPATIBILITY_ARRAYS: OFF
-  TILEDB_ASSERTIONS: ON
-  TILEDB_S3: OFF
-  TILEDB_AZURE: OFF
-  TILEDB_GCS: OFF
-  TILEDB_SERIALIZATION: ON
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
 jobs:
@@ -67,11 +61,8 @@ jobs:
           cmake -S . \
             -B build \
             -G Ninja \
-            -DTILEDB_AZURE=${TILEDB_AZURE}\
-            -DTILEDB_GCS=${TILEDB_GCS} \
-            -DTILEDB_S3=${TILEDB_S3} \
-            -DTILEDB_SERIALIZATION=${TILEDB_SERIALIZATION} \
-            -DTILEDB_ASSERTIONS=${TILEDB_ASSERTIONS}
+            -DTILEDB_SERIALIZATION=ON \
+            -DTILEDB_ASSERTIONS=ON
           cmake --build build -j4
           # Build all unit tests
           cmake --build build/tiledb --target tests -j4

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -61,6 +61,7 @@ jobs:
           cmake -S . \
             -B build \
             -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
             -DTILEDB_SERIALIZATION=ON \
             -DTILEDB_ASSERTIONS=ON
           cmake --build build -j4

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -13,6 +13,7 @@ jobs:
         os: [macos-latest, ubuntu-latest, windows-latest]
       fail-fast: false
     name: Build - ${{ matrix.os }}
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -70,8 +70,8 @@ jobs:
 
       - name: 'Run standalone unit tests'
         run: |
-          ctest -C build/tiledb -R '^unit_' -R 'test_assert'
-          ctest -C build/tiledb -R 'test_ci_asserts'
+          ctest --test-dir build/tiledb -R '^unit_' -R 'test_assert' -U --no-tests=error
+          ctest --test-dir build/tiledb -R 'test_ci_asserts'
 
       - name: "Print log files (failed build only)"
         run: |

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -247,9 +247,14 @@ TEST_CASE("C API: tiledb_vfs_is_dir argument validation", "[capi][vfs]") {
     CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null uri") {
-    // Null URI is treated as empty.
+    if constexpr (tiledb::platform::is_os_windows) {
+      // Windows handles empty (which gets converted from null) paths
+      // differently. Reconsider when the logic gets unified across paltforms
+      // (SC-28225).
+      return;
+    }
     auto rc{tiledb_vfs_is_dir(x.ctx, x.vfs, nullptr, &is_dir)};
-    CHECK(tiledb_status(rc) == TILEDB_OK);
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null flag") {
     auto rc{tiledb_vfs_is_dir(x.ctx, x.vfs, TEST_URI, nullptr)};
@@ -418,9 +423,14 @@ TEST_CASE("C API: tiledb_vfs_is_file argument validation", "[capi][vfs]") {
     CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null uri") {
-    // Null URI is treated as empty.
+    if constexpr (tiledb::platform::is_os_windows) {
+      // Windows handles empty (which gets converted from null) paths
+      // differently. Reconsider when the logic gets unified across paltforms
+      // (SC-28225).
+      return;
+    }
     auto rc{tiledb_vfs_is_file(x.ctx, x.vfs, nullptr, &is_file)};
-    CHECK(tiledb_status(rc) == TILEDB_OK);
+    CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null flag") {
     auto rc{tiledb_vfs_is_file(x.ctx, x.vfs, TEST_URI, nullptr)};

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -32,6 +32,7 @@
 #include <test/support/tdb_catch.h>
 #include "../vfs_api_internal.h"
 #include "tiledb/api/c_api_test_support/testsupport_capi_vfs.h"
+#include "tiledb/platform/platform.h"
 
 using tiledb::api::test_support::ordinary_vfs;
 using tiledb::api::test_support::ordinary_vfs_fh;
@@ -246,8 +247,9 @@ TEST_CASE("C API: tiledb_vfs_is_dir argument validation", "[capi][vfs]") {
     CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null uri") {
+    // Null URI is treated as empty.
     auto rc{tiledb_vfs_is_dir(x.ctx, x.vfs, nullptr, &is_dir)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
+    CHECK(tiledb_status(rc) == TILEDB_OK);
   }
   SECTION("null flag") {
     auto rc{tiledb_vfs_is_dir(x.ctx, x.vfs, TEST_URI, nullptr)};
@@ -331,6 +333,10 @@ TEST_CASE("C API: tiledb_vfs_move_dir argument validation", "[capi][vfs]") {
 }
 
 TEST_CASE("C API: tiledb_vfs_copy_dir argument validation", "[capi][vfs]") {
+  if constexpr (tiledb::platform::is_os_windows) {
+    // This API is not yet supported on Windows.
+    return;
+  }
   ordinary_vfs x;
   SECTION("success") {
     auto rc{tiledb_vfs_copy_dir(x.ctx, x.vfs, TEST_URI, "new_dir")};
@@ -412,8 +418,9 @@ TEST_CASE("C API: tiledb_vfs_is_file argument validation", "[capi][vfs]") {
     CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null uri") {
+    // Null URI is treated as empty.
     auto rc{tiledb_vfs_is_file(x.ctx, x.vfs, nullptr, &is_file)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
+    CHECK(tiledb_status(rc) == TILEDB_OK);
   }
   SECTION("null flag") {
     auto rc{tiledb_vfs_is_file(x.ctx, x.vfs, TEST_URI, nullptr)};
@@ -477,6 +484,10 @@ TEST_CASE("C API: tiledb_vfs_move_file argument validation", "[capi][vfs]") {
 }
 
 TEST_CASE("C API: tiledb_vfs_copy_file argument validation", "[capi][vfs]") {
+  if constexpr (tiledb::platform::is_os_windows) {
+    // This API is not yet supported on Windows.
+    return;
+  }
   ordinary_vfs x;
   SECTION("success") {
     auto rc{tiledb_vfs_copy_file(x.ctx, x.vfs, TEST_URI, "new_uri")};

--- a/tiledb/api/c_api_test_support/testsupport_capi_vfs.h
+++ b/tiledb/api/c_api_test_support/testsupport_capi_vfs.h
@@ -65,7 +65,8 @@ struct ordinary_vfs_fh {
   tiledb_ctx_handle_t* ctx{vfs.ctx};  // allow access to ordinary_vfs's ctx
   tiledb_vfs_fh_handle_t* vfs_fh{nullptr};
   ordinary_vfs_fh() {
-    auto rc = tiledb_vfs_open(vfs.ctx, vfs.vfs, " ", TILEDB_VFS_WRITE, &vfs_fh);
+    auto rc = tiledb_vfs_open(
+        vfs.ctx, vfs.vfs, "test.txt", TILEDB_VFS_WRITE, &vfs_fh);
     if (rc != TILEDB_OK) {
       throw std::runtime_error("error creating test vfs file handle");
     }

--- a/tiledb/common/test/unit_alt_var_length_view.cc
+++ b/tiledb/common/test/unit_alt_var_length_view.cc
@@ -475,14 +475,20 @@ TEST_CASE("alt_var_length_view: Viewness", "[alt_var_length_view]") {
   }
 
   REQUIRE(v.begin() == v.begin());
+  REQUIRE(v.end() == v.end());
+
+  // MSVC in debug iterators mode fails with an assert if iterators of different
+  // collections are compared.
+  // https://learn.microsoft.com/en-us/cpp/standard-library/debug-iterator-support?view=msvc-170#incompatible-iterators
+#if !defined(_ITERATOR_DEBUG_LEVEL) || _ITERATOR_DEBUG_LEVEL != 2
   CHECK(v.begin() != w.begin());
   CHECK(v.begin() != u.begin());
   CHECK(w.begin() != u.begin());
 
-  REQUIRE(v.end() == v.end());
   CHECK(v.end() != w.end());
   CHECK(v.end() != u.end());
   CHECK(w.end() != u.end());
+#endif
 
   for (size_t i = 0; i < 3; ++i) {
     CHECK(v.size() == x.size());

--- a/tiledb/common/test/unit_var_length_view.cc
+++ b/tiledb/common/test/unit_var_length_view.cc
@@ -306,12 +306,33 @@ TEST_CASE("var_length_view: Viewness", "[var_length_view]") {
   std::vector<double> s = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
   std::vector<size_t> o = {0, 3, 6, 10};
   std::vector<size_t> m = {0, 3, 6, 10};
+  std::vector<double> q = {
+      21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
+  std::vector<size_t> p = {0, 2, 7, 10};
   std::vector<size_t> n = {0, 3, 6, 10};
 
   auto v = var_length_view(r, o);
+  auto w = var_length_view(q, p);
+  auto u = var_length_view(q, n);
   auto x = var_length_view(r, m);
   auto y = var_length_view(s, m);
   auto z = var_length_view(s, n);
+
+  REQUIRE(v.begin() == v.begin());
+  REQUIRE(v.end() == v.end());
+
+  // MSVC in debug iterators mode fails with an assert if iterators of different
+  // collections are compared.
+  // https://learn.microsoft.com/en-us/cpp/standard-library/debug-iterator-support?view=msvc-170#incompatible-iterators
+#if !defined(_ITERATOR_DEBUG_LEVEL) || _ITERATOR_DEBUG_LEVEL != 2
+  CHECK(v.begin() != w.begin());
+  CHECK(v.begin() != u.begin());
+  CHECK(w.begin() != u.begin());
+
+  CHECK(v.end() != w.end());
+  CHECK(v.end() != u.end());
+  CHECK(w.end() != u.end());
+#endif
 
   for (size_t i = 0; i < 3; ++i) {
     CHECK(v.size() == x.size());

--- a/tiledb/common/test/unit_var_length_view.cc
+++ b/tiledb/common/test/unit_var_length_view.cc
@@ -306,27 +306,12 @@ TEST_CASE("var_length_view: Viewness", "[var_length_view]") {
   std::vector<double> s = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
   std::vector<size_t> o = {0, 3, 6, 10};
   std::vector<size_t> m = {0, 3, 6, 10};
-  std::vector<double> q = {
-      21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
-  std::vector<size_t> p = {0, 2, 7, 10};
   std::vector<size_t> n = {0, 3, 6, 10};
 
   auto v = var_length_view(r, o);
-  auto w = var_length_view(q, p);
-  auto u = var_length_view(q, n);
   auto x = var_length_view(r, m);
   auto y = var_length_view(s, m);
   auto z = var_length_view(s, n);
-
-  REQUIRE(v.begin() == v.begin());
-  CHECK(v.begin() != w.begin());
-  CHECK(v.begin() != u.begin());
-  CHECK(w.begin() != u.begin());
-
-  REQUIRE(v.end() == v.end());
-  CHECK(v.end() != w.end());
-  CHECK(v.end() != u.end());
-  CHECK(w.end() != u.end());
 
   for (size_t i = 0; i < 3; ++i) {
     CHECK(v.size() == x.size());

--- a/tiledb/common/test/unit_zip_view.cc
+++ b/tiledb/common/test/unit_zip_view.cc
@@ -284,8 +284,13 @@ TEST_CASE("zip_view: basic iterator properties", "[zip_view]") {
   CHECK(it == z.begin() + 1);
 
   CHECK(it[0] == *it);
+  // MSVC in debug iterators mode fails with an assert if out of range iterators
+  // are dereferenced.
+  // https://learn.microsoft.com/en-us/cpp/standard-library/debug-iterator-support
+#if !defined(_ITERATOR_DEBUG_LEVEL) || _ITERATOR_DEBUG_LEVEL != 2
   CHECK(it[1] == *(it + 1));
   CHECK(it[2] == *(it + 2));
+#endif
   CHECK(it[0] == std::tuple{2, 5, 11});
 }
 

--- a/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
+++ b/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
@@ -74,7 +74,8 @@ TEST_CASE("VFS Read Log Modes", "[vfs][read-logging-modes]") {
     char buffer[123];
     for (auto& uri : uris_to_read) {
       // None of these files exist, so we expect every read to fail.
-      REQUIRE_THROWS(res.vfs().read(URI(uri), 123, buffer, 456));
+      REQUIRE_THROWS(
+          throw_if_not_ok(res.vfs().read(URI(uri), 123, buffer, 456)));
     }
   }
 }

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -111,7 +111,7 @@ URI URI::add_trailing_slash() const {
 }
 
 URI URI::remove_trailing_slash() const {
-  if (uri_.back() == '/') {
+  if (!uri_.empty() && uri_.back() == '/') {
     std::string uri_str = uri_;
     uri_str.pop_back();
     return URI(uri_str);

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -326,7 +326,7 @@ Status Win::init(const Config& config) {
 }
 
 bool Win::is_dir(const std::string& path) const {
-  return PathIsDirectory(path.c_str());
+  return PathFileExists(path.c_str()) && PathIsDirectory(path.c_str());
 }
 
 bool Win::is_file(const std::string& path) const {

--- a/tiledb/sm/fragment/fragment_identifier.cc
+++ b/tiledb/sm/fragment/fragment_identifier.cc
@@ -110,7 +110,7 @@ FragmentID::FragmentID(const URI& uri)
 }
 
 FragmentID::FragmentID(const std::string_view& path)
-    : FragmentID(URI(path.data())) {
+    : FragmentID(URI(path)) {
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/readers/aggregators/test/unit_aggregators.cc
+++ b/tiledb/sm/query/readers/aggregators/test/unit_aggregators.cc
@@ -481,17 +481,17 @@ void basic_aggregation_test(std::vector<double> expected_results) {
         10,
         10,
         &fixed_data[0],
-        sizeof(T),
+        sizeof(fixed_data[0]),
         &fixed_data[0],
-        sizeof(T),
+        sizeof(fixed_data[0]),
         zero.data());
     auto tile_metadata = TileMetadata(
         10,
         5,
         &fixed_data[0],
-        sizeof(T),
+        sizeof(fixed_data[0]),
         &fixed_data[0],
-        sizeof(T),
+        sizeof(fixed_data[0]),
         full_tile_sum.data());
     if (aggregator.has_value()) {
       // Regular attribute.


### PR DESCRIPTION
[SC-46305](https://app.shortcut.com/tiledb-inc/story/46305/add-standalone-windows-tests-to-ci)

This PR cleans up the `unit-test-runs.yml` workflow enables it to run on Windows (and cleans it up), and fixes Windows failures in the test programs.

---
TYPE: NO_HISTORY