### PR TITLE
Eliminate storage_manager argument from post_array_from_rest.

### DIFF
--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -2605,13 +2605,12 @@ TEST_CASE_METHOD(
       1,
       &buff);
   REQUIRE(rc == TILEDB_OK);
-  auto st = tiledb::sm::serialization::array_deserialize(
+  tiledb::sm::serialization::array_deserialize(
       array->array_.get(),
       tiledb::sm::SerializationType::CAPNP,
       buff->buffer(),
-      ctx_->storage_manager(),
+      ctx_->context().resources(),
       memory_tracker_);
-  REQUIRE(st.ok());
 
   // 6. Server: Close array and clean up
   rc = tiledb_array_close(ctx_, deserialized_array_server);

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB Inc.
+ * @copyright Copyright (c) 2023-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -2950,8 +2950,8 @@ void EnumerationFx::ser_des_array(
     SerializationType stype) {
   Buffer buf;
   throw_if_not_ok(serialization::array_serialize(in, stype, &buf, client_side));
-  throw_if_not_ok(serialization::array_deserialize(
-      out, stype, buf, ctx.storage_manager(), memory_tracker_));
+  serialization::array_deserialize(
+      out, stype, buf, ctx.resources(), memory_tracker_);
 }
 
 #else  // No TILEDB_SERIALIZATION

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -173,11 +173,7 @@ Status Array::open_without_fragments(
         }
         set_array_schema_latest(array_schema_latest.value());
       } else {
-        auto st = rest_client->post_array_from_rest(
-            array_uri_, storage_manager_, this);
-        if (!st.ok()) {
-          throw StatusException(st);
-        }
+        rest_client->post_array_from_rest(array_uri_, resources_, this);
       }
     } else {
       {
@@ -338,11 +334,7 @@ Status Array::open(
         throw_if_not_ok(st);
         set_array_schema_latest(array_schema_latest.value());
       } else {
-        auto st = rest_client->post_array_from_rest(
-            array_uri_, storage_manager_, this);
-        if (!st.ok()) {
-          throw StatusException(st);
-        }
+        rest_client->post_array_from_rest(array_uri_, resources_, this);
       }
     } else if (query_type == QueryType::READ) {
       {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3431,14 +3431,14 @@ int32_t tiledb_deserialize_array(
 
   auto memory_tracker = ctx->context().resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::ARRAY_LOAD);
-  if (SAVE_ERROR_CATCH(
-          ctx,
-          tiledb::sm::serialization::array_deserialize(
-              (*array)->array_.get(),
-              (tiledb::sm::SerializationType)serialize_type,
-              buffer->buffer(),
-              ctx->storage_manager(),
-              memory_tracker))) {
+  try {
+    tiledb::sm::serialization::array_deserialize(
+        (*array)->array_.get(),
+        (tiledb::sm::SerializationType)serialize_type,
+        buffer->buffer(),
+        ctx->context().resources(),
+        memory_tracker);
+  } catch (StatusException& e) {
     delete *array;
     *array = nullptr;
     return TILEDB_ERR;

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -44,8 +44,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class ArraySchema;
 class ArraySchemaEvolution;
@@ -130,11 +129,11 @@ class RestClient {
    * Post the array config and get an array from rest server
    *
    * @param uri of array being loaded
-   * @param storage_manager storage manager of array being loaded
+   * @param resources the context resources
    * @param array array to load into
    */
-  Status post_array_from_rest(
-      const URI& uri, StorageManager* storage_manager, Array* array);
+  void post_array_from_rest(
+      const URI& uri, ContextResources& resources, Array* array);
 
   /**
    * Post a data array schema to rest server
@@ -569,7 +568,6 @@ class RestClient {
   Status ensure_json_null_delimited_string(Buffer* buffer);
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_REST_CLIENT_H

--- a/tiledb/sm/serialization/array.h
+++ b/tiledb/sm/serialization/array.h
@@ -69,7 +69,7 @@ Status array_to_capnp(
 /**
  * Deserialize an Array from Cap'n proto
  * @param array_reader cap'n proto class
- * @param storage_manager the storage manager associated with the array
+ * @param resources the context resources associated with the array
  * @param array Array to deserialize into
  * @param client_side Allows to specify different behavior depending on who is
  * @param memory_tracker Memory tracker to use for memory allocations.
@@ -78,9 +78,9 @@ Status array_to_capnp(
  * @param memory_tracker Memory tracker to use on the deserialized object.
  * @return Status
  */
-Status array_from_capnp(
+void array_from_capnp(
     const capnp::Array::Reader& array_reader,
-    StorageManager* storage_manager,
+    ContextResources& resources,
     Array* array,
     const bool client_side,
     shared_ptr<MemoryTracker> memory_tracker);
@@ -134,11 +134,20 @@ Status array_serialize(
     Buffer* serialized_buffer,
     const bool client_side);
 
-Status array_deserialize(
+/**
+ * Deserialize an array via Cap'n Proto.
+ *
+ * @param array array object to set the array details into
+ * @param serialize_type format the data is serialized in: Cap'n Proto of JSON
+ * @param serialized_buffer buffer to read serialized bytes from
+ * @param resources the context resources associated with the array
+ * @param memory_tracker the memory tracker to use on the deserialized object
+ */
+void array_deserialize(
     Array* array,
     SerializationType serialize_type,
     const Buffer& serialized_buffer,
-    StorageManager* storage_manager,
+    ContextResources& resources,
     shared_ptr<MemoryTracker> memory_tracker);
 
 /**

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -80,9 +80,7 @@
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
 
-namespace tiledb {
-namespace sm {
-namespace serialization {
+namespace tiledb::sm::serialization {
 
 #ifdef TILEDB_SERIALIZATION
 
@@ -2297,12 +2295,12 @@ Status array_from_query_deserialize(
             query_builder);
         capnp::Query::Reader query_reader = query_builder.asReader();
         // Deserialize array instance.
-        RETURN_NOT_OK(array_from_capnp(
+        array_from_capnp(
             query_reader.getArray(),
-            storage_manager,
+            storage_manager->resources(),
             &array,
             false,
-            memory_tracker));
+            memory_tracker);
         break;
       }
       case SerializationType::CAPNP: {
@@ -2329,12 +2327,12 @@ Status array_from_query_deserialize(
 
         capnp::Query::Reader query_reader = reader.getRoot<capnp::Query>();
         // Deserialize array instance.
-        RETURN_NOT_OK(array_from_capnp(
+        array_from_capnp(
             query_reader.getArray(),
-            storage_manager,
+            storage_manager->resources(),
             &array,
             false,
-            memory_tracker));
+            memory_tracker);
         break;
       }
       default:
@@ -3219,6 +3217,4 @@ Status query_est_result_size_deserialize(
 
 #endif  // TILEDB_SERIALIZATION
 
-}  // namespace serialization
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::serialization


### PR DESCRIPTION
As a larger part of eliminating class `StorageManager`, all usages of member variable `storage_manager_` must also be eliminated from class `Array`. To that effect, this PR removes `storage_manager` as an argument in `post_array_to_rest`, subsequently also removing it from `array_from_capnp` and `array_deserialize`. 

---

[sc-47009]
---
TYPE: NO_HISTORY
DESC: Eliminate the storage_manager argument from post_array_from_rest.
