### PR TITLE
Fix partial tile offsets loading testing in Windows nightlies. 

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1002,7 +1002,7 @@ TEST_CASE_METHOD(
     write_1d_fragment(coords4.data(), &coords4_size, data4.data(), &data4_size);
   }
 
-  total_budget_ = "3000000";
+  total_budget_ = "3300000";
   ratio_array_data_ = "0.002";
   partial_tile_offsets_loading_ =
       enable_partial_tile_offsets_loading ? "true" : "false";


### PR DESCRIPTION
Fix nightly failures for partial offsets testing by slightly increasing the budget. Failure here: https://github.com/TileDB-Inc/TileDB/actions/runs/9410904346/job/25923315811#step:7:4571

---
TYPE: NO_HISTORY 
DESC: Fix partial tile offsets loading testing in Windows nightlies. 
