### PR TITLE
Migrate APIs out of StorageManager: delete_group.

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -294,28 +294,6 @@ Status Group::get_query_type(QueryType* query_type) const {
   return Status::Ok();
 }
 
-void Group::delete_group(
-    const URI& uri, VFS* vfs, tiledb::common::ThreadPool* compute_tp) {
-  auto group_dir = GroupDirectory(
-      vfs, compute_tp, uri, 0, std::numeric_limits<uint64_t>::max());
-
-  // Delete the group detail, group metadata and group files
-  vfs->remove_files(compute_tp, group_dir.group_detail_uris());
-  vfs->remove_files(compute_tp, group_dir.group_meta_uris());
-  vfs->remove_files(compute_tp, group_dir.group_meta_uris_to_vacuum());
-  vfs->remove_files(compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
-  vfs->remove_files(compute_tp, group_dir.group_file_uris());
-
-  // Delete all tiledb child directories
-  // Note: using vfs()->ls() here could delete user data
-  std::vector<URI> dirs;
-  auto parent_dir = group_dir.uri().c_str();
-  for (auto group_dir_name : constants::group_dir_names) {
-    dirs.emplace_back(URI(parent_dir + group_dir_name));
-  }
-  vfs->remove_dirs(compute_tp, dirs);
-}
-
 void Group::delete_group(const URI& uri, bool recursive) {
   // Check that group is open
   if (!is_open_) {
@@ -354,8 +332,27 @@ void Group::delete_group(const URI& uri, bool recursive) {
         }
       }
     }
-    Group::delete_group(
-        uri, storage_manager_->vfs(), storage_manager_->compute_tp());
+
+    auto& vfs = resources_.vfs();
+    auto& compute_tp = resources_.compute_tp();
+    auto group_dir = GroupDirectory(
+        &vfs, &compute_tp, uri, 0, std::numeric_limits<uint64_t>::max());
+
+    // Delete the group detail, group metadata and group files
+    vfs.remove_files(&compute_tp, group_dir.group_detail_uris());
+    vfs.remove_files(&compute_tp, group_dir.group_meta_uris());
+    vfs.remove_files(&compute_tp, group_dir.group_meta_uris_to_vacuum());
+    vfs.remove_files(&compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
+    vfs.remove_files(&compute_tp, group_dir.group_file_uris());
+
+    // Delete all tiledb child directories
+    // Note: using vfs().ls() here could delete user data
+    std::vector<URI> dirs;
+    auto parent_dir = group_dir.uri().c_str();
+    for (auto group_dir_name : constants::group_dir_names) {
+      dirs.emplace_back(URI(parent_dir + group_dir_name));
+    }
+    vfs.remove_dirs(&compute_tp, dirs);
   }
   // Clear metadata and other pending changes to avoid patching a deleted group.
   metadata_.clear();

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -117,11 +117,24 @@ class Group {
   void clear();
 
   /**
-   * Deletes data from and closes a group opened in MODIFY_EXCLUSIVE mode.
+   * Performs deletion of data and closes the local group with the given URI.
    *
-   * Note: if recursive == false, data added to the group will be left as-is.
+   * @param uri The URI of the group to be deleted.
+   * @param vfs The virtual filesystem on which the local group sits.
+   * @param tp The compute thread pool.
    *
-   * @param uri The address of the group to be deleted.
+   */
+  static void delete_group(
+      const URI& uri, VFS* vfs, tiledb::common::ThreadPool* tp);
+
+  /**
+   *
+   * Handles local and remote deletion of data from a group with the given URI.
+   *
+   * @pre The group must be opened in MODIFY_EXCLUSIVE mode.
+   * @note If recursive == false, data added to the group will be left as-is.
+   *
+   * @param uri The URI of the group to be deleted.
    * @param recursive True if all data inside the group is to be deleted.
    */
   void delete_group(const URI& uri, bool recursive = false);

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -117,17 +117,6 @@ class Group {
   void clear();
 
   /**
-   * Performs deletion of data and closes the local group with the given URI.
-   *
-   * @param uri The URI of the group to be deleted.
-   * @param vfs The virtual filesystem on which the local group sits.
-   * @param tp The compute thread pool.
-   *
-   */
-  static void delete_group(
-      const URI& uri, VFS* vfs, tiledb::common::ThreadPool* tp);
-
-  /**
    *
    * Handles local and remote deletion of data from a group with the given URI.
    *

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -226,36 +226,6 @@ void StorageManagerCanonical::delete_fragments(
       }));
 }
 
-void StorageManagerCanonical::delete_group(const char* group_name) {
-  if (group_name == nullptr) {
-    throw Status_StorageManagerError(
-        "[delete_group] Group name cannot be null");
-  }
-
-  auto group_dir = GroupDirectory(
-      vfs(),
-      compute_tp(),
-      URI(group_name),
-      0,
-      std::numeric_limits<uint64_t>::max());
-
-  // Delete the group detail, group metadata and group files
-  vfs()->remove_files(compute_tp(), group_dir.group_detail_uris());
-  vfs()->remove_files(compute_tp(), group_dir.group_meta_uris());
-  vfs()->remove_files(compute_tp(), group_dir.group_meta_uris_to_vacuum());
-  vfs()->remove_files(compute_tp(), group_dir.group_meta_vac_uris_to_vacuum());
-  vfs()->remove_files(compute_tp(), group_dir.group_file_uris());
-
-  // Delete all tiledb child directories
-  // Note: using vfs()->ls() here could delete user data
-  std::vector<URI> dirs;
-  auto parent_dir = group_dir.uri().c_str();
-  for (auto group_dir_name : constants::group_dir_names) {
-    dirs.emplace_back(URI(parent_dir + group_dir_name));
-  }
-  vfs()->remove_dirs(compute_tp(), dirs);
-}
-
 Status StorageManagerCanonical::array_create(
     const URI& array_uri,
     const shared_ptr<ArraySchema>& array_schema,

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -197,13 +197,6 @@ class StorageManagerCanonical {
       const char* array_name, uint64_t timestamp_start, uint64_t timestamp_end);
 
   /**
-   * Cleans up the group data.
-   *
-   * @param group_name The name of the group whose data is to be deleted.
-   */
-  void delete_group(const char* group_name);
-
-  /**
    * Creates a TileDB array storing its schema.
    *
    * @param array_uri The URI of the array to be created.


### PR DESCRIPTION
Migrate APIs out of `StorageManager`: `delete_group`.

---
[sc-46728]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of StorageManager: delete_group
