### PR TITLE
Implement proxy sort permutation for external sort.

### DIFF
--- a/tiledb/common/permutation_view.h
+++ b/tiledb/common/permutation_view.h
@@ -35,6 +35,14 @@
  * the data range.  For a data range `r` and a permutation `p`, and a
  * permutation_view `v`, based on `r` and `p`, the expression `v[i]` is
  * equivalent to `r[p[i]]`.
+ *
+ * To create an inverse permutation:
+ *
+ * std::vector<int> perm(N);
+ * proxy_sort(shuffled, perm);
+ *
+ * std::vector<int> i_perm(N);
+ * proxy_sort(perm, i_perm);
  */
 
 #ifndef TILEDB_PERMUTATION_VIEW_H
@@ -43,6 +51,7 @@
 #include <cassert>
 #include <ranges>
 #include "iterator_facade.h"
+#include "proxy_sort.h"
 
 /**
  * A view that creates a permutation of the underlying view, as determined by
@@ -52,30 +61,32 @@
  * @tparam P Type of the index range, assumed to be a random access range.
  *
  * @todo R could be a view rather than a range.
+ * @todo Implement with view_interface.
  */
 template <
-    std::ranges::random_access_range R,
-    std::ranges::random_access_range P>
-class permutation_view : public std::ranges::view_base {
+    std::ranges::random_access_range ElementRange,
+    std::ranges::random_access_range IndexRange>
+class permutation_view : public std::ranges::view_interface<
+                             permutation_view<ElementRange, IndexRange>> {
   /** Forward reference of the iterator over the range of permuted data. */
   template <class Reference>
   struct private_iterator;
 
   /** The data type of the permutation view. */
-  using data_iterator_type = std::ranges::iterator_t<R>;
+  using data_iterator_type = std::ranges::iterator_t<ElementRange>;
 
   /** The index type of the permutation view indexing into underlying range. */
   using data_index_type = std::iter_difference_t<data_iterator_type>;
 
   /** The type of the iterator over the index range -- It should derference to
    * something that can index into the data range (e.g., the data_index_type)*/
-  using index_iterator_type = std::ranges::iterator_t<const P>;
+  using index_iterator_type = std::ranges::iterator_t<IndexRange>;
 
-  /** The value_type dereferenced by the iterator is the value_type R */
-  using permuted_value_type = std::ranges::range_value_t<R>;
+  /** The permuted view value_type is value_type of ElementRange */
+  using permuted_value_type = std::ranges::range_value_t<ElementRange>;
 
-  /** The value_type dereferenced by the iterator is the value_type R */
-  using permuted_reference = std::ranges::range_reference_t<R>;
+  /** The permuted view reference is the reference type of ElementRange */
+  using permuted_reference = std::ranges::range_reference_t<ElementRange>;
 
   /** The type of the iterator over the permuted data range */
   using permuted_iterator = private_iterator<permuted_reference>;
@@ -84,8 +95,11 @@ class permutation_view : public std::ranges::view_base {
   using permuted_const_iterator = private_iterator<permuted_value_type const>;
 
  public:
-  /** Primary constructor */
-  permutation_view(R& data, const P& permutation)
+  /**
+   * Primary constructor
+   * @note IndexRange is not const
+   */
+  permutation_view(ElementRange& data, IndexRange& permutation)
       : data_begin_(std::ranges::begin(data))
       , data_end_(std::ranges::end(data))
       , index_begin_(std::ranges::begin(permutation))
@@ -130,7 +144,7 @@ class permutation_view : public std::ranges::view_base {
   }
 
   /** Size of the permutation view */
-  auto size() const {
+  size_t size() const {
     return data_end_ - data_begin_;
   }
 
@@ -138,6 +152,115 @@ class permutation_view : public std::ranges::view_base {
   auto& operator[](size_t i) const {
     // More general? return *(data_begin_ + *(index_begin_ + i));
     return data_begin_[index_begin_[i]];
+  }
+
+  /*****************************************************************************
+   * Member functions for sorting the permutation view.  These will sort the
+   * permutation view with the type given of the data range.  If this is a
+   * tuple, it will sort based on the first element, then the second, etc.
+   * @note These functions are not part of the view interface
+   * @todo Add variants to sort tuple based on given indexes, rather than by
+   * default order
+   ****************************************************************************/
+
+  /**
+   * Apply `proxy_sort` to the permutation view.  This will permute the index
+   * range so that the indexed data range is sorted. The index range will be
+   * initialized with the identity permutation.
+   */
+  void proxy_sort() {
+    ::proxy_sort(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_));
+  }
+
+  /**
+   * Apply `proxy_sort_no_init` to the permutation view.  This will permute the
+   * index range so that the indexed data range is sorted.  The index range is
+   * assumed to be a valid permutation of [0, data.size())
+   */
+  void proxy_sort_no_init() {
+    ::proxy_sort_no_init(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_));
+  }
+
+  /**
+   * Apply `proxy_sort` to the permutation view.  This will permute the index
+   * range so that the indexed data range is sorted based on the comparison
+   * functor `cmp`. The index range will be initialized with the identity
+   * permutation.
+   */
+  template <class Compare>
+  void proxy_sort(Compare comp) {
+    ::proxy_sort(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_),
+        comp);
+  }
+
+  /**
+   * Apply `proxy_sort` to the permutation view.  This will permute the index
+   * range so that the indexed data range is sorted based on the comparison
+   * functor `cmp`. The index range is assumed to be a valid permutation of [0,
+   * data.size())
+   */
+  template <class Compare>
+  void proxy_sort_no_init(Compare comp) {
+    ::proxy_sort_no_init(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_),
+        comp);
+  }
+
+  /**
+   * Apply `stable_proxy_sort` to the permutation view.  This will permute the
+   * index range so that the indexed data range is sorted. The index range will
+   * be initialized with the identity permutation.
+   */
+  void stable_proxy_sort() {
+    ::stable_proxy_sort(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_));
+  }
+
+  /**
+   * Apply `stable_proxy_sort_no_init` to the permutation view.  This will
+   * permute the index range so that the indexed data range is sorted.  The
+   * index range is assumed to be a valid permutation of [0, data.size())
+   */
+  void stable_proxy_sort_no_init() {
+    ::stable_proxy_sort_no_init(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_));
+  }
+
+  /**
+   * Apply `stable_proxy_sort` to the permutation view.  This will permute the
+   * index range so that the indexed data range is sorted based on the
+   * comparison functor `cmp`. The index range will be initialized with the
+   * identity permutation.
+   */
+  template <class Compare>
+  void stable_proxy_sort(Compare comp) {
+    ::stable_proxy_sort(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_),
+        comp);
+  }
+
+  /**
+   * Apply `stable_proxy_sort` to the permutation view.  This will permute the
+   * index range so that the indexed data range is sorted based on the
+   * comparison functor `cmp`. The index range is assumed to be a valid
+   * permutation of [0, data.size())
+   */
+  template <class Compare>
+  void stable_proxy_sort_no_init(Compare comp) {
+    ::stable_proxy_sort_no_init(
+        std::ranges::subrange(data_begin_, data_end_),
+        std::ranges::subrange(index_begin_, index_end_),
+        comp);
   }
 
  private:
