### PR TITLE
Fix exceptions with message: ```unknown exception type; no further information```.

### DIFF
--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -246,7 +246,6 @@ Status Array::create(
     const URI& array_uri,
     const shared_ptr<ArraySchema>& array_schema,
     const EncryptionKey& encryption_key) {
-
   // Check array schema
   if (array_schema == nullptr) {
     throw ArrayException("Cannot create array; Empty array schema");

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -246,6 +246,7 @@ Status Array::create(
     const URI& array_uri,
     const shared_ptr<ArraySchema>& array_schema,
     const EncryptionKey& encryption_key) {
+
   // Check array schema
   if (array_schema == nullptr) {
     throw ArrayException("Cannot create array; Empty array schema");
@@ -386,7 +387,7 @@ Status Array::open_without_fragments(
     if (remote_) {
       auto rest_client = resources_.rest_client();
       if (rest_client == nullptr) {
-        throw Status_ArrayError(
+        throw ArrayException(
             "Cannot open array; remote array with no REST client.");
       }
       /* #TODO Change get_array_schema_from_rest function signature to
@@ -675,7 +676,7 @@ Status Array::close() {
         set_metadata_loaded(true);
         auto rest_client = resources_.rest_client();
         if (rest_client == nullptr) {
-          throw Status_ArrayError(
+          throw ArrayException(
               "Error closing array; remote array with no REST client.");
         }
         throw_if_not_ok(rest_client->post_array_metadata_to_rest(
@@ -699,7 +700,7 @@ Status Array::close() {
     opened_array_.reset();
   } catch (std::exception& e) {
     is_opening_or_closing_ = false;
-    throw Status_ArrayError(e.what());
+    throw ArrayException(e.what());
   }
 
   is_opening_or_closing_ = false;
@@ -1159,7 +1160,7 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
       set_array_closed();
     } catch (std::exception& e) {
       is_opening_or_closing_ = false;
-      throw Status_ArrayError(e.what());
+      throw ArrayException(e.what());
     }
     is_opening_or_closing_ = false;
 

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -48,6 +48,13 @@
 
 namespace tiledb::sm {
 
+class FragmentInfoException : public StatusException {
+ public:
+  explicit FragmentInfoException(const std::string& message)
+      : StatusException("FragmentInfo", message) {
+  }
+};
+
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
 /* ****************************** */
@@ -182,7 +189,7 @@ Status FragmentInfo::get_total_cell_num(uint64_t* cell_num) const {
 const std::string& FragmentInfo::fragment_name(uint32_t fid) const {
   ensure_loaded();
   if (fid >= fragment_num())
-    throw Status_FragmentInfoError(
+    throw FragmentInfoException(
         "Cannot get fragment URI; Invalid fragment index");
 
   return single_fragment_info_vec_[fid].name();
@@ -936,7 +943,7 @@ Status FragmentInfo::load(const ArrayDirectory& array_dir) {
 
 void FragmentInfo::ensure_loaded() const {
   if (!loaded_) {
-    throw Status_FragmentInfoError("Fragment info has not been loaded.");
+    throw FragmentInfoException("Fragment info has not been loaded.");
   }
 }
 

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -46,6 +46,14 @@
 namespace tiledb {
 namespace sm {
 
+/** Class for generic status exceptions. */
+class GenericException : public StatusException {
+ public:
+  explicit GenericException(const std::string& msg)
+      : StatusException("Generic", msg) {
+  }
+};
+
 using namespace tiledb::common;
 
 class Posix;

--- a/tiledb/sm/misc/utils.h
+++ b/tiledb/sm/misc/utils.h
@@ -46,14 +46,6 @@
 namespace tiledb {
 namespace sm {
 
-/** Class for generic status exceptions. */
-class GenericException : public StatusException {
- public:
-  explicit GenericException(const std::string& msg)
-      : StatusException("Generic", msg) {
-  }
-};
-
 using namespace tiledb::common;
 
 class Posix;

--- a/tiledb/sm/query/ast/query_ast.cc
+++ b/tiledb/sm/query/ast/query_ast.cc
@@ -33,6 +33,7 @@
 #include "query_ast.h"
 #include "tiledb/sm/array_schema/enumeration.h"
 #include "tiledb/sm/misc/integral_type_casts.h"
+#include "tiledb/sm/query/query_condition.h"
 
 using namespace tiledb::common;
 
@@ -317,8 +318,8 @@ Status ASTNodeVal::check_node_validity(const ArraySchema& array_schema) const {
       (op_ == QueryConditionOp::IN || op_ == QueryConditionOp::NOT_IN)) {
     for (auto& member : members_) {
       if (member.size() != cell_size) {
-        throw Status_QueryConditionError(
-            "Value node set memmber size mismatch: " +
+        throw QueryConditionException(
+            "Value node set member size mismatch: " +
             std::to_string(cell_size) + " != " + std::to_string(member.size()));
       }
     }

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -47,6 +47,13 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+class QueryConditionException : public StatusException {
+ public:
+  explicit QueryConditionException(const std::string& message)
+      : StatusException("QueryCondition", message) {
+  }
+};
+
 class FragmentMetadata;
 class MemoryTracker;
 struct ResultCellSlab;

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -736,7 +736,8 @@ void RestClient::post_query_plan_from_rest(
   // Get array
   const Array* array = query.array();
   if (array == nullptr) {
-    throw RestClientException("Error submitting query plan to REST; null array.");
+    throw RestClientException(
+        "Error submitting query plan to REST; null array.");
   }
 
   Buffer buff;

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -318,7 +318,7 @@ shared_ptr<ArraySchema> RestClient::post_array_schema_from_rest(
       &returned_data,
       cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0) {
-    throw Status_RestError(
+    throw RestClientException(
         "Error getting array schema from REST; server returned no data.");
   }
 
@@ -676,7 +676,7 @@ RestClient::post_enumerations_from_rest(
     const std::vector<std::string>& enumeration_names,
     shared_ptr<MemoryTracker> memory_tracker) {
   if (array == nullptr) {
-    throw Status_RestError(
+    throw RestClientException(
         "Error getting enumerations from REST; array is null.");
   }
 
@@ -721,7 +721,7 @@ RestClient::post_enumerations_from_rest(
       &returned_data,
       cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0) {
-    throw Status_RestError(
+    throw RestClientException(
         "Error getting enumerations from REST; server returned no data.");
   }
 
@@ -736,7 +736,7 @@ void RestClient::post_query_plan_from_rest(
   // Get array
   const Array* array = query.array();
   if (array == nullptr) {
-    throw Status_RestError("Error submitting query plan to REST; null array.");
+    throw RestClientException("Error submitting query plan to REST; null array.");
   }
 
   Buffer buff;
@@ -779,7 +779,7 @@ void RestClient::post_query_plan_from_rest(
       &returned_data,
       cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0) {
-    throw Status_RestError(
+    throw RestClientException(
         "Error getting query plan from REST; server returned no data.");
   }
 
@@ -1650,7 +1650,7 @@ RestClient::post_consolidation_plan_from_rest(
       &returned_data,
       cache_key));
   if (returned_data.data() == nullptr || returned_data.size() == 0) {
-    throw Status_RestError(
+    throw RestClientException(
         "Error getting query plan from REST; server returned no data.");
   }
 

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -69,6 +69,8 @@
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/serialization/array_schema.h"
 #include "tiledb/sm/serialization/enumeration.h"
+#include "tiledb/sm/misc/utils.h"
+
 
 #include <cstring>
 #include <set>
@@ -1862,18 +1864,18 @@ void serialize_load_array_schema_request(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing load array schema request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load array schema request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load array schema request; exception " +
         std::string(e.what()));
   }
@@ -1907,17 +1909,17 @@ LoadArraySchemaRequest deserialize_load_array_schema_request(
         return load_array_schema_request_from_capnp(reader);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing load array schema request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load array schema request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load array schema request; exception " +
         std::string(e.what()));
   }
@@ -1963,18 +1965,18 @@ void serialize_load_array_schema_response(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing load array schema response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load array schema response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load array schema response; exception " +
         std::string(e.what()));
   }
@@ -2012,17 +2014,17 @@ shared_ptr<ArraySchema> deserialize_load_array_schema_response(
         return load_array_schema_response_from_capnp(reader, memory_tracker);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing load array schema response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load array schema response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load array schema response; exception " +
         std::string(e.what()));
   }
@@ -2081,25 +2083,25 @@ Status max_buffer_sizes_deserialize(
 
 void serialize_load_array_schema_request(
     const Config&, const LoadArraySchemaRequest&, SerializationType, Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 LoadArraySchemaRequest deserialize_load_array_schema_request(
     SerializationType, const Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 void serialize_load_array_schema_response(
     const ArraySchema&, SerializationType, Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 shared_ptr<ArraySchema> deserialize_load_array_schema_response(
     SerializationType, const Buffer&, shared_ptr<MemoryTracker>) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -67,10 +67,9 @@
 #include "tiledb/sm/filter/webp_filter.h"
 #include "tiledb/sm/filter/xor_filter.h"
 #include "tiledb/sm/misc/constants.h"
+#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/serialization/array_schema.h"
 #include "tiledb/sm/serialization/enumeration.h"
-#include "tiledb/sm/misc/utils.h"
-
 
 #include <cstring>
 #include <set>
@@ -2083,26 +2082,22 @@ Status max_buffer_sizes_deserialize(
 
 void serialize_load_array_schema_request(
     const Config&, const LoadArraySchemaRequest&, SerializationType, Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 LoadArraySchemaRequest deserialize_load_array_schema_request(
     SerializationType, const Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 void serialize_load_array_schema_response(
     const ArraySchema&, SerializationType, Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 shared_ptr<ArraySchema> deserialize_load_array_schema_response(
     SerializationType, const Buffer&, shared_ptr<MemoryTracker>) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/consolidation.cc
+++ b/tiledb/sm/serialization/consolidation.cc
@@ -44,7 +44,6 @@
 
 #include "tiledb/common/logger_public.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/serialization/config.h"
 #include "tiledb/sm/serialization/consolidation.h"
 
@@ -53,6 +52,22 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 namespace serialization {
+
+class ConsolidationSerializationException : public StatusException {
+ public:
+  explicit ConsolidationSerializationException(const std::string& message)
+      : StatusException("[TileDB::Serialization][Consolidation]", message) {
+  }
+};
+
+class ConsolidationSerializationDisabledException
+    : public ConsolidationSerializationException {
+ public:
+  explicit ConsolidationSerializationDisabledException()
+      : ConsolidationSerializationException(
+            "Cannot (de)serialize; serialization not enabled.") {
+  }
+};
 
 #ifdef TILEDB_SERIALIZATION
 
@@ -270,18 +285,18 @@ void serialize_consolidation_plan_request(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw ConsolidationSerializationException(
             "Error serializing consolidation plan request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error serializing consolidation plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error serializing consolidation plan request; exception " +
         std::string(e.what()));
   }
@@ -311,17 +326,17 @@ uint64_t deserialize_consolidation_plan_request(
         return consolidation_plan_request_from_capnp(reader);
       }
       default: {
-        throw SerializationStatusException(
+        throw ConsolidationSerializationException(
             "Error deserializing consolidation plan request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error deserializing consolidation plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error deserializing consolidation plan request; exception " +
         std::string(e.what()));
   }
@@ -361,18 +376,18 @@ void serialize_consolidation_plan_response(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw ConsolidationSerializationException(
             "Error serializing consolidation plan response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error serializing consolidation plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error serializing consolidation plan response; exception " +
         std::string(e.what()));
   }
@@ -402,17 +417,17 @@ std::vector<std::vector<std::string>> deserialize_consolidation_plan_response(
         return consolidation_plan_response_from_capnp(reader);
       }
       default: {
-        throw SerializationStatusException(
+        throw ConsolidationSerializationException(
             "Error deserializing consolidation plan response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error deserializing consolidation plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw ConsolidationSerializationException(
         "Error deserializing consolidation plan response; exception " +
         std::string(e.what()));
   }
@@ -434,22 +449,22 @@ Status array_consolidation_request_deserialize(
 
 void serialize_consolidation_plan_request(
     uint64_t, const Config&, SerializationType, Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw ConsolidationSerializationDisabledException();
 }
 
 uint64_t deserialize_consolidation_plan_request(
     SerializationType, const Buffer&) {
-  throw GenericException("Cannot deserialize; serialization not enabled.");
+  throw ConsolidationSerializationDisabledException();
 }
 
 void serialize_consolidation_plan_response(
     const ConsolidationPlan&, SerializationType, Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw ConsolidationSerializationDisabledException();
 }
 
 std::vector<std::vector<std::string>> deserialize_consolidation_plan_response(
     SerializationType, const Buffer&) {
-  throw GenericException("Cannot deserialize; serialization not enabled.");
+  throw ConsolidationSerializationDisabledException();
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/consolidation.cc
+++ b/tiledb/sm/serialization/consolidation.cc
@@ -46,6 +46,8 @@
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/serialization/config.h"
 #include "tiledb/sm/serialization/consolidation.h"
+#include "tiledb/sm/misc/utils.h"
+
 
 using namespace tiledb::common;
 
@@ -269,18 +271,18 @@ void serialize_consolidation_plan_request(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing consolidation plan request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing consolidation plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing consolidation plan request; exception " +
         std::string(e.what()));
   }
@@ -310,17 +312,17 @@ uint64_t deserialize_consolidation_plan_request(
         return consolidation_plan_request_from_capnp(reader);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing consolidation plan request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing consolidation plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing consolidation plan request; exception " +
         std::string(e.what()));
   }
@@ -360,18 +362,18 @@ void serialize_consolidation_plan_response(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing consolidation plan response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing consolidation plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing consolidation plan response; exception " +
         std::string(e.what()));
   }
@@ -401,17 +403,17 @@ std::vector<std::vector<std::string>> deserialize_consolidation_plan_response(
         return consolidation_plan_response_from_capnp(reader);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing consolidation plan response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing consolidation plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing consolidation plan response; exception " +
         std::string(e.what()));
   }
@@ -433,25 +435,25 @@ Status array_consolidation_request_deserialize(
 
 void serialize_consolidation_plan_request(
     uint64_t, const Config&, SerializationType, Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 uint64_t deserialize_consolidation_plan_request(
     SerializationType, const Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot deserialize; serialization not enabled.");
 }
 
 void serialize_consolidation_plan_response(
     const ConsolidationPlan&, SerializationType, Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 std::vector<std::vector<std::string>> deserialize_consolidation_plan_response(
     SerializationType, const Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot deserialize; serialization not enabled.");
 }
 

--- a/tiledb/sm/serialization/consolidation.cc
+++ b/tiledb/sm/serialization/consolidation.cc
@@ -44,10 +44,9 @@
 
 #include "tiledb/common/logger_public.h"
 #include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/serialization/config.h"
 #include "tiledb/sm/serialization/consolidation.h"
-#include "tiledb/sm/misc/utils.h"
-
 
 using namespace tiledb::common;
 
@@ -435,26 +434,22 @@ Status array_consolidation_request_deserialize(
 
 void serialize_consolidation_plan_request(
     uint64_t, const Config&, SerializationType, Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 uint64_t deserialize_consolidation_plan_request(
     SerializationType, const Buffer&) {
-  throw GenericException(
-      "Cannot deserialize; serialization not enabled.");
+  throw GenericException("Cannot deserialize; serialization not enabled.");
 }
 
 void serialize_consolidation_plan_response(
     const ConsolidationPlan&, SerializationType, Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 std::vector<std::vector<std::string>> deserialize_consolidation_plan_response(
     SerializationType, const Buffer&) {
-  throw GenericException(
-      "Cannot deserialize; serialization not enabled.");
+  throw GenericException("Cannot deserialize; serialization not enabled.");
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -42,12 +42,27 @@
 #include "tiledb/sm/array_schema/enumeration.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/serialization/enumeration.h"
 
 using namespace tiledb::common;
 
 namespace tiledb::sm::serialization {
+
+class EnumerationSerializationException : public StatusException {
+ public:
+  explicit EnumerationSerializationException(const std::string& message)
+      : StatusException("[TileDB::Serialization][Enumeration]", message) {
+  }
+};
+
+class EnumerationSerializationDisabledException
+    : public EnumerationSerializationException {
+ public:
+  explicit EnumerationSerializationDisabledException()
+      : EnumerationSerializationException(
+            "Cannot (de)serialize; serialization not enabled.") {
+  }
+};
 
 #ifdef TILEDB_SERIALIZATION
 
@@ -199,18 +214,18 @@ void serialize_load_enumerations_request(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw EnumerationSerializationException(
             "Error serializing load enumerations request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error serializing load enumerations request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error serializing load enumerations request; exception " +
         std::string(e.what()));
   }
@@ -240,17 +255,17 @@ std::vector<std::string> deserialize_load_enumerations_request(
         return load_enumerations_request_from_capnp(reader);
       }
       default: {
-        throw SerializationStatusException(
+        throw EnumerationSerializationException(
             "Error deserializing load enumerations request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error deserializing load enumerations request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error deserializing load enumerations request; exception " +
         std::string(e.what()));
   }
@@ -290,18 +305,18 @@ void serialize_load_enumerations_response(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw EnumerationSerializationException(
             "Error serializing load enumerations response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error serializing load enumerations response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error serializing load enumerations response; exception " +
         std::string(e.what()));
   }
@@ -334,17 +349,17 @@ deserialize_load_enumerations_response(
         return load_enumerations_response_from_capnp(reader, memory_tracker);
       }
       default: {
-        throw SerializationStatusException(
+        throw EnumerationSerializationException(
             "Error deserializing load enumerations response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error deserializing load enumerations response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw EnumerationSerializationException(
         "Error deserializing load enumerations response; exception " +
         std::string(e.what()));
   }
@@ -357,25 +372,25 @@ void serialize_load_enumerations_request(
     const std::vector<std::string>&,
     SerializationType,
     Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw EnumerationSerializationDisabledException();
 }
 
 std::vector<std::string> deserialize_load_enumerations_request(
     SerializationType, const Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw EnumerationSerializationDisabledException();
 }
 
 void serialize_load_enumerations_response(
     const std::vector<shared_ptr<const Enumeration>>&,
     SerializationType,
     Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw EnumerationSerializationDisabledException();
 }
 
 std::vector<shared_ptr<const Enumeration>>
 deserialize_load_enumerations_response(
     SerializationType, const Buffer&, shared_ptr<MemoryTracker>) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw EnumerationSerializationDisabledException();
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -43,6 +43,8 @@
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/serialization/enumeration.h"
+#include "tiledb/sm/misc/utils.h"
+
 
 using namespace tiledb::common;
 
@@ -198,18 +200,18 @@ void serialize_load_enumerations_request(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing load enumerations request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load enumerations request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load enumerations request; exception " +
         std::string(e.what()));
   }
@@ -239,17 +241,17 @@ std::vector<std::string> deserialize_load_enumerations_request(
         return load_enumerations_request_from_capnp(reader);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing load enumerations request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load enumerations request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load enumerations request; exception " +
         std::string(e.what()));
   }
@@ -289,18 +291,18 @@ void serialize_load_enumerations_response(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing load enumerations response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load enumerations response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing load enumerations response; exception " +
         std::string(e.what()));
   }
@@ -333,17 +335,17 @@ deserialize_load_enumerations_response(
         return load_enumerations_response_from_capnp(reader, memory_tracker);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing load enumerations response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load enumerations response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing load enumerations response; exception " +
         std::string(e.what()));
   }
@@ -356,13 +358,13 @@ void serialize_load_enumerations_request(
     const std::vector<std::string>&,
     SerializationType,
     Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 std::vector<std::string> deserialize_load_enumerations_request(
     SerializationType, const Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
@@ -370,14 +372,14 @@ void serialize_load_enumerations_response(
     const std::vector<shared_ptr<const Enumeration>>&,
     SerializationType,
     Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 std::vector<shared_ptr<const Enumeration>>
 deserialize_load_enumerations_response(
     SerializationType, const Buffer&, shared_ptr<MemoryTracker>) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -42,9 +42,8 @@
 #include "tiledb/sm/array_schema/enumeration.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/serialization/enumeration.h"
 #include "tiledb/sm/misc/utils.h"
-
+#include "tiledb/sm/serialization/enumeration.h"
 
 using namespace tiledb::common;
 
@@ -358,29 +357,25 @@ void serialize_load_enumerations_request(
     const std::vector<std::string>&,
     SerializationType,
     Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 std::vector<std::string> deserialize_load_enumerations_request(
     SerializationType, const Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 void serialize_load_enumerations_response(
     const std::vector<shared_ptr<const Enumeration>>&,
     SerializationType,
     Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 std::vector<shared_ptr<const Enumeration>>
 deserialize_load_enumerations_response(
     SerializationType, const Buffer&, shared_ptr<MemoryTracker>) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/query_plan.cc
+++ b/tiledb/sm/serialization/query_plan.cc
@@ -46,13 +46,28 @@
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/serialization/query.h"
 #include "tiledb/sm/serialization/query_plan.h"
 
 using namespace tiledb::common;
 
 namespace tiledb::sm::serialization {
+
+class QueryPlanSerializationException : public StatusException {
+ public:
+  explicit QueryPlanSerializationException(const std::string& message)
+      : StatusException("[TileDB::Serialization][QueryPlan]", message) {
+  }
+};
+
+class QueryPlanSerializationDisabledException
+    : public QueryPlanSerializationException {
+ public:
+  explicit QueryPlanSerializationDisabledException()
+      : QueryPlanSerializationException(
+            "Cannot (de)serialize; serialization not enabled.") {
+  }
+};
 
 #ifdef TILEDB_SERIALIZATION
 
@@ -179,18 +194,18 @@ void serialize_query_plan_request(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw QueryPlanSerializationException(
             "Error serializing query plan request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error serializing query plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error serializing query plan request; exception " +
         std::string(e.what()));
   }
@@ -226,17 +241,17 @@ void deserialize_query_plan_request(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw QueryPlanSerializationException(
             "Error deserializing query plan request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error deserializing query plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error deserializing query plan request; exception " +
         std::string(e.what()));
   }
@@ -276,18 +291,18 @@ void serialize_query_plan_response(
         break;
       }
       default: {
-        throw SerializationStatusException(
+        throw QueryPlanSerializationException(
             "Error serializing query plan response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error serializing query plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error serializing query plan response; exception " +
         std::string(e.what()));
   }
@@ -319,17 +334,17 @@ QueryPlan deserialize_query_plan_response(
         return query_plan_response_from_capnp(reader, query);
       }
       default: {
-        throw SerializationStatusException(
+        throw QueryPlanSerializationException(
             "Error deserializing query plan response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error deserializing query plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw SerializationStatusException(
+    throw QueryPlanSerializationException(
         "Error deserializing query plan response; exception " +
         std::string(e.what()));
   }
@@ -339,22 +354,22 @@ QueryPlan deserialize_query_plan_response(
 
 void serialize_query_plan_request(
     const Config&, Query&, const SerializationType, Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw QueryPlanSerializationDisabledException();
 }
 
 void deserialize_query_plan_request(
     const SerializationType, const Buffer&, ThreadPool&, Query&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw QueryPlanSerializationDisabledException();
 }
 
 void serialize_query_plan_response(
     const QueryPlan&, const SerializationType, Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw QueryPlanSerializationDisabledException();
 }
 
 QueryPlan deserialize_query_plan_response(
     Query&, const SerializationType, const Buffer&) {
-  throw GenericException("Cannot serialize; serialization not enabled.");
+  throw QueryPlanSerializationDisabledException();
 }
 
 #endif  // TILEDB_SERIALIZATION

--- a/tiledb/sm/serialization/query_plan.cc
+++ b/tiledb/sm/serialization/query_plan.cc
@@ -48,6 +48,7 @@
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/serialization/query.h"
 #include "tiledb/sm/serialization/query_plan.h"
+#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::common;
 
@@ -178,18 +179,18 @@ void serialize_query_plan_request(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing query plan request; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing query plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing query plan request; exception " +
         std::string(e.what()));
   }
@@ -225,17 +226,17 @@ void deserialize_query_plan_request(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing query plan request; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing query plan request; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing query plan request; exception " +
         std::string(e.what()));
   }
@@ -275,18 +276,18 @@ void serialize_query_plan_response(
         break;
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error serializing query plan response; "
             "Unknown serialization type passed");
       }
     }
 
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing query plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error serializing query plan response; exception " +
         std::string(e.what()));
   }
@@ -318,17 +319,17 @@ QueryPlan deserialize_query_plan_response(
         return query_plan_response_from_capnp(reader, query);
       }
       default: {
-        throw Status_SerializationError(
+        throw SerializationStatusException(
             "Error deserializing query plan response; "
             "Unknown serialization type passed");
       }
     }
   } catch (kj::Exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing query plan response; kj::Exception: " +
         std::string(e.getDescription().cStr()));
   } catch (std::exception& e) {
-    throw Status_SerializationError(
+    throw SerializationStatusException(
         "Error deserializing query plan response; exception " +
         std::string(e.what()));
   }
@@ -338,25 +339,25 @@ QueryPlan deserialize_query_plan_response(
 
 void serialize_query_plan_request(
     const Config&, Query&, const SerializationType, Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 void deserialize_query_plan_request(
     const SerializationType, const Buffer&, ThreadPool&, Query&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 void serialize_query_plan_response(
     const QueryPlan&, const SerializationType, Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 
 QueryPlan deserialize_query_plan_response(
     Query&, const SerializationType, const Buffer&) {
-  throw Status_SerializationError(
+  throw GenericException(
       "Cannot serialize; serialization not enabled.");
 }
 

--- a/tiledb/sm/serialization/query_plan.cc
+++ b/tiledb/sm/serialization/query_plan.cc
@@ -46,9 +46,9 @@
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/enums/serialization_type.h"
+#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/serialization/query.h"
 #include "tiledb/sm/serialization/query_plan.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::common;
 
@@ -339,26 +339,22 @@ QueryPlan deserialize_query_plan_response(
 
 void serialize_query_plan_request(
     const Config&, Query&, const SerializationType, Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 void deserialize_query_plan_request(
     const SerializationType, const Buffer&, ThreadPool&, Query&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 void serialize_query_plan_response(
     const QueryPlan&, const SerializationType, Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 QueryPlan deserialize_query_plan_response(
     Query&, const SerializationType, const Buffer&) {
-  throw GenericException(
-      "Cannot serialize; serialization not enabled.");
+  throw GenericException("Cannot serialize; serialization not enabled.");
 }
 
 #endif  // TILEDB_SERIALIZATION


### PR DESCRIPTION
This PR migrates from ```throw Status_*Error()``` to ```throw *Exception()```. This was causing some exceptions to be silenced because the previous implementation was not handling them correctly resulting in the display of the generic error message: ```unknown exception type; no further information```


To achieve this migration I had to create the following Exception classes: ```FragmentInfoException```,  ```QueryConditionException```, ```ArraySchemaSerializationDisabledException```, ```ArraySchemaSerializationException```, ```ConsolidationSerializationDisabledException```, ```ConsolidationSerializationException```,  ```EnumerationSerializationDisabledException```, ```EnumerationSerializationException```, ```QueryPlanSerializationDisabledException```, ```QueryPlanSerializationException```

[sc-48757]

---
TYPE: BUG
DESC: Fix exceptions with message: ```unknown exception type; no further information```.
