### PR TITLE
Remove deprecated APIs from tests, part 3.

### DIFF
--- a/test/src/unit-compression-delta.cc
+++ b/test/src/unit-compression-delta.cc
@@ -179,9 +179,11 @@ TEST_CASE(
   // Sanity check reading
   array.open(TILEDB_READ);
   std::vector<int> subarray = {0, 10};
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
   std::vector<float> a1_read(2);
   Query query_r(ctx, array);
-  query_r.set_subarray(subarray)
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_UNORDERED)
       .set_data_buffer("a1", a1_read);
   REQUIRE(query_r.submit() == Query::Status::COMPLETE);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -197,7 +197,9 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic][rest]") {
 
     Query query(ctx, array, TILEDB_WRITE);
     CHECK(query.query_type() == TILEDB_WRITE);
-    query.set_subarray(subarray);
+    Subarray sub(ctx, array);
+    sub.set_subarray(subarray);
+    query.set_subarray(sub);
     query.set_data_buffer("a1", a1);
     query.set_data_buffer("a2", a2buf.second);
     query.set_offsets_buffer("a2", a2buf.first);
@@ -254,6 +256,8 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic][rest]") {
       a1.resize(48);
 
       Query query(ctx, array);
+      Subarray sub(ctx, array);
+      sub.set_subarray(subarray);
 
       CHECK(!query.has_results());
 
@@ -265,7 +269,7 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic][rest]") {
       query.set_offsets_buffer("a4", a4buf.first);
       query.set_data_buffer("a5", a5);
       query.set_layout(TILEDB_ROW_MAJOR);
-      query.set_subarray(subarray);
+      query.set_subarray(sub);
 
       // Make sure no segfault when called before submit
       query.result_buffer_elements();
@@ -346,7 +350,9 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic][rest]") {
 
     Array array(ctx, array_uri_, TILEDB_WRITE);
     Query query(ctx, array, TILEDB_WRITE);
-    query.set_subarray(subarray);
+    Subarray sub(ctx, array);
+    sub.set_subarray(subarray);
+    query.set_subarray(sub);
     query.set_data_buffer("a1", a1);
     query.set_data_buffer("a2", a2buf.second);
     query.set_offsets_buffer("a2", a2buf.first);
@@ -405,7 +411,9 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic][rest]") {
     std::vector<int> subarray = {0, 1, 0, 0};
     Array array(ctx, array_uri_, TILEDB_WRITE);
     Query query(ctx, array, TILEDB_WRITE);
-    query.set_subarray(subarray);
+    Subarray sub(ctx, array);
+    sub.set_subarray(subarray);
+    query.set_subarray(sub);
     query.set_data_buffer("a1", a1);
     query.set_layout(TILEDB_GLOBAL_ORDER);
     // Incorrect subarray for global order
@@ -509,8 +517,10 @@ TEST_CASE(
     a = {};
     const std::vector<int> subarray = {0, 2};
     Query q(ctx, array, TILEDB_READ);
+    Subarray s(ctx, array);
+    s.set_subarray(subarray);
     q.set_layout(TILEDB_GLOBAL_ORDER);
-    q.set_subarray(subarray);
+    q.set_subarray(s);
     q.set_data_buffer("a", a);
     q.set_offsets_buffer("a", a_offset);
     q.set_data_buffer("b", b);
@@ -603,7 +613,9 @@ TEST_CASE(
         Query query(ctx, array);
         const std::vector<int> subarray = {0, 3, 0, 3};
         std::vector<int> data(16);
-        query.set_subarray(subarray)
+        Subarray sub(ctx, array);
+        sub.set_subarray(subarray);
+        query.set_subarray(sub)
             .set_layout(TILEDB_ROW_MAJOR)
             .set_data_buffer("a", data);
         query.submit();
@@ -757,7 +769,9 @@ TEST_CASE("C++ API: Encrypted array", "[cppapi][encryption][non-rest]") {
   std::vector<int> subarray = {0, 3};
   std::vector<int> a_read(4);
   Query query_r(ctx, array);
-  query_r.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_read);
   query_r.submit();
@@ -769,7 +783,9 @@ TEST_CASE("C++ API: Encrypted array", "[cppapi][encryption][non-rest]") {
   Array array_3(ctx, array_name, TILEDB_READ);
   a_read = std::vector<int>(4, 0);
   Query query_r2(ctx, array_3);
-  query_r2.set_subarray(subarray)
+  Subarray sub2(ctx, array_3);
+  sub2.set_subarray(subarray);
+  query_r2.set_subarray(sub2)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_read);
   query_r2.submit();
@@ -843,7 +859,9 @@ TEST_CASE(
   std::vector<int> subarray = {0, 3};
   std::vector<int> a_read(4);
   Query query_r(ctx, array);
-  query_r.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_read);
   query_r.submit();
@@ -909,7 +927,9 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at][rest]") {
   std::vector<int> subarray = {1, 4};
   std::vector<int> a_r(4);
   Query query_r(ctx, array_r);
-  query_r.set_subarray(subarray)
+  Subarray sub(ctx, array_r);
+  sub.set_subarray(subarray);
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r);
   query_r.submit();
@@ -928,7 +948,9 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at][rest]") {
 
   std::vector<int> a_r_at_0(4);
   Query query_r_at_0(ctx, array_r_at_0);
-  query_r_at_0.set_subarray(subarray)
+  Subarray sub2(ctx, array_r_at_0);
+  sub2.set_subarray(subarray);
+  query_r_at_0.set_subarray(sub2)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r_at_0);
   query_r_at_0.submit();
@@ -950,7 +972,9 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at][rest]") {
 
   std::vector<int> a_r_at(4);
   Query query_r_at(ctx, array_r_at);
-  query_r_at.set_subarray(subarray)
+  Subarray sub3(ctx, array_r_at);
+  sub3.set_subarray(subarray);
+  query_r_at.set_subarray(sub3)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r_at_0);
   query_r_at.submit();
@@ -964,7 +988,9 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at][rest]") {
   CHECK(array_reopen_at.open_timestamp_end() == first_timestamp);
   std::vector<int> a_r_reopen_at(4);
   Query query_r_reopen_at(ctx, array_reopen_at);
-  query_r_reopen_at.set_subarray(subarray)
+  Subarray sub4(ctx, array_reopen_at);
+  sub4.set_subarray(subarray);
+  query_r_reopen_at.set_subarray(sub4)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r_reopen_at);
   query_r_reopen_at.submit();
@@ -1007,7 +1033,9 @@ TEST_CASE(
   std::vector<int> subarray = {1, 4};
   std::vector<int> a_r(4);
   Query query_r(ctx, array_r);
-  query_r.set_subarray(subarray)
+  Subarray sub(ctx, array_r);
+  sub.set_subarray(subarray);
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r);
   query_r.submit();
@@ -1031,7 +1059,9 @@ TEST_CASE(
 
   std::vector<int> a_r_at_0(4);
   Query query_r_at_0(ctx, array_r_at_0);
-  query_r_at_0.set_subarray(subarray)
+  Subarray sub2(ctx, array_r_at_0);
+  sub2.set_subarray(subarray);
+  query_r_at_0.set_subarray(sub2)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r_at_0);
   query_r_at_0.submit();
@@ -1058,7 +1088,9 @@ TEST_CASE(
 
   std::vector<int> a_r_at(4);
   Query query_r_at(ctx, array_r_at);
-  query_r_at.set_subarray(subarray)
+  Subarray sub3(ctx, array_r_at);
+  sub3.set_subarray(subarray);
+  query_r_at.set_subarray(sub3)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_r_at_0);
   query_r_at.submit();
