### PR TITLE
Improve detection of macOS deployment target, for choosing pmr implementation.

### DIFF
--- a/cmake/Modules/DetectStdPmr.cmake
+++ b/cmake/Modules/DetectStdPmr.cmake
@@ -26,16 +26,14 @@
 #
 # Detect whether polymorphic allocators are available on the system.
 
-# Special case for macOS when the MACOSX_DEPLOYMENT_TARGET is set to anything
+# Special case for macOS when the CMAKE_OSX_DEPLOYMENT_TARGET is set to anything
 # less than 14. For some reason, std::pmr is still detectable, but the resulting
 # binary dies with a dyld missing symbol error.
 
-if (ENV{MACOSX_DEPLOYMENT_TARGET})
-  if (ENV{MACOSX_DEPLOYMENT_TARGET} STRLESS "14")
-    set(TILEDB_USE_CPP17_PMR ON)
-    message(STATUS "Using vendored cpp17::pmr for polymorphic allocators")
-    return()
-  endif()
+if (APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET LESS 14)
+  set(TILEDB_USE_CPP17_PMR ON)
+  message(STATUS "Using vendored cpp17::pmr for polymorphic allocators because of macOS deployment target ${CMAKE_OSX_DEPLOYMENT_TARGET} < 14")
+  return()
 endif()
 
 # Otherwise, if we're not building a targeted macOS version, we just detect


### PR DESCRIPTION
SC-48427

#4995 changed detection of `std::pmr` from trying to _run_ a C++ file referencing pmr APIs, to trying to _compile_ it, which works in cross compilation scenarios and fixed Conda failures for reasons I do not understand.

However in macOS versions prior to 14 the pmr headers exist, but binaries compiled with it fail ot run. There was already a check to force using the vendored pmr in such versions but it was defective, because it checked the `MACOS_DEPLOYMENT_TARGET` environment variable, which might not exist. Before #4995, the runtime failure on these versions would be caught by `try_run`. This PR updates the detection script to use the [`CMAKE_OSX_DEPLOYMENT_TARGET`](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) variable, which gets automatically filled by CMake either from the aforementioned environment variable or automatically.

---
TYPE: NO_HISTORY
