### PR TITLE
Fix traversal limit in array metadata serialization

### DIFF
--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -566,6 +566,7 @@ capi_return_t tiledb_deserialize_group_metadata(
 
   throw_if_not_ok(tiledb::sm::serialization::metadata_deserialize(
       group->group().unsafe_metadata(),
+      group->group().config(),
       static_cast<tiledb::sm::SerializationType>(serialize_type),
       buffer->buffer()));
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -4038,6 +4038,7 @@ int32_t tiledb_deserialize_array_metadata(
   // Deserialize
   throw_if_not_ok(tiledb::sm::serialization::metadata_deserialize(
       array->array_->unsafe_metadata(),
+      array->array_->config(),
       (tiledb::sm::SerializationType)serialize_type,
       buffer->buffer()));
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -622,7 +622,10 @@ Status RestClient::get_array_metadata_from_rest(
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::metadata_deserialize(
-      array->unsafe_metadata(), serialization_type_, returned_data);
+      array->unsafe_metadata(),
+      array->config(),
+      serialization_type_,
+      returned_data);
 }
 
 Status RestClient::post_array_metadata_to_rest(
@@ -1400,7 +1403,10 @@ Status RestClient::post_group_metadata_from_rest(const URI& uri, Group* group) {
   // Ensure data has a null delimiter for cap'n proto if using JSON
   RETURN_NOT_OK(ensure_json_null_delimited_string(&returned_data));
   return serialization::metadata_deserialize(
-      group->unsafe_metadata(), serialization_type_, returned_data);
+      group->unsafe_metadata(),
+      group->config(),
+      serialization_type_,
+      returned_data);
 }
 
 Status RestClient::put_group_metadata_to_rest(const URI& uri, Group* group) {

--- a/tiledb/sm/serialization/array.h
+++ b/tiledb/sm/serialization/array.h
@@ -183,6 +183,7 @@ Status metadata_serialize(
 
 Status metadata_deserialize(
     Metadata* metadata,
+    const Config& config,
     SerializationType serialize_type,
     const Buffer& serialized_buffer);
 

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -433,11 +433,20 @@ Status group_deserialize(
         break;
       }
       case SerializationType::CAPNP: {
+        // Set traversal limit from config
+        uint64_t limit =
+            group->config().get<uint64_t>("rest.capnp_traversal_limit").value();
+        ::capnp::ReaderOptions readerOptions;
+        // capnp uses the limit in words
+        readerOptions.traversalLimitInWords = limit / sizeof(::capnp::word);
+
         const auto mBytes =
             reinterpret_cast<const kj::byte*>(serialized_buffer.data());
-        ::capnp::FlatArrayMessageReader reader(kj::arrayPtr(
-            reinterpret_cast<const ::capnp::word*>(mBytes),
-            serialized_buffer.size() / sizeof(::capnp::word)));
+        ::capnp::FlatArrayMessageReader reader(
+            kj::arrayPtr(
+                reinterpret_cast<const ::capnp::word*>(mBytes),
+                serialized_buffer.size() / sizeof(::capnp::word)),
+            readerOptions);
         capnp::Group::Reader group_reader = reader.getRoot<capnp::Group>();
         RETURN_NOT_OK(group_from_capnp(group_reader, group));
         break;
@@ -533,11 +542,20 @@ Status group_details_deserialize(
         break;
       }
       case SerializationType::CAPNP: {
+        // Set traversal limit from config
+        uint64_t limit =
+            group->config().get<uint64_t>("rest.capnp_traversal_limit").value();
+        ::capnp::ReaderOptions readerOptions;
+        // capnp uses the limit in words
+        readerOptions.traversalLimitInWords = limit / sizeof(::capnp::word);
+
         const auto mBytes =
             reinterpret_cast<const kj::byte*>(serialized_buffer.data());
-        ::capnp::FlatArrayMessageReader reader(kj::arrayPtr(
-            reinterpret_cast<const ::capnp::word*>(mBytes),
-            serialized_buffer.size() / sizeof(::capnp::word)));
+        ::capnp::FlatArrayMessageReader reader(
+            kj::arrayPtr(
+                reinterpret_cast<const ::capnp::word*>(mBytes),
+                serialized_buffer.size() / sizeof(::capnp::word)),
+            readerOptions);
         capnp::Group::GroupDetails::Reader group_details_reader =
             reader.getRoot<capnp::Group::GroupDetails>();
         RETURN_NOT_OK(group_details_from_capnp(group_details_reader, group));
@@ -637,11 +655,20 @@ Status group_update_deserialize(
         break;
       }
       case SerializationType::CAPNP: {
+        // Set traversal limit from config
+        uint64_t limit =
+            group->config().get<uint64_t>("rest.capnp_traversal_limit").value();
+        ::capnp::ReaderOptions readerOptions;
+        // capnp uses the limit in words
+        readerOptions.traversalLimitInWords = limit / sizeof(::capnp::word);
+
         const auto mBytes =
             reinterpret_cast<const kj::byte*>(serialized_buffer.data());
-        ::capnp::FlatArrayMessageReader reader(kj::arrayPtr(
-            reinterpret_cast<const ::capnp::word*>(mBytes),
-            serialized_buffer.size() / sizeof(::capnp::word)));
+        ::capnp::FlatArrayMessageReader reader(
+            kj::arrayPtr(
+                reinterpret_cast<const ::capnp::word*>(mBytes),
+                serialized_buffer.size() / sizeof(::capnp::word)),
+            readerOptions);
         capnp::Group::Reader group_reader = reader.getRoot<capnp::Group>();
         RETURN_NOT_OK(group_from_capnp(group_reader, group));
         break;


### PR DESCRIPTION
[sc-46026]

Reading the VCF `allele_count` array with a specific `tiledb://` URI was failing with `TileDBError: [TileDB::Serialization] Error: Error deserializing array metadata; kj::Exception: Exceeded message traversal limit.  See capnp::ReaderOptions.`

This is a classic issue we have seen before where Capnp is reaching the traversal limit and is solved by explicitly setting the traversal limit to `rest.capnp_traversal_limit` config option.

As validation , I have run the failing python script provided in the ticket description and now it passes.

---
TYPE: BUG
DESC: Fix traversal limit in array metadata serialization