@@ -1105,7 +1137,9 @@ TEST_CASE(
   Query query(ctx, array);
   const std::vector<int> subarray = {0, 0, 0, 0};
   std::vector<int> data(1);
-  query.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", data);
   query.submit();
@@ -1256,8 +1290,10 @@ TEST_CASE(
   query_r.set_data_buffer("d2", buff_d2_r);
   query_r.set_data_buffer("a", buff_a_r);
   query_r.set_layout(TILEDB_UNORDERED);
-  query_r.add_range(0, 1.0f, 20.0f);
-  query_r.add_range(1, (int64_t)1, (int64_t)30);
+  Subarray subarray_r(ctx, array_r);
+  subarray_r.add_range(0, 1.0f, 20.0f);
+  subarray_r.add_range(1, (int64_t)1, (int64_t)30);
+  query_r.set_subarray(subarray_r);
   query_r.submit();
 
   auto ret = query.result_buffer_elements();
@@ -1326,46 +1362,54 @@ TEST_CASE(
   Query query_r(ctx, array_r, TILEDB_READ);
 
   SECTION("Non empty range") {
-    query_r.add_range(0, s1, s2);
-    CHECK_THROWS(query_r.add_range(1, s1, s2));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, s1, s2);
+    CHECK_THROWS(subarray_r.add_range(1, s1, s2));
+    query_r.set_subarray(subarray_r);
 
     // Check range
-    CHECK_THROWS(query_r.range(1, 1));
-    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK_THROWS(subarray_r.range(1, 1));
+    std::array<std::string, 2> range = subarray_r.range(0, 0);
     CHECK(range[0] == s1);
     CHECK(range[1] == s2);
   }
 
   SECTION("Empty first range") {
-    query_r.add_range(0, "", s2);
-    CHECK_THROWS(query_r.add_range(1, "", s2));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, "", s2);
+    CHECK_THROWS(subarray_r.add_range(1, "", s2));
+    query_r.set_subarray(subarray_r);
 
     // Check range
-    CHECK_THROWS(query_r.range(1, 1));
-    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK_THROWS(subarray_r.range(1, 1));
+    std::array<std::string, 2> range = subarray_r.range(0, 0);
     CHECK(range[0] == "");
     CHECK(range[1] == s2);
   }
 
   SECTION("Empty second range") {
-    query_r.add_range(0, s1, "");
-    CHECK_THROWS(query_r.add_range(1, s1, ""));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, s1, "");
+    CHECK_THROWS(subarray_r.add_range(1, s1, ""));
+    query_r.set_subarray(subarray_r);
 
     // Check range
-    CHECK_THROWS(query_r.range(1, 1));
-    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK_THROWS(subarray_r.range(1, 1));
+    std::array<std::string, 2> range = subarray_r.range(0, 0);
     CHECK(range[0] == s1);
     CHECK(range[1] == "");
     empty_results = true;
   }
 
   SECTION("Empty ranges") {
-    query_r.add_range(0, std::string(""), std::string(""));
-    CHECK_THROWS(query_r.add_range(1, std::string(""), std::string("")));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, std::string(""), std::string(""));
+    CHECK_THROWS(subarray_r.add_range(1, std::string(""), std::string("")));
+    query_r.set_subarray(subarray_r);
 
     // Check range
-    CHECK_THROWS(query_r.range(1, 1));
-    std::array<std::string, 2> range = query_r.range(0, 0);
+    CHECK_THROWS(subarray_r.range(1, 1));
+    std::array<std::string, 2> range = subarray_r.range(0, 0);
     CHECK(range[0] == "");
     CHECK(range[1] == "");
     empty_results = true;
