### PR TITLE
Unordered tile/cell order is now rejected when creating an ArraySchema

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -1083,6 +1083,26 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     ArraySchemaFx,
+    "C API: Test array schema with invalid cell/tile order",
+    "[capi][array-schema]") {
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  int rc = tiledb_array_schema_alloc(ctx_, TILEDB_SPARSE, &array_schema);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check that UNORDERED order fails
+  rc = tiledb_array_schema_set_tile_order(ctx_, array_schema, TILEDB_UNORDERED);
+  REQUIRE(rc == TILEDB_ERR);
+
+  rc = tiledb_array_schema_set_cell_order(ctx_, array_schema, TILEDB_UNORDERED);
+  REQUIRE(rc == TILEDB_ERR);
+
+  // Clean up
+  tiledb_array_schema_free(&array_schema);
+}
+
+TEST_CASE_METHOD(
+    ArraySchemaFx,
     "C API: Test array schema with invalid dimension domain and tile extent",
     "[capi][array-schema]") {
   // Domain range exceeds type range - error

--- a/test/src/unit-cppapi-schema.cc
+++ b/test/src/unit-cppapi-schema.cc
@@ -74,6 +74,8 @@ TEST_CASE("C++ API: Schema", "[cppapi][schema]") {
     schema.add_attribute(a2);
     schema.add_attribute(a3);
     schema.add_attribute(a4);
+    CHECK_THROWS(schema.set_cell_order(TILEDB_UNORDERED));
+    CHECK_THROWS(schema.set_tile_order(TILEDB_UNORDERED));
     schema.set_cell_order(TILEDB_ROW_MAJOR);
     schema.set_tile_order(TILEDB_COL_MAJOR);
     CHECK_THROWS(schema.set_allows_dups(1));
@@ -152,6 +154,8 @@ TEST_CASE("C++ API: Schema", "[cppapi][schema]") {
     schema.add_attribute(a2);
     schema.add_attribute(a3);
     schema.add_attribute(a4);
+    CHECK_THROWS(schema.set_cell_order(TILEDB_UNORDERED));
+    CHECK_THROWS(schema.set_tile_order(TILEDB_UNORDERED));
     schema.set_cell_order(TILEDB_ROW_MAJOR);
     schema.set_tile_order(TILEDB_COL_MAJOR);
     schema.set_allows_dups(true);

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -1524,6 +1524,11 @@ Status ArraySchema::set_cell_order(Layout cell_order) {
         Status_ArraySchemaError("Cannot set cell order; Hilbert order is only "
                                 "applicable to sparse arrays"));
 
+  if (cell_order == Layout::UNORDERED)
+    return LOG_STATUS(Status_ArraySchemaError(
+        "Cannot set cell order; Cannot create ArraySchema "
+        "with UNORDERED cell order"));
+
   cell_order_ = cell_order;
 
   return Status::Ok();
@@ -1617,6 +1622,11 @@ Status ArraySchema::set_tile_order(Layout tile_order) {
   if (tile_order == Layout::HILBERT)
     return LOG_STATUS(Status_ArraySchemaError(
         "Cannot set tile order; Hilbert order is not applicable to tiles"));
+
+  if (tile_order == Layout::UNORDERED)
+    return LOG_STATUS(Status_ArraySchemaError(
+        "Cannot set tile order; Cannot create ArraySchema "
+        "with UNORDERED tile order"));
 
   tile_order_ = tile_order;
   return Status::Ok();


### PR DESCRIPTION
This PR disables the ability to create an Array Schema with UNORDERED tile/cell order. + Tests (C/C++).

[sc-47276]

---
TYPE: BUG
DESC: Rejecting unordered tile/cell order when creating an ArraySchema.
