### PR TITLE
Remove `StorageManager::config()`

### DIFF
--- a/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
@@ -30,6 +30,13 @@
  * Tests the CPP API for consolidation with timestamps.
  */
 
+/*
+ * WARNING:
+ *   [2024/05/13] This file has succumbed to bit rot. It used to be a copy of
+ *   a file by the same name within `tiledb_unit`, but it no longer is. It
+ *   should not be expected to compile.
+ */
+
 #include <test/support/tdb_catch.h>
 #include "test/support/src/helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"

--- a/test/performance/msys_handle_leakage/unit.cc
+++ b/test/performance/msys_handle_leakage/unit.cc
@@ -35,6 +35,11 @@
  * unit.cc along with some previously observed results.
  */
 
+/*
+ * WARNING:
+ *   [2024/05/13] This file has succumbed to bit rot. It no longer compiles.
+ */
+
 // clang-format off
 //.\tiledb\test\performance\RelWithDebInfo\tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-iters=1 --wait-for-keypress both
 //./tiledb/test/performance/tiledb_explore_msys_handle_leakage.exe --read-sparse-iters=1 --perform-query=1 --consolidate-sparse-sparse-iters=1 --wait-for-keypress both

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -85,8 +85,7 @@ capi_return_t tiledb_ctx_get_stats(
 capi_return_t tiledb_ctx_get_config(
     tiledb_ctx_handle_t* ctx, tiledb_config_handle_t** config) {
   api::ensure_output_pointer_is_valid(config);
-  *config =
-      tiledb_config_handle_t::make_handle(ctx->storage_manager()->config());
+  *config = tiledb_config_handle_t::make_handle(ctx->config());
   return TILEDB_OK;
 }
 

--- a/tiledb/api/c_api/context/context_api_internal.h
+++ b/tiledb/api/c_api/context/context_api_internal.h
@@ -63,6 +63,10 @@ struct tiledb_ctx_handle_t
     return ctx_.resources();
   }
 