@@ -1448,7 +1492,9 @@ TEST_CASE(
   std::string s1("a", 1);
   std::string s2("ee", 2);
   Query query_r(ctx, array_r, TILEDB_READ);
-  query_r.add_range(0, s1, s2);
+  Subarray subarray_r(ctx, array_r);
+  subarray_r.add_range(0, s1, s2);
+  query_r.set_subarray(subarray_r);
   std::string data;
   data.resize(10);
   std::vector<uint64_t> offsets(4);
@@ -1498,7 +1544,9 @@ TEST_CASE(
   Query query(ctx, array);
   const std::vector<int> subarray = {0, 0, 0, 0};
   std::vector<int> rows(1);
-  query.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub)
       .set_layout(TILEDB_GLOBAL_ORDER)
       .set_data_buffer("rows", rows);
   query.submit();
@@ -1543,7 +1591,9 @@ TEST_CASE(
   Query query(ctx, array);
   const std::vector<int> subarray = {0, 0, 0, 0};
   std::vector<int> rows(1);
-  query.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub)
       .set_layout(TILEDB_UNORDERED)
       .set_data_buffer("rows", rows);
   query.submit();
@@ -1582,10 +1632,10 @@ TEST_CASE(
   // Read
   Array array(ctx, array_uri, TILEDB_READ);
   Query query(ctx, array);
+  Subarray subarray(ctx, array);
+  subarray.add_range(0, 0, 1).add_range(0, 3, 3).add_range(1, 0, 3);
   std::vector<int> data(12);
-  query.add_range(0, 0, 1)
-      .add_range(0, 3, 3)
-      .add_range(1, 0, 3)
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", data);
   query.submit();
@@ -1747,9 +1797,10 @@ TEST_CASE(
   // Read
   Array array(ctx, array_name, TILEDB_READ);
   Query query(ctx, array, TILEDB_READ);
+  Subarray subarray(ctx, array);
+  subarray.add_range(0, 1, 2).add_range(1, 2, 4);
   std::vector<int> data(6);
-  query.add_range(0, 1, 2)
-      .add_range(1, 2, 4)
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", data);
   query.submit();
@@ -2009,7 +2060,9 @@ TEST_CASE(
   std::vector<int> a_read(16);
 
   Query query(ctx, array);
-  query.set_subarray(subarray_read)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray_read);
+  query.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", a_read);
   query.submit_async();

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1360,9 +1360,9 @@ TEST_CASE(
   std::string s1("a", 1);
   std::string s2("ee", 2);
   Query query_r(ctx, array_r, TILEDB_READ);
+  Subarray subarray_r(ctx, array_r);
 
   SECTION("Non empty range") {
-    Subarray subarray_r(ctx, array_r);
     subarray_r.add_range(0, s1, s2);
     CHECK_THROWS(subarray_r.add_range(1, s1, s2));
     query_r.set_subarray(subarray_r);
@@ -1375,7 +1375,6 @@ TEST_CASE(
   }
 
   SECTION("Empty first range") {
-    Subarray subarray_r(ctx, array_r);
     subarray_r.add_range(0, "", s2);
     CHECK_THROWS(subarray_r.add_range(1, "", s2));
     query_r.set_subarray(subarray_r);
@@ -1388,7 +1387,6 @@ TEST_CASE(
   }
 
   SECTION("Empty second range") {
-    Subarray subarray_r(ctx, array_r);
     subarray_r.add_range(0, s1, "");
     CHECK_THROWS(subarray_r.add_range(1, s1, ""));
     query_r.set_subarray(subarray_r);
@@ -1402,7 +1400,6 @@ TEST_CASE(
   }
 
   SECTION("Empty ranges") {
-    Subarray subarray_r(ctx, array_r);
     subarray_r.add_range(0, std::string(""), std::string(""));
     CHECK_THROWS(subarray_r.add_range(1, std::string(""), std::string("")));
     query_r.set_subarray(subarray_r);

--- a/test/src/unit-cppapi-checksum.cc
+++ b/test/src/unit-cppapi-checksum.cc
@@ -111,7 +111,9 @@ static void run_checksum_test(tiledb_filter_type_t filter_type) {
   std::string a2_read_data;
   a2_read_data.resize(7);
   Query query_r(ctx2, array);
-  query_r.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer(tiledb::test::TILEDB_COORDS, coords_read)
       .set_data_buffer("a1", a1_read)
@@ -182,7 +184,9 @@ static void run_checksum_test(tiledb_filter_type_t filter_type) {
   std::string a2_read_data2;
   a2_read_data2.resize(7);
   Query query_r2(ctx, array);
-  query_r2.set_subarray(subarray)
+  Subarray sub2(ctx, array);
+  sub2.set_subarray(subarray);
+  query_r2.set_subarray(sub2)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer(tiledb::test::TILEDB_COORDS, coords_read2)
       .set_data_buffer("a1", a1_read2)

--- a/test/src/unit-cppapi-consolidation-sparse.cc
+++ b/test/src/unit-cppapi-consolidation-sparse.cc
@@ -78,9 +78,11 @@ void read_array(
   Array array(ctx, array_name, TILEDB_READ);
   Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_ROW_MAJOR);
+  Subarray subarray(ctx, array);
   for (auto& r : ranges) {
-    query.add_range(0, r, r);
+    subarray.add_range(0, r, r);
   }
+  query.set_subarray(subarray);
   std::vector<int> d(100);
   std::vector<int> values(100);
   query.set_data_buffer("d", d);

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -1309,8 +1309,10 @@ TEST_CASE_METHOD(
   query.set_data_buffer(tiledb_timestamps(), timestamps);
 
   // Add overlapping ranges
-  query.add_range<uint64_t>(1, 2, 3);
-  query.add_range<uint64_t>(1, 2, 3);
+  Subarray subarray(ctx_, array);
+  subarray.add_range<uint64_t>(1, 2, 3);
+  subarray.add_range<uint64_t>(1, 2, 3);
+  query.set_subarray(subarray);
 
   // Submit/finalize the query
   query.submit();

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -63,7 +63,9 @@ void write_array(
   Array array(ctx, array_name, TILEDB_WRITE);
   Query query(ctx, array, TILEDB_WRITE);
   query.set_layout(TILEDB_ROW_MAJOR);
-  query.set_subarray(subarray);
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub);
   query.set_data_buffer("a", values);
   query.submit();
   array.close();
@@ -77,7 +79,9 @@ void read_array(
   Array array(ctx, array_name, TILEDB_READ);
   Query query(ctx, array, TILEDB_READ);
   query.set_layout(TILEDB_ROW_MAJOR);
-  query.set_subarray(subarray);
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub);
   std::vector<int> values(10);
   query.set_data_buffer("a", values);
   query.submit();

--- a/test/src/unit-cppapi-datetimes.cc
+++ b/test/src/unit-cppapi-datetimes.cc
@@ -128,9 +128,11 @@ TEST_CASE("C++ API: Datetime dimension", "[cppapi][datetime]") {
   std::vector<int64_t> subarray_r = {0, 9};
   Array array_r(ctx, array_name, TILEDB_READ);
   Query query_r(ctx, array_r);
+  Subarray sub(ctx, array_r);
+  sub.set_subarray(subarray_r);
   query_r.set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a", data_r)
-      .set_subarray(subarray_r);
+      .set_subarray(sub);
   REQUIRE(query_r.submit() == Query::Status::COMPLETE);
 
   auto result_num = query_r.result_buffer_elements()["a"].second;

--- a/test/src/unit-cppapi-dense-qc-coords-mode.cc
+++ b/test/src/unit-cppapi-dense-qc-coords-mode.cc
@@ -75,7 +75,9 @@ struct CPPDenseQcCoordsModeFx {
 
     Array array(ctx_, array_name, TILEDB_WRITE);
     Query query(ctx_, array, TILEDB_WRITE);
-    query.set_subarray(subarray);
+    Subarray sub(ctx_, array);
+    sub.set_subarray(subarray);
+    query.set_subarray(sub);
     query.set_data_buffer("a1", a1_buff);
     query.set_layout(TILEDB_ROW_MAJOR);
     REQUIRE(query.submit() == Query::Status::COMPLETE);
@@ -167,7 +169,9 @@ TEST_CASE_METHOD(
   std::vector<int> subarray = {1, 10, 1, 10};
   std::vector<int> d1(100);
   std::vector<int> d2(100);
-  query.set_subarray(subarray);
+  Subarray sub(ctx_, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub);
   query.set_layout(read_layout);
   query.set_data_buffer("d1", d1);
   query.set_data_buffer("d2", d2);

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -413,7 +413,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr1", attr1)
@@ -449,7 +451,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr1", attr1)
@@ -490,7 +494,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr1", attr1)
@@ -536,7 +542,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr1", attr1)
@@ -568,7 +576,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr1", attr1)
@@ -593,7 +603,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr1", attr1)
@@ -639,7 +651,9 @@ TEST_CASE_METHOD(
 
   auto array = Array(ctx_, uri_, TILEDB_READ);
   Query query(ctx_, array);
-  query.add_range("dim", 1, 5)
+  Subarray subarray(ctx_, array);
+  subarray.add_range("dim", 1, 5);
+  query.set_subarray(subarray)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("dim", dim)
       .set_data_buffer("attr3", attr3)

--- a/test/src/unit-cppapi-fill_values.cc
+++ b/test/src/unit-cppapi-fill_values.cc
@@ -587,8 +587,10 @@ TEST_CASE(
 
     Array array(ctx, array_name, TILEDB_READ);
     Query query(ctx, array, TILEDB_READ);
-    query.add_range<int32_t>(0, 2, 3);
-    query.add_range<int32_t>(0, 9, 10);
+    Subarray subarray(ctx, array);
+    subarray.add_range<int32_t>(0, 2, 3);
+    subarray.add_range<int32_t>(0, 9, 10);
+    query.set_subarray(subarray);
     auto est_a1 = query.est_result_size("a1");
     auto est_a2 = query.est_result_size_var("a2");
     auto est_a3 = query.est_result_size("a3");
@@ -655,8 +657,10 @@ TEST_CASE(
 
     Array array(ctx, array_name, TILEDB_READ);
     Query query(ctx, array, TILEDB_READ);
-    query.add_range<int32_t>(0, 2, 3);
-    query.add_range<int32_t>(0, 9, 10);
+    Subarray subarray(ctx, array);
+    subarray.add_range<int32_t>(0, 2, 3);
+    subarray.add_range<int32_t>(0, 9, 10);
+    query.set_subarray(subarray);
     auto est_a1 = query.est_result_size("a1");
     auto est_a2 = query.est_result_size_var("a2");
     auto est_a3 = query.est_result_size("a3");
@@ -754,8 +758,10 @@ TEST_CASE(
 
     Array array(ctx, array_name, TILEDB_READ);
     Query query(ctx, array, TILEDB_READ);
-    query.add_range<int32_t>(0, 2, 3);
-    query.add_range<int32_t>(0, 9, 10);
+    Subarray subarray(ctx, array);
+    subarray.add_range<int32_t>(0, 2, 3);
+    subarray.add_range<int32_t>(0, 9, 10);
+    query.set_subarray(subarray);
     auto est_a1 = query.est_result_size_nullable("a1");
     auto est_a2 = query.est_result_size_var_nullable("a2");
     auto est_a3 = query.est_result_size_nullable("a3");

--- a/test/src/unit-cppapi-filter.cc
+++ b/test/src/unit-cppapi-filter.cc
@@ -208,7 +208,9 @@ TEST_CASE(
   std::string a2_read_data;
   a2_read_data.resize(7);
   Query query_r(ctx, array);
-  query_r.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query_r.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a1", a1_read)
       .set_data_buffer("a2", a2_read_data)

--- a/test/src/unit-cppapi-float-scaling-filter.cc
+++ b/test/src/unit-cppapi-float-scaling-filter.cc
@@ -149,10 +149,12 @@ struct FloatScalingFilterTestStruct {
     Query query_r(ctx, array_r);
     query_r.set_layout(TILEDB_ROW_MAJOR).set_data_buffer("a", a_data_read);
 
+    Subarray subarray_r(ctx, array_r);
     if (array_type == TILEDB_DENSE) {
       int range[] = {1, dim_hi};
-      query_r.add_range("rows", range[0], range[1])
+      subarray_r.add_range("rows", range[0], range[1])
           .add_range("cols", range[0], range[1]);
+      query_r.set_subarray(subarray_r);
     }
 
     query_r.submit();

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -384,9 +384,11 @@ TEST_CASE(
     query_r.set_data_buffer("d1", r_buff_d1);
     query_r.set_data_buffer("d2", r_buff_d2);
 
-    query_r.add_range("d1", (int32_t)1, (int32_t)5);
-    query_r.add_range("d2", (int32_t)1, (int32_t)3);
-    query_r.add_range("d2", (int32_t)2, (int32_t)4);
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range("d1", (int32_t)1, (int32_t)5);
+    subarray_r.add_range("d2", (int32_t)1, (int32_t)3);
+    subarray_r.add_range("d2", (int32_t)2, (int32_t)4);
+    query_r.set_subarray(subarray_r);
     query_r.set_layout(TILEDB_UNORDERED);
     // Submit query
     query_r.submit();
@@ -1874,8 +1876,10 @@ TEST_CASE(
     query_r.set_data_buffer("d2", r_buff_d2);
     query_r.set_offsets_buffer("d2", r_off_d2);
     query_r.set_layout(TILEDB_ROW_MAJOR);
-    query_r.add_range(0, std::string("3"), std::string("z"));
-    query_r.add_range(1, std::string("a"), std::string("vase"));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, std::string("3"), std::string("z"));
+    subarray_r.add_range(1, std::string("a"), std::string("vase"));
+    query_r.set_subarray(subarray_r);
     CHECK_NOTHROW(query_r.submit());
 
     // Check results
@@ -1915,8 +1919,10 @@ TEST_CASE(
     query_r.set_data_buffer("d2", r_buff_d2);
     query_r.set_offsets_buffer("d2", r_off_d2);
     query_r.set_layout(TILEDB_GLOBAL_ORDER);
-    query_r.add_range(0, std::string("3"), std::string("z"));
-    query_r.add_range(1, std::string("a"), std::string("vase"));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, std::string("3"), std::string("z"));
+    subarray_r.add_range(1, std::string("a"), std::string("vase"));
+    query_r.set_subarray(subarray_r);
     CHECK_NOTHROW(query_r.submit());
 
     // Check results. Hilbert values:
@@ -2087,8 +2093,10 @@ TEST_CASE(
     query_r.set_offsets_buffer("d1", r_off_d1);
     query_r.set_data_buffer("d2", r_buff_d2);
     query_r.set_offsets_buffer("d2", r_off_d2);
-    query_r.add_range(0, std::string("1a", 2), std::string("w", 1));
-    query_r.add_range(1, std::string("ca", 2), std::string("t1", 2));
+    Subarray subarray_r(ctx, array_r);
+    subarray_r.add_range(0, std::string("1a", 2), std::string("w", 1));
+    subarray_r.add_range(1, std::string("ca", 2), std::string("t1", 2));
+    query_r.set_subarray(subarray_r);
     query_r.set_layout(TILEDB_GLOBAL_ORDER);
     CHECK_NOTHROW(query_r.submit());
 

--- a/test/src/unit-cppapi-nullable.cc
+++ b/test/src/unit-cppapi-nullable.cc
@@ -313,10 +313,9 @@ void NullableArrayCppFx::read(
     }
   }
 
+  // Set the subarray to read.
   Subarray sub(ctx_, array);
   sub.set_subarray(subarray);
-
-  // Set the subarray to read.
   query.set_subarray(sub);
 
   // Submit the query.

--- a/test/src/unit-cppapi-nullable.cc
+++ b/test/src/unit-cppapi-nullable.cc
@@ -313,8 +313,11 @@ void NullableArrayCppFx::read(
     }
   }
 
+  Subarray sub(ctx_, array);
+  sub.set_subarray(subarray);
+
   // Set the subarray to read.
-  query.set_subarray(subarray);
+  query.set_subarray(sub);
 
   // Submit the query.
   REQUIRE(query.submit() == Query::Status::COMPLETE);

--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -206,7 +206,9 @@ TEST_CASE(
   Array array1(ctx, array_name, TILEDB_READ);
   Query query1(ctx, array1);
   int range[] = {1, 2};
-  query1.add_range(0, range[0], range[1]).add_range(1, range[0], range[1]);
+  Subarray subarray1(ctx, array1);
+  subarray1.add_range(0, range[0], range[1]).add_range(1, range[0], range[1]);
+  query1.set_subarray(subarray1);
   auto est_size = query1.est_result_size("a");
   std::vector<int> data(est_size);
   query1.set_layout(TILEDB_ROW_MAJOR).set_data_buffer("a", data);
@@ -266,21 +268,22 @@ TEST_CASE(
   // Add 1 range per dimension
   std::string s1("a", 1);
   std::string s2("cc", 2);
-  CHECK_NOTHROW(query.add_range("d1", s1, s2));
+  Subarray subarray(ctx, array);
+  CHECK_NOTHROW(subarray.add_range("d1", s1, s2));
   int range[] = {1, 2};
-  CHECK_NOTHROW(query.add_range("d2", range[0], range[1]));
+  CHECK_NOTHROW(subarray.add_range("d2", range[0], range[1]));
 
   // Check number of ranges on each dimension
-  int range_num = query.range_num("d1");
+  int range_num = subarray.range_num("d1");
   CHECK(range_num == 1);
-  range_num = query.range_num("d2");
+  range_num = subarray.range_num("d2");
   CHECK(range_num == 1);
 
   // Check ranges
-  std::array<std::string, 2> range1 = query.range("d1", 0);
+  std::array<std::string, 2> range1 = subarray.range("d1", 0);
   CHECK(range1[0] == s1);
   CHECK(range1[1] == s2);
-  std::array<int, 3> range2 = query.range<int>("d2", 0);
+  std::array<int, 3> range2 = subarray.range<int>("d2", 0);
   CHECK(range2[0] == 1);
   CHECK(range2[1] == 2);
   CHECK(range2[2] == 0);

--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -180,8 +180,9 @@ TEST_CASE(
 
     // Prepare the query
     Query query(ctx, array, TILEDB_READ);
-    query.add_range(0, 1, 4)
-        .add_range(1, 1, 4)
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, 1, 4).add_range(1, 1, 4);
+    query.set_subarray(subarray)
         .set_layout(layout)
         .set_data_buffer("a", data)
         .set_data_buffer("d1", d1_data)
@@ -301,8 +302,9 @@ TEST_CASE(
 
     // Prepare the query
     Query query(ctx, array, TILEDB_READ);
-    query.add_range(0, 1, 4)
-        .add_range(1, 1, 4)
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, 1, 4).add_range(1, 1, 4);
+    query.set_subarray(subarray)
         .set_layout(layout)
         .set_data_buffer("a", a_data)
         .set_data_buffer("b", b_data)
@@ -452,10 +454,10 @@ TEST_CASE(
 
     // Prepare the query
     Query query(ctx, array, TILEDB_READ);
-    query.add_range(0, 1, 4)
-        .add_range(0, 1, 4)
-        .add_range(1, 1, 4)
-        .add_range(1, 1, 4)
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, 1, 4).add_range(0, 1, 4).add_range(1, 1, 4).add_range(
+        1, 1, 4);
+    query.set_subarray(subarray)
         .set_layout(layout)
         .set_data_buffer("a", a_data)
         .set_data_buffer("b", b_data)

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -250,7 +250,7 @@ TEST_CASE(
   CHECK_THROWS(array.non_empty_domain<int32_t>());
   std::vector<int32_t> subarray = {1, 2, 1, 3};
 
-  // Query checks
+  // Query/subarray checks
   Query query(ctx, array, TILEDB_READ);
   Subarray sub(ctx, array);
   CHECK_THROWS(sub.set_subarray(subarray));

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -252,7 +252,8 @@ TEST_CASE(
 
   // Query checks
   Query query(ctx, array, TILEDB_READ);
-  CHECK_THROWS(query.set_subarray(subarray));
+  Subarray sub(ctx, array);
+  CHECK_THROWS(sub.set_subarray(subarray));
   std::vector<int32_t> buff = {1, 2, 4};
   CHECK_THROWS(query.set_data_buffer(tiledb::test::TILEDB_COORDS, buff));
 

--- a/test/src/unit-cppapi-string-dims.cc
+++ b/test/src/unit-cppapi-string-dims.cc
@@ -167,12 +167,14 @@ TEST_CASE(
   // Prepare a read query.
   Array array_read(ctx, array_name, TILEDB_READ);
   Query query_read(ctx, array_read, TILEDB_READ);
+  Subarray subarray_read(ctx, array_read);
   auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
   auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
-  query_read.add_range(
+  subarray_read.add_range(
       0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-  query_read.add_range<int32_t>(
+  subarray_read.add_range<int32_t>(
       1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
+  query_read.set_subarray(subarray_read);
 
   // Prepare buffers with small enough sizes to ensure the string dimension
   // must split.
@@ -254,6 +256,7 @@ TEST_CASE(
     // Prepare a read query.
     Array array_read(ctx, array_name, TILEDB_READ);
     Query query_read(ctx, array_read, TILEDB_READ);
+    Subarray subarray_read(ctx, array_read);
     auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
     auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
     auto dim3_non_empty_domain = array_read.non_empty_domain_var(2);
@@ -264,7 +267,7 @@ TEST_CASE(
     // editors.
     switch (option) {
       case 1:
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
         expected_dim1 = {"bb", "c", "d"};
         expected_dim2 = {1, 1, 2};
@@ -272,11 +275,11 @@ TEST_CASE(
         expected_a1_data = {2, 3, 4};
         break;
       case 2:
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c", "d"};
         expected_dim2 = {1, 2};
@@ -284,9 +287,9 @@ TEST_CASE(
         expected_a1_data = {3, 4};
         break;
       case 3:
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"a", "bb", "c", "d", "ee", "f"};
         expected_dim2 = {1, 1, 1, 2, 2, 2};
@@ -294,15 +297,15 @@ TEST_CASE(
         expected_a1_data = {1, 2, 3, 4, 5, 6};
         break;
       case 4:
-        query_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
         expected_dim1 = {"c", "d"};
         expected_dim2 = {1, 2};
         expected_dim3 = {"i", "j"};
         expected_a1_data = {3, 4};
         break;
       case 5:
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"c", "d"};
         expected_dim2 = {1, 2};
@@ -310,9 +313,9 @@ TEST_CASE(
         expected_a1_data = {3, 4};
         break;
       case 6:
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"bb", "c", "d"};
         expected_dim2 = {1, 1, 2};
@@ -320,9 +323,9 @@ TEST_CASE(
         expected_a1_data = {2, 3, 4};
         break;
       case 7:
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c", "d"};
         expected_dim2 = {1, 2};
@@ -330,8 +333,8 @@ TEST_CASE(
         expected_a1_data = {3, 4};
         break;
       case 8:
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c", "d"};
         expected_dim2 = {1, 2};
@@ -339,9 +342,9 @@ TEST_CASE(
         expected_a1_data = {3, 4};
         break;
       case 9:
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c", "d", "ee"};
         expected_dim2 = {1, 2, 2};
@@ -349,8 +352,8 @@ TEST_CASE(
         expected_a1_data = {3, 4, 5};
         break;
       case 10:
-        query_read.add_range(0, std::string("c"), std::string("ee"));
-        query_read.add_range(
+        subarray_read.add_range(0, std::string("c"), std::string("ee"));
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kk"));
         expected_dim1 = {"c", "d", "ee"};
         expected_dim2 = {1, 2, 2};
@@ -358,6 +361,7 @@ TEST_CASE(
         expected_a1_data = {3, 4, 5};
         break;
     }
+    query_read.set_subarray(subarray_read);
 
     std::vector<char> dim1;
     std::vector<uint64_t> dim1_offsets;
@@ -481,6 +485,7 @@ TEST_CASE(
     // Prepare a read query. Do not set a range for the last string dimension.
     Array array_read(ctx, array_name, TILEDB_READ);
     Query query_read(ctx, array_read, TILEDB_READ);
+    Subarray subarray_read(ctx, array_read);
     auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
     auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
 
@@ -497,7 +502,7 @@ TEST_CASE(
       case 1:
         expected_result_num = 4;
         initial_expected_read_status = Query::Status::INCOMPLETE;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
         expected_dim1 = {"bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2};
@@ -507,11 +512,11 @@ TEST_CASE(
       case 2:
         expected_result_num = 2;
         initial_expected_read_status = Query::Status::COMPLETE;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"bb", "c"};
         expected_dim2 = {2, 1};
@@ -521,9 +526,9 @@ TEST_CASE(
       case 3:
         expected_result_num = 6;
         initial_expected_read_status = Query::Status::INCOMPLETE;
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"a", "a", "bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2, 1, 2};
@@ -533,7 +538,7 @@ TEST_CASE(
       case 4:
         expected_result_num = 2;
         initial_expected_read_status = Query::Status::COMPLETE;
-        query_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
         expected_dim1 = {"c", "c"};
         expected_dim2 = {1, 2};
         expected_dim3 = {"i", "l"};
@@ -542,8 +547,8 @@ TEST_CASE(
       case 5:
         expected_result_num = 2;
         initial_expected_read_status = Query::Status::COMPLETE;
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"c", "c"};
         expected_dim2 = {1, 2};
@@ -553,9 +558,9 @@ TEST_CASE(
       case 6:
         expected_result_num = 4;
         initial_expected_read_status = Query::Status::INCOMPLETE;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2};
@@ -565,9 +570,9 @@ TEST_CASE(
       case 7:
         expected_result_num = 2;
         initial_expected_read_status = Query::Status::COMPLETE;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"bb", "c"};
         expected_dim2 = {2, 1};
@@ -578,8 +583,8 @@ TEST_CASE(
         expected_result_num = 1;
         initial_result_num = 1;
         initial_expected_read_status = Query::Status::COMPLETE;
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c"};
         expected_dim2 = {1};
@@ -590,9 +595,9 @@ TEST_CASE(
         expected_result_num = 3;
         initial_result_num = 3;
         initial_expected_read_status = Query::Status::COMPLETE;
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"a", "bb", "c"};
         expected_dim2 = {2, 2, 1};
@@ -600,6 +605,7 @@ TEST_CASE(
         expected_a1_data = {4, 5, 3};
         break;
     }
+    query_read.set_subarray(subarray_read);
 
     std::vector<char> dim1;
     std::vector<uint64_t> dim1_offsets;
@@ -721,6 +727,7 @@ TEST_CASE(
   // Prepare a read query. Do not set a range for the last string dimension.
   Array array_read(ctx, array_name, TILEDB_READ);
   Query query_read(ctx, array_read, TILEDB_READ);
+  Subarray subarray_read(ctx, array_read);
   auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
   auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
 
@@ -738,7 +745,7 @@ TEST_CASE(
     which_option = 1;
     expected_result_num = 4;
     initial_expected_read_status = Query::Status::INCOMPLETE;
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim1"), std::string("az"), std::string("de"));
     expected_dim1 = {"bb", "bb", "c", "c"};
     expected_dim2 = {1, 2, 1, 2};
@@ -749,11 +756,11 @@ TEST_CASE(
     which_option = 2;
     expected_result_num = 2;
     initial_expected_read_status = Query::Status::COMPLETE;
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim1"), std::string("az"), std::string("de"));
-    query_read.add_range<int32_t>(
+    subarray_read.add_range<int32_t>(
         1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim3"), std::string("i"), std::string("kl"));
     expected_dim1 = {"bb", "c"};
     expected_dim2 = {2, 1};
@@ -764,9 +771,9 @@ TEST_CASE(
     which_option = 3;
     expected_result_num = 6;
     initial_expected_read_status = Query::Status::INCOMPLETE;
-    query_read.add_range(
+    subarray_read.add_range(
         0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-    query_read.add_range<int32_t>(
+    subarray_read.add_range<int32_t>(
         1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
     expected_dim1 = {"a", "a", "bb", "bb", "c", "c"};
     expected_dim2 = {1, 2, 1, 2, 1, 2};
@@ -777,7 +784,7 @@ TEST_CASE(
     which_option = 4;
     expected_result_num = 2;
     initial_expected_read_status = Query::Status::COMPLETE;
-    query_read.add_range(0, std::string("c"), std::string("d"));
+    subarray_read.add_range(0, std::string("c"), std::string("d"));
     expected_dim1 = {"c", "c"};
     expected_dim2 = {1, 2};
     expected_dim3 = {"i", "l"};
@@ -787,8 +794,8 @@ TEST_CASE(
     which_option = 5;
     expected_result_num = 2;
     initial_expected_read_status = Query::Status::COMPLETE;
-    query_read.add_range(0, std::string("c"), std::string("d"));
-    query_read.add_range<int32_t>(
+    subarray_read.add_range(0, std::string("c"), std::string("d"));
+    subarray_read.add_range<int32_t>(
         1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
     expected_dim1 = {"c", "c"};
     expected_dim2 = {1, 2};
@@ -799,9 +806,9 @@ TEST_CASE(
     which_option = 6;
     expected_result_num = 4;
     initial_expected_read_status = Query::Status::INCOMPLETE;
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim1"), std::string("az"), std::string("de"));
-    query_read.add_range<int32_t>(
+    subarray_read.add_range<int32_t>(
         1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
     expected_dim1 = {"bb", "bb", "c", "c"};
     expected_dim2 = {1, 2, 1, 2};
@@ -812,9 +819,9 @@ TEST_CASE(
     which_option = 7;
     expected_result_num = 2;
     initial_expected_read_status = Query::Status::COMPLETE;
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim1"), std::string("az"), std::string("de"));
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim3"), std::string("i"), std::string("kl"));
     expected_dim1 = {"bb", "c"};
     expected_dim2 = {2, 1};
@@ -826,8 +833,8 @@ TEST_CASE(
     expected_result_num = 1;
     initial_result_num = 1;
     initial_expected_read_status = Query::Status::COMPLETE;
-    query_read.add_range(0, std::string("c"), std::string("d"));
-    query_read.add_range(
+    subarray_read.add_range(0, std::string("c"), std::string("d"));
+    subarray_read.add_range(
         std::string("dim3"), std::string("i"), std::string("kl"));
     expected_dim1 = {"c"};
     expected_dim2 = {1};
@@ -839,15 +846,16 @@ TEST_CASE(
     expected_result_num = 3;
     initial_result_num = 3;
     initial_expected_read_status = Query::Status::COMPLETE;
-    query_read.add_range(
+    subarray_read.add_range(
         0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-    query_read.add_range(
+    subarray_read.add_range(
         std::string("dim3"), std::string("i"), std::string("kl"));
     expected_dim1 = {"a", "bb", "c"};
     expected_dim2 = {2, 2, 1};
     expected_dim3 = {"j", "kk", "i"};
     expected_a1_data = {4, 5, 3};
   }
+  query_read.set_subarray(subarray_read);
 
   std::vector<uint64_t> dim1_offsets;
   std::vector<int32_t> dim2;
@@ -995,6 +1003,7 @@ TEST_CASE(
     // Prepare a read query. Ranges set vary in the different switch cases.
     Array array_read(ctx, array_name, TILEDB_READ);
     Query query_read(ctx, array_read, TILEDB_READ);
+    Subarray subarray_read(ctx, array_read);
     auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
     auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
 
@@ -1007,7 +1016,7 @@ TEST_CASE(
     switch (option) {
       case 1:
         expected_result_num = 4;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
         expected_dim1 = {"bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2};
@@ -1017,11 +1026,11 @@ TEST_CASE(
         break;
       case 2:
         expected_result_num = 2;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"bb", "c"};
         expected_dim2 = {2, 1};
@@ -1030,9 +1039,9 @@ TEST_CASE(
         break;
       case 3:
         expected_result_num = 6;
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"a", "a", "bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2, 1, 2};
@@ -1041,7 +1050,7 @@ TEST_CASE(
         break;
       case 4:
         expected_result_num = 2;
-        query_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
         expected_dim1 = {"c", "c"};
         expected_dim2 = {1, 2};
         expected_dim3 = {"i", "l"};
@@ -1049,8 +1058,8 @@ TEST_CASE(
         break;
       case 5:
         expected_result_num = 2;
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"c", "c"};
         expected_dim2 = {1, 2};
@@ -1059,9 +1068,9 @@ TEST_CASE(
         break;
       case 6:
         expected_result_num = 4;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2};
@@ -1070,9 +1079,9 @@ TEST_CASE(
         break;
       case 7:
         expected_result_num = 2;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"bb", "c"};
         expected_dim2 = {2, 1};
@@ -1081,8 +1090,8 @@ TEST_CASE(
         break;
       case 8:
         expected_result_num = 1;
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c"};
         expected_dim2 = {1};
@@ -1091,9 +1100,9 @@ TEST_CASE(
         break;
       case 9:
         expected_result_num = 3;
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"a", "bb", "c"};
         expected_dim2 = {2, 2, 1};
@@ -1101,6 +1110,7 @@ TEST_CASE(
         expected_a1_data = {4, 5, 3};
         break;
     }
+    query_read.set_subarray(subarray_read);
 
     std::vector<char> dim1;
     std::vector<uint64_t> dim1_offsets;
@@ -1247,6 +1257,7 @@ TEST_CASE(
     // Prepare a read query. Ranges set vary in the different switch cases.
     Array array_read(ctx, array_name, TILEDB_READ);
     Query query_read(ctx, array_read, TILEDB_READ);
+    Subarray subarray_read(ctx, array_read);
     auto dim1_non_empty_domain = array_read.non_empty_domain_var(0);
     auto dim2_non_empty_domain = array_read.non_empty_domain<int32_t>(1);
 
@@ -1259,7 +1270,7 @@ TEST_CASE(
     switch (option) {
       case 1:
         expected_result_num = 4;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
         expected_dim1 = {"bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2};
@@ -1269,11 +1280,11 @@ TEST_CASE(
         break;
       case 2:
         expected_result_num = 2;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"bb", "c"};
         expected_dim2 = {2, 1};
@@ -1282,9 +1293,9 @@ TEST_CASE(
         break;
       case 3:
         expected_result_num = 6;
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"a", "a", "bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2, 1, 2};
@@ -1293,7 +1304,7 @@ TEST_CASE(
         break;
       case 4:
         expected_result_num = 2;
-        query_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
         expected_dim1 = {"c", "c"};
         expected_dim2 = {1, 2};
         expected_dim3 = {"i", "l"};
@@ -1301,8 +1312,8 @@ TEST_CASE(
         break;
       case 5:
         expected_result_num = 2;
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"c", "c"};
         expected_dim2 = {1, 2};
@@ -1311,9 +1322,9 @@ TEST_CASE(
         break;
       case 6:
         expected_result_num = 4;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range<int32_t>(
+        subarray_read.add_range<int32_t>(
             1, dim2_non_empty_domain.first, dim2_non_empty_domain.second);
         expected_dim1 = {"bb", "bb", "c", "c"};
         expected_dim2 = {1, 2, 1, 2};
@@ -1322,9 +1333,9 @@ TEST_CASE(
         break;
       case 7:
         expected_result_num = 2;
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim1"), std::string("az"), std::string("de"));
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"bb", "c"};
         expected_dim2 = {2, 1};
@@ -1333,8 +1344,8 @@ TEST_CASE(
         break;
       case 8:
         expected_result_num = 1;
-        query_read.add_range(0, std::string("c"), std::string("d"));
-        query_read.add_range(
+        subarray_read.add_range(0, std::string("c"), std::string("d"));
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"c"};
         expected_dim2 = {1};
@@ -1343,9 +1354,9 @@ TEST_CASE(
         break;
       case 9:
         expected_result_num = 3;
-        query_read.add_range(
+        subarray_read.add_range(
             0, dim1_non_empty_domain.first, dim1_non_empty_domain.second);
-        query_read.add_range(
+        subarray_read.add_range(
             std::string("dim3"), std::string("i"), std::string("kl"));
         expected_dim1 = {"a", "bb", "c"};
         expected_dim2 = {2, 2, 1};
@@ -1353,6 +1364,7 @@ TEST_CASE(
         expected_a1_data = {4, 5, 3};
         break;
     }
+    query_read.set_subarray(subarray_read);
 
     std::vector<char> dim1;
     std::vector<uint64_t> dim1_offsets;
@@ -1479,8 +1491,12 @@ void read_and_check_sparse_array_string_dim(
   std::string data_back;
   data_back.resize(expected_data.size());
 
+  Subarray subarray(ctx, array);
+  subarray.add_range(
+      "dim1", std::string("ATSD987JIO"), std::string("TGSD987JPO"));
+
   Query query(ctx, array, TILEDB_READ);
-  query.add_range("dim1", std::string("ATSD987JIO"), std::string("TGSD987JPO"));
+  query.set_subarray(subarray);
   query.set_data_buffer("dim1", (char*)data_back.data(), data_back.size());
   query.set_offsets_buffer("dim1", offsets_back.data(), offsets_back.size());
   query.set_layout(layout);

--- a/test/src/unit-cppapi-time.cc
+++ b/test/src/unit-cppapi-time.cc
@@ -148,9 +148,11 @@ TEST_CASE("C++ API: Time dimension", "[cppapi][time]") {
     std::vector<int64_t> subarray_r = {0, 9};
     Array array_r(ctx, array_name, TILEDB_READ);
     Query query_r(ctx, array_r);
+    Subarray sub(ctx, array_r);
+    sub.set_subarray(subarray_r);
     query_r.set_layout(TILEDB_ROW_MAJOR)
         .set_data_buffer("a", data_r)
-        .set_subarray(subarray_r);
+        .set_subarray(sub);
     REQUIRE(query_r.submit() == Query::Status::COMPLETE);
 
     auto result_num = query_r.result_buffer_elements()["a"].second;

--- a/test/src/unit-cppapi-updates.cc
+++ b/test/src/unit-cppapi-updates.cc
@@ -104,7 +104,9 @@ TEST_CASE(
   std::vector<int> r_data_a1;
   r_data_a1.resize(300);
 
-  query.set_subarray(subarray)
+  Subarray sub(ctx, array);
+  sub.set_subarray(subarray);
+  query.set_subarray(sub)
       .set_layout(TILEDB_ROW_MAJOR)
       .set_data_buffer("a1", r_data_a1)
       .set_offsets_buffer("a1", r_offsets_a1);

--- a/test/src/unit-cppapi-var-offsets.cc
+++ b/test/src/unit-cppapi-var-offsets.cc
@@ -226,8 +226,10 @@ struct VariableOffsetsFx {
     // Query outside unwritten coordinates of the array
     int64_t d1_start = 1, d1_end = 2;
     int64_t d2_start = 3, d2_end = 4;
-    query.add_range("d1", d1_start, d1_end);
-    query.add_range("d2", d2_start, d2_end);
+    Subarray subarray(ctx, array);
+    subarray.add_range("d1", d1_start, d1_end);
+    subarray.add_range("d2", d2_start, d2_end);
+    query.set_subarray(subarray);
 
     // Submit query
     query.submit();
@@ -1742,7 +1744,9 @@ TEST_CASE_METHOD(
 
     auto array = tiledb::Array(ctx, array_name, TILEDB_READ);
     Query query(ctx, array, TILEDB_READ);
-    query.add_range(0, std::string("aa"), std::string("dddd"));
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, std::string("aa"), std::string("dddd"));
+    query.set_subarray(subarray);
     query.set_data_buffer("dim1", (char*)data_back.data(), data_back.size());
     query.set_offsets_buffer(
         "dim1", (uint64_t*)offsets_back.data(), offsets_back.size());
@@ -1782,7 +1786,9 @@ TEST_CASE_METHOD(
     auto array = tiledb::Array(ctx, array_name, TILEDB_READ);
     Query query(ctx, array, TILEDB_READ);
     // this query range should return empty result
-    query.add_range(0, std::string("xyz"), std::string("xyz"));
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, std::string("xyz"), std::string("xyz"));
+    query.set_subarray(subarray);
     query.set_data_buffer("dim1", (char*)data_back.data(), data_back.size());
 
     // here we set the buffer at an offset of 2*uint64_t (== 4 * uint32_t)

--- a/test/src/unit-cppapi-xor-filter.cc
+++ b/test/src/unit-cppapi-xor-filter.cc
@@ -103,10 +103,12 @@ void xor_filter_api_test(Context& ctx, tiledb_array_type_t array_type) {
   Query query_r(ctx, array_r);
   query_r.set_layout(TILEDB_ROW_MAJOR).set_data_buffer("a", a_data_read);
 
+  Subarray subarray_r(ctx, array_r);
   if (array_type == TILEDB_DENSE) {
     int range[] = {1, xor_dim_hi};
-    query_r.add_range("rows", range[0], range[1])
+    subarray_r.add_range("rows", range[0], range[1])
         .add_range("cols", range[0], range[1]);
+    query_r.set_subarray(subarray_r);
   }
 
   query_r.submit();

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -317,6 +317,7 @@ void CDenseFx::write_1d_fragment(
 
   // Create the query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
@@ -325,8 +326,13 @@ void CDenseFx::write_1d_fragment(
   REQUIRE(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
-  CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   // Submit query.
   rc = tiledb_query_submit(ctx_, query);
@@ -356,6 +362,7 @@ void CDenseFx::write_1d_fragment_strings(
 
   // Create the query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
@@ -366,8 +373,13 @@ void CDenseFx::write_1d_fragment_strings(
   REQUIRE(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
-  CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   // Submit query.
   rc = tiledb_query_submit(ctx_, query);
@@ -399,6 +411,7 @@ void CDenseFx::write_1d_fragment_fixed_strings(
 
   // Create the query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
@@ -412,8 +425,13 @@ void CDenseFx::write_1d_fragment_fixed_strings(
   REQUIRE(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
-  CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   // Submit query.
   rc = tiledb_query_submit(ctx_, query);
@@ -443,12 +461,18 @@ void CDenseFx::read(
 
   // Create query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -534,12 +558,18 @@ void CDenseFx::read_evolved(
 
   // Create query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -576,12 +606,18 @@ void CDenseFx::read_strings(
 
   // Create query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -655,12 +691,18 @@ void CDenseFx::read_strings_evolved(
 
   // Create query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
@@ -706,12 +748,18 @@ void CDenseFx::read_fixed_strings(
 
   // Create query.
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
 
   // Set subarray.
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);

--- a/test/src/unit-duplicates.cc
+++ b/test/src/unit-duplicates.cc
@@ -137,6 +137,7 @@ TEST_CASE_METHOD(
 
   // Create the query
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
@@ -176,8 +177,13 @@ TEST_CASE_METHOD(
   // Create query
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
@@ -230,6 +236,7 @@ TEST_CASE_METHOD(
 
   // Create the query
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx_, array, TILEDB_WRITE, &query);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
@@ -303,8 +310,13 @@ TEST_CASE_METHOD(
   // Create query
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
@@ -365,8 +377,13 @@ TEST_CASE_METHOD(
   // Create query
   rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_set_subarray(ctx_, query, subarray);
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
   CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+  CHECK(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_ROW_MAJOR);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
@@ -493,12 +510,19 @@ TEST_CASE_METHOD(
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
+  // Create subarray
+  tiledb_subarray_t* subarray = nullptr;
+  rc = tiledb_subarray_alloc(ctx_, array, &subarray);
+  CHECK(rc == TILEDB_OK);
+
   // Set multi-range subarray to query
   int start_1 = 1, end_1 = 2;
   int start_2 = 4, end_2 = 10;
-  rc = tiledb_query_add_range(ctx_, query, 0, &start_1, &end_1, NULL);
+  rc = tiledb_subarray_add_range(ctx_, subarray, 0, &start_1, &end_1, NULL);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_add_range(ctx_, query, 0, &start_2, &end_2, NULL);
+  rc = tiledb_subarray_add_range(ctx_, subarray, 0, &start_2, &end_2, NULL);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -534,6 +558,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 
   // Validate results
   CHECK(num_found_coords[1] == 2);
@@ -613,9 +638,16 @@ TEST_CASE_METHOD(
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
+  // Create subarray
+  tiledb_subarray_t* subarray = nullptr;
+  rc = tiledb_subarray_alloc(ctx_, array, &subarray);
+  CHECK(rc == TILEDB_OK);
+
   // Set empty subarray to query
   int start_1 = 9, end_1 = 10;
-  rc = tiledb_query_add_range(ctx_, query, 0, &start_1, &end_1, NULL);
+  rc = tiledb_subarray_add_range(ctx_, subarray, 0, &start_1, &end_1, NULL);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -635,6 +667,7 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -702,12 +735,19 @@ TEST_CASE_METHOD(
   rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
   CHECK(rc == TILEDB_OK);
 
+  // Create subarray
+  tiledb_subarray_t* subarray = nullptr;
+  rc = tiledb_subarray_alloc(ctx_, array, &subarray);
+  CHECK(rc == TILEDB_OK);
+
   // Set multi-range subarray to query
   int start_1 = 9, end_1 = 10;
   int start_2 = 1, end_2 = 2;
-  rc = tiledb_query_add_range(ctx_, query, 0, &start_1, &end_1, NULL);
+  rc = tiledb_subarray_add_range(ctx_, subarray, 0, &start_1, &end_1, NULL);
   CHECK(rc == TILEDB_OK);
-  rc = tiledb_query_add_range(ctx_, query, 0, &start_2, &end_2, NULL);
+  rc = tiledb_subarray_add_range(ctx_, subarray, 0, &start_2, &end_2, NULL);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
 
   // Submit query
@@ -730,4 +770,5 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }

--- a/test/src/unit-empty-var-length.cc
+++ b/test/src/unit-empty-var-length.cc
@@ -1,5 +1,5 @@
 /**
- * @file   unit-capi-empty-var-length.cc
+ * @file   unit-empty-var-length.cc
  *
  * @section LICENSE
  *
@@ -282,6 +282,7 @@ void StringEmptyFx::read_array(const std::string& array_name) {
 
   // Create query
   tiledb_query_t* query;
+  tiledb_subarray_t* sub;
   rc = tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
@@ -289,8 +290,13 @@ void StringEmptyFx::read_array(const std::string& array_name) {
 
   // Set subarray
   uint64_t subarray[] = {1, 5};
-  rc = tiledb_query_set_subarray(ctx, query, subarray);
-  CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_alloc(ctx, array, &sub);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx, sub, subarray);
+  REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_query_set_subarray_t(ctx, query, sub);
+  REQUIRE(rc == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   // Set buffer
   uint64_t buffer_d1_size = 1024;
@@ -498,8 +504,10 @@ void StringEmptyFx2::read_array(const std::string& array_name) {
   query.set_data_buffer("", r_data);
   query.set_offsets_buffer("", r_offsets);
 
-  query.add_range(0, (uint64_t)0, (uint64_t)3);
-  query.add_range(1, (uint64_t)0, (uint64_t)3);
+  Subarray subarray(ctx, array);
+  subarray.add_range(0, (uint64_t)0, (uint64_t)3);
+  subarray.add_range(1, (uint64_t)0, (uint64_t)3);
+  query.set_subarray(subarray);
 
   query.submit();
 
@@ -576,8 +584,10 @@ TEST_CASE_METHOD(
     query.set_data_buffer("", r_data);
     query.set_offsets_buffer("", r_offsets);
 
-    query.add_range(0, (uint64_t)0, (uint64_t)3);
-    query.add_range(1, (uint64_t)0, (uint64_t)3);
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, (uint64_t)0, (uint64_t)3);
+    subarray.add_range(1, (uint64_t)0, (uint64_t)3);
+    query.set_subarray(subarray);
 
     query.submit();
 
@@ -601,8 +611,10 @@ TEST_CASE_METHOD(
     query.set_data_buffer("", r_data);
     query.set_offsets_buffer("", r_offsets);
 
-    query.add_range(0, (uint64_t)0, (uint64_t)1);
-    query.add_range(1, (uint64_t)1, (uint64_t)2);
+    Subarray subarray(ctx, array);
+    subarray.add_range(0, (uint64_t)0, (uint64_t)1);
+    subarray.add_range(1, (uint64_t)1, (uint64_t)2);
+    query.set_subarray(subarray);
 
     query.submit();
 

--- a/test/src/unit-query-plan.cc
+++ b/test/src/unit-query-plan.cc
@@ -72,7 +72,11 @@ TEST_CASE_METHOD(
   CHECK(tiledb_query_set_layout(ctx_c_, query, TILEDB_ROW_MAJOR) == TILEDB_OK);
 
   int64_t dom[] = {1, 2, 1, 2};
-  CHECK(tiledb_query_set_subarray(ctx_c_, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* sub;
+  CHECK(tiledb_subarray_alloc(ctx_c_, array, &sub) == TILEDB_OK);
+  CHECK(tiledb_subarray_set_subarray(ctx_c_, sub, &dom) == TILEDB_OK);
+  CHECK(tiledb_query_set_subarray_t(ctx_c_, query, sub) == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   std::vector<int32_t> d(4);
   uint64_t size = 1;
@@ -86,7 +90,10 @@ TEST_CASE_METHOD(
   // API lifecycle checks
   // It's not possible to set subarrays, layout, query condition or new buffers
   // once the query plan got generated.
-  CHECK(tiledb_query_set_subarray(ctx_c_, query, &dom) == TILEDB_ERR);
+  CHECK(tiledb_subarray_alloc(ctx_c_, array, &sub) == TILEDB_OK);
+  CHECK(tiledb_subarray_set_subarray(ctx_c_, sub, &dom) == TILEDB_OK);
+  CHECK(tiledb_query_set_subarray_t(ctx_c_, query, sub) == TILEDB_ERR);
+  tiledb_subarray_free(&sub);
   CHECK(tiledb_query_set_layout(ctx_c_, query, TILEDB_COL_MAJOR) == TILEDB_ERR);
   tiledb_query_condition_t* qc;
   CHECK(tiledb_query_condition_alloc(ctx_c_, &qc) == TILEDB_OK);
@@ -127,7 +134,11 @@ TEST_CASE_METHOD(
   CHECK(tiledb_query_set_layout(ctx_c_, query, TILEDB_ROW_MAJOR) == TILEDB_OK);
 
   int64_t dom[] = {1, 2, 1, 2};
-  CHECK(tiledb_query_set_subarray(ctx_c_, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* sub;
+  CHECK(tiledb_subarray_alloc(ctx_c_, array, &sub) == TILEDB_OK);
+  CHECK(tiledb_subarray_set_subarray(ctx_c_, sub, &dom) == TILEDB_OK);
+  CHECK(tiledb_query_set_subarray_t(ctx_c_, query, sub) == TILEDB_OK);
+  tiledb_subarray_free(&sub);
 
   std::vector<int32_t> d(4);
   uint64_t size = 1;

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -205,12 +205,19 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_array_alloc(ctx, uri_.c_str(), &array) == TILEDB_OK);
   REQUIRE(tiledb_array_open(ctx, array, TILEDB_READ) == TILEDB_OK);
 
+  // Create subarray
+  tiledb_subarray_t* sub;
+  rc = tiledb_subarray_alloc(ctx_, array, &sub);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+  CHECK(rc == TILEDB_OK);
+
   // Create query
   tiledb_query_t* query = nullptr;
   REQUIRE(tiledb_query_alloc(ctx, array, TILEDB_READ, &query) == TILEDB_OK);
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR) == TILEDB_OK);
   int32_t dom[] = {1, 2, 1, 2};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, &sub) == TILEDB_OK);
 
   uint64_t size = 1;
   std::vector<int32_t> a1(2);
@@ -240,6 +247,7 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_query_free(&query);
   tiledb_array_free(&array);
+  tiledb_subarray_free(&sub);
   tiledb_ctx_free(&ctx);
 }
 

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -206,18 +206,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_array_open(ctx, array, TILEDB_READ) == TILEDB_OK);
 
   // Create subarray
+  int32_t dom[] = {1, 2, 1, 2};
   tiledb_subarray_t* sub;
-  rc = tiledb_subarray_alloc(ctx_, array, &sub);
-  CHECK(rc == TILEDB_OK);
-  rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
-  CHECK(rc == TILEDB_OK);
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &sub) == TILEDB_OK);
+  REQUIRE(tiledb_subarray_set_subarray(ctx, sub, dom) == TILEDB_OK);
 
   // Create query
   tiledb_query_t* query = nullptr;
   REQUIRE(tiledb_query_alloc(ctx, array, TILEDB_READ, &query) == TILEDB_OK);
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_ROW_MAJOR) == TILEDB_OK);
-  int32_t dom[] = {1, 2, 1, 2};
-  REQUIRE(tiledb_query_set_subarray_t(ctx, query, &sub) == TILEDB_OK);
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, sub) == TILEDB_OK);
 
   uint64_t size = 1;
   std::vector<int32_t> a1(2);

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -365,8 +365,14 @@ int32_t CSparseGlobalOrderFx::read(
 
   if (set_subarray) {
     // Set subarray.
-    rc = tiledb_query_set_subarray(ctx_, query, subarray.data());
+    tiledb_subarray_t* sub;
+    rc = tiledb_subarray_alloc(ctx_, array, &sub);
     CHECK(rc == TILEDB_OK);
+    rc = tiledb_subarray_set_subarray(ctx_, sub, subarray.data());
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+    CHECK(rc == TILEDB_OK);
+    tiledb_subarray_free(&sub);
   }
 
   if (qc_idx != 0) {
@@ -448,8 +454,14 @@ int32_t CSparseGlobalOrderFx::read_strings(
 
   if (set_subarray) {
     // Set subarray.
-    rc = tiledb_query_set_subarray(ctx_, query, subarray.data());
+    tiledb_subarray_t* sub;
+    rc = tiledb_subarray_alloc(ctx_, array, &sub);
     CHECK(rc == TILEDB_OK);
+    rc = tiledb_subarray_set_subarray(ctx_, sub, subarray.data());
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+    CHECK(rc == TILEDB_OK);
+    tiledb_subarray_free(&sub);
   }
 
   rc = tiledb_query_set_layout(ctx_, query, TILEDB_GLOBAL_ORDER);

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -410,8 +410,14 @@ int32_t CSparseUnorderedWithDupsFx::read(
   if (set_subarray) {
     // Set subarray.
     int subarray[] = {1, 200};
-    rc = tiledb_query_set_subarray(ctx_, query, subarray);
+    tiledb_subarray_t* sub;
+    rc = tiledb_subarray_alloc(ctx_, array, &sub);
     CHECK(rc == TILEDB_OK);
+    rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+    CHECK(rc == TILEDB_OK);
+    tiledb_subarray_free(&sub);
   }
 
   if (qc_idx != 0) {
@@ -675,8 +681,14 @@ void CSparseUnorderedWithDupsVarDataFx::read_and_check_data(bool set_subarray) {
   if (set_subarray) {
     // Set subarray.
     int64_t subarray[] = {1, 4, 1, 4};
-    rc = tiledb_query_set_subarray(ctx_, query, subarray);
+    tiledb_subarray_t* sub;
+    rc = tiledb_subarray_alloc(ctx_, array, &sub);
     CHECK(rc == TILEDB_OK);
+    rc = tiledb_subarray_set_subarray(ctx_, sub, subarray);
+    CHECK(rc == TILEDB_OK);
+    rc = tiledb_query_set_subarray_t(ctx_, query, sub);
+    CHECK(rc == TILEDB_OK);
+    tiledb_subarray_free(&sub);
   }
 
   std::vector<int32_t> data(3);

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1180,15 +1180,23 @@ void read_array(
   rc = tiledb_query_set_layout(ctx, query, layout);
   CHECK(rc == TILEDB_OK);
 
+  // Create subarray
+  tiledb_subarray_t* subarray;
+  rc = tiledb_subarray_alloc(ctx, array, &subarray);
+  CHECK(rc == TILEDB_OK);
+
   auto dim_num = (unsigned)ranges.size();
   for (unsigned i = 0; i < dim_num; ++i) {
     auto dim_range_num = ranges[i].size() / 2;
     for (size_t j = 0; j < dim_range_num; ++j) {
-      rc = tiledb_query_add_range(
-          ctx, query, i, &ranges[i][2 * j], &ranges[i][2 * j + 1], nullptr);
+      rc = tiledb_subarray_add_range(
+          ctx, subarray, i, &ranges[i][2 * j], &ranges[i][2 * j + 1], nullptr);
       CHECK(rc == TILEDB_OK);
     }
   }
+
+  // Set the subarray
+  tiledb_query_set_subarray_t(ctx, query, subarray);
 
   // Set buffers
   for (const auto& b : buffers) {
@@ -1230,6 +1238,7 @@ void read_array(
 
   // Clean up
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 int32_t num_commits(Context ctx, const std::string& array_name) {

--- a/tiledb/api/c_api/query_aggregate/test/unit_capi_query_aggregate.cc
+++ b/tiledb/api/c_api/query_aggregate/test/unit_capi_query_aggregate.cc
@@ -230,7 +230,10 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 9, 1, 2};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(tiledb_subarray_set_subarray(ctx, subarray, &dom) == TILEDB_OK);
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   // nullptr context
   tiledb_query_channel_t* default_channel = nullptr;
@@ -324,6 +327,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -340,7 +344,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 9, 1, 2};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -365,6 +378,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -381,7 +395,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 10, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -411,6 +434,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -427,7 +451,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 10, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -459,6 +492,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -475,7 +509,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 10, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -506,6 +549,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -522,7 +566,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 10, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -553,6 +606,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -569,7 +623,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 10, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -601,6 +664,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -617,7 +681,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 9, 1, 2};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -654,6 +727,7 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -668,7 +742,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_alloc(ctx, array, TILEDB_READ, &query) == TILEDB_OK);
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
   int64_t dom[] = {1, 2, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   std::vector<int32_t> d(4);
   uint64_t size = 1;
@@ -697,6 +780,7 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }
 
 TEST_CASE_METHOD(
@@ -713,7 +797,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
 
   int64_t dom[] = {1, 10, 1, 1};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 0, &dom[0], &dom[1], nullptr) ==
+      TILEDB_OK);
+  REQUIRE(
+      tiledb_subarray_add_range(ctx, subarray, 1, &dom[2], &dom[3], nullptr) ==
+      TILEDB_OK);
+
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_channel_t* default_channel;
   REQUIRE(
@@ -751,4 +844,5 @@ TEST_CASE_METHOD(
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
   tiledb_query_free(&query);
+  tiledb_subarray_free(&subarray);
 }

--- a/tiledb/api/c_api/query_field/test/unit_capi_query_field.cc
+++ b/tiledb/api/c_api/query_field/test/unit_capi_query_field.cc
@@ -292,7 +292,10 @@ TEST_CASE_METHOD(QueryFieldFx, "C API: get_field", "[capi][query_field]") {
 
   REQUIRE(tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED) == TILEDB_OK);
   int64_t dom[] = {1, 9, 1, 2};
-  REQUIRE(tiledb_query_set_subarray(ctx, query, &dom) == TILEDB_OK);
+  tiledb_subarray_t* subarray;
+  REQUIRE(tiledb_subarray_alloc(ctx, array, &subarray) == TILEDB_OK);
+  REQUIRE(tiledb_subarray_set_subarray(ctx, subarray, &dom) == TILEDB_OK);
+  REQUIRE(tiledb_query_set_subarray_t(ctx, query, subarray) == TILEDB_OK);
 
   tiledb_query_field_t* field = nullptr;
   tiledb_datatype_t type;
@@ -393,4 +396,5 @@ TEST_CASE_METHOD(QueryFieldFx, "C API: get_field", "[capi][query_field]") {
   tiledb_query_free(&query);
   CHECK(tiledb_array_close(ctx, array) == TILEDB_OK);
   tiledb_array_free(&array);
+  tiledb_subarray_free(&subarray);
 }


### PR DESCRIPTION
This removed deprecated APIs from tests. It will be split into multiple PRs to facilitate code reviewing.

[sc-46307]

---
TYPE: NO_HISTORY
DESC: Remove deprecated APIs from tests, part 3.
