### PR TITLE
Restore rest.resubmit_incomplete config parameter

### DIFF
--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -1699,7 +1699,12 @@ TEST_CASE_METHOD(
     DenseArrayRESTFx,
     "C API: REST Test dense array, incomplete reads",
     "[capi][rest][dense][incomplete]") {
-  // TODO: refactor for each supported FS.
+  tiledb_error_t* error;
+  tiledb_config_t* config;
+  tiledb_config_alloc(&config, &error);
+  REQUIRE(
+      tiledb_config_set(config, "rest.resubmit_incomplete", "false", &error) ==
+      TILEDB_OK);
   check_incomplete_reads();
 }
 

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -623,6 +623,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    Authentication token for REST server (used instead of
  *    username/password). <br>
  *    **Default**: ""
+ * - `rest.resubmit_incomplete` <br>
+ *    If true, incomplete queries received from server are automatically
+ *    resubmitted before returning to user control. <br>
+ *    **Default**: "true"
  * - `rest.ignore_ssl_validation` <br>
  *    Have curl ignore ssl peer and host validation for REST server. <br>
  *    **Default**: false

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -801,6 +801,10 @@ class Config {
    *    Authentication token for REST server (used instead of
    *    username/password). <br>
    *    **Default**: ""
+   * - `rest.resubmit_incomplete` <br>
+   *    If true, incomplete queries received from server are automatically
+   *    resubmitted before returning to user control. <br>
+   *    **Default**: "true"
    * - `rest.ignore_ssl_validation` <br>
    *    Have curl ignore ssl peer and host validation for REST server. <br>
    *    **Default**: false

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -144,6 +144,10 @@ Status RestClient::init(
   if (c_str != nullptr)
     RETURN_NOT_OK(serialization_type_enum(c_str, &serialization_type_));
 
+  bool found = false;
+  RETURN_NOT_OK(config_->get<bool>(
+      "rest.resubmit_incomplete", &resubmit_incomplete_, &found));
+
   return Status::Ok();
 }
 


### PR DESCRIPTION
For some inexplicable reason I thought `rest.resubmit_incomplete` config variable wasn't used anymore and removed it in https://github.com/TileDB-Inc/TileDB/pull/3879 .

This PR is for reverting this change.

---
TYPE: IMPROVEMENT
DESC: Restore rest.resubmit_incomplete config parameter
