### PR TITLE
Simplify handling of unsupported C API `stride` arguments

### DIFF
--- a/tiledb/api/c_api_support/argument_validation.h
+++ b/tiledb/api/c_api_support/argument_validation.h
@@ -73,6 +73,21 @@ inline void ensure_output_pointer_is_valid(void* p) {
   }
 }
 
+/**
+ * Ensure that the output pointer for a stride argument is null.
+ *
+ * The C API has arguments for the "stride" of a range, but does not support
+ * such arguments at the present time. This validation ensures that the argument
+ * is null.
+ *
+ * @param p The value of a `stride` argument to a C API function
+ */
+inline void ensure_unsupported_stride_is_null(const void* p) {
+  if (p != nullptr) {
+    throw CAPIException("Stride is currently unsupported");
+  }
+}
+
 }  // namespace tiledb::api
 
 #endif  // TILEDB_CAPI_SUPPORT_ARGUMENT_VALIDATION_H

--- a/tiledb/sm/c_api/api_argument_validator.h
+++ b/tiledb/sm/c_api/api_argument_validator.h
@@ -69,17 +69,17 @@ inline int32_t sanity_check(tiledb_ctx_t* ctx, const tiledb_array_t* array) {
   return TILEDB_OK;
 }
 
-inline int32_t sanity_check(
-    tiledb_ctx_t* ctx, const tiledb_subarray_t* subarray) {
-  if (subarray == nullptr || subarray->subarray_ == nullptr ||
-      subarray->subarray_->array() == nullptr) {
-    auto st = Status_Error("Invalid TileDB subarray object");
-    LOG_STATUS_NO_RETURN_VALUE(st);
-    save_error(ctx, st);
-    return TILEDB_ERR;
+namespace tiledb::api {
+/**
+ * Returns if a subarray handle (old style) is valid. Throws otherwise.
+ */
+inline void ensure_subarray_is_valid(const tiledb_subarray_t* p) {
+  if (p == nullptr || p->subarray_ == nullptr ||
+      p->subarray_->array() == nullptr) {
+    throw CAPIException("Invalid TileDB subarray object");
   }
-  return TILEDB_OK;
 }
+}  // namespace tiledb::api
 
 inline int32_t sanity_check(
     tiledb_ctx_t* ctx, const tiledb_array_schema_t* array_schema) {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1789,9 +1789,7 @@ int32_t tiledb_subarray_set_coalesce_ranges(
 }
 
 int32_t tiledb_subarray_set_subarray(
-    tiledb_ctx_t*,
-    tiledb_subarray_t* subarray_obj,
-    const void* subarray_vals) {
+    tiledb_ctx_t*, tiledb_subarray_t* subarray_obj, const void* subarray_vals) {
   ensure_subarray_is_valid(subarray_obj);
   subarray_obj->subarray_->set_subarray(subarray_vals);
   return TILEDB_OK;
@@ -1926,8 +1924,7 @@ int32_t tiledb_subarray_get_range_from_name(
   if (stride != nullptr) {
     *stride = nullptr;
   }
-  subarray->subarray_->get_range_from_name(
-      dim_name, range_idx, start, end);
+  subarray->subarray_->get_range_from_name(dim_name, range_idx, start, end);
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1072,12 +1072,11 @@ int32_t tiledb_query_set_subarray_t(
     tiledb_query_t* query,
     const tiledb_subarray_t* subarray) {
   // Sanity check
-  if (sanity_check(ctx, query) == TILEDB_ERR ||
-      sanity_check(ctx, subarray) == TILEDB_ERR)
+  if (sanity_check(ctx, query) == TILEDB_ERR) {
     return TILEDB_ERR;
-
+  }
+  ensure_subarray_is_valid(subarray);
   query->query_->set_subarray(*subarray->subarray_);
-
   return TILEDB_OK;
 }
 
@@ -1762,9 +1761,8 @@ capi_return_t tiledb_subarray_alloc(
 }
 
 int32_t tiledb_subarray_set_config(
-    tiledb_ctx_t* ctx, tiledb_subarray_t* subarray, tiledb_config_t* config) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+    tiledb_ctx_t*, tiledb_subarray_t* subarray, tiledb_config_t* config) {
+  ensure_subarray_is_valid(subarray);
   api::ensure_config_is_valid(config);
   subarray->subarray_->set_config(
       tiledb::sm::QueryType::READ, config->config());
@@ -1784,196 +1782,188 @@ void tiledb_subarray_free(tiledb_subarray_t** subarray) {
 }
 
 int32_t tiledb_subarray_set_coalesce_ranges(
-    tiledb_ctx_t* ctx, tiledb_subarray_t* subarray, int coalesce_ranges) {
-  // Sanity check
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+    tiledb_ctx_t*, tiledb_subarray_t* subarray, int coalesce_ranges) {
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->set_coalesce_ranges(coalesce_ranges != 0);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_set_subarray(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_subarray_t* subarray_obj,
     const void* subarray_vals) {
-  if (sanity_check(ctx, subarray_obj) == TILEDB_ERR)
-    return TILEDB_ERR;
-
+  ensure_subarray_is_valid(subarray_obj);
   subarray_obj->subarray_->set_subarray(subarray_vals);
-
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_add_range(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const void* start,
     const void* end,
     const void* stride) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
-
-  subarray->subarray_->add_range(dim_idx, start, end, stride);
-
+  ensure_subarray_is_valid(subarray);
+  ensure_unsupported_stride_is_null(stride);
+  subarray->subarray_->add_range(dim_idx, start, end);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_add_point_ranges(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const void* start,
     uint64_t count) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->add_point_ranges(dim_idx, start, count);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_add_range_by_name(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_subarray_t* subarray,
     const char* dim_name,
     const void* start,
     const void* end,
     const void* stride) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
-  subarray->subarray_->add_range_by_name(dim_name, start, end, stride);
+  ensure_subarray_is_valid(subarray);
+  ensure_unsupported_stride_is_null(stride);
+  subarray->subarray_->add_range_by_name(dim_name, start, end);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_add_range_var(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     const void* start,
     uint64_t start_size,
     const void* end,
     uint64_t end_size) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->add_range_var(dim_idx, start, start_size, end, end_size);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_add_range_var_by_name(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     tiledb_subarray_t* subarray,
     const char* dim_name,
     const void* start,
     uint64_t start_size,
     const void* end,
     uint64_t end_size) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->add_range_var_by_name(
       dim_name, start, start_size, end, end_size);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_num(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t* range_num) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_range_num(dim_idx, range_num);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_num_from_name(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t* range_num) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_range_num_from_name(dim_name, range_num);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t range_idx,
     const void** start,
     const void** end,
     const void** stride) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
-  subarray->subarray_->get_range(dim_idx, range_idx, start, end, stride);
+  ensure_subarray_is_valid(subarray);
+  ensure_output_pointer_is_valid(start);
+  ensure_output_pointer_is_valid(end);
+  if (stride != nullptr) {
+    *stride = nullptr;
+  }
+  subarray->subarray_->get_range(dim_idx, range_idx, start, end);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_var_size(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t range_idx,
     uint64_t* start_size,
     uint64_t* end_size) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_range_var_size(
       dim_idx, range_idx, start_size, end_size);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_from_name(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     const void** start,
     const void** end,
     const void** stride) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
+  ensure_output_pointer_is_valid(start);
+  ensure_output_pointer_is_valid(end);
+  if (stride != nullptr) {
+    *stride = nullptr;
+  }
   subarray->subarray_->get_range_from_name(
-      dim_name, range_idx, start, end, stride);
+      dim_name, range_idx, start, end);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_var_size_from_name(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     uint64_t* start_size,
     uint64_t* end_size) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_range_var_size_from_name(
       dim_name, range_idx, start_size, end_size);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_var(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     uint32_t dim_idx,
     uint64_t range_idx,
     void* start,
     void* end) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_range_var(dim_idx, range_idx, start, end);
   return TILEDB_OK;
 }
 
 int32_t tiledb_subarray_get_range_var_from_name(
-    tiledb_ctx_t* ctx,
+    tiledb_ctx_t*,
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t range_idx,
     void* start,
     void* end) {
-  if (sanity_check(ctx, subarray) == TILEDB_ERR)
-    return TILEDB_ERR;
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_range_var_from_name(dim_name, range_idx, start, end);
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb_dimension_label.cc
+++ b/tiledb/sm/c_api/tiledb_dimension_label.cc
@@ -130,7 +130,9 @@ capi_return_t tiledb_subarray_add_label_range(
     const void* start,
     const void* end,
     const void* stride) {
-  subarray->subarray_->add_label_range(label_name, start, end, stride);
+  ensure_subarray_is_valid(subarray);
+  ensure_unsupported_stride_is_null(stride);
+  subarray->subarray_->add_label_range(label_name, start, end);
   return TILEDB_OK;
 }
 
@@ -141,6 +143,7 @@ capi_return_t tiledb_subarray_add_label_range_var(
     uint64_t start_size,
     const void* end,
     uint64_t end_size) {
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->add_label_range_var(
       label_name, start, start_size, end, end_size);
   return TILEDB_OK;
@@ -148,6 +151,7 @@ capi_return_t tiledb_subarray_add_label_range_var(
 
 capi_return_t tiledb_subarray_get_label_name(
     tiledb_subarray_t* subarray, uint32_t dim_idx, const char** label_name) {
+  ensure_subarray_is_valid(subarray);
   const auto& name = subarray->subarray_->get_label_name(dim_idx);
   *label_name = name.c_str();
   return TILEDB_OK;
@@ -160,7 +164,13 @@ capi_return_t tiledb_subarray_get_label_range(
     const void** start,
     const void** end,
     const void** stride) {
-  subarray->subarray_->get_label_range(dim_name, range_idx, start, end, stride);
+  ensure_subarray_is_valid(subarray);
+  ensure_output_pointer_is_valid(start);
+  ensure_output_pointer_is_valid(end);
+  if (stride != nullptr) {
+    *stride = nullptr;
+  }
+  subarray->subarray_->get_label_range(dim_name, range_idx, start, end);
   return TILEDB_OK;
 }
 
@@ -168,6 +178,7 @@ capi_return_t tiledb_subarray_get_label_range_num(
     const tiledb_subarray_t* subarray,
     const char* dim_name,
     uint64_t* range_num) {
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_label_range_num(dim_name, range_num);
   return TILEDB_OK;
 }
@@ -178,6 +189,7 @@ capi_return_t tiledb_subarray_get_label_range_var(
     uint64_t range_idx,
     void* start,
     void* end) {
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_label_range_var(dim_name, range_idx, start, end);
   return TILEDB_OK;
 }
@@ -188,6 +200,7 @@ capi_return_t tiledb_subarray_get_label_range_var_size(
     uint64_t range_idx,
     uint64_t* start_size,
     uint64_t* end_size) {
+  ensure_subarray_is_valid(subarray);
   subarray->subarray_->get_label_range_var_size(
       dim_name, range_idx, start_size, end_size);
   return TILEDB_OK;
@@ -197,6 +210,7 @@ capi_return_t tiledb_subarray_has_label_ranges(
     const tiledb_subarray_t* subarray,
     const uint32_t dim_idx,
     int32_t* has_label_ranges) {
+  ensure_subarray_is_valid(subarray);
   bool has_ranges = subarray->subarray_->has_label_ranges(dim_idx);
   *has_label_ranges = has_ranges ? 1 : 0;
   return TILEDB_OK;

--- a/tiledb/sm/query_plan/test/unit_query_plan.cc
+++ b/tiledb/sm/query_plan/test/unit_query_plan.cc
@@ -135,7 +135,7 @@ TEST_CASE_METHOD(QueryPlanFx, "Query plan dump_json", "[query_plan][dump]") {
   stats::Stats stats("foo");
   Subarray subarray(array_shared.get(), &stats, logger_);
   uint64_t r[2]{0, 1};
-  subarray.add_range(0, r, r + 1, nullptr);
+  subarray.add_range(0, r, r + 1);
   query.set_subarray(subarray);
 
   std::vector<uint64_t> data(2);

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -246,17 +246,10 @@ void Subarray::add_label_range(
 }
 
 void Subarray::add_label_range(
-    const std::string& label_name,
-    const void* start,
-    const void* end,
-    const void* stride) {
+    const std::string& label_name, const void* start, const void* end) {
   // Check input range data is valid data.
   if (start == nullptr || end == nullptr) {
     throw SubarrayException("[add_label_range] Invalid range");
-  }
-  if (stride != nullptr) {
-    throw SubarrayException(
-        "[add_label_range] Setting range stride is currently unsupported");
   }
   // Get dimension label range and check the label is in fact fixed-sized.
   const auto& dim_label_ref =
@@ -383,7 +376,7 @@ void Subarray::set_subarray_unsafe(const void* subarray) {
 }
 
 void Subarray::add_range(
-    unsigned dim_idx, const void* start, const void* end, const void* stride) {
+    unsigned dim_idx, const void* start, const void* end) {
   if (dim_idx >= this->array_->array_schema_latest().dim_num())
     throw SubarrayException("Cannot add range; Invalid dimension index");
 
@@ -395,11 +388,6 @@ void Subarray::add_range(
 
   if (start == nullptr || end == nullptr) {
     throw SubarrayException("Cannot add range; Invalid range");
-  }
-
-  if (stride != nullptr) {
-    throw SubarrayException(
-        "Cannot add range; Setting range stride is currently unsupported");
   }
 
   if (this->array_->array_schema_latest()
@@ -506,11 +494,10 @@ void Subarray::add_ranges_list(
 void Subarray::add_range_by_name(
     const std::string& dim_name,
     const void* start,
-    const void* end,
-    const void* stride) {
+    const void* end) {
   unsigned dim_idx =
       array_->array_schema_latest().domain().get_dimension_index(dim_name);
-  add_range(dim_idx, start, end, stride);
+  add_range(dim_idx, start, end);
 }
 
 void Subarray::add_range_var(
@@ -585,8 +572,7 @@ void Subarray::get_label_range(
     const std::string& label_name,
     uint64_t range_idx,
     const void** start,
-    const void** end,
-    const void** stride) const {
+    const void** end) const {
   auto dim_idx = array_->array_schema_latest()
                      .dimension_label(label_name)
                      .dimension_index();
@@ -599,7 +585,6 @@ void Subarray::get_label_range(
   const auto& range = label_range_subset_[dim_idx].value().ranges_[range_idx];
   *start = range.start_fixed();
   *end = range.end_fixed();
-  *stride = nullptr;
 }
 
 void Subarray::get_label_range_num(
@@ -659,8 +644,7 @@ void Subarray::get_range_var(
 
   const void* range_start;
   const void* range_end;
-  const void* stride;
-  get_range(dim_idx, range_idx, &range_start, &range_end, &stride);
+  get_range(dim_idx, range_idx, &range_start, &range_end);
 
   std::memcpy(start, range_start, start_size);
   std::memcpy(end, range_end, end_size);
@@ -673,25 +657,14 @@ void Subarray::get_range_num_from_name(
   get_range_num(dim_idx, range_num);
 }
 
-void Subarray::get_range(
-    unsigned dim_idx,
-    uint64_t range_idx,
-    const void** start,
-    const void** end,
-    const void** stride) const {
-  *stride = nullptr;
-  this->get_range(dim_idx, range_idx, start, end);
-}
-
 void Subarray::get_range_from_name(
     const std::string& dim_name,
     uint64_t range_idx,
     const void** start,
-    const void** end,
-    const void** stride) const {
+    const void** end) const {
   unsigned dim_idx =
       array_->array_schema_latest().domain().get_dimension_index(dim_name);
-  get_range(dim_idx, range_idx, start, end, stride);
+  get_range(dim_idx, range_idx, start, end);
 }
 
 void Subarray::get_range_var_size_from_name(

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -375,8 +375,7 @@ void Subarray::set_subarray_unsafe(const void* subarray) {
   }
 }
 
-void Subarray::add_range(
-    unsigned dim_idx, const void* start, const void* end) {
+void Subarray::add_range(unsigned dim_idx, const void* start, const void* end) {
   if (dim_idx >= this->array_->array_schema_latest().dim_num())
     throw SubarrayException("Cannot add range; Invalid dimension index");
 
@@ -492,9 +491,7 @@ void Subarray::add_ranges_list(
 }
 
 void Subarray::add_range_by_name(
-    const std::string& dim_name,
-    const void* start,
-    const void* end) {
+    const std::string& dim_name, const void* start, const void* end) {
   unsigned dim_idx =
       array_->array_schema_latest().domain().get_dimension_index(dim_name);
   add_range(dim_idx, start, end);

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -459,8 +459,7 @@ class Subarray {
    * The range components must be of the same type as the domain type of the
    * underlying array.
    */
-  void add_range(
-      unsigned dim_idx, const void* start, const void* end);
+  void add_range(unsigned dim_idx, const void* start, const void* end);
 
   /**
    * @brief Set point ranges from an array
@@ -521,9 +520,7 @@ class Subarray {
    * underlying array.
    */
   void add_range_by_name(
-      const std::string& dim_name,
-      const void* start,
-      const void* end);
+      const std::string& dim_name, const void* start, const void* end);
 
   /**
    * Adds a variable-sized range to the (read/write) query on the input

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -429,13 +429,9 @@ class Subarray {
    * @param label_name The name of the dimension label to add the range to.
    * @param start The range start.
    * @param end The range end.
-   * @param stride The range stride.
    */
   void add_label_range(
-      const std::string& label_name,
-      const void* start,
-      const void* end,
-      const void* stride);
+      const std::string& label_name, const void* start, const void* end);
 
   /**
    * Adds a variable-sized range along the dimension with the given index for
@@ -459,13 +455,12 @@ class Subarray {
       uint32_t dim_idx, Range&& range, const bool read_range_oob_error = true);
 
   /**
-   * Adds a range to the subarray on the input dimension by index,
-   * in the form of (start, end, stride).
+   * Adds a range to the subarray on the input dimension by index.
    * The range components must be of the same type as the domain type of the
    * underlying array.
    */
   void add_range(
-      unsigned dim_idx, const void* start, const void* end, const void* stride);
+      unsigned dim_idx, const void* start, const void* end);
 
   /**
    * @brief Set point ranges from an array
@@ -521,16 +516,14 @@ class Subarray {
   void add_range_unsafe(uint32_t dim_idx, const Range& range);
 
   /**
-   * Adds a range to the (read/write) query on the input dimension by name,
-   * in the form of (start, end, stride).
+   * Adds a range to the (read/write) query on the input dimension by name.
    * The range components must be of the same type as the domain type of the
    * underlying array.
    */
   void add_range_by_name(
       const std::string& dim_name,
       const void* start,
-      const void* end,
-      const void* stride);
+      const void* end);
 
   /**
    * Adds a variable-sized range to the (read/write) query on the input
@@ -567,22 +560,19 @@ class Subarray {
   const std::string& get_label_name(const uint32_t dim_index) const;
 
   /**
-   * Retrieves a range from a dimension label name in the form (start, end,
-   * stride).
+   * Retrieves a range from a dimension label name.
    *
    * @param label_name The name of the dimension label to retrieve the range
    *     from.
    * @param range_idx The id of the range to retrieve.
    * @param start The range start to retrieve.
    * @param end The range end to retrieve.
-   * @param stride The range stride to retrieve.
    */
   void get_label_range(
       const std::string& label_name,
       uint64_t range_idx,
       const void** start,
-      const void** end,
-      const void** stride) const;
+      const void** end) const;
 
   /**
    * Retrieves the number of ranges of the subarray for the given dimension
@@ -633,20 +623,18 @@ class Subarray {
       const std::string& dim_name, uint64_t* range_num) const;
 
   /**
-   * Retrieves a range from a dimension name in the form (start, end, stride).
+   * Retrieves a range from a dimension name.
    *
    * @param dim_name The dimension to retrieve the range from.
    * @param range_idx The id of the range to retrieve.
    * @param start The range start to retrieve.
    * @param end The range end to retrieve.
-   * @param stride The range stride to retrieve.
    */
   void get_range_from_name(
       const std::string& dim_name,
       uint64_t range_idx,
       const void** start,
-      const void** end,
-      const void** stride) const;
+      const void** end) const;
 
   /**
    * Retrieves a range's sizes for a variable-length dimension name
@@ -894,22 +882,6 @@ class Subarray {
 
   /** Retrieves the number of ranges on the given dimension index. */
   void get_range_num(uint32_t dim_idx, uint64_t* range_num) const;
-
-  /**
-   * Retrieves a range from a dimension index in the form (start, end, stride).
-   *
-   * @param dim_idx The dimension to retrieve the range from.
-   * @param range_idx The id of the range to retrieve.
-   * @param start The range start to retrieve.
-   * @param end The range end to retrieve.
-   * @param stride The range stride to retrieve.
-   */
-  void get_range(
-      unsigned dim_idx,
-      uint64_t range_idx,
-      const void** start,
-      const void** end,
-      const void** stride) const;
 
   /**
    * ``True`` if the specified dimension is set by default.


### PR DESCRIPTION
The C API contains arguments for `stride` that are unsupported. This PR simplifies the internal handling of them. The main tactic for simplification is deal with these arguments in the C API implementation function and remove the arguments from the functions that support them.

Add `ensure_subarray_is_valid` replaces the old `sanity_check` function for subarray. Added validation to all relevant dimension label functions, which heretofore weren't validating subarray arguments in any way.

---
TYPE: NO_HISTORY
DESC: Simplify handling of unsupported C API `stride` arguments
