### PR TITLE
Remove unused TileTuple from ResultTile::init_attr_tile.

### DIFF
--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -143,14 +143,6 @@ void ResultTile::init_attr_tile(
     const std::string& name,
     const TileSizes tile_sizes,
     const TileData tile_data) {
-  auto tuple = TileTuple(
-      format_version,
-      array_schema,
-      name,
-      tile_sizes,
-      tile_data,
-      memory_tracker_);
-
   if (name == constants::coords) {
     coords_tile_.emplace(
         format_version,


### PR DESCRIPTION
This removes an unused TileTuple object from ResultTile::init_attr_tile added in #4705.

[SC-47703](https://app.shortcut.com/tiledb-inc/story/47703/remove-unused-tiletuple-in-resulttile-init-attr-tile)

---
TYPE: NO_HISTORY
DESC: Remove unused TileTuple from ResultTile::init_attr_tile.