### PR TITLE
Add missing include required by std::copy_n use.

### DIFF
--- a/tiledb/api/c_api_support/cpp_string/cpp_string.h
+++ b/tiledb/api/c_api_support/cpp_string/cpp_string.h
@@ -32,6 +32,7 @@
 #ifndef TILEDB_CAPI_SUPPORT_CPP_STRING_H
 #define TILEDB_CAPI_SUPPORT_CPP_STRING_H
 
+#include <algorithm>                 // std::copy_n
 #include <cstring>                   // std::memchr
 #include <string>                    // std::string_view
 #include "../argument_validation.h"  // CAPIException


### PR DESCRIPTION
Use of `std::copy_n`, added in #4915, requires adding the `algorithms` header under `g++` compilation

[sc-46538]

---
TYPE: NO_HISTORY
DESC: Add `algorithms` header for `std::copy_n`
