### PR TITLE
Fix performance regression in group::dump() for `tiledb://` arrays

### DIFF
--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -1464,16 +1464,15 @@ TEST_CASE_METHOD(
   remove_temp_dir(temp_dir);
 }
 
-TEST_CASE_METHOD(GroupFx, "C API: Group, dump", "[capi][group][dump]") {
+TEST_CASE_METHOD(GroupFx, "C API: Group, dump", "[capi][group][dump][rest]") {
   // Create and open group in write mode
-  // TODO: refactor for each supported FS.
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
 
-  tiledb::sm::URI group1_uri(temp_dir + "group1");
+  std::string group1_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group1");
   REQUIRE(tiledb_group_create(ctx_, group1_uri.c_str()) == TILEDB_OK);
 
-  tiledb::sm::URI group2_uri(temp_dir + "group2");
+  std::string group2_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group2");
   REQUIRE(tiledb_group_create(ctx_, group2_uri.c_str()) == TILEDB_OK);
 
   tiledb_group_t* group1;

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -1464,7 +1464,10 @@ TEST_CASE_METHOD(
   remove_temp_dir(temp_dir);
 }
 
-TEST_CASE_METHOD(GroupFx, "C API: Group, dump", "[capi][group][dump][rest]") {
+TEST_CASE_METHOD(
+    GroupFx,
+    "C API: Group, dump",
+    "[capi][group][dump][rest-fails][sc-48099]") {
   // Create and open group in write mode
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);


### PR DESCRIPTION
This [fix](https://github.com/TileDB-Inc/TileDB/pull/4582) to [38499](https://app.shortcut.com/tiledb-inc/story/38499/recursively-dumping-a-group-fails-when-a-subgroup-does-not-exist) , introduced a performance regression to `Group::dump` for `tiledb://` arrays, since now the method calls `object_type` for every member in a for loop, where every `object_type` call initiates two REST requests for `tiledb://` arrays (one for `is_array` and one for `is_group`).

The fix in this PR is to let group open fail when the group is not there instead, check on the return value and log that the array doesn't exist.

---
TYPE: BUG
DESC: Fix performance regression in group::dump() for "tiledb://" arrays
