### PR TITLE
Do not allow adding members with relative URIs in remote groups.

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -573,11 +573,19 @@ void Group::mark_member_for_addition(
     throw GroupException("Cannot add member; Group is not open");
   }
 
+  if (remote_ && relative) {
+    // Relative URIs are supported in the capnp serialization format, but the
+    // REST server has not yet implemented the logic.
+    throw GroupException(
+        "Cannot add member; Remote groups do not support members with relative "
+        "URIs");
+  }
+
   // Check mode
   if (query_type_ != QueryType::WRITE &&
       query_type_ != QueryType::MODIFY_EXCLUSIVE) {
     throw GroupException(
-        "Cannot get member; Group was not opened in write or modify_exclusive "
+        "Cannot add member; Group was not opened in write or modify_exclusive "
         "mode");
   }
   group_details_->mark_member_for_addition(


### PR DESCRIPTION
[SC-39197](https://app.shortcut.com/tiledb-inc/story/39197/failed-to-write-group-with-relative-uri-to-rest)

Adding group members with relative URIs currently fails at the time of making the REST API call when closing the group, because the REST server has not yet implemented the logic to get the group's absolute path.

This PR improves experience by failing earlier, at the time of adding the member, if it is on a remote group and has a relative URI.

---
TYPE: BUG
DESC: Fail early when trying to add members with relative URIs in remote groups.