### PR TITLE
Implement alt var length view for external sort.

### DIFF
--- a/tiledb/common/alt_var_length_view.h
+++ b/tiledb/common/alt_var_length_view.h
@@ -1,0 +1,183 @@
+/**
+ * @file   alt_alt_var_length_view.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains the definition of the alt_var_length_view class, which
+ * splits a given view into subranges of variable length, as delimited by
+ * adjacent pairs of values in an index range.
+ *
+ * The difference between `alt_var_length_view` and `var_length_view` is that
+ * `alt_var_length_view` maintains a materialized range of subranges, whereas
+ * `var_length_view` creates subrange views on the fly as proxy objects.  As a
+ * result
+ * * An `alt_var_length_view` does not need to refer to the offsets array after
+ * it is constructed
+ * * An `alt_var_length_view` can be sorted
+ *
+ *
+ * Usage example:
+ * ```
+ * std::vector<int> x {1, 2, 3, 4, 5, 6, 7, 8, 9}; // Data range
+ * std::vector<size_t> indices {0, 4, 7, 9};       // Index range
+ * alt_var_length_view v(x, indices);
+ * CHECK(std::ranges::equal(v[0], std::vector<int>{1, 2, 3, 4}));
+ * CHECK(std::ranges::equal(v[1], std::vector<int>{5, 6, 7}));
+ * CHECK(std::ranges::equal(v[2], std::vector<int>{8, 9}));
+ * ```
+ */
+
+#ifndef TILEDB_ALT_VAR_LENGTH_VIEW_H
+#define TILEDB_ALT_VAR_LENGTH_VIEW_H
+
+#include <ranges>
+
+#include "iterator_facade.h"
+
+/**
+ * A view that splits a view into subranges of variable length, as delimited by
+ * a range of indices. The resulting view is a range of subranges, each of which
+ * is a view into the original data range. The iterator over the
+ * alt_var_length_view is a random_access_iterator that dereferences to a
+ * subrange of the data range.
+ *
+ * @tparam R Type of the data range, assumed to be a random access range.
+ * @tparam I Type of the index range, assumed to be a random access range.
+ *
+ * @todo R could be a view rather than a range.
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range I>
+class alt_var_length_view : public std::ranges::view_base {
+  // Forward reference of the iterator over the range of variable length data
+  template <class Value>
+  struct private_iterator;
+
+  /** The type of the iterator over the var length data range */
+  using data_iterator_type = std::ranges::iterator_t<R>;
+
+  /** The type that can index into the var length data range */
+  using data_index_type = std::iter_difference_t<data_iterator_type>;
+
+  /** The type dereferenced by the iterator is a subrange */
+  using var_length_type = std::ranges::subrange<data_iterator_type>;
+
+  /** The type of the iterator over the var length view */
+  using var_length_iterator = private_iterator<var_length_type>;
+
+  /** The type of the const iterator over the var length view */
+  using var_length_const_iterator = private_iterator<var_length_type const>;
+
+ public:
+  /*****************************************************************************
+   * Constructors
+   * @note: Since this view has ownership of the subranges, we don't allow
+   * copying, but do allow moves.
+   ****************************************************************************/
+
+  /** Default constructor */
+  alt_var_length_view() = default;
+
+  /** Copy constructor is deleted */
+  alt_var_length_view(const alt_var_length_view&) = delete;
+
+  /** Move constructor */
+  alt_var_length_view(alt_var_length_view&&) = default;
+
+  /** Copy assignment is deleted */
+  alt_var_length_view& operator=(const alt_var_length_view&) = delete;
+
+  /** Move assignment */
+  alt_var_length_view& operator=(alt_var_length_view&&) = default;
+
+  /** Primary constructor. All offsets are contained in the input (notably, the
+   * index to the end of the data range). */
+  alt_var_length_view(R& data, const I& index) {
+    auto data_begin(std::ranges::begin(data));
+
+    subranges_.reserve(std::ranges::size(index) - 1);
+    for (size_t i = 0; i < std::ranges::size(index) - 1; ++i) {
+      subranges_.emplace_back(data_begin + index[i], data_begin + index[i + 1]);
+    }
+  }
+
+  /** Constructor. The offsets do not contain the final index value (which would
+   * be the end of the data range), so the final index is passed in as a
+   * separate argument.
+   */
+  alt_var_length_view(R& data, const I& index, data_index_type end_index) {
+    auto data_begin(std::ranges::begin(data));
+
+    subranges_.reserve(std::ranges::size(index) - 1);
+
+    for (size_t i = 0; i < std::ranges::size(index) - 1; ++i) {
+      subranges_.emplace_back(data_begin + index[i], data_begin + index[i + 1]);
+    }
+    subranges_.emplace_back(data_begin + index.back(), data_begin + end_index);
+  }
+
+  /** Return iterator to the beginning of the var length view */
+  auto begin() {
+    return subranges_.begin();
+  }
+
+  /** Return iterator to the end of the var length view */
+  auto end() {
+    return subranges_.end();
+  }
+
+  /** Return const iterator to the beginning of the var length view */
+  auto begin() const {
+    return subranges_.cbegin();
+  }
+
+  /** Return const iterator to the end of the var length view */
+  auto end() const {
+    return subranges_.cend();
+  }
+
+  /** Return const iterator to the beginning of the var length view */
+  auto cbegin() const {
+    return subranges_.cbegin();
+  }
+
+  /** Return const iterator to the end of the var length view */
+  auto cend() const {
+    return subranges_.cend();
+  }
+
+  /** Return the number of subranges in the var length view */
+  auto size() const {
+    return std::ranges::size(subranges_);
+  }
+
+ private:
+  std::vector<var_length_type> subranges_;
+};
+
+#endif  // TILEDB_ALT_VAR_LENGTH_VIEW_H

