### PR TITLE
Support `ls_recursive` in Azure.

### DIFF
--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -507,8 +507,10 @@ TEST_CASE(
   }
 }
 
-using ls_recursive_test_types =
-    std::tuple<tiledb::test::LocalFsTest, tiledb::test::S3Test>;
+using ls_recursive_test_types = std::tuple<
+    tiledb::test::LocalFsTest,
+    tiledb::test::S3Test,
+    tiledb::test::AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "CPP API: VFS ls_recursive filter",
     "[cppapi][vfs][ls-recursive]",

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -623,7 +623,8 @@ TEST_CASE("VFS: test ls_with_sizes", "[vfs][ls-with-sizes]") {
 }
 
 // Currently only local, S3 and Azure is supported for VFS::ls_recursive.
-using TestBackends = std::tuple<LocalFsTest, S3Test, AzureTest>;
+// TODO: LocalFsTest currently fails. Fix and re-enable.
+using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: Test internal ls_filtered recursion argument",
     "[vfs][ls_filtered][recursion]",

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -622,8 +622,8 @@ TEST_CASE("VFS: test ls_with_sizes", "[vfs][ls-with-sizes]") {
   require_tiledb_ok(vfs_ls.remove_dir(URI(path)));
 }
 
-// Currently only S3 and Azure is supported for VFS::ls_recursive.
-using TestBackends = std::tuple<S3Test, AzureTest>;
+// Currently only local, S3 and Azure is supported for VFS::ls_recursive.
+using TestBackends = std::tuple<LocalFsTest, S3Test, AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: Test internal ls_filtered recursion argument",
     "[vfs][ls_filtered][recursion]",

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -622,8 +622,8 @@ TEST_CASE("VFS: test ls_with_sizes", "[vfs][ls-with-sizes]") {
   require_tiledb_ok(vfs_ls.remove_dir(URI(path)));
 }
 
-// Currently only S3 is supported for VFS::ls_recursive.
-using TestBackends = std::tuple<S3Test>;
+// Currently only S3 and Azure is supported for VFS::ls_recursive.
+using TestBackends = std::tuple<S3Test, AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: Test internal ls_filtered recursion argument",
     "[vfs][ls_filtered][recursion]",
