### PR TITLE
Fix the documentation for the `array_schema` object library

### DIFF
--- a/tiledb/sm/array_schema/CMakeLists.txt
+++ b/tiledb/sm/array_schema/CMakeLists.txt
@@ -74,10 +74,10 @@ commence(object_library array_schema)
         attribute domain enumeration fragment time uri_format vfs)
 conclude(object_library)
 
-# This is linked outside the object_library scope because ContextResources
-# is recompiled as part of the capi_context_stub. Including context_resources
-# here like this prevents many headaches revolving around duplicate symbols
-# when linking executables.
+# This is linked outside the object_library scope as an active subversion of
+# the principle that object libraries must compile as standalone modules. As
+# long as this directive is necessary to have to the compile test pass, we
+# cannot consider `array_schema` as a properly-constructed object library.
 target_link_libraries(compile_array_schema PRIVATE context_resources generic_tile_io)
 
 add_test_subdirectory()


### PR DESCRIPTION
This change removes any confusion that in its present state the `array_schema` object library is not properly specified as a freestanding library capable of resolving all its symbols without additional external dependencies.

[sc-46557]

---
TYPE: NO_HISTORY
DESC: Fix the documentation for the `array_schema` object library
