### PR TITLE
Add API to get the default VFS of a context.

### DIFF
--- a/examples/c_api/config.c
+++ b/examples/c_api/config.c
@@ -46,7 +46,7 @@ void set_get_config_ctx_vfs() {
 
   // Set/Get config to/from bfs
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, config, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
   tiledb_vfs_get_config(ctx, vfs, &config_vfs);
 
   // Clean up

--- a/examples/c_api/groups.c
+++ b/examples/c_api/groups.c
@@ -103,7 +103,7 @@ void create_arrays_groups() {
 
   // Create dense_arrays folder
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, NULL, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
   tiledb_vfs_create_dir(ctx, vfs, "my_group/dense_arrays");
   tiledb_vfs_free(&vfs);
 

--- a/examples/c_api/query_condition_dense.c
+++ b/examples/c_api/query_condition_dense.c
@@ -275,7 +275,7 @@ int main() {
   tiledb_ctx_alloc(NULL, &ctx);
 
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, NULL, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
 
   int32_t is_dir = 0;
   tiledb_vfs_is_dir(ctx, vfs, array_name, &is_dir);

--- a/examples/c_api/query_condition_sparse.c
+++ b/examples/c_api/query_condition_sparse.c
@@ -265,7 +265,7 @@ int main() {
   tiledb_ctx_alloc(NULL, &ctx);
 
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, NULL, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
 
   int32_t is_dir = 0;
   tiledb_vfs_is_dir(ctx, vfs, array_name, &is_dir);

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -47,7 +47,7 @@ void remove_file(const std::string& filename) {
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  REQUIRE(tiledb_vfs_alloc(ctx, nullptr, &vfs) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx, &vfs) == TILEDB_OK);
   CHECK(tiledb_vfs_remove_file(ctx, vfs, filename.c_str()) == TILEDB_OK);
   tiledb_vfs_free(&vfs);
   tiledb_ctx_free(&ctx);

--- a/test/src/unit-capi-fill_values.cc
+++ b/test/src/unit-capi-fill_values.cc
@@ -52,7 +52,7 @@ void check_dump(
 
   // Clean up
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
   CHECK(tiledb_vfs_remove_file(ctx, vfs, "gold_fout.txt") == TILEDB_OK);
   CHECK(tiledb_vfs_remove_file(ctx, vfs, "fout.txt") == TILEDB_OK);
   tiledb_vfs_free(&vfs);

--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -48,7 +48,7 @@ TEST_CASE(
   tiledb_ctx_t* ctx = nullptr;
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create fragment info object
@@ -189,7 +189,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   bool encrypt = false;
@@ -572,7 +572,7 @@ TEST_CASE("C API: Test MBR fragment info", "[capi][fragment_info][mbr]") {
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Key
@@ -771,7 +771,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   remove_dir(array_name, ctx, vfs);
@@ -956,7 +956,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array
@@ -1168,7 +1168,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array
@@ -1364,7 +1364,7 @@ TEST_CASE("C API: Test fragment info, dump", "[capi][fragment_info][dump]") {
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array
@@ -1567,7 +1567,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array
@@ -1735,7 +1735,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array
@@ -1843,7 +1843,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array
@@ -1958,7 +1958,7 @@ TEST_CASE(
   int rc = tiledb_ctx_alloc(nullptr, &ctx);
   REQUIRE(rc == TILEDB_OK);
   tiledb_vfs_t* vfs = nullptr;
-  rc = tiledb_vfs_alloc(ctx, nullptr, &vfs);
+  rc = tiledb_vfs_get_default(ctx, &vfs);
   REQUIRE(rc == TILEDB_OK);
 
   // Create array

--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -207,7 +207,7 @@ NullableArrayFx::NullableArrayFx() {
   throw_if_setup_failed(ctx_ != nullptr);
 
   // Create the VFS.
-  throw_if_setup_failed(tiledb_vfs_alloc(ctx_, config, &vfs_));
+  throw_if_setup_failed(tiledb_vfs_get_default(ctx_, &vfs_));
   throw_if_setup_failed(vfs_ != nullptr);
   tiledb_config_free(&config);
 }

--- a/test/src/unit-capi-partial-attribute-write.cc
+++ b/test/src/unit-capi-partial-attribute-write.cc
@@ -78,7 +78,7 @@ PartialAttrWriteFx::PartialAttrWriteFx() {
   tiledb_config_set(
       config, "sm.allow_separate_attribute_writes", "true", &error);
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_alloc(ctx_, nullptr, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
 }
 
 PartialAttrWriteFx::~PartialAttrWriteFx() {

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -388,7 +388,7 @@ SmokeTestFx::SmokeTestFx() {
   throw_if_setup_failed(ctx_ != nullptr);
 
   // Create the VFS.
-  throw_if_setup_failed(tiledb_vfs_alloc(ctx_, config, &vfs_));
+  throw_if_setup_failed(tiledb_vfs_get_default(ctx_, &vfs_));
   throw_if_setup_failed(vfs_ != nullptr);
   tiledb_config_free(&config);
 }

--- a/test/src/unit-cppapi-webp-filter.cc
+++ b/test/src/unit-cppapi-webp-filter.cc
@@ -477,7 +477,7 @@ TEST_CASE("C API: WEBP Filter", "[capi][filter][webp]") {
     tiledb_ctx_t* ctx;
     tiledb_ctx_alloc(nullptr, &ctx);
     tiledb_vfs_t* vfs;
-    tiledb_vfs_alloc(ctx, nullptr, &vfs);
+    tiledb_vfs_get_default(ctx, &vfs);
     int32_t is_dir = false;
     tiledb_vfs_is_dir(ctx, vfs, webp_array_name.c_str(), &is_dir);
     if (is_dir) {

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -185,7 +185,7 @@ void CDenseFx::update_config() {
 
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 }
 

--- a/test/src/unit-duplicates.cc
+++ b/test/src/unit-duplicates.cc
@@ -70,7 +70,7 @@ CDuplicatesFx::CDuplicatesFx() {
   tiledb_error_t* error = nullptr;
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 
 // Create temporary directory based on the supported filesystem

--- a/test/src/unit-result-coords.cc
+++ b/test/src/unit-result-coords.cc
@@ -69,7 +69,7 @@ CResultCoordsFx::CResultCoordsFx(uint64_t num_cells) {
   REQUIRE(error == nullptr);
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Create temporary directory based on the supported filesystem.

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -76,7 +76,7 @@ CResultTileFx::CResultTileFx()
   REQUIRE(error == nullptr);
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Create temporary directory based on the supported filesystem.

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -184,7 +184,7 @@ void CSparseGlobalOrderFx::update_config() {
 
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 }
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -200,7 +200,7 @@ void CSparseUnorderedWithDupsFx::update_config() {
 
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 }
 
@@ -571,7 +571,7 @@ CSparseUnorderedWithDupsVarDataFx::CSparseUnorderedWithDupsVarDataFx() {
   REQUIRE(error == nullptr);
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Create temporary directory based on the supported filesystem.
@@ -1845,7 +1845,7 @@ TEST_CASE_METHOD(
 
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 
   // Try to read with every possible buffer sizes. When varying
@@ -1994,7 +1994,7 @@ TEST_CASE_METHOD(
 
   REQUIRE(tiledb_ctx_alloc(config, &ctx_) == TILEDB_OK);
   REQUIRE(error == nullptr);
-  REQUIRE(tiledb_vfs_alloc(ctx_, config, &vfs_) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(ctx_, &vfs_) == TILEDB_OK);
   tiledb_config_free(&config);
 
   tiledb_array_t* array;

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -111,7 +111,7 @@ Status vfs_test_init(
   }
 
   REQUIRE(tiledb_ctx_alloc(config_tmp, ctx) == TILEDB_OK);
-  REQUIRE(tiledb_vfs_alloc(*ctx, config_tmp, vfs) == TILEDB_OK);
+  REQUIRE(tiledb_vfs_get_default(*ctx, vfs) == TILEDB_OK);
   if (config == nullptr) {
     tiledb_config_free(&config_tmp);
   }

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -50,7 +50,7 @@ TEST_CASE("C API: ls_recursive callback", "[vfs][ls-recursive]") {
   tiledb_ctx_t* ctx;
   tiledb_ctx_alloc(vfs_config.config, &ctx);
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, vfs_config.config, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
 
   LsObjects data;
   tiledb_ls_callback_t cb = [](const char* path,
@@ -98,7 +98,7 @@ TEST_CASE("C API: ls_recursive throwing callback", "[vfs][ls-recursive]") {
   tiledb_ctx_t* ctx;
   tiledb_ctx_alloc(vfs_config.config, &ctx);
   tiledb_vfs_t* vfs;
-  tiledb_vfs_alloc(ctx, vfs_config.config, &vfs);
+  tiledb_vfs_get_default(ctx, &vfs);
 
   LsObjects data;
   tiledb_ls_callback_t cb =

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -75,6 +75,14 @@ void tiledb_vfs_free(tiledb_vfs_t** vfs) {
   tiledb_vfs_t::break_handle(*vfs);
 }
 
+capi_return_t tiledb_vfs_get_default(
+    tiledb_ctx_handle_t* ctx, tiledb_vfs_handle_t** vfs) {
+  api::ensure_output_pointer_is_valid(vfs);
+  *vfs = tiledb_vfs_handle_t::make_handle(std::shared_ptr<sm::VFS>(
+      ctx->get_shared_ptr(), ctx->storage_manager()->vfs()));
+  return TILEDB_OK;
+}
+
 capi_return_t tiledb_vfs_get_config(
     tiledb_vfs_t* vfs, tiledb_config_t** config) {
   ensure_vfs_is_valid(vfs);
@@ -232,7 +240,7 @@ capi_return_t tiledb_vfs_open(
   auto vfs_mode = static_cast<tiledb::sm::VFSMode>(mode);
 
   // Throws if opening the uri is unsuccessful
-  *fh = tiledb_vfs_fh_t::make_handle(fh_uri, vfs->vfs(), vfs_mode);
+  *fh = tiledb_vfs_fh_t::make_handle(fh_uri, vfs->vfs().get(), vfs_mode);
 
   return TILEDB_OK;
 }
@@ -351,6 +359,11 @@ CAPI_INTERFACE(
 
 CAPI_INTERFACE_VOID(vfs_free, tiledb_vfs_t** vfs) {
   return tiledb::api::api_entry_void<tiledb::api::tiledb_vfs_free>(vfs);
+}
+
+CAPI_INTERFACE(vfs_get_default, tiledb_ctx_t* ctx, tiledb_vfs_t** vfs) {
+  return tiledb::api::api_entry_with_context<
+      tiledb::api::tiledb_vfs_get_default>(ctx, vfs);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/api/c_api/vfs/vfs_api_external.h
+++ b/tiledb/api/c_api/vfs/vfs_api_external.h
@@ -109,6 +109,28 @@ TILEDB_EXPORT capi_return_t tiledb_vfs_alloc(
 TILEDB_EXPORT void tiledb_vfs_free(tiledb_vfs_t** vfs) TILEDB_NOEXCEPT;
 
 /**
+ * Retrieves a reference to the default VFS of a TileDB
+ * context. This is useful to avoid allocating multiple
+ * VFS objects, and to access the raw data of in-memory
+ * arrays.
+ *
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_vfs_t* vfs;
+ * tiledb_vfs_get_default(ctx, &vfs);
+ * // Make sure to free the retrieved VFS
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param vfs The VFS to be retrieved.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t
+tiledb_vfs_get_default(tiledb_ctx_t* ctx, tiledb_vfs_t** vfs) TILEDB_NOEXCEPT;
+
+/**
  * Retrieves the config from a VFS context.
  *
  * **Example:**

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -50,7 +50,7 @@ struct tiledb_vfs_handle_t
   static constexpr std::string_view object_type_name{"vfs"};
 
  private:
-  using vfs_type = tiledb::sm::VFS;
+  using vfs_type = shared_ptr<tiledb::sm::VFS>;
   vfs_type vfs_;
 
  public:
@@ -59,92 +59,100 @@ struct tiledb_vfs_handle_t
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
       const tiledb::sm::Config& config)
-      : vfs_{parent_stats, compute_tp, io_tp, config} {
+      : vfs_{make_shared<tiledb::sm::VFS>(
+            HERE(), parent_stats, compute_tp, io_tp, config)} {
   }
 
-  vfs_type* vfs() {
-    return &vfs_;
+  /**
+   * Constructor from shared pointer to a `VFS`.
+   */
+  explicit tiledb_vfs_handle_t(vfs_type vfs)
+      : vfs_{std::move(vfs)} {
+  }
+
+  vfs_type vfs() {
+    return vfs_;
   }
 
   tiledb::sm::Config config() const {
-    return vfs_.config();
+    return vfs_->config();
   }
 
   Status create_bucket(const tiledb::sm::URI& uri) const {
-    return vfs_.create_bucket(uri);
+    return vfs_->create_bucket(uri);
   }
 
   Status remove_bucket(const tiledb::sm::URI& uri) const {
-    return vfs_.remove_bucket(uri);
+    return vfs_->remove_bucket(uri);
   }
 
   Status empty_bucket(const tiledb::sm::URI& uri) const {
-    return vfs_.empty_bucket(uri);
+    return vfs_->empty_bucket(uri);
   }
 
   Status is_empty_bucket(const tiledb::sm::URI& uri, bool* is_empty) const {
-    return vfs_.is_empty_bucket(uri, is_empty);
+    return vfs_->is_empty_bucket(uri, is_empty);
   }
 
   Status is_bucket(const tiledb::sm::URI& uri, bool* is_bucket) const {
-    return vfs_.is_bucket(uri, is_bucket);
+    return vfs_->is_bucket(uri, is_bucket);
   }
 
   Status create_dir(const tiledb::sm::URI& uri) const {
-    return vfs_.create_dir(uri);
+    return vfs_->create_dir(uri);
   }
 
   Status is_dir(const tiledb::sm::URI& uri, bool* is_dir) const {
-    return vfs_.is_dir(uri, is_dir);
+    return vfs_->is_dir(uri, is_dir);
   }
 
   Status remove_dir(const tiledb::sm::URI& uri) const {
-    return vfs_.remove_dir(uri);
+    return vfs_->remove_dir(uri);
   }
 
   Status is_file(const tiledb::sm::URI& uri, bool* is_file) const {
-    return vfs_.is_file(uri, is_file);
+    return vfs_->is_file(uri, is_file);
   }
 
   Status remove_file(const tiledb::sm::URI& uri) const {
-    return vfs_.remove_file(uri);
+    return vfs_->remove_file(uri);
   }
 
   Status dir_size(const tiledb::sm::URI& dir_name, uint64_t* dir_size) const {
-    return vfs_.dir_size(dir_name, dir_size);
+    return vfs_->dir_size(dir_name, dir_size);
   }
 
   Status file_size(const tiledb::sm::URI& uri, uint64_t* size) const {
-    return vfs_.file_size(uri, size);
+    return vfs_->file_size(uri, size);
   }
 
   Status move_file(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    return vfs_.move_file(old_uri, new_uri);
+    return vfs_->move_file(old_uri, new_uri);
   }
 
   Status move_dir(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    return vfs_.move_dir(old_uri, new_uri);
+    return vfs_->move_dir(old_uri, new_uri);
   }
 
   Status copy_file(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    return vfs_.copy_file(old_uri, new_uri);
+    return vfs_->copy_file(old_uri, new_uri);
   }
 
   Status copy_dir(
       const tiledb::sm::URI& old_uri, const tiledb::sm::URI& new_uri) {
-    return vfs_.copy_dir(old_uri, new_uri);
+    return vfs_->copy_dir(old_uri, new_uri);
   }
 
   Status ls(
       const tiledb::sm::URI& parent, std::vector<tiledb::sm::URI>* uris) const {
-    return vfs_.ls(parent, uris);
+    return vfs_->ls(parent, uris);
   }
 
   Status touch(const tiledb::sm::URI& uri) const {
-    return vfs_.touch(uri);
+    return vfs_->touch(uri);
   }
 
   void ls_recursive(
@@ -152,7 +160,7 @@ struct tiledb_vfs_handle_t
       tiledb_ls_callback_t cb,
       void* data) const {
     tiledb::sm::CallbackWrapperCAPI wrapper(cb, data);
-    vfs_.ls_recursive(parent, wrapper);
+    vfs_->ls_recursive(parent, wrapper);
   }
 };
 

--- a/tiledb/api/c_api_support/handle/handle.h
+++ b/tiledb/api/c_api_support/handle/handle.h
@@ -200,6 +200,15 @@ class CAPIHandle {
     return *self_.get();
   }
 
+  /**
+   * Shared pointer
+   *
+   * @return shared pointer to our stored object
+   */
+  inline shared_ptr_type get_shared_ptr() {
+    return self_;
+  }
+
   inline static std::string handle_name() {
     return std::string(T::object_type_name);
   }

--- a/tiledb/api/c_api_test_support/testsupport_capi_vfs.h
+++ b/tiledb/api/c_api_test_support/testsupport_capi_vfs.h
@@ -42,16 +42,17 @@ struct ordinary_vfs {
   tiledb_ctx_handle_t* ctx{nullptr};
   tiledb_vfs_handle_t* vfs{nullptr};
   ordinary_vfs(tiledb_config_t* config = nullptr) {
-    auto rc = tiledb_ctx_alloc(nullptr, &ctx);
+    auto rc = tiledb_ctx_alloc(config, &ctx);
     if (rc != TILEDB_OK) {
       throw std::runtime_error("error creating test context");
     }
-    rc = tiledb_vfs_alloc(ctx, config, &vfs);
+    rc = tiledb_vfs_get_default(ctx, &vfs);
     if (rc != TILEDB_OK) {
       throw std::runtime_error("error creating test vfs");
     }
     if (vfs == nullptr) {
-      throw std::logic_error("tiledb_vfs_alloc returned OK but without vfs");
+      throw std::logic_error(
+          "tiledb_vfs_get_default returned OK but without vfs");
     }
   }
   ~ordinary_vfs() {

--- a/tiledb/doxygen/source/c-api.rst
+++ b/tiledb/doxygen/source/c-api.rst
@@ -613,6 +613,8 @@ VFS
     :project: TileDB-C
 .. doxygenfunction:: tiledb_vfs_free
     :project: TileDB-C
+.. doxygenfunction:: tiledb_vfs_get_default
+    :project: TileDB-C
 .. doxygenfunction:: tiledb_vfs_get_config
     :project: TileDB-C
 .. doxygenfunction:: tiledb_vfs_create_bucket

--- a/tiledb/sm/cpp_api/vfs.h
+++ b/tiledb/sm/cpp_api/vfs.h
@@ -383,6 +383,17 @@ class VFS {
   /*                API                */
   /* ********************************* */
 
+  /** Gets the default VFS of a context. */
+  static VFS get_default(const Context& ctx) {
+    tiledb_vfs_t* vfs;
+    int rc = tiledb_vfs_get_default(ctx.ptr().get(), &vfs);
+    if (rc != TILEDB_OK)
+      throw std::runtime_error(
+          "[TileDB::C++API] Error: Failed to get default VFS object");
+
+    return VFS{ctx, std::shared_ptr<tiledb_vfs_t>{vfs, impl::Deleter{}}};
+  }
+
   /** Creates an object store bucket with the input URI. */
   void create_bucket(const std::string& uri) const {
     auto& ctx = ctx_.get();
@@ -580,6 +591,11 @@ class VFS {
   /* ********************************* */
   /*          PRIVATE METHODS          */
   /* ********************************* */
+
+  explicit VFS(const Context& ctx, std::shared_ptr<tiledb_vfs_t> vfs)
+      : ctx_(ctx)
+      , vfs_(vfs) {
+  }
 
   /** Creates a TileDB C VFS object, using the input config. */
   void create_vfs(tiledb_config_t* config) {


### PR DESCRIPTION
[SC-37859](https://app.shortcut.com/tiledb-inc/story/37859/add-api-to-get-the-vfs-of-a-context)

If you want to access a file using the VFS API, you will have to create a new VFS object. Besides the potential waste of resources, if you have written an array in a MemFS URI, the new VFS will have an entirely new MemFS instance, making it impossible to access the written files.

This PR adds a new C API to return a reference to the internal VFS object held by a context:

```c
TILEDB_EXPORT capi_return_t tiledb_vfs_get_default(
    tiledb_ctx_t* ctx, tiledb_vfs_t** vfs) TILEDB_NOEXCEPT;
```

The API is implemented by changing the internal definition of `tiledb_vfs_t` to store a shared pointer to a VFS instead of a VFS itself. We then create the shared pointer to the default VFS with the constructor overload that takes another shared pointer –in this case the shared pointer to the context–, making sure that the VFS does not outlive its associated context.

For the C++ API, I added a constructor overload to the `VFS` class that accepts a `DefaultVFS` marker value. There are other alternatives such as a static `VFS::get_default` method or a free `get_default_vfs` function, but the constructor overload feels better to me. Feedback appreciated.

I also updated usages of `tiledb_vfs_alloc` in tests and examples to use the new API in the following cases:

* The config parameter is null or the same to the config passed when creating the VFS' context
* The call is not in a test that specifically tests `tiledb_vfs_alloc`

### TODO

- [ ] Decide on the shape of the C++ API
  - [ ] Update usages in tests and examples when applicable
- [ ] Add specific testing for the new API

---
TYPE: C_API
DESC: Add `tiledb_vfs_get_default` API that gets a reference to the default VFS of a context.

---
TYPE: CPP_API
DESC: Add constructor overload to the `VFS` class that creates a reference to the default VFS of a context.