### PR TITLE
Use new memory tracker for tile offsets

### DIFF
--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -672,8 +672,8 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "11000");
-  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.4");
+  cfg.set("sm.mem.total_budget", "20000");
+  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.22");
   ctx_ = Context(cfg);
 
   std::string stats;
@@ -722,8 +722,8 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "11000");
-  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.4");
+  cfg.set("sm.mem.total_budget", "20000");
+  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.22");
   ctx_ = Context(cfg);
 
   std::string stats;

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1147,67 +1147,67 @@ TEST_CASE_METHOD(
       &a2_offsets_r_size,
       2);
 
-  CHECK(a1_data_r_size == a1_data_size);
-  CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
-  CHECK(a2_data_r_size == a2_data_size);
-  CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
-  CHECK(a2_offsets_r_size == a2_offsets_size);
-  CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+  // CHECK(a1_data_r_size == a1_data_size);
+  // CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
+  // CHECK(a2_data_r_size == a2_data_size);
+  // CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
+  // CHECK(a2_offsets_r_size == a2_offsets_size);
+  // CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
 
-  // Now read with QC set for a1 only.
-  read_fixed_strings(
-      subarray,
-      a1_data_r,
-      &a1_data_r_size,
-      a2_data_r,
-      &a2_data_r_size,
-      a2_offsets_r,
-      &a2_offsets_r_size,
-      2,
-      true,
-      false);
+  // // Now read with QC set for a1 only.
+  // read_fixed_strings(
+  //     subarray,
+  //     a1_data_r,
+  //     &a1_data_r_size,
+  //     a2_data_r,
+  //     &a2_data_r_size,
+  //     a2_offsets_r,
+  //     &a2_offsets_r_size,
+  //     2,
+  //     true,
+  //     false);
 
-  CHECK(a1_data_r_size == a1_data_size);
-  CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
-  CHECK(a2_data_r_size == a2_data_size);
-  CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
-  CHECK(a2_offsets_r_size == a2_offsets_size);
-  CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+  // CHECK(a1_data_r_size == a1_data_size);
+  // CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
+  // CHECK(a2_data_r_size == a2_data_size);
+  // CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
+  // CHECK(a2_offsets_r_size == a2_offsets_size);
+  // CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
 
-  // Now read with QC set for a2 only.
-  read_fixed_strings(
-      subarray,
-      a1_data_r,
-      &a1_data_r_size,
-      a2_data_r,
-      &a2_data_r_size,
-      a2_offsets_r,
-      &a2_offsets_r_size,
-      2,
-      false,
-      true);
+  // // Now read with QC set for a2 only.
+  // read_fixed_strings(
+  //     subarray,
+  //     a1_data_r,
+  //     &a1_data_r_size,
+  //     a2_data_r,
+  //     &a2_data_r_size,
+  //     a2_offsets_r,
+  //     &a2_offsets_r_size,
+  //     2,
+  //     false,
+  //     true);
 
-  CHECK(a1_data_r_size == a1_data_size);
-  CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
-  CHECK(a2_data_r_size == a2_data_size);
-  CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
-  CHECK(a2_offsets_r_size == a2_offsets_size);
-  CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+  // CHECK(a1_data_r_size == a1_data_size);
+  // CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
+  // CHECK(a2_data_r_size == a2_data_size);
+  // CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
+  // CHECK(a2_offsets_r_size == a2_offsets_size);
+  // CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
 
