### PR TITLE
Remove error statuses from inside `parallel_for`.

### DIFF
--- a/test/src/unit-backwards_compat.cc
+++ b/test/src/unit-backwards_compat.cc
@@ -150,8 +150,8 @@ TEST_CASE(
   std::string array_uri(arrays_dir + "/dense_array_v1_3_0");
   REQUIRE_THROWS_WITH(
       Array(ctx, array_uri, TILEDB_READ),
-      "[TileDB::Array] Error: [TileDB::ArrayDirectory] Error: Reading data "
-      "past end of serialized data size.");
+      Catch::Matchers::EndsWith(
+          "Reading data past end of serialized data size."));
 }
 
 template <typename T>

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -740,11 +740,11 @@ void Array::delete_fragments(
   auto vfs = &(resources.vfs());
   throw_if_not_ok(parallel_for(
       &resources.compute_tp(), 0, fragment_uris.size(), [&](size_t i) {
-        RETURN_NOT_OK(vfs->remove_dir(fragment_uris[i].uri_));
+        throw_if_not_ok(vfs->remove_dir(fragment_uris[i].uri_));
         bool is_file = false;
-        RETURN_NOT_OK(vfs->is_file(commit_uris_to_delete[i], &is_file));
+        throw_if_not_ok(vfs->is_file(commit_uris_to_delete[i], &is_file));
         if (is_file) {
-          RETURN_NOT_OK(vfs->remove_file(commit_uris_to_delete[i]));
+          throw_if_not_ok(vfs->remove_file(commit_uris_to_delete[i]));
         }
         return Status::Ok();
       }));

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -177,9 +177,10 @@ ArrayDirectory::load_all_array_schemas(
           array_schema->set_array_uri(uri_);
           schema_vector[schema_ith] = array_schema;
         } catch (std::exception& e) {
-          std::throw_with_nested(ArrayDirectoryException(
-              "Cannot load array schema from URI '" + schema_uri.to_string() +
-              "'."));
+          // TODO: We could throw a nested exception, but converting exceptions
+          // to statuses loses the inner exception messages. We can revisit this
+          // when Status gets removed from this module.
+          throw ArrayDirectoryException(e.what());
         }
 
         return Status::Ok();

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -841,7 +841,7 @@ Status Azure::remove_dir(const URI& uri) const {
   std::vector<std::string> paths;
   RETURN_NOT_OK(ls(uri, &paths, ""));
   auto status = parallel_for(thread_pool_, 0, paths.size(), [&](size_t i) {
-    RETURN_NOT_OK(remove_blob(URI(paths[i])));
+    throw_if_not_ok(remove_blob(URI(paths[i])));
     return Status::Ok();
   });
   RETURN_NOT_OK(status);

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -439,7 +439,7 @@ Status GCS::remove_dir(const URI& uri) const {
   std::vector<std::string> paths;
   RETURN_NOT_OK(ls(uri, &paths, ""));
   auto status = parallel_for(thread_pool_, 0, paths.size(), [&](size_t i) {
-    RETURN_NOT_OK(remove_object(URI(paths[i])));
+    throw_if_not_ok(remove_object(URI(paths[i])));
     return Status::Ok();
   });
   RETURN_NOT_OK(status);

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -432,9 +432,9 @@ void VFS::remove_dirs(
     ThreadPool* compute_tp, const std::vector<URI>& uris) const {
   throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
     bool is_dir;
-    RETURN_NOT_OK(this->is_dir(uris[i], &is_dir));
+    throw_if_not_ok(this->is_dir(uris[i], &is_dir));
     if (is_dir) {
-      RETURN_NOT_OK(remove_dir(uris[i]));
+      throw_if_not_ok(remove_dir(uris[i]));
     }
     return Status::Ok();
   }));
@@ -486,7 +486,7 @@ Status VFS::remove_file(const URI& uri) const {
 void VFS::remove_files(
     ThreadPool* compute_tp, const std::vector<URI>& uris) const {
   throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
-    RETURN_NOT_OK(remove_file(uris[i]));
+    throw_if_not_ok(remove_file(uris[i]));
     return Status::Ok();
   }));
 }
