### PR TITLE
Use unique pointers to manage the lifetime of queries when consolidating.

### DIFF
--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -560,7 +560,7 @@ Status FragmentConsolidator::consolidate_internal(
   // Create queries
   tdb_unique_ptr<Query> query_r = nullptr;
   tdb_unique_ptr<Query> query_w = nullptr;
-  RETURN_NOT_OK(create_queries(
+  throw_if_not_ok(create_queries(
       array_for_reads,
       array_for_writes,
       union_non_empty_domains,
@@ -585,8 +585,8 @@ Status FragmentConsolidator::consolidate_internal(
   auto st = query_w->finalize();
   if (!st.ok()) {
     bool is_dir = false;
-    auto st2 = storage_manager_->vfs()->is_dir(*new_fragment_uri, &is_dir);
-    (void)st2;  // Perhaps report this once we support an error stack
+    throw_if_not_ok(
+        storage_manager_->vfs()->is_dir(*new_fragment_uri, &is_dir));
     if (is_dir)
       throw_if_not_ok(storage_manager_->vfs()->remove_dir(*new_fragment_uri));
     return st;

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -316,8 +316,8 @@ class FragmentConsolidator : public Consolidator {
       shared_ptr<Array> array_for_reads,
       shared_ptr<Array> array_for_writes,
       const NDRange& subarray,
-      Query** query_r,
-      Query** query_w,
+      tdb_unique_ptr<Query>& query_r,
+      tdb_unique_ptr<Query>& query_w,
       URI* new_fragment_uri);
 
   /**


### PR DESCRIPTION
[SC-46580](https://app.shortcut.com/tiledb-inc/story/46580/fragment-consolidation-uses-raw-pointers-for-the-read-and-write-queries)

This PR updates the `FragmentConsolidator` class to manage the lifetime of queries using unique pointers, instead of manually allocating and deallocating them. This increases exception safety and allows us to remove several calls to `tdb_delete`.

---
TYPE: NO_HISTORY