### PR TITLE
Fix build errors where the fmt headers could not be found for spdlog.

### DIFF
--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -36,7 +36,7 @@
 #ifndef TILEDB_LOGGER_H
 #define TILEDB_LOGGER_H
 
-#include <fmt/format.h>
+#include <spdlog/fmt/fmt.h>
 #include <atomic>
 #include <sstream>
 


### PR DESCRIPTION
Fixes regression introduced in #4881. Fixes #5006.

[sc-48092]

---
TYPE: BUILD
DESC: Fix build errors where the fmt headers could not be found for spdlog.