@@ -210,17 +333,202 @@ class permutation_view : public std::ranges::view_base {
   };
 
   /** Iterator to the beginning of the data range */
-  std::ranges::iterator_t<R> data_begin_;
+  data_iterator_type data_begin_;
 
   /** Iterator to the end of the data range */
-  std::ranges::iterator_t<R> data_end_;
+  data_iterator_type data_end_;
 
   /** const_iterator is c++23.  For now we just use an iterator to const */
   /** Iterator to the beginning of the index range */
-  std::ranges::iterator_t<const P> index_begin_;
+  index_iterator_type index_begin_;
 
   /** Iterator to the end of the index range */
-  std::ranges::iterator_t<const P> index_end_;
+  index_iterator_type index_end_;
 };
 
+/**
+ * Overload of `proxy_sort` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @param x permutation_view to be sorted
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P>
+void proxy_sort_no_init(permutation_view<R, P>& x) {
+  x.proxy_sort_no_init();
+}
+
+/**
+ * Overload of `proxy_sort_no_init` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @param x permutation_view to be sorted
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P>
+void proxy_sort(permutation_view<R, P>& x) {
+  x.proxy_sort();
+}
+
+/**
+ * Overload of `proxy_sort` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @tparam Compare Type of comparison function
+ * @param x permutation_view to be sorted
+ * @param comp Comparison function
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P,
+    class Compare>
+void proxy_sort_no_init(permutation_view<R, P>& x, Compare comp) {
+  x.proxy_sort_no_init(comp);
+}
+
+/**
+ * Overload of `proxy_sort_no_init` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @tparam Compare Type of comparison function
+ * @param x permutation_view to be sorted
+ * @param comp Comparison function
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P,
+    class Compare>
+void proxy_sort(permutation_view<R, P>& x, Compare comp) {
+  x.proxy_sort(comp);
+}
+
+/**
+ * Overload of `stable_proxy_sort` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @param x permutation_view to be sorted
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P>
+void stable_proxy_sort_no_init(permutation_view<R, P>& x) {
+  x.stable_proxy_sort_no_init();
+}
+
+/**
+ * Overload of `stable_proxy_sort_no_init` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @param x permutation_view to be sorted
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P>
+void stable_proxy_sort(permutation_view<R, P>& x) {
+  x.stable_proxy_sort();
+}
+
+/**
+ * Overload of `stable_proxy_sort` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @tparam Compare Type of comparison function
+ * @param x permutation_view to be sorted
+ * @param comp Comparison function
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P,
+    class Compare>
+void stable_proxy_sort_no_init(permutation_view<R, P>& x, Compare comp) {
+  x.stable_proxy_sort_no_init(comp);
+}
+
+/**
+ * Overload of `stable_proxy_sort_no_init` for permutation_view.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @tparam Compare Type of comparison function
+ * @param x permutation_view to be sorted
+ * @param comp Comparison function
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P,
+    class Compare>
+void stable_proxy_sort(permutation_view<R, P>& x, Compare comp) {
+  x.stable_proxy_sort(comp);
+}
+
+/**
+ * Overloads of `std::sort` for permutation_view. We take the view "as-is",
+ * i.e., we use `proxy_sort_no_init` to do the sorting.
+ */
+namespace std {
+
+/**
+ * Overload of `std::sort` for permutation_view.  We take the view "as-is",
+ * i.e., we use `proxy_sort_no_init` to do the sorting.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @param x permutation_view to be sorted
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P>
+void sort(permutation_view<R, P>& x) {
+  x.proxy_sort_no_init();
+}
+
+/**
+ * Overload of `std::sort` for permutation_view.  We take the view "as-is",
+ * i.e., we use `proxy_sort_no_init` to do the sorting.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @tparam Compare Type of comparison function
+ * @param x permutation_view to be sorted
+ * @param comp Comparison function
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P,
+    class Compare>
+void sort(permutation_view<R, P>& x, Compare comp) {
+  x.proxy_sort_no_init(comp);
+}
+
+/**
+ * Overload of `std::stable_sort` for permutation_view.  We take the view
+ * "as-is", i.e., we use `proxy_sort_no_init` to do the sorting.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @param x permutation_view to be sorted
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P>
+void stable_sort(permutation_view<R, P>& x) {
+  x.stable_proxy_sort_no_init();
+}
+
+/**
+ * Overload of `std::stable_sort` for permutation_view.  We take the view
+ * "as-is", i.e., we use `proxy_sort_no_init` to do the sorting.
+ * @tparam R Type of data range
+ * @tparam P Type of permutation range
+ * @tparam Compare Type of comparison function
+ * @param x permutation_view to be sorted
+ * @param comp Comparison function
+ */
+template <
+    std::ranges::random_access_range R,
+    std::ranges::random_access_range P,
+    class Compare>
+void stable_sort(permutation_view<R, P>& x, Compare comp) {
+  x.stable_proxy_sort_no_init(comp);
+}
+
+}  // namespace std
 #endif  // TILEDB_PERMUTATION_VIEW_H