+  inline tiledb::sm::Config& config() {
+    return ctx_.resources().config();
+  }
+
   inline tiledb::sm::StorageManager* storage_manager() {
     return ctx_.storage_manager();
   }

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -577,8 +577,7 @@ capi_return_t tiledb_group_consolidate_metadata(
     tiledb_ctx_handle_t* ctx, const char* group_uri, tiledb_config_t* config) {
   ensure_group_uri_argument_is_valid(group_uri);
 
-  auto cfg =
-      (config == nullptr) ? ctx->storage_manager()->config() : config->config();
+  auto cfg = (config == nullptr) ? ctx->config() : config->config();
   throw_if_not_ok(
       ctx->storage_manager()->group_metadata_consolidate(group_uri, cfg));
 
@@ -589,8 +588,7 @@ capi_return_t tiledb_group_vacuum_metadata(
     tiledb_ctx_handle_t* ctx, const char* group_uri, tiledb_config_t* config) {
   ensure_group_uri_argument_is_valid(group_uri);
 
-  auto cfg =
-      (config == nullptr) ? ctx->storage_manager()->config() : config->config();
+  auto cfg = (config == nullptr) ? ctx->config() : config->config();
   ctx->storage_manager()->group_metadata_vacuum(group_uri, cfg);
 
   return TILEDB_OK;

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -57,14 +57,15 @@ capi_return_t tiledb_vfs_alloc(
   ensure_output_pointer_is_valid(vfs);
 
   // Create VFS object
-  auto stats = ctx->storage_manager()->stats();
-  auto compute_tp = ctx->storage_manager()->compute_tp();
-  auto io_tp = ctx->storage_manager()->io_tp();
-  auto ctx_config = ctx->storage_manager()->config();
+  auto& resources{ctx->resources()};
+  auto& stats{resources.stats()};
+  auto& compute_tp{resources.compute_tp()};
+  auto& io_tp{resources.io_tp()};
+  auto& ctx_config{resources.config()};
   if (config) {
     ctx_config.inherit((config->config()));
   }
-  *vfs = tiledb_vfs_t::make_handle(stats, compute_tp, io_tp, ctx_config);
+  *vfs = tiledb_vfs_t::make_handle(&stats, &compute_tp, &io_tp, ctx_config);
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
+++ b/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
@@ -71,9 +71,6 @@ class StorageManagerStub {
   inline stats::Stats* stats() {
     return &resources_.stats();
   }
-  const Config& config() {
-    return config_;
-  }
   inline VFS* vfs() {
     throw std::logic_error("StorageManagerStub does not instantiate a VFS");
   }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2708,7 +2708,7 @@ int32_t tiledb_array_consolidate(
       tiledb::sm::EncryptionType::NO_ENCRYPTION,
       nullptr,
       0,
-      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
+      (config == nullptr) ? ctx->config() : config->config(),
       ctx->storage_manager());
   return TILEDB_OK;
 }
@@ -2727,7 +2727,7 @@ int32_t tiledb_array_consolidate_with_key(
       static_cast<tiledb::sm::EncryptionType>(encryption_type),
       encryption_key,
       key_length,
-      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
+      (config == nullptr) ? ctx->config() : config->config(),
       ctx->storage_manager());
 
   return TILEDB_OK;
@@ -2754,7 +2754,7 @@ int32_t tiledb_array_consolidate_fragments(
       nullptr,
       0,
       uris,
-      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
+      (config == nullptr) ? ctx->config() : config->config(),
       ctx->storage_manager());
 
   return TILEDB_OK;
@@ -2764,7 +2764,7 @@ int32_t tiledb_array_vacuum(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
   tiledb::sm::Consolidator::array_vacuum(
       array_uri,
-      (config == nullptr) ? ctx->storage_manager()->config() : config->config(),
+      (config == nullptr) ? ctx->config() : config->config(),
       ctx->storage_manager());
 
   return TILEDB_OK;
@@ -3107,9 +3107,7 @@ int32_t tiledb_array_upgrade_version(
 
   // Upgrade version
   throw_if_not_ok(ctx->storage_manager()->array_upgrade_version(
-      uri,
-      (config == nullptr) ? ctx->storage_manager()->config() :
-                            config->config()));
+      uri, (config == nullptr) ? ctx->config() : config->config()));
 
   return TILEDB_OK;
 }

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -89,7 +89,7 @@ int32_t tiledb_filestore_schema_create(
         &context.resources().stats(),
         context.compute_tp(),
         context.io_tp(),
-        context.storage_manager()->config());
+        context.resources().config());
     uint64_t file_size;
     throw_if_not_ok(vfs.file_size(tiledb::sm::URI(uri), &file_size));
     if (file_size) {
@@ -202,7 +202,7 @@ int32_t tiledb_filestore_uri_import(
       &context.resources().stats(),
       context.compute_tp(),
       context.io_tp(),
-      context.storage_manager()->config());
+      context.resources().config());
   uint64_t file_size;
   throw_if_not_ok(vfs.file_size(tiledb::sm::URI(file_uri), &file_size));
   if (!file_size) {
@@ -271,8 +271,8 @@ int32_t tiledb_filestore_uri_import(
   // timestamped fragments in row-major order.
   bool is_tiledb_uri = array->is_remote();
   uint64_t tile_extent = compute_tile_extent_based_on_file_size(file_size);
-  auto buffer_size = get_buffer_size_from_config(
-      context.storage_manager()->config(), tile_extent);
+  auto buffer_size =
+      get_buffer_size_from_config(context.resources().config(), tile_extent);
 
   tiledb::sm::Query query(context.storage_manager(), array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::GLOBAL_ORDER));
@@ -390,7 +390,7 @@ int32_t tiledb_filestore_uri_export(
       &context.resources().stats(),
       context.compute_tp(),
       context.io_tp(),
-      context.storage_manager()->config());
+      context.resources().config());
   if (!vfs.open_file(tiledb::sm::URI(file_uri), tiledb::sm::VFSMode::VFS_WRITE)
            .ok()) {
     throw api::CAPIException(
@@ -422,8 +422,8 @@ int32_t tiledb_filestore_uri_export(
 
   uint64_t file_size = *static_cast<const uint64_t*>(file_size_ptr);
   uint64_t tile_extent = compute_tile_extent_based_on_file_size(file_size);
-  auto buffer_size = get_buffer_size_from_config(
-      context.storage_manager()->config(), tile_extent);
+  auto buffer_size =
+      get_buffer_size_from_config(context.resources().config(), tile_extent);
 
   std::vector<std::byte> data(buffer_size);
   uint64_t start_range = 0;

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -146,7 +146,7 @@ void ArrayMetaConsolidator::vacuum(const char* array_name) {
 
 Status ArrayMetaConsolidator::set_config(const Config& config) {
   // Set the consolidation config for ease of use
-  Config merged_config = storage_manager_->config();
+  Config merged_config = resources_.config();
   merged_config.inherit(config);
   bool found = false;
   RETURN_NOT_OK(merged_config.get<uint64_t>(

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -105,7 +105,8 @@ ConsolidationMode Consolidator::mode_from_config(
 /* ****************************** */
 
 Consolidator::Consolidator(StorageManager* storage_manager)
-    : storage_manager_(storage_manager)
+    : resources_(storage_manager->resources())
+    , storage_manager_(storage_manager)
     , consolidator_memory_tracker_(
           storage_manager_->resources().create_memory_tracker())
     , stats_(storage_manager_->stats()->create_child("Consolidator"))

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -238,6 +238,11 @@ class Consolidator {
   /*       PROTECTED ATTRIBUTES        */
   /* ********************************* */
 
+  /**
+   * Resources used to perform the operation
+   */
+  ContextResources& resources_;
+
   /** The storage manager. */
   StorageManager* storage_manager_;
 

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -914,7 +914,7 @@ void FragmentConsolidator::set_query_buffers(
 
 Status FragmentConsolidator::set_config(const Config& config) {
   // Set the consolidation config for ease of use
-  Config merged_config = storage_manager_->config();
+  Config merged_config = resources_.config();
   merged_config.inherit(config);
   bool found = false;
   config_.amplification_ = 0.0f;

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -138,7 +138,7 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
 
 Status GroupMetaConsolidator::set_config(const Config& config) {
   // Set the consolidation config for ease of use
-  Config merged_config = storage_manager_->config();
+  Config merged_config = resources_.config();
   merged_config.inherit(config);
   bool found = false;
   RETURN_NOT_OK(merged_config.get<uint64_t>(

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -70,7 +70,7 @@ Group::Group(
     : memory_tracker_(resources.create_memory_tracker())
     , group_uri_(group_uri)
     , storage_manager_(storage_manager)
-    , config_(storage_manager_->config())
+    , config_(resources.config())
     , remote_(group_uri.is_tiledb())
     , metadata_(memory_tracker_)
     , metadata_loaded_(false)

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -165,10 +165,7 @@ Status DeletesAndUpdates::dowork() {
 
   auto uri = commit_uri.join_path(new_fragment_str);
   GenericTileIO::store_data(
-      storage_manager_->resources(),
-      uri,
-      serialized_condition,
-      *array_->encryption_key());
+      resources_, uri, serialized_condition, *array_->encryption_key());
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -76,12 +76,14 @@ Query::Query(
     shared_ptr<Array> array,
     optional<std::string> fragment_name,
     optional<uint64_t> memory_budget)
-    : query_memory_tracker_(
+    : resources_(storage_manager->resources())
+    , query_memory_tracker_(
           storage_manager->resources().create_memory_tracker())
     , array_shared_(array)
     , array_(array_shared_.get())
     , opened_array_(array->opened_array())
     , array_schema_(array->array_schema_latest_ptr())
+    , config_(resources_.config())
     , type_(array_->get_query_type())
     , layout_(
           (type_ == QueryType::READ || array_schema_->dense()) ?
@@ -129,9 +131,6 @@ Query::Query(
   callback_ = nullptr;
   callback_data_ = nullptr;
   status_ = QueryStatus::UNINITIALIZED;
-
-  if (storage_manager != nullptr)
-    config_ = storage_manager->config();
 
   // Set initial subarray configuration
   subarray_.set_config(type_, config_);

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -922,6 +922,11 @@ class Query {
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
 
+  /**
+   * Resource used for operations
+   */
+  ContextResources& resources_;
+
   /** The query memory tracker. */
   shared_ptr<MemoryTracker> query_memory_tracker_;
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -1001,7 +1001,7 @@ Status ReaderBase::unfilter_tile(
           t_min,
           t_max,
           concurrency_level,
-          storage_manager_->config()));
+          resources_.config()));
     }
 
     // Prevent processing past the end of chunks in case there are more
@@ -1020,7 +1020,7 @@ Status ReaderBase::unfilter_tile(
           tvar_min,
           tvar_max,
           concurrency_level,
-          storage_manager_->config()));
+          resources_.config()));
     }
   }
 
@@ -1044,7 +1044,7 @@ Status ReaderBase::unfilter_tile(
         tval_min,
         tval_max,
         concurrency_level,
-        storage_manager_->config()));
+        resources_.config()));
   }
 
   return Status::Ok();

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -47,7 +47,8 @@ namespace sm {
 
 StrategyBase::StrategyBase(
     stats::Stats* stats, shared_ptr<Logger> logger, StrategyParams& params)
-    : array_memory_tracker_(params.array_memory_tracker())
+    : resources_(params.resources())
+    , array_memory_tracker_(params.array_memory_tracker())
     , query_memory_tracker_(params.query_memory_tracker())
     , stats_(stats)
     , logger_(logger)

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -37,7 +37,8 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/misc/types.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
+#include "tiledb/sm/storage_manager/storage_manager.h"
 
 namespace tiledb {
 namespace sm {
@@ -78,7 +79,8 @@ class StrategyParams {
       std::optional<QueryCondition>& condition,
       DefaultChannelAggregates& default_channel_aggregates,
       bool skip_checks_serialization)
-      : array_memory_tracker_(array_memory_tracker)
+      : resources_(storage_manager->resources())
+      , array_memory_tracker_(array_memory_tracker)
       , query_memory_tracker_(query_memory_tracker)
       , storage_manager_(storage_manager)
       , array_(array)
@@ -96,6 +98,13 @@ class StrategyParams {
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
+
+  /**
+   * Accessor for the resources
+   */
+  inline ContextResources& resources() {
+    return resources_;
+  }
 
   /** Return the array memory tracker. */
   inline shared_ptr<MemoryTracker> array_memory_tracker() {
@@ -165,6 +174,11 @@ class StrategyParams {
   /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
+
+  /**
+   * Resources used to perform operations
+   */
+  ContextResources& resources_;
 
   /** Array Memory tracker. */
   shared_ptr<MemoryTracker> array_memory_tracker_;
@@ -262,6 +276,11 @@ class StrategyBase {
   /* ********************************* */
   /*        PROTECTED ATTRIBUTES       */
   /* ********************************* */
+
+  /**
+   * Resources used for operations
+   */
+  ContextResources& resources_;
 
   /** The array memory tracker. */
   shared_ptr<MemoryTracker> array_memory_tracker_;

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2310,7 +2310,8 @@ Status array_from_query_deserialize(
               "Could not deserialize query; buffer is not 8-byte aligned."));
 
         // Set traversal limit from config
-        uint64_t limit = storage_manager->config()
+        uint64_t limit = storage_manager->resources()
+                             .config()
                              .get<uint64_t>("rest.capnp_traversal_limit")
                              .value();
         ::capnp::ReaderOptions readerOptions;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -122,7 +122,7 @@ StorageManagerCanonical::~StorageManagerCanonical() {
   bool found{false};
   bool use_malloc_trim{false};
   const Status& st =
-      config().get<bool>("sm.mem.malloc_trim", &use_malloc_trim, &found);
+      config_.get<bool>("sm.mem.malloc_trim", &use_malloc_trim, &found);
   if (st.ok() && found && use_malloc_trim) {
     tdb_malloc_trim();
   }
@@ -443,10 +443,6 @@ Status StorageManagerCanonical::cancel_all_tasks() {
 bool StorageManagerCanonical::cancellation_in_progress() {
   std::unique_lock<std::mutex> lck(cancellation_in_progress_mtx_);
   return cancellation_in_progress_;
-}
-
-const Config& StorageManagerCanonical::config() const {
-  return config_;
 }
 
 void StorageManagerCanonical::decrement_in_progress() {

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -209,9 +209,6 @@ class StorageManagerCanonical {
   /** Returns true while all tasks are being cancelled. */
   bool cancellation_in_progress();
 
-  /** Returns the configuration parameters. */
-  const Config& config() const;
-
   /** Returns the current map of any set tags. */
   const std::unordered_map<std::string, std::string>& tags() const;
 


### PR DESCRIPTION
Remove the member function `StorageManager::config()` and replace it (ultimately) with access to the `Config` instance through `ContextResources`. Add `ContextResources` member variables paralleling `StorageManager` ones where necessary. Add a direct accessor for the C API handle for `Context`.

Documented some bit-rotted code discovered during the development of this PR.

[sc-47339]

---
TYPE: NO_HISTORY
DESC: Remove `StorageManager::config()`