-  // Now read with QC set for a1 and a2, should fail.
-  read_fixed_strings(
-      subarray,
-      a1_data_r,
-      &a1_data_r_size,
-      a2_data_r,
-      &a2_data_r_size,
-      a2_offsets_r,
-      &a2_offsets_r_size,
-      0,
-      true,
-      true,
-      "DenseReader: Cannot process a single tile because of query "
-      "condition, increase memory budget");
+  // // Now read with QC set for a1 and a2, should fail.
+  // read_fixed_strings(
+  //     subarray,
+  //     a1_data_r,
+  //     &a1_data_r_size,
+  //     a2_data_r,
+  //     &a2_data_r_size,
+  //     a2_offsets_r,
+  //     &a2_offsets_r_size,
+  //     0,
+  //     true,
+  //     true,
+  //     "DenseReader: Cannot process a single tile because of query "
+  //     "condition, increase memory budget");
 }
 
 TEST_CASE_METHOD(
@@ -1243,8 +1243,8 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "640";
-  tile_upper_memory_limit_ = "210";
+  total_budget_ = "1150";
+  tile_upper_memory_limit_ = "500";
   update_config();
 
   // Try to read.
@@ -1296,7 +1296,7 @@ TEST_CASE_METHOD(
       "DenseReader: Cannot process a single tile because of query "
       "condition, increase memory budget");
 
-  // Now read with QC set for a1 and a2, should fail.
+  // // Now read with QC set for a1 and a2, should fail.
   read_fixed_strings(
       subarray,
       a1_data_r,

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1147,67 +1147,67 @@ TEST_CASE_METHOD(
       &a2_offsets_r_size,
       2);
 
-  // CHECK(a1_data_r_size == a1_data_size);
-  // CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
-  // CHECK(a2_data_r_size == a2_data_size);
-  // CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
-  // CHECK(a2_offsets_r_size == a2_offsets_size);
-  // CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+  CHECK(a1_data_r_size == a1_data_size);
+  CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
+  CHECK(a2_data_r_size == a2_data_size);
+  CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
+  CHECK(a2_offsets_r_size == a2_offsets_size);
+  CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
 
-  // // Now read with QC set for a1 only.
-  // read_fixed_strings(
-  //     subarray,
-  //     a1_data_r,
-  //     &a1_data_r_size,
-  //     a2_data_r,
-  //     &a2_data_r_size,
-  //     a2_offsets_r,
-  //     &a2_offsets_r_size,
-  //     2,
-  //     true,
-  //     false);
+  // Now read with QC set for a1 only.
+  read_fixed_strings(
+      subarray,
+      a1_data_r,
+      &a1_data_r_size,
+      a2_data_r,
+      &a2_data_r_size,
+      a2_offsets_r,
+      &a2_offsets_r_size,
+      2,
+      true,
+      false);
 
-  // CHECK(a1_data_r_size == a1_data_size);
-  // CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
-  // CHECK(a2_data_r_size == a2_data_size);
-  // CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
-  // CHECK(a2_offsets_r_size == a2_offsets_size);
-  // CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+  CHECK(a1_data_r_size == a1_data_size);
+  CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
+  CHECK(a2_data_r_size == a2_data_size);
+  CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
+  CHECK(a2_offsets_r_size == a2_offsets_size);
+  CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
 
-  // // Now read with QC set for a2 only.
-  // read_fixed_strings(
-  //     subarray,
-  //     a1_data_r,
-  //     &a1_data_r_size,
-  //     a2_data_r,
-  //     &a2_data_r_size,
-  //     a2_offsets_r,
-  //     &a2_offsets_r_size,
-  //     2,
-  //     false,
-  //     true);
+  // Now read with QC set for a2 only.
+  read_fixed_strings(
+      subarray,
+      a1_data_r,
+      &a1_data_r_size,
+      a2_data_r,
+      &a2_data_r_size,
+      a2_offsets_r,
+      &a2_offsets_r_size,
+      2,
+      false,
+      true);
 
-  // CHECK(a1_data_r_size == a1_data_size);
-  // CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
-  // CHECK(a2_data_r_size == a2_data_size);
-  // CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
-  // CHECK(a2_offsets_r_size == a2_offsets_size);
-  // CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+  CHECK(a1_data_r_size == a1_data_size);
+  CHECK(!std::memcmp(a1_data.data(), a1_data_r, a1_data_size));
+  CHECK(a2_data_r_size == a2_data_size);
+  CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
+  CHECK(a2_offsets_r_size == a2_offsets_size);
+  CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
 
-  // // Now read with QC set for a1 and a2, should fail.
-  // read_fixed_strings(
-  //     subarray,
-  //     a1_data_r,
-  //     &a1_data_r_size,
-  //     a2_data_r,
-  //     &a2_data_r_size,
-  //     a2_offsets_r,
-  //     &a2_offsets_r_size,
-  //     0,
-  //     true,
-  //     true,
-  //     "DenseReader: Cannot process a single tile because of query "
-  //     "condition, increase memory budget");
+  // Now read with QC set for a1 and a2, should fail.
+  read_fixed_strings(
+      subarray,
+      a1_data_r,
+      &a1_data_r_size,
+      a2_data_r,
+      &a2_data_r_size,
+      a2_offsets_r,
+      &a2_offsets_r_size,
+      0,
+      true,
+      true,
+      "DenseReader: Cannot process a single tile because of query "
+      "condition, increase memory budget");
 }
 
 TEST_CASE_METHOD(
@@ -1296,7 +1296,7 @@ TEST_CASE_METHOD(
       "DenseReader: Cannot process a single tile because of query "
       "condition, increase memory budget");
 
-  // // Now read with QC set for a1 and a2, should fail.
+  // Now read with QC set for a1 and a2, should fail.
   read_fixed_strings(
       subarray,
       a1_data_r,

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1126,8 +1126,8 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "660";
-  tile_upper_memory_limit_ = "210";
+  total_budget_ = "1200";
+  tile_upper_memory_limit_ = "500";
   update_config();
 
   // Try to read.

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1312,7 +1312,7 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords, &coords_size, data, &data_size);
   }
 
-  // Two result tile (2 * (~1200 + 8) will be bigger than the per fragment
+  // Two result tile (2 * (~2600 + 8) will be bigger than the per fragment
   // budget (1000).
   total_budget_ = "26000";
   ratio_coords_ = "0.30";

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -788,10 +788,10 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords, &coords_size, data, &data_size);
   }
 
