### PR TITLE
Migrate APIs out of StorageManager: array_get_encryption.

### DIFF
--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -469,6 +469,19 @@ class Array {
   }
 
   /**
+   * Retrieves the encryption type.
+   *
+   * @param resources The context resources.
+   * @param uri The URI of the array.
+   * @param encryption_type Set to the encryption type.
+   * @return Status
+   */
+  static Status encryption_type(
+      ContextResources& resources,
+      const URI& uri,
+      EncryptionType* encryption_type);
+
+  /**
    * Get the enumeration for the given name.
    *
    * This function retrieves the enumeration for the given name. If the

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2934,14 +2934,14 @@ int32_t tiledb_array_encryption_type(
     const char* array_uri,
     tiledb_encryption_type_t* encryption_type) {
   // Sanity checks
-  if (array_uri == nullptr || encryption_type == nullptr)
+  if (array_uri == nullptr || encryption_type == nullptr) {
     return TILEDB_ERR;
+  }
 
-  auto uri = tiledb::sm::URI(array_uri);
   // Get encryption type
   tiledb::sm::EncryptionType enc;
-  throw_if_not_ok(ctx->storage_manager()->array_get_encryption(uri, &enc));
-
+  throw_if_not_ok(sm::Array::encryption_type(
+      ctx->resources(), tiledb::sm::URI(array_uri), &enc));
   *encryption_type = static_cast<tiledb_encryption_type_t>(enc);
 
   return TILEDB_OK;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -497,37 +497,6 @@ Status StorageManagerCanonical::array_upgrade_version(
   return Status::Ok();
 }
 
-Status StorageManagerCanonical::array_get_encryption(
-    const URI& uri, EncryptionType* encryption_type) {
-  if (uri.is_invalid()) {
-    return logger_->status(Status_StorageManagerError(
-        "Cannot get array encryption; Invalid array URI"));
-  }
-
-  if (uri.is_tiledb()) {
-    throw std::invalid_argument(
-        "Getting the encryption type of remote arrays is not supported.");
-  }
-
-  // Load URIs from the array directory
-  optional<tiledb::sm::ArrayDirectory> array_dir;
-  array_dir.emplace(
-      resources_,
-      uri,
-      0,
-      UINT64_MAX,
-      tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY);
-
-  const URI& schema_uri = array_dir->latest_array_schema_uri();
-
-  // Read tile header
-  auto&& header =
-      GenericTileIO::read_generic_tile_header(resources_, schema_uri, 0);
-  *encryption_type = static_cast<EncryptionType>(header.encryption_type);
-
-  return Status::Ok();
-}
-
 Status StorageManagerCanonical::async_push_query(Query* query) {
   cancelable_tasks_.execute(
       compute_tp(),

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -243,15 +243,6 @@ class StorageManagerCanonical {
   Status array_upgrade_version(const URI& uri, const Config& config);
 
   /**
-   * Retrieves the encryption type from an array.
-   *
-   * @param uri The URI of the array.
-   * @param encryption_type Set to the encryption type of the array.
-   * @return Status
-   */
-  Status array_get_encryption(const URI& uri, EncryptionType* encryption_type);
-
-  /**
    * Pushes an async query to the queue.
    *
    * @param query The async query.


### PR DESCRIPTION
Migrate APIs out of `StorageManager`: `array_get_encryption`.

---
[sc-44995]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of StorageManager: array_get_encryption.
