### PR TITLE
Disallow possibly-invalid reinterpret datatypes for delta and double delta compression filters.

### DIFF
--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -105,7 +105,7 @@ bool CompressionFilter::accepts_input_datatype(Datatype input_type) const {
                                                      input_type)) {
       return false;
     }
-    // we must receive an integral number of units of the reinterpret datatype
+    // We must receive an integral number of units of the reinterpret datatype
     else if (
         reinterpret_datatype_ != Datatype::ANY &&
         datatype_size(input_type) % datatype_size(reinterpret_datatype_) != 0) {

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -105,6 +105,12 @@ bool CompressionFilter::accepts_input_datatype(Datatype input_type) const {
                                                      input_type)) {
       return false;
     }
+    // we must receive an integral number of units of the reinterpret datatype
+    else if (
+        reinterpret_datatype_ != Datatype::ANY &&
+        datatype_size(input_type) % datatype_size(reinterpret_datatype_) != 0) {
+      return false;
+    }
   }
 
   return true;

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -1055,8 +1055,8 @@ TEST_CASE(
       ", reinterpret_datatype = " + datatype_str(reinterpret_datatype)) {
     if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
         0) {
-      /* there is an integral number of units of `reinterpret_datatype`,
-       * should always work */
+      // There is an integral number of units of `reinterpret_datatype`,
+      // should always work
       auto compressor = CompressionFilter(
           Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
 
@@ -1071,7 +1071,7 @@ TEST_CASE(
           &tile_data_generator,
           tracker);
     } else {
-      /* there may be a partial instance of `reinterpret_datatype` */
+      // there may be a partial instance of `reinterpret_datatype`
       auto compressor = CompressionFilter(
           Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
       FilterPipeline pipeline;
@@ -1109,8 +1109,8 @@ TEST_CASE(
       ", reinterpret_datatype = " + datatype_str(reinterpret_datatype)) {
     if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
         0) {
-      /* there is an integral number of units of `reinterpret_datatype`,
-       * should always work */
+      // there is an integral number of units of `reinterpret_datatype`,
+      // should always work
       auto compressor = CompressionFilter(
           Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
 
@@ -1125,7 +1125,7 @@ TEST_CASE(
           &tile_data_generator,
           tracker);
     } else {
-      /* there may be a partial instance of `reinterpret_datatype` */
+      // there may be a partial instance of `reinterpret_datatype`
       auto compressor = CompressionFilter(
           Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
       FilterPipeline pipeline;

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -1054,8 +1054,8 @@ TEST_CASE(
       0) {
     /* there is an integral number of units of `reinterpret_datatype`,
      * should always work */
-    auto compressor =
-        CompressionFilter(Compressor::DELTA, 1, reinterpret_datatype);
+    auto compressor = CompressionFilter(
+        Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
 
     FilterPipeline pipeline;
     pipeline.add_filter(compressor);
@@ -1069,37 +1069,14 @@ TEST_CASE(
         tracker);
   } else {
     /* there may be a partial instance of `reinterpret_datatype` */
-    /* TODO: this should be disallowed whether or not it happens to work out
-     * right now it probably works */
-    if (tile->size() % datatype_size(reinterpret_datatype) == 0) {
-      /* integral number of instances, it happens to work out */
-      auto compressor =
-          CompressionFilter(Compressor::DELTA, 1, reinterpret_datatype);
-      FilterPipeline pipeline;
-      pipeline.add_filter(compressor);
-      check_run_pipeline_roundtrip(
-          config,
-          tp,
-          tile,
-          offsets_tile,
-          pipeline,
-          &tile_data_generator,
-          tracker);
-    } else {
-      /* today, there are no safeguards against this, it is expected to work */
-      auto compressor =
-          CompressionFilter(Compressor::DELTA, 1, reinterpret_datatype);
-      FilterPipeline pipeline;
-      pipeline.add_filter(compressor);
-      check_run_pipeline_roundtrip(
-          config,
-          tp,
-          tile,
-          offsets_tile,
-          pipeline,
-          &tile_data_generator,
-          tracker);
-    }
+    auto compressor = CompressionFilter(
+        Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
+    FilterPipeline pipeline;
+    pipeline.add_filter(compressor);
+    CHECK_THROWS(
+        FilterPipeline::check_filter_types(pipeline, input_datatype, false));
+    CHECK_THROWS(
+        FilterPipeline::check_filter_types(pipeline, input_datatype, true));
   }
 }
 
@@ -1127,8 +1104,8 @@ TEST_CASE(
       0) {
     /* there is an integral number of units of `reinterpret_datatype`,
      * should always work */
-    auto compressor =
-        CompressionFilter(Compressor::DOUBLE_DELTA, 1, reinterpret_datatype);
+    auto compressor = CompressionFilter(
+        Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
 
     FilterPipeline pipeline;
     pipeline.add_filter(compressor);
@@ -1142,36 +1119,13 @@ TEST_CASE(
         tracker);
   } else {
     /* there may be a partial instance of `reinterpret_datatype` */
-    /* TODO: this should be disallowed whether or not it happens to work out
-     * right now it probably works */
-    if (tile->size() % datatype_size(reinterpret_datatype) == 0) {
-      /* integral number of instances, it happens to work out */
-      auto compressor =
-          CompressionFilter(Compressor::DOUBLE_DELTA, 1, reinterpret_datatype);
-      FilterPipeline pipeline;
-      pipeline.add_filter(compressor);
-      check_run_pipeline_roundtrip(
-          config,
-          tp,
-          tile,
-          offsets_tile,
-          pipeline,
-          &tile_data_generator,
-          tracker);
-    } else {
-      /* today, there are no safeguards against this, it is expected to work */
-      auto compressor =
-          CompressionFilter(Compressor::DOUBLE_DELTA, 1, reinterpret_datatype);
-      FilterPipeline pipeline;
-      pipeline.add_filter(compressor);
-      check_run_pipeline_roundtrip(
-          config,
-          tp,
-          tile,
-          offsets_tile,
-          pipeline,
-          &tile_data_generator,
-          tracker);
-    }
+    auto compressor = CompressionFilter(
+        Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
+    FilterPipeline pipeline;
+    pipeline.add_filter(compressor);
+    CHECK_THROWS(
+        FilterPipeline::check_filter_types(pipeline, input_datatype, false));
+    CHECK_THROWS(
+        FilterPipeline::check_filter_types(pipeline, input_datatype, true));
   }
 }

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -1050,33 +1050,37 @@ TEST_CASE(
   auto reinterpret_datatype = GENERATE(
       Datatype::UINT8, Datatype::UINT16, Datatype::UINT32, Datatype::UINT64);
 
-  if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
-      0) {
-    /* there is an integral number of units of `reinterpret_datatype`,
-     * should always work */
-    auto compressor = CompressionFilter(
-        Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
+  DYNAMIC_SECTION(
+      "input_datatype = " + datatype_str(input_datatype) +
+      ", reinterpret_datatype = " + datatype_str(reinterpret_datatype)) {
+    if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
+        0) {
+      /* there is an integral number of units of `reinterpret_datatype`,
+       * should always work */
+      auto compressor = CompressionFilter(
+          Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
 
-    FilterPipeline pipeline;
-    pipeline.add_filter(compressor);
-    check_run_pipeline_roundtrip(
-        config,
-        tp,
-        tile,
-        offsets_tile,
-        pipeline,
-        &tile_data_generator,
-        tracker);
-  } else {
-    /* there may be a partial instance of `reinterpret_datatype` */
-    auto compressor = CompressionFilter(
-        Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
-    FilterPipeline pipeline;
-    pipeline.add_filter(compressor);
-    CHECK_THROWS(
-        FilterPipeline::check_filter_types(pipeline, input_datatype, false));
-    CHECK_THROWS(
-        FilterPipeline::check_filter_types(pipeline, input_datatype, true));
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      check_run_pipeline_roundtrip(
+          config,
+          tp,
+          tile,
+          offsets_tile,
+          pipeline,
+          &tile_data_generator,
+          tracker);
+    } else {
+      /* there may be a partial instance of `reinterpret_datatype` */
+      auto compressor = CompressionFilter(
+          Compressor::DELTA, 1, input_datatype, reinterpret_datatype);
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      CHECK_THROWS(
+          FilterPipeline::check_filter_types(pipeline, input_datatype, false));
+      CHECK_THROWS(
+          FilterPipeline::check_filter_types(pipeline, input_datatype, true));
+    }
   }
 }
 
@@ -1100,32 +1104,36 @@ TEST_CASE(
   auto reinterpret_datatype = GENERATE(
       Datatype::UINT8, Datatype::UINT16, Datatype::UINT32, Datatype::UINT64);
 
-  if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
-      0) {
-    /* there is an integral number of units of `reinterpret_datatype`,
-     * should always work */
-    auto compressor = CompressionFilter(
-        Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
+  DYNAMIC_SECTION(
+      "input_datatype = " + datatype_str(input_datatype) +
+      ", reinterpret_datatype = " + datatype_str(reinterpret_datatype)) {
+    if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
+        0) {
+      /* there is an integral number of units of `reinterpret_datatype`,
+       * should always work */
+      auto compressor = CompressionFilter(
+          Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
 
-    FilterPipeline pipeline;
-    pipeline.add_filter(compressor);
-    check_run_pipeline_roundtrip(
-        config,
-        tp,
-        tile,
-        offsets_tile,
-        pipeline,
-        &tile_data_generator,
-        tracker);
-  } else {
-    /* there may be a partial instance of `reinterpret_datatype` */
-    auto compressor = CompressionFilter(
-        Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
-    FilterPipeline pipeline;
-    pipeline.add_filter(compressor);
-    CHECK_THROWS(
-        FilterPipeline::check_filter_types(pipeline, input_datatype, false));
-    CHECK_THROWS(
-        FilterPipeline::check_filter_types(pipeline, input_datatype, true));
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      check_run_pipeline_roundtrip(
+          config,
+          tp,
+          tile,
+          offsets_tile,
+          pipeline,
+          &tile_data_generator,
+          tracker);
+    } else {
+      /* there may be a partial instance of `reinterpret_datatype` */
+      auto compressor = CompressionFilter(
+          Compressor::DOUBLE_DELTA, 1, input_datatype, reinterpret_datatype);
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      CHECK_THROWS(
+          FilterPipeline::check_filter_types(pipeline, input_datatype, false));
+      CHECK_THROWS(
+          FilterPipeline::check_filter_types(pipeline, input_datatype, true));
+    }
   }
 }

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -1082,7 +1082,7 @@ TEST_CASE(
 
 TEST_CASE(
     "Filter: Test double delta filter reinterpret_datatype validity",
-    "[filter][delta]") {
+    "[filter][double-delta]") {
   // Create TileDB needed for running pipeline.
   Config config;
   ThreadPool tp(4);

--- a/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_run_filter_pipeline.cc
@@ -1029,3 +1029,149 @@ TEST_CASE("Filter: Test compression var", "[filter][compression][var]") {
         tracker);
   }
 }
+
+TEST_CASE(
+    "Filter: Test delta filter reinterpret_datatype validity",
+    "[filter][delta]") {
+  // Create TileDB needed for running pipeline.
+  Config config;
+  ThreadPool tp(4);
+
+  auto tracker = tiledb::test::create_test_memory_tracker();
+
+  constexpr Datatype input_datatype = Datatype::UINT8;
+
+  // Set-up test data.
+  IncrementTileDataGenerator<uint8_t, input_datatype> tile_data_generator(100);
+  auto&& [tile, offsets_tile] =
+      tile_data_generator.create_writer_tiles(tracker);
+  std::vector<uint64_t> elements_per_chunk{100};
+
+  auto reinterpret_datatype = GENERATE(
+      Datatype::UINT8, Datatype::UINT16, Datatype::UINT32, Datatype::UINT64);
+
+  if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
+      0) {
+    /* there is an integral number of units of `reinterpret_datatype`,
+     * should always work */
+    auto compressor =
+        CompressionFilter(Compressor::DELTA, 1, reinterpret_datatype);
+
+    FilterPipeline pipeline;
+    pipeline.add_filter(compressor);
+    check_run_pipeline_roundtrip(
+        config,
+        tp,
+        tile,
+        offsets_tile,
+        pipeline,
+        &tile_data_generator,
+        tracker);
+  } else {
+    /* there may be a partial instance of `reinterpret_datatype` */
+    /* TODO: this should be disallowed whether or not it happens to work out
+     * right now it probably works */
+    if (tile->size() % datatype_size(reinterpret_datatype) == 0) {
+      /* integral number of instances, it happens to work out */
+      auto compressor =
+          CompressionFilter(Compressor::DELTA, 1, reinterpret_datatype);
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      check_run_pipeline_roundtrip(
+          config,
+          tp,
+          tile,
+          offsets_tile,
+          pipeline,
+          &tile_data_generator,
+          tracker);
+    } else {
+      /* today, there are no safeguards against this, it is expected to work */
+      auto compressor =
+          CompressionFilter(Compressor::DELTA, 1, reinterpret_datatype);
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      check_run_pipeline_roundtrip(
+          config,
+          tp,
+          tile,
+          offsets_tile,
+          pipeline,
+          &tile_data_generator,
+          tracker);
+    }
+  }
+}
+
+TEST_CASE(
+    "Filter: Test double delta filter reinterpret_datatype validity",
+    "[filter][delta]") {
+  // Create TileDB needed for running pipeline.
+  Config config;
+  ThreadPool tp(4);
+
+  auto tracker = tiledb::test::create_test_memory_tracker();
+
+  constexpr Datatype input_datatype = Datatype::UINT8;
+
+  // Set-up test data.
+  IncrementTileDataGenerator<uint8_t, input_datatype> tile_data_generator(100);
+  auto&& [tile, offsets_tile] =
+      tile_data_generator.create_writer_tiles(tracker);
+  std::vector<uint64_t> elements_per_chunk{100};
+
+  auto reinterpret_datatype = GENERATE(
+      Datatype::UINT8, Datatype::UINT16, Datatype::UINT32, Datatype::UINT64);
+
+  if (datatype_size(input_datatype) % datatype_size(reinterpret_datatype) ==
+      0) {
+    /* there is an integral number of units of `reinterpret_datatype`,
+     * should always work */
+    auto compressor =
+        CompressionFilter(Compressor::DOUBLE_DELTA, 1, reinterpret_datatype);
+
+    FilterPipeline pipeline;
+    pipeline.add_filter(compressor);
+    check_run_pipeline_roundtrip(
+        config,
+        tp,
+        tile,
+        offsets_tile,
+        pipeline,
+        &tile_data_generator,
+        tracker);
+  } else {
+    /* there may be a partial instance of `reinterpret_datatype` */
+    /* TODO: this should be disallowed whether or not it happens to work out
+     * right now it probably works */
+    if (tile->size() % datatype_size(reinterpret_datatype) == 0) {
+      /* integral number of instances, it happens to work out */
+      auto compressor =
+          CompressionFilter(Compressor::DOUBLE_DELTA, 1, reinterpret_datatype);
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      check_run_pipeline_roundtrip(
+          config,
+          tp,
+          tile,
+          offsets_tile,
+          pipeline,
+          &tile_data_generator,
+          tracker);
+    } else {
+      /* today, there are no safeguards against this, it is expected to work */
+      auto compressor =
+          CompressionFilter(Compressor::DOUBLE_DELTA, 1, reinterpret_datatype);
+      FilterPipeline pipeline;
+      pipeline.add_filter(compressor);
+      check_run_pipeline_roundtrip(
+          config,
+          tp,
+          tile,
+          offsets_tile,
+          pipeline,
+          &tile_data_generator,
+          tracker);
+    }
+  }
+}


### PR DESCRIPTION
Found by `tiledb-rs` property testing!

If the delta or double delta compressor `reinterpret_datatype_` field does not divide the `input_type`, then there is a risk of an assertion failure when running the compressor.
```
tiledb/sm/compressors/delta_compressor.cc:230: static void tiledb::sm::Delta::compress(tiledb::sm::ConstBuffer*, tiledb::sm::Buffer*) [with T = long unsigned int]: Assertion `num > 0 && (input_buffer->size() % value_size == 0)' failed.

```
`value_size` is the size of the reinterpreted type, but if we have something like `u32` in the input but `u64` for the reinterpreted type, then this assertion can fail.

This pull request fixes this behavior by checking the input type against reinterpret_datatype in the `accepts_input_datatype` function.

---
TYPE: BUG
DESC: Disallow possibly-invalid reinterpret datatypes for delta and double delta compression filters.