-  // Two result tile (2 * (~1200 + 8) will be bigger than the per fragment
+  // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "12000";
-  ratio_coords_ = "0.30";
+  total_budget_ = "30000";
+  ratio_coords_ = "0.12";
   update_config();
 
   tiledb_array_t* array = nullptr;
@@ -870,7 +870,7 @@ TEST_CASE_METHOD(
   write_1d_fragment(coords, &coords_size, data, &data_size);
 
   // One result tile (8 + ~440) will be bigger than the budget (400).
-  total_budget_ = "10000";
+  total_budget_ = "13000";
   ratio_coords_ = "0.04";
   update_config();
 
@@ -1207,7 +1207,7 @@ TEST_CASE(
     "Sparse global order reader: attribute copy memory limit",
     "[sparse-global-order][attribute-copy][memory-limit][rest]") {
   Config config;
-  config["sm.mem.total_budget"] = "10000";
+  config["sm.mem.total_budget"] = "15000";
   VFSTestSetup vfs_test_setup(config.ptr().get());
   std::string array_name = vfs_test_setup.array_uri("test_sparse_global_order");
   auto ctx = vfs_test_setup.ctx();
@@ -1314,7 +1314,7 @@ TEST_CASE_METHOD(
 
   // Two result tile (2 * (~1200 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "12000";
+  total_budget_ = "26000";
   ratio_coords_ = "0.30";
   update_config();
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -932,7 +932,7 @@ TEST_CASE_METHOD(
   uint64_t data2_size = data.size() * sizeof(int);
   write_1d_fragment(coords2.data(), &coords2_size, data2.data(), &data2_size);
 
-  total_budget_ = "1000000";
+  total_budget_ = "1500000";
   ratio_array_data_ = set_subarray ? "0.003" : "0.002";
   partial_tile_offsets_loading_ = "true";
   update_config();
@@ -1020,8 +1020,8 @@ TEST_CASE_METHOD(
   }
 
   // Two result tile (2 * ~1208) will be bigger than the budget (1500).
-  total_budget_ = "10000";
-  ratio_coords_ = "0.15";
+  total_budget_ = "25500";
+  ratio_coords_ = "0.06";
   update_config();
 
   tiledb_array_t* array = nullptr;
@@ -1099,7 +1099,7 @@ TEST_CASE_METHOD(
   write_1d_fragment(coords, &coords_size, data, &data_size);
 
   // One result tile (~505) will be larger than leftover memory.
-  total_budget_ = "800";
+  total_budget_ = "1500";
   ratio_array_data_ = "0.99";
   ratio_coords_ = "0.0005";
   update_config();

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -316,6 +316,9 @@ class MemoryTracker {
    */
   uint64_t get_memory_available() {
     std::lock_guard<std::mutex> lg(mutex_);
+    if (memory_usage_ + counters_[MemoryType::TILE_OFFSETS] > memory_budget_) {
+      return 0;
+    }
     return memory_budget_ - memory_usage_ - counters_[MemoryType::TILE_OFFSETS];
   }
 

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -255,10 +255,6 @@ class MemoryTracker {
   bool take_memory(uint64_t size, MemoryType mem_type) {
     std::lock_guard<std::mutex> lg(mutex_);
     if (memory_usage_ + size <= memory_budget_) {
-      if (mem_type == MemoryType::TILE_OFFSETS) {
-        // tile offsets are only measured in the counter_
-        return true;
-      }
       memory_usage_ += size;
       memory_usage_by_type_[mem_type] += size;
       return true;

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -349,7 +349,7 @@ class MemoryTracker {
       , id_(generate_id())
       , type_(MemoryTrackerType::ANONYMOUS)
       , upstream_(tdb::pmr::get_default_resource())
-      , total_counter_(0) {};
+      , total_counter_(0){};
 
  private:
   /** Protects all non-atomic member variables. */

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -2547,6 +2547,8 @@ void FragmentMetadata::load_footer(
 
   unsigned num = array_schema_->attribute_num() + 1 + has_timestamps_ +
                  has_delete_meta_ * 2;
+
+  // If version < 5 we use zipped coordinates, otherwise separate
   num += (version_ >= 5) ? array_schema_->dim_num() : 0;
 
   loaded_metadata_ptr_->resize_offsets(num);

--- a/tiledb/sm/fragment/ondemand_fragment_metadata.cc
+++ b/tiledb/sm/fragment/ondemand_fragment_metadata.cc
@@ -174,16 +174,8 @@ void OndemandFragmentMetadata::load_tile_offsets(
   // Get tile offsets
   if (tile_offsets_num != 0) {
     auto size = tile_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile offsets; Insufficient memory budget; Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
+    // Get tile offsets
     tile_offsets_[idx].resize(tile_offsets_num);
     deserializer.read(&tile_offsets_[idx][0], size);
   }
@@ -223,17 +215,8 @@ void OndemandFragmentMetadata::load_tile_var_offsets(
   // Get variable tile offsets
   if (tile_var_offsets_num != 0) {
     auto size = tile_var_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile var offsets; Insufficient memory budget; "
-          "Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
+    // Get tile var offsets
     tile_var_offsets_[idx].resize(tile_var_offsets_num);
     deserializer.read(&tile_var_offsets_[idx][0], size);
   }
@@ -268,17 +251,8 @@ void OndemandFragmentMetadata::load_tile_var_sizes(
   // Get variable tile sizes
   if (tile_var_sizes_num != 0) {
     auto size = tile_var_sizes_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile var sizes; Insufficient memory budget; "
-          "Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
+    // Get tile var sizes
     tile_var_sizes_[idx].resize(tile_var_sizes_num);
     deserializer.read(&tile_var_sizes_[idx][0], size);
   }
@@ -321,17 +295,8 @@ void OndemandFragmentMetadata::load_tile_validity_offsets(
   // Get tile offsets
   if (tile_validity_offsets_num != 0) {
     auto size = tile_validity_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile validity offsets; Insufficient memory budget; "
-          "Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
+    // Get tile validity offsets
     tile_validity_offsets_[idx].resize(tile_validity_offsets_num);
     if (!buff->read(&tile_validity_offsets_[idx][0], size).ok()) {
       throw FragmentMetadataStatusException(

--- a/tiledb/sm/fragment/v1v2preloaded_fragment_metadata.cc
+++ b/tiledb/sm/fragment/v1v2preloaded_fragment_metadata.cc
@@ -73,15 +73,6 @@ void V1V2PreloadedFragmentMetadata::load_tile_offsets(
       continue;
 
     auto size = tile_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile offsets; Insufficient memory budget; Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
     // Get tile offsets
     tile_offsets_[i].resize(tile_offsets_num);
@@ -119,16 +110,6 @@ void V1V2PreloadedFragmentMetadata::load_tile_var_offsets(
       continue;
 
     auto size = tile_var_offsets_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile var offsets; Insufficient memory budget; "
-          "Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
     // Get variable tile offsets
     tile_var_offsets_[i].resize(tile_var_offsets_num);
@@ -163,16 +144,6 @@ void V1V2PreloadedFragmentMetadata::load_tile_var_sizes(
       continue;
 
     auto size = tile_var_sizes_num * sizeof(uint64_t);
-    if (memory_tracker_ != nullptr &&
-        !memory_tracker_->take_memory(size, MemoryType::TILE_OFFSETS)) {
-      throw FragmentMetadataStatusException(
-          "Cannot load tile var sizes; Insufficient memory budget; "
-          "Needed " +
-          std::to_string(size) + " but only had " +
-          std::to_string(memory_tracker_->get_memory_available()) +
-          " from budget " +
-          std::to_string(memory_tracker_->get_memory_budget()));
-    }
 
     // Get variable tile sizes
     tile_var_sizes_[i].resize(tile_var_sizes_num);

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -730,8 +730,7 @@ uint64_t DenseReader::compute_space_tiles_end(
     ThreadPool::Task& compute_task) {
   // For easy reference.
   const auto& tile_coords = subarray.tile_coords();
-  uint64_t available_memory =
-      memory_budget_ - array_memory_tracker_->get_memory_usage();
+  uint64_t available_memory = array_memory_tracker_->get_memory_available();
 
   // If the available memory is less than the tile upper memory limit, we cannot
   // load two batches at once. Wait for the first compute task to complete
@@ -823,8 +822,7 @@ uint64_t DenseReader::compute_space_tiles_end(
 
   // If we only include one tile, make sure we don't exceed the memory budget.
   if (t_end == t_start + 1) {
-    const auto available_memory =
-        memory_budget_ - array_memory_tracker_->get_memory_usage();
+    const auto available_memory = array_memory_tracker_->get_memory_available();
     for (auto mem : required_memory) {
       if (mem > available_memory) {
         throw DenseReaderStatusException(

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -248,9 +248,7 @@ void SparseGlobalOrderReader<BitmapType>::load_all_tile_offsets() {
     // Make sure we have enough space for tile offsets data.
     uint64_t total_tile_offset_usage =
         tile_offsets_size(subarray_.relevant_fragments());
-    uint64_t available_memory =
-        array_memory_tracker_->get_memory_available() -
-        array_memory_tracker_->get_memory_usage(MemoryType::TILE_OFFSETS);
+    uint64_t available_memory = array_memory_tracker_->get_memory_available();
     if (total_tile_offset_usage > available_memory) {
       throw SparseGlobalOrderReaderStatusException(
           "Cannot load tile offsets, computed size (" +

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -240,17 +240,31 @@ std::vector<uint64_t> SparseIndexReaderBase::tile_offset_sizes() {
           num += deletes_consolidation_no_purge_;
         }
 
+        // Finally set the size of the loaded data.
+
+        // The expected size of the tile offsets
+        unsigned offsets_size = num * tile_num * sizeof(uint64_t);
+
         // Other than the offsets themselves, there is also memory used for the
         // initialization of the vectors that hold them. This initialization
-        // takes place in fragment_metadata.cc::load_footer()
-        unsigned num_vectors = schema->attribute_num() + 1 +
-                               fragment->has_timestamps() +
-                               fragment->has_delete_meta() * 2;
-        num_vectors += (fragment->version() >= 5) ? schema->dim_num() : 0;
+        // takes place in LoadedFragmentMetadata::resize_offsets()
 
-        // Finally set the size of the loaded data.
-        ret[frag_idx] =
-            num * tile_num * sizeof(uint64_t) + (num_vectors * 4 * 32);
+        // Calculate the number of fields
+        unsigned num_fields = schema->attribute_num() + 1 +
+                              fragment->has_timestamps() +
+                              fragment->has_delete_meta() * 2;
+
+        // If version < 5 we use zipped coordinates, otherwise separate
+        num_fields += (fragment->version() >= 5) ? schema->dim_num() : 0;
+
+        // The additional memory required for the vectors to
+        // store the tile offsets. The number of fields is calculated above.
+        // Each vector requires 32 bytes. Each field requires 4 vectors. These
+        // are: tile_offsets_, tile_var_offsets_, tile_var_sizes_,
+        // tile_validity_offsets_ and are located in loaded_fragment_metadata.h
+        unsigned offsets_init_size = num_fields * 4 * 32;
+
+        ret[frag_idx] = offsets_size + offsets_init_size;
         return Status::Ok();
       }));
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -240,9 +240,9 @@ std::vector<uint64_t> SparseIndexReaderBase::tile_offset_sizes() {
           num += deletes_consolidation_no_purge_;
         }
 
-        // Other that the offsets themselves, there is also memory used for the
+        // Other than the offsets themselves, there is also memory used for the
         // initialization of the vectors that hold them. This initialization
-        // takes place in fragment_metadata.cc::3702-3713
+        // takes place in fragment_metadata.cc::load_footer()
         unsigned num_vectors = schema->attribute_num() + 1 +
                                fragment->has_timestamps() +
                                fragment->has_delete_meta() * 2;
@@ -442,9 +442,6 @@ Status SparseIndexReaderBase::load_initial_data() {
 
   // Load per fragment tile offsets memory usage.
   per_frag_tile_offsets_usage_ = tile_offset_sizes();
-
-  // todo per frag metadata usage. This needs to be calculated in our memory
-  // estimation so that we know
 
   // Set a limit to the array memory.
   if (!array_memory_tracker_->set_budget(

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -240,6 +240,9 @@ std::vector<uint64_t> SparseIndexReaderBase::tile_offset_sizes() {
           num += deletes_consolidation_no_purge_;
         }
 
+        // Other that the offsets themselves, there is also memory used for the
+        // initialization of the vectors that hold them. This initialization
+        // takes place in fragment_metadata.cc::3702-3713
         unsigned num_vectors = schema->attribute_num() + 1 +
                                fragment->has_timestamps() +
                                fragment->has_delete_meta() * 2;

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -252,8 +252,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::load_tile_offsets_data() {
   bool initial_load =
       tile_offsets_min_frag_idx_ == std::numeric_limits<unsigned>::max() &&
       tile_offsets_max_frag_idx_ == 0;
-  uint64_t available_memory =
-      array_memory_tracker_->get_memory_available();
+  uint64_t available_memory = array_memory_tracker_->get_memory_available();
   auto& relevant_fragments = subarray_.relevant_fragments();
 
   if (!partial_tile_offsets_loading_) {

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -253,8 +253,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::load_tile_offsets_data() {
       tile_offsets_min_frag_idx_ == std::numeric_limits<unsigned>::max() &&
       tile_offsets_max_frag_idx_ == 0;
   uint64_t available_memory =
-      array_memory_tracker_->get_memory_available() -
-      array_memory_tracker_->get_memory_usage(MemoryType::TILE_OFFSETS);
+      array_memory_tracker_->get_memory_available();
   auto& relevant_fragments = subarray_.relevant_fragments();
 
   if (!partial_tile_offsets_loading_) {


### PR DESCRIPTION
This PR is responsible for two things:

1. Fix the memory usage estimation for the tile offsets to match the memory tracker result
2. Switch to use the new memory tracker for offsets only. (All readers related)

 [sc-46275]

---
TYPE: NO_HISTORY
DESC: Use new memory tracker for tile offsets.
