### PR TITLE
Migrate APIs out of StorageManager: object_move, object_remove.

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3083,13 +3083,13 @@ int32_t tiledb_object_type(
 }
 
 int32_t tiledb_object_remove(tiledb_ctx_t* ctx, const char* path) {
-  throw_if_not_ok(ctx->storage_manager()->object_remove(path));
+  throw_if_not_ok(object_remove(ctx->resources(), path));
   return TILEDB_OK;
 }
 
 int32_t tiledb_object_move(
     tiledb_ctx_t* ctx, const char* old_path, const char* new_path) {
-  throw_if_not_ok(ctx->storage_manager()->object_move(old_path, new_path));
+  throw_if_not_ok(object_move(ctx->resources(), old_path, new_path));
   return TILEDB_OK;
 }
 

--- a/tiledb/sm/object/object.h
+++ b/tiledb/sm/object/object.h
@@ -78,6 +78,26 @@ Status is_group(ContextResources& resources, const URI& uri, bool* is_group);
 Status object_type(
     ContextResources& resources, const URI& uri, ObjectType* type);
 
+/**
+ * Moves a TileDB object. If `new_path` exists, it will be overwritten.
+ *
+ * @param resources the context resources.
+ * @param old_path the old path of the object.
+ * @param new_path the new path of the object.
+ * @return Status
+ */
+Status object_move(
+    ContextResources& resources, const char* old_path, const char* new_path);
+
+/**
+ * Removes a TileDB object.
+ *
+ * @param resources the context resources.
+ * @param path the path to the object to be removed.
+ * @return Status
+ */
+Status object_remove(ContextResources& resources, const char* path);
+
 }  // namespace tiledb::sm
 
 #endif

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -424,44 +424,6 @@ void StorageManagerCanonical::decrement_in_progress() {
   queries_in_progress_cv_.notify_all();
 }
 
-Status StorageManagerCanonical::object_remove(const char* path) const {
-  auto uri = URI(path);
-  if (uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
-        std::string("Cannot remove object '") + path + "'; Invalid URI"));
-
-  ObjectType obj_type;
-  throw_if_not_ok(object_type(resources_, uri, &obj_type));
-  if (obj_type == ObjectType::INVALID)
-    return logger_->status(Status_StorageManagerError(
-        std::string("Cannot remove object '") + path +
-        "'; Invalid TileDB object"));
-
-  return resources_.vfs().remove_dir(uri);
-}
-
-Status StorageManagerCanonical::object_move(
-    const char* old_path, const char* new_path) const {
-  auto old_uri = URI(old_path);
-  if (old_uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
-        std::string("Cannot move object '") + old_path + "'; Invalid URI"));
-
-  auto new_uri = URI(new_path);
-  if (new_uri.is_invalid())
-    return logger_->status(Status_StorageManagerError(
-        std::string("Cannot move object to '") + new_path + "'; Invalid URI"));
-
-  ObjectType obj_type;
-  throw_if_not_ok(object_type(resources_, old_uri, &obj_type));
-  if (obj_type == ObjectType::INVALID)
-    return logger_->status(Status_StorageManagerError(
-        std::string("Cannot move object '") + old_path +
-        "'; Invalid TileDB object"));
-
-  return resources_.vfs().move_dir(old_uri, new_uri);
-}
-
 const std::unordered_map<std::string, std::string>&
 StorageManagerCanonical::tags() const {
   return tags_;

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -199,15 +199,6 @@ class StorageManagerCanonical {
    */
   Status group_create(const std::string& group);
 
-  /** Removes a TileDB object (group, array). */
-  Status object_remove(const char* path) const;
-
-  /**
-   * Renames a TileDB object (group, array). If
-   * `new_path` exists, `new_path` will be overwritten.
-   */
-  Status object_move(const char* old_path, const char* new_path) const;
-
   /**
    * Creates a new object iterator for the input path. The iteration
    * in this case will be recursive in the entire directory tree rooted


### PR DESCRIPTION
Migrate APIs out of StorageManager: `object_move`, `object_remove`.

[sc-46731]
[sc-46732]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of `StorageManager`: `object_move`, `object_remove`.