--- a/tiledb/common/proxy_sort.h
+++ b/tiledb/common/proxy_sort.h
@@ -79,10 +79,12 @@
 template <
     std::ranges::random_access_range R,
     std::ranges::random_access_range I>
-void proxy_sort_no_init(const R& x, I& perm) {
+void proxy_sort_no_init(const R& x, I&& perm) {
   assert(perm.size() == x.size());
   std::sort(
-      perm.begin(), perm.end(), [&](auto a, auto b) { return x[a] < x[b]; });
+      std::forward<I>(perm).begin(),
+      std::forward<I>(perm).end(),
+      [&](auto a, auto b) { return x[a] < x[b]; });
 }
 
 /**
@@ -98,10 +100,10 @@ void proxy_sort_no_init(const R& x, I& perm) {
 template <
     std::ranges::random_access_range R,
     std::ranges::random_access_range I>
-void proxy_sort(const R& x, I& perm) {
+void proxy_sort(R&& x, I&& perm) {
   assert(perm.size() == x.size());
   std::iota(perm.begin(), perm.end(), 0);
-  proxy_sort_no_init(x, perm);
+  proxy_sort_no_init(std::forward<R>(x), std::forward<I>(perm));
 }
 
 /**
@@ -120,11 +122,12 @@ template <
     std::ranges::random_access_range R,
     std::ranges::random_access_range I,
     class Compare>
-void proxy_sort_no_init(const R& x, I& perm, Compare comp) {
+void proxy_sort_no_init(const R& x, I&& perm, Compare comp) {
   assert(perm.size() == x.size());
-  std::sort(perm.begin(), perm.end(), [&](auto a, auto b) {
-    return comp(x[a], x[b]);
-  });
+  std::sort(
+      std::forward<I>(perm).begin(),
+      std::forward<I>(perm).end(),
+      [&](auto a, auto b) { return comp(x[a], x[b]); });
 }
 
 /**
@@ -143,10 +146,10 @@ template <
     std::ranges::random_access_range R,
     std::ranges::random_access_range I,
     class Compare>
-void proxy_sort(const R& x, I& perm, Compare comp) {
+void proxy_sort(R&& x, I&& perm, Compare comp) {
   assert(perm.size() == x.size());
   std::iota(perm.begin(), perm.end(), 0);
-  proxy_sort_no_init(x, perm, comp);
+  proxy_sort_no_init(std::forward<R>(x), std::forward<I>(perm), comp);
 }
 
 /**

--- a/tiledb/common/test/CMakeLists.txt
+++ b/tiledb/common/test/CMakeLists.txt
@@ -42,7 +42,7 @@ commence(unit_test memory_tracker_types)
 conclude(unit_test)
 
 commence(unit_test common_utils)
-    this_target_sources(main.cc unit_alt_var_length_view.cc unit_iterator_facade.cc unit_permutation_view.cc unit_proxy_sort.cc unit_sort_zip.cc unit_var_length_view.cc unit_zip_view.cc)
+    this_target_sources(main.cc unit_alt_var_length_view.cc unit_iterator_facade.cc unit_permutation_sort.cc unit_permutation_view.cc unit_proxy_sort.cc unit_sort_zip.cc unit_var_length_view.cc unit_zip_view.cc)
     this_target_object_libraries(baseline)
 conclude(unit_test)
 

--- a/tiledb/common/test/unit_permutation_sort.cc
+++ b/tiledb/common/test/unit_permutation_sort.cc
@@ -1,0 +1,341 @@
+/**
+ * @file   unit_permutation_sort.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements unit tests for sorting for/with a permutation view.
+ */
+
+#include <algorithm>
+#include <catch2/catch_all.hpp>
+#include <iostream>
+#include <random>
+#include <ranges>
+#include <vector>
+#include "../alt_var_length_view.h"
+#include "../permutation_view.h"
+#include "../proxy_sort.h"
+#include "../var_length_view.h"
+#include "../zip_view.h"
+
+TEST_CASE("permutation_sort: Null test", "[permutation_sort][null_test]") {
+  REQUIRE(true);
+}
+
+TEST_CASE("permutation_sort: integers", "[permutation_sort]") {
+  size_t seed = Catch::rngSeed();
+  size_t N = 100'000;
+  std::mt19937 g(seed);
+
+  std::vector<int> init(N);
+  std::iota(begin(init), end(init), 0);
+
+  std::vector<int> perm(N);
+  std::iota(begin(perm), end(perm), 0);
+
+  auto init_19 = std::vector<int>(N);
+  std::iota(begin(init_19), end(init_19), 19);
+
+  std::vector<int> unshuffled(init);
+  std::vector<int> shuffled(unshuffled);
+
+  std::shuffle(shuffled.begin(), shuffled.end(), g);
+  std::vector<int> shuffled_copy(shuffled);
+
+  /* Sort the shuffled vector */
+  proxy_sort_no_init(shuffled, perm);
+
+  /* Generate the inverse permutation */
+  std::vector<int> i_perm(init);
+  proxy_sort_no_init(perm, i_perm);
+
+  SECTION("check setup") {
+    CHECK(!std::equal(shuffled.begin(), shuffled.end(), unshuffled.begin()));
+    CHECK(std::equal(shuffled.begin(), shuffled.end(), shuffled_copy.begin()));
+
+    auto b = permutation_view(init_19, perm);
+    CHECK(std::equal(b.begin(), b.end(), perm.begin(), [](auto a, auto b) {
+      return a == b + 19;
+    }));
+
+    auto yy = permutation_view(shuffled, perm);  // -> unshuffled
+    auto zz = permutation_view(yy, i_perm);      // -> shuffled
+    CHECK(std::equal(begin(zz), end(zz), begin(shuffled)));
+  }
+
+  SECTION("sort, permute") {
+    auto x = permutation_view(shuffled, perm);
+    CHECK(std::equal(x.begin(), x.end(), unshuffled.begin()));
+    CHECK(std::equal(shuffled.begin(), shuffled.end(), shuffled_copy.begin()));
+  }
+
+  SECTION("sort, permute, zip") {
+    /* Create permutation view */
+    auto x = permutation_view(shuffled, perm);
+
+    /* Zip permutation view with init_19 */
+    auto z = zip(x, init_19);
+
+    /* First component of z should appear to be unshuffled */
+    CHECK(std::equal(begin(z), z.end(), begin(unshuffled), [](auto a, auto b) {
+      return std::get<0>(a) == b;
+    }));
+
+    CHECK(std::equal(begin(z), end(z), begin(init), [](auto a, auto b) {
+      return std::get<1>(a) == b + 19;
+    }));
+  }
+
+  SECTION("sort, zip, permute") {
+    /* Zip shuffled with init_19 */
+    auto z = zip(shuffled, init_19);
+
+    /* Permute the zipped view */
+    auto x = permutation_view(z, perm);
+
+    /* First component of x should appear to be unshuffled */
+    CHECK(std::equal(begin(x), end(x), begin(unshuffled), [](auto a, auto b) {
+      return std::get<0>(a) == b;
+    }));
+
+    CHECK(std::equal(begin(x), end(x), begin(perm), [](auto a, auto b) {
+      return std::get<1>(a) == b + 19;
+    }));
+  }
+
+  SECTION("sort, permute, inv_permute") {
+    /* Create permutation view */
+    auto x = permutation_view(shuffled, perm);
+
+    /* Inverse permute the permutation view */
+    auto y = permutation_view(x, i_perm);
+
+    /* y should appear to be shuffled */
+    CHECK(std::equal(begin(y), end(y), begin(shuffled)));
+  }
+}
+
+TEST_CASE("permutation_sort: multiple integers", "[permutation_sort]") {
+  size_t seed = Catch::rngSeed();
+  size_t N = 100'000;
+  std::mt19937 g(seed);
+
+  std::vector<int> init(N);
+  std::iota(begin(init), end(init), 0);
+
+  auto x = std::vector<std::vector<int>>(7, std::vector<int>(init));
+  for (auto& v : x) {
+    std::shuffle(begin(v), end(v), g);
+  }
+
+  auto perm = std::vector<std::vector<int>>(7, std::vector<int>(init));
+  for (size_t i = 0; i < size(x); ++i) {
+    proxy_sort(x[i], perm[i]);
+  }
+
+  auto i_perm = std::vector<std::vector<int>>(7, std::vector<int>(init));
+  for (size_t i = 0; i < size(perm); ++i) {
+    proxy_sort(perm[i], i_perm[i]);
+  }
+
+  SECTION("check setup") {
+    for (size_t i = 0; i < size(x); ++i) {
+      auto a = permutation_view(x[i], perm[i]);
+      CHECK(std::equal(begin(a), end(a), begin(init)));
+
+      auto b = permutation_view(a, i_perm[i]);
+      CHECK(std::equal(begin(b), end(b), begin(x[i])));
+    }
+  }
+
+  SECTION("sort, zip, permute some") {
+    /* Zip shuffled with init_19 */
+    auto z = zip(x[0], x[1], x[2], x[3], x[4], x[5], x[6]);
+
+    /* Permute the zipped view */
+    auto x = permutation_view(z, perm[0]);
+
+    /* First component of x should appear to be unshuffled */
+    CHECK(std::equal(begin(x), end(x), begin(init), [](auto a, auto b) {
+      return std::get<0>(a) == b;
+    }));
+  }
+
+  SECTION("sort, zip, permute all") {
+    for (size_t j = 0; j < size(x); ++j) {
+      auto z =
+          zip(x[j % 7],
+              x[(j + 1) % 7],
+              x[(j + 2) % 7],
+              x[(j + 3) % 7],
+              x[(j + 4) % 7],
+              x[(j + 5) % 7],
+              x[(j + 6) % 7]);
+
+      auto p0 = permutation_view(z, perm[j % 7]);
+      CHECK(std::equal(begin(p0), end(p0), begin(init), [](auto a, auto b) {
+        return std::get<0>(a) == b;
+      }));
+      auto p1 = permutation_view(z, perm[(j + 1) % 7]);
+      CHECK(std::equal(begin(p1), end(p1), begin(init), [](auto a, auto b) {
+        return std::get<1>(a) == b;
+      }));
+      auto p2 = permutation_view(z, perm[(j + 2) % 7]);
+      CHECK(std::equal(begin(p2), end(p2), begin(init), [](auto a, auto b) {
+        return std::get<2>(a) == b;
+      }));
+      auto p3 = permutation_view(z, perm[(j + 3) % 7]);
+      CHECK(std::equal(begin(p3), end(p3), begin(init), [](auto a, auto b) {
+        return std::get<3>(a) == b;
+      }));
+      auto p4 = permutation_view(z, perm[(j + 4) % 7]);
+      CHECK(std::equal(begin(p4), end(p4), begin(init), [](auto a, auto b) {
+        return std::get<4>(a) == b;
+      }));
+      auto p5 = permutation_view(z, perm[(j + 5) % 7]);
+      CHECK(std::equal(begin(p5), end(p5), begin(init), [](auto a, auto b) {
+        return std::get<5>(a) == b;
+      }));
+      auto p6 = permutation_view(z, perm[(j + 6) % 7]);
+      CHECK(std::equal(begin(p6), end(p6), begin(init), [](auto a, auto b) {
+        return std::get<6>(a) == b;
+      }));
+    }
+  }
+}
+
+TEST_CASE(
+    "permutation_sort: direct proxy_sort multiple integers",
+    "[permutation_sort]") {
+  size_t seed = Catch::rngSeed();
+  size_t N = 100'000;
+  std::mt19937 g(seed);
+
+  std::vector<int> init(N);
+  std::iota(begin(init), end(init), 0);
+
+  auto x = std::vector<std::vector<int>>(7, std::vector<int>(init));
+  for (auto& v : x) {
+    std::shuffle(begin(v), end(v), g);
+  }
+
+  CHECK(!std::equal(begin(x[0]), end(x[0]), begin(init)));
+
+  auto perm = std::vector<std::vector<int>>(7, std::vector<int>(init));
+  auto i_perm = std::vector<std::vector<int>>(7, std::vector<int>(init));
+
+  SECTION("zip, sort some") {
+    /* Zip shuffled with init_19 */
+    auto z = zip(x[0], x[1], x[2], x[3], x[4], x[5], x[6]);
+
+    /* Create permutation view with zipped view */
+    auto x = permutation_view(z, perm[0]);
+
+    SECTION("less") {
+      SECTION("x.proxy_sort_no_init") {
+        x.proxy_sort_no_init();
+      }
+      SECTION("x.proxy_sort_") {
+        x.proxy_sort();
+      }
+
+      SECTION("x.proxy_sort_no_init") {
+        x.proxy_sort_no_init(std::less<>());
+      }
+      SECTION("x.proxy_sort_") {
+        x.proxy_sort(std::less<>());
+      }
+      SECTION("x.proxy_sort_no_init") {
+        proxy_sort_no_init(x);
+      }
+      SECTION("x.proxy_sort_") {
+        proxy_sort(x);
+      }
+      SECTION("x.proxy_sort_no_init") {
+        proxy_sort_no_init(x, std::less<>());
+      }
+      SECTION("x.proxy_sort_") {
+        proxy_sort(x, std::less<>());
+      }
+      SECTION("std::sort") {
+        std::sort(x);
+      }
+      SECTION("std::sort") {
+        std::sort(x, std::less<>());
+      }
+
+      /* First component of x should appear to be unshuffled */
+      CHECK(std::equal(begin(x), end(x), begin(init), [](auto a, auto b) {
+        return std::get<0>(a) == b;
+      }));
+    }
+    SECTION("greater") {
+      auto reverse_index = std::vector<int>(init);
+      std::ranges::reverse(reverse_index);
+      SECTION("x.proxy_sort_no_init") {
+        x.proxy_sort_no_init(std::greater<>());
+      }
+      SECTION("x.proxy_sort_") {
+        x.proxy_sort(std::greater<>());
+      }
+      SECTION("x.proxy_sort_no_init") {
+        proxy_sort_no_init(x, std::greater<>());
+      }
+      SECTION("x.proxy_sort_") {
+        proxy_sort(x, std::greater<>());
+      }
+      SECTION("std::sort") {
+        std::sort(x, std::greater<>());
+      }
+
+      /* First component of x should appear to be unshuffled */
+      CHECK(std::equal(
+          begin(x), end(x), begin(reverse_index), [](auto a, auto b) {
+            return std::get<0>(a) == b;
+          }));
+    }
+  }
+
+  SECTION("sort, zip, permute all") {
+    for (size_t j = 0; j < size(x); ++j) {
+      auto z =
+          zip(x[j % 7],
+              x[(j + 1) % 7],
+              x[(j + 2) % 7],
+              x[(j + 3) % 7],
+              x[(j + 4) % 7],
+              x[(j + 5) % 7],
+              x[(j + 6) % 7]);
+
+      auto v = permutation_view(z, perm[0]);
+      proxy_sort(v);
+      CHECK(std::equal(begin(v), end(v), begin(init), [](auto a, auto b) {
+        return std::get<0>(a) == b;
+      }));
+    }
+  }
+}