@@ -637,10 +637,9 @@ TEMPLATE_LIST_TEST_CASE(
   DYNAMIC_SECTION(
       fs.temp_dir_.backend_name()
       << " ls_filtered with recursion: " << (recursive ? "true" : "false")) {
-#ifdef HAVE_S3
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
-    auto ls_objects = fs.get_s3().ls_filtered(
+    auto ls_objects = fs.vfs_.ls_filtered(
         path, VFSTestBase::accept_all_files, accept_all_dirs, recursive);
 
     auto expected = fs.expected_results();
@@ -654,7 +653,6 @@ TEMPLATE_LIST_TEST_CASE(
 
     CHECK(ls_objects.size() == expected.size());
     CHECK(ls_objects == expected);
-#endif
   }
 }
 
@@ -669,7 +667,7 @@ TEST_CASE(
   }
   std::string backend = vfs_test.temp_dir_.backend_name();
 
-  if (vfs_test.temp_dir_.is_s3()) {
+  if (vfs_test.temp_dir_.is_s3() || vfs_test.temp_dir_.is_azure()) {
     DYNAMIC_SECTION(backend << " supported backend should not throw") {
       CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
           vfs_test.temp_dir_, VFSTestBase::accept_all_files));
@@ -688,7 +686,7 @@ TEST_CASE(
 TEST_CASE(
     "VFS: Throwing FileFilter for ls_recursive",
     "[vfs][ls_recursive][file-filter]") {
-  std::string prefix = "s3://";
+  std::string prefix = GENERATE("s3://", "azure://");
   VFSTest vfs_test({0}, prefix);
   if (!vfs_test.is_supported()) {
     return;

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1107,6 +1107,7 @@ class AzureTest : public VFSTestBase {
  public:
   explicit AzureTest(const std::vector<size_t>& test_tree)
       : VFSTestBase(test_tree, "azure://") {
+#ifdef HAVE_AZURE
     vfs_.create_bucket(temp_dir_).ok();
     for (size_t i = 1; i <= test_tree_.size(); i++) {
       sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
@@ -1121,6 +1122,7 @@ class AzureTest : public VFSTestBase {
       }
     }
     std::sort(expected_results().begin(), expected_results().end());
+#endif
   }
 };
 

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1107,6 +1107,20 @@ class AzureTest : public VFSTestBase {
  public:
   explicit AzureTest(const std::vector<size_t>& test_tree)
       : VFSTestBase(test_tree, "azure://") {
+    vfs_.create_bucket(temp_dir_).ok();
+    for (size_t i = 1; i <= test_tree_.size(); i++) {
+      sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
+      // VFS::create_dir is a no-op for Azure; Just create objects.
+      for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
+        auto object_uri = path.join_path("test_file_" + std::to_string(j));
+        vfs_.touch(object_uri).ok();
+        std::string data(j * 10, 'a');
+        vfs_.write(object_uri, data.data(), data.size()).ok();
+        vfs_.close_file(object_uri).ok();
+        expected_results().emplace_back(object_uri.to_string(), data.size());
+      }
+    }
+    std::sort(expected_results().begin(), expected_results().end());
   }
 };
 

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -38,13 +38,17 @@
 
 using namespace tiledb::test;
 
-TEST_CASE("C API: ls_recursive callback", "[vfs][ls-recursive]") {
+// Currently only local, S3 and Azure is supported for VFS::ls_recursive.
+using TestBackends = std::tuple<LocalFsTest, S3Test, AzureTest>;
+
+TEMPLATE_LIST_TEST_CASE(
+    "C API: ls_recursive callback", "[vfs][ls-recursive]", TestBackends) {
   using tiledb::sm::LsObjects;
-  S3Test s3_test({10, 50});
-  if (!s3_test.is_supported()) {
+  TestType test({10, 50});
+  if (!test.is_supported()) {
     return;
   }
-  auto expected = s3_test.expected_results();
+  auto expected = test.expected_results();
 
   vfs_config vfs_config;
   tiledb_ctx_t* ctx;
@@ -80,19 +84,22 @@ TEST_CASE("C API: ls_recursive callback", "[vfs][ls-recursive]") {
   }
 
   CHECK(
-      tiledb_vfs_ls_recursive(ctx, vfs, s3_test.temp_dir_.c_str(), cb, &data) ==
+      tiledb_vfs_ls_recursive(ctx, vfs, test.temp_dir_.c_str(), cb, &data) ==
       TILEDB_OK);
   CHECK(data.size() == expected.size());
   CHECK(data == expected);
 }
 
-TEST_CASE("C API: ls_recursive throwing callback", "[vfs][ls-recursive]") {
+TEMPLATE_LIST_TEST_CASE(
+    "C API: ls_recursive throwing callback",
+    "[vfs][ls-recursive]",
+    TestBackends) {
   using tiledb::sm::LsObjects;
-  S3Test s3_test({10, 50});
-  if (!s3_test.is_supported()) {
+  TestType test({10, 50});
+  if (!test.is_supported()) {
     return;
   }
-  auto expected = s3_test.expected_results();
+  auto expected = test.expected_results();
 
   vfs_config vfs_config;
   tiledb_ctx_t* ctx;
@@ -107,7 +114,7 @@ TEST_CASE("C API: ls_recursive throwing callback", "[vfs][ls-recursive]") {
   };
 
   CHECK(
-      tiledb_vfs_ls_recursive(ctx, vfs, s3_test.temp_dir_.c_str(), cb, &data) ==
+      tiledb_vfs_ls_recursive(ctx, vfs, test.temp_dir_.c_str(), cb, &data) ==
       TILEDB_ERR);
   CHECK(data.empty());
 }

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -39,7 +39,8 @@
 using namespace tiledb::test;
 
 // Currently only local, S3 and Azure is supported for VFS::ls_recursive.
-using TestBackends = std::tuple<LocalFsTest, S3Test, AzureTest>;
+// TODO: LocalFsTest currently fails. Fix and re-enable.
+using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest>;
 
 TEMPLATE_LIST_TEST_CASE(
     "C API: ls_recursive callback", "[vfs][ls-recursive]", TestBackends) {

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -58,8 +58,8 @@ typedef int32_t (*tiledb_ls_callback_t)(
  * on error. The callback is responsible for writing gathered entries into the
  * `data` buffer, for example using a pointer to a user-defined struct.
  *
- * Currently only Posix and S3 are supported, and the `path` must be a valid URI
- * for one of those filesystems.
+ * Currently only local filesystem, S3 and Azure are supported, and the `path`
+ * must be a valid URI for one of those filesystems.
  *
  * **Example:**
  *

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -161,7 +161,8 @@ class VFSExperimental {
    * be included in the results and false otherwise. If no inclusion predicate
    * is provided, all results are returned.
    *
-   * Currently only S3 is supported, and the `path` must be a valid S3 URI.
+   * Currently only local filesystem, S3 and Azure is supported, and the `path`
+   * must be a valid URI for one of those filesystems.
    *
    * @code{.c}
    * VFSExperimental::LsInclude predicate = [](std::string_view path,

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -542,7 +542,7 @@ Status Azure::is_blob(
   return Status_Ok();
 }
 
-std::string Azure::remove_front_slash(const std::string& path) const {
+std::string Azure::remove_front_slash(const std::string& path) {
   if (path.front() == '/') {
     return path.substr(1, path.length());
   }
@@ -550,7 +550,7 @@ std::string Azure::remove_front_slash(const std::string& path) const {
   return path;
 }
 
-std::string Azure::add_trailing_slash(const std::string& path) const {
+std::string Azure::add_trailing_slash(const std::string& path) {
   if (path.back() != '/') {
     return path + "/";
   }
@@ -558,7 +558,7 @@ std::string Azure::add_trailing_slash(const std::string& path) const {
   return path;
 }
 
-std::string Azure::remove_trailing_slash(const std::string& path) const {
+std::string Azure::remove_trailing_slash(const std::string& path) {
   if (path.back() == '/') {
     return path.substr(0, path.length() - 1);
   }
@@ -1111,7 +1111,7 @@ Status Azure::upload_block(
 Status Azure::parse_azure_uri(
     const URI& uri,
     std::string* const container_name,
-    std::string* const blob_path) const {
+    std::string* const blob_path) {
   assert(uri.is_azure());
   const std::string uri_str = uri.to_string();
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -602,17 +602,6 @@ class Azure {
   Status copy_blob(const URI& old_uri, const URI& new_uri);
 
   /**
-   * Waits for a blob with `container_name` and `blob_path`
-   * to exist on Azure.
-   *
-   * @param container_name The blob's container name.
-   * @param blob_path The blob's path
-   * @return Status
-   */
-  Status wait_for_blob_to_propagate(
-      const std::string& container_name, const std::string& blob_path) const;
-
-  /**
    * Check if 'container_name' is a container on Azure.
    *
    * @param container_name The container's name.

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -176,7 +176,7 @@ class AzureScanner : public LsScanner<F, D> {
    * Returns true if there are more results to fetch from Azure.
    */
   [[nodiscard]] inline bool more_to_fetch() const {
-    return has_fetched_ && !continuation_token_.has_value();
+    return !has_fetched_ || continuation_token_.has_value();
   }
 
   /**
@@ -226,7 +226,7 @@ class AzureScanner : public LsScanner<F, D> {
   }
 
   /**
-   * Fetch the next batch of results from S3. This also handles setting the
+   * Fetch the next batch of results from Azure. This also handles setting the
    * continuation token for the next request, if the results were truncated.
    *
    * @return A pointer to the first result in the new batch. The return value

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -149,7 +149,7 @@ class Azure;
  *      iterators returned by a previous request. To be able to detect this, we
  *      can track the batch number and compare it to the batch number associated
  *      with the iterator returned by the previous request. Batch number can be
- *      tracked by the total number of times we submit a ListObjectsV2 request
+ *      tracked by the total number of times we submit a ListBlobs request
  *      within fetch_results().
  *
  * @tparam F The FilePredicate type used to filter object results.
@@ -780,7 +780,8 @@ class Azure {
    * exit, will hold the continuation token to pass to the next listing
    * operation, or nullopt if there are no more results.
    *
-   * @return A vector with the blobs and directories found.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
    *
    * @note If continuation_token is not nullopt, callers must ensure that the
    * container_name, blob_path and recursive parameters are the same as the

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -587,10 +587,8 @@ class Azure {
    * @param blob_path Mutates to the blob path.
    * @return Status
    */
-  Status parse_azure_uri(
-      const URI& uri,
-      std::string* container_name,
-      std::string* blob_path) const;
+  static Status parse_azure_uri(
+      const URI& uri, std::string* container_name, std::string* blob_path);
 
   /**
    * Copies the blob at 'old_uri' to `new_uri`.
@@ -629,21 +627,21 @@ class Azure {
    *
    * @param path the string to remove the leading slash from.
    */
-  std::string remove_front_slash(const std::string& path) const;
+  static std::string remove_front_slash(const std::string& path);
 
   /**
    * Adds a trailing slash from 'path' if it doesn't already have one.
    *
    * @param path the string to add the trailing slash to.
    */
-  std::string add_trailing_slash(const std::string& path) const;
+  static std::string add_trailing_slash(const std::string& path);
 
   /**
    * Removes a trailing slash from 'path' if it exists.
    *
    * @param path the string to remove the trailing slash from.
    */
-  std::string remove_trailing_slash(const std::string& path) const;
+  static std::string remove_trailing_slash(const std::string& path);
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -878,8 +878,8 @@ AzureScanner<F, D>::AzureScanner(
     throw AzureException("URI is not an Azure URI: " + prefix.to_string());
   }
 
-  throw_if_not_ok(
-      Azure::parse_azure_uri(prefix, &container_name_, &blob_path_));
+  throw_if_not_ok(Azure::parse_azure_uri(
+      prefix.add_trailing_slash(), &container_name_, &blob_path_));
   fetch_results();
   next(begin_);
 }

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -582,9 +582,9 @@ class VFS : private VFSBase, protected S3_within_VFS {
   }
 
   /**
-   * Lists objects and object information that start with `prefix`, invoking
-   * the FilePredicate on each entry collected and the DirectoryPredicate on
-   * common prefixes for pruning.
+   * Recursively lists objects and object information that start with `prefix`,
+   * invoking the FilePredicate on each entry collected and the
+   * DirectoryPredicate on common prefixes for pruning.
    *
    * Currently this API is only supported for local files, S3 and Azure.
    *

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -514,31 +514,33 @@ class VFS : private VFSBase, protected S3_within_VFS {
    * the FilePredicate on each entry collected and the DirectoryPredicate on
    * common prefixes for pruning.
    *
-   * Currently this API is only supported for Posix and S3.
+   * Currently this API is only supported for local files, S3 and Azure.
    *
    * @param parent The parent prefix to list sub-paths.
    * @param f The FilePredicate to invoke on each object for filtering.
    * @param d The DirectoryPredicate to invoke on each common prefix for
    *    pruning. This is currently unused, but is kept here for future support.
+   * @param recursive Whether to list the objects recursively.
    * @return Vector of results with each entry being a pair of the string URI
    *    and object size.
    */
   template <FilePredicate F, DirectoryPredicate D = DirectoryFilter>
-  LsObjects ls_recursive(
+  LsObjects ls_filtered(
       const URI& parent,
       [[maybe_unused]] F f,
-      [[maybe_unused]] D d = accept_all_dirs) const {
+      [[maybe_unused]] D d,
+      bool recursive) const {
     LsObjects results;
     try {
       if (parent.is_file()) {
 #ifdef _WIN32
-        results = win_.ls_filtered(parent, f, d, true);
+        results = win_.ls_filtered(parent, f, d, recursive);
 #else
-        results = posix_.ls_filtered(parent, f, d, true);
+        results = posix_.ls_filtered(parent, f, d, recursive);
 #endif
       } else if (parent.is_s3()) {
 #ifdef HAVE_S3
-        results = s3().ls_filtered(parent, f, d, true);
+        results = s3().ls_filtered(parent, f, d, recursive);
 #else
         throw filesystem::VFSException("TileDB was built without S3 support");
 #endif
@@ -552,7 +554,7 @@ class VFS : private VFSBase, protected S3_within_VFS {
 #endif
       } else if (parent.is_azure()) {
 #ifdef HAVE_AZURE
-        results = azure_.ls_filtered(parent, f, d, true);
+        results = azure_.ls_filtered(parent, f, d, recursive);
 #else
         throw filesystem::VFSException(
             "TileDB was built without Azure support");
@@ -577,6 +579,28 @@ class VFS : private VFSBase, protected S3_within_VFS {
       throw;
     }
     return results;
+  }
+
+  /**
+   * Lists objects and object information that start with `prefix`, invoking
+   * the FilePredicate on each entry collected and the DirectoryPredicate on
+   * common prefixes for pruning.
+   *
+   * Currently this API is only supported for local files, S3 and Azure.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param f The FilePredicate to invoke on each object for filtering.
+   * @param d The DirectoryPredicate to invoke on each common prefix for
+   *    pruning. This is currently unused, but is kept here for future support.
+   * @return Vector of results with each entry being a pair of the string URI
+   *    and object size.
+   */
+  template <FilePredicate F, DirectoryPredicate D = DirectoryFilter>
+  LsObjects ls_recursive(
+      const URI& parent,
+      [[maybe_unused]] F f,
+      [[maybe_unused]] D d = accept_all_dirs) const {
+    return ls_filtered(parent, f, d, true);
   }
 
   /**

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -552,9 +552,7 @@ class VFS : private VFSBase, protected S3_within_VFS {
 #endif
       } else if (parent.is_azure()) {
 #ifdef HAVE_AZURE
-        throw filesystem::VFSException(
-            "Recursive ls over " + parent.backend_name() +
-            " storage backend is not supported.");
+        results = azure_.ls_filtered(parent, f, d, true);
 #else
         throw filesystem::VFSException(
             "TileDB was built without Azure support");


### PR DESCRIPTION
[SC-44943](https://app.shortcut.com/tiledb-inc/story/44943/add-support-for-ls-recursive-in-azure)

This PR implements `ls_recursive` in the Azure VFS. The design is based on the S3 implementation, but unlike S3, the Azure SDK calls are cleanly separated, which prevents the Azure SDK headers from leaking to the VFS header.

---
TYPE: C_API
DESC: Support VFS `ls_recursive` API for Azure filesystem.