### PR TITLE
Eliminate usage of StorageManager from class Subarray.

### DIFF
--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -115,6 +115,11 @@ class OpenedArray {
         encryption_key_->set_key(encryption_type, key_bytes, key_length));
   }
 
+  /** Returns the context resources. */
+  inline ContextResources& resources() {
+    return resources_;
+  }
+
   /** Returns the array directory object. */
   inline const ArrayDirectory& array_directory() const {
     return array_dir_.value();

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1723,8 +1723,7 @@ capi_return_t tiledb_subarray_alloc(
         array->array_.get(),
         (tiledb::sm::stats::Stats*)nullptr,
         ctx->resources().logger(),
-        true,
-        ctx->storage_manager());
+        true);
     (*subarray)->is_allocated_ = true;
   } catch (...) {
     delete *subarray;

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -279,11 +279,7 @@ int32_t tiledb_filestore_uri_import(
   std::vector<std::byte> buffer(buffer_size);
 
   tiledb::sm::Subarray subarray(
-      array.get(),
-      nullptr,
-      context.resources().logger(),
-      true,
-      context.storage_manager());
+      array.get(), nullptr, context.resources().logger(), true);
   // We need to get the right end boundary of the last space tile.
   // The last chunk either falls exactly on the end of the file
   // or it goes beyond the end of the file so that it's equal in size
@@ -303,11 +299,7 @@ int32_t tiledb_filestore_uri_import(
     tiledb::sm::Query query(context.storage_manager(), array);
     throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
     tiledb::sm::Subarray subarray_cloud_fix(
-        array.get(),
-        nullptr,
-        context.resources().logger(),
-        true,
-        context.storage_manager());
+        array.get(), nullptr, context.resources().logger(), true);
 
     uint64_t cloud_fix_range_arr[] = {start, end};
     tiledb::type::Range subarray_range_cloud_fix(
@@ -431,11 +423,7 @@ int32_t tiledb_filestore_uri_export(
   do {
     uint64_t write_size = end_range - start_range + 1;
     tiledb::sm::Subarray subarray(
-        array.get(),
-        nullptr,
-        context.resources().logger(),
-        true,
-        context.storage_manager());
+        array.get(), nullptr, context.resources().logger(), true);
     uint64_t subarray_range_arr[] = {start_range, end_range};
     tiledb::type::Range subarray_range(
         static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
@@ -548,11 +536,7 @@ int32_t tiledb_filestore_buffer_import(
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
 
   tiledb::sm::Subarray subarray(
-      array.get(),
-      nullptr,
-      context.resources().logger(),
-      true,
-      context.storage_manager());
+      array.get(), nullptr, context.resources().logger(), true);
   uint64_t subarray_range_arr[] = {
       static_cast<uint64_t>(0), static_cast<uint64_t>(size - 1)};
   tiledb::type::Range subarray_range(
@@ -610,11 +594,7 @@ int32_t tiledb_filestore_buffer_export(
   }
 
   tiledb::sm::Subarray subarray(
-      array.get(),
-      nullptr,
-      context.resources().logger(),
-      true,
-      context.storage_manager());
+      array.get(), nullptr, context.resources().logger(), true);
   uint64_t subarray_range_arr[] = {
       static_cast<uint64_t>(offset), static_cast<uint64_t>(offset + size - 1)};
   tiledb::type::Range subarray_range(

--- a/tiledb/sm/query/writers/writer_base.h
+++ b/tiledb/sm/query/writers/writer_base.h
@@ -45,13 +45,11 @@
 #include "tiledb/sm/query/strategy_base.h"
 #include "tiledb/sm/query/writers/dense_tiler.h"
 #include "tiledb/sm/stats/stats.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 class DomainBuffersView;
@@ -501,7 +499,6 @@ class WriterBase : public StrategyBase, public IQueryStrategy {
   bool remote_query() const;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_WRITER_BASE_H

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -50,7 +50,6 @@
 #include "tiledb/sm/serialization/array_directory.h"
 #include "tiledb/sm/serialization/array_schema.h"
 #include "tiledb/sm/serialization/fragment_metadata.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;

--- a/tiledb/sm/serialization/array_directory.h
+++ b/tiledb/sm/serialization/array_directory.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,13 +42,12 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
-
+namespace tiledb::sm {
 class ArrayDirectory;
 enum class SerializationType : uint8_t;
+}  // namespace tiledb::sm
 
-namespace serialization {
+namespace tiledb::sm::serialization {
 
 #ifdef TILEDB_SERIALIZATION
 
@@ -78,8 +77,6 @@ void array_directory_to_capnp(
 
 #endif
 
-}  // namespace serialization
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::serialization
 
 #endif  // TILEDB_SERIALIZATION_ARRAY_DIRECTORY_H

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -43,7 +43,6 @@
 #include "tiledb/sm/misc/tile_overlap.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/stats/stats.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 #include "tiledb/sm/subarray/range_subset.h"
 #include "tiledb/sm/subarray/relevant_fragments.h"
 #include "tiledb/sm/subarray/subarray_tile_overlap.h"
@@ -368,8 +367,7 @@ class Subarray {
       const Array* array,
       stats::Stats* parent_stats,
       shared_ptr<Logger> logger,
-      bool coalesce_ranges = true,
-      StorageManager* storage_manager = nullptr);
+      bool coalesce_ranges = true);
 
   /**
    * Constructor.
@@ -388,8 +386,7 @@ class Subarray {
       Layout layout,
       stats::Stats* parent_stats,
       shared_ptr<Logger> logger,
-      bool coalesce_ranges = true,
-      StorageManager* storage_manager = nullptr);
+      bool coalesce_ranges = true);
 
   /**
    * Constructor.
@@ -408,8 +405,7 @@ class Subarray {
       Layout layout,
       stats::Stats* parent_stats,
       shared_ptr<Logger> logger,
-      bool coalesce_ranges = true,
-      StorageManager* storage_manager = nullptr);
+      bool coalesce_ranges = true);
 
   /**
    * Copy constructor. This performs a deep copy (including memcpy of

--- a/tiledb/sm/subarray/test/unit_add_ranges_list.cc
+++ b/tiledb/sm/subarray/test/unit_add_ranges_list.cc
@@ -102,11 +102,7 @@ TEST_CASE("Subarray::add_ranges_list", "[subarray]") {
 
   // The Subarray used to test add_ranges_list.
   tiledb::sm::Subarray sa(
-      &a,
-      &test::g_helper_stats,
-      test::g_helper_logger(),
-      true,
-      ctx.storage_manager());
+      &a, &test::g_helper_stats, test::g_helper_logger(), true);
 
   // Add ranges
   // NOTE: The type used here for the range needs to match the type used for the


### PR DESCRIPTION
Eliminate usage of `StorageManager` from class `Subarray`.

[sc-49398]

---
TYPE: NO_HISTORY
DESC: Eliminate usage of `StorageManager` from class `Subarray`.
