### PR TITLE
Add stat counter for when queries go over budget.

### DIFF
--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -338,6 +338,17 @@ class MemoryTracker {
     return legacy_memory_budget_;
   }
 
+  /**
+   * Refresh the memory budget used by the new system.
+   *
+   * @param new_budget The new memory budget.
+   */
+  void refresh_memory_budget(uint64_t new_budget) {
+    memory_budget_.store(new_budget, std::memory_order_relaxed);
+    // Should we call on_budget_exceeded_ if the new budget has exceeded the
+    // current total counter?
+  }
+
  protected:
   /**
    * Constructor.
@@ -403,7 +414,7 @@ class MemoryTracker {
   std::atomic<uint64_t> total_counter_;
 
   /** Memory budget. */
-  const uint64_t memory_budget_;
+  std::atomic<uint64_t> memory_budget_;
 
   /** A function to call when the budget is exceeded. */
   std::function<void()> on_budget_exceeded_;

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -343,12 +343,14 @@ class MemoryTracker {
   /**
    * Refresh the memory budget used by the new system.
    *
+   * This method should be called only by Query::set_config, which gets called
+   * by the REST server after deserializing the query and creating its strategy,
+   * with a config that contains the new memory budget.
+   *
    * @param new_budget The new memory budget.
    */
   void refresh_memory_budget(uint64_t new_budget) {
     memory_budget_.store(new_budget, std::memory_order_relaxed);
-    // Should we call on_budget_exceeded_ if the new budget has exceeded the
-    // current total counter?
   }
 
  protected:

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -323,10 +323,11 @@ class MemoryTracker {
    */
   uint64_t get_memory_available() {
     std::lock_guard<std::mutex> lg(mutex_);
-    if (total_counter_ + counters_[MemoryType::TILE_OFFSETS] > memory_budget_) {
+    if (legacy_memory_usage_ + counters_[MemoryType::TILE_OFFSETS] >
+        legacy_memory_budget_) {
       return 0;
     }
-    return memory_budget_ - total_counter_ -
+    return legacy_memory_budget_ - legacy_memory_usage_ -
            counters_[MemoryType::TILE_OFFSETS];
   }
 

--- a/tiledb/common/test/CMakeLists.txt
+++ b/tiledb/common/test/CMakeLists.txt
@@ -36,8 +36,8 @@ commence(unit_test experimental)
         )
 conclude(unit_test)
 
-commence(unit_test memory_tracker_types)
-    this_target_sources(main.cc unit_memory_tracker_types.cc)
+commence(unit_test memory_tracker)
+    this_target_sources(main.cc unit_memory_tracker.cc unit_memory_tracker_types.cc)
     this_target_object_libraries(baseline)
 conclude(unit_test)
 

--- a/tiledb/common/test/unit_memory_tracker.cc
+++ b/tiledb/common/test/unit_memory_tracker.cc
@@ -1,0 +1,53 @@
+/**
+ * @file unit_memory_tracker.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file tests the MemoryTracker class.
+ */
+
+#include <iostream>
+
+#include <test/support/tdb_catch.h>
+#include "tiledb/common/memory_tracker.h"
+#include "tiledb/common/pmr.h"
+
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "Memory tracker: Test budget exceeded callback",
+    "[memory_tracker][budget_exceeded]") {
+  MemoryTrackerManager tracker_manager;
+  auto tracker = tracker_manager.create_tracker(
+      100, []() { throw std::runtime_error("Budget exceeded"); });
+  CHECK_THROWS_WITH(
+      [&tracker]() {
+        std::ignore = tdb::pmr::vector<uint8_t>(
+            1000, tracker->get_resource(MemoryType::TILE_DATA));
+      }(),
+      "Budget exceeded");
+}

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -92,7 +92,7 @@ Query::Query(
     , query_memory_tracker_(resources_.memory_tracker_manager().create_tracker(
           get_effective_memory_budget(resources_.config(), memory_budget),
           [stats = stats_]() {
-            stats->add_counter("memory_budget_exhausted", 1);
+            stats->add_counter("memory_budget_exceeded", 1);
           }))
     , array_shared_(array)
     , array_(array_shared_.get())

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -90,7 +90,10 @@ Query::Query(
     , stats_(resources_.stats().create_child("Query"))
     , logger_(resources_.logger()->clone("Query", ++logger_id_))
     , query_memory_tracker_(resources_.memory_tracker_manager().create_tracker(
-          get_effective_memory_budget(resources_.config(), memory_budget)))
+          get_effective_memory_budget(resources_.config(), memory_budget),
+          [stats = stats_]() {
+            stats->add_counter("memory_budget_exhausted", 1);
+          }))
     , array_shared_(array)
     , array_(array_shared_.get())
     , opened_array_(array->opened_array())

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -924,6 +924,12 @@ class Query {
   /** Resource used for operations. */
   ContextResources& resources_;
 
+  /** The class stats. */
+  stats::Stats* stats_;
+
+  /** The class logger. */
+  shared_ptr<Logger> logger_;
+
   /** The query memory tracker. */
   shared_ptr<MemoryTracker> query_memory_tracker_;
 
@@ -969,12 +975,6 @@ class Query {
 
   /** The query strategy. */
   tdb_unique_ptr<IQueryStrategy> strategy_;
-
-  /** The class stats. */
-  stats::Stats* stats_;
-
-  /** The class logger. */
-  shared_ptr<Logger> logger_;
 
   /** UID of the logger instance */
   inline static std::atomic<uint64_t> logger_id_ = 0;

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -111,6 +111,10 @@ class ContextResources {
     return rest_client_;
   }
 
+  [[nodiscard]] inline MemoryTrackerManager& memory_tracker_manager() const {
+    return *memory_tracker_manager_;
+  }
+
   /**
    * Create a new MemoryTracker
    *


### PR DESCRIPTION
[SC-46304](https://app.shortcut.com/tiledb-inc/story/46304)

This PR adds budgeting capabilities to the new memory tracking system. Memory trackers can be created with two parameters: a budget, and a function that gets called everybody the budget gets exceeded.

Subsequently, the `Query` class got updated to pass its memory budget to the memory manager, and sets a callback that increments the `memory_budget_exceeded` stats counter. This will allow applications to detect whether a query went over budget.

---
TYPE: FEATURE
DESC: Add stats counter `memory_budget_exceeded` for when a query goes over budget.