### PR TITLE
Add a ContextResources& argument to the consolidation constructors.

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2666,6 +2666,7 @@ int32_t tiledb_array_consolidate(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
   api::ensure_config_is_valid_if_present(config);
   tiledb::sm::Consolidator::array_consolidate(
+      ctx->resources(),
       array_uri,
       tiledb::sm::EncryptionType::NO_ENCRYPTION,
       nullptr,
@@ -2685,6 +2686,7 @@ int32_t tiledb_array_consolidate_with_key(
   // Sanity checks
 
   tiledb::sm::Consolidator::array_consolidate(
+      ctx->resources(),
       array_uri,
       static_cast<tiledb::sm::EncryptionType>(encryption_type),
       encryption_key,
@@ -2711,6 +2713,7 @@ int32_t tiledb_array_consolidate_fragments(
   }
 
   tiledb::sm::Consolidator::fragments_consolidate(
+      ctx->resources(),
       array_uri,
       tiledb::sm::EncryptionType::NO_ENCRYPTION,
       nullptr,
@@ -2725,6 +2728,7 @@ int32_t tiledb_array_consolidate_fragments(
 int32_t tiledb_array_vacuum(
     tiledb_ctx_t* ctx, const char* array_uri, tiledb_config_t* config) {
   tiledb::sm::Consolidator::array_vacuum(
+      ctx->resources(),
       array_uri,
       (config == nullptr) ? ctx->config() : config->config(),
       ctx->storage_manager());

--- a/tiledb/sm/consolidator/array_meta_consolidator.h
+++ b/tiledb/sm/consolidator/array_meta_consolidator.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
@@ -54,11 +55,21 @@ class ArrayMetaConsolidator : public Consolidator {
   /**
    * Constructor.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of all Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * ArrayMetaConsolidator(ContextResources&, const Config&).
+   *
+   * @param resources The context resources.
    * @param config Config.
-   * @param storage_manager Storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
   explicit ArrayMetaConsolidator(
-      const Config& config, StorageManager* storage_manager);
+      ContextResources& resources,
+      const Config& config,
+      StorageManager* storage_manager);
 
   /** Destructor. */
   ~ArrayMetaConsolidator() = default;

--- a/tiledb/sm/consolidator/commits_consolidator.h
+++ b/tiledb/sm/consolidator/commits_consolidator.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
@@ -54,9 +55,18 @@ class CommitsConsolidator : public Consolidator {
   /**
    * Constructor.
    *
-   * @param storage_manager Storage manager.
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of all Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * CommitsConsolidator(ContextResources&).
+   *
+   * @param resources The context resources.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
-  explicit CommitsConsolidator(StorageManager* storage_manager);
+  explicit CommitsConsolidator(
+      ContextResources& resources, StorageManager* storage_manager);
 
   /** Destructor. */
   ~CommitsConsolidator() = default;

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -55,22 +55,26 @@ namespace tiledb::sm {
 
 /** Factory function to create the consolidator depending on mode. */
 shared_ptr<Consolidator> Consolidator::create(
+    ContextResources& resources,
     const ConsolidationMode mode,
     const Config& config,
     StorageManager* storage_manager) {
   switch (mode) {
     case ConsolidationMode::FRAGMENT_META:
-      return make_shared<FragmentMetaConsolidator>(HERE(), storage_manager);
+      return make_shared<FragmentMetaConsolidator>(
+          HERE(), resources, storage_manager);
     case ConsolidationMode::FRAGMENT:
-      return make_shared<FragmentConsolidator>(HERE(), config, storage_manager);
+      return make_shared<FragmentConsolidator>(
+          HERE(), resources, config, storage_manager);
     case ConsolidationMode::ARRAY_META:
       return make_shared<ArrayMetaConsolidator>(
-          HERE(), config, storage_manager);
+          HERE(), resources, config, storage_manager);
     case ConsolidationMode::COMMITS:
-      return make_shared<CommitsConsolidator>(HERE(), storage_manager);
+      return make_shared<CommitsConsolidator>(
+          HERE(), resources, storage_manager);
     case ConsolidationMode::GROUP_META:
       return make_shared<GroupMetaConsolidator>(
-          HERE(), config, storage_manager);
+          HERE(), resources, config, storage_manager);
     default:
       return nullptr;
   }
@@ -105,8 +109,9 @@ ConsolidationMode Consolidator::mode_from_config(
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
 
-Consolidator::Consolidator(StorageManager* storage_manager)
-    : resources_(storage_manager->resources())
+Consolidator::Consolidator(
+    ContextResources& resources, StorageManager* storage_manager)
+    : resources_(resources)
     , storage_manager_(storage_manager)
     , consolidator_memory_tracker_(resources_.create_memory_tracker())
     , stats_(resources_.stats().create_child("Consolidator"))
@@ -125,8 +130,7 @@ Status Consolidator::consolidate(
     [[maybe_unused]] EncryptionType encryption_type,
     [[maybe_unused]] const void* encryption_key,
     [[maybe_unused]] uint32_t key_length) {
-  return logger_->status(
-      Status_ConsolidatorError("Cannot consolidate; Invalid object"));
+  throw ConsolidatorException("Cannot consolidate; Invalid object");
 }
 
 void Consolidator::vacuum([[maybe_unused]] const char* array_name) {
@@ -134,6 +138,7 @@ void Consolidator::vacuum([[maybe_unused]] const char* array_name) {
 }
 
 void Consolidator::array_consolidate(
+    ContextResources& resources,
     const char* array_name,
     EncryptionType encryption_type,
     const void* encryption_key,
@@ -148,8 +153,7 @@ void Consolidator::array_consolidate(
 
   // Check if array exists
   ObjectType obj_type;
-  throw_if_not_ok(
-      object_type(storage_manager->resources(), array_uri, &obj_type));
+  throw_if_not_ok(object_type(resources, array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
     throw ConsolidatorException(
@@ -158,8 +162,7 @@ void Consolidator::array_consolidate(
 
   if (array_uri.is_tiledb()) {
     throw_if_not_ok(
-        storage_manager->resources().rest_client()->post_consolidation_to_rest(
-            array_uri, config));
+        resources.rest_client()->post_consolidation_to_rest(array_uri, config));
   } else {
     // Get encryption key from config
     std::string encryption_key_from_cfg;
@@ -190,13 +193,15 @@ void Consolidator::array_consolidate(
 
     // Consolidate
     auto mode = Consolidator::mode_from_config(config);
-    auto consolidator = Consolidator::create(mode, config, storage_manager);
+    auto consolidator =
+        Consolidator::create(resources, mode, config, storage_manager);
     throw_if_not_ok(consolidator->consolidate(
         array_name, encryption_type, encryption_key, key_length));
   }
 }
 
 void Consolidator::fragments_consolidate(
+    ContextResources& resources,
     const char* array_name,
     EncryptionType encryption_type,
     const void* encryption_key,
@@ -212,8 +217,7 @@ void Consolidator::fragments_consolidate(
 
   // Check if array exists
   ObjectType obj_type;
-  throw_if_not_ok(
-      object_type(storage_manager->resources(), array_uri, &obj_type));
+  throw_if_not_ok(object_type(resources, array_uri, &obj_type));
 
   if (obj_type != ObjectType::ARRAY) {
     throw ConsolidatorException(
@@ -249,7 +253,7 @@ void Consolidator::fragments_consolidate(
 
   // Consolidate
   auto consolidator = Consolidator::create(
-      ConsolidationMode::FRAGMENT, config, storage_manager);
+      resources, ConsolidationMode::FRAGMENT, config, storage_manager);
   auto fragment_consolidator =
       dynamic_cast<FragmentConsolidator*>(consolidator.get());
   throw_if_not_ok(fragment_consolidator->consolidate_fragments(
@@ -315,19 +319,20 @@ void Consolidator::write_consolidated_commits_file(
 }
 
 void Consolidator::array_vacuum(
+    ContextResources& resources,
     const char* array_name,
     const Config& config,
     StorageManager* storage_manager) {
   URI array_uri(array_name);
   if (array_uri.is_tiledb()) {
     throw_if_not_ok(
-        storage_manager->resources().rest_client()->post_vacuum_to_rest(
-            array_uri, config));
+        resources.rest_client()->post_vacuum_to_rest(array_uri, config));
     return;
   }
 
   auto mode = Consolidator::mode_from_config(config, true);
-  auto consolidator = Consolidator::create(mode, config, storage_manager);
+  auto consolidator =
+      Consolidator::create(resources, mode, config, storage_manager);
   consolidator->vacuum(array_name);
 }
 

--- a/tiledb/sm/consolidator/consolidator.h
+++ b/tiledb/sm/consolidator/consolidator.h
@@ -37,6 +37,7 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 #include <vector>
@@ -76,13 +77,22 @@ class Consolidator {
   /**
    * Factory method to make a new Consolidator instance given the config mode.
    *
+   * @section Maturity Notes
+   * This is a transitional method in the sense that we are working
+   * on removing the dependency of the Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be create(ContextResources&, ...).
+   *
+   * @param resources The context resources.
    * @param mode Consolidation mode.
    * @param config Configuration parameters for the consolidation
    *     (`nullptr` means default).
-   * @param storage_manager Storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    * @return New Consolidator instance or nullptr on error.
    */
   static shared_ptr<Consolidator> create(
+      ContextResources& resources,
       const ConsolidationMode mode,
       const Config& config,
       StorageManager* storage_manager);
@@ -134,6 +144,14 @@ class Consolidator {
   /**
    * Consolidates the fragments of an array into a single one.
    *
+   * @section Maturity Notes
+   * This is a transitional method in the sense that we are working
+   * on removing the dependency of the Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * array_consolidate(ContextResources&, ...).
+   *
+   * @param resources The context resources.
    * @param array_name The name of the array to be consolidated.
    * @param encryption_type The encryption type of the array
    * @param encryption_key If the array is encrypted, the private encryption
@@ -142,9 +160,11 @@ class Consolidator {
    * @param config Configuration parameters for the consolidation
    *     (`nullptr` means default, which will use the config associated with
    *      this instance).
-   * @param storage_manager The storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
   static void array_consolidate(
+      ContextResources& resources,
       const char* array_name,
       EncryptionType encryption_type,
       const void* encryption_key,
@@ -155,6 +175,14 @@ class Consolidator {
   /**
    * Consolidates the fragments of an array into a single one.
    *
+   * @section Maturity Notes
+   * This is a transitional method in the sense that we are working
+   * on removing the dependency of the Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * fragments_consolidate(ContextResources&, ...).
+   *
+   * @param resources The context resources.
    * @param array_name The name of the array to be consolidated.
    * @param encryption_type The encryption type of the array
    * @param encryption_key If the array is encrypted, the private encryption
@@ -164,9 +192,11 @@ class Consolidator {
    * @param config Configuration parameters for the consolidation
    *     (`nullptr` means default, which will use the config associated with
    *      this instance).
-   * @param storage_manager The storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
   static void fragments_consolidate(
+      ContextResources& resources,
       const char* array_name,
       EncryptionType encryption_type,
       const void* encryption_key,
@@ -194,11 +224,21 @@ class Consolidator {
    * metadata. Note that this will coarsen the granularity of time traveling
    * (see docs for more information).
    *
+   * @section Maturity Notes
+   * This is a transitional method in the sense that we are working
+   * on removing the dependency of the Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * array_vacuum(ContextResources&, ...).
+   *
+   * @param resources The context resources.
    * @param array_name The name of the array to be vacuumed.
    * @param config Configuration parameters for vacuuming.
-   * @param storage_manager The storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
   static void array_vacuum(
+      ContextResources& resources,
       const char* array_name,
       const Config& config,
       StorageManager* storage_manager);
@@ -223,9 +263,18 @@ class Consolidator {
   /**
    * Constructor.
    *
-   * @param storage_manager Storage manager.
+   * Constructs a Consolidator object given a ContextResources reference.
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of the Consolidator class on StorageManager. For
+   * now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be Consolidator(ContextResources&).
+   *
+   * @param resources The context resources.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
-  explicit Consolidator(StorageManager* storage_manager);
+  explicit Consolidator(
+      ContextResources& resources, StorageManager* storage_manager);
 
   /**
    * Checks if the array is remote.

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -583,7 +583,9 @@ Status FragmentConsolidator::consolidate_internal(
     vac_uri =
         array_for_reads->array_directory().get_vacuum_uri(*new_fragment_uri);
   } catch (std::exception& e) {
-    std::throw_with_nested(FragmentConsolidatorException(e.what()));
+    std::throw_with_nested(FragmentConsolidatorException(
+        "Internal consolidation failed with exception" +
+        std::string(e.what())));
   }
 
   // Read from one array and write to the other

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -583,9 +583,8 @@ Status FragmentConsolidator::consolidate_internal(
     vac_uri =
         array_for_reads->array_directory().get_vacuum_uri(*new_fragment_uri);
   } catch (std::exception& e) {
-    std::throw_with_nested(FragmentConsolidatorException(
-        "Internal consolidation failed with exception" +
-        std::string(e.what())));
+    FragmentConsolidatorException(
+        "Internal consolidation failed with exception" + std::string(e.what()));
   }
 
   // Read from one array and write to the other

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -187,8 +187,10 @@ void FragmentConsolidationWorkspace::resize_buffers(
 /* ****************************** */
 
 FragmentConsolidator::FragmentConsolidator(
-    const Config& config, StorageManager* storage_manager)
-    : Consolidator(storage_manager) {
+    ContextResources& resources,
+    const Config& config,
+    StorageManager* storage_manager)
+    : Consolidator(resources, storage_manager) {
   auto st = set_config(config);
   if (!st.ok()) {
     throw FragmentConsolidatorException(st.message());
@@ -209,15 +211,14 @@ Status FragmentConsolidator::consolidate(
   check_array_uri(array_name);
 
   // Open array for reading
-  auto array_for_reads{make_shared<Array>(
-      HERE(), storage_manager_->resources(), URI(array_name))};
-  RETURN_NOT_OK(array_for_reads->open_without_fragments(
+  auto array_for_reads{make_shared<Array>(HERE(), resources_, URI(array_name))};
+  throw_if_not_ok(array_for_reads->open_without_fragments(
       encryption_type, encryption_key, key_length));
 
   // Open array for writing
-  auto array_for_writes{make_shared<Array>(
-      HERE(), storage_manager_->resources(), array_for_reads->array_uri())};
-  RETURN_NOT_OK(array_for_writes->open(
+  auto array_for_writes{
+      make_shared<Array>(HERE(), resources_, array_for_reads->array_uri())};
+  throw_if_not_ok(array_for_writes->open(
       QueryType::WRITE, encryption_type, encryption_key, key_length));
 
   // Disable consolidation with timestamps on older arrays.
@@ -232,7 +233,7 @@ Status FragmentConsolidator::consolidate(
   // must be fetched (even before `config_.timestamp_start_`),
   // to compute the anterior ND range that can help determine
   // which dense fragments are consolidatable.
-  FragmentInfo fragment_info(URI(array_name), storage_manager_->resources());
+  FragmentInfo fragment_info(URI(array_name), resources_);
   auto st = fragment_info.load(
       array_for_reads->array_directory(),
       config_.timestamp_start_,
@@ -305,7 +306,7 @@ Status FragmentConsolidator::consolidate(
 
   RETURN_NOT_OK_ELSE(
       array_for_reads->close(), throw_if_not_ok(array_for_writes->close()));
-  RETURN_NOT_OK(array_for_writes->close());
+  throw_if_not_ok(array_for_writes->close());
 
   stats_->add_counter("consolidate_step_num", step);
 
@@ -321,15 +322,14 @@ Status FragmentConsolidator::consolidate_fragments(
   auto timer_se = stats_->start_timer("consolidate_frags");
 
   // Open array for reading
-  auto array_for_reads{make_shared<Array>(
-      HERE(), storage_manager_->resources(), URI(array_name))};
-  RETURN_NOT_OK(array_for_reads->open_without_fragments(
+  auto array_for_reads{make_shared<Array>(HERE(), resources_, URI(array_name))};
+  throw_if_not_ok(array_for_reads->open_without_fragments(
       encryption_type, encryption_key, key_length));
 
   // Open array for writing
-  auto array_for_writes{make_shared<Array>(
-      HERE(), storage_manager_->resources(), array_for_reads->array_uri())};
-  RETURN_NOT_OK(array_for_writes->open(
+  auto array_for_writes{
+      make_shared<Array>(HERE(), resources_, array_for_reads->array_uri())};
+  throw_if_not_ok(array_for_writes->open(
       QueryType::WRITE, encryption_type, encryption_key, key_length));
 
   // Disable consolidation with timestamps on older arrays.
@@ -344,7 +344,7 @@ Status FragmentConsolidator::consolidate_fragments(
   }
 
   // Get all fragment info
-  FragmentInfo fragment_info(URI(array_name), storage_manager_->resources());
+  FragmentInfo fragment_info(URI(array_name), resources_);
   auto st = fragment_info.load(
       array_for_reads->array_directory(),
       0,
@@ -383,8 +383,8 @@ Status FragmentConsolidator::consolidate_fragments(
   }
 
   if (count != fragment_uris.size()) {
-    return logger_->status(Status_ConsolidatorError(
-        "Cannot consolidate; Not all fragments could be found"));
+    throw FragmentConsolidatorException(
+        "Cannot consolidate; Not all fragments could be found");
   }
 
   FragmentConsolidationWorkspace cw(consolidator_memory_tracker_);
@@ -429,7 +429,7 @@ void FragmentConsolidator::vacuum(const char* array_name) {
 
   // Get the fragment URIs and vacuum file URIs to be vacuumed
   ArrayDirectory array_dir(
-      storage_manager_->resources(),
+      resources_,
       URI(array_name),
       0,
       std::numeric_limits<uint64_t>::max(),
@@ -583,8 +583,7 @@ Status FragmentConsolidator::consolidate_internal(
     vac_uri =
         array_for_reads->array_directory().get_vacuum_uri(*new_fragment_uri);
   } catch (std::exception& e) {
-    std::throw_with_nested(
-        std::logic_error("[FragmentConsolidator::consolidate_internal] "));
+    std::throw_with_nested(FragmentConsolidatorException(e.what()));
   }
 
   // Read from one array and write to the other
@@ -669,14 +668,14 @@ Status FragmentConsolidator::create_queries(
   // Create read query
   query_r = tdb_unique_ptr<Query>(tdb_new(
       Query, storage_manager_, array_for_reads, nullopt, read_memory_budget));
-  RETURN_NOT_OK(query_r->set_layout(Layout::GLOBAL_ORDER));
+  throw_if_not_ok(query_r->set_layout(Layout::GLOBAL_ORDER));
 
   // Dense consolidation will do a tile aligned read.
   if (dense) {
     NDRange read_subarray = subarray;
     auto& domain{array_for_reads->array_schema_latest().domain()};
     domain.expand_to_tiles(&read_subarray);
-    RETURN_NOT_OK(query_r->set_subarray_unsafe(read_subarray));
+    throw_if_not_ok(query_r->set_subarray_unsafe(read_subarray));
   }
 
   // Enable consolidation with timestamps on the reader, if applicable.
@@ -699,11 +698,11 @@ Status FragmentConsolidator::create_queries(
       array_for_writes,
       fragment_name,
       write_memory_budget));
-  RETURN_NOT_OK(query_w->set_layout(Layout::GLOBAL_ORDER));
-  RETURN_NOT_OK(query_w->disable_checks_consolidation());
+  throw_if_not_ok(query_w->set_layout(Layout::GLOBAL_ORDER));
+  throw_if_not_ok(query_w->disable_checks_consolidation());
   query_w->set_fragment_size(config_.max_fragment_size_);
   if (array_for_reads->array_schema_latest().dense()) {
-    RETURN_NOT_OK(query_w->set_subarray_unsafe(subarray));
+    throw_if_not_ok(query_w->set_subarray_unsafe(subarray));
   }
 
   // Set the processed conditions on new fragment.
@@ -931,11 +930,11 @@ Status FragmentConsolidator::set_config(const Config& config) {
   merged_config.inherit(config);
   bool found = false;
   config_.amplification_ = 0.0f;
-  RETURN_NOT_OK(merged_config.get<float>(
+  throw_if_not_ok(merged_config.get<float>(
       "sm.consolidation.amplification", &config_.amplification_, &found));
   assert(found);
   config_.steps_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint32_t>(
+  throw_if_not_ok(merged_config.get<uint32_t>(
       "sm.consolidation.steps", &config_.steps_, &found));
   assert(found);
   config_.buffer_size_ = 0;
@@ -946,54 +945,54 @@ Status FragmentConsolidator::set_config(const Config& config) {
         "The `sm.consolidation.buffer_size configuration setting has been "
         "deprecated. Set consolidation buffer sizes using the newer "
         "`sm.mem.consolidation.buffers_weight` setting.");
-    RETURN_NOT_OK(merged_config.get<uint64_t>(
+    throw_if_not_ok(merged_config.get<uint64_t>(
         "sm.consolidation.buffer_size", &config_.buffer_size_, &found));
     assert(found);
   }
   config_.total_budget_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.mem.total_budget", &config_.total_budget_, &found));
   assert(found);
   config_.buffers_weight_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.mem.consolidation.buffers_weight", &config_.buffers_weight_, &found));
   assert(found);
   config_.reader_weight_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.mem.consolidation.reader_weight", &config_.reader_weight_, &found));
   assert(found);
   config_.writer_weight_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.mem.consolidation.writer_weight", &config_.writer_weight_, &found));
   assert(found);
   config_.max_fragment_size_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.consolidation.max_fragment_size",
       &config_.max_fragment_size_,
       &found));
   assert(found);
   config_.size_ratio_ = 0.0f;
-  RETURN_NOT_OK(merged_config.get<float>(
+  throw_if_not_ok(merged_config.get<float>(
       "sm.consolidation.step_size_ratio", &config_.size_ratio_, &found));
   assert(found);
   config_.purge_deleted_cells_ = false;
-  RETURN_NOT_OK(merged_config.get<bool>(
+  throw_if_not_ok(merged_config.get<bool>(
       "sm.consolidation.purge_deleted_cells",
       &config_.purge_deleted_cells_,
       &found));
   assert(found);
   config_.min_frags_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint32_t>(
+  throw_if_not_ok(merged_config.get<uint32_t>(
       "sm.consolidation.step_min_frags", &config_.min_frags_, &found));
   assert(found);
   config_.max_frags_ = 0;
-  RETURN_NOT_OK(merged_config.get<uint32_t>(
+  throw_if_not_ok(merged_config.get<uint32_t>(
       "sm.consolidation.step_max_frags", &config_.max_frags_, &found));
   assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_start", &config_.timestamp_start_, &found));
   assert(found);
-  RETURN_NOT_OK(merged_config.get<uint64_t>(
+  throw_if_not_ok(merged_config.get<uint64_t>(
       "sm.consolidation.timestamp_end", &config_.timestamp_end_, &found));
   assert(found);
   std::string reader =
@@ -1005,17 +1004,17 @@ Status FragmentConsolidator::set_config(const Config& config) {
 
   // Sanity checks
   if (config_.min_frags_ > config_.max_frags_)
-    return logger_->status(Status_ConsolidatorError(
+    throw FragmentConsolidatorException(
         "Invalid configuration; Minimum fragments config parameter is larger "
-        "than the maximum"));
+        "than the maximum");
   if (config_.size_ratio_ > 1.0f || config_.size_ratio_ < 0.0f)
-    return logger_->status(Status_ConsolidatorError(
+    throw FragmentConsolidatorException(
         "Invalid configuration; Step size ratio config parameter must be in "
-        "[0.0, 1.0]"));
+        "[0.0, 1.0]");
   if (config_.amplification_ < 0)
-    return logger_->status(
-        Status_ConsolidatorError("Invalid configuration; Amplification config "
-                                 "parameter must be non-negative"));
+    throw FragmentConsolidatorException(
+        "Invalid configuration; Amplification config parameter must be "
+        "non-negative");
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -40,6 +40,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 #include <vector>
@@ -173,11 +174,21 @@ class FragmentConsolidator : public Consolidator {
   /**
    * Constructor.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of all Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * FragmentConsolidator(ContextResources&, const Config&).
+   *
+   * @param resources The context resources.
    * @param config Config.
-   * @param storage_manager Storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
   explicit FragmentConsolidator(
-      const Config& config, StorageManager* storage_manager);
+      ContextResources& resources,
+      const Config& config,
+      StorageManager* storage_manager);
 
   /** Destructor. */
   ~FragmentConsolidator() = default;

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -52,8 +52,8 @@ namespace tiledb::sm {
 /* ****************************** */
 
 FragmentMetaConsolidator::FragmentMetaConsolidator(
-    StorageManager* storage_manager)
-    : Consolidator(storage_manager) {
+    ContextResources& resources, StorageManager* storage_manager)
+    : Consolidator(resources, storage_manager) {
 }
 
 /* ****************************** */
@@ -70,8 +70,8 @@ Status FragmentMetaConsolidator::consolidate(
   check_array_uri(array_name);
 
   // Open array for reading
-  Array array(storage_manager_->resources(), URI(array_name));
-  RETURN_NOT_OK(
+  Array array(resources_, URI(array_name));
+  throw_if_not_ok(
       array.open(QueryType::READ, encryption_type, encryption_key, key_length));
 
   // Include only fragments with footers / separate basic metadata
@@ -129,7 +129,7 @@ Status FragmentMetaConsolidator::consolidate(
 
         return Status::Ok();
       });
-  RETURN_NOT_OK(status);
+  throw_if_not_ok(status);
 
   auto serialize_data = [&](Serializer& serializer, uint64_t offset) {
     // Write number of fragments
@@ -166,10 +166,10 @@ Status FragmentMetaConsolidator::consolidate(
   serialize_data(serializer, offset);
 
   // Close array
-  RETURN_NOT_OK(array.close());
+  throw_if_not_ok(array.close());
 
   EncryptionKey enc_key;
-  RETURN_NOT_OK(enc_key.set_key(encryption_type, encryption_key, key_length));
+  throw_if_not_ok(enc_key.set_key(encryption_type, encryption_key, key_length));
 
   GenericTileIO tile_io(resources_, uri);
   [[maybe_unused]] uint64_t nbytes = 0;

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
@@ -54,9 +55,18 @@ class FragmentMetaConsolidator : public Consolidator {
   /**
    * Constructor.
    *
-   * @param storage_manager Storage manager.
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of all Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * FragmentMetaConsolidator(ContextResources&).
+   *
+   * @param resources The context resources.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
-  explicit FragmentMetaConsolidator(StorageManager* storage_manager);
+  explicit FragmentMetaConsolidator(
+      ContextResources& resources, StorageManager* storage_manager);
 
   /** Destructor. */
   ~FragmentMetaConsolidator() = default;

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -70,12 +70,12 @@ Status GroupMetaConsolidator::consolidate(
 
   // Open group for reading
   auto group_uri = URI(group_name);
-  Group group_for_reads(resources_, group_uri, storage_manager_);
+  Group group_for_reads(resources_, group_uri);
   group_for_reads.open(
       QueryType::READ, config_.timestamp_start_, config_.timestamp_end_);
 
   // Open group for writing
-  Group group_for_writes(resources_, group_uri, storage_manager_);
+  Group group_for_writes(resources_, group_uri);
 
   try {
     group_for_writes.open(QueryType::WRITE);

--- a/tiledb/sm/consolidator/group_meta_consolidator.h
+++ b/tiledb/sm/consolidator/group_meta_consolidator.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/consolidator/consolidator.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
@@ -53,11 +54,21 @@ class GroupMetaConsolidator : public Consolidator {
   /**
    * Constructor.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of all Consolidator classes on StorageManager.
+   * For now we still need to keep the storage_manager argument, but once the
+   * dependency is gone the signature will be
+   * GroupMetaConsolidator(ContextResources&, const Config&).
+   *
+   * @param resources The context resources.
    * @param config Config.
-   * @param storage_manager Storage manager.
+   * @param storage_manager A StorageManager pointer.
+   *    (this will go away in the near future)
    */
   explicit GroupMetaConsolidator(
-      const Config& config, StorageManager* storage_manager);
+      ContextResources& resources,
+      const Config& config,
+      StorageManager* storage_manager);
 
   /** Destructor. */
   ~GroupMetaConsolidator() = default;

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -587,8 +587,8 @@ Status Group::consolidate_metadata(
   // Consolidate
   // Encryption credentials are loaded by Group from config
   StorageManager sm(resources, resources.logger(), config);
-  auto consolidator =
-      Consolidator::create(ConsolidationMode::GROUP_META, config, &sm);
+  auto consolidator = Consolidator::create(
+      resources, ConsolidationMode::GROUP_META, config, &sm);
   return consolidator->consolidate(
       group_name, EncryptionType::NO_ENCRYPTION, nullptr, 0);
 }
@@ -610,8 +610,8 @@ void Group::vacuum_metadata(
   }
 
   StorageManager sm(resources, resources.logger(), config);
-  auto consolidator =
-      Consolidator::create(ConsolidationMode::GROUP_META, config, &sm);
+  auto consolidator = Consolidator::create(
+      resources, ConsolidationMode::GROUP_META, config, &sm);
   consolidator->vacuum(group_name);
 }
 


### PR DESCRIPTION
Add a `ContextResources&` argument to the consolidation constructors. This is the first step in transitional work to replace `StorageManager` with `ContextResources` everywhere in the consolidation code. Future work has been documented appropriately.

[sc-49373]

---
TYPE: NO_HISTORY
DESC: Add a `ContextResources&` argument to the consolidation constructors.
