### PR TITLE
Fix OS detection in Unix CI et. al.

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -26,7 +26,7 @@ jobs:
       # Need this for virtualenv and arrow tests if enabled
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.9'
       - run: |
           set -e pipefail
           python -m pip install --upgrade pip virtualenv

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -55,7 +55,7 @@ on:
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_CI_BACKEND: ${{ inputs.ci_backend }}
-  TILEDB_CI_OS: runner.os
+  TILEDB_CI_OS: ${{ startsWith(inputs.matrix_image, 'ubuntu-') && 'Linux' || 'macOS' }}
   # Installing Python does not work on manylinux.
   TILEDB_ARROW_TESTS: ${{ !inputs.manylinux && 'ON' || 'OFF' }}
   TILEDB_MANYLINUX: ${{ !inputs.manylinux && 'ON' || 'OFF' }}

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/setup-python@v4
         if: ${{ !inputs.manylinux }}
         with:
-          python-version: '3.8'
+          python-version: '3.9'
           cache: 'pip'
 
       - name: 'Set up Python dependencies'

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: HDFS
-      matrix_image: ubuntu-22.04
+      matrix_image: ubuntu-24.04
       matrix_compiler_cc: 'gcc-13'
       matrix_compiler_cxx: 'g++-13'
       timeout: 300


### PR DESCRIPTION
[SC-48004](https://app.shortcut.com/tiledb-inc/story/48004)

This PR updates the Linux-Mac CI workflow to correctly set the `TILEDB_CI_OS` environment variable, which would enable scripts to perform the appropriate preliminary actions on Linux, such as calling `sudo apt-get update`.

Fix failures early in the HDFS nightly run, see https://github.com/TileDB-Inc/TileDB/issues/4869#issuecomment-2126437572 for more information. Initially, that job still failed because [GCC 13 is not available for Ubuntu 22.04](https://launchpad.net/ubuntu/+source/gcc-13), which led to using the beta image for Ubuntu 24.04, which led to errors because Python 3.8 could not be installed, which led to updating it to 3.9 but for all CI jobs.

---
TYPE: NO_HISTORY