### PR TITLE
Add CMake option to disable auto-downloading of vcpkg.

### DIFF
--- a/cmake/Options/BuildOptions.cmake
+++ b/cmake/Options/BuildOptions.cmake
@@ -50,7 +50,7 @@ if (DEFINED TILEDB_STATIC)
 endif()
 
 if (NOT TILEDB_VCPKG)
-  message(FATAL_ERROR "Disabling TILEDB_VCPKG is not supported.")
+  message(FATAL_ERROR "Disabling TILEDB_VCPKG is not supported. To disable automatically downloading vcpkg, enable the TILEDB_DISABLE_AUTO_VCPKG option, or set ENV{TILEDB_DISABLE_AUTO_VCPKG} to any value.")
 endif()
 
 # enable assertions by default for debug builds

--- a/cmake/Options/BuildOptions.cmake
+++ b/cmake/Options/BuildOptions.cmake
@@ -34,6 +34,7 @@ option(TILEDB_LOG_OUTPUT_ON_FAILURE "If true, print error logs if dependency sub
 option(TILEDB_SKIP_S3AWSSDK_DIR_LENGTH_CHECK "If true, skip check needed path length for awssdk (TILEDB_S3) dependent builds" OFF)
 option(TILEDB_EXPERIMENTAL_FEATURES "If true, build and include experimental features" OFF)
 option(TILEDB_TESTS_AWS_S3_CONFIG "Use an S3 config appropriate for AWS in tests" OFF)
+option(TILEDB_DISABLE_AUTO_VCPKG "Do not automatically download vcpkg. Ignored if CMAKE_TOOLCHAIN_FILE or ENV{VCPKG_ROOT} is set." OFF)
 
 option(CMAKE_EXPORT_COMPILE_COMMANDS "cmake compile commands" ON)
 

--- a/cmake/Options/TileDBToolchain.cmake
+++ b/cmake/Options/TileDBToolchain.cmake
@@ -41,7 +41,7 @@ if (NOT DEFINED CMAKE_TOOLCHAIN_FILE)
         set(CMAKE_TOOLCHAIN_FILE
             "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
             CACHE STRING "Vcpkg toolchain file")
-    elseif(NOT DEFINED ENV{TILEDB_DISABLE_AUTO_VCPKG})
+    elseif(NOT (DEFINED ENV{TILEDB_DISABLE_AUTO_VCPKG} OR TILEDB_DISABLE_AUTO_VCPKG))
         # Inspired from https://github.com/Azure/azure-sdk-for-cpp/blob/azure-core_1.10.3/cmake-modules/AzureVcpkg.cmake
         message("TILEDB_DISABLE_AUTO_VCPKG is not defined. Fetch a local copy of vcpkg.")
         # To help with resolving conflicts, when you update the commit, also update its date.


### PR DESCRIPTION
[SC-48929](https://app.shortcut.com/tiledb-inc/story/48929/add-cmake-option-to-disable-auto-downloading-vcpkg)

This PR adds a CMake option to disable auto-downloading of vcpkg, as requested in https://github.com/msys2/MINGW-packages/pull/21081#issuecomment-2149716403. There is already an environment variable that serves the same purpose, but the CMake option has the advantage of being cached across configures.

I also updated the error message when `TILEDB_VCPKG` is disabled, making the migration path more clear.

Validated by configuring locally with this option specified, and observing that vcpkg was not downloaded, and `find_package` calls failed.

---
TYPE: BUILD
DESC: Automatic downloading of vcpkg can be disabled by enabling the `TILEDB_DISABLE_AUTO_VCPKG` CMake option, in addition to setting the environment variable with trhe same name.