### PR TITLE
Migrate APIs out of StorageManager: group_metadata_consolidate.

### DIFF
--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -576,8 +576,8 @@ capi_return_t tiledb_group_consolidate_metadata(
   ensure_group_uri_argument_is_valid(group_uri);
 
   auto cfg = (config == nullptr) ? ctx->config() : config->config();
-  throw_if_not_ok(
-      ctx->storage_manager()->group_metadata_consolidate(group_uri, cfg));
+  throw_if_not_ok(tiledb::sm::Group::consolidate_metadata(
+      ctx->resources(), group_uri, cfg));
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
+++ b/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
@@ -61,10 +61,6 @@ class StorageManagerStub {
   inline Status cancel_all_tasks() {
     return Status{};
   }
-  inline Status group_metadata_consolidate(const char*, const Config&) {
-    throw std::logic_error(
-        "StorageManagerStub does not support group metadata consolidation");
-  }
   inline Status group_metadata_vacuum(const char*, const Config&) {
     throw std::logic_error(
         "StorageManagerStub does not support group metadata vacuum");

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -36,6 +36,7 @@
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/enums/query_type.h"
@@ -571,6 +572,31 @@ Metadata* Group::unsafe_metadata() {
 
 void Group::set_metadata_loaded(const bool metadata_loaded) {
   metadata_loaded_ = metadata_loaded;
+}
+
+Status Group::consolidate_metadata(
+    ContextResources& resources, const char* group_name, const Config& config) {
+  // Check group URI
+  URI group_uri(group_name);
+  if (group_uri.is_invalid()) {
+    throw GroupException("Cannot consolidate group metadata; Invalid URI");
+  }
+  // Check if group exists
+  ObjectType obj_type;
+  throw_if_not_ok(object_type(resources, group_uri, &obj_type));
+
+  if (obj_type != ObjectType::GROUP) {
+    throw GroupException(
+        "Cannot consolidate group metadata; Group does not exist");
+  }
+
+  // Consolidate
+  // Encryption credentials are loaded by Group from config
+  StorageManager sm(resources, resources.logger(), config);
+  auto consolidator =
+      Consolidator::create(ConsolidationMode::GROUP_META, config, &sm);
+  return consolidator->consolidate(
+      group_name, EncryptionType::NO_ENCRYPTION, nullptr, 0);
 }
 
 const EncryptionKey* Group::encryption_key() const {

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -238,6 +238,22 @@ class Group {
    */
   void set_metadata_loaded(const bool metadata_loaded);
 
+  /**
+   * Consolidates the metadata of a group into a single file.
+   *
+   * @param resources The context resources.
+   * @param group_name The name of the group whose metadata will be
+   *     consolidated.
+   * @param config Configuration parameters for the consolidation
+   *     (`nullptr` means default, which will use the config associated with
+   *      this instance).
+   * @return Status
+   */
+  static Status consolidate_metadata(
+      ContextResources& resources,
+      const char* group_name,
+      const Config& config);
+
   /** Returns a constant pointer to the encryption key. */
   const EncryptionKey* encryption_key() const;
 

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -640,31 +640,6 @@ Status StorageManagerCanonical::set_default_tags() {
   return Status::Ok();
 }
 
-Status StorageManagerCanonical::group_metadata_consolidate(
-    const char* group_name, const Config& config) {
-  // Check group URI
-  URI group_uri(group_name);
-  if (group_uri.is_invalid()) {
-    throw StorageManagerException(
-        "Cannot consolidate group metadata; Invalid URI");
-  }
-  // Check if group exists
-  ObjectType obj_type;
-  throw_if_not_ok(object_type(resources_, group_uri, &obj_type));
-
-  if (obj_type != ObjectType::GROUP) {
-    throw StorageManagerException(
-        "Cannot consolidate group metadata; Group does not exist");
-  }
-
-  // Consolidate
-  // Encryption credentials are loaded by Group from config
-  auto consolidator =
-      Consolidator::create(ConsolidationMode::GROUP_META, config, this);
-  return consolidator->consolidate(
-      group_name, EncryptionType::NO_ENCRYPTION, nullptr, 0);
-}
-
 void StorageManagerCanonical::group_metadata_vacuum(
     const char* group_name, const Config& config) {
   // Check group URI

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -291,19 +291,6 @@ class StorageManagerCanonical {
   }
 
   /**
-   * Consolidates the metadata of a group into a single file.
-   *
-   * @param group_name The name of the group whose metadata will be
-   *     consolidated.
-   * @param config Configuration parameters for the consolidation
-   *     (`nullptr` means default, which will use the config associated with
-   *      this instance).
-   * @return Status
-   */
-  Status group_metadata_consolidate(
-      const char* group_name, const Config& config);
-
-  /**
    * Vacuums the consolidated metadata files of a group.
    *
    * @param group_name The name of the group whose metadata will be


### PR DESCRIPTION
Migrate APIs out of `StorageManager`: `group_metadata_consolidate`.

[sc-48743]

---
TYPE: NO_HISTORY
DESC: Migrate APIs out of `StorageManager`: `group_metadata_consolidate`.
