### PR TITLE
Remove Status_StorageManagerError and Migrate group_metadata_vacuum out of StorageManager.

### DIFF
--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -587,7 +587,7 @@ capi_return_t tiledb_group_vacuum_metadata(
   ensure_group_uri_argument_is_valid(group_uri);
 
   auto cfg = (config == nullptr) ? ctx->config() : config->config();
-  ctx->storage_manager()->group_metadata_vacuum(group_uri, cfg);
+  sm::Group::vacuum_metadata(ctx->resources(), group_uri, cfg);
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
+++ b/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
@@ -61,10 +61,6 @@ class StorageManagerStub {
   inline Status cancel_all_tasks() {
     return Status{};
   }
-  inline Status group_metadata_vacuum(const char*, const Config&) {
-    throw std::logic_error(
-        "StorageManagerStub does not support group metadata vacuum");
-  }
   inline Status set_tag(const std::string&, const std::string&) {
     return Status{};
   }

--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -5,7 +5,7 @@
  *
  * The BSD License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *            Copyright (c) 2011 The LevelDB Authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -60,8 +60,7 @@
 #include "tiledb/common/common-std.h"
 #include "tiledb/common/heap_memory.h"
 
-namespace tiledb {
-namespace common {
+namespace tiledb::common {
 
 #define RETURN_NOT_OK(s) \
   do {                   \
@@ -250,10 +249,6 @@ inline Status Status_Ok() {
 inline Status Status_Error(const std::string& msg) {
   return {"Error", msg};
 };
-/** Return a StorageManager error class Status with a given message **/
-inline Status Status_StorageManagerError(const std::string& msg) {
-  return {"[TileDB::StorageManager] Error", msg};
-}
 /** Return a FragmentMetadata error class Status with a given message **/
 inline Status Status_FragmentMetadataError(const std::string& msg) {
   return {"[TileDB::FragmentMetadata] Error", msg};
@@ -433,7 +428,6 @@ inline Status Status_TaskError(const std::string& msg) {
 inline Status Status_RangeError(const std::string& msg) {
   return {"[TileDB::Range] Error", msg};
 }
-}  // namespace common
-}  // namespace tiledb
+}  // namespace tiledb::common
 
 #endif  // TILEDB_STATUS_H

--- a/tiledb/common/logger.cc
+++ b/tiledb/common/logger.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -145,10 +145,6 @@ void Logger::fatal(const char* msg) {
 Status Logger::status(const Status& st) {
   logger_->error(st.message());
   return st;
-}
-
-void Logger::status_no_return_value(const Status& st) {
-  logger_->error(st.message());
 }
 
 void Logger::trace(const std::string& msg) {

--- a/tiledb/common/logger.h
+++ b/tiledb/common/logger.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,8 +48,7 @@ namespace spdlog {
 class logger;
 }
 
-namespace tiledb {
-namespace common {
+namespace tiledb::common {
 
 /** Definition of class Logger. */
 class Logger {
@@ -316,13 +315,6 @@ class Logger {
   Status status(const Status& st);
 
   /**
-   * Log a message from a Status object without returning it.
-   *
-   * @param st The Status object to log
-   */
-  void status_no_return_value(const Status& st);
-
-  /**
    * Log an error and exit with a non-zero status.
    *
    * @param msg The string to log.
@@ -457,8 +449,7 @@ inline Status logger_format_from_string(
   return Status::Ok();
 }
 
-}  // namespace common
-}  // namespace tiledb
+}  // namespace tiledb::common
 
 // Also include the public-permissible logger functions here.
 #include "tiledb/common/logger_public.h"

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -1200,19 +1200,18 @@ class Array {
       std::unordered_map<std::string, shared_ptr<ArraySchema>>>
   open_for_reads_without_fragments();
 
-  /** Opens an array for writes.
+  /**
+   * Opens an array for writes.
    *
    * @param array The array to open.
-   * @return tuple of Status, latest ArraySchema and map of all array schemas
-   *        Status Ok on success, else error
+   * @return tuple of latest ArraySchema and map of all array schemas
    *        ArraySchema The array schema to be retrieved after the
    *          array is opened.
    *        ArraySchemaMap Map of all array schemas found keyed by name
    */
   tuple<
-      Status,
-      optional<shared_ptr<ArraySchema>>,
-      optional<std::unordered_map<std::string, shared_ptr<ArraySchema>>>>
+      shared_ptr<ArraySchema>,
+      std::unordered_map<std::string, shared_ptr<ArraySchema>>>
   open_for_writes();
 
   /** Clears the cached max buffer sizes and subarray. */

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -120,7 +120,7 @@ Status ArrayMetaConsolidator::consolidate(
 
 void ArrayMetaConsolidator::vacuum(const char* array_name) {
   if (array_name == nullptr) {
-    throw Status_StorageManagerError(
+    throw std::invalid_argument(
         "Cannot vacuum array metadata; Array name cannot be null");
   }
 

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -103,7 +103,7 @@ Status CommitsConsolidator::consolidate(
 
 void CommitsConsolidator::vacuum(const char* array_name) {
   if (array_name == nullptr) {
-    throw Status_StorageManagerError(
+    throw std::invalid_argument(
         "Cannot vacuum array metadata; Array name cannot be null");
   }
 

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -181,7 +181,7 @@ Status FragmentMetaConsolidator::consolidate(
 
 void FragmentMetaConsolidator::vacuum(const char* array_name) {
   if (array_name == nullptr) {
-    throw Status_StorageManagerError(
+    throw std::invalid_argument(
         "Cannot vacuum fragment metadata; Array name cannot be null");
   }
 

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -110,7 +110,7 @@ Status GroupMetaConsolidator::consolidate(
 
 void GroupMetaConsolidator::vacuum(const char* group_name) {
   if (group_name == nullptr) {
-    throw Status_StorageManagerError(
+    throw std::invalid_argument(
         "Cannot vacuum group metadata; Group name cannot be null");
   }
 

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -574,31 +574,6 @@ void Group::set_metadata_loaded(const bool metadata_loaded) {
   metadata_loaded_ = metadata_loaded;
 }
 
-Status Group::consolidate_metadata(
-    ContextResources& resources, const char* group_name, const Config& config) {
-  // Check group URI
-  URI group_uri(group_name);
-  if (group_uri.is_invalid()) {
-    throw GroupException("Cannot consolidate group metadata; Invalid URI");
-  }
-  // Check if group exists
-  ObjectType obj_type;
-  throw_if_not_ok(object_type(resources, group_uri, &obj_type));
-
-  if (obj_type != ObjectType::GROUP) {
-    throw GroupException(
-        "Cannot consolidate group metadata; Group does not exist");
-  }
-
-  // Consolidate
-  // Encryption credentials are loaded by Group from config
-  StorageManager sm(resources, resources.logger(), config);
-  auto consolidator =
-      Consolidator::create(ConsolidationMode::GROUP_META, config, &sm);
-  return consolidator->consolidate(
-      group_name, EncryptionType::NO_ENCRYPTION, nullptr, 0);
-}
-
 const EncryptionKey* Group::encryption_key() const {
   return encryption_key_.get();
 }

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -574,6 +574,53 @@ void Group::set_metadata_loaded(const bool metadata_loaded) {
   metadata_loaded_ = metadata_loaded;
 }
 
+Status Group::consolidate_metadata(
+    ContextResources& resources, const char* group_name, const Config& config) {
+  // Check group URI
+  URI group_uri(group_name);
+  if (group_uri.is_invalid()) {
+    throw GroupException("Cannot consolidate group metadata; Invalid URI");
+  }
+  // Check if group exists
+  ObjectType obj_type;
+  throw_if_not_ok(object_type(resources, group_uri, &obj_type));
+
+  if (obj_type != ObjectType::GROUP) {
+    throw GroupException(
+        "Cannot consolidate group metadata; Group does not exist");
+  }
+
+  // Consolidate
+  // Encryption credentials are loaded by Group from config
+  StorageManager sm(resources, resources.logger(), config);
+  auto consolidator =
+      Consolidator::create(ConsolidationMode::GROUP_META, config, &sm);
+  return consolidator->consolidate(
+      group_name, EncryptionType::NO_ENCRYPTION, nullptr, 0);
+}
+
+void Group::vacuum_metadata(
+    ContextResources& resources, const char* group_name, const Config& config) {
+  // Check group URI
+  URI group_uri(group_name);
+  if (group_uri.is_invalid()) {
+    throw GroupException("Cannot vacuum group metadata; Invalid URI");
+  }
+
+  // Check if group exists
+  ObjectType obj_type;
+  throw_if_not_ok(object_type(resources, group_uri, &obj_type));
+
+  if (obj_type != ObjectType::GROUP) {
+    throw GroupException("Cannot vacuum group metadata; Group does not exist");
+  }
+
+  StorageManager sm(resources, resources.logger(), config);
+  auto consolidator =
+      Consolidator::create(ConsolidationMode::GROUP_META, config, &sm);
+  consolidator->vacuum(group_name);
+}
+
 const EncryptionKey* Group::encryption_key() const {
   return encryption_key_.get();
 }

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -238,22 +238,6 @@ class Group {
    */
   void set_metadata_loaded(const bool metadata_loaded);
 
-  /**
-   * Consolidates the metadata of a group into a single file.
-   *
-   * @param resources The context resources.
-   * @param group_name The name of the group whose metadata will be
-   *     consolidated.
-   * @param config Configuration parameters for the consolidation
-   *     (`nullptr` means default, which will use the config associated with
-   *      this instance).
-   * @return Status
-   */
-  static Status consolidate_metadata(
-      ContextResources& resources,
-      const char* group_name,
-      const Config& config);
-
   /** Returns a constant pointer to the encryption key. */
   const EncryptionKey* encryption_key() const;
 

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -238,6 +238,37 @@ class Group {
    */
   void set_metadata_loaded(const bool metadata_loaded);
 
+  /**
+   * Consolidates the metadata of a group into a single file.
+   *
+   * @param resources The context resources.
+   * @param group_name The name of the group whose metadata will be
+   *     consolidated.
+   * @param config Configuration parameters for the consolidation
+   *     (`nullptr` means default, which will use the config associated with
+   *      this instance).
+   * @return Status
+   */
+  static Status consolidate_metadata(
+      ContextResources& resources,
+      const char* group_name,
+      const Config& config);
+
+  /**
+   * Vacuums the consolidated metadata files of a group.
+   *
+   * @param resources The context resources.
+   * @param group_name The name of the group whose metadata will be
+   *     vacuumed.
+   * @param config Configuration parameters for vacuuming
+   *     (`nullptr` means default, which will use the config associated with
+   *      this instance).
+   */
+  static void vacuum_metadata(
+      ContextResources& resources,
+      const char* group_name,
+      const Config& config);
+
   /** Returns a constant pointer to the encryption key. */
   const EncryptionKey* encryption_key() const;
 

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -273,7 +273,7 @@ Status UnorderedWriter::check_coord_dups() const {
         return Status::Ok();
       });
 
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
+  RETURN_NOT_OK_ELSE(status, logger_->error(status.message()));
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -345,7 +345,7 @@ Status WriterBase::calculate_hilbert_values(
         return Status::Ok();
       });
 
-  RETURN_NOT_OK_ELSE(status, logger_->status_no_return_value(status));
+  RETURN_NOT_OK_ELSE(status, logger_->error(status.message()));
 
   return Status::Ok();
 }

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,8 +37,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 static common::Logger::Level get_log_level(const Config& config);
 
@@ -67,7 +66,7 @@ Context::Context(const Config& config)
   /*
    * Logger class is not yet C.41-compliant
    */
-  throw_if_not_ok(init_loggers(config));
+  init_loggers(config);
 }
 
 /* ****************************** */
@@ -111,9 +110,10 @@ Status Context::get_config_thread_count(
       config.get<uint64_t>("sm.num_async_threads", &num_async_threads, &found));
   if (found) {
     config_thread_count = std::max(config_thread_count, num_async_threads);
-    logger_->status_no_return_value(Status_StorageManagerError(
+    logger_->error(
+        "[Context::get_config_thread_count] "
         "Config parameter \"sm.num_async_threads\" has been removed; use "
-        "config parameter \"sm.compute_concurrency_level\"."));
+        "config parameter \"sm.compute_concurrency_level\".");
   }
 
   uint64_t num_reader_threads{0};
@@ -121,9 +121,10 @@ Status Context::get_config_thread_count(
       "sm.num_reader_threads", &num_reader_threads, &found));
   if (found) {
     config_thread_count = std::max(config_thread_count, num_reader_threads);
-    logger_->status_no_return_value(Status_StorageManagerError(
+    logger_->error(
+        "[Context::get_config_thread_count] "
         "Config parameter \"sm.num_reader_threads\" has been removed; use "
-        "config parameter \"sm.compute_concurrency_level\"."));
+        "config parameter \"sm.compute_concurrency_level\".");
   }
 
   uint64_t num_writer_threads{0};
@@ -131,9 +132,10 @@ Status Context::get_config_thread_count(
       "sm.num_writer_threads", &num_writer_threads, &found));
   if (found) {
     config_thread_count = std::max(config_thread_count, num_writer_threads);
-    logger_->status_no_return_value(Status_StorageManagerError(
+    logger_->error(
+        "[Context::get_config_thread_count] "
         "Config parameter \"sm.num_writer_threads\" has been removed; use "
-        "config parameter \"sm.compute_concurrency_level\"."));
+        "config parameter \"sm.compute_concurrency_level\".");
   }
 
   uint64_t num_vfs_threads{0};
@@ -141,9 +143,10 @@ Status Context::get_config_thread_count(
       config.get<uint64_t>("sm.num_vfs_threads", &num_vfs_threads, &found));
   if (found) {
     config_thread_count = std::max(config_thread_count, num_vfs_threads);
-    logger_->status_no_return_value(Status_StorageManagerError(
+    logger_->error(
+        "[Context::get_config_thread_count] "
         "Config parameter \"sm.num_vfs_threads\" has been removed; use "
-        "config parameter \"sm.io_concurrency_level\"."));
+        "config parameter \"sm.io_concurrency_level\".");
   }
 
   // The "sm.num_tbb_threads" has been deprecated. Users may still be setting
@@ -156,9 +159,10 @@ Status Context::get_config_thread_count(
   if (found) {
     config_thread_count =
         std::max(config_thread_count, static_cast<uint64_t>(num_tbb_threads));
-    logger_->status_no_return_value(Status_StorageManagerError(
+    logger_->error(
+        "[Context::get_config_thread_count] "
         "Config parameter \"sm.num_tbb_threads\" has been removed; use "
-        "config parameter \"sm.io_concurrency_level\"."));
+        "config parameter \"sm.io_concurrency_level\".");
   }
 
   config_thread_count_ret = static_cast<size_t>(config_thread_count);
@@ -210,16 +214,16 @@ size_t Context::get_io_thread_count(const Config& config) {
       std::max(config_thread_count, io_concurrency_level));
 }
 
-Status Context::init_loggers(const Config& config) {
+void Context::init_loggers(const Config& config) {
   // temporarily set level to error so that possible errors reading
   // configuration are visible to the user
   logger_->set_level(Logger::Level::ERR);
 
   const char* format_conf;
-  RETURN_NOT_OK(config.get("config.logging_format", &format_conf));
+  throw_if_not_ok(config.get("config.logging_format", &format_conf));
   assert(format_conf != nullptr);
   Logger::Format format = Logger::Format::DEFAULT;
-  RETURN_NOT_OK(logger_format_from_string(format_conf, &format));
+  throw_if_not_ok(logger_format_from_string(format_conf, &format));
 
   global_logger(format);
   logger_->set_format(static_cast<Logger::Format>(format));
@@ -227,18 +231,16 @@ Status Context::init_loggers(const Config& config) {
   // set logging level from config
   bool found = false;
   uint32_t level = static_cast<unsigned int>(Logger::Level::ERR);
-  RETURN_NOT_OK(config.get<uint32_t>("config.logging_level", &level, &found));
+  throw_if_not_ok(config.get<uint32_t>("config.logging_level", &level, &found));
   assert(found);
   if (level > static_cast<unsigned int>(Logger::Level::TRACE)) {
-    return logger_->status(Status_StorageManagerError(
+    throw std::invalid_argument(
         "Cannot set logger level; Unsupported level:" + std::to_string(level) +
-        "set in configuration"));
+        "set in configuration");
   }
 
   global_logger().set_level(static_cast<Logger::Level>(level));
   logger_->set_level(static_cast<Logger::Level>(level));
-
-  return Status::Ok();
 }
 
 common::Logger::Level get_log_level(const Config& config) {
@@ -260,5 +262,4 @@ common::Logger::Level get_log_level(const Config& config) {
   }
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -39,6 +39,13 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
+class ContextException : public StatusException {
+ public:
+  explicit ContextException(const std::string& message)
+      : StatusException("Context", message) {
+  }
+};
+
 static common::Logger::Level get_log_level(const Config& config);
 
 /* ****************************** */
@@ -234,7 +241,7 @@ void Context::init_loggers(const Config& config) {
   throw_if_not_ok(config.get<uint32_t>("config.logging_level", &level, &found));
   assert(found);
   if (level > static_cast<unsigned int>(Logger::Level::TRACE)) {
-    throw std::invalid_argument(
+    throw ContextException(
         "Cannot set logger level; Unsupported level:" + std::to_string(level) +
         "set in configuration");
   }

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -202,9 +202,8 @@ class Context {
    * Initializes global and local logger.
    *
    * @param config The configuration parameters.
-   * @return Status
    */
-  Status init_loggers(const Config& config);
+  void init_loggers(const Config& config);
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -250,17 +250,6 @@ class StorageManagerCanonical {
     return resources_;
   }
 
-  /**
-   * Vacuums the consolidated metadata files of a group.
-   *
-   * @param group_name The name of the group whose metadata will be
-   *     vacuumed.
-   * @param config Configuration parameters for vacuuming
-   *     (`nullptr` means default, which will use the config associated with
-   *      this instance).
-   */
-  void group_metadata_vacuum(const char* group_name, const Config& config);
-
  private:
   /* ********************************* */
   /*        PRIVATE DATATYPES          */


### PR DESCRIPTION
Remove `Status_StorageManagerError` and its occurrences.
Related subsequent fixes:
* Remove `Logger::status_no_return_value` and replace occurrences with `Logger::error`.
* Remove `Status` and `std::optional` from returned tuple of `Array::open_for_writes`.
* de-`Status` `Context::init_loggers`.
* Migrate `StorageManagerCanonical::group_metadata_vacuum` -> `static Group::vacuum_metadata`.

[sc-48630]
[sc-48639]

---
TYPE: NO_HISTORY
DESC: Remove `Status_StorageManagerError` and Migrate `group_metadata_vacuum` out of `StorageManager`. 
