### PR TITLE
Migrate APIs out of StorageManager: store_metadata.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -463,8 +463,8 @@ Status Array::close() {
     } else {
       if (query_type_ == QueryType::WRITE ||
           query_type_ == QueryType::MODIFY_EXCLUSIVE) {
-        st = (&opened_array_->metadata())
-                 ->store(resources_, array_uri_, *encryption_key());
+        st = (opened_array_->metadata())
+                 .store(resources_, array_uri_, *encryption_key());
         if (!st.ok()) {
           throw StatusException(st);
         }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -463,8 +463,8 @@ Status Array::close() {
     } else {
       if (query_type_ == QueryType::WRITE ||
           query_type_ == QueryType::MODIFY_EXCLUSIVE) {
-        st = storage_manager_->store_metadata(
-            array_uri_, *encryption_key(), &opened_array_->metadata());
+        st = (&opened_array_->metadata())
+                 ->store(resources_, array_uri_, *encryption_key());
         if (!st.ok()) {
           throw StatusException(st);
         }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -463,8 +463,8 @@ Status Array::close() {
     } else {
       if (query_type_ == QueryType::WRITE ||
           query_type_ == QueryType::MODIFY_EXCLUSIVE) {
-        st = (opened_array_->metadata())
-                 .store(resources_, array_uri_, *encryption_key());
+        st = opened_array_->metadata().store(
+            resources_, array_uri_, *encryption_key());
         if (!st.ok()) {
           throw StatusException(st);
         }

--- a/tiledb/sm/metadata/CMakeLists.txt
+++ b/tiledb/sm/metadata/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2021-2023 TileDB, Inc.
+# Copyright (c) 2021-2024 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ include(object_library)
 #
 commence(object_library metadata)
     this_target_sources(metadata.cc)
-    this_target_object_libraries(baseline buffer constants time uri_format vfs)
+    this_target_object_libraries(baseline buffer constants generic_tile_io time uri_format vfs)
 conclude(object_library)
 
 add_test_subdirectory()

--- a/tiledb/sm/metadata/metadata.h
+++ b/tiledb/sm/metadata/metadata.h
@@ -42,6 +42,7 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/pmr.h"
 #include "tiledb/sm/filesystem/uri.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/tile/tile.h"
 #include "tiledb/storage_format/serialization/serializers.h"
 
@@ -135,6 +136,19 @@ class Metadata {
 
   /** Serializes all key-value metadata items into the input buffer. */
   void serialize(Serializer& serializer) const;
+
+  /**
+   * Stores the metadata into persistent storage.
+   *
+   * @param resources The context resources.
+   * @param uri The object URI.
+   * @param encryption_key The encryption key to use.
+   * @return Status
+   */
+  Status store(
+      ContextResources& resources,
+      const URI& uri,
+      const EncryptionKey& encryption_key);
 
   /**
    * Deletes a metadata item.

--- a/tiledb/sm/metadata/test/CMakeLists.txt
+++ b/tiledb/sm/metadata/test/CMakeLists.txt
@@ -27,8 +27,6 @@ include(unit_test)
 
 commence(unit_test metadata)
     this_target_object_libraries(metadata mem_helpers)	
-    # The dependency on the `tile` object library is suspect, but here for now.	
-    this_target_object_libraries(tile)
     this_target_link_libraries(tiledb_test_support_lib)
     this_target_sources(main.cc unit_metadata.cc)
 conclude(unit_test)

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -392,17 +392,6 @@ class StorageManagerCanonical {
       const shared_ptr<ArraySchema>& array_schema,
       const EncryptionKey& encryption_key);
 
-  /**
-   * Stores the metadata into persistent storage.
-   *
-   * @param uri The object URI.
-   * @param encryption_key The encryption key to use.
-   * @param metadata The  metadata.
-   * @return Status
-   */
-  Status store_metadata(
-      const URI& uri, const EncryptionKey& encryption_key, Metadata* metadata);
-
   [[nodiscard]] inline ContextResources& resources() const {
     return resources_;
   }


### PR DESCRIPTION
Migrate APIs out of `StorageManager`: `store_metadata`.

[sc-46746]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of `StorageManager`: `store_metadata`.
