### PR TITLE
Remove statuses from `ls_with_sizes` and do not mask failures on POSIX.

### DIFF
--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -92,8 +92,7 @@ regex_make_shared = re.compile(r"std::make_shared<")
 
 # Contains per-file exceptions to violations of "make_shared".
 make_shared_exceptions = {
-    "*": ["tdb::make_shared"],
-    "*": ["tiledb::common::make_shared"],
+    "*": ["tdb::make_shared", "tiledb::common::make_shared"],
 }
 
 # Match C++ unique_ptr objects.
@@ -148,7 +147,7 @@ violation_checkers = [
 
 
 def iter_file_violations(file_path: str) -> Iterable[Violation]:
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         for line_num, line in enumerate(f):
             line = line.strip()
             for checker in violation_checkers:

--- a/scripts/find_heap_api_violations.py
+++ b/scripts/find_heap_api_violations.py
@@ -103,7 +103,7 @@ regex_unique_ptr = re.compile(r"unique_ptr<")
 unique_ptr_exceptions = {
     "*": ["tdb_unique_ptr", "tiledb_unique_ptr", "tdb::pmr::unique_ptr"],
     "zstd_compressor.h": ["std::unique_ptr<ZSTD_DCtx, decltype(&ZSTD_freeDCtx)> ctx_;", "std::unique_ptr<ZSTD_CCtx, decltype(&ZSTD_freeCCtx)> ctx_;"],
-    "posix.cc": ["static std::unique_ptr<char, decltype(&free)> cwd_(getcwd(nullptr, 0), free);"],
+    "posix.cc": ["std::unique_ptr<DIR, UniqueDIRDeleter>", "static std::unique_ptr<char, decltype(&free)> cwd_(getcwd(nullptr, 0), free);"],
     "curl.h": ["std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>"],
     "pmr.h": ["std::unique_ptr", "unique_ptr<Tp> make_unique("],
 }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -339,9 +339,7 @@ TEMPLATE_LIST_TEST_CASE(
     std::string s = "abcdef";
     require_tiledb_ok(vfs.write(ls_file, s.data(), s.size()));
     require_tiledb_ok(vfs.close_file(ls_file));
-    auto&& [status, opt_children] = vfs.ls_with_sizes(ls_dir);
-    require_tiledb_ok(status);
-    auto children = opt_children.value();
+    auto children = vfs.ls_with_sizes(ls_dir);
 #ifdef _WIN32
     // Normalization only for Windows
     ls_file = URI(tiledb::sm::path_win::uri_from_path(ls_file.to_string()));
@@ -599,9 +597,7 @@ TEST_CASE("VFS: test ls_with_sizes", "[vfs][ls-with-sizes]") {
   require_tiledb_ok(vfs_ls.write(URI(subdir_file), s2.data(), s2.size()));
 
   // List
-  auto&& [status, rv] = vfs_ls.ls_with_sizes(URI(dir));
-  auto children = *rv;
-  require_tiledb_ok(status);
+  auto children = vfs_ls.ls_with_sizes(URI(dir));
 
 #ifdef _WIN32
   // Normalization only for Windows

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -451,12 +451,16 @@ VFSTestBase::VFSTestBase(
 }
 
 VFSTestBase::~VFSTestBase() {
-  if (vfs_.supports_uri_scheme(temp_dir_)) {
-    bool is_dir = false;
-    vfs_.is_dir(temp_dir_, &is_dir).ok();
-    if (is_dir) {
-      vfs_.remove_dir(temp_dir_).ok();
+  try {
+    if (vfs_.supports_uri_scheme(temp_dir_)) {
+      bool is_dir = false;
+      vfs_.is_dir(temp_dir_, &is_dir).ok();
+      if (is_dir) {
+        vfs_.remove_dir(temp_dir_).ok();
+      }
     }
+  } catch (const std::exception& e) {
+    // Suppress exceptions in destructors.
   }
 }
 

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -583,9 +583,7 @@ const std::set<std::string>& ArrayDirectory::dir_names() {
 }
 
 std::vector<URI> ArrayDirectory::ls(const URI& uri) const {
-  auto&& [st, opt_dir_entries] = resources_.get().vfs().ls_with_sizes(uri);
-  throw_if_not_ok(st);
-  auto dir_entries = opt_dir_entries.value();
+  auto dir_entries = resources_.get().vfs().ls_with_sizes(uri);
   auto dirs = dir_names();
   std::vector<URI> uris;
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -392,8 +392,7 @@ class Azure {
    * @param max_paths The maximum number of paths to be retrieved
    * @return A list of directory_entry objects
    */
-  tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(
+  std::vector<filesystem::directory_entry> ls_with_sizes(
       const URI& uri,
       const std::string& delimiter = "/",
       int max_paths = -1) const;

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -115,8 +115,8 @@ class FilesystemBase {
    * @param parent The target directory to list.
    * @return All entries that are contained in the parent
    */
-  virtual tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(const URI& parent) const = 0;
+  virtual std::vector<filesystem::directory_entry> ls_with_sizes(
+      const URI& parent) const = 0;
 
   /**
    * Renames a file.

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -268,8 +268,7 @@ class GCS {
    * @param max_paths The maximum number of paths to be retrieved
    * @return A list of directory_entry objects
    */
-  tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(
+  std::vector<filesystem::directory_entry> ls_with_sizes(
       const URI& uri,
       const std::string& delimiter = "/",
       int max_paths = -1) const;

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -37,6 +37,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "tiledb/common/exception/exception.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
 
@@ -51,6 +52,14 @@ class directory_entry;
 namespace sm {
 
 class URI;
+
+/** Class for MemFS status exceptions. */
+class MemFSException : public StatusException {
+ public:
+  explicit MemFSException(const std::string& msg)
+      : StatusException("MemFS", msg) {
+  }
+};
 
 /**
  * The in-memory filesystem.
@@ -139,10 +148,9 @@ class MemFilesystem {
    * Lists files and files information under path
    *
    * @param path  The parent path to list sub-paths
-   * @return Status
+   * @return A list of directory_entry objects
    */
-  tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(const URI& path) const;
+  std::vector<filesystem::directory_entry> ls_with_sizes(const URI& path) const;
 
   /**
    * Move a given filesystem path.

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -61,7 +61,9 @@ namespace tiledb::sm {
 struct UniqueDIRDeleter {
   void operator()(DIR* dir) {
     if (dir != nullptr) {
-      closedir(dir);
+      // The only possible error is EBADF, which should not happen here.
+      [[maybe_unused]] auto status = closedir(dir);
+      assert(status == 0);
     }
   }
 };

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -310,7 +310,14 @@ std::vector<directory_entry> Posix::ls_with_sizes(const URI& uri) const {
   struct dirent* next_path = nullptr;
   DIR* dir = opendir(path.c_str());
   if (dir == nullptr) {
-    return {};
+    auto last_error = errno;
+    // If the directory does not exist, return an empty vector. Otherwise we
+    // have an error.
+    if (last_error == ENOENT) {
+      return {};
+    }
+    throw IOError(
+        std::string("Cannot open directory; ") + strerror(last_error));
   }
 
   std::vector<directory_entry> entries;

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -260,8 +260,8 @@ class Posix : public FilesystemBase {
    * @param uri The parent path to list sub-paths.
    * @return A list of directory_entry objects
    */
-  tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(const URI& uri) const override;
+  std::vector<filesystem::directory_entry> ls_with_sizes(
+      const URI& uri) const override;
 
   /**
    * Lists objects and object information that start with `prefix`, invoking

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -791,8 +791,7 @@ class S3 : FilesystemBase {
    * @param parent The target directory to list.
    * @return All entries that are contained in the parent
    */
-  tuple<Status, optional<std::vector<directory_entry>>> ls_with_sizes(
-      const URI& parent) const override;
+  std::vector<directory_entry> ls_with_sizes(const URI& parent) const override;
 
   /**
    * Disconnects a S3 client.
@@ -889,9 +888,9 @@ class S3 : FilesystemBase {
    * @param prefix The parent path to list sub-paths.
    * @param delimiter The uri is truncated to the first delimiter.
    * @param max_paths The maximum number of paths to be retrieved.
-   * @return Status tuple where second is a list of directory_entry objects.
+   * @return A list of directory_entry objects.
    */
-  tuple<Status, optional<std::vector<directory_entry>>> ls_with_sizes(
+  std::vector<directory_entry> ls_with_sizes(
       const URI& prefix, const std::string& delimiter, int max_paths) const;
 
   /**

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -749,9 +749,9 @@ std::vector<directory_entry> VFS::ls_with_sizes(const URI& parent) const {
 #endif
   } else if (parent.is_hdfs()) {
 #ifdef HAVE_HDFS
-    Status st;
-    std::tie(st, entries) = hdfs_->ls_with_sizes(parent);
+    auto&& [st, entries_optional] = hdfs_->ls_with_sizes(parent);
     throw_if_not_ok(st);
+    entries = *std::move(entries_optional);
 #else
     throw BuiltWithout("HDFS");
 #endif

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -222,10 +222,8 @@ Status VFS::dir_size(const URI& dir_name, uint64_t* dir_size) const {
   do {
     auto uri = to_ls.front();
     to_ls.pop_front();
-    auto&& [st, children] = ls_with_sizes(uri);
-    RETURN_NOT_OK(st);
 
-    for (const auto& child : *children) {
+    for (const auto& child : ls_with_sizes(uri)) {
       if (!child.is_directory()) {
         *dir_size += child.file_size();
       } else {
@@ -703,90 +701,74 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
 
 Status VFS::ls(const URI& parent, std::vector<URI>* uris) const {
   stats_->add_counter("ls_num", 1);
-  auto&& [st, entries] = ls_with_sizes(parent);
-  RETURN_NOT_OK(st);
 
-  for (auto& fs : *entries) {
+  for (auto& fs : ls_with_sizes(parent)) {
     uris->emplace_back(fs.path().native());
   }
 
   return Status::Ok();
 }
 
-tuple<Status, optional<std::vector<directory_entry>>> VFS::ls_with_sizes(
-    const URI& parent) const {
+std::vector<directory_entry> VFS::ls_with_sizes(const URI& parent) const {
   // Noop if `parent` is not a directory, do not error out.
   // For S3, GCS and Azure, `ls` on a non-directory will just
   // return an empty `uris` vector.
   if (!(parent.is_s3() || parent.is_gcs() || parent.is_azure())) {
     bool flag = false;
-    RETURN_NOT_OK_TUPLE(this->is_dir(parent, &flag), nullopt);
+    throw_if_not_ok(this->is_dir(parent, &flag));
 
     if (!flag) {
-      return {Status::Ok(), std::vector<directory_entry>()};
+      return {};
     }
   }
 
-  optional<std::vector<directory_entry>> entries;
+  std::vector<directory_entry> entries;
   if (parent.is_file()) {
 #ifdef _WIN32
-    Status st;
-    std::tie(st, entries) = win_.ls_with_sizes(parent);
+    entries = win_.ls_with_sizes(parent);
 #else
-    Status st;
-    std::tie(st, entries) = posix_.ls_with_sizes(parent);
+    entries = posix_.ls_with_sizes(parent);
 #endif
-    RETURN_NOT_OK_TUPLE(st, nullopt);
   } else if (parent.is_s3()) {
 #ifdef HAVE_S3
-    Status st;
-    std::tie(st, entries) = s3().ls_with_sizes(parent);
+    entries = s3().ls_with_sizes(parent);
 #else
-    auto st = Status_VFSError("TileDB was built without S3 support");
+    throw BuiltWithout("S3");
 #endif
-    RETURN_NOT_OK_TUPLE(st, nullopt);
   } else if (parent.is_azure()) {
 #ifdef HAVE_AZURE
-    Status st;
-    std::tie(st, entries) = azure_.ls_with_sizes(parent);
+    entries = azure_.ls_with_sizes(parent);
 #else
-    auto st = Status_VFSError("TileDB was built without Azure support");
+    throw BuiltWithout("Azure");
 #endif
-    RETURN_NOT_OK_TUPLE(st, nullopt);
   } else if (parent.is_gcs()) {
 #ifdef HAVE_GCS
-    Status st;
-    std::tie(st, entries) = gcs_.ls_with_sizes(parent);
+    entries = gcs_.ls_with_sizes(parent);
 #else
-    auto st = Status_VFSError("TileDB was built without GCS support");
+    throw BuiltWithout("GCS");
 #endif
-    RETURN_NOT_OK_TUPLE(st, nullopt);
   } else if (parent.is_hdfs()) {
 #ifdef HAVE_HDFS
     Status st;
     std::tie(st, entries) = hdfs_->ls_with_sizes(parent);
+    throw_if_not_ok(st);
 #else
-    auto st = Status_VFSError("TileDB was built without HDFS support");
+    throw BuiltWithout("HDFS");
 #endif
-    RETURN_NOT_OK_TUPLE(st, nullopt);
   } else if (parent.is_memfs()) {
-    Status st;
-    std::tie(st, entries) =
-        memfs_.ls_with_sizes(URI("mem://" + parent.to_path()));
-    RETURN_NOT_OK_TUPLE(st, nullopt);
+    entries = memfs_.ls_with_sizes(URI("mem://" + parent.to_path()));
   } else {
-    auto st = Status_VFSError("Unsupported URI scheme: " + parent.to_string());
-    return {st, std::nullopt};
+    throw UnsupportedURI(parent.to_string());
   }
   parallel_sort(
       compute_tp_,
-      entries->begin(),
-      entries->end(),
+      entries.begin(),
+      entries.end(),
       [](const directory_entry& l, const directory_entry& r) {
         return l.path().native() < r.path().native();
       });
 
-  return {Status::Ok(), entries};
+  return entries;
 }
 
 Status VFS::move_file(const URI& old_uri, const URI& new_uri) {

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -506,8 +506,7 @@ class VFS : private VFSBase, protected S3_within_VFS {
    * @param parent The target directory to list.
    * @return All entries that are contained in the parent
    */
-  tuple<Status, optional<std::vector<directory_entry>>> ls_with_sizes(
-      const URI& parent) const;
+  std::vector<directory_entry> ls_with_sizes(const URI& parent) const;
 
   /**
    * Lists objects and object information that start with `prefix`, invoking

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -161,8 +161,7 @@ class Win {
    * @param path The parent path to list sub-paths.
    * @return A list of directory_entry objects
    */
-  tuple<Status, optional<std::vector<filesystem::directory_entry>>>
-  ls_with_sizes(const URI& path) const;
+  std::vector<filesystem::directory_entry> ls_with_sizes(const URI& path) const;
 
   /**
    * Lists objects and object information that start with `prefix`, invoking


### PR DESCRIPTION
[SC-23179](https://app.shortcut.com/tiledb-inc/story/23179)
[SC-48851](https://app.shortcut.com/tiledb-inc/story/48851)
[SC-48854](https://app.shortcut.com/tiledb-inc/story/48854)

This PR updates the signature of `ls_with_sizes` in the `VFS` class and the specific VFS implementations[^1] to indicate errors by throwing exceptions instead of returning `Status`.

On top of that, `Posix::ls_with_sizes` was updated to fail if `opendir` failed with an error code other than `ENOENT` (see also https://github.com/TileDB-Inc/TileDB/pull/5037#discussion_r1624775918).

Also in `Posix::ls_with_sizes`, the pointer returned by `opendir` was updated to be placed inside a smart pointer, making sure it gets freed. This caused errors in the `find_head_api_violations.py` script, which were fixed.

[^1]: HDFS was not updated to minimize risk.

---
TYPE: BUG
DESC: Do not mask failures when listing a directory fails on POSIX.