### PR TITLE
Migrate APIs out of StorageManager: group_close_for_reads.

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -246,7 +246,7 @@ Status Group::close() {
     // Storage manager does not own the group schema for remote groups.
   } else {
     if (query_type_ == QueryType::READ) {
-      RETURN_NOT_OK(storage_manager_->group_close_for_reads(this));
+      RETURN_NOT_OK(close_for_reads());
     } else if (
         query_type_ == QueryType::WRITE ||
         query_type_ == QueryType::MODIFY_EXCLUSIVE) {

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -108,6 +108,16 @@ class Group {
   Status open(
       QueryType query_type, uint64_t timestamp_start, uint64_t timestamp_end);
 
+  /**
+   * Closes a group opened for reads.
+   *
+   * @return Status
+   */
+  inline Status close_for_reads() {
+    // Closing a group opened for reads does nothing at present.
+    return Status::Ok();
+  }
+
   /** Closes the group and frees all memory. */
   Status close();
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -133,11 +133,6 @@ StorageManagerCanonical::~StorageManagerCanonical() {
 /*               API              */
 /* ****************************** */
 
-Status StorageManagerCanonical::group_close_for_reads(Group*) {
-  // Closing a group does nothing at present
-  return Status::Ok();
-}
-
 Status StorageManagerCanonical::group_close_for_writes(Group* group) {
   // Flush the group metadata
   RETURN_NOT_OK(store_metadata(

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -149,14 +149,6 @@ class StorageManagerCanonical {
   /* ********************************* */
 
   /**
-   * Closes an group opened for reads.
-   *
-   * @param group The group to be closed.
-   * @return Status
-   */
-  Status group_close_for_reads(tiledb::sm::Group* group);
-
-  /**
    * Closes an group opened for writes.
    *
    * @param group The group to be closed.


### PR DESCRIPTION
Migrate APIs out of `StorageManager`: `group_close_for_reads`. 

---
[sc-46725]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of StorageManager: group_close_for_reads.
