### PR TITLE
Update macOS CI images to `macos-14`.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -51,6 +51,11 @@ on:
         description: 'Enable manylinux builds'
         required: false
         type: boolean
+      vcpkg_base_triplet:
+        default: ''
+        description: 'Base triplet for vcpkg'
+        required: false
+        type: string
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
@@ -63,7 +68,7 @@ env:
   CC: ${{ inputs.matrix_compiler_cc }}
   CFLAGS: ${{ inputs.matrix_compiler_cflags }}
   CXXFLAGS: ${{ inputs.matrix_compiler_cxxflags }}
-  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=x64-${{ startsWith(inputs.matrix_image, 'ubuntu-') && 'linux' || 'osx' }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
+  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'x64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: S3
-      matrix_image: macos-12
+      matrix_image: macos-14
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: GCS
-      matrix_image: macos-12
+      matrix_image: macos-14
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -99,7 +99,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: AZURE
-      matrix_image: macos-12
+      matrix_image: macos-14
       timeout: 120
       bootstrap_args: '--enable-azure'
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -58,6 +58,7 @@ jobs:
     with:
       ci_backend: S3
       matrix_image: macos-14
+      vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -66,6 +67,7 @@ jobs:
     with:
       ci_backend: GCS
       matrix_image: macos-14
+      vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -100,6 +102,7 @@ jobs:
     with:
       ci_backend: AZURE
       matrix_image: macos-14
+      vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable-azure'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
             triplet: x64-linux-release
             manylinux: true
           - platform: macos-x86_64
-            os: macos-12
+            os: macos-14
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release
           - platform: macos-arm64
-            os: macos-12
+            os: macos-14
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=arm64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: arm64-osx-release

--- a/scripts/ci/bootstrap_libtiledb.sh
+++ b/scripts/ci/bootstrap_libtiledb.sh
@@ -25,17 +25,6 @@
 #
 set -xeuo pipefail
 
-# Check for clean configure with tests disabled
-# This will not validate linkage, but we can't
-# build all variations separately right now.
-
-CONFIG_TMP_PATH=`mktemp -d`
-pushd $CONFIG_TMP_PATH
-$GITHUB_WORKSPACE/bootstrap $bootstrap_args --disable-tests
-popd
-
-###############################################
-
 # Build and test libtiledb
 
 # Set up arguments for bootstrap.sh


### PR DESCRIPTION
See TileDB-Inc#5069.

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
