### PR TITLE
Update budget tests to fix windows nightly builds.

### DIFF
--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -672,8 +672,8 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "20000");
-  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.22");
+  cfg.set("sm.mem.total_budget", "30000");
+  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 
   std::string stats;
@@ -722,8 +722,8 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "20000");
-  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.22");
+  cfg.set("sm.mem.total_budget", "30000");
+  cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 
   std::string stats;

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1126,7 +1126,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "1209";
+  total_budget_ = "2500";
   tile_upper_memory_limit_ = "200";
   update_config();
 
@@ -1193,6 +1193,9 @@ TEST_CASE_METHOD(
   CHECK(!std::memcmp(a2_data.data(), a2_data_r, a2_data_size));
   CHECK(a2_offsets_r_size == a2_offsets_size);
   CHECK(!std::memcmp(a2_offsets.data(), a2_offsets_r, a2_offsets_size));
+
+  total_budget_ = "1100";
+  update_config();
 
   // Now read with QC set for a1 and a2, should fail.
   read_fixed_strings(

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1126,7 +1126,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "1205";
+  total_budget_ = "1209";
   update_config();
 
   // Try to read.

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1127,6 +1127,7 @@ TEST_CASE_METHOD(
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
   total_budget_ = "1209";
+  tile_upper_memory_limit_ = "200";
   update_config();
 
   // Try to read.
@@ -1242,7 +1243,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "1160";
+  total_budget_ = "1100";
   update_config();
 
   // Try to read.
@@ -1291,8 +1292,7 @@ TEST_CASE_METHOD(
       0,
       false,
       true,
-      "DenseReader: Cannot process a single tile because of query "
-      "condition, increase memory budget");
+      "DenseReader: Cannot process a single tile, increase memory budget");
 
   // Now read with QC set for a1 and a2, should fail.
   read_fixed_strings(

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1242,8 +1242,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "1150";
-  tile_upper_memory_limit_ = "500";
+  total_budget_ = "1160";
   update_config();
 
   // Try to read.

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -1126,8 +1126,7 @@ TEST_CASE_METHOD(
   // Each var tiles are 91 and 100 bytes respectively, this will only allow to
   // load one as the budget is split across two potential reads. Fixed tiles are
   // both 40 so they both fit in the budget.
-  total_budget_ = "1200";
-  tile_upper_memory_limit_ = "500";
+  total_budget_ = "1205";
   update_config();
 
   // Try to read.

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1314,8 +1314,8 @@ TEST_CASE_METHOD(
 
   // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "30000";
-  ratio_coords_ = "0.30";
+  total_budget_ = "40000";
+  ratio_coords_ = "0.22";
   update_config();
 
   tiledb_array_t* array = nullptr;

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1312,7 +1312,7 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords, &coords_size, data, &data_size);
   }
 
-  // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
+  // Two result tile (2 * (~4000 + 8) will be bigger than the per fragment
   // budget (1000).
   total_budget_ = "40000";
   ratio_coords_ = "0.22";

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -870,7 +870,7 @@ TEST_CASE_METHOD(
   write_1d_fragment(coords, &coords_size, data, &data_size);
 
   // One result tile (8 + ~440) will be bigger than the budget (400).
-  total_budget_ = "13000";
+  total_budget_ = "19000";
   ratio_coords_ = "0.04";
   update_config();
 
@@ -1207,7 +1207,7 @@ TEST_CASE(
     "Sparse global order reader: attribute copy memory limit",
     "[sparse-global-order][attribute-copy][memory-limit][rest]") {
   Config config;
-  config["sm.mem.total_budget"] = "15000";
+  config["sm.mem.total_budget"] = "20000";
   VFSTestSetup vfs_test_setup(config.ptr().get());
   std::string array_name = vfs_test_setup.array_uri("test_sparse_global_order");
   auto ctx = vfs_test_setup.ctx();
@@ -1312,9 +1312,9 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords, &coords_size, data, &data_size);
   }
 
-  // Two result tile (2 * (~2600 + 8) will be bigger than the per fragment
+  // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "26000";
+  total_budget_ = "30000";
   ratio_coords_ = "0.30";
   update_config();
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -790,8 +790,8 @@ TEST_CASE_METHOD(
 
   // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
   // budget (1000).
-  total_budget_ = "30000";
-  ratio_coords_ = "0.12";
+  total_budget_ = "35000";
+  ratio_coords_ = "0.11";
   update_config();
 
   tiledb_array_t* array = nullptr;

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -932,7 +932,7 @@ TEST_CASE_METHOD(
   uint64_t data2_size = data.size() * sizeof(int);
   write_1d_fragment(coords2.data(), &coords2_size, data2.data(), &data2_size);
 
-  total_budget_ = "1500000";
+  total_budget_ = "1600000";
   ratio_array_data_ = set_subarray ? "0.003" : "0.002";
   partial_tile_offsets_loading_ = "true";
   update_config();
@@ -1020,7 +1020,7 @@ TEST_CASE_METHOD(
   }
 
   // Two result tile (2 * ~1208) will be bigger than the budget (1500).
-  total_budget_ = "25500";
+  total_budget_ = "30000";
   ratio_coords_ = "0.06";
   update_config();
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -932,7 +932,7 @@ TEST_CASE_METHOD(
   uint64_t data2_size = data.size() * sizeof(int);
   write_1d_fragment(coords2.data(), &coords2_size, data2.data(), &data2_size);
 
-  total_budget_ = "1600000";
+  total_budget_ = "1625000";
   ratio_array_data_ = set_subarray ? "0.003" : "0.002";
   partial_tile_offsets_loading_ = "true";
   update_config();

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -61,6 +61,7 @@ struct CSparseUnorderedWithDupsFx {
   std::string array_name_;
   const char* ARRAY_NAME = "test_sparse_unordered_with_dups";
   std::string total_budget_;
+  std::string tile_upper_memory_limit_;
   std::string ratio_tile_ranges_;
   std::string ratio_array_data_;
   std::string ratio_coords_;
@@ -165,6 +166,16 @@ void CSparseUnorderedWithDupsFx::update_config() {
           config, "sm.mem.total_budget", total_budget_.c_str(), &error) ==
       TILEDB_OK);
   REQUIRE(error == nullptr);
+
+  if (tile_upper_memory_limit_ != "") {
+    REQUIRE(
+      tiledb_config_set(
+          config,
+          "sm.mem.tile_upper_memory_limit",
+          tile_upper_memory_limit_.c_str(),
+          &error) == TILEDB_OK);
+    REQUIRE(error == nullptr);
+  }
 
   REQUIRE(
       tiledb_config_set(
@@ -932,7 +943,8 @@ TEST_CASE_METHOD(
   uint64_t data2_size = data.size() * sizeof(int);
   write_1d_fragment(coords2.data(), &coords2_size, data2.data(), &data2_size);
 
-  total_budget_ = "1625000";
+  total_budget_ = "1900000";
+  tile_upper_memory_limit_ = "100000";
   ratio_array_data_ = set_subarray ? "0.003" : "0.002";
   partial_tile_offsets_loading_ = "true";
   update_config();

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1020,8 +1020,8 @@ TEST_CASE_METHOD(
   }
 
   // Two result tile (2 * ~1208) will be bigger than the budget (1500).
-  total_budget_ = "30000";
-  ratio_coords_ = "0.06";
+  total_budget_ = "40000";
+  ratio_coords_ = "0.04";
   update_config();
 
   tiledb_array_t* array = nullptr;
@@ -1099,7 +1099,7 @@ TEST_CASE_METHOD(
   write_1d_fragment(coords, &coords_size, data, &data_size);
 
   // One result tile (~505) will be larger than leftover memory.
-  total_budget_ = "1500";
+  total_budget_ = "1800";
   ratio_array_data_ = "0.99";
   ratio_coords_ = "0.0005";
   update_config();

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -169,11 +169,11 @@ void CSparseUnorderedWithDupsFx::update_config() {
 
   if (tile_upper_memory_limit_ != "") {
     REQUIRE(
-      tiledb_config_set(
-          config,
-          "sm.mem.tile_upper_memory_limit",
-          tile_upper_memory_limit_.c_str(),
-          &error) == TILEDB_OK);
+        tiledb_config_set(
+            config,
+            "sm.mem.tile_upper_memory_limit",
+            tile_upper_memory_limit_.c_str(),
+            &error) == TILEDB_OK);
     REQUIRE(error == nullptr);
   }
 


### PR DESCRIPTION
Fixes the nightly tests in windows after #4929. The memory budgets tests were failing because structures take more memory in ASAN debug. Adjusting the budgeting values so they pass in all build flavors.

Successful run here: https://github.com/TileDB-Inc/TileDB/actions/runs/9209028209.

---
TYPE: NO_HISTORY
DESC: Update budget tests to fix windows nightly builds.
