### PR TITLE
Correct defective return value in `Posix::ls_with_sizes`

### DIFF
--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -311,7 +311,7 @@ tuple<Status, optional<std::vector<directory_entry>>> Posix::ls_with_sizes(
   struct dirent* next_path = nullptr;
   DIR* dir = opendir(path.c_str());
   if (dir == nullptr) {
-    return {Status::Ok(), nullopt};
+    return {Status::Ok(), std::vector<directory_entry{}};
   }
 
   std::vector<directory_entry> entries;

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -311,7 +311,7 @@ tuple<Status, optional<std::vector<directory_entry>>> Posix::ls_with_sizes(
   struct dirent* next_path = nullptr;
   DIR* dir = opendir(path.c_str());
   if (dir == nullptr) {
-    return {Status::Ok(), std::vector<directory_entry{}};
+    return {Status::Ok(), std::vector<directory_entry>{}};
   }
 
   std::vector<directory_entry> entries;


### PR DESCRIPTION
PR #2671 introduced `ls_with_sizes`. There was a defect in `class Posix` where an empty directory returned `nullopt` instead of an empty vector. This PR corrects that defect.

I audited the original PR for possible related errors. This was the only one.

[sc-48646]

---
TYPE: BUG
DESC: Correct defective return value in `Posix::ls_with_sizes`
