### PR TITLE
Dense reader: improve memory consumption for tile structures.

### DIFF
--- a/test/src/unit-Subarray.cc
+++ b/test/src/unit-Subarray.cc
@@ -317,6 +317,9 @@ TEST_CASE_METHOD(
   CHECK_NOTHROW(cropped_subarray.get_range(1, 1, &range));
   CHECK(!memcmp(range->data(), &c_range_1_1[0], 2 * sizeof(uint64_t)));
 
+  auto tile_cell_num = subarray.tile_cell_num(&tile_coords[0]);
+  CHECK(tile_cell_num == cropped_subarray.cell_num());
+
   close_array(ctx_, array_);
 }
 

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -226,6 +226,7 @@ TEST_CASE(
 
   Context ctx;
   Config config;
+  config.set("sm.consolidation.buffer_size", "1000");
 
   FragmentInfo fragment_info(ctx, array_name);
   fragment_info.load();

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -76,6 +76,35 @@ class Reader : public ReaderBase, public IQueryStrategy {
   DISABLE_COPY_AND_COPY_ASSIGN(Reader);
   DISABLE_MOVE_AND_MOVE_ASSIGN(Reader);
 
+  /**
+   * Computes a mapping (tile coordinates) -> (result space tile).
+   * The produced result space tiles will contain information only
+   * about fragments that will contribute results. Specifically, if
+   * a fragment is completely covered by a more recent fragment
+   * in a particular space tile, then it will certainly not contribute
+   * results and, thus, no information about that fragment is included
+   * in the space tile.
+   *
+   * @tparam T The datatype of the tile domains.
+   * @param domain The array domain
+   * @param tile_coords The unique coordinates of the tiles that intersect
+   *     a subarray.
+   * @param array_tile_domain The array tile domain.
+   * @param frag_tile_domains The tile domains of each fragment. These
+   *     are assumed to be ordered from the most recent to the oldest
+   *     fragment.
+   * @param result_space_tiles The result space tiles to be produced
+   *     by the function.
+   */
+  template <class T>
+  static void compute_result_space_tiles(
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
+      const std::vector<std::vector<uint8_t>>& tile_coords,
+      const TileDomain<T>& array_tile_domain,
+      const std::vector<TileDomain<T>>& frag_tile_domains,
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
+      shared_ptr<MemoryTracker> memory_tracker);
+
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
@@ -110,6 +139,20 @@ class Reader : public ReaderBase, public IQueryStrategy {
 
   /** Returns the name of the strategy */
   std::string name();
+
+  /**
+   * Computes the result space tiles based on the current partition.
+   *
+   * @tparam T The domain datatype.
+   * @param subarray The input subarray.
+   * @param partitioner_subarray The partitioner subarray.
+   * @param result_space_tiles The result space tiles to be computed.
+   */
+  template <class T>
+  void compute_result_space_tiles(
+      const Subarray& subarray,
+      const Subarray& partitioner_subarray,
+      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles) const;
 
   /**
    * Computes the result cell slabs for the input subarray, given the

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -253,10 +253,10 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
    * @param frag_tile_domains The relevant fragments tile domains.
    * @param iteration_tile_data The iteration data.
    *
-   * @return wait_compute_task_before_read, tile_end, result_space_tiles.
+   * @return wait_compute_task_before_read, result_space_tiles.
    */
   template <class DimType>
-  tuple<bool, uint64_t, std::map<const DimType*, ResultSpaceTile<DimType>>>
+  tuple<bool, std::map<const DimType*, ResultSpaceTile<DimType>>>
   compute_result_space_tiles(
       const uint64_t t_start,
       const std::vector<std::string>& names,

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -38,7 +38,6 @@
 #include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
-#include "tiledb/sm/array_schema/dynamic_array.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/query/iquery_strategy.h"
 #include "tiledb/sm/query/query_buffer.h"
@@ -56,28 +55,80 @@ class Array;
 /** Processes dense read queries. */
 class DenseReader : public ReaderBase, public IQueryStrategy {
   /**
-   * TileSubarrays class to store tile subarrays inside of a dynamic array with
-   * custom destructor.
+   * Class that stores the tile data for an internal loop of the reader.
    */
-  class TileSubarrays : public DynamicArray<Subarray> {
+  template <class DimType>
+  class IterationTileData {
    public:
-    TileSubarrays(uint64_t n)
-        : DynamicArray<Subarray>(
-              n,
-              tdb::allocator<Subarray>{},
-              Tag<DynamicArray<Subarray>::NullInitializer>{})
-        , n_(n) {
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+    IterationTileData() = delete;
+
+    IterationTileData(
+        ThreadPool& compute_tp,
+        Subarray& subarray,
+        uint64_t t_start,
+        uint64_t t_end,
+        std::map<const DimType*, ResultSpaceTile<DimType>>&& result_space_tiles)
+        : t_start_(t_start)
+        , t_end_(t_end)
+        , tile_subarrays_(t_end - t_start, subarray.dim_num())
+        , result_space_tiles_(std::move(result_space_tiles)) {
+      auto& tile_coords = subarray.tile_coords();
+      throw_if_not_ok(
+          parallel_for(&compute_tp, 0, tile_subarrays_.size(), [&](uint64_t t) {
+            subarray.crop_to_tile(
+                tile_subarrays_[t],
+                (const DimType*)&tile_coords[t + t_start][0]);
+            return Status::Ok();
+          }));
+    };
+
+    DISABLE_COPY_AND_COPY_ASSIGN(IterationTileData);
+    DISABLE_MOVE_AND_MOVE_ASSIGN(IterationTileData);
+
+    /* ********************************* */
+    /*          PUBLIC METHODS           */
+    /* ********************************* */
+
+    /** Returns the tile start index. */
+    inline uint64_t t_start() {
+      return t_start_;
     }
 
-    ~TileSubarrays() {
-      // Delete the tile subarrays.
-      for (uint64_t i = 0; i < n_; i++) {
-        (*this)[i].~Subarray();
-      }
+    /** Returns the tile end index. */
+    inline uint64_t& t_end() {
+      return t_end_;
+    }
+
+    /** Returns the tile subarrays. */
+    inline DenseTileSubarray<DimType>& tile_subarray(uint64_t t) {
+      return tile_subarrays_[t - t_start_];
+    }
+
+    /** Returns the result space tiles. */
+    inline std::map<const DimType*, ResultSpaceTile<DimType>>&
+    result_space_tiles() {
+      return result_space_tiles_;
     }
 
    private:
-    uint64_t n_;
+    /* ********************************* */
+    /*         PRIVATE ATTRIBUTES        */
+    /* ********************************* */
+
+    /** Start tile to process. */
+    uint64_t t_start_;
+
+    /** End tile to process. */
+    uint64_t t_end_;
+
+    /** Tile subarrays. */
+    std::vector<DenseTileSubarray<DimType>> tile_subarrays_;
+
+    /** Result space tiles. */
+    std::map<const DimType*, ResultSpaceTile<DimType>> result_space_tiles_;
   };
 
  public:
@@ -190,18 +241,30 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::unordered_set<std::string>& condition_names);
 
   /**
-   * Compute the result space tiles to process on an iteration to respect the
-   * memory budget.
+   * Computes the result space tiles based on the current partition.
+   *
+   * @tparam T The domain datatype.
+   * @param t_start The start tile index in the tile coords.
+   * @param names The fields to process.
+   * @param condition_names The fields in the query condition.
+   * @param subarray The input subarray.
+   * @param tiles_cell_num The cell num for all tiles.
+   * @param array_tile_domain The array tile domain.
+   * @param frag_tile_domains The relevant fragments tile domains.
+   * @param iteration_tile_data The iteration data.
+   *
+   * @return wait_compute_task_before_read, tile_end, result_space_tiles.
    */
   template <class DimType>
-  uint64_t compute_space_tiles_end(
+  tuple<bool, uint64_t, std::map<const DimType*, ResultSpaceTile<DimType>>>
+  compute_result_space_tiles(
+      const uint64_t t_start,
       const std::vector<std::string>& names,
       const std::unordered_set<std::string>& condition_names,
-      Subarray& subarray,
-      uint64_t t_start,
-      std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
-      const DynamicArray<Subarray>& tile_subarrays,
-      ThreadPool::Task& compute_task);
+      const Subarray& subarray,
+      const std::vector<uint64_t>& tiles_cell_num,
+      const TileDomain<DimType>& array_tile_domain,
+      const std::vector<TileDomain<DimType>>& frag_tile_domains) const;
 
   /** Compute the result tiles to load for a name. */
   template <class DimType>
@@ -209,24 +272,20 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const optional<std::string> name,
       const std::unordered_set<std::string>& condition_names,
       const Subarray& subarray,
-      const uint64_t t_start,
-      const uint64_t t_end,
-      std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
-      const DynamicArray<Subarray>& tile_subarrays) const;
+      shared_ptr<IterationTileData<DimType>> iteration_tile_data,
+      const std::vector<uint64_t>& tiles_cell_num) const;
 
   /** Apply the query condition. */
   template <class DimType, class OffType>
   Status apply_query_condition(
       ThreadPool::Task& compute_task,
       Subarray& subarray,
-      const uint64_t t_start,
-      const uint64_t t_end,
       const std::unordered_set<std::string>& condition_names,
       const std::vector<DimType>& tile_extents,
-      DynamicArray<Subarray>& tile_subarrays,
+      const std::vector<uint64_t>& tiles_cell_num,
       std::vector<uint64_t>& tile_offsets,
       const std::vector<RangeInfo<DimType>>& range_info,
-      std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
+      shared_ptr<IterationTileData<DimType>> iteration_tile_data,
       const uint64_t num_range_threads,
       std::vector<uint8_t>& qc_result);
 
@@ -246,15 +305,12 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<DimType>& tile_extents,
       const Subarray& subarray,
-      const uint64_t t_start,
-      const uint64_t t_end,
       const uint64_t subarray_start_cell,
       const uint64_t subarray_end_cell,
-      const DynamicArray<Subarray>& tile_subarrays,
       const std::vector<uint64_t>& tile_offsets,
       uint64_t& var_buffer_size,
       const std::vector<RangeInfo<DimType>>& range_info,
-      std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
+      shared_ptr<IterationTileData<DimType>> iteration_tile_data,
       const std::vector<uint8_t>& qc_result,
       const uint64_t num_range_threads);
 
@@ -277,14 +333,14 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
    *
    * @param name Name of the field to process.
    * @param rst Result space tile.
-   * @param tile_subarray Tile subarray.
+   * @param tile_cell_num Tile cell num.
    * @return If we can do the aggregation with the frag md or not.
    */
   template <class DimType>
   inline bool can_aggregate_tile_with_frag_md(
       const std::string& name,
       ResultSpaceTile<DimType>& rst,
-      const Subarray& tile_subarray) const {
+      const uint64_t tile_cell_num) const {
     if (array_schema_.is_dim(name)) {
       return false;
     }
@@ -304,8 +360,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
 
     // Make sure this tile isn't cropped by ranges and the fragment metadata has
     // tile metadata.
-    if (tile_subarray.cell_num() != rt.cell_num() ||
-        !frag_md->has_tile_metadata()) {
+    if (tile_cell_num != rt.cell_num() || !frag_md->has_tile_metadata()) {
       return false;
     }
 
@@ -329,12 +384,10 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::string& name,
       const std::vector<DimType>& tile_extents,
       const Subarray& subarray,
-      const uint64_t t_start,
-      const uint64_t t_end,
-      const DynamicArray<Subarray>& tile_subarrays,
+      const std::vector<uint64_t>& tiles_cell_num,
       const std::vector<uint64_t>& tile_offsets,
       const std::vector<RangeInfo<DimType>>& range_info,
-      std::map<const DimType*, ResultSpaceTile<DimType>>& result_space_tiles,
+      shared_ptr<IterationTileData<DimType>> iteration_tile_data,
       const std::vector<uint8_t>& qc_result,
       const uint64_t num_range_threads);
 
@@ -356,7 +409,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::vector<DimType>& tile_extents,
       ResultSpaceTile<DimType>& result_space_tile,
       const Subarray& subarray,
-      const Subarray& tile_subarray,
+      const DenseTileSubarray<DimType>& tile_subarray,
       const uint64_t global_cell_offset,
       const std::vector<RangeInfo<DimType>>& range_info,
       const std::vector<uint8_t>& qc_result,
@@ -370,7 +423,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::vector<DimType>& tile_extents,
       ResultSpaceTile<DimType>& result_space_tile,
       const Subarray& subarray,
-      const Subarray& tile_subarray,
+      const DenseTileSubarray<DimType>& tile_subarray,
       const uint64_t subarray_start_cell,
       const uint64_t global_cell_offset,
       std::vector<void*>& var_data,
@@ -386,7 +439,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::vector<DimType>& tile_extents,
       ResultSpaceTile<DimType>& result_space_tile,
       const Subarray& subarray,
-      const Subarray& tile_subarray,
+      const DenseTileSubarray<DimType>& tile_subarray,
       const uint64_t subarray_start_cell,
       const uint64_t global_cell_offset,
       std::vector<void*>& var_data,
@@ -403,7 +456,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       const std::vector<DimType>& tile_extents,
       ResultSpaceTile<DimType>& result_space_tile,
       const Subarray& subarray,
-      const Subarray& tile_subarray,
+      const DenseTileSubarray<DimType>& tile_subarray,
       const uint64_t global_cell_offset,
       const std::vector<RangeInfo<DimType>>& range_info,
       const std::vector<uint8_t>& qc_result,

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -101,66 +101,6 @@ ReaderBase::ReaderBase(
   }
 }
 
-/* ********************************* */
-/*          STATIC FUNCTIONS         */
-/* ********************************* */
-
-template <class T>
-void ReaderBase::compute_result_space_tiles(
-    const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
-    const std::vector<std::vector<uint8_t>>& tile_coords,
-    const TileDomain<T>& array_tile_domain,
-    const std::vector<TileDomain<T>>& frag_tile_domains,
-    std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
-    shared_ptr<MemoryTracker> memory_tracker) {
-  auto fragment_num = (unsigned)frag_tile_domains.size();
-  auto dim_num = array_tile_domain.dim_num();
-  std::vector<T> start_coords;
-  const T* coords;
-  start_coords.resize(dim_num);
-
-  // For all tile coordinates
-  for (const auto& tc : tile_coords) {
-    coords = (T*)(&(tc[0]));
-    start_coords = array_tile_domain.start_coords(coords);
-
-    // Create result space tile and insert into the map
-    auto r =
-        result_space_tiles.emplace(coords, ResultSpaceTile<T>(memory_tracker));
-    auto& result_space_tile = r.first->second;
-    result_space_tile.set_start_coords(start_coords);
-
-    // Add fragment info to the result space tile
-    for (unsigned f = 0; f < fragment_num; ++f) {
-      // Check if the fragment overlaps with the space tile
-      if (!frag_tile_domains[f].in_tile_domain(coords))
-        continue;
-
-      // Check if any previous fragment covers this fragment
-      // for the tile identified by `coords`
-      bool covered = false;
-      for (unsigned j = 0; j < f; ++j) {
-        if (frag_tile_domains[j].covers(coords, frag_tile_domains[f])) {
-          covered = true;
-          break;
-        }
-      }
-
-      // Exclude this fragment from the space tile
-      if (covered)
-        continue;
-
-      // Include this fragment in the space tile
-      auto frag_domain = frag_tile_domains[f].domain_slice();
-      auto frag_idx = frag_tile_domains[f].id();
-      result_space_tile.append_frag_domain(frag_idx, frag_domain);
-      auto tile_idx = frag_tile_domains[f].tile_pos(coords);
-      result_space_tile.set_result_tile(
-          frag_idx, tile_idx, *fragment_metadata[frag_idx].get());
-    }
-  }
-}
-
 /* ****************************** */
 /*         PUBLIC METHODS         */
 /* ****************************** */
@@ -1056,7 +996,7 @@ uint64_t ReaderBase::offsets_bytesize() const {
 }
 
 uint64_t ReaderBase::get_attribute_tile_size(
-    const std::string& name, unsigned f, uint64_t t) {
+    const std::string& name, unsigned f, uint64_t t) const {
   uint64_t tile_size = 0;
   if (!fragment_metadata_[f]->array_schema()->is_field(name)) {
     return tile_size;
@@ -1077,11 +1017,34 @@ uint64_t ReaderBase::get_attribute_tile_size(
   return tile_size;
 }
 
+uint64_t ReaderBase::get_attribute_persisted_tile_size(
+    const std::string& name, unsigned f, uint64_t t) const {
+  uint64_t tile_size = 0;
+  if (!fragment_metadata_[f]->array_schema()->is_field(name)) {
+    return tile_size;
+  }
+
+  tile_size +=
+      fragment_metadata_[f]->loaded_metadata()->persisted_tile_size(name, t);
+
+  if (array_schema_.var_size(name)) {
+    tile_size +=
+        fragment_metadata_[f]->loaded_metadata()->persisted_tile_var_size(
+            name, t);
+  }
+
+  if (array_schema_.is_nullable(name)) {
+    tile_size +=
+        fragment_metadata_[f]->loaded_metadata()->persisted_tile_validity_size(
+            name, t);
+  }
+
+  return tile_size;
+}
+
 template <class T>
-void ReaderBase::compute_result_space_tiles(
-    const Subarray& subarray,
-    const Subarray& partitioner_subarray,
-    std::map<const T*, ResultSpaceTile<T>>& result_space_tiles) const {
+std::pair<TileDomain<T>, std::vector<TileDomain<T>>>
+ReaderBase::compute_tile_domains(const Subarray& partitioner_subarray) const {
   // For easy reference
   auto domain = array_schema_.domain().domain();
   auto tile_extents = array_schema_.domain().tile_extents();
@@ -1102,19 +1065,9 @@ void ReaderBase::compute_result_space_tiles(
     }
   }
 
-  // Get tile coords and array domain
-  const auto& tile_coords = subarray.tile_coords();
-  TileDomain<T> array_tile_domain(
-      UINT32_MAX, domain, domain, tile_extents, tile_order);
-
-  // Compute result space tiles
-  compute_result_space_tiles<T>(
-      fragment_metadata_,
-      tile_coords,
-      array_tile_domain,
-      frag_tile_domains,
-      result_space_tiles,
-      query_memory_tracker_);
+  return {
+      TileDomain<T>(UINT32_MAX, domain, domain, tile_extents, tile_order),
+      frag_tile_domains};
 }
 
 bool ReaderBase::has_coords() const {
@@ -1263,38 +1216,22 @@ void ReaderBase::validate_attribute_order(
 }
 
 // Explicit template instantiations
-template void ReaderBase::compute_result_space_tiles<int8_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const int8_t*, ResultSpaceTile<int8_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<uint8_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const uint8_t*, ResultSpaceTile<uint8_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<int16_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const int16_t*, ResultSpaceTile<int16_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<uint16_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const uint16_t*, ResultSpaceTile<uint16_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<int32_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const int32_t*, ResultSpaceTile<int32_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<uint32_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const uint32_t*, ResultSpaceTile<uint32_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<int64_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const int64_t*, ResultSpaceTile<int64_t>>&) const;
-template void ReaderBase::compute_result_space_tiles<uint64_t>(
-    const Subarray&,
-    const Subarray&,
-    std::map<const uint64_t*, ResultSpaceTile<uint64_t>>&) const;
+template std::pair<TileDomain<int8_t>, std::vector<TileDomain<int8_t>>>
+ReaderBase::compute_tile_domains<int8_t>(const Subarray&) const;
+template std::pair<TileDomain<uint8_t>, std::vector<TileDomain<uint8_t>>>
+ReaderBase::compute_tile_domains<uint8_t>(const Subarray&) const;
+template std::pair<TileDomain<int16_t>, std::vector<TileDomain<int16_t>>>
+ReaderBase::compute_tile_domains<int16_t>(const Subarray&) const;
+template std::pair<TileDomain<uint16_t>, std::vector<TileDomain<uint16_t>>>
+ReaderBase::compute_tile_domains<uint16_t>(const Subarray&) const;
+template std::pair<TileDomain<int32_t>, std::vector<TileDomain<int32_t>>>
+ReaderBase::compute_tile_domains<int32_t>(const Subarray&) const;
+template std::pair<TileDomain<uint32_t>, std::vector<TileDomain<uint32_t>>>
+ReaderBase::compute_tile_domains<uint32_t>(const Subarray&) const;
+template std::pair<TileDomain<int64_t>, std::vector<TileDomain<int64_t>>>
+ReaderBase::compute_tile_domains<int64_t>(const Subarray&) const;
+template std::pair<TileDomain<uint64_t>, std::vector<TileDomain<uint64_t>>>
+ReaderBase::compute_tile_domains<uint64_t>(const Subarray&) const;
 template tuple<Range, std::vector<const void*>, std::vector<uint64_t>>
 ReaderBase::cache_dimension_label_data<int8_t>();
 template tuple<Range, std::vector<const void*>, std::vector<uint64_t>>

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -175,35 +175,6 @@ class ReaderBase : public StrategyBase {
   /* ********************************* */
 
   /**
-   * Computes a mapping (tile coordinates) -> (result space tile).
-   * The produced result space tiles will contain information only
-   * about fragments that will contribute results. Specifically, if
-   * a fragment is completely covered by a more recent fragment
-   * in a particular space tile, then it will certainly not contribute
-   * results and, thus, no information about that fragment is included
-   * in the space tile.
-   *
-   * @tparam T The datatype of the tile domains.
-   * @param domain The array domain
-   * @param tile_coords The unique coordinates of the tiles that intersect
-   *     a subarray.
-   * @param array_tile_domain The array tile domain.
-   * @param frag_tile_domains The tile domains of each fragment. These
-   *     are assumed to be ordered from the most recent to the oldest
-   *     fragment.
-   * @param result_space_tiles The result space tiles to be produced
-   *     by the function.
-   */
-  template <class T>
-  static void compute_result_space_tiles(
-      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
-      const std::vector<std::vector<uint8_t>>& tile_coords,
-      const TileDomain<T>& array_tile_domain,
-      const std::vector<TileDomain<T>>& frag_tile_domains,
-      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles,
-      shared_ptr<MemoryTracker> memory_tracker);
-
-  /**
    * Computes the minimum and maximum indexes of tile chunks to process based on
    * the available threads.
    *
@@ -659,21 +630,29 @@ class ReaderBase : public StrategyBase {
    * @return Tile size.
    */
   uint64_t get_attribute_tile_size(
-      const std::string& name, unsigned f, uint64_t t);
+      const std::string& name, unsigned f, uint64_t t) const;
 
   /**
-   * Computes the result space tiles based on the current partition.
+   * Get the on disk size of an attribute tile.
+   *
+   * @param name The attribute name.
+   * @param f The fragment idx.
+   * @param t The tile idx.
+   * @return Tile size.
+   */
+  uint64_t get_attribute_persisted_tile_size(
+      const std::string& name, unsigned f, uint64_t t) const;
+
+  /**
+   * Computes the tile domains based on the current partition.
    *
    * @tparam T The domain datatype.
-   * @param subarray The input subarray.
    * @param partitioner_subarray The partitioner subarray.
-   * @param result_space_tiles The result space tiles to be computed.
+   * @return array tile domain, fragments tile domains.
    */
   template <class T>
-  void compute_result_space_tiles(
-      const Subarray& subarray,
-      const Subarray& partitioner_subarray,
-      std::map<const T*, ResultSpaceTile<T>>& result_space_tiles) const;
+  std::pair<TileDomain<T>, std::vector<TileDomain<T>>> compute_tile_domains(
+      const Subarray& partitioner_subarray) const;
 
   /** Returns `true` if the coordinates are included in the attributes. */
   bool has_coords() const;

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -825,17 +825,50 @@ template <class T>
 Subarray Subarray::crop_to_tile(const T* tile_coords, Layout layout) const {
   // TBD: is it ok that Subarray log id will increase as if it's a new subarray?
   Subarray ret(array_, layout, stats_->parent(), logger_, false);
-  crop_to_tile_impl(tile_coords, ret);
+  crop_to_tile_impl<T, Subarray>(tile_coords, ret);
 
   return ret;
 }
 
 template <class T>
 void Subarray::crop_to_tile(
-    Subarray* ret, const T* tile_coords, Layout layout) const {
-  new (ret) Subarray(array_, layout, stats_->parent(), logger_, false);
-  Subarray(array_, layout, stats_->parent(), logger_, false);
-  crop_to_tile_impl(tile_coords, *ret);
+    DenseTileSubarray<T>& ret, const T* tile_coords) const {
+  crop_to_tile_impl<T, DenseTileSubarray<T>>(tile_coords, ret);
+}
+
+template <class T>
+uint64_t Subarray::tile_cell_num(const T* tile_coords) const {
+  uint64_t ret = 1;
+  T new_range[2];
+  bool overlaps;
+
+  // Get tile subarray based on the input coordinates
+  const auto& array_schema = array_->array_schema_latest();
+  std::vector<T> tile_subarray(2 * dim_num());
+  array_schema.domain().get_tile_subarray(tile_coords, &tile_subarray[0]);
+
+  // Compute cell num per dims.
+  for (unsigned d = 0; d < dim_num(); ++d) {
+    uint64_t cell_num_for_dim = 0;
+    for (size_t r = 0; r < range_subset_[d].num_ranges(); ++r) {
+      const auto& range = range_subset_[d][r];
+      utils::geometry::overlap(
+          (const T*)range.data(),
+          &tile_subarray[2 * d],
+          1,
+          new_range,
+          &overlaps);
+
+      if (overlaps) {
+        cell_num_for_dim +=
+            static_cast<uint64_t>(new_range[1] - new_range[0] + 1);
+      }
+    }
+
+    ret *= cell_num_for_dim;
+  }
+
+  return ret;
 }
 
 uint32_t Subarray::dim_num() const {
@@ -2651,8 +2684,8 @@ bool Subarray::non_overlapping_ranges_for_dim(const uint64_t dim_idx) {
   return true;
 }
 
-template <class T>
-void Subarray::crop_to_tile_impl(const T* tile_coords, Subarray& ret) const {
+template <class T, class SubarrayT>
+void Subarray::crop_to_tile_impl(const T* tile_coords, SubarrayT& ret) const {
   T new_range[2];
   bool overlaps;
 
@@ -2676,9 +2709,9 @@ void Subarray::crop_to_tile_impl(const T* tile_coords, Subarray& ret) const {
 
       if (overlaps) {
         ret.add_range_unsafe(d, Range(new_range, r_size));
-        ret.original_range_idx_.resize(dim_num());
-        ret.original_range_idx_[d].resize(i + 1);
-        ret.original_range_idx_[d][i++] = r;
+        ret.original_range_idx_unsafe().resize(dim_num());
+        ret.original_range_idx_unsafe()[d].resize(i + 1);
+        ret.original_range_idx_unsafe()[d][i++] = r;
       }
     }
   }
@@ -2749,25 +2782,38 @@ template Subarray Subarray::crop_to_tile<double>(
     const double* tile_coords, Layout layout) const;
 
 template void Subarray::crop_to_tile<int8_t>(
-    Subarray* ret, const int8_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<int8_t>& ret, const int8_t* tile_coords) const;
 template void Subarray::crop_to_tile<uint8_t>(
-    Subarray* ret, const uint8_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<uint8_t>& ret, const uint8_t* tile_coords) const;
 template void Subarray::crop_to_tile<int16_t>(
-    Subarray* ret, const int16_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<int16_t>& ret, const int16_t* tile_coords) const;
 template void Subarray::crop_to_tile<uint16_t>(
-    Subarray* ret, const uint16_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<uint16_t>& ret, const uint16_t* tile_coords) const;
 template void Subarray::crop_to_tile<int32_t>(
-    Subarray* ret, const int32_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<int32_t>& ret, const int32_t* tile_coords) const;
 template void Subarray::crop_to_tile<uint32_t>(
-    Subarray* ret, const uint32_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<uint32_t>& ret, const uint32_t* tile_coords) const;
 template void Subarray::crop_to_tile<int64_t>(
-    Subarray* ret, const int64_t* tile_coords, Layout layout) const;
+    DenseTileSubarray<int64_t>& ret, const int64_t* tile_coords) const;
 template void Subarray::crop_to_tile<uint64_t>(
-    Subarray* ret, const uint64_t* tile_coords, Layout layout) const;
-template void Subarray::crop_to_tile<float>(
-    Subarray* ret, const float* tile_coords, Layout layout) const;
-template void Subarray::crop_to_tile<double>(
-    Subarray* ret, const double* tile_coords, Layout layout) const;
+    DenseTileSubarray<uint64_t>& ret, const uint64_t* tile_coords) const;
+
+template uint64_t Subarray::tile_cell_num<int8_t>(
+    const int8_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<uint8_t>(
+    const uint8_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<int16_t>(
+    const int16_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<uint16_t>(
+    const uint16_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<int32_t>(
+    const int32_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<uint32_t>(
+    const uint32_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<int64_t>(
+    const int64_t* tile_coords) const;
+template uint64_t Subarray::tile_cell_num<uint64_t>(
+    const uint64_t* tile_coords) const;
 
 /* ********************************* */
 /*         LABEL RANGE SUBSET        */

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -860,6 +860,8 @@ uint64_t Subarray::tile_cell_num(const T* tile_coords) const {
           &overlaps);
 
       if (overlaps) {
+        // Here we need to do +1 because both the start and end are included in
+        // the number of cells.
         cell_num_for_dim +=
             static_cast<uint64_t>(new_range[1] - new_range[0] + 1);
       }
@@ -1936,7 +1938,7 @@ void Subarray::compute_relevant_fragment_est_result_sizes(
             (*result_sizes)[n].size_var_ += tile_var_size;
             if (nullable[n])
               (*result_sizes)[n].size_validity_ +=
-                  tile_var_size / attr_datatype_size *
+                  tile_size / constants::cell_var_offset_size *
                   constants::cell_validity_size;
           }
         }
@@ -1977,7 +1979,7 @@ void Subarray::compute_relevant_fragment_est_result_sizes(
           (*result_sizes)[n].size_var_ += tile_var_size * ratio;
           if (nullable[n])
             (*result_sizes)[n].size_validity_ +=
-                (tile_var_size / attr_datatype_size *
+                (tile_size / constants::cell_var_offset_size *
                  constants::cell_validity_size) *
                 ratio;
         }

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -93,6 +93,80 @@ class FragmentMetadata;
 enum class Layout : uint8_t;
 enum class QueryType : uint8_t;
 
+template <class T>
+class DenseTileSubarray {
+ public:
+  /**
+   * Stores information about a range along a single dimension. The
+   * whole range resides in a single tile.
+   */
+  struct DenseTileRange {
+    /** The start of the range in global coordinates. */
+    T start_;
+    /** The end of the range in global coordinates. */
+    T end_;
+
+    /** Constructor. */
+    DenseTileRange(T start, T end)
+        : start_(start)
+        , end_(end) {
+    }
+
+    /** Equality operator. */
+    bool operator==(const DenseTileRange& r) const {
+      return (r.start_ == start_ && r.end_ == end_);
+    }
+  };
+
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
+  DenseTileSubarray() = delete;
+
+  DenseTileSubarray(unsigned dim_num)
+      : ranges_(dim_num) {
+  }
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /** Returns the orignal range indexes. */
+  inline const std::vector<std::vector<uint64_t>>& original_range_idx() const {
+    return original_range_idx_;
+  }
+
+  /** Returns the ranges. */
+  inline const std::vector<std::vector<DenseTileRange>>& ranges() const {
+    return ranges_;
+  }
+
+  /** Returns the orignal range indexes to be modified. */
+  inline std::vector<std::vector<uint64_t>>& original_range_idx_unsafe() {
+    return original_range_idx_;
+  }
+
+  /**
+   * Adds a range along the dimension with the given index, without
+   * performing any error checks.
+   */
+  void add_range_unsafe(uint32_t dim_idx, const Range& range) {
+    ranges_[dim_idx].emplace_back(range.start_as<T>(), range.end_as<T>());
+  }
+
+ private:
+  /* ********************************* */
+  /*         PRIVATE ATTRIBUTES        */
+  /* ********************************* */
+
+  /** Stores a vector of 1D ranges per dimension. */
+  std::vector<std::vector<uint64_t>> original_range_idx_;
+
+  /** Stores the ranges per dimension. */
+  std::vector<std::vector<DenseTileRange>> ranges_;
+};
+
 /**
  * Interface to implement for a class that can store tile ranges computed by
  * this class.
@@ -508,6 +582,11 @@ class Subarray {
       const void* end,
       uint64_t end_size);
 
+  /** Returns the orignal range indexes to be modified. */
+  inline std::vector<std::vector<uint64_t>>& original_range_idx_unsafe() {
+    return original_range_idx_;
+  }
+
   /**
    * Adds a range along the dimension with the given index, without
    * performing any error checks.
@@ -807,7 +886,13 @@ class Subarray {
    * the input `layout`.
    */
   template <class T>
-  void crop_to_tile(Subarray* ret, const T* tile_coords, Layout layout) const;
+  void crop_to_tile(DenseTileSubarray<T>& ret, const T* tile_coords) const;
+
+  /**
+   * Returns the number of cells in a specfic tile for this subarray.
+   */
+  template <class T>
+  uint64_t tile_cell_num(const T* tile_coords) const;
 
   /** Returns the number of dimensions of the subarray. */
   uint32_t dim_num() const;
@@ -1556,8 +1641,8 @@ class Subarray {
    * tile with the input coordinates. The new subarray will have
    * the input `layout`.
    */
-  template <class T>
-  void crop_to_tile_impl(const T* tile_coords, Subarray& ret) const;
+  template <class T, class SubarrayT>
+  void crop_to_tile_impl(const T* tile_coords, SubarrayT& ret) const;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -889,7 +889,7 @@ class Subarray {
   void crop_to_tile(DenseTileSubarray<T>& ret, const T* tile_coords) const;
 
   /**
-   * Returns the number of cells in a specfic tile for this subarray.
+   * Returns the number of cells in a specific tile for this subarray.
    */
   template <class T>
   uint64_t tile_cell_num(const T* tile_coords) const;

--- a/tiledb/sm/subarray/tile_cell_slab_iter.cc
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.cc
@@ -58,7 +58,7 @@ TileCellSlabIter<T>::TileCellSlabIter(
     const uint64_t range_thread_idx,
     const uint64_t num_range_threads,
     const Subarray& root_subarray,
-    const Subarray& subarray,
+    const DenseTileSubarray<T>& subarray,
     const std::vector<T>& tile_extents,
     const std::vector<T>& start_coords,
     const std::vector<RangeInfo<T>>& range_info,
@@ -66,8 +66,11 @@ TileCellSlabIter<T>::TileCellSlabIter(
     : num_ranges_(root_subarray.range_num())
     , original_range_idx_(subarray.original_range_idx())
     , range_info_(range_info)
-    , layout_(subarray.layout())
-    , dim_num_(subarray.dim_num())
+    , layout_(
+          root_subarray.layout() == Layout::GLOBAL_ORDER ?
+              cell_order :
+              root_subarray.layout())
+    , dim_num_(root_subarray.dim_num())
     , global_offset_(0)
     , pos_in_tile_(0)
     , dest_offset_row_col_(0)
@@ -75,13 +78,9 @@ TileCellSlabIter<T>::TileCellSlabIter(
     , end_(false)
     , last_(true)
     , global_order_(root_subarray.layout() == Layout::GLOBAL_ORDER)
-    , mult_extents_(subarray.dim_num())
+    , ranges_(subarray.ranges())
+    , mult_extents_(root_subarray.dim_num())
     , start_coords_(start_coords) {
-  if (!init_ranges(subarray).ok()) {
-    throw std::logic_error(
-        "Could not initialize TileCellSlabIter in constructor");
-  }
-
   init_coords();
   init_cell_slab_lengths();
 
@@ -285,27 +284,6 @@ void TileCellSlabIter<T>::init_coords() {
     range_coords_[i] = 0;
     cell_slab_coords_[i] = ranges_[i][0].start_;
   }
-}
-
-template <class T>
-Status TileCellSlabIter<T>::init_ranges(const Subarray& subarray) {
-  // For easy reference
-  const auto& array_schema = subarray.array()->array_schema_latest();
-  auto array_domain = array_schema.domain().domain();
-  uint64_t range_num;
-  const tiledb::type::Range* r;
-  ranges_.resize(dim_num_);
-  for (int d = 0; d < dim_num_; ++d) {
-    subarray.get_range_num(d, &range_num);
-    ranges_[d].reserve(range_num);
-    for (uint64_t j = 0; j < range_num; ++j) {
-      subarray.get_range(d, j, &r);
-      auto range = (const T*)(*r).data();
-      ranges_[d].emplace_back(range[0], range[1]);
-    }
-  }
-
-  return Status::Ok();
 }
 
 template <class T>

--- a/tiledb/sm/subarray/tile_cell_slab_iter.h
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.h
@@ -65,32 +65,6 @@ template <class T>
 class TileCellSlabIter {
  public:
   /* ********************************* */
-  /*          TYPE DEFINITIONS         */
-  /* ********************************* */
-
-  /**
-   * Stores information about a range along a single dimension. The
-   * whole range resides in a single tile.
-   */
-  struct Range {
-    /** The start of the range in global coordinates. */
-    T start_;
-    /** The end of the range in global coordinates. */
-    T end_;
-
-    /** Constructor. */
-    Range(T start, T end)
-        : start_(start)
-        , end_(end) {
-    }
-
-    /** Equality operator. */
-    bool operator==(const Range& r) const {
-      return (r.start_ == start_ && r.end_ == end_);
-    }
-  };
-
-  /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
@@ -99,7 +73,7 @@ class TileCellSlabIter {
       const uint64_t range_thread_idx,
       const uint64_t num_range_threads,
       const Subarray& root_subarray,
-      const Subarray& subarray,
+      const DenseTileSubarray<T>& subarray,
       const std::vector<T>& tile_extents,
       const std::vector<T>& start_coords,
       const std::vector<RangeInfo<T>>& range_info,
@@ -217,7 +191,8 @@ class TileCellSlabIter {
    * ranges, after appropriately splitting them so that no range crosses
    * more that one tile.
    */
-  std::vector<std::vector<Range>> ranges_;
+  const std::vector<std::vector<typename DenseTileSubarray<T>::DenseTileRange>>&
+      ranges_;
 
   /** Saved multiplication of tile extents in cell order. */
   std::vector<uint64_t> mult_extents_;
@@ -243,13 +218,6 @@ class TileCellSlabIter {
 
   /** Initializes the range coords and the cell slab coords. */
   void init_coords();
-
-  /**
-   * Initializes the ranges per dimension, splitting appropriately the
-   * subarray ranges on tile boundaries. Eventually the produced `ranges_`
-   * should not never cross more than one tile.
-   */
-  Status init_ranges(const Subarray& subarray);
 
   /**
    * Updates the current cell slab, based on the current state of


### PR DESCRIPTION
This change significantly reduces the memory usage for tile structures (result space tile and tile subarray) by doing three things:
- Only create the structures for the tiles that will be processed in an internal loop.
- Using a structure to store the tile subarray with a smaller memory footprint.
- Adding estimation for the tile structure size when determining the tiles to process for an iteration.

For the first point, a new class was added: `IterationTileData` to store the tile structurres for an iteration. It is held in a shared pointer so that the compute task can take tile data to finish processing tiles in a thread safe/efficient manner. A problem that arose here is that the tile subarrays were used to get the number of cells when computing the tiles that it can process in an iteration. Since the tile subarrays are heavy to compute, and should be computed in a parallel manner, this posed a problem. To solve this, a new method was added to Subarray to return the cell count of a particular tile (`Subarray::tile_cell_num``). Since the method doesn't allocate any memory, it can run significantly fast and there are no noticeable performance degradation, even in large queries. With this method, we can compute the tiles to process and then compute the tile subarrays later once we know the number of tiles for an iteration.

For the second point, a new class was added: `DenseTileSubarray` to store the tile subarrays. This class takes much less memory than `Subarray` and is also much fater to create in memory. Since this is for dense only, the ranges can be types, which also uses less memory as we don't need to store a size. Finally, the computed ranges for a tile can be used in `TileCellSlabIter` as a const reference, which surely improves performance and reduce small memory allocations.

For the third bullet point, `compute_result_space_tiles` now tries to estimate the memory for the tile structures as it can be significant when the tile size is small (ie: 1000 cells). I've also changed the code to take into account the filtered data size when computing memory against the memory budget to improve our accuracy.

Note that this PR extracted `ReaderBase::compute_tile_domains`, which is common code for the new dense reader and the legacy reader to compute the result space tiles. The rest of the code was split between the legacy reader class and the new dense reader class as their implementations diverged significantly.

Finally, I've made a small change to release the filtered data as soon as unfiltering is done to limit the memory footprint even further.

[sc-38387]
[sc-48388]

---
TYPE: IMPROVEMENT
DESC: Dense reader: improve memory consumption for tile structures.