--- a/tiledb/common/test/CMakeLists.txt
+++ b/tiledb/common/test/CMakeLists.txt
@@ -42,7 +42,7 @@ commence(unit_test memory_tracker_types)
 conclude(unit_test)
 
 commence(unit_test common_utils)
-    this_target_sources(main.cc unit_iterator_facade.cc unit_permutation_view.cc unit_proxy_sort.cc unit_var_length_view.cc)
+    this_target_sources(main.cc unit_alt_var_length_view.cc unit_iterator_facade.cc unit_permutation_view.cc unit_proxy_sort.cc unit_var_length_view.cc)
     this_target_object_libraries(baseline)
 conclude(unit_test)
 

--- a/tiledb/common/test/unit_alt_var_length_view.cc
+++ b/tiledb/common/test/unit_alt_var_length_view.cc
@@ -1,0 +1,459 @@
+/**
+ * @file   unit_alt_var_length_view.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements unit tests for the alt_var_length_view class.
+ */
+
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <vector>
+#include "../alt_var_length_view.h"
+
+TEST_CASE(
+    "alt_var_length_view: Null test", "[alt_var_length_view][null_test]") {
+  REQUIRE(true);
+}
+
+// Test that the alt_var_length_view satisfies the expected concepts
+TEST_CASE(
+    "alt_var_length_view: Range concepts", "[alt_var_length_view][concepts]") {
+  using test_type = alt_var_length_view<std::vector<double>, std::vector<int>>;
+
+  CHECK(std::ranges::range<test_type>);
+  CHECK(!std::ranges::borrowed_range<test_type>);
+  CHECK(std::ranges::sized_range<test_type>);
+  CHECK(std::ranges::view<test_type>);
+  CHECK(std::ranges::input_range<test_type>);
+
+  // @todo: Do we actually want alt_var_length_view to be an output_range?
+  CHECK(std::ranges::
+            output_range<test_type, std::ranges::range_value_t<test_type>>);
+  CHECK(std::ranges::forward_range<test_type>);
+  CHECK(std::ranges::bidirectional_range<test_type>);
+  CHECK(std::ranges::random_access_range<test_type>);
+
+  // @todo: Do we actually want alt_var_length_view to be a contiguous_range?
+  CHECK(std::ranges::contiguous_range<test_type>);
+  CHECK(std::ranges::common_range<test_type>);
+  CHECK(std::ranges::viewable_range<test_type>);
+
+  CHECK(std::ranges::view<test_type>);
+}
+
+// Test that the alt_var_length_view iterators satisfy the expected concepts
+TEST_CASE(
+    "alt_var_length_view: Iterator concepts",
+    "[alt_var_length_view][concepts]") {
+  using test_type = alt_var_length_view<std::vector<double>, std::vector<int>>;
+  using test_type_iterator = std::ranges::iterator_t<test_type>;
+  using test_type_const_iterator = std::ranges::iterator_t<const test_type>;
+
+  CHECK(std::input_or_output_iterator<test_type_iterator>);
+  CHECK(std::input_or_output_iterator<test_type_const_iterator>);
+  CHECK(std::input_iterator<test_type_iterator>);
+  CHECK(std::input_iterator<test_type_const_iterator>);
+
+  // @todo: Do we actually want alt_var_length_view to be an output_range?
+  CHECK(std::output_iterator<
+        test_type_iterator,
+        std::ranges::range_value_t<test_type>>);
+  CHECK(!std::output_iterator<
+        test_type_const_iterator,
+        std::ranges::range_value_t<test_type>>);
+  CHECK(std::forward_iterator<test_type_iterator>);
+  CHECK(std::forward_iterator<test_type_const_iterator>);
+  CHECK(std::bidirectional_iterator<test_type_iterator>);
+  CHECK(std::bidirectional_iterator<test_type_const_iterator>);
+  CHECK(std::random_access_iterator<test_type_iterator>);
+  CHECK(std::random_access_iterator<test_type_const_iterator>);
+}
+
+// Test that the alt_var_length_view value_type satisfies the expected concepts
+TEST_CASE(
+    "alt_var_length_view: value_type concepts",
+    "[alt_var_length_view][concepts]") {
+  using test_type = alt_var_length_view<std::vector<double>, std::vector<int>>;
+  CHECK(std::ranges::range<test_type>);
+
+  using test_iterator_type = std::ranges::iterator_t<test_type>;
+  using test_iterator_value_type = std::iter_value_t<test_iterator_type>;
+  using test_iterator_reference_type =
+      std::iter_reference_t<test_iterator_type>;
+
+  using range_value_type = std::ranges::range_value_t<test_type>;
+  using range_reference_type = std::ranges::range_reference_t<test_type>;
+
+  CHECK(std::is_same_v<test_iterator_value_type, range_value_type>);
+  CHECK(std::is_same_v<test_iterator_reference_type, range_reference_type>);
+}
+
+// Simple test that the alt_var_length_view can be constructed
+TEST_CASE("alt_var_length_view: Basic constructor", "[alt_var_length_view]") {
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+
+  SECTION("Arrow format") {
+    std::vector<size_t> o = {0, 3, 6, 10};
+    auto u = alt_var_length_view(r, o);
+    auto v = alt_var_length_view{r, o};
+    alt_var_length_view w(r, o);
+    alt_var_length_view x{r, o};
+
+    CHECK(size(u) == 3);
+    CHECK(size(v) == 3);
+    CHECK(size(w) == 3);
+    CHECK(size(x) == 3);
+  }
+  SECTION("TileDB format") {
+    std::vector<size_t> o = {0, 3, 6};
+    auto u = alt_var_length_view(r, o, 10);
+    auto v = alt_var_length_view{r, o, 10};
+    alt_var_length_view w(r, o, 10);
+    alt_var_length_view x{r, o, 10};
+
+    CHECK(size(u) == 3);
+    CHECK(size(v) == 3);
+    CHECK(size(w) == 3);
+    CHECK(size(x) == 3);
+  }
+}
+
+// Check that the sizes of the alt_var_length_view are correct
+TEST_CASE("alt_var_length_view: size()", "[alt_var_length_view]") {
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+
+  alt_var_length_view<std::vector<double>, std::vector<size_t>> v;
+  SECTION("arrow format") {
+    std::vector<size_t> o = {0, 3, 6, 10};
+    v = alt_var_length_view{r, o};
+  }
+  CHECK(size(v) == 3);
+  std::vector<size_t> o = {0, 3, 6};
+  v = alt_var_length_view{r, o, 10};
+  CHECK((v.begin() + 1)->size() == 3);
+  CHECK((v.begin() + 2)->size() == 4);
+
+  size_t count = 0;
+  for (auto i : v) {
+    (void)i;
+    count++;
+  }
+  CHECK(count == 3);
+  count = 0;
+  for (auto i = v.begin(); i != v.end(); ++i) {
+    count++;
+  }
+  CHECK(count == 3);
+}
+
+// Check that various properties of iterators hold
+TEST_CASE("alt_var_length_view: Basic iterators", "[alt_var_length_view]") {
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+
+  alt_var_length_view<std::vector<double>, std::vector<size_t>> v;
+  auto end_v = GENERATE(0, 10);
+
+  if (end_v == 0) {
+    std::vector<size_t> o = {0, 3, 6, 10};
+    v = alt_var_length_view(r, o);
+  } else {
+    std::vector<size_t> o = {0, 3, 6};
+    v = alt_var_length_view(r, o, end_v);
+  }
+
+  auto a = v.begin();
+  auto b = v.end();
+  auto c = begin(v);
+  auto d = end(v);
+
+  SECTION("Check begin and end") {
+    REQUIRE(a == a);
+    CHECK(a == c);
+    CHECK(b == d);
+  }
+  SECTION("Check dereference") {
+    CHECK(std::equal(a->begin(), a->end(), r.begin()));
+    CHECK(std::equal(a->begin(), a->end(), c->begin()));
+    // CHECK(std::ranges::equal(*a, r));  // size() not the same
+    CHECK(std::ranges::equal(*a, *c));
+  }
+  SECTION("Check  pre-increment + dereference") {
+    ++a;
+    ++c;
+    CHECK(std::equal(a->begin(), a->end(), c->begin()));
+    CHECK(std::equal(a->begin(), a->end(), r.begin() + 3));
+    CHECK(std::ranges::equal(*a, *c));
+    ++a;
+    ++c;
+    CHECK(std::equal(a->begin(), a->end(), c->begin()));
+    CHECK(std::equal(a->begin(), a->end(), r.begin() + 6));
+    CHECK(std::ranges::equal(*a, *c));
+  }
+  SECTION("Check  post-increment + dereference") {
+    a++;
+    c++;
+    CHECK(std::equal(a->begin(), a->end(), c->begin()));
+    CHECK(std::equal(a->begin(), a->end(), r.begin() + 3));
+    CHECK(std::ranges::equal(*a, *c));
+    a++;
+    c++;
+    CHECK(std::equal(a->begin(), a->end(), c->begin()));
+    CHECK(std::equal(a->begin(), a->end(), r.begin() + 6));
+    CHECK(std::ranges::equal(*a, *c));
+  }
+  SECTION("operator[]") {
+    CHECK(std::equal(a[0].begin(), a[0].end(), r.begin()));
+    CHECK(std::equal(a[1].begin(), a[1].end(), r.begin() + 3));
+    CHECK(std::equal(a[2].begin(), a[2].end(), r.begin() + 6));
+    CHECK(std::equal(a[0].begin(), a[0].end(), c[0].begin()));
+    CHECK(std::equal(a[1].begin(), a[1].end(), c[1].begin()));
+    CHECK(std::equal(a[2].begin(), a[2].end(), c[2].begin()));
+    CHECK(!std::equal(a[0].begin(), a[0].end(), c[1].begin()));
+    CHECK(!std::equal(a[0].begin(), a[0].end(), c[2].begin()));
+
+    CHECK(a[0][0] == 1.0);
+    CHECK(a[0][1] == 2.0);
+    CHECK(a[0][2] == 3.0);
+    CHECK(a[1][0] == 4.0);
+    CHECK(a[1][1] == 5.0);
+    CHECK(a[1][2] == 6.0);
+    CHECK(a[2][0] == 7.0);
+    CHECK(a[2][1] == 8.0);
+    CHECK(a[2][2] == 9.0);
+    CHECK(a[2][3] == 10.0);
+  }
+  SECTION("More operator[]") {
+    size_t count = 0;
+    for (auto i : v) {
+      for (auto j : i) {
+        ++count;
+        CHECK(j == count);
+      }
+    }
+  }
+  SECTION("Equality, etc") {
+    CHECK(a == c);
+    CHECK(!(a != c));
+    CHECK(!(a < c));
+    CHECK(!(a > c));
+    CHECK(a <= c);
+    CHECK(a >= c);
+
+    CHECK(a != b);
+    CHECK(!(a == b));
+    CHECK(a < b);
+    CHECK(!(a > b));
+    CHECK(a <= b);
+    CHECK(!(a >= b));
+
+    ++a;
+    CHECK(a != c);
+    CHECK(!(a == c));
+    CHECK(!(a < c));
+    CHECK(a > c);
+    CHECK(!(a <= c));
+    CHECK(a >= c);
+    --a;
+    CHECK(a == c);
+    CHECK(!(a != c));
+    CHECK(!(a < c));
+    CHECK(!(a > c));
+    CHECK(a <= c);
+    CHECK(a >= c);
+    c++;
+    CHECK(a != c);
+    CHECK(!(a == c));
+    CHECK(!(a > c));
+    CHECK(a < c);
+    CHECK(!(a >= c));
+    CHECK(a <= c);
+    c--;
+    CHECK(a == c);
+    CHECK(!(a != c));
+    CHECK(!(a < c));
+    CHECK(!(a > c));
+    CHECK(a <= c);
+    CHECK(a >= c);
+  }
+}
+
+// Test that we can read and write to the elements of the alt_var_length_view
+TEST_CASE("alt_var_length_view: Viewness", "[alt_var_length_view]") {
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<double> s = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<size_t> o = {0, 3, 6, 10};
+  std::vector<size_t> m = {0, 3, 6, 10};
+  std::vector<double> q = {
+      21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
+  std::vector<size_t> p = {0, 2, 7, 10};
+  std::vector<size_t> n = {0, 3, 6, 10};
+
+  alt_var_length_view<std::vector<double>, std::vector<size_t>> u, v, w, x, y,
+      z;
+  SECTION("Arrow format") {
+    u = alt_var_length_view(q, n);
+    v = alt_var_length_view(r, o);
+    w = alt_var_length_view(q, p);
+    x = alt_var_length_view(r, m);
+    y = alt_var_length_view(s, m);
+    z = alt_var_length_view(s, n);
+  }
+  SECTION("TileDB format") {
+    std::vector<size_t> o = {0, 3, 6};
+    std::vector<size_t> p = {0, 2, 7};
+    u = alt_var_length_view(q, o, 10);
+    v = alt_var_length_view(r, o, 10);
+    w = alt_var_length_view(q, p, 10);
+    x = alt_var_length_view(r, o, 10);
+    y = alt_var_length_view(s, o, 10);
+    z = alt_var_length_view(s, o, 10);
+  }
+
+  REQUIRE(v.begin() == v.begin());
+  CHECK(v.begin() != w.begin());
+  CHECK(v.begin() != u.begin());
+  CHECK(w.begin() != u.begin());
+
+  REQUIRE(v.end() == v.end());
+  CHECK(v.end() != w.end());
+  CHECK(v.end() != u.end());
+  CHECK(w.end() != u.end());
+
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(v.size() == x.size());
+    CHECK(std::equal(
+        v.begin()[i].begin(), v.begin()[i].end(), x.begin()[i].begin()));
+    for (size_t j = 0; j < x.size(); ++j) {
+      CHECK(v.begin()[i][j] == x.begin()[i][j]);
+    }
+  }
+  for (auto&& i : y) {
+    for (auto& j : i) {
+      j += 13.0;
+    }
+  }
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(v.size() == x.size());
+    for (size_t j = 0; j < x.size(); ++j) {
+      CHECK(y.begin()[i][j] == v.begin()[i][j] + 13.0);
+      CHECK(z.begin()[i][j] == y.begin()[i][j]);
+      CHECK(z.cbegin()[i][j] == y.begin()[i][j]);
+      CHECK(z.cbegin()[i][j] == y.cbegin()[i][j]);
+      CHECK(z.cbegin()[i][j] == z.begin()[i][j]);
+    }
+  }
+}
+
+// Test that the alt_var_length_view can be sorted
+TEST_CASE("alt_var_length_view: Sort", "[alt_var_length_view]") {
+  std::vector<double> r = {
+      1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
+  std::vector<size_t> o = {0, 3, 6, 10, 12};
+  alt_var_length_view<std::vector<double>, std::vector<size_t>> v(r, o);
+
+  SECTION("Sort by size, ascending") {
+    std::vector<std::vector<double>> expected = {
+        {11.0, 12.0},
+        {1.0, 2.0, 3.0},
+        {4.0, 5.0, 6.0},
+        {7.0, 8.0, 9.0, 10.0},
+    };
+
+    std::sort(v.begin(), v.end(), [](auto& a, auto& b) {
+      return a.size() < b.size();
+    });
+
+    CHECK(v.begin()->size() == 2);
+    CHECK((v.begin() + 1)->size() == 3);
+    CHECK((v.begin() + 2)->size() == 3);
+    CHECK((v.begin() + 3)->size() == 4);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+  SECTION("Sort by size, descending") {
+    std::vector<std::vector<double>> expected = {
+        {7.0, 8.0, 9.0, 10.0},
+        {1.0, 2.0, 3.0},
+        {4.0, 5.0, 6.0},
+        {11.0, 12.0},
+    };
+
+    std::sort(v.begin(), v.end(), [](auto& a, auto& b) {
+      return a.size() > b.size();
+    });
+
+    CHECK(v.begin()->size() == 4);
+    CHECK((v.begin() + 1)->size() == 3);
+    CHECK((v.begin() + 2)->size() == 3);
+    CHECK((v.begin() + 3)->size() == 2);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+  SECTION("Sort by first element, ascending") {
+    std::vector<std::vector<double>> expected = {
+        {1.0, 2.0, 3.0},
+        {4.0, 5.0, 6.0},
+        {7.0, 8.0, 9.0, 10.0},
+        {11.0, 12.0},
+    };
+
+    std::sort(v.begin(), v.end(), [](auto& a, auto& b) { return a[0] < b[0]; });
+
+    CHECK(v.begin()->size() == 3);
+    CHECK((v.begin() + 1)->size() == 3);
+    CHECK((v.begin() + 2)->size() == 4);
+    CHECK((v.begin() + 3)->size() == 2);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+  SECTION("Sort by first element, descending") {
+    std::vector<std::vector<double>> expected = {
+        {11.0, 12.0},
+        {7.0, 8.0, 9.0, 10.0},
+        {4.0, 5.0, 6.0},
+        {1.0, 2.0, 3.0},
+    };
+
+    std::sort(v.begin(), v.end(), [](auto& a, auto& b) { return a[0] > b[0]; });
+
+    CHECK(v.begin()->size() == 2);
+    CHECK((v.begin() + 1)->size() == 4);
+    CHECK((v.begin() + 2)->size() == 3);
+    CHECK((v.begin() + 3)->size() == 3);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+}

--- a/tiledb/common/test/unit_iterator_facade.cc
+++ b/tiledb/common/test/unit_iterator_facade.cc
@@ -1,4 +1,3 @@
-
 /**
  * @file   unit_iterator_facade.cc
  *
@@ -364,6 +363,7 @@ enum class month : int {
   october,
   november,
   december,
+  end,
 };
 
 /*
@@ -410,50 +410,11 @@ class month_iterator : public iterator_facade<month_iterator> {
     return _cur == other._cur;
   }
 };
-
-/*
- * A second month_iterator to test writing to the iterator.
- */
-
-class month_iterator_2 : public iterator_facade<month_iterator_2> {
-  // Since we are faking an iterator over data, we can make the value mutable.
-  mutable month _cur = month::january;
-
- public:
-  month_iterator_2() = default;
-  explicit month_iterator_2(month m)
-      : _cur(m) {
-  }
-
-  month& dereference() const {
-    return _cur;
-  }
-
-  void advance(int n) {
-    _cur = month(int(_cur) + n);
-  }
-  int distance_to(month_iterator_2 o) const {
-    return int(o._cur) - int(_cur);
-  }
-
-  bool operator==(month_iterator_2 o) const {
-    return _cur == o._cur;
-  }
-};
-
 }  // namespace
 
 TEMPLATE_TEST_CASE(
-    "iterator_facade: month_iterator",
-    "[iterator_facade]",
-    month_iterator,
-    month_iterator_2) {
-  CHECK(std::input_iterator<TestType>);
-  if (std::is_same_v<TestType, month_iterator_2>) {
-    CHECK(std::output_iterator<month_iterator_2, month>);
-  } else {
-    CHECK(!std::output_iterator<month_iterator, month>);
-  }
+    "iterator_facade: month_iterator", "[iterator_facade]", month_iterator) {
+  CHECK(!std::output_iterator<month_iterator, month>);
 
   CHECK(std::forward_iterator<TestType>);
   CHECK(std::bidirectional_iterator<TestType>);
@@ -483,52 +444,12 @@ TEMPLATE_TEST_CASE(
   CHECK(*it == month::november);
   ++it;
   CHECK(*it == month::december);
+
   // We should be able to increment once more and get the sentinel value,
   // but this is not working for some reason.
   // @todo Fix this.
   // ++it;
   //  CHECK(it == month_iterator::sentinel_type());
-}
-
-TEST_CASE("iterator_facade: month_iterator_2 write") {
-  month_iterator_2 it;
-  *it = month::august;
-  CHECK(*it == month::august);
-  ++it;
-  CHECK(*it == month::september);
-
-  *it = month::may;
-  CHECK(*it == month::may);
-  it++;
-  CHECK(*it == month::june);
-  CHECK(*it++ == month::june);
-  CHECK(*it == month::july);
-
-  it.advance(3);
-  CHECK(*it == month::october);
-  *it = month::july;
-  it += 3;
-  CHECK(*it == month::october);
-
-  auto a = *(it + 0);
-  CHECK(a == month::october);
-  auto b = *(it + 1);
-  CHECK(b == month::november);
-
-  // These fail for some reason.
-  // @todo Fix this.
-  // auto c = it[0];
-  // CHECK(c == month::october);
-  // auto d = it[1];
-  // CHECK(d == month::november);
-
-  CHECK(*(it + 0) == month::october);
-  CHECK(*(it + 1) == month::november);
-
-  // These fail for some reason.
-  // @todo Fix this.
-  // CHECK(it[0] == month::october);
-  // CHECK(it[1] == month::november);
 }
 
 /*

--- a/tiledb/common/var_length_view.h
+++ b/tiledb/common/var_length_view.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR implements an alternate view for var length data.  Instead of maintaining an offsets range, as in the first `var_length_view`, this class materializes all of the individual subranges over the var length data.  The associated unit tests for this PR include tests for sorting.

Advantages:
* The `alt_var_length_view` has the advantage of not returning a proxy when accessed and, as a result, can be directly sorted.  Also, not having to create the proxy on access can result in more efficiency.
* The `alt_var_length_view` class can be constructed with either the "Arrow" format for offsets or the "TileDB" format.  In the latter case, the constructor takes the offsets ranges, as well as the final value.

Disadvanatages:
* The `alt_var_length_view` requires more storage.  An individual `std::ranges::subrange` consumes 16 bytes, whereas a `size_t` consumes 8 bytes.  On the other hand, if sorting of the original `var_length_view` is of interest, the offsets range plus a permutation range will also result in 16 bytes storage per var length element.

Notes:
* The `alt_var_length_view` class ends up being a fairly thin wrapper around `std::vector<std::ranges::subrange>>`.  However, it is considered not to be good practice to inherit from `std::vector`, so it was kept as member data.
* Because this view does maintain internal data that is not O(1), the copy constructor and copy assignment operator are disabled.

---
TYPE: IMPROVEMENT
DESC: Implement alt var length view for external sort.

<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