--- a/tiledb/common/test/unit_sort_zip.cc
+++ b/tiledb/common/test/unit_sort_zip.cc
@@ -40,17 +40,17 @@ TEST_CASE("sort_zip: Null test", "[zip_view][null_test]") {
   REQUIRE(true);
 }
 
-std::vector<double> q = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
-std::vector<double> r = {
-    21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
-
-std::vector<size_t> o = {0, 3, 6, 10};
-std::vector<size_t> p = {0, 2, 7, 10};
-
 using avl_test_type =
     alt_var_length_view<std::vector<double>, std::vector<size_t>>;
 
 TEST_CASE("sort_zip: swap alt_var_length_view", "[zip_view]") {
+  std::vector<double> q = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<double> r = {
+      21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
+
+  std::vector<size_t> o = {0, 3, 6, 10};
+  std::vector<size_t> p = {0, 2, 7, 10};
+
   auto a = avl_test_type{q, o};
   std::swap(a[0], a[1]);
   CHECK(std::ranges::equal(a[0], std::vector<double>{4.0, 5.0, 6.0}));
@@ -74,6 +74,13 @@ TEST_CASE("sort_zip: swap alt_var_length_view", "[zip_view]") {
 }
 
 TEST_CASE("sort_zip: iter_swap alt_var_length_view", "[zip_view]") {
+  std::vector<double> q = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+  std::vector<double> r = {
+      21.0, 20.0, 19.0, 18.0, 17.0, 16.0, 15.0, 14.0, 13.0, 12.0};
+
+  std::vector<size_t> o = {0, 3, 6, 10};
+  std::vector<size_t> p = {0, 2, 7, 10};
+
   auto a = avl_test_type{q, o};
   auto a0 = a.begin();
   auto a1 = a0 + 1;

--- a/tiledb/common/test/unit_zip_view.cc
+++ b/tiledb/common/test/unit_zip_view.cc
@@ -46,7 +46,8 @@ TEST_CASE("zip_view: Should not copy", "[zip_view]") {
     explicit foo(int N)
         : std::vector<int>(N) {
     }
-    foo(const foo&) {
+    foo(const foo&)
+        : std::vector<int>() {
       CHECK(false);
       CHECK(true);
     }

--- a/tiledb/common/test/unit_zip_view.cc
+++ b/tiledb/common/test/unit_zip_view.cc
@@ -41,6 +41,28 @@ TEST_CASE("zip_view: Null test", "[zip_view][null_test]") {
   REQUIRE(true);
 }
 
+TEST_CASE("zip_view: Should not copy", "[zip_view]") {
+  struct foo : public std::vector<int> {
+    explicit foo(int N)
+        : std::vector<int>(N) {
+    }
+    foo(const foo&) {
+      CHECK(false);
+      CHECK(true);
+    }
+    foo(foo&&) = delete;
+    foo& operator=(foo&) = delete;
+    foo& operator=(foo&&) = delete;
+    foo() = delete;
+    ~foo() = default;
+  };
+
+  auto f = foo(10);
+  auto g = foo(10);
+  auto h = foo(10);
+  [[maybe_unused]] auto z = zip(f, g, h);
+}
+
 /** Test that the zip_view type satisfies the expected range concepts */
 TEST_CASE("zip_view: Range concepts", "[zip_view][concepts]") {
   using test_type = zip_view<std::vector<double>, std::vector<int>>;
@@ -230,6 +252,7 @@ TEST_CASE("zip_view: basic iterator properties", "[zip_view]") {
 
   auto z = zip(a, b, c);
   auto it = z.begin();
+  CHECK(it == begin(z));
   auto it2 = z.begin();
   CHECK(it == it2);
   CHECK(*it == *it2);
@@ -239,6 +262,7 @@ TEST_CASE("zip_view: basic iterator properties", "[zip_view]") {
   CHECK(it == it2);
   CHECK(*it == *it2);
   auto jt = z.end();
+  CHECK(jt == end(z));
   CHECK(it != jt);
   CHECK(it < jt);
   CHECK(it <= jt);


### PR DESCRIPTION
This PR implements proxy sorting for `permutation_view`.  The goal is to be able to efficiently sort a `zip_view` containing a number of ranges.

With the PR, we can sort a zipped `permutation_view` as follows:
```c++
  auto z = zip(u, v, w, x);
  auto p = permutation_view(z);
  sort(p);
```
resulting in `z` being sorted along `u` (then `v`, etc).

Because the iterator for `permutation_view` only returns a value, with no information about the index, we can't sort a `permutation_view` directly with, e.g., `std::sort`.  To enable sorting, we instead provide sorting member functions to the `permutation_view` and have free functions that are overloaded on `permutation_view`  invoke the member functions.

The functions added include
* proxy sort member functions in `permutation_view` with `_no_init`, `stable_`, and comparison function variants.
* proxy sort free functions overloaded on `permutation_view` with variants as above
* Overloads of `std::sort` and `std::stable_sort`.  These invoke the `no_init` member function, the assumption being that we just want to stack permutations on top of each other.

Since the `proxy_sort` functions mutate the indexes in the `permutation_view`, the interfaces to the existing `proxy_sort` function were updated to take a forwarding reference.

A few notes:
* Sorting a `permutation_view` will mutate the underlying permutation index range.  Right now, the permutation view is just a view over two containers (the one to be permuted and the permutation itself).  Sorting the `permutation_view` will change the ordering of the container passed in to the constructor.
* When sorting a `permutation_view` with a tuple value type, the sorting will be done with the built-in tuple comparator.  We may want to add variants that let us specify which members to sort on (using indexes passed in as variadic template parameters). However, using a specialized comparator is probably good enough.

[sc-44172]

---
TYPE: IMPROVEMENT
DESC: Implement proxy sort permutation for external sort.
