### PR TITLE
Migrate APIs out of StorageManager: group_close_for_writes.

### DIFF
--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -118,6 +118,13 @@ class Group {
     return Status::Ok();
   }
 
+  /**
+   * Closes a group opened for writes.
+   *
+   * @return Status
+   */
+  Status close_for_writes();
+
   /** Closes the group and frees all memory. */
   Status close();
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -131,24 +131,6 @@ StorageManagerCanonical::~StorageManagerCanonical() {
 /*               API              */
 /* ****************************** */
 
-Status StorageManagerCanonical::group_close_for_writes(Group* group) {
-  // Flush the group metadata
-  throw_if_not_ok(group->unsafe_metadata()->store(
-      resources_, group->group_uri(), *group->encryption_key()));
-
-  // Store any changes required
-  if (group->group_details()->is_modified()) {
-    const URI& group_detail_folder_uri = group->group_detail_uri();
-    auto group_detail_uri = group->generate_detail_uri();
-    throw_if_not_ok(group->group_details()->store(
-        resources_,
-        group_detail_folder_uri,
-        group_detail_uri,
-        *group->encryption_key()));
-  }
-  return Status::Ok();
-}
-
 Status StorageManagerCanonical::array_create(
     const URI& array_uri,
     const shared_ptr<ArraySchema>& array_schema,

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -147,14 +147,6 @@ class StorageManagerCanonical {
   /* ********************************* */
 
   /**
-   * Closes an group opened for writes.
-   *
-   * @param group The group to be closed.
-   * @return Status
-   */
-  Status group_close_for_writes(tiledb::sm::Group* group);
-
-  /**
    * Creates a TileDB array storing its schema.
    *
    * @param array_uri The URI of the array to be created.


### PR DESCRIPTION
Migrate APIs out of `StorageManager`: `group_close_for_writes`.

[sc-46726]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of `StorageManager`: `group_close_for_writes`.
