### PR TITLE
Implement consolidation memory budget variables.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -260,7 +260,6 @@ void check_save_to_file() {
   ss << "sm.consolidation.steps 4294967295\n";
   ss << "sm.consolidation.timestamp_end " << std::to_string(UINT64_MAX) << "\n";
   ss << "sm.consolidation.timestamp_start 0\n";
-  ss << "sm.consolidation.total_buffer_size 2147483648\n";
   ss << "sm.dedup_coords false\n";
   ss << "sm.enable_signal_handlers true\n";
   ss << "sm.encryption_type NO_ENCRYPTION\n";
@@ -272,6 +271,9 @@ void check_save_to_file() {
   ss << "sm.io_concurrency_level " << std::thread::hardware_concurrency()
      << "\n";
   ss << "sm.max_tile_overlap_size 314572800\n";
+  ss << "sm.mem.consolidation.buffers_weight 1\n";
+  ss << "sm.mem.consolidation.reader_weight 3\n";
+  ss << "sm.mem.consolidation.writer_weight 2\n";
   ss << "sm.mem.malloc_trim true\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_array_data 0.1\n";
   ss << "sm.mem.reader.sparse_global_order.ratio_coords 0.5\n";
@@ -632,6 +634,9 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.query.dense.reader"] = "refactored";
   all_param_values["sm.query.sparse_global_order.reader"] = "refactored";
   all_param_values["sm.query.sparse_unordered_with_dups.reader"] = "refactored";
+  all_param_values["sm.mem.consolidation.buffers_weight"] = "1";
+  all_param_values["sm.mem.consolidation.reader_weight"] = "3";
+  all_param_values["sm.mem.consolidation.writer_weight"] = "2";
   all_param_values["sm.mem.malloc_trim"] = "true";
   all_param_values["sm.mem.tile_upper_memory_limit"] = "1073741824";
   all_param_values["sm.mem.total_budget"] = "10737418240";
@@ -663,7 +668,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.consolidation.step_min_frags"] = "4294967295";
   all_param_values["sm.consolidation.step_max_frags"] = "4294967295";
   all_param_values["sm.consolidation.buffer_size"] = "50000000";
-  all_param_values["sm.consolidation.total_buffer_size"] = "2147483648";
   all_param_values["sm.consolidation.max_fragment_size"] =
       std::to_string(UINT64_MAX);
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";

--- a/test/src/unit-capi-fragment_info.cc
+++ b/test/src/unit-capi-fragment_info.cc
@@ -1271,7 +1271,15 @@ TEST_CASE(
   REQUIRE(error == nullptr);
 
   rc = tiledb_config_set(
-      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+      config, "sm.mem.consolidation.buffers_weight", "1", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.reader_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.writer_weight", "5000", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -1644,7 +1652,15 @@ TEST_CASE(
   REQUIRE(error == nullptr);
 
   rc = tiledb_config_set(
-      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+      config, "sm.mem.consolidation.buffers_weight", "1", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.reader_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.writer_weight", "5000", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 

--- a/test/src/unit-capi-sparse_heter.cc
+++ b/test/src/unit-capi-sparse_heter.cc
@@ -1003,7 +1003,15 @@ TEST_CASE_METHOD(
   REQUIRE(error == nullptr);
 
   auto rc = tiledb_config_set(
-      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+      config, "sm.mem.consolidation.buffers_weight", "1", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.reader_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.writer_weight", "5000", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 
@@ -1356,8 +1364,16 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
   REQUIRE(error == nullptr);
 
-  int rc = tiledb_config_set(
-      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+  auto rc = tiledb_config_set(
+      config, "sm.mem.consolidation.buffers_weight", "1", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.reader_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.writer_weight", "5000", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -2125,8 +2125,17 @@ TEST_CASE_METHOD(
       config, "sm.consolidation.mode", "fragment_meta", &error);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_config_set(
-      config, "sm.consolidation.total_buffer_size", "1048576", &error);
-  CHECK(rc == TILEDB_OK);
+      config, "sm.mem.consolidation.buffers_weight", "1", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.reader_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.writer_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
 
   // Consolidate fragment metadata
   rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -663,7 +663,10 @@ TEST_CASE(
     "C++ API: Consolidation of sequential fragment writes",
     "[cppapi][consolidation][sequential][non-rest]") {
   tiledb::Config cfg;
-  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+
+  cfg["sm.mem.consolidation.buffers_weight"] = "1";
+  cfg["sm.mem.consolidation.reader_weight"] = "5000";
+  cfg["sm.mem.consolidation.writer_weight"] = "5000";
   Context ctx(cfg);
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";
@@ -714,7 +717,9 @@ TEST_CASE(
 TEST_CASE("C++ API: Encrypted array", "[cppapi][encryption][non-rest]") {
   const char key[] = "0123456789abcdeF0123456789abcdeF";
   tiledb::Config cfg;
-  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+  cfg["sm.mem.consolidation.buffers_weight"] = "1";
+  cfg["sm.mem.consolidation.reader_weight"] = "5000";
+  cfg["sm.mem.consolidation.writer_weight"] = "5000";
   cfg["sm.encryption_type"] = "AES_256_GCM";
   cfg["sm.encryption_key"] = key;
   Context ctx(cfg);
@@ -805,7 +810,9 @@ TEST_CASE(
   tiledb::Config cfg;
   cfg["sm.encryption_type"] = "AES_256_GCM";
   cfg["sm.encryption_key"] = key.c_str();
-  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+  cfg["sm.mem.consolidation.buffers_weight"] = "1";
+  cfg["sm.mem.consolidation.reader_weight"] = "5000";
+  cfg["sm.mem.consolidation.writer_weight"] = "5000";
   Context ctx(cfg);
   VFS vfs(ctx);
   const std::string array_name = "cpp_unit_array";

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -1270,7 +1270,9 @@ TEST_CASE_METHOD(
   // fully removed for overlapping ranges, this test case can be deleted.
   tiledb::Config cfg;
   cfg.set("sm.merge_overlapping_ranges_experimental", "false");
-  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+  cfg["sm.mem.consolidation.buffers_weight"] = "1";
+  cfg["sm.mem.consolidation.reader_weight"] = "5000";
+  cfg["sm.mem.consolidation.writer_weight"] = "5000";
   ctx_ = Context(cfg);
   sm_ = ctx_.ptr().get()->storage_manager();
   vfs_ = VFS(ctx_);

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -125,7 +125,9 @@ TEST_CASE(
 
   // Create array
   tiledb::Config cfg;
-  cfg["sm.consolidation.total_buffer_size"] = "1048576";
+  cfg["sm.mem.consolidation.buffers_weight"] = "1";
+  cfg["sm.mem.consolidation.reader_weight"] = "5000";
+  cfg["sm.mem.consolidation.writer_weight"] = "5000";
   Context ctx(cfg);
   Domain domain(ctx);
   auto d = Dimension::create<int>(ctx, "d1", {{10, 110}}, 50);

--- a/test/src/unit-cppapi-fragment_info.cc
+++ b/test/src/unit-cppapi-fragment_info.cc
@@ -879,7 +879,9 @@ TEST_CASE(
     // Consolidate fragments
     Config config;
     config["sm.consolidation.mode"] = "fragments";
-    config["sm.consolidation.total_buffer_size"] = "1048576";
+    config["sm.mem.consolidation.buffers_weight"] = "1";
+    config["sm.mem.consolidation.reader_weight"] = "5000";
+    config["sm.mem.consolidation.writer_weight"] = "5000";
     Array::consolidate(ctx, array_name, &config);
 
     // Load fragment info

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -1780,7 +1780,9 @@ TEST_CASE(
   Config config;
   config["sm.consolidation.mode"] = "fragments";
   config["sm.vacuum.mode"] = "fragments";
-  config["sm.consolidation.total_buffer_size"] = "1048576";
+  config["sm.mem.consolidation.buffers_weight"] = "1";
+  config["sm.mem.consolidation.reader_weight"] = "5000";
+  config["sm.mem.consolidation.writer_weight"] = "5000";
   CHECK_NOTHROW(Array::consolidate(ctx, array_name, &config));
   CHECK_NOTHROW(Array::vacuum(ctx, array_name, &config));
   auto contents = vfs.ls(get_fragment_dir(array_name));

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -243,7 +243,9 @@ struct CPPMaxFragmentSizeFx {
       uint64_t max_fragment_size = std::numeric_limits<uint64_t>::max()) {
     auto config = ctx_.config();
     config["sm.consolidation.max_fragment_size"] = max_fragment_size;
-    config["sm.consolidation.total_buffer_size"] = "1048576";
+    config["sm.mem.consolidation.buffers_weight"] = "1";
+    config["sm.mem.consolidation.reader_weight"] = "5000";
+    config["sm.mem.consolidation.writer_weight"] = "5000";
     Array::consolidate(ctx_, array_name, &config);
   }
 

--- a/test/src/unit-duplicates.cc
+++ b/test/src/unit-duplicates.cc
@@ -353,7 +353,15 @@ TEST_CASE_METHOD(
   REQUIRE(error == nullptr);
 
   rc = tiledb_config_set(
-      config, "sm.consolidation.total_buffer_size", "1048576", &error);
+      config, "sm.mem.consolidation.buffers_weight", "1", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.reader_weight", "5000", &error);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(error == nullptr);
+  rc = tiledb_config_set(
+      config, "sm.mem.consolidation.writer_weight", "5000", &error);
   REQUIRE(rc == TILEDB_OK);
   REQUIRE(error == nullptr);
 

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -171,11 +171,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    The size (in bytes) of the attribute buffers used during
  *    consolidation. <br>
  *    **Default**: 50,000,000
- * - `sm.consolidation.total_buffer_size` <br>
- *    **Deprecated**
- *    The size (in bytes) of all attribute buffers used during
- *    consolidation. <br>
- *    **Default**: 2,147,483,648
  * - `sm.consolidation.max_fragment_size` <br>
  *    **Experimental** <br>
  *    The size (in bytes) of the maximum on-disk fragment size that will be
@@ -261,6 +256,26 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `sm.mem.total_budget` <br>
  *    Memory budget for readers and writers. <br>
  *    **Default**: 10GB
+ * - `sm.mem.consolidation.buffers_weight` <br>
+ *    Weight used to split `sm.mem.total_budget` and assign to the
+ *    consolidation buffers. The budget is split across 3 values,
+ *    `sm.mem.consolidation.buffers_weight`,
+ *    `sm.mem.consolidation.reader_weight` and
+ *    `sm.mem.consolidation.writer_weight`. <br>
+ *    **Default**: 1
+ * - `sm.mem.consolidation.reader_weight` <br>
+ *    Weight used to split `sm.mem.total_budget` and assign to the
+ *    reader query. The budget is split across 3 values,
+ *    `sm.mem.consolidation.buffers_weight`,
+ *    `sm.mem.consolidation.reader_weight` and
+ *    `sm.mem.consolidation.writer_weight`. <br>
+ *    **Default**: 3
+ *    Weight used to split `sm.mem.total_budget` and assign to the
+ *    writer query. The budget is split across 3 values,
+ *    `sm.mem.consolidation.buffers_weight`,
+ *    `sm.mem.consolidation.reader_weight` and
+ *    `sm.mem.consolidation.writer_weight`. <br>
+ *    **Default**: 2
  * - `sm.mem.reader.sparse_global_order.ratio_coords` <br>
  *    Ratio of the budget allocated for coordinates in the sparse global
  *    order reader. <br>

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -118,6 +118,9 @@ const std::string Config::SM_QUERY_SPARSE_UNORDERED_WITH_DUPS_READER =
 const std::string Config::SM_MEM_MALLOC_TRIM = "true";
 const std::string Config::SM_UPPER_MEMORY_LIMIT = "1073741824";  // 1GB
 const std::string Config::SM_MEM_TOTAL_BUDGET = "10737418240";   // 10GB
+const std::string Config::SM_MEM_CONSOLIDATION_BUFFERS_WEIGHT = "1";
+const std::string Config::SM_MEM_CONSOLIDATION_READER_WEIGHT = "3";
+const std::string Config::SM_MEM_CONSOLIDATION_WRITER_WEIGHT = "2";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS = "0.5";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_TILE_RANGES = "0.1";
 const std::string Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_ARRAY_DATA = "0.1";
@@ -135,7 +138,6 @@ const std::string Config::SM_IO_CONCURRENCY_LEVEL =
 const std::string Config::SM_SKIP_CHECKSUM_VALIDATION = "false";
 const std::string Config::SM_CONSOLIDATION_AMPLIFICATION = "1.0";
 const std::string Config::SM_CONSOLIDATION_BUFFER_SIZE = "50000000";
-const std::string Config::SM_CONSOLIDATION_TOTAL_BUFFER_SIZE = "2147483648";
 const std::string Config::SM_CONSOLIDATION_MAX_FRAGMENT_SIZE =
     std::to_string(UINT64_MAX);
 const std::string Config::SM_CONSOLIDATION_PURGE_DELETED_CELLS = "false";
@@ -308,6 +310,15 @@ const std::map<std::string, std::string> default_config_values = {
         "sm.mem.tile_upper_memory_limit", Config::SM_UPPER_MEMORY_LIMIT),
     std::make_pair("sm.mem.total_budget", Config::SM_MEM_TOTAL_BUDGET),
     std::make_pair(
+        "sm.mem.consolidation.buffers_weight",
+        Config::SM_MEM_CONSOLIDATION_BUFFERS_WEIGHT),
+    std::make_pair(
+        "sm.mem.consolidation.reader_weight",
+        Config::SM_MEM_CONSOLIDATION_READER_WEIGHT),
+    std::make_pair(
+        "sm.mem.consolidation.writer_weight",
+        Config::SM_MEM_CONSOLIDATION_WRITER_WEIGHT),
+    std::make_pair(
         "sm.mem.reader.sparse_global_order.ratio_coords",
         Config::SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS),
     std::make_pair(
@@ -337,9 +348,6 @@ const std::map<std::string, std::string> default_config_values = {
         Config::SM_CONSOLIDATION_AMPLIFICATION),
     std::make_pair(
         "sm.consolidation.buffer_size", Config::SM_CONSOLIDATION_BUFFER_SIZE),
-    std::make_pair(
-        "sm.consolidation.total_buffer_size",
-        Config::SM_CONSOLIDATION_TOTAL_BUFFER_SIZE),
     std::make_pair(
         "sm.consolidation.max_fragment_size",
         Config::SM_CONSOLIDATION_MAX_FRAGMENT_SIZE),
@@ -762,8 +770,6 @@ Status Config::sanity_check(
   } else if (param == "sm.consolidation.amplification") {
     RETURN_NOT_OK(utils::parse::convert(value, &vf));
   } else if (param == "sm.consolidation.buffer_size") {
-    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
-  } else if (param == "sm.consolidation.total_buffer_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.consolidation.max_fragment_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -227,6 +227,15 @@ class Config {
   /** Maximum memory budget for readers and writers. */
   static const std::string SM_MEM_TOTAL_BUDGET;
 
+  /** Weight for consolidation buffers used to split total budget. */
+  static const std::string SM_MEM_CONSOLIDATION_BUFFERS_WEIGHT;
+
+  /** Weight for consolidation read query used to split total budget. */
+  static const std::string SM_MEM_CONSOLIDATION_READER_WEIGHT;
+
+  /** Weight for consolidation write query used to split total budget. */
+  static const std::string SM_MEM_CONSOLIDATION_WRITER_WEIGHT;
+
   /** Ratio of the sparse global order reader budget used for coords. */
   static const std::string SM_MEM_SPARSE_GLOBAL_ORDER_RATIO_COORDS;
 
@@ -276,9 +285,6 @@ class Config {
 
   /** The buffer size for each attribute used in consolidation. */
   static const std::string SM_CONSOLIDATION_BUFFER_SIZE;
-
-  /** The total buffer size for all attributes during consolidation. */
-  static const std::string SM_CONSOLIDATION_TOTAL_BUFFER_SIZE;
 
   /** The maximum fragment size used in consolidation. */
   static const std::string SM_CONSOLIDATION_MAX_FRAGMENT_SIZE;

--- a/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
@@ -223,7 +223,7 @@ TEST_CASE(
   cfg.buffer_size_ = 1000;
 
   FragmentConsolidationWorkspace cw(tiledb::test::get_test_memory_tracker());
-  cw.resize_buffers(&statistics, cfg, *schema, avg_cell_sizes);
+  cw.resize_buffers(&statistics, cfg, *schema, avg_cell_sizes, 1);
   auto& buffers = cw.buffers();
   auto& buffer_sizes = cw.sizes();
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -346,11 +346,6 @@ class Config {
    *    The size (in bytes) of the attribute buffers used during
    *    consolidation. <br>
    *    **Default**: 50,000,000
-   * - `sm.consolidation.total_buffer_size` <br>
-   *    **Deprecated**
-   *    The size (in bytes) of all attribute buffers used during
-   *    consolidation. <br>
-   *    **Default**: 2,147,483,648
    * - `sm.consolidation.max_fragment_size` <br>
    *    **Experimental** <br>
    *    The size (in bytes) of the maximum on-disk fragment size that will be
@@ -437,11 +432,29 @@ class Config {
    *    incur performance penalties during memory movement operations. It is a
    *    soft limit that we might go over if a single tile doesn't fit into
    *    memory, we will allow to load that tile if it still fits within
-   *    `sm.mem.total_budget`. <br>
-   *    **Default**: 1GB
    * - `sm.mem.total_budget` <br>
    *    Memory budget for readers and writers. <br>
    *    **Default**: 10GB
+   * - `sm.mem.consolidation.buffers_weight` <br>
+   *    Weight used to split `sm.mem.total_budget` and assign to the
+   *    consolidation buffers. The budget is split across 3 values,
+   *    `sm.mem.consolidation.buffers_weight`,
+   *    `sm.mem.consolidation.reader_weight` and
+   *    `sm.mem.consolidation.writer_weight`. <br>
+   *    **Default**: 1
+   * - `sm.mem.consolidation.reader_weight` <br>
+   *    Weight used to split `sm.mem.total_budget` and assign to the
+   *    reader query. The budget is split across 3 values,
+   *    `sm.mem.consolidation.buffers_weight`,
+   *    `sm.mem.consolidation.reader_weight` and
+   *    `sm.mem.consolidation.writer_weight`. <br>
+   *    **Default**: 3
+   *    Weight used to split `sm.mem.total_budget` and assign to the
+   *    writer query. The budget is split across 3 values,
+   *    `sm.mem.consolidation.buffers_weight`,
+   *    `sm.mem.consolidation.reader_weight` and
+   *    `sm.mem.consolidation.writer_weight`. <br>
+   *    **Default**: 2
    * - `sm.mem.reader.sparse_global_order.ratio_coords` <br>
    *    Ratio of the budget allocated for coordinates in the sparse global
    *    order reader. <br>


### PR DESCRIPTION
This implement 3 new variables for memory budgetting for consolidation. The values are a set of 3 weights that weigh each parts of the consolidation algorithm. The buffers, the read operation and the write operation. All weights are summed and ratios are computed to divide sm.mem.total_budget. The values are:
* `sm.mem.consolidation.buffers_weight`
* `sm.mem.consolidation.reader_weight`
* `sm.mem.consolidation.writer_weight`

Note this also removes the total_buffer_size deprecated setting.

---
TYPE: CONFIG
DESC: Implement consolidation memory budget variables.
