### PR TITLE
Support `ls_recursive` in GCS.

### DIFF
--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -510,7 +510,8 @@ TEST_CASE(
 using ls_recursive_test_types = std::tuple<
     tiledb::test::LocalFsTest,
     tiledb::test::S3Test,
-    tiledb::test::AzureTest>;
+    tiledb::test::AzureTest,
+    tiledb::test::GCSTest>;
 TEMPLATE_LIST_TEST_CASE(
     "CPP API: VFS ls_recursive filter",
     "[cppapi][vfs][ls-recursive]",

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1131,6 +1131,22 @@ class GCSTest : public VFSTestBase {
  public:
   explicit GCSTest(const std::vector<size_t>& test_tree)
       : VFSTestBase(test_tree, "gcs://") {
+#ifdef HAVE_GCS
+    vfs_.create_bucket(temp_dir_).ok();
+    for (size_t i = 1; i <= test_tree_.size(); i++) {
+      sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
+      // VFS::create_dir is a no-op for Azure; Just create objects.
+      for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
+        auto object_uri = path.join_path("test_file_" + std::to_string(j));
+        vfs_.touch(object_uri).ok();
+        std::string data(j * 10, 'a');
+        vfs_.write(object_uri, data.data(), data.size()).ok();
+        vfs_.close_file(object_uri).ok();
+        expected_results().emplace_back(object_uri.to_string(), data.size());
+      }
+    }
+    std::sort(expected_results().begin(), expected_results().end());
+#endif
   }
 };
 

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1135,7 +1135,7 @@ class GCSTest : public VFSTestBase {
     vfs_.create_bucket(temp_dir_).ok();
     for (size_t i = 1; i <= test_tree_.size(); i++) {
       sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
-      // VFS::create_dir is a no-op for Azure; Just create objects.
+      // VFS::create_dir is a no-op for GCS; Just create objects.
       for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
         auto object_uri = path.join_path("test_file_" + std::to_string(j));
         vfs_.touch(object_uri).ok();

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -38,9 +38,9 @@
 
 using namespace tiledb::test;
 
-// Currently only local, S3 and Azure is supported for VFS::ls_recursive.
+// Currently only local, S3, Azure and GCS are supported for VFS::ls_recursive.
 // TODO: LocalFsTest currently fails. Fix and re-enable.
-using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest>;
+using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest, GCSTest>;
 
 TEMPLATE_LIST_TEST_CASE(
     "C API: ls_recursive callback", "[vfs][ls-recursive]", TestBackends) {

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -58,8 +58,8 @@ typedef int32_t (*tiledb_ls_callback_t)(
  * on error. The callback is responsible for writing gathered entries into the
  * `data` buffer, for example using a pointer to a user-defined struct.
  *
- * Currently only local filesystem, S3 and Azure are supported, and the `path`
- * must be a valid URI for one of those filesystems.
+ * Currently only local filesystem, S3, Azure and GCS are supported, and the
+ * `path` must be a valid URI for one of those filesystems.
  *
  * **Example:**
  *

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -161,8 +161,8 @@ class VFSExperimental {
    * be included in the results and false otherwise. If no inclusion predicate
    * is provided, all results are returned.
    *
-   * Currently only local filesystem, S3 and Azure is supported, and the `path`
-   * must be a valid URI for one of those filesystems.
+   * Currently only local filesystem, S3, Azure and GCS are supported, and the
+   * `path` must be a valid URI for one of those filesystems.
    *
    * @code{.c}
    * VFSExperimental::LsInclude predicate = [](std::string_view path,

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -561,8 +561,8 @@ LsObjects GCS::ls_filtered_impl(
   const URI uri_dir = uri.add_trailing_slash();
 
   if (!uri_dir.is_gcs()) {
-    throw StatusException(Status_GCSError(
-        std::string("URI is not a GCS URI: " + uri_dir.to_string())));
+    throw GCSException(
+        std::string("URI is not a GCS URI: " + uri_dir.to_string()));
   }
 
   std::string prefix = uri_dir.backend_name() + "://";
@@ -603,9 +603,9 @@ LsObjects GCS::ls_filtered_impl(
         google::cloud::storage::Delimiter("/"));
     for (const auto& object_metadata : it) {
       if (!object_metadata) {
-        throw StatusException(Status_GCSError(std::string(
+        throw GCSException(std::string(
             "List objects failed on: " + uri.to_string() + " (" +
-            object_metadata.status().message() + ")")));
+            object_metadata.status().message() + ")"));
       }
 
       LsObjects::value_type entry;

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -70,6 +70,14 @@ class directory_entry;
 
 namespace sm {
 
+/** Class for GCS status exceptions. */
+class GCSException : public StatusException {
+ public:
+  explicit GCSException(const std::string& msg)
+      : StatusException("GCS", msg) {
+  }
+};
+
 class GCS {
  public:
   /* ********************************* */
@@ -235,6 +243,8 @@ class GCS {
    * @param d The DirectoryPredicate to invoke on each common prefix for
    *    pruning. This is currently unused, but is kept here for future support.
    * @param recursive Whether to recursively list subdirectories.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
    */
   template <FilePredicate F, DirectoryPredicate D>
   LsObjects ls_filtered(
@@ -626,6 +636,8 @@ class GCS {
    * @param uri The parent path to list sub-paths.
    * @param f The FilePredicate to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
    */
   LsObjects ls_filtered_impl(
       const URI& uri,

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -546,9 +546,7 @@ class VFS : private VFSBase, protected S3_within_VFS {
 #endif
       } else if (parent.is_gcs()) {
 #ifdef HAVE_GCS
-        throw filesystem::VFSException(
-            "Recursive ls over " + parent.backend_name() +
-            " storage backend is not supported.");
+        results = gcs_.ls_filtered(parent, f, d, recursive);
 #else
         throw filesystem::VFSException("TileDB was built without GCS support");
 #endif
@@ -586,7 +584,7 @@ class VFS : private VFSBase, protected S3_within_VFS {
    * invoking the FilePredicate on each entry collected and the
    * DirectoryPredicate on common prefixes for pruning.
    *
-   * Currently this API is only supported for local files, S3 and Azure.
+   * Currently this API is only supported for local files, S3, Azure and GCS.
    *
    * @param parent The parent prefix to list sub-paths.
    * @param f The FilePredicate to invoke on each object for filtering.


### PR DESCRIPTION
[SC-47218](https://app.shortcut.com/tiledb-inc/story/47218/add-support-for-ls-recursive-in-gcs)

This PR implements `ls_recursive` in the GCS VFS. Due to the structure of the GCS SDK APIs, adding a `GCSScanner` like Azure and S3 is not possible without refactoring the `LsScanner` infrastructure. Instead I only implemented `ls_filtered`, using a design that keeps the implementation in the `gcs.cc` implementation file and prevents SDK headers from leaking, which would regress build times.

---
TYPE: C_API
DESC: Support VFS `ls_recursive` API for Google Cloud Storage filesystem.