### PR TITLE
Update documentation of `vfs.gcs.project_id` to mention that it is only needed when creating buckets.

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -389,7 +389,8 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    attempts, in milliseconds.
  *    **Default**: 60000
  * - `vfs.gcs.project_id` <br>
- *    Set the GCS project id. <br>
+ *    Set the GCS project ID to create new buckets to. Not required unless you
+ *    are going to use the VFS to create buckets. <br>
  *    **Default**: ""
  * - `vfs.gcs.service_account_key` <br>
  *    **Experimental** <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -567,7 +567,8 @@ class Config {
    *    attempts, in milliseconds.
    *    **Default**: 60000
    * - `vfs.gcs.project_id` <br>
-   *    Set the GCS project id. <br>
+   *    Set the GCS project ID to create new buckets to. Not required unless you
+   *    are going to use the VFS to create buckets. <br>
    *    **Default**: ""
    * - `vfs.gcs.service_account_key` <br>
    *    **Experimental** <br>


### PR DESCRIPTION
[SC-47367](https://app.shortcut.com/tiledb-inc/story/47367/update-documentation-of-vfs-gcs-project-id-to-mention-that-it-is-only-needed-when-creating-buckets)

[This](https://github.com/TileDB-Inc/TileDB/blob/acfb4e8816ed9cdd858a5cb673a536ee40811aa1/tiledb/sm/filesystem/gcs.cc#L276-L277) is the only place this config option is used. [Bucket names are globally unique across projects.](https://cloud.google.com/storage/docs/buckets#considerations)

---
TYPE: NO_HISTORY