### PR TITLE
Remove pin to MSVC toolset version in CI.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -131,10 +131,6 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x64
-          # By default Visual Studio 2022 chooses the earliest installed toolset
-          # version for the main build and vcpkg chooses the latest. Force it to
-          # use the latest (14.39 currently).
-          toolset: ${{ matrix.os == 'windows-2022' && '14.39' || '' }}
       # This must happen after checkout, because checkout would remove the directory.
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@v4

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -32,10 +32,6 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows-') }}
         with:
           arch: x64
-          # By default Visual Studio 2022 chooses the earliest installed toolset
-          # version for the main build and vcpkg chooses the latest. Force it to
-          # use the latest (14.39 currently).
-          toolset: '14.39'
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache


### PR DESCRIPTION
[SC-48973](https://app.shortcut.com/tiledb-inc/story/48973/revert-pins-to-msvc-toolset-14-39)

GitHub Actions is starting to update the MSVC toolset version in CI, causing [occasional failures](https://github.com/TileDB-Inc/TileDB/actions/runs/9386900730/job/25848568717). This PR removes the pin to version 14.39 added in #4759, hoping it is no longer necessary.

---
TYPE: NO_HISTORY