### PR TITLE
Remove StorageManager::compute_tp().

### DIFF
--- a/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
+++ b/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
@@ -62,9 +62,6 @@ class StorageManagerStub {
       , config_(config) {
   }
 
-  inline common::ThreadPool* compute_tp() {
-    return &resources_.compute_tp();
-  }
   inline common::ThreadPool* io_tp() {
     return &resources_.io_tp();
   }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -258,7 +258,7 @@ int32_t tiledb_array_schema_alloc(
   }
 
   // Create a new ArraySchema object
-  auto memory_tracker = ctx->context().resources().create_memory_tracker();
+  auto memory_tracker = ctx->resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::ARRAY_CREATE);
   (*array_schema)->array_schema_ = make_shared<tiledb::sm::ArraySchema>(
       HERE(), static_cast<tiledb::sm::ArrayType>(array_type), memory_tracker);
@@ -486,14 +486,11 @@ int32_t tiledb_array_schema_load(
     throw_if_not_ok(
         key.set_key(tiledb::sm::EncryptionType::NO_ENCRYPTION, nullptr, 0));
 
-    // For easy reference
-    auto storage_manager{ctx->storage_manager()};
-
     // Load URIs from the array directory
     optional<tiledb::sm::ArrayDirectory> array_dir;
     try {
       array_dir.emplace(
-          storage_manager->resources(),
+          ctx->resources(),
           uri,
           0,
           UINT64_MAX,
@@ -506,7 +503,7 @@ int32_t tiledb_array_schema_load(
       return TILEDB_ERR;
     }
 
-    auto tracker = storage_manager->resources().ephemeral_memory_tracker();
+    auto tracker = ctx->resources().ephemeral_memory_tracker();
 
     // Load latest array schema
     auto&& array_schema_latest =
@@ -569,14 +566,11 @@ int32_t tiledb_array_schema_load_with_key(
       return TILEDB_ERR;
     }
 
-    // For easy reference
-    auto storage_manager{ctx->storage_manager()};
-
     // Load URIs from the array directory
     optional<tiledb::sm::ArrayDirectory> array_dir;
     try {
       array_dir.emplace(
-          storage_manager->resources(),
+          ctx->resources(),
           uri,
           0,
           UINT64_MAX,
@@ -589,7 +583,7 @@ int32_t tiledb_array_schema_load_with_key(
       return TILEDB_ERR;
     }
 
-    auto tracker = storage_manager->resources().ephemeral_memory_tracker();
+    auto tracker = ctx->resources().ephemeral_memory_tracker();
 
     // Load latest array schema
     auto&& array_schema_latest =
@@ -809,7 +803,7 @@ int32_t tiledb_array_schema_evolution_alloc(
   }
 
   // Create a new SchemaEvolution object
-  auto memory_tracker = ctx->context().resources().create_memory_tracker();
+  auto memory_tracker = ctx->resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::SCHEMA_EVOLUTION);
   (*array_schema_evolution)->array_schema_evolution_ =
       new (std::nothrow) tiledb::sm::ArraySchemaEvolution(memory_tracker);
@@ -3376,14 +3370,14 @@ int32_t tiledb_deserialize_array(
     return TILEDB_OOM;
   }
 
-  auto memory_tracker = ctx->context().resources().create_memory_tracker();
+  auto memory_tracker = ctx->resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::ARRAY_LOAD);
   try {
     tiledb::sm::serialization::array_deserialize(
         (*array)->array_.get(),
         (tiledb::sm::SerializationType)serialize_type,
         buffer->buffer(),
-        ctx->context().resources(),
+        ctx->resources(),
         memory_tracker);
   } catch (StatusException& e) {
     delete *array;
@@ -3441,7 +3435,7 @@ int32_t tiledb_deserialize_array_schema(
   }
 
   try {
-    auto memory_tracker = ctx->context().resources().create_memory_tracker();
+    auto memory_tracker = ctx->resources().create_memory_tracker();
     memory_tracker->set_type(sm::MemoryTrackerType::ARRAY_LOAD);
     (*array_schema)->array_schema_ =
         tiledb::sm::serialization::array_schema_deserialize(
@@ -3594,7 +3588,7 @@ int32_t tiledb_deserialize_array_schema_evolution(
     return TILEDB_OOM;
   }
 
-  auto memory_tracker = ctx->context().resources().create_memory_tracker();
+  auto memory_tracker = ctx->resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::SCHEMA_EVOLUTION);
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -3657,7 +3651,7 @@ int32_t tiledb_deserialize_query(
       client_side == 1,
       nullptr,
       query->query_,
-      ctx->storage_manager()->compute_tp()));
+      &ctx->resources().compute_tp()));
 
   return TILEDB_OK;
 }
@@ -3751,7 +3745,7 @@ int32_t tiledb_deserialize_query_and_array(
       client_side == 1,
       nullptr,
       (*query)->query_,
-      ctx->storage_manager()->compute_tp()));
+      &ctx->resources().compute_tp()));
 
   return TILEDB_OK;
 }
@@ -4226,7 +4220,7 @@ int32_t tiledb_deserialize_fragment_info(
     return TILEDB_ERR;
   }
 
-  auto memory_tracker = ctx->context().resources().create_memory_tracker();
+  auto memory_tracker = ctx->resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::FRAGMENT_INFO_LOAD);
   if (SAVE_ERROR_CATCH(
           ctx,

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -126,14 +126,13 @@ void ArrayMetaConsolidator::vacuum(const char* array_name) {
 
   // Get the array metadata URIs and vacuum file URIs to be vacuum
   auto& vfs = resources_.vfs();
-  auto compute_tp = storage_manager_->compute_tp();
-
+  auto& compute_tp = resources_.compute_tp();
   auto array_dir = ArrayDirectory(
       resources_, URI(array_name), 0, std::numeric_limits<uint64_t>::max());
 
   // Delete the array metadata and vacuum files
-  vfs.remove_files(compute_tp, array_dir.array_meta_uris_to_vacuum());
-  vfs.remove_files(compute_tp, array_dir.array_meta_vac_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, array_dir.array_meta_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, array_dir.array_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -117,9 +117,10 @@ void CommitsConsolidator::vacuum(const char* array_name) {
 
   // Delete the commits and vacuum files
   auto& vfs = resources_.vfs();
-  auto compute_tp = storage_manager_->compute_tp();
-  vfs.remove_files(compute_tp, array_dir.commit_uris_to_vacuum());
-  vfs.remove_files(compute_tp, array_dir.consolidated_commits_uris_to_vacuum());
+  auto& compute_tp = resources_.compute_tp();
+  vfs.remove_files(&compute_tp, array_dir.commit_uris_to_vacuum());
+  vfs.remove_files(
+      &compute_tp, array_dir.consolidated_commits_uris_to_vacuum());
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -446,12 +446,11 @@ void FragmentConsolidator::vacuum(const char* array_name) {
     array_dir.write_commit_ignore_file(commit_uris_to_ignore);
   }
 
-  auto& vfs = resources_.vfs();
-  auto compute_tp = storage_manager_->compute_tp();
-
   // Delete fragment directories
+  auto& vfs = resources_.vfs();
+  auto& compute_tp = resources_.compute_tp();
   throw_if_not_ok(parallel_for(
-      compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
+      &compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
         // Remove the commit file, if present.
         auto commit_uri = array_dir.get_commit_uri(fragment_uris_to_vacuum[i]);
         bool is_file = false;
@@ -471,7 +470,7 @@ void FragmentConsolidator::vacuum(const char* array_name) {
 
   // Delete the vacuum files.
   vfs.remove_files(
-      compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
+      &compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -113,12 +113,12 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
 
   // Get the group metadata URIs and vacuum file URIs to be vacuumed
   auto& vfs = resources_.vfs();
-  auto compute_tp = storage_manager_->compute_tp();
+  auto& compute_tp = resources_.compute_tp();
   GroupDirectory group_dir;
   try {
     group_dir = GroupDirectory(
         &vfs,
-        compute_tp,
+        &compute_tp,
         URI(group_name),
         0,
         std::numeric_limits<uint64_t>::max());
@@ -127,8 +127,8 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
   }
 
   // Delete the group metadata and vacuum files
-  vfs.remove_files(compute_tp, group_dir.group_meta_uris_to_vacuum());
-  vfs.remove_files(compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, group_dir.group_meta_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -867,7 +867,7 @@ Status FragmentInfo::load(const ArrayDirectory& array_dir) {
 
   // Get fragment sizes
   std::vector<uint64_t> sizes(fragment_num, 0);
-  RETURN_NOT_OK(parallel_for(
+  throw_if_not_ok(parallel_for(
       &resources_->compute_tp(),
       0,
       fragment_num,

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -164,7 +164,7 @@ Status Group::open(
       group_dir_ = make_shared<GroupDirectory>(
           HERE(),
           &resources_.vfs(),
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           group_uri_,
           timestamp_start,
           timestamp_end);
@@ -178,7 +178,7 @@ Status Group::open(
       group_dir_ = make_shared<GroupDirectory>(
           HERE(),
           &resources_.vfs(),
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           group_uri_,
           timestamp_start,
           (timestamp_end != 0) ? timestamp_end :
@@ -758,7 +758,7 @@ void Group::load_metadata_from_storage(
             uri,
             0,
             encryption_key,
-            storage_manager_->resources().ephemeral_memory_tracker());
+            resources_.ephemeral_memory_tracker());
 
         return Status::Ok();
       }));

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,8 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
     const std::unordered_map<std::string, QueryBuffer>& array_buffers,
     const optional<std::string>& fragment_name)
-    : storage_manager_(storage_manager)
+    : resources_(storage_manager->resources())
+    , storage_manager_(storage_manager)
     , label_range_queries_by_dim_idx_(subarray.dim_num(), nullptr)
     , label_data_queries_by_dim_idx_(subarray.dim_num())
     , range_query_status_{QueryStatus::UNINITIALIZED}
@@ -150,7 +151,7 @@ std::vector<DimensionLabelQuery*> ArrayDimensionLabelQueries::get_data_query(
 
 void ArrayDimensionLabelQueries::process_data_queries() {
   throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       data_queries_.size(),
       [&](const size_t query_idx) {
@@ -170,7 +171,7 @@ void ArrayDimensionLabelQueries::process_data_queries() {
 void ArrayDimensionLabelQueries::process_range_queries(Query* parent_query) {
   // Process queries and update the subarray.
   throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       label_range_queries_by_dim_idx_.size(),
       [&](const uint32_t dim_idx) {

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -159,6 +159,9 @@ class ArrayDimensionLabelQueries {
   void process_range_queries(Query* parent_query);
 
  private:
+  /** The context resources. */
+  ContextResources& resources_;
+
   /** The storage manager. */
   StorageManager* storage_manager_;
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -257,10 +257,7 @@ Status DenseReader::dense_read() {
   const auto& layout =
       layout_ == Layout::GLOBAL_ORDER ? array_schema_.cell_order() : layout_;
   auto status = parallel_for(
-      storage_manager_->compute_tp(),
-      0,
-      tile_subarrays.size(),
-      [&](uint64_t t) {
+      &resources_.compute_tp(), 0, tile_subarrays.size(), [&](uint64_t t) {
         subarray.crop_to_tile(
             &tile_subarrays[t], (const DimType*)&tile_coords[t][0], layout);
         return Status::Ok();
@@ -388,8 +385,7 @@ Status DenseReader::dense_read() {
 
     // Compute parallelization parameters.
     uint64_t num_range_threads = 1;
-    const auto num_threads =
-        storage_manager_->compute_tp()->concurrency_level();
+    const auto num_threads = resources_.compute_tp().concurrency_level();
     if ((t_end - t_start) < num_threads) {
       // Ceil the division between thread_num and tile_num.
       num_range_threads = 1 + ((num_threads - 1) / (t_end - t_start));
@@ -446,73 +442,72 @@ Status DenseReader::dense_read() {
       }
 
       if (compute_task.valid()) {
-        RETURN_NOT_OK(storage_manager_->compute_tp()->wait(compute_task));
+        throw_if_not_ok(resources_.compute_tp().wait(compute_task));
         if (read_state_.overflowed_) {
           return Status::Ok();
         }
       }
 
-      compute_task =
-          storage_manager_->compute_tp()->execute([&,
-                                                   filtered_data,
-                                                   dense_dim,
-                                                   name,
-                                                   validity_only,
-                                                   t_start,
-                                                   t_end,
-                                                   subarray_start_cell,
-                                                   subarray_end_cell,
-                                                   num_range_threads,
-                                                   result_tiles]() {
-            if (!dense_dim) {
-              // Unfilter tiles.
-              RETURN_NOT_OK(unfilter_tiles(name, validity_only, result_tiles));
+      compute_task = resources_.compute_tp().execute([&,
+                                                      filtered_data,
+                                                      dense_dim,
+                                                      name,
+                                                      validity_only,
+                                                      t_start,
+                                                      t_end,
+                                                      subarray_start_cell,
+                                                      subarray_end_cell,
+                                                      num_range_threads,
+                                                      result_tiles]() {
+        if (!dense_dim) {
+          // Unfilter tiles.
+          RETURN_NOT_OK(unfilter_tiles(name, validity_only, result_tiles));
 
-              // Only copy names that are present in the user buffers.
-              if (buffers_.count(name) != 0) {
-                // Copy attribute data to users buffers.
-                auto& var_buffer_size = var_buffer_sizes[name];
-                status = copy_attribute<DimType, OffType>(
-                    name,
-                    tile_extents,
-                    subarray,
-                    t_start,
-                    t_end,
-                    subarray_start_cell,
-                    subarray_end_cell,
-                    tile_subarrays,
-                    tile_offsets,
-                    var_buffer_size,
-                    range_info,
-                    result_space_tiles,
-                    qc_result,
-                    num_range_threads);
-                RETURN_CANCEL_OR_ERROR(status);
-              }
-            }
+          // Only copy names that are present in the user buffers.
+          if (buffers_.count(name) != 0) {
+            // Copy attribute data to users buffers.
+            auto& var_buffer_size = var_buffer_sizes[name];
+            status = copy_attribute<DimType, OffType>(
+                name,
+                tile_extents,
+                subarray,
+                t_start,
+                t_end,
+                subarray_start_cell,
+                subarray_end_cell,
+                tile_subarrays,
+                tile_offsets,
+                var_buffer_size,
+                range_info,
+                result_space_tiles,
+                qc_result,
+                num_range_threads);
+            RETURN_CANCEL_OR_ERROR(status);
+          }
+        }
 
-            if (aggregates_.count(name) != 0) {
-              status = process_aggregates<DimType, OffType>(
-                  name,
-                  tile_extents,
-                  subarray,
-                  t_start,
-                  t_end,
-                  tile_subarrays,
-                  tile_offsets,
-                  range_info,
-                  result_space_tiles,
-                  qc_result,
-                  num_range_threads);
-              RETURN_CANCEL_OR_ERROR(status);
-            }
+        if (aggregates_.count(name) != 0) {
+          status = process_aggregates<DimType, OffType>(
+              name,
+              tile_extents,
+              subarray,
+              t_start,
+              t_end,
+              tile_subarrays,
+              tile_offsets,
+              range_info,
+              result_space_tiles,
+              qc_result,
+              num_range_threads);
+          RETURN_CANCEL_OR_ERROR(status);
+        }
 
-            if (!dense_dim) {
-              clear_tiles(name, result_tiles);
-            }
+        if (!dense_dim) {
+          clear_tiles(name, result_tiles);
+        }
 
-            return Status::Ok();
-          });
+        return Status::Ok();
+      });
     }
 
     // Process count aggregates.
@@ -539,7 +534,7 @@ Status DenseReader::dense_read() {
   }
 
   if (compute_task.valid()) {
-    RETURN_NOT_OK(storage_manager_->compute_tp()->wait(compute_task));
+    throw_if_not_ok(resources_.compute_tp().wait(compute_task));
   }
 
   // For `qc_coords_mode` just fill in the coordinates and skip attribute
@@ -618,7 +613,7 @@ void DenseReader::init_read_state() {
       std::numeric_limits<uint64_t>::max(),
       std::numeric_limits<uint64_t>::max(),
       std::numeric_limits<uint64_t>::max(),
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       stats_,
       logger_);
   read_state_.overflowed_ = false;
@@ -737,7 +732,7 @@ uint64_t DenseReader::compute_space_tiles_end(
   // load two batches at once. Wait for the first compute task to complete
   // before loading more tiles.
   if (compute_task.valid() && available_memory < tile_upper_memory_limit_) {
-    throw_if_not_ok(storage_manager_->compute_tp()->wait(compute_task));
+    throw_if_not_ok(resources_.compute_tp().wait(compute_task));
   }
 
   const uint64_t upper_memory_limit =
@@ -928,16 +923,16 @@ Status DenseReader::apply_query_condition(
             NameToLoad::from_string_vec(qc_names), result_tiles));
 
     if (compute_task.valid()) {
-      RETURN_NOT_OK(storage_manager_->compute_tp()->wait(compute_task));
+      throw_if_not_ok(resources_.compute_tp().wait(compute_task));
     }
 
-    compute_task = storage_manager_->compute_tp()->execute([&,
-                                                            filtered_data,
-                                                            qc_names,
-                                                            t_start,
-                                                            t_end,
-                                                            num_range_threads,
-                                                            result_tiles]() {
+    compute_task = resources_.compute_tp().execute([&,
+                                                    filtered_data,
+                                                    qc_names,
+                                                    t_start,
+                                                    t_end,
+                                                    num_range_threads,
+                                                    result_tiles]() {
       // For easy reference.
       const auto& tile_coords = subarray.tile_coords();
       const auto dim_num = array_schema_.dim_num();
@@ -956,7 +951,7 @@ Status DenseReader::apply_query_condition(
 
       // Process all tiles in parallel.
       auto status = parallel_for_2d(
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           t_start,
           t_end,
           0,
@@ -1137,7 +1132,7 @@ Status DenseReader::copy_attribute(
     {
       auto timer_se = stats_->start_timer("copy_offset_tiles");
       auto status = parallel_for_2d(
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           t_start,
           t_end,
           0,
@@ -1197,7 +1192,7 @@ Status DenseReader::copy_attribute(
       auto timer_se = stats_->start_timer("copy_var_tiles");
       // Process var data in parallel.
       auto status = parallel_for_2d(
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           t_start,
           t_end,
           0,
@@ -1239,7 +1234,7 @@ Status DenseReader::copy_attribute(
       auto timer_se = stats_->start_timer("copy_fixed_tiles");
       // Process values in parallel.
       auto status = parallel_for_2d(
-          storage_manager_->compute_tp(),
+          &resources_.compute_tp(),
           t_start,
           t_end,
           0,
@@ -1339,7 +1334,7 @@ Status DenseReader::process_aggregates(
 
   // Process values in parallel.
   auto status = parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       t_start,
       t_end,
       0,

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -53,8 +53,7 @@ using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class SparseGlobalOrderReaderStatusException : public StatusException {
  public:
@@ -365,7 +364,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles(
   if (subarray_.is_set()) {
     // Load as many tiles as the memory budget allows.
     throw_if_not_ok(parallel_for(
-        storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+        &resources_.compute_tp(), 0, fragment_num, [&](uint64_t f) {
           uint64_t t = 0;
           auto& tile_ranges = tmp_read_state_.tile_ranges(f);
           while (!tile_ranges.empty()) {
@@ -414,7 +413,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles(
   } else {
     // Load as many tiles as the memory budget allows.
     throw_if_not_ok(parallel_for(
-        storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+        &resources_.compute_tp(), 0, fragment_num, [&](uint64_t f) {
           uint64_t t = 0;
           auto tile_num = fragment_metadata_[f]->tile_num();
 
@@ -493,8 +492,8 @@ void SparseGlobalOrderReader<BitmapType>::clean_tile_list(
     std::vector<ResultTilesList>& result_tiles) {
   // Clear result tiles that are not necessary anymore.
   auto fragment_num = fragment_metadata_.size();
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+  throw_if_not_ok(
+      parallel_for(&resources_.compute_tp(), 0, fragment_num, [&](uint64_t f) {
         auto it = result_tiles[f].begin();
         while (it != result_tiles[f].end()) {
           if (it->result_num() == 0) {
@@ -522,7 +521,7 @@ void SparseGlobalOrderReader<BitmapType>::dedup_tiles_with_timestamps(
 
   // Process all tiles in parallel.
   throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
+      &resources_.compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
         const auto f = result_tiles[t]->frag_idx();
         if (fragment_metadata_[f]->has_timestamps()) {
           // For easy reference.
@@ -597,8 +596,8 @@ void SparseGlobalOrderReader<BitmapType>::dedup_fragments_with_timestamps(
 
   // Run all fragments in parallel.
   auto fragment_num = fragment_metadata_.size();
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+  throw_if_not_ok(
+      parallel_for(&resources_.compute_tp(), 0, fragment_num, [&](uint64_t f) {
         // Run only for fragments with timestamps.
         if (fragment_metadata_[f]->has_timestamps()) {
           // Process all tiles.
@@ -848,7 +847,7 @@ void SparseGlobalOrderReader<BitmapType>::compute_hilbert_values(
 
   // Parallelize on tiles.
   throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
+      &resources_.compute_tp(), 0, result_tiles.size(), [&](uint64_t t) {
         auto tile =
             static_cast<GlobalOrderResultTile<BitmapType>*>(result_tiles[t]);
         auto cell_num =
@@ -928,7 +927,7 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
   // For all fragments, get the first tile in the sorting queue.
   std::vector<TileListIt> to_delete;
   throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, result_tiles.size(), [&](uint64_t f) {
+      &resources_.compute_tp(), 0, result_tiles.size(), [&](uint64_t f) {
         if (result_tiles[f].size() > 0) {
           // Initialize the iterator for this fragment.
           rt_it[f] = result_tiles[f].begin();
@@ -1175,7 +1174,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_offsets_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_cell_slabs.size(),
       0,
@@ -1281,7 +1280,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_var_data_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_cell_slabs.size(),
       0,
@@ -1352,7 +1351,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_fixed_data_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_cell_slabs.size(),
       0,
@@ -1452,7 +1451,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_timestamps_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_cell_slabs.size(),
       0,
@@ -1519,7 +1518,7 @@ void SparseGlobalOrderReader<BitmapType>::copy_delete_meta_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_cell_slabs.size(),
       0,
@@ -1628,8 +1627,8 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
   uint64_t max_cs_idx = result_cell_slabs.size();
   std::mutex max_cs_idx_mtx;
   std::vector<uint64_t> total_mem_usage_per_attr(names.size());
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, names.size(), [&](uint64_t i) {
+  throw_if_not_ok(
+      parallel_for(&resources_.compute_tp(), 0, names.size(), [&](uint64_t i) {
         // For easy reference.
         const auto& name = names[i];
         const bool agg_only = aggregate_only(name);
@@ -1839,7 +1838,7 @@ void SparseGlobalOrderReader<BitmapType>::process_slabs(
 
   // Compute parallelization parameters.
   uint64_t num_range_threads = 1;
-  const auto num_threads = storage_manager_->compute_tp()->concurrency_level();
+  const auto num_threads = resources_.compute_tp().concurrency_level();
   if (result_cell_slabs.size() < num_threads) {
     // Ceil the division between thread_num and tile_num.
     num_range_threads = 1 + ((num_threads - 1) / result_cell_slabs.size());
@@ -2121,7 +2120,7 @@ void SparseGlobalOrderReader<BitmapType>::process_aggregates(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_cell_slabs.size(),
       0,
@@ -2196,8 +2195,8 @@ void SparseGlobalOrderReader<BitmapType>::end_iteration(
   auto fragment_num = fragment_metadata_.size();
 
   // Clear fully processed tiles in each fragments.
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, fragment_num, [&](uint64_t f) {
+  throw_if_not_ok(
+      parallel_for(&resources_.compute_tp(), 0, fragment_num, [&](uint64_t f) {
         while (!result_tiles[f].empty() &&
                result_tiles[f].front().tile_idx() <
                    read_state_.frag_idx()[f].tile_idx_) {
@@ -2228,5 +2227,4 @@ template SparseGlobalOrderReader<uint8_t>::SparseGlobalOrderReader(
 template SparseGlobalOrderReader<uint64_t>::SparseGlobalOrderReader(
     stats::Stats*, shared_ptr<Logger>, StrategyParams&, bool);
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,8 +50,7 @@ using namespace tiledb;
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class SparseUnorderedWithDupsReaderStatusException : public StatusException {
  public:
@@ -765,7 +764,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::copy_offsets_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_tiles.size(),
       0,
@@ -871,7 +870,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::copy_var_data_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_tiles.size(),
       0,
@@ -1243,7 +1242,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::copy_fixed_data_tiles(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_tiles.size(),
       0,
@@ -1446,8 +1445,8 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
   uint64_t max_rt_idx = result_tiles.size();
   std::mutex max_rt_idx_mtx;
   std::vector<uint64_t> total_mem_usage_per_attr(names.size());
-  throw_if_not_ok(parallel_for(
-      storage_manager_->compute_tp(), 0, names.size(), [&](uint64_t i) {
+  throw_if_not_ok(
+      parallel_for(&resources_.compute_tp(), 0, names.size(), [&](uint64_t i) {
         // For easy reference.
         const auto& name = names[i];
         const bool agg_only = aggregate_only(name);
@@ -1625,7 +1624,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
 
   // Compute parallelization parameters.
   uint64_t num_range_threads = 1;
-  const auto num_threads = storage_manager_->compute_tp()->concurrency_level();
+  const auto num_threads = resources_.compute_tp().concurrency_level();
   if (result_tiles.size() < num_threads) {
     // Ceil the division between thread_num and tile_num.
     num_range_threads = 1 + ((num_threads - 1) / result_tiles.size());
@@ -1926,7 +1925,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::process_aggregates(
 
   // Process all tiles/cells in parallel.
   throw_if_not_ok(parallel_for_2d(
-      storage_manager_->compute_tp(),
+      &resources_.compute_tp(),
       0,
       result_tiles.size(),
       0,
@@ -2034,5 +2033,4 @@ template SparseUnorderedWithDupsReader<uint8_t>::SparseUnorderedWithDupsReader(
 template SparseUnorderedWithDupsReader<uint64_t>::SparseUnorderedWithDupsReader(
     stats::Stats*, shared_ptr<Logger>, StrategyParams&);
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -196,7 +196,7 @@ Status OrderedWriter::ordered_write() {
 
   // Prepare, filter and write tiles for all attributes
   auto attr_num = buffers_.size();
-  auto compute_tp = storage_manager_->compute_tp();
+  auto* compute_tp = &resources_.compute_tp();
   auto thread_num = compute_tp->concurrency_level();
   std::unordered_map<std::string, IndexedList<WriterTileTupleVector>> tiles;
   for (const auto& buff : buffers_) {
@@ -334,7 +334,7 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
     {
       auto timer_se = stats_->start_timer("prepare_and_filter_tiles");
       auto st = parallel_for(
-          storage_manager_->compute_tp(), 0, batch_size, [&](uint64_t i) {
+          &resources_.compute_tp(), 0, batch_size, [&](uint64_t i) {
             // Prepare and filter tiles
             auto& writer_tile = tile_batches[b][i];
             RETURN_NOT_OK(

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -394,7 +394,7 @@ Status StorageManagerCanonical::array_upgrade_version(
 
 Status StorageManagerCanonical::async_push_query(Query* query) {
   cancelable_tasks_.execute(
-      compute_tp(),
+      &resources_.compute_tp(),
       [this, query]() {
         // Process query.
         Status st = query_submit(query);

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -78,7 +78,6 @@ class Metadata;
 class MemoryTracker;
 class Query;
 class RestClient;
-class VFS;
 
 enum class EncryptionType : uint8_t;
 enum class ObjectType : uint8_t;
@@ -217,11 +216,6 @@ class StorageManagerCanonical {
    * @return Status
    */
   Status group_create(const std::string& group);
-
-  /** Returns the thread pool for compute-bound tasks. */
-  [[nodiscard]] inline ThreadPool* compute_tp() const {
-    return &(resources_.compute_tp());
-  }
 
   /** Returns the thread pool for io-bound tasks. */
   [[nodiscard]] inline ThreadPool* io_tp() const {


### PR DESCRIPTION
Remove `StorageManager::compute_tp()`. This also removes a lot of StorageManager variables.

[sc-47579]

---
TYPE: NO_HISTORY
DESC: Remove `StorageManager::compute_tp()`.