@@ -494,7 +494,7 @@ void VFS::remove_files(
 void VFS::remove_files(
     ThreadPool* compute_tp, const std::vector<TimestampedURI>& uris) const {
   throw_if_not_ok(parallel_for(compute_tp, 0, uris.size(), [&](size_t i) {
-    RETURN_NOT_OK(remove_file(uris[i].uri_));
+    throw_if_not_ok(remove_file(uris[i].uri_));
     return Status::Ok();
   }));
 }

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -357,11 +357,11 @@ Status FilterPipeline::filter_chunks_forward(
     std::memcpy((char*)dest + dest_offset, &metadata_size, sizeof(uint32_t));
     dest_offset += sizeof(uint32_t);
     // Write the chunk metadata
-    RETURN_NOT_OK(
+    throw_if_not_ok(
         final_stage_output_metadata.copy_to((char*)dest + dest_offset));
     dest_offset += metadata_size;
     // Write the chunk data
-    RETURN_NOT_OK(final_stage_output_data.copy_to((char*)dest + dest_offset));
+    throw_if_not_ok(final_stage_output_data.copy_to((char*)dest + dest_offset));
     return Status::Ok();
   });
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -770,7 +770,7 @@ std::vector<shared_ptr<FragmentMetadata>> FragmentMetadata::load(
         FragmentID fragment_id{sf.uri_};
         if (fragment_id.array_format_version() <= 2) {
           bool sparse;
-          RETURN_NOT_OK(resources.vfs().is_file(coords_uri, &sparse));
+          throw_if_not_ok(resources.vfs().is_file(coords_uri, &sparse));
           metadata = make_shared<FragmentMetadata>(
               HERE(),
               &resources,

--- a/tiledb/sm/query/iquery_strategy.h
+++ b/tiledb/sm/query/iquery_strategy.h
@@ -42,6 +42,14 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+/** Class for query status exceptions. */
+class QueryException : public StatusException {
+ public:
+  explicit QueryException(const std::string& msg)
+      : StatusException("Query", msg) {
+  }
+};
+
 class IQueryStrategy {
  public:
   /** Destructor. */

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -61,14 +61,6 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
-/** Class for query status exceptions. */
-class QueryException : public StatusException {
- public:
-  explicit QueryException(const std::string& msg)
-      : StatusException("Query", msg) {
-  }
-};
-
 class Array;
 class ArrayDimensionLabelQueries;
 

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -1141,7 +1141,7 @@ Status DenseReader::apply_query_condition(
                       *(fragment_metadata_[frag_domains[i].fid()]
                             ->array_schema()
                             .get()));
-                  RETURN_NOT_OK(condition_->apply_dense(
+                  throw_if_not_ok(condition_->apply_dense(
                       params,
                       result_space_tile.result_tile(frag_domains[i].fid()),
                       start,
@@ -1172,7 +1172,7 @@ Status DenseReader::apply_query_condition(
 
             return Status::Ok();
           });
-      RETURN_NOT_OK(status);
+      throw_if_not_ok(status);
 
       // For `qc_coords_mode` just fill in the coordinates and skip
       // attribute
@@ -1273,7 +1273,7 @@ Status DenseReader::copy_attribute(
             auto& result_space_tile = result_space_tiles.at(tc);
 
             // Copy the tile offsets.
-            return copy_offset_tiles<DimType, OffType>(
+            throw_if_not_ok(copy_offset_tiles<DimType, OffType>(
                 name,
                 tile_extents,
                 result_space_tile,
@@ -1285,7 +1285,8 @@ Status DenseReader::copy_attribute(
                 range_info,
                 qc_result,
                 range_thread_idx,
-                num_range_threads);
+                num_range_threads));
+            return Status::Ok();
           });
       RETURN_NOT_OK(status);
     }
@@ -1332,7 +1333,7 @@ Status DenseReader::copy_attribute(
             const DimType* tc = (DimType*)&tile_coords[t][0];
             auto& result_space_tile = result_space_tiles.at(tc);
 
-            return copy_var_tiles<DimType, OffType>(
+            throw_if_not_ok(copy_var_tiles<DimType, OffType>(
                 name,
                 tile_extents,
                 result_space_tile,
@@ -1345,7 +1346,7 @@ Status DenseReader::copy_attribute(
                 t == iteration_tile_data->t_end() - 1,
                 var_buffer_size,
                 range_thread_idx,
-                num_range_threads);
+                num_range_threads));
 
             return Status::Ok();
           });
@@ -1375,7 +1376,7 @@ Status DenseReader::copy_attribute(
             auto& result_space_tile = result_space_tiles.at(tc);
 
             // Copy the tile fixed values.
-            RETURN_NOT_OK(copy_fixed_tiles(
+            throw_if_not_ok(copy_fixed_tiles(
                 name,
                 tile_extents,
                 result_space_tile,
@@ -1485,7 +1486,7 @@ Status DenseReader::process_aggregates(
             }
           }
         } else {
-          RETURN_NOT_OK(aggregate_tiles(
+          throw_if_not_ok(aggregate_tiles(
               name,
               tile_extents,
               result_space_tile,

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -817,7 +817,7 @@ Status ReaderBase::unfilter_tiles(
                 tiles_chunk_data[i],
                 tiles_chunk_var_data[i],
                 tiles_chunk_validity_data[i]);
-        RETURN_NOT_OK(st);
+        throw_if_not_ok(st);
         unfiltered_tile_size[i] = tile_size.value();
         unfiltered_tile_var_size[i] = tile_var_size.value();
         unfiltered_tile_validity_size[i] = tile_validity_size.value();
@@ -836,7 +836,7 @@ Status ReaderBase::unfilter_tiles(
       0,
       num_range_threads,
       [&](uint64_t i, uint64_t range_thread_idx) {
-        return unfilter_tile(
+        throw_if_not_ok(unfilter_tile(
             name,
             validity_only,
             result_tiles[i],
@@ -846,7 +846,8 @@ Status ReaderBase::unfilter_tiles(
             num_range_threads,
             tiles_chunk_data[i],
             tiles_chunk_var_data[i],
-            tiles_chunk_validity_data[i]);
+            tiles_chunk_validity_data[i]));
+        return Status::Ok();
       });
   RETURN_CANCEL_OR_ERROR(status);
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -678,7 +678,7 @@ void SparseIndexReaderBase::compute_tile_bitmaps(
           {
             auto timer_compute_results_count_sparse =
                 stats_->start_timer("compute_results_count_sparse");
-            RETURN_NOT_OK(rt->compute_results_count_sparse(
+            throw_if_not_ok(rt->compute_results_count_sparse(
                 dim_idx,
                 ranges_for_dim,
                 relevant_ranges,
@@ -738,7 +738,7 @@ void SparseIndexReaderBase::apply_query_condition(
             // Remove cells with partial overlap from the bitmap.
             QueryCondition::Params params(
                 query_memory_tracker_, *(frag_meta->array_schema().get()));
-            RETURN_NOT_OK(partial_overlap_condition_.apply_sparse<BitmapType>(
+            throw_if_not_ok(partial_overlap_condition_.apply_sparse<BitmapType>(
                 params, *rt, rt->bitmap()));
             rt->count_cells();
           }
@@ -755,8 +755,9 @@ void SparseIndexReaderBase::apply_query_condition(
             // Remove cells deleted cells using the open timestamp.
             QueryCondition::Params params(
                 query_memory_tracker_, *(frag_meta->array_schema().get()));
-            RETURN_NOT_OK(delete_timestamps_condition_.apply_sparse<BitmapType>(
-                params, *rt, rt->post_dedup_bitmap()));
+            throw_if_not_ok(
+                delete_timestamps_condition_.apply_sparse<BitmapType>(
+                    params, *rt, rt->post_dedup_bitmap()));
             if (array_schema_.allows_dups()) {
               rt->count_cells();
             }
@@ -766,7 +767,7 @@ void SparseIndexReaderBase::apply_query_condition(
           if (condition_.has_value()) {
             QueryCondition::Params params(
                 query_memory_tracker_, *(frag_meta->array_schema().get()));
-            RETURN_NOT_OK(condition_->apply_sparse<BitmapType>(
+            throw_if_not_ok(condition_->apply_sparse<BitmapType>(
                 params, *rt, rt->post_dedup_bitmap()));
             if (array_schema_.allows_dups()) {
               rt->count_cells();
@@ -801,12 +802,12 @@ void SparseIndexReaderBase::apply_query_condition(
                       *(frag_meta->array_schema().get()));
                   if (!frag_meta->has_timestamps() ||
                       delete_timestamp > frag_meta->timestamp_range().second) {
-                    RETURN_NOT_OK(
+                    throw_if_not_ok(
                         delete_and_update_conditions_[i]
                             .apply_sparse<BitmapType>(
                                 params, *rt, rt->post_dedup_bitmap()));
                   } else {
-                    RETURN_NOT_OK(
+                    throw_if_not_ok(
                         timestamped_delete_and_update_conditions_[i]
                             .apply_sparse<BitmapType>(
                                 params, *rt, rt->post_dedup_bitmap()));

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -36,6 +36,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/misc/tdb_time.h"
+#include "tiledb/sm/query/iquery_strategy.h"
 #include "tiledb/sm/query/query_buffer.h"
 
 namespace tiledb {
@@ -98,6 +99,12 @@ void StrategyBase::get_dim_attr_stats() const {
         }
       }
     }
+  }
+}
+
+void StrategyBase::throw_if_cancellation_requested() const {
+  if (storage_manager_->cancellation_in_progress()) {
+    throw QueryException("Query was cancelled");
   }
 }
 

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -338,6 +338,11 @@ class StrategyBase {
    * the query.
    */
   void get_dim_attr_stats() const;
+
+  /**
+   * Throws an exception if the query is canceled.
+   */
+  void throw_if_cancellation_requested() const;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -872,8 +872,8 @@ Status GlobalOrderWriter::prepare_full_tiles(
     auto buff_it = buffers_.begin();
     std::advance(buff_it, i);
     const auto& name = buff_it->first;
-    RETURN_CANCEL_OR_ERROR(
-        prepare_full_tiles(name, coord_dups, &tiles->at(name)));
+    throw_if_not_ok(prepare_full_tiles(name, coord_dups, &tiles->at(name)));
+    this->throw_if_cancellation_requested();
     return Status::Ok();
   });
 

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -337,21 +337,21 @@ Status OrderedWriter::prepare_filter_and_write_tiles(
           &resources_.compute_tp(), 0, batch_size, [&](uint64_t i) {
             // Prepare and filter tiles
             auto& writer_tile = tile_batches[b][i];
-            RETURN_NOT_OK(
+            throw_if_not_ok(
                 dense_tiler->get_tile(frag_tile_id + i, name, writer_tile));
 
             if (!var) {
-              RETURN_NOT_OK(filter_tile(
+              throw_if_not_ok(filter_tile(
                   name, &writer_tile.fixed_tile(), nullptr, false, false));
             } else {
               auto offset_tile = &writer_tile.offset_tile();
-              RETURN_NOT_OK(filter_tile(
+              throw_if_not_ok(filter_tile(
                   name, &writer_tile.var_tile(), offset_tile, false, false));
-              RETURN_NOT_OK(
+              throw_if_not_ok(
                   filter_tile(name, offset_tile, nullptr, true, false));
             }
             if (nullable) {
-              RETURN_NOT_OK(filter_tile(
+              throw_if_not_ok(filter_tile(
                   name, &writer_tile.validity_tile(), nullptr, false, true));
             }
             return Status::Ok();

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -387,8 +387,8 @@ Status UnorderedWriter::prepare_tiles(
       parallel_for(&resources_.compute_tp(), 0, tiles->size(), [&](uint64_t i) {
         auto tiles_it = tiles->begin();
         std::advance(tiles_it, i);
-        RETURN_CANCEL_OR_ERROR(
-            prepare_tiles(tiles_it->first, &(tiles_it->second)));
+        throw_if_not_ok(prepare_tiles(tiles_it->first, &(tiles_it->second)));
+        this->throw_if_cancellation_requested();
         return Status::Ok();
       });
 

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -809,8 +809,8 @@ Status WriterBase::filter_tiles(
       parallel_for(&resources_.compute_tp(), 0, tiles->size(), [&](uint64_t i) {
         auto tiles_it = tiles->begin();
         std::advance(tiles_it, i);
-        RETURN_CANCEL_OR_ERROR(
-            filter_tiles(tiles_it->first, &tiles_it->second));
+        throw_if_not_ok(filter_tiles(tiles_it->first, &tiles_it->second));
+        this->throw_if_cancellation_requested();
         return Status::Ok();
       });
 
@@ -846,7 +846,7 @@ Status WriterBase::filter_tiles(
       parallel_for(&resources_.compute_tp(), 0, args.size(), [&](uint64_t i) {
         const auto& [tile, offset_tile, contains_offsets, is_nullable] =
             args[i];
-        RETURN_NOT_OK(filter_tile(
+        throw_if_not_ok(filter_tile(
             name, tile, offset_tile, contains_offsets, is_nullable));
         return Status::Ok();
       });
@@ -857,7 +857,7 @@ Status WriterBase::filter_tiles(
     auto status = parallel_for(
         &resources_.compute_tp(), 0, tiles->size(), [&](uint64_t i) {
           auto& tile = (*tiles)[i];
-          RETURN_NOT_OK(
+          throw_if_not_ok(
               filter_tile(name, &tile.offset_tile(), nullptr, true, false));
           return Status::Ok();
         });


### PR DESCRIPTION
[SC-49251](https://app.shortcut.com/tiledb-inc/story/49251/remove-status-from-all-parallel-for-s)

As preparation for removing `Status` from the thread pool and parallel functions, this PR removes returning statuses _in the bodies of functions passed to `parallel_for***`_. Specifically:

* Calls to `RETURN_NOT_OK` were replaced by calls to `throw_if_not_ok`.
* Returning statuses was replaced with passing them to `throw_if_not_ok` and returning `Status::Ok()`.
* Calls to `RETURN_CANCEL_OR_ERROR` were replaced by calls to `throw_if_not_ok` and calls to `StrategyBase::throw_if_cancellation_requested()`, a new method that throws if the query has been cancelled.

---
TYPE: NO_HISTORY