### PR TITLE
Update GroupDirectory constructor to use references instead of pointers.

### DIFF
--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -114,11 +114,12 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
   // Get the group metadata URIs and vacuum file URIs to be vacuumed
   auto& vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
-  GroupDirectory group_dir;
+  shared_ptr<GroupDirectory> group_dir;
   try {
-    group_dir = GroupDirectory(
-        &vfs,
-        &compute_tp,
+    group_dir = make_shared<GroupDirectory>(
+        HERE(),
+        vfs,
+        compute_tp,
         URI(group_name),
         0,
         std::numeric_limits<uint64_t>::max());
@@ -127,8 +128,8 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
   }
 
   // Delete the group metadata and vacuum files
-  vfs.remove_files(&compute_tp, group_dir.group_meta_uris_to_vacuum());
-  vfs.remove_files(&compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, group_dir->group_meta_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, group_dir->group_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -114,22 +114,16 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
   // Get the group metadata URIs and vacuum file URIs to be vacuumed
   auto& vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
-  shared_ptr<GroupDirectory> group_dir;
-  try {
-    group_dir = make_shared<GroupDirectory>(
-        HERE(),
-        vfs,
-        compute_tp,
-        URI(group_name),
-        0,
-        std::numeric_limits<uint64_t>::max());
-  } catch (const std::logic_error& le) {
-    throw Status_GroupDirectoryError(le.what());
-  }
+  GroupDirectory group_dir(
+      vfs,
+      compute_tp,
+      URI(group_name),
+      0,
+      std::numeric_limits<uint64_t>::max());
 
   // Delete the group metadata and vacuum files
-  vfs.remove_files(&compute_tp, group_dir->group_meta_uris_to_vacuum());
-  vfs.remove_files(&compute_tp, group_dir->group_meta_vac_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, group_dir.group_meta_uris_to_vacuum());
+  vfs.remove_files(&compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -163,8 +163,8 @@ Status Group::open(
     try {
       group_dir_ = make_shared<GroupDirectory>(
           HERE(),
-          &resources_.vfs(),
-          &resources_.compute_tp(),
+          resources_.vfs(),
+          resources_.compute_tp(),
           group_uri_,
           timestamp_start,
           timestamp_end);
@@ -177,8 +177,8 @@ Status Group::open(
     try {
       group_dir_ = make_shared<GroupDirectory>(
           HERE(),
-          &resources_.vfs(),
-          &resources_.compute_tp(),
+          resources_.vfs(),
+          resources_.compute_tp(),
           group_uri_,
           timestamp_start,
           (timestamp_end != 0) ? timestamp_end :
@@ -355,7 +355,7 @@ void Group::delete_group(const URI& uri, bool recursive) {
     auto& vfs = resources_.vfs();
     auto& compute_tp = resources_.compute_tp();
     auto group_dir = GroupDirectory(
-        &vfs, &compute_tp, uri, 0, std::numeric_limits<uint64_t>::max());
+        vfs, compute_tp, uri, 0, std::numeric_limits<uint64_t>::max());
 
     // Delete the group detail, group metadata and group files
     vfs.remove_files(&compute_tp, group_dir.group_detail_uris());

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -160,35 +160,23 @@ Status Group::open(
 
     RETURN_NOT_OK(rest_client->post_group_from_rest(group_uri_, this));
   } else if (query_type == QueryType::READ) {
-    try {
-      group_dir_ = make_shared<GroupDirectory>(
-          HERE(),
-          resources_.vfs(),
-          resources_.compute_tp(),
-          group_uri_,
-          timestamp_start,
-          timestamp_end);
-    } catch (const std::logic_error& le) {
-      return Status_GroupDirectoryError(le.what());
-    }
-
+    group_dir_ = make_shared<GroupDirectory>(
+        HERE(),
+        resources_.vfs(),
+        resources_.compute_tp(),
+        group_uri_,
+        timestamp_start,
+        timestamp_end);
     group_open_for_reads();
   } else {
-    try {
-      group_dir_ = make_shared<GroupDirectory>(
-          HERE(),
-          resources_.vfs(),
-          resources_.compute_tp(),
-          group_uri_,
-          timestamp_start,
-          (timestamp_end != 0) ? timestamp_end :
-                                 utils::time::timestamp_now_ms());
-    } catch (const std::logic_error& le) {
-      return Status_GroupDirectoryError(le.what());
-    }
-
+    group_dir_ = make_shared<GroupDirectory>(
+        HERE(),
+        resources_.vfs(),
+        resources_.compute_tp(),
+        group_uri_,
+        timestamp_start,
+        (timestamp_end != 0) ? timestamp_end : utils::time::timestamp_now_ms());
     group_open_for_writes();
-
     metadata_.reset(timestamp_end);
   }
 

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -52,8 +52,8 @@ namespace tiledb::sm {
  * anywhere in the code at present, though that might change.
  */
 GroupDirectory::GroupDirectory(
-    VFS* vfs,
-    ThreadPool* tp,
+    VFS& vfs,
+    ThreadPool& tp,
     const URI& uri,
     uint64_t timestamp_start,
     uint64_t timestamp_end,
@@ -124,9 +124,9 @@ Status GroupDirectory::load() {
   // Lists all directories in parallel. Skipping for schema only.
   // Some processing is also done here for things that don't depend on others.
   // List (in parallel) the root directory URIs
-  tasks.emplace_back(tp_->execute([&]() {
+  tasks.emplace_back(tp_.execute([&]() {
     auto&& [st, uris] = list_root_dir_uris();
-    RETURN_NOT_OK(st);
+    throw_if_not_ok(st);
 
     root_dir_uris = std::move(uris.value());
 
@@ -134,13 +134,13 @@ Status GroupDirectory::load() {
   }));
 
   // Load (in parallel) the group metadata URIs
-  tasks.emplace_back(tp_->execute([&]() { return load_group_meta_uris(); }));
+  tasks.emplace_back(tp_.execute([&]() { return load_group_meta_uris(); }));
 
   // Load (in paralell) the group details URIs
-  tasks.emplace_back(tp_->execute([&] { return load_group_detail_uris(); }));
+  tasks.emplace_back(tp_.execute([&] { return load_group_detail_uris(); }));
 
   // Wait for all tasks to complete
-  RETURN_NOT_OK(tp_->wait_all(tasks));
+  throw_if_not_ok(tp_.wait_all(tasks));
 
   // Error check
   bool is_group = false;
@@ -177,7 +177,7 @@ bool GroupDirectory::loaded() const {
 tuple<Status, optional<std::vector<URI>>> GroupDirectory::list_root_dir_uris() {
   // List the group directory URIs
   std::vector<URI> group_dir_uris;
-  RETURN_NOT_OK_TUPLE(vfs_->ls(uri_, &group_dir_uris), nullopt);
+  RETURN_NOT_OK_TUPLE(vfs_.ls(uri_, &group_dir_uris), nullopt);
 
   return {Status::Ok(), group_dir_uris};
 }
@@ -186,7 +186,7 @@ Status GroupDirectory::load_group_meta_uris() {
   // Load the URIs in the group metadata directory
   std::vector<URI> group_meta_dir_uris;
   auto group_meta_uri = uri_.join_path(constants::group_metadata_dir_name);
-  RETURN_NOT_OK(vfs_->ls(group_meta_uri, &group_meta_dir_uris));
+  throw_if_not_ok(vfs_.ls(group_meta_uri, &group_meta_dir_uris));
 
   // Compute and group metadata URIs and the vacuum file URIs to vacuum.
   auto&& [st1, group_meta_uris_to_vacuum, group_meta_vac_uris_to_vacuum] =
@@ -210,12 +210,12 @@ Status GroupDirectory::load_group_detail_uris() {
   // Load the URIs in the group details directory
   std::vector<URI> group_detail_dir_uris;
   auto group_detail_uri = uri_.join_path(constants::group_detail_dir_name);
-  RETURN_NOT_OK(vfs_->ls(group_detail_uri, &group_detail_dir_uris));
+  throw_if_not_ok(vfs_.ls(group_detail_uri, &group_detail_dir_uris));
 
   // Compute and group details URIs and the vacuum file URIs to vacuum.
   auto&& [st1, group_detail_uris_to_vacuum, group_detail_vac_uris_to_vacuum] =
       compute_uris_to_vacuum(group_detail_dir_uris);
-  RETURN_NOT_OK(st1);
+  throw_if_not_ok(st1);
   group_detail_uris_to_vacuum_ = std::move(group_detail_uris_to_vacuum.value());
   group_detail_vac_uris_to_vacuum_ =
       std::move(group_detail_vac_uris_to_vacuum.value());
@@ -223,7 +223,7 @@ Status GroupDirectory::load_group_detail_uris() {
   // Compute filtered group details URIs
   auto&& [st2, group_detail_filtered_uris] = compute_filtered_uris(
       group_detail_dir_uris, group_detail_uris_to_vacuum_);
-  RETURN_NOT_OK(st2);
+  throw_if_not_ok(st2);
   group_detail_uris_ = std::move(group_detail_filtered_uris.value());
   group_detail_dir_uris.clear();
 
@@ -263,12 +263,12 @@ GroupDirectory::compute_uris_to_vacuum(const std::vector<URI>& uris) const {
   // Also determine which vac files to vacuum
   std::vector<int32_t> to_vacuum_vec(uris.size(), 0);
   std::vector<int32_t> to_vacuum_vac_files_vec(vac_files.size(), 0);
-  auto status = parallel_for(tp_, 0, vac_files.size(), [&](size_t i) {
+  auto status = parallel_for(&tp_, 0, vac_files.size(), [&](size_t i) {
     uint64_t size = 0;
-    RETURN_NOT_OK(vfs_->file_size(vac_files[i], &size));
+    throw_if_not_ok(vfs_.file_size(vac_files[i], &size));
     std::string names;
     names.resize(size);
-    RETURN_NOT_OK(vfs_->read(vac_files[i], 0, &names[0], size));
+    throw_if_not_ok(vfs_.read(vac_files[i], 0, &names[0], size));
     std::stringstream ss(names);
     bool vacuum_vac_file = true;
     for (std::string uri_str; std::getline(ss, uri_str);) {

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -43,6 +43,13 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
+class GroupDirectoryException : public StatusException {
+ public:
+  explicit GroupDirectoryException(const std::string& message)
+      : StatusException("GroupDirectory", message) {
+  }
+};
+
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
 /* ********************************* */
@@ -66,7 +73,7 @@ GroupDirectory::GroupDirectory(
     , loaded_(false) {
   auto st = load();
   if (!st.ok()) {
-    throw std::logic_error(st.message());
+    throw GroupDirectoryException(st.message());
   }
 }
 
@@ -156,8 +163,7 @@ Status GroupDirectory::load() {
   }
 
   if (!is_group) {
-    return LOG_STATUS(
-        Status_GroupDirectoryError("Cannot open group; Group does not exist."));
+    throw GroupDirectoryException("Cannot open group; Group does not exist.");
   }
 
   // The URI manager has been loaded successfully

--- a/tiledb/sm/group/group_directory.h
+++ b/tiledb/sm/group/group_directory.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,13 +61,10 @@ class GroupDirectory {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
-  /** Constructor */
-  GroupDirectory() = default;
-
   /**
    * Constructor.
    *
-   * @param vfs A pointer to a VFS object for all IO.
+   * @param vfs A reference to a VFS object for all IO.
    * @param tp A thread pool used for parallelism.
    * @param uri The URI of the group directory.
    * @param timestamp_start Only group fragments, metadata, etc. that
@@ -81,8 +78,8 @@ class GroupDirectory {
    * @param mode The mode to load the group directory in.
    */
   GroupDirectory(
-      VFS* vfs,
-      ThreadPool* tp,
+      VFS& vfs,
+      ThreadPool& tp,
       const URI& uri,
       uint64_t timestamp_start,
       uint64_t timestamp_end,
@@ -134,10 +131,10 @@ class GroupDirectory {
   URI uri_;
 
   /** The storage manager. */
-  VFS* vfs_;
+  VFS& vfs_;
 
   /** A thread pool used for parallelism. */
-  ThreadPool* tp_;
+  ThreadPool& tp_;
 
   /** The URIs of all group files. */
   std::vector<URI> group_file_uris_;

--- a/tiledb/sm/group/group_directory.h
+++ b/tiledb/sm/group/group_directory.h
@@ -61,6 +61,9 @@ class GroupDirectory {
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
+  /** Constructor. */
+  GroupDirectory() = delete;
+
   /**
    * Constructor.
    *

--- a/tiledb/sm/group/group_member.cc
+++ b/tiledb/sm/group/group_member.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,8 +36,15 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
+
+class GroupMemberException : public StatusException {
+ public:
+  explicit GroupMemberException(const std::string& message)
+      : StatusException("GroupMember", message) {
+  }
+};
+
 GroupMember::GroupMember(
     const URI& uri,
     const ObjectType& type,
@@ -78,8 +85,7 @@ format_version_t GroupMember::version() const {
 }
 
 void GroupMember::serialize(Serializer&) {
-  throw StatusException(
-      Status_GroupMemberError("Invalid call to GroupMember::serialize"));
+  throw GroupMemberException("Invalid call to GroupMember::serialize");
 }
 
 shared_ptr<GroupMember> GroupMember::deserialize(Deserializer& deserializer) {
@@ -90,11 +96,10 @@ shared_ptr<GroupMember> GroupMember::deserialize(Deserializer& deserializer) {
   } else if (version == 2) {
     return GroupMemberV2::deserialize(deserializer);
   }
-  throw StatusException(Status_GroupError(
-      "Unsupported group member version " + std::to_string(version)));
+  throw GroupMemberException(
+      "Unsupported group member version " + std::to_string(version));
 }
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 std::ostream& operator<<(
     std::ostream& os, const tiledb::sm::GroupMember& group_member) {

--- a/tiledb/sm/group/group_member.h
+++ b/tiledb/sm/group/group_member.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,21 +43,11 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
-/** Return a Status_GroupDirectoryError error class Status with a given
- * message **/
-inline Status Status_GroupDirectoryError(const std::string& msg) {
-  return {"[TileDB::GroupDirectory] Error", msg};
-}
 /** Return an Group error class Status with a given message **/
 inline Status Status_GroupError(const std::string& msg) {
   return {"[TileDB::Group] Error", msg};
-}
-/** Return an GroupMember error class Status with a given message **/
-inline Status Status_GroupMemberError(const std::string& msg) {
-  return {"[TileDB::GroupMember] Error", msg};
 }
 
 class GroupMember {
@@ -142,8 +132,7 @@ class GroupMember {
   /** Is group member deleted from group. */
   bool deleted_;
 };
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 std::ostream& operator<<(
     std::ostream& os, const tiledb::sm::GroupMember& group_member);


### PR DESCRIPTION
Update `GroupDirectory` constructor to use references instead of pointers.

[sc-47557]

---
TYPE: NO_HISTORY
DESC: Update `GroupDirectory` constructor to use references instead of pointers.
