### PR TITLE
Clarify performance implication of coords check options on writes.

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -102,13 +102,16 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `sm.dedup_coords` <br>
  *    If `true`, cells with duplicate coordinates will be removed during sparse
  *    fragment writes. Note that ties during deduplication are broken
- *    arbitrarily. <br>
+ *    arbitrarily. Also note that this check means that it will take longer to
+ *    perform the write operation. <br>
  *    **Default**: false
  * - `sm.check_coord_dups` <br>
  *    This is applicable only if `sm.dedup_coords` is `false`.
  *    If `true`, an error will be thrown if there are cells with duplicate
  *    coordinates during sparse fragmnet writes. If `false` and there are
- *    duplicates, the duplicates will be written without errors. <br>
+ *    duplicates, the duplicates will be written without errors. Note that this
+ *    check is much ligher weight than the coordinate deduplication check
+ *    enabled by `sm.dedup_coords`. <br>
  *    **Default**: true
  * - `sm.check_coord_oob` <br>
  *    If `true`, an error will be thrown if there are cells with coordinates

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -276,14 +276,16 @@ class Config {
    * - `sm.dedup_coords` <br>
    *    If `true`, cells with duplicate coordinates will be removed during
    *    sparse fragment writes. Note that ties during deduplication are broken
-   *    arbitrarily. <br>
+   *    arbitrarily. Also note that this check means that it will take longer to
+   *    perform the write operation. <br>
    *    **Default**: false
    * - `sm.check_coord_dups` <br>
    *    This is applicable only if `sm.dedup_coords` is `false`.
    *    If `true`, an error will be thrown if there are cells with duplicate
-   *    coordinates during sparse fragment writes. If `false` and there are
-   *    duplicates, the duplicates will be written without errors. <br>
-   *    **Default**: true
+   *    coordinates during sparse fragmnet writes. If `false` and there are
+   *    duplicates, the duplicates will be written without errors. Note that
+   *    this check is much ligher weight than the coordinate deduplication check
+   *    enabled by `sm.dedup_coords`. <br>
    * - `sm.check_coord_oob` <br>
    *    If `true`, an error will be thrown if there are cells with coordinates
    *    falling outside the array domain during sparse fragment writes. <br>


### PR DESCRIPTION
The documentation on https://docs.tiledb.com/main/how-to/performance/performance-tips/summary-of-factors#coordinate-deduplication had more details on the performance implications of `sm.dedup_coords` and `sm.check_coord_dups` than the API docs. This reconciles the two.

[sc-44431]

---
TYPE: NO_HISTORY
DESC: Clarify performance implication of coords check options on writes.
