### PR TITLE
Write iter_swap for zip_view for external sort.

### DIFF
--- a/tiledb/common/alt_var_length_view.h
+++ b/tiledb/common/alt_var_length_view.h
@@ -65,16 +65,15 @@
  * alt_var_length_view is a random_access_iterator that dereferences to a
  * subrange of the data range.
  *
- * @tparam R Type of the data range, assumed to be a random access range.
- * @tparam I Type of the index range, assumed to be a random access range.
+ * @tparam R Type of the data range, required to be viewable_range
+ * @tparam I Type of the index range, required to be viewable_range
  *
- * @todo R could be a view rather than a range.
- * @todo Would using `std::ranges::view_interface` be better tha `view_base`?
+ * @note We use view_interface instead of view_base to get operator[] (among
+ * other things).
  */
-template <
-    std::ranges::random_access_range R,
-    std::ranges::random_access_range I>
-class alt_var_length_view : public std::ranges::view_base {
+template <std::ranges::viewable_range R, std::ranges::viewable_range I>
+class alt_var_length_view
+    : public std::ranges::view_interface<alt_var_length_view<R, I>> {
   /**
    * Forward reference of the iterator over the range of variable length data
    */

--- a/tiledb/common/alt_var_length_view.h
+++ b/tiledb/common/alt_var_length_view.h
@@ -71,7 +71,20 @@
  * @note We use view_interface instead of view_base to get operator[] (among
  * other things).
  */
+
+/** @todo This should go in some common place */
+#define GCC_VERSION \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION > 120000
 template <std::ranges::viewable_range R, std::ranges::viewable_range I>
+  requires std::ranges::random_access_range<R> &&
+           std::ranges::random_access_range<I>
+#else
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range I>
+#endif
 class alt_var_length_view
     : public std::ranges::view_interface<alt_var_length_view<R, I>> {
   /**

--- a/tiledb/common/test/CMakeLists.txt
+++ b/tiledb/common/test/CMakeLists.txt
@@ -42,7 +42,7 @@ commence(unit_test memory_tracker_types)
 conclude(unit_test)
 
 commence(unit_test common_utils)
-    this_target_sources(main.cc unit_alt_var_length_view.cc unit_iterator_facade.cc unit_permutation_view.cc unit_proxy_sort.cc unit_var_length_view.cc unit_zip_view.cc)
+    this_target_sources(main.cc unit_alt_var_length_view.cc unit_iterator_facade.cc unit_permutation_view.cc unit_proxy_sort.cc unit_sort_zip.cc unit_var_length_view.cc unit_zip_view.cc)
     this_target_object_libraries(baseline)
 conclude(unit_test)
 

--- a/tiledb/common/test/unit_alt_var_length_view.cc
+++ b/tiledb/common/test/unit_alt_var_length_view.cc
@@ -66,6 +66,12 @@ TEST_CASE(
   CHECK(std::ranges::view<test_type>);
 }
 
+struct dummy_compare {
+  bool operator()(auto&&, auto&&) const {
+    return true;
+  }
+};
+
 // Test that the alt_var_length_view iterators satisfy the expected concepts
 TEST_CASE(
     "alt_var_length_view: Iterator concepts",
@@ -92,6 +98,29 @@ TEST_CASE(
   CHECK(std::bidirectional_iterator<test_type_const_iterator>);
   CHECK(std::random_access_iterator<test_type_iterator>);
   CHECK(std::random_access_iterator<test_type_const_iterator>);
+
+  using ZI = test_type_iterator;
+  CHECK(std::indirectly_writable<ZI, std::iter_rvalue_reference_t<ZI>>);
+  CHECK(std::indirectly_writable<ZI, std::iter_value_t<ZI>>);
+
+  CHECK(std::indirectly_movable<ZI, ZI>);
+
+  CHECK(std::indirectly_movable_storable<ZI, ZI>);
+
+  CHECK(std::movable<std::iter_value_t<ZI>>);
+  CHECK(std::constructible_from<
+        std::iter_value_t<ZI>,
+        std::iter_rvalue_reference_t<ZI>>);
+  CHECK(std::assignable_from<
+        std::iter_value_t<ZI>&,
+        std::iter_rvalue_reference_t<ZI>>);
+  CHECK(std::forward_iterator<ZI>);
+
+  CHECK(std::indirectly_swappable<ZI, ZI>);
+  CHECK(std::permutable<ZI>);
+  CHECK(!std::sortable<ZI>);
+
+  CHECK(std::sortable<ZI, dummy_compare>);
 }
 
 // Test that the alt_var_length_view value_type satisfies the expected concepts

--- a/tiledb/common/test/unit_sort_zip.cc
+++ b/tiledb/common/test/unit_sort_zip.cc
@@ -1,0 +1,361 @@
+/**
+ * @file   unit_sort_zip.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements unit tests for the sort_zip class.
+ */
+
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <vector>
+#include "../alt_var_length_view.h"
+#include "../zip_view.h"
+
+TEST_CASE("sort_zip: Null test", "[zip_view][null_test]") {
+  REQUIRE(true);
+}
+
+std::vector<double> q = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+std::vector<double> r = {
+    21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
+
+std::vector<size_t> o = {0, 3, 6, 10};
+std::vector<size_t> p = {0, 2, 7, 10};
+
+using avl_test_type =
+    alt_var_length_view<std::vector<double>, std::vector<size_t>>;
+
+TEST_CASE("sort_zip: swap alt_var_length_view", "[zip_view]") {
+  auto a = avl_test_type{q, o};
+  std::swap(a[0], a[1]);
+  CHECK(std::ranges::equal(a[0], std::vector<double>{4.0, 5.0, 6.0}));
+  CHECK(std::ranges::equal(a[1], std::vector<double>{1.0, 2.0, 3.0}));
+
+  std::swap(*(a.begin()), *((a.begin()) + 1));
+  CHECK(std::ranges::equal(a[0], std::vector<double>{1.0, 2.0, 3.0}));
+  CHECK(std::ranges::equal(a[1], std::vector<double>{4.0, 5.0, 6.0}));
+
+  auto x = a.begin();
+  auto y = x + 1;
+  std::swap(*x, *y);
+  CHECK(std::ranges::equal(a[0], std::vector<double>{4.0, 5.0, 6.0}));
+  CHECK(std::ranges::equal(a[1], std::vector<double>{1.0, 2.0, 3.0}));
+
+  auto b = avl_test_type{r, p};
+  std::swap(b[0], b[1]);
+  CHECK(std::ranges::equal(
+      b[0], std::vector<double>{19.0, 18.0, 17.0, 16.0, 15.0}));
+  CHECK(std::ranges::equal(b[1], std::vector<double>{21.0, 20.0}));
+}
+
+TEST_CASE("sort_zip: iter_swap alt_var_length_view", "[zip_view]") {
+  auto a = avl_test_type{q, o};
+  auto a0 = a.begin();
+  auto a1 = a0 + 1;
+  std::iter_swap(a0, a1);
+  CHECK(std::ranges::equal(a0[0], std::vector<double>{4.0, 5.0, 6.0}));
+  CHECK(std::ranges::equal(a0[1], std::vector<double>{1.0, 2.0, 3.0}));
+
+  std::iter_swap(a0, a0 + 1);
+  CHECK(std::ranges::equal(a0[0], std::vector<double>{1.0, 2.0, 3.0}));
+  CHECK(std::ranges::equal(a0[1], std::vector<double>{4.0, 5.0, 6.0}));
+
+  std::swap(*a0, *a1);
+  CHECK(std::ranges::equal(a0[0], std::vector<double>{4.0, 5.0, 6.0}));
+  CHECK(std::ranges::equal(a0[1], std::vector<double>{1.0, 2.0, 3.0}));
+
+  std::swap(*a0, *(a0 + 1));
+  CHECK(std::ranges::equal(a0[0], std::vector<double>{1.0, 2.0, 3.0}));
+  CHECK(std::ranges::equal(a0[1], std::vector<double>{4.0, 5.0, 6.0}));
+
+  auto b = avl_test_type{r, p};
+  auto b0 = b.begin();
+  auto b1 = b0 + 1;
+  std::iter_swap(b0, b1);
+  CHECK(std::ranges::equal(
+      b[0], std::vector<double>{19.0, 18.0, 17.0, 16.0, 15.0}));
+  CHECK(std::ranges::equal(b[1], std::vector<double>{21.0, 20.0}));
+
+  std::iter_swap(b1, b0);
+  CHECK(std::ranges::equal(b[0], std::vector<double>{21.0, 20.0}));
+  CHECK(std::ranges::equal(
+      b[1], std::vector<double>{19.0, 18.0, 17.0, 16.0, 15.0}));
+
+  std::iter_swap(b0, b0);
+  CHECK(std::ranges::equal(b[0], std::vector<double>{21.0, 20.0}));
+  CHECK(std::ranges::equal(
+      b[1], std::vector<double>{19.0, 18.0, 17.0, 16.0, 15.0}));
+
+  std::iter_swap(b1, b1);
+  CHECK(std::ranges::equal(b[0], std::vector<double>{21.0, 20.0}));
+  CHECK(std::ranges::equal(
+      b[1], std::vector<double>{19.0, 18.0, 17.0, 16.0, 15.0}));
+}
+
+TEST_CASE("sort_zip: iter_swap zip view", "[zip_view]") {
+  std::vector<int> a = {1, 2, 3, 4, 5};
+  std::vector<int> b = {5, 4, 3, 2, 1};
+
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<size_t> o = {0, 3, 6, 10};
+  auto v = alt_var_length_view{r, o};
+
+  SECTION("a") {
+    auto z = zip(a);
+    iter_swap(z.begin(), z.begin());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+    auto it = z.begin();
+    iter_swap(it, it + 1);
+    CHECK(a == std::vector<int>{2, 1, 3, 4, 5});
+  }
+  SECTION("a, b") {
+    auto z = zip(a, b);
+    iter_swap(z.begin(), z.begin());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+    CHECK(b == std::vector<int>{5, 4, 3, 2, 1});
+    auto it = z.begin();
+    iter_swap(it, it + 1);
+    CHECK(a == std::vector<int>{2, 1, 3, 4, 5});
+    CHECK(b == std::vector<int>{4, 5, 3, 2, 1});
+    it++;
+    iter_swap(it, it + 1);
+    CHECK(a == std::vector<int>{2, 3, 1, 4, 5});
+    CHECK(b == std::vector<int>{4, 3, 5, 2, 1});
+  }
+  SECTION("a, b, v") {
+    auto z = zip(a, b, v);
+    iter_swap(z.begin(), z.begin());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+    CHECK(b == std::vector<int>{5, 4, 3, 2, 1});
+    CHECK(std::ranges::equal(v[0], std::vector<double>{1.0, 2.0, 3.0}));
+    CHECK(std::ranges::equal(v[1], std::vector<double>{4.0, 5.0, 6.0}));
+    CHECK(std::ranges::equal(v[2], std::vector<double>{7.0, 8.0, 9.0, 10.0}));
+    auto it = z.begin();
+    iter_swap(it, it + 1);
+    CHECK(a == std::vector<int>{2, 1, 3, 4, 5});
+    CHECK(b == std::vector<int>{4, 5, 3, 2, 1});
+    CHECK(std::ranges::equal(v[0], std::vector<double>{4.0, 5.0, 6.0}));
+    CHECK(std::ranges::equal(v[1], std::vector<double>{1.0, 2.0, 3.0}));
+    CHECK(std::ranges::equal(v[2], std::vector<double>{7.0, 8.0, 9.0, 10.0}));
+    it++;
+    iter_swap(it, it + 1);
+    CHECK(a == std::vector<int>{2, 3, 1, 4, 5});
+    CHECK(b == std::vector<int>{4, 3, 5, 2, 1});
+    CHECK(std::ranges::equal(v[0], std::vector<double>{4.0, 5.0, 6.0}));
+    CHECK(std::ranges::equal(v[1], std::vector<double>{7.0, 8.0, 9.0, 10.0}));
+    CHECK(std::ranges::equal(v[2], std::vector<double>{1.0, 2.0, 3.0}));
+  }
+}
+
+template <class Out, class T>
+concept one = requires(Out&& o, T&& t) { *o = std::forward<T>(t); };
+template <class Out, class T>
+concept two =
+    requires(Out&& o, T&& t) { *std::forward<Out>(o) = std::forward<T>(t); };
+template <class Out, class T>
+concept three = requires(Out&& o, T&& t) {
+  const_cast<const std::iter_reference_t<Out>&&>(*o) = std::forward<T>(t);
+};
+template <class Out, class T>
+concept four = requires(Out&& o, T&& t) {
+  const_cast<const std::iter_reference_t<Out>&&>(*std::forward<Out>(o)) =
+      std::forward<T>(t);
+};
+
+TEST_CASE("sort_zip: mini sort zip view", "[zip_view]") {
+  std::vector<int> a = {1, 2, 3, 4, 5};
+  std::vector<int> b = {5, 4, 3, 2, 1};
+
+  SECTION("a") {
+    auto z = zip(a);
+    std::sort(z.begin(), z.end());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+  }
+}
+
+TEST_CASE("sort_zip: range sort zip view concepts", "[zip_view]") {
+  using VI = std::ranges::iterator_t<std::vector<int>>;
+  using ZI = std::ranges::iterator_t<zip_view<std::vector<int>>>;
+
+  CHECK(std::forward_iterator<VI>);
+  CHECK(std::indirectly_movable_storable<VI, VI>);
+  CHECK(std::indirectly_swappable<VI, VI>);
+  CHECK(std::permutable<VI>);
+  CHECK(std::sortable<VI>);
+
+  CHECK(std::indirectly_readable<ZI>);
+
+  // This will work in C++23 but not C++20
+  // Hence, we cannot use std::ranges::sort with zip_view in C++20
+#if 0
+  {
+    int i = 0;
+    using T = std::tuple<int&>;
+
+    auto xx = T{i};
+    const_cast<const std::tuple<int&>&&>(xx) = xx;
+  }
+#endif
+
+  CHECK(one<ZI, std::iter_rvalue_reference_t<ZI>>);
+  CHECK(one<ZI, std::iter_value_t<ZI>>);
+  CHECK(two<ZI, std::iter_rvalue_reference_t<ZI>>);
+  CHECK(two<ZI, std::iter_value_t<ZI>>);
+
+  // These need to pass in order for zip_view to work with std::ranges::sort
+  // (all due to std::tuple issues -- see above)
+  CHECK(!three<ZI, std::iter_rvalue_reference_t<ZI>>);
+  CHECK(!three<ZI, std::iter_value_t<ZI>>);
+  CHECK(!four<ZI, std::iter_rvalue_reference_t<ZI>>);
+  CHECK(!four<ZI, std::iter_value_t<ZI>>);
+
+  // Once three and four don't pass, the following chain will not pass
+  CHECK(!std::indirectly_writable<ZI, std::iter_rvalue_reference_t<ZI>>);
+  CHECK(!std::indirectly_writable<ZI, std::iter_value_t<ZI>>);
+  CHECK(!std::indirectly_movable<ZI, ZI>);
+  CHECK(!std::indirectly_movable_storable<ZI, ZI>);
+  CHECK(!std::permutable<ZI>);
+  CHECK(!std::sortable<ZI>);
+
+  CHECK(std::movable<std::iter_value_t<ZI>>);
+  CHECK(std::constructible_from<
+        std::iter_value_t<ZI>,
+        std::iter_rvalue_reference_t<ZI>>);
+  CHECK(std::assignable_from<
+        std::iter_value_t<ZI>&,
+        std::iter_rvalue_reference_t<ZI>>);
+  CHECK(std::forward_iterator<ZI>);
+  CHECK(std::indirectly_swappable<ZI, ZI>);
+  CHECK(std::is_swappable_v<ZI>);
+}
+
+#if 0
+TEST_CASE("sort_zip: range sort zip view", "[zip_view]") {
+  std::vector<int> a = {1, 2, 3, 4, 5};
+  std::vector<int> b = {5, 4, 3, 2, 1};
+
+  SECTION("a") {
+      auto z = zip(a);
+      std::ranges::sort(z);
+      CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+  }
+}
+#endif
+
+TEST_CASE("sort_zip: swap zip view", "[zip_view]") {
+  std::vector<int> a = {1, 2, 3, 4, 5};
+  std::vector<int> b = {5, 4, 3, 2, 1};
+  auto z0 = zip(a);
+
+  swap(z0[0], z0[1]);
+  CHECK(a == std::vector<int>{2, 1, 3, 4, 5});
+  CHECK(b == std::vector<int>{5, 4, 3, 2, 1});
+
+  auto z1 = zip(a, b);
+  swap(z1[2], z1[3]);
+  CHECK(a == std::vector<int>{2, 1, 4, 3, 5});
+  CHECK(b == std::vector<int>{5, 4, 2, 3, 1});
+}
+
+TEST_CASE("sort_zip: mini iter_swap zip view", "[zip_view]") {
+  std::vector<int> a = {1, 2, 3, 4, 5};
+  std::vector<int> b = {5, 4, 3, 2, 1};
+  auto z0 = zip(a);
+  auto z00 = z0.begin();
+  auto z01 = z00 + 1;
+
+  iter_swap(z00, z01);
+  CHECK(a == std::vector<int>{2, 1, 3, 4, 5});
+  CHECK(b == std::vector<int>{5, 4, 3, 2, 1});
+
+  auto z1 = zip(a, b);
+  swap(z1[2], z1[3]);
+  CHECK(a == std::vector<int>{2, 1, 4, 3, 5});
+  CHECK(b == std::vector<int>{5, 4, 2, 3, 1});
+}
+
+TEST_CASE("sort_zip: sort zip view", "[zip_view]") {
+  std::vector<int> a = {1, 2, 3, 4, 5};
+  std::vector<int> b = {5, 4, 3, 2, 1};
+
+  SECTION("a") {
+    auto z = zip(a);
+    std::sort(z.begin(), z.end());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+  }
+  SECTION("b") {
+    auto z = zip(b);
+    std::sort(z.begin(), z.end());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+  }
+  SECTION("a, b") {
+    auto z = zip(a, b);
+    std::sort(z.begin(), z.end());
+    CHECK(a == std::vector<int>{1, 2, 3, 4, 5});
+    CHECK(b == std::vector<int>{5, 4, 3, 2, 1});
+  }
+  SECTION("b, a") {
+    auto z = zip(b, a);
+    std::sort(z.begin(), z.end());
+    CHECK(a == std::vector<int>{5, 4, 3, 2, 1});
+    CHECK(b == std::vector<int>{1, 2, 3, 4, 5});
+  }
+}
+
+TEST_CASE(
+    "sort_zip: sort zip view containing alt_var_length_view", "[zip_view]") {
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<size_t> o = {0, 3, 6, 10};
+  auto v = alt_var_length_view{r, o};
+  std::vector<int> a{8, 6, 7};
+
+  auto z = zip(a, v);
+  std::sort(z.begin(), z.end(), [](const auto& x, const auto& y) {
+    return std::get<0>(x) < std::get<0>(y);
+  });
+  CHECK(a == std::vector<int>{6, 7, 8});
+  CHECK(std::ranges::equal(v[0], std::vector<double>{4.0, 5.0, 6.0}));
+  CHECK(std::ranges::equal(v[1], std::vector<double>{7.0, 8.0, 9.0, 10.0}));
+  CHECK(std::ranges::equal(v[2], std::vector<double>{1.0, 2.0, 3.0}));
+}
+
+TEST_CASE("sort_zip: sort zip view using alt_var_length_view", "[zip_view]") {
+  std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<size_t> o = {0, 3, 6, 10};
+  auto v = alt_var_length_view{r, o};
+  std::vector<int> a{8, 6, 7};
+
+  auto z = zip(a, v);
+  std::sort(z.begin(), z.end(), [](const auto& x, const auto& y) {
+    return std::get<1>(x)[0] > std::get<1>(y)[0];
+  });
+  CHECK(a == std::vector<int>{7, 6, 8});
+  CHECK(std::ranges::equal(v[0], std::vector<double>{7.0, 8.0, 9.0, 10.0}));
+  CHECK(std::ranges::equal(v[1], std::vector<double>{4.0, 5.0, 6.0}));
+  CHECK(std::ranges::equal(v[2], std::vector<double>{1.0, 2.0, 3.0}));
+}


### PR DESCRIPTION
This PR stacks on #4930.  The actual code for implementing the PR is fairly small, but with extensive unit tests.

The PR contains `swap` function for `zip_view` in order to be able to use `std::sort` on a `zip_view`.  The difficulty is that dereferencing a `zip_view` iterator returns a proxy, specifically a tuple of references.  In order to enable `swap` to be found for this via ADL, we write
```c++
template <class... Ts>
  requires(std::is_swappable<Ts>::value && ...)
void swap(std::tuple<Ts...>&& x, std::tuple<Ts...>&& y) {
  using std::get;
  using std::swap;
  [&]<std::size_t... i>(std::index_sequence<i...>) {
    (swap(get<i>(x), get<i>(y)), ...);
  }(std::make_index_sequence<sizeof...(Ts)>());
}
```
and then put it into the `std` namespace:
```c++
namespace std {
using ::swap;
}
```

The provided unit tests exercise `swap`, `iter_swap`, and `sort`, including on `zip_view`s containing `alt_var_length_view`s.

(NOTE:  I didn't specifically write an `item_swap` as `std::iter_swap` falls back to `swap`.)

The PR also changes `alt_var_length_view` and `zip_view` to derive from `std::ranges::view_interface` rather than `std::ranges::view_base` in order to automagically get `operator[]` for the view.

NOTES:
1. Not all implementations of `std::sort` use `std::swap` for all problem sizes, but will use insertion sort instead for small sizes.
2. For insertion sort to work properly with a tuple of references, i.e., a proxy, it is important to get all of the details of `value_type` and `reference` correct.  There was a bug that took a while to track down of `value_type` not being defined in the `zip_iterator`.  The `iterator_facade` will create the wrong default thing.

---
TYPE: IMPROVEMENT
DESC: Write iter_swap for zip_view for external sort.
