### PR TITLE
Use Ninja on macOS CI.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -56,9 +56,15 @@ on:
         description: 'Base triplet for vcpkg'
         required: false
         type: string
+      cmake_generator:
+        default: 'Unix Makefiles' # TODO: Ninja is much better than makefiles. Should it be the default?
+        description: 'CMake generator'
+        required: false
+        type: string
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
+  CMAKE_GENERATOR: ${{ inputs.cmake_generator }}
   TILEDB_CI_BACKEND: ${{ inputs.ci_backend }}
   TILEDB_CI_OS: ${{ startsWith(inputs.matrix_image, 'ubuntu-') && 'Linux' || 'macOS' }}
   # Installing Python does not work on manylinux.
@@ -123,6 +129,11 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+
+      # This must happen after checkout, because checkout would remove the directory.
+      - name: Install Ninja
+        if: inputs.cmake_generator == 'Ninja'
+        uses: seanmiddleditch/gha-setup-ninja@v4
 
       - name: 'Set up Python dependencies'
         if: ${{ !inputs.manylinux }}

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -51,6 +51,11 @@ on:
         description: 'Enable manylinux builds'
         required: false
         type: boolean
+      vcpkg_base_triplet:
+        default: ''
+        description: 'Base triplet for vcpkg'
+        required: false
+        type: string
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
@@ -63,7 +68,7 @@ env:
   CC: ${{ inputs.matrix_compiler_cc }}
   CFLAGS: ${{ inputs.matrix_compiler_cflags }}
   CXXFLAGS: ${{ inputs.matrix_compiler_cxxflags }}
-  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=x64-${{ startsWith(inputs.matrix_image, 'ubuntu-') && 'linux' || 'osx' }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
+  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'x64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -58,6 +58,7 @@ jobs:
     with:
       ci_backend: S3
       matrix_image: macos-12
+      cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -66,6 +67,7 @@ jobs:
     with:
       ci_backend: GCS
       matrix_image: macos-12
+      cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -100,6 +102,7 @@ jobs:
     with:
       ci_backend: AZURE
       matrix_image: macos-12
+      cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       timeout: 120
       bootstrap_args: '--enable-azure'
 

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -30,5 +30,5 @@ pushd $GITHUB_WORKSPACE/test/benchmarking
 mkdir -p build
 cd build
 cmake -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/build/dist;$GITHUB_WORKSPACE/build/vcpkg_installed/$VCPKG_TARGET_TRIPLET" ../src
-make
+cmake --build .
 popd

--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -31,13 +31,13 @@ set -xeuo pipefail
 
 cd $GITHUB_WORKSPACE/build
 
-make -j4
+cmake --build . -j4
 
-make -C tiledb install
+cmake --build tiledb --target install
 
 ls -la
 
-make -j4 -C tiledb tiledb_unit
-make -j4 -C tiledb unit_vfs
-make -j4 -C tiledb tiledb_regression
-make -j4 -C tiledb all_link_complete
+cmake --build tiledb -j4 --target tiledb_unit
+cmake --build tiledb -j4 --target unit_vfs
+cmake --build tiledb -j4 --target tiledb_regression
+cmake --build tiledb -j4 --target all_link_complete


### PR DESCRIPTION
[SC-49308](https://app.shortcut.com/tiledb-inc/story/49308/macos-runners-significantly-slower-after-pr-5001)

This PR updates all macOS CI jobs to use Ninja instead of makefiles, which was observed to fix unexplained significant performance regressions. Certain other scripts were updated to be generator-agnostic by invoking `cmake --build` instead of `make`.

Nightly builds were not updated to keep testing coverage with makefiles, and the standalone unit tests were not updated because their performance has not regressed.

---
TYPE: NO_HISTORY