### PR TITLE
Fix broken unit build on macos.

### DIFF
--- a/tiledb/common/test/unit_iterator_facade.cc
+++ b/tiledb/common/test/unit_iterator_facade.cc
@@ -622,9 +622,10 @@ struct simple_mutable_struct {
   using iterator = simple_mutable_iterator<SValue>;
   using const_iterator = simple_mutable_iterator<const SValue>;
 
-  using value_type = std::iterator_traits<iterator>::value_type;
-  using reference = std::iterator_traits<iterator>::reference;
-  using const_reference = std::iterator_traits<const_iterator>::reference;
+  using value_type = typename std::iterator_traits<iterator>::value_type;
+  using reference = typename std::iterator_traits<iterator>::reference;
+  using const_reference =
+      typename std::iterator_traits<const_iterator>::reference;
 
   auto begin() {
     return iterator{value.begin()};


### PR DESCRIPTION
This fixes
```
unit_iterator_facade.cc:625:22: error: missing 'typename' prior to dependent type name 'std::iterator_tra
its<iterator>::value_type'                                                                                                                                    
  using value_type = std::iterator_traits<iterator>::value_type; 
 ```
which I got building units on my macos.

[sc-46539]

---
TYPE: NO_HISTORY
DESC: Fix broken unit build on macos.
