### PR TITLE
Additional constructors for external sort classes.

### DIFF
--- a/tiledb/common/test/unit_alt_var_length_view.cc
+++ b/tiledb/common/test/unit_alt_var_length_view.cc
@@ -116,9 +116,44 @@ TEST_CASE(
 // Simple test that the alt_var_length_view can be constructed
 TEST_CASE("alt_var_length_view: Basic constructor", "[alt_var_length_view]") {
   std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<size_t> o = {0, 3, 6, 10};
+  std::vector<std::vector<double>> expected = {
+      {1.0, 2.0, 3.0},
+      {4.0, 5.0, 6.0},
+      {7.0, 8.0, 9.0, 10.0},
+  };
 
-  SECTION("Arrow format") {
-    std::vector<size_t> o = {0, 3, 6, 10};
+  SECTION("iterator pair") {
+    auto u = alt_var_length_view(r.begin(), r.end(), o.begin(), o.end());
+    auto v = alt_var_length_view{r.begin(), r.end(), o.begin(), o.end()};
+    alt_var_length_view w(r.begin(), r.end(), o.begin(), o.end());
+    alt_var_length_view x{r.begin(), r.end(), o.begin(), o.end()};
+
+    CHECK(size(u) == 3);
+    CHECK(size(v) == 3);
+    CHECK(size(w) == 3);
+    CHECK(size(x) == 3);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+  SECTION("iterator pair with size") {
+    auto u = alt_var_length_view(r.begin(), r.end(), 6, o.begin(), o.end(), 3);
+    auto v = alt_var_length_view{r.begin(), r.end(), 6, o.begin(), o.end(), 3};
+    alt_var_length_view w(r.begin(), r.end(), 6, o.begin(), o.end(), 3);
+    alt_var_length_view x{r.begin(), r.end(), 6, o.begin(), o.end(), 3};
+
+    CHECK(size(u) == 2);
+    CHECK(size(v) == 2);
+    CHECK(size(w) == 2);
+    CHECK(size(x) == 2);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+  SECTION("range") {
     auto u = alt_var_length_view(r, o);
     auto v = alt_var_length_view{r, o};
     alt_var_length_view w(r, o);
@@ -128,18 +163,94 @@ TEST_CASE("alt_var_length_view: Basic constructor", "[alt_var_length_view]") {
     CHECK(size(v) == 3);
     CHECK(size(w) == 3);
     CHECK(size(x) == 3);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
   }
-  SECTION("TileDB format") {
-    std::vector<size_t> o = {0, 3, 6};
-    auto u = alt_var_length_view(r, o, 10);
-    auto v = alt_var_length_view{r, o, 10};
-    alt_var_length_view w(r, o, 10);
-    alt_var_length_view x{r, o, 10};
+
+  SECTION("range with size") {
+    auto u = alt_var_length_view(r, 6, o, 3);
+    auto v = alt_var_length_view{r, 6, o, 3};
+    alt_var_length_view w(r, 6, o, 3);
+    alt_var_length_view x{r, 6, o, 3};
+
+    CHECK(size(u) == 2);
+    CHECK(size(v) == 2);
+    CHECK(size(w) == 2);
+    CHECK(size(x) == 2);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+
+  SECTION("iterator pair, tiledb format") {
+    auto u =
+        alt_var_length_view(r.begin(), r.end(), o.begin(), o.end() - 1, 10);
+    auto v =
+        alt_var_length_view{r.begin(), r.end(), o.begin(), o.end() - 1, 10};
+    alt_var_length_view w(r.begin(), r.end(), o.begin(), o.end() - 1, 10);
+    alt_var_length_view x{r.begin(), r.end(), o.begin(), o.end() - 1, 10};
 
     CHECK(size(u) == 3);
     CHECK(size(v) == 3);
     CHECK(size(w) == 3);
     CHECK(size(x) == 3);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+
+  SECTION("iterator pair with size, tiledb format") {
+    auto u =
+        alt_var_length_view(r.begin(), r.end(), 6, o.begin(), o.end(), 2, 6);
+    auto v =
+        alt_var_length_view{r.begin(), r.end(), 6, o.begin(), o.end(), 2, 6};
+    alt_var_length_view w(r.begin(), r.end(), 6, o.begin(), o.end(), 2, 6);
+    alt_var_length_view x{r.begin(), r.end(), 6, o.begin(), o.end(), 2, 6};
+
+    CHECK(size(u) == 2);
+    CHECK(size(v) == 2);
+    CHECK(size(w) == 2);
+    CHECK(size(x) == 2);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+
+  SECTION("range, tiledb format") {
+    auto u = alt_var_length_view(r, std::ranges::views::take(o, 3), 10);
+    auto v = alt_var_length_view{r, std::ranges::views::take(o, 3), 10};
+    alt_var_length_view w(r, std::ranges::views::take(o, 3), 10);
+    alt_var_length_view x{r, std::ranges::views::take(o, 3), 10};
+
+    CHECK(size(u) == 3);
+    CHECK(size(v) == 3);
+    CHECK(size(w) == 3);
+    CHECK(size(x) == 3);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+
+  SECTION("range with size, tiledb format") {
+    auto u = alt_var_length_view(r, 6, o, 2, 6);
+    auto v = alt_var_length_view{r, 6, o, 2, 6};
+    alt_var_length_view w(r, 6, o, 2, 6);
+    alt_var_length_view x{r, 6, o, 2, 6};
+
+    CHECK(size(u) == 2);
+    CHECK(size(v) == 2);
+    CHECK(size(w) == 2);
+    CHECK(size(x) == 2);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
   }
 }
 

--- a/tiledb/common/test/unit_var_length_view.cc
+++ b/tiledb/common/test/unit_var_length_view.cc
@@ -103,19 +103,54 @@ TEST_CASE(
 }
 
 // Simple test that the var_length_view can be constructed
-TEST_CASE("var_length_view: Basic constructor", "[var_length_view]") {
+TEST_CASE("var_length_view: Constructors", "[var_length_view]") {
   std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
   std::vector<size_t> o = {0, 3, 6, 10};
 
-  auto u = var_length_view(r, o);
-  auto v = var_length_view{r, o};
-  var_length_view w(r, o);
-  var_length_view x{r, o};
+  SECTION("iterator pair") {
+    auto u = var_length_view(r.begin(), r.end(), o.begin(), o.end());
+    auto v = var_length_view{r.begin(), r.end(), o.begin(), o.end()};
+    var_length_view w(r.begin(), r.end(), o.begin(), o.end());
+    var_length_view x{r.begin(), r.end(), o.begin(), o.end()};
 
-  CHECK(size(u) == 3);
-  CHECK(size(v) == 3);
-  CHECK(size(w) == 3);
-  CHECK(size(x) == 3);
+    CHECK(size(u) == 3);
+    CHECK(size(v) == 3);
+    CHECK(size(w) == 3);
+    CHECK(size(x) == 3);
+  }
+  SECTION("iterator pair with size") {
+    auto u = var_length_view(r.begin(), r.end(), 6, o.begin(), o.end(), 3);
+    auto v = var_length_view{r.begin(), r.end(), 6, o.begin(), o.end(), 3};
+    var_length_view w(r.begin(), r.end(), 6, o.begin(), o.end(), 3);
+    var_length_view x{r.begin(), r.end(), 6, o.begin(), o.end(), 3};
+
+    CHECK(size(u) == 2);
+    CHECK(size(v) == 2);
+    CHECK(size(w) == 2);
+    CHECK(size(x) == 2);
+  }
+  SECTION("range") {
+    auto u = var_length_view(r, o);
+    auto v = var_length_view{r, o};
+    var_length_view w(r, o);
+    var_length_view x{r, o};
+
+    CHECK(size(u) == 3);
+    CHECK(size(v) == 3);
+    CHECK(size(w) == 3);
+    CHECK(size(x) == 3);
+  }
+  SECTION("range with size") {
+    auto u = var_length_view(r, 6, o, 3);
+    auto v = var_length_view{r, 6, o, 3};
+    var_length_view w(r, 6, o, 3);
+    var_length_view x{r, 6, o, 3};
+
+    CHECK(size(u) == 2);
+    CHECK(size(v) == 2);
+    CHECK(size(w) == 2);
+    CHECK(size(x) == 2);
+  }
 }
 
 // Check that the sizes of the var_length_view are correct


### PR DESCRIPTION
This PR is stacked on #4925.  It adds additional constructors for the two view classes for var length data.

The previous implementations had constructors that just took input ranges, and constructed a var length view over the data specified by those ranges.  However, in general, we may have a range that is not completely filled with data, and so may need to specify the data to be viewed in some other way.  The complete set of constructors take
* ranges for data and offsets (arrow format) - the size of the resulting view is one less than the size of the offset range
* ranges plus sizes for data and offsets (arrow format) - the size of the resulting view is one less than the size given for the offset range
* iterator pairs for data and offsets (arrow format) - the size of the resulting view is one less than the difference between end and begin of the offsets pair
* iterator pairs for data and offsets, with sizes (arrow format) - the size of the resulting view is one less than the size given for the offset range
* ranges for data and offsets (tilledb format) - the size of the resulting view is equal to the size of the offset range (takes an extra argument for last offset value)
* ranges plus sizes for data and offsets (tiledb format) - the size of the resulting view is equal to the size given for the offset range (takes an extra argument for last offset value)
* iterator pairs for data and offsets (tiledb format) - the size of the resulting view is equal to the difference between end and begin of the offsets pair (takes an extra argument for last offset value)
* iterator pairs for data and offsets, with sizes (tiledb format) - the size of the resulting view is equal than the size given for the offset range (takes an extra argument for last offset value)

[sc-44576]

---
TYPE: NO_HISTORY
DESC: Additional constructors for external sort classes.
