### PR TITLE
Migrate APIs out of StorageManager: is_array and is_group.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -241,6 +241,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/types.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/utils.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/win_constants.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/object/object.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/ast/query_ast.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/deletes_and_updates/serialization.cc

--- a/tiledb/sm/object/object.cc
+++ b/tiledb/sm/object/object.cc
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * This file implements the Object class.
+ * This file implements standalone object functions.
  */
 
 #include "tiledb/sm/object/object.h"
@@ -40,7 +40,7 @@ namespace tiledb::sm {
 /*                API                */
 /* ********************************* */
 
-bool Object::is_array(ContextResources& resources, const URI& uri) {
+bool is_array(ContextResources& resources, const URI& uri) {
   // Handle remote array
   if (uri.is_tiledb()) {
     auto&& [st, exists] =
@@ -50,9 +50,9 @@ bool Object::is_array(ContextResources& resources, const URI& uri) {
     return exists.value();
   } else {
     // Check if the schema directory exists or not
-    auto vfs = &(resources.vfs());
+    auto& vfs = resources.vfs();
     bool dir_exists = false;
-    throw_if_not_ok(vfs->is_dir(
+    throw_if_not_ok(vfs.is_dir(
         uri.join_path(constants::array_schema_dir_name), &dir_exists));
 
     if (dir_exists) {
@@ -61,16 +61,13 @@ bool Object::is_array(ContextResources& resources, const URI& uri) {
 
     bool schema_exists = false;
     // If there is no schema directory, we check schema file
-    throw_if_not_ok(vfs->is_file(
+    throw_if_not_ok(vfs.is_file(
         uri.join_path(constants::array_schema_filename), &schema_exists));
     return schema_exists;
   }
-
-  // TODO: mark unreachable
 }
 
-Status Object::is_group(
-    ContextResources& resources, const URI& uri, bool* is_group) {
+Status is_group(ContextResources& resources, const URI& uri, bool* is_group) {
   // Handle remote array
   if (uri.is_tiledb()) {
     auto&& [st, exists] =
@@ -79,9 +76,9 @@ Status Object::is_group(
     *is_group = *exists;
   } else {
     // Check for new group details directory
-    auto vfs = &(resources.vfs());
+    auto& vfs = resources.vfs();
     throw_if_not_ok(
-        vfs->is_dir(uri.join_path(constants::group_detail_dir_name), is_group));
+        vfs.is_dir(uri.join_path(constants::group_detail_dir_name), is_group));
 
     if (*is_group) {
       return Status::Ok();
@@ -89,7 +86,7 @@ Status Object::is_group(
 
     // Fall back to older group file to check for legacy (pre-format 12) groups
     throw_if_not_ok(
-        vfs->is_file(uri.join_path(constants::group_filename), is_group));
+        vfs.is_file(uri.join_path(constants::group_filename), is_group));
   }
   return Status::Ok();
 }

--- a/tiledb/sm/object/object.cc
+++ b/tiledb/sm/object/object.cc
@@ -1,0 +1,97 @@
+/**
+ * @file   object.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements the Object class.
+ */
+
+#include "tiledb/sm/object/object.h"
+#include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/rest/rest_client.h"
+
+namespace tiledb::sm {
+
+/* ********************************* */
+/*                API                */
+/* ********************************* */
+
+bool Object::is_array(ContextResources& resources, const URI& uri) {
+  // Handle remote array
+  if (uri.is_tiledb()) {
+    auto&& [st, exists] =
+        resources.rest_client()->check_array_exists_from_rest(uri);
+    throw_if_not_ok(st);
+    assert(exists.has_value());
+    return exists.value();
+  } else {
+    // Check if the schema directory exists or not
+    auto vfs = &(resources.vfs());
+    bool dir_exists = false;
+    throw_if_not_ok(vfs->is_dir(
+        uri.join_path(constants::array_schema_dir_name), &dir_exists));
+
+    if (dir_exists) {
+      return true;
+    }
+
+    bool schema_exists = false;
+    // If there is no schema directory, we check schema file
+    throw_if_not_ok(vfs->is_file(
+        uri.join_path(constants::array_schema_filename), &schema_exists));
+    return schema_exists;
+  }
+
+  // TODO: mark unreachable
+}
+
+Status Object::is_group(
+    ContextResources& resources, const URI& uri, bool* is_group) {
+  // Handle remote array
+  if (uri.is_tiledb()) {
+    auto&& [st, exists] =
+        resources.rest_client()->check_group_exists_from_rest(uri);
+    throw_if_not_ok(st);
+    *is_group = *exists;
+  } else {
+    // Check for new group details directory
+    auto vfs = &(resources.vfs());
+    throw_if_not_ok(
+        vfs->is_dir(uri.join_path(constants::group_detail_dir_name), is_group));
+
+    if (*is_group) {
+      return Status::Ok();
+    }
+
+    // Fall back to older group file to check for legacy (pre-format 12) groups
+    throw_if_not_ok(
+        vfs->is_file(uri.join_path(constants::group_filename), is_group));
+  }
+  return Status::Ok();
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/object/object.h
+++ b/tiledb/sm/object/object.h
@@ -1,0 +1,87 @@
+/**
+ * @file object.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines the Object class.
+ */
+
+#ifndef TILEDB_OBJECT_H
+#define TILEDB_OBJECT_H
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+class Object {
+ public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  /** Constructor. */
+  Object() = default;
+
+  /** Destructor. */
+  ~Object() = default;
+
+  DISABLE_COPY_AND_COPY_ASSIGN(Object);
+  DISABLE_MOVE_AND_MOVE_ASSIGN(Object);
+
+  /* ********************************* */
+  /*                API                */
+  /* ********************************* */
+
+  /**
+   * Checks if the input URI represents an array.
+   *
+   * @param resources the context resources.
+   * @param uri the URI to be checked.
+   * @return bool
+   */
+  static bool is_array(ContextResources& resources, const URI& uri);
+
+  /**
+   * Checks if the input URI represents a group.
+   *
+   * @param resources the context resources.
+   * @param uri the URI to be checked.
+   * @param is_group Set to `true` if the URI is a group and `false`
+   *     otherwise.
+   * @return Status
+   */
+  static Status is_group(
+      ContextResources& resources, const URI& uri, bool* is_group);
+};
+
+}  // namespace tiledb::sm
+
+#endif

--- a/tiledb/sm/object/object.h
+++ b/tiledb/sm/object/object.h
@@ -27,7 +27,7 @@
  *
  * @section DESCRIPTION
  *
- * This file defines the Object class.
+ * This file defines standalone object functions.
  */
 
 #ifndef TILEDB_OBJECT_H
@@ -41,46 +41,29 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
-class Object {
- public:
-  /* ********************************* */
-  /*     CONSTRUCTORS & DESTRUCTORS    */
-  /* ********************************* */
+/* ********************************* */
+/*                API                */
+/* ********************************* */
 
-  /** Constructor. */
-  Object() = default;
+/**
+ * Checks if the input URI represents an array.
+ *
+ * @param resources the context resources.
+ * @param uri the URI to be checked.
+ * @return bool
+ */
+bool is_array(ContextResources& resources, const URI& uri);
 
-  /** Destructor. */
-  ~Object() = default;
-
-  DISABLE_COPY_AND_COPY_ASSIGN(Object);
-  DISABLE_MOVE_AND_MOVE_ASSIGN(Object);
-
-  /* ********************************* */
-  /*                API                */
-  /* ********************************* */
-
-  /**
-   * Checks if the input URI represents an array.
-   *
-   * @param resources the context resources.
-   * @param uri the URI to be checked.
-   * @return bool
-   */
-  static bool is_array(ContextResources& resources, const URI& uri);
-
-  /**
-   * Checks if the input URI represents a group.
-   *
-   * @param resources the context resources.
-   * @param uri the URI to be checked.
-   * @param is_group Set to `true` if the URI is a group and `false`
-   *     otherwise.
-   * @return Status
-   */
-  static Status is_group(
-      ContextResources& resources, const URI& uri, bool* is_group);
-};
+/**
+ * Checks if the input URI represents a group.
+ *
+ * @param resources the context resources.
+ * @param uri the URI to be checked.
+ * @param is_group Set to `true` if the URI is a group and `false`
+ *     otherwise.
+ * @return Status
+ */
+Status is_group(ContextResources& resources, const URI& uri, bool* is_group);
 
 }  // namespace tiledb::sm
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -161,7 +161,7 @@ Status StorageManagerCanonical::array_create(
   }
 
   // Check if array exists
-  if (Object::is_array(resources_, array_uri)) {
+  if (is_array(resources_, array_uri)) {
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot create array; Array '") + array_uri.c_str() +
         "' already exists"));
@@ -271,7 +271,7 @@ Status StorageManager::array_evolve_schema(
       tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY};
 
   // Check if array exists
-  if (!Object::is_array(resources_, array_uri)) {
+  if (!is_array(resources_, array_uri)) {
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot evolve array; Array '") + array_uri.c_str() +
         "' not exists"));
@@ -316,7 +316,7 @@ Status StorageManager::array_evolve_schema(
 Status StorageManagerCanonical::array_upgrade_version(
     const URI& array_uri, const Config& override_config) {
   // Check if array exists
-  if (!Object::is_array(resources_, array_uri))
+  if (!is_array(resources_, array_uri))
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot upgrade array; Array '") + array_uri.c_str() +
         "' does not exist"));
@@ -504,7 +504,7 @@ Status StorageManagerCanonical::group_create(const std::string& group_uri) {
 
   // Check if group exists
   bool exists;
-  RETURN_NOT_OK(Object::is_group(resources_, uri, &exists));
+  RETURN_NOT_OK(is_group(resources_, uri, &exists));
   if (exists)
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot create group; Group '") + uri.c_str() +
@@ -560,13 +560,13 @@ Status StorageManagerCanonical::object_type(
       return Status::Ok();
     }
   }
-  bool exists = Object::is_array(resources_, uri);
+  bool exists = is_array(resources_, uri);
   if (exists) {
     *type = ObjectType::ARRAY;
     return Status::Ok();
   }
 
-  RETURN_NOT_OK(Object::is_group(resources_, uri, &exists));
+  RETURN_NOT_OK(is_group(resources_, uri, &exists));
   if (exists) {
     *type = ObjectType::GROUP;
     return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -64,6 +64,7 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/object/object.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/stats/global_stats.h"
@@ -160,11 +161,11 @@ Status StorageManagerCanonical::array_create(
   }
 
   // Check if array exists
-  bool exists = is_array(array_uri);
-  if (exists)
+  if (Object::is_array(resources_, array_uri)) {
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot create array; Array '") + array_uri.c_str() +
         "' already exists"));
+  }
 
   std::lock_guard<std::mutex> lock{object_create_mtx_};
   array_schema->set_array_uri(array_uri);
@@ -270,7 +271,7 @@ Status StorageManager::array_evolve_schema(
       tiledb::sm::ArrayDirectoryMode::SCHEMA_ONLY};
 
   // Check if array exists
-  if (!is_array(array_uri)) {
+  if (!Object::is_array(resources_, array_uri)) {
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot evolve array; Array '") + array_uri.c_str() +
         "' not exists"));
@@ -315,7 +316,7 @@ Status StorageManager::array_evolve_schema(
 Status StorageManagerCanonical::array_upgrade_version(
     const URI& array_uri, const Config& override_config) {
   // Check if array exists
-  if (!is_array(array_uri))
+  if (!Object::is_array(resources_, array_uri))
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot upgrade array; Array '") + array_uri.c_str() +
         "' does not exist"));
@@ -503,7 +504,7 @@ Status StorageManagerCanonical::group_create(const std::string& group_uri) {
 
   // Check if group exists
   bool exists;
-  RETURN_NOT_OK(is_group(uri, &exists));
+  RETURN_NOT_OK(Object::is_group(resources_, uri, &exists));
   if (exists)
     return logger_->status(Status_StorageManagerError(
         std::string("Cannot create group; Group '") + uri.c_str() +
@@ -540,55 +541,6 @@ void StorageManagerCanonical::increment_in_progress() {
   queries_in_progress_cv_.notify_all();
 }
 
-bool StorageManagerCanonical::is_array(const URI& uri) const {
-  // Handle remote array
-  if (uri.is_tiledb()) {
-    auto&& [st, exists] = rest_client()->check_array_exists_from_rest(uri);
-    throw_if_not_ok(st);
-    assert(exists.has_value());
-    return exists.value();
-  } else {
-    // Check if the schema directory exists or not
-    bool dir_exists = false;
-    throw_if_not_ok(resources_.vfs().is_dir(
-        uri.join_path(constants::array_schema_dir_name), &dir_exists));
-
-    if (dir_exists) {
-      return true;
-    }
-
-    // If there is no schema directory, we check schema file
-    bool schema_exists = false;
-    throw_if_not_ok(resources_.vfs().is_file(
-        uri.join_path(constants::array_schema_filename), &schema_exists));
-    return schema_exists;
-  }
-
-  // TODO: mark unreachable
-}
-
-Status StorageManagerCanonical::is_group(const URI& uri, bool* is_group) const {
-  // Handle remote array
-  if (uri.is_tiledb()) {
-    auto&& [st, exists] = rest_client()->check_group_exists_from_rest(uri);
-    RETURN_NOT_OK(st);
-    *is_group = *exists;
-  } else {
-    // Check for new group details directory
-    throw_if_not_ok(resources_.vfs().is_dir(
-        uri.join_path(constants::group_detail_dir_name), is_group));
-
-    if (*is_group) {
-      return Status::Ok();
-    }
-
-    // Fall back to older group file to check for legacy (pre-format 12) groups
-    throw_if_not_ok(resources_.vfs().is_file(
-        uri.join_path(constants::group_filename), is_group));
-  }
-  return Status::Ok();
-}
-
 Status StorageManagerCanonical::object_type(
     const URI& uri, ObjectType* type) const {
   URI dir_uri = uri;
@@ -608,13 +560,13 @@ Status StorageManagerCanonical::object_type(
       return Status::Ok();
     }
   }
-  bool exists = is_array(uri);
+  bool exists = Object::is_array(resources_, uri);
   if (exists) {
     *type = ObjectType::ARRAY;
     return Status::Ok();
   }
 
-  RETURN_NOT_OK(is_group(uri, &exists));
+  RETURN_NOT_OK(Object::is_group(resources_, uri, &exists));
   if (exists) {
     *type = ObjectType::GROUP;
     return Status::Ok();

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -236,24 +236,6 @@ class StorageManagerCanonical {
     return resources_.rest_client().get();
   }
 
-  /**
-   * Checks if the input URI represents an array.
-   *
-   * @param The URI to be checked.
-   * @return bool
-   */
-  bool is_array(const URI& uri) const;
-
-  /**
-   * Checks if the input URI represents a group.
-   *
-   * @param The URI to be checked.
-   * @param is_group Set to `true` if the URI is a group and `false`
-   *     otherwise.
-   * @return Status
-   */
-  Status is_group(const URI& uri, bool* is_group) const;
-
   /** Removes a TileDB object (group, array). */
   Status object_remove(const char* path) const;
 


### PR DESCRIPTION
Create a new directory, `tiledb/sm/object` to house `is_array` and `is_group`, migrated from `StorageManager`. 

---

[sc-46734]
[sc-46735]
[sc-47013]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of `StorageManager`: `is_array` and `is_group`.