### PR TITLE
Add concept definitions for `FilePredicate` and `DirectoryPredicate`.

### DIFF
--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -41,12 +41,27 @@
 #include <functional>
 #include <stdexcept>
 
-/** Inclusion predicate for objects collected by ls. */
+/**
+ * Inclusion predicate for objects collected by ls.
+ *
+ * The predicate accepts:
+ * - A string_view of the path to the object.
+ * - The size of the object in bytes.
+ *
+ * The predicate returns true if the object should be included in the results,
+ * and false otherwise.
+ */
 template <class F>
 concept FilePredicate = std::predicate<F, const std::string_view, uint64_t>;
 
 /**
  * Recursion predicate for directories collected by ls.
+ *
+ * The predicate accepts:
+ * - A string_view of the path to the directory.
+ *
+ * The predicate returns true if items inside the directory should be traversed,
+ * and false otherwise.
  *
  * Directory pruning is currently supported only in local filesystem, and not
  * exposed in the user-facing C API.

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -41,16 +41,18 @@
 #include <functional>
 #include <stdexcept>
 
-/** Inclusion predicate for objects collected by ls */
+/** Inclusion predicate for objects collected by ls. */
 template <class F>
-concept FilePredicate = true;
+concept FilePredicate = std::predicate<F, const std::string_view, uint64_t>;
 
 /**
- * DirectoryPredicate is currently unused, but is kept here for adding directory
- * pruning support in the future.
+ * Recursion predicate for directories collected by ls.
+ *
+ * Directory pruning is currently supported only in local filesystem, and not
+ * exposed in the user-facing C API.
  */
-template <class F>
-concept DirectoryPredicate = true;
+template <class D>
+concept DirectoryPredicate = std::predicate<D, const std::string_view>;
 
 namespace tiledb::sm {
 class LsScanException : public StatusException {


### PR DESCRIPTION
[SC-48083](https://app.shortcut.com/tiledb-inc/story/48083/add-concept-definitions-for-filepredicate-and-directorypredicate)

This PR provides proper definitions of `FilePredicate` and `DirectoryPredicate`, as predicates that accept a constant string view and –in the former case only– a `uint64_t`. This will improve the experience when working with `ls_recursive`'s infrastructure.

---
TYPE: NO_HISTORY