### PR TITLE
Add array uri to tiledb_array_deserialize

### DIFF
--- a/test/support/src/serialization_wrappers.cc
+++ b/test/support/src/serialization_wrappers.cc
@@ -141,7 +141,13 @@ int array_serialize_wrapper(
   REQUIRE(rc == TILEDB_OK);
 
   // Load array from the rest server
-  rc = tiledb_deserialize_array(ctx, buff, serialize_type, 0, new_array);
+  rc = tiledb_deserialize_array(
+      ctx,
+      buff,
+      serialize_type,
+      0,
+      array->array_->array_uri().c_str(),
+      new_array);
   REQUIRE(rc == TILEDB_OK);
 
   // Clean up.

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3391,6 +3391,7 @@ int32_t tiledb_deserialize_array(
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t,
+    const char* array_uri,
     tiledb_array_t** array) {
   // Sanity check
 
@@ -3406,7 +3407,7 @@ int32_t tiledb_deserialize_array(
   }
 
   // Check array URI
-  auto uri = tiledb::sm::URI("deserialized_array");
+  auto uri = tiledb::sm::URI(array_uri);
   if (uri.is_invalid()) {
     auto st = Status_Error("Failed to create TileDB array object; Invalid URI");
     delete *array;
@@ -6945,9 +6946,10 @@ CAPI_INTERFACE(
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
+    const char* array_uri,
     tiledb_array_t** array) {
   return api_entry<tiledb::api::tiledb_deserialize_array>(
-      ctx, buffer, serialize_type, client_side, array);
+      ctx, buffer, serialize_type, client_side, array_uri, array);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -106,6 +106,7 @@ TILEDB_EXPORT int32_t tiledb_serialize_array(
  * @param client_side Allows to specify different behavior depending on who is
  * serializing, the client (1) or the Cloud server (0). This is sometimes needed
  * since they are both using the same Core library APIs for serialization.
+ * @param array_uri uri of the array to deserialize.
  * @param array Will be set to a newly allocated array.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
@@ -114,6 +115,7 @@ TILEDB_EXPORT int32_t tiledb_deserialize_array(
     const tiledb_buffer_t* buffer,
     tiledb_serialization_type_t serialize_type,
     int32_t client_side,
+    const char* array_uri,
     tiledb_array_t** array) TILEDB_NOEXCEPT;
 
 /**

--- a/tiledb/sm/c_api/tiledb_serialization.h
+++ b/tiledb/sm/c_api/tiledb_serialization.h
@@ -28,6 +28,8 @@
  * @section DESCRIPTION
  *
  * This file declares the TileDB C API for serialization.
+ * APIs defined in this header are currently unstable and subject to breaking
+ * changes between minor releases.
  */
 
 #ifndef TILEDB_SERIALIZATION_H


### PR DESCRIPTION
[sc-47129
](https://app.shortcut.com/tiledb-inc/story/47129/add-array-uri-to-tiledb-array-deserialize
)
Today `tiledb_array_deserialize` is using a hardcoded uri name (`"deserialized_array"`) , whereas `tiledb_deserialize_query_and_array` is requiring the actual `array_uri` as an argument. The former is problematic for wrapping those calls in python, so this ticket is aiming to unify the two to both receive the `array_uri` as input. (history on why this is needed here: https://app.shortcut.com/tiledb-inc/story/47139/investigate-if-core-serialization-apis-could-be-used-externally-to-pass-cache-open-arrays)

There's no backward compatibility issue here as this is a deserialization function only called by REST Server, so we don't need to keep both versions of `tiledb_array_deserialize`.

That said, the REST-CI tests that run based on latest dev on Core and latest master in Cloud-REST will break after this change. We will handle this by adapting the REST-CI script to patch temporarily Cloud-REST master with the needed change and remove when 2.24 is released https://github.com/TileDB-Inc/TileDB-Internal/pull/27  . Another idea was to maintain both flavors until the release is ready to go out and then remove but C doesn't support overloading functions.

Future work to track:  https://github.com/TileDB-Inc/TileDB/pull/4961

---
TYPE: IMPROVEMENT
DESC: Add array uri to tiledb_array_deserialize
