### PR TITLE
Fix the deletes test taking too long.

### DIFF
--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -175,6 +175,7 @@ void DeletesFx::create_simple_array(const std::string& path) {
 
 void DeletesFx::create_sparse_array(bool allows_dups, bool encrypt) {
   Config config;
+  config.set("sm.consolidation.buffer_size", "1000");
   if (encrypt) {
     config["sm.encryption_type"] = enc_type_str_.c_str();
     config["sm.encryption_key"] = key_;


### PR DESCRIPTION
The change in #4957 caused us to create a full consolidation workspace on some deletes tests which in debug mode creates a few GB of memory to be initialized. This takes multiple seconds.

[sc-47836]

---
TYPE: NO_HISTORY
DESC: Fix the deletes test taking too long.
