### PR TITLE
Add mutex to guard context tags

### DIFF
--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -686,6 +686,7 @@ Status StorageManagerCanonical::query_submit_async(Query* query) {
 
 Status StorageManagerCanonical::set_tag(
     const std::string& key, const std::string& value) {
+  std::lock_guard<std::mutex> lock{tags_mtx_};
   tags_[key] = value;
 
   // Tags are added to REST requests as HTTP headers.

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -418,6 +418,9 @@ class StorageManagerCanonical {
   /** Tags for the context object. */
   std::unordered_map<std::string, std::string> tags_;
 
+  /** Mutex for providing thread-safety upon setting tags. */
+  std::mutex tags_mtx_;
+
   /* ********************************* */
   /*         PRIVATE METHODS           */
   /* ********************************* */


### PR DESCRIPTION
For C-API tracing, we ended up using tags instead of config to store trace context for Jaeger traces, because we needed that to be mutable (to be able to update the tag when we'd like traces to nest). However, tags were not protected via some locking mechanism, so this PR is adding a mutex to guard `tags_` variable.

---
TYPE: NO_HISTORY
DESC: Add mutex to guard context tags
