### PR TITLE
Disable nightly testing of HDFS and log a warning when HDFS is enabled.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -61,6 +61,11 @@ on:
         description: 'CMake generator'
         required: false
         type: string
+      build_only:
+        default: false
+        description: 'Whether to only build TileDB and not run tests'
+        required: false
+        type: boolean
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
@@ -176,6 +181,7 @@ jobs:
 
       - name: 'Test libtiledb'
         id: test
+        if: ${{ !inputs.build_only }}
         shell: bash
         env:
           ASAN_OPTIONS: ${{ inputs.asan && 'detect_leaks=0' || '' }}
@@ -266,6 +272,7 @@ jobs:
             /cores/
 
       - name: 'Test status check'
+        if: ${{ !inputs.build_only }}
         run: |
           # tiledb_unit is configured to set a  variable TILEDB_CI_SUCCESS=1
           # following the test run. If this variable is not set, the build should fail.

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           cmake --build build --target check --config ${{ matrix.config || 'Release' }}
 
-  test_hdfs:
+  test_hdfs_build:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: HDFS
@@ -73,6 +73,7 @@ jobs:
       matrix_compiler_cc: 'gcc-13'
       matrix_compiler_cxx: 'g++-13'
       timeout: 300
+      build_only: true
       bootstrap_args: '--enable-hdfs --enable-static-tiledb --disable-werror'
 
   create_issue_on_fail:
@@ -81,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
-      - test_hdfs
+      - test_hdfs_build
     if: failure() || cancelled()
     steps:
       - name: Checkout TileDB `dev`

--- a/cmake/Options/BuildOptions.cmake
+++ b/cmake/Options/BuildOptions.cmake
@@ -53,6 +53,10 @@ if (NOT TILEDB_VCPKG)
   message(FATAL_ERROR "Disabling TILEDB_VCPKG is not supported. To disable automatically downloading vcpkg, enable the TILEDB_DISABLE_AUTO_VCPKG option, or set ENV{TILEDB_DISABLE_AUTO_VCPKG} to any value.")
 endif()
 
+if (TILEDB_HDFS)
+  message(DEPRECATION "The HDFS storage backend is deprecated and untested. It will be removed in TileDB 2.28.")
+endif()
+
 # enable assertions by default for debug builds
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(TILEDB_ASSERTIONS TRUE)

--- a/cmake/Options/BuildOptions.cmake
+++ b/cmake/Options/BuildOptions.cmake
@@ -54,7 +54,7 @@ if (NOT TILEDB_VCPKG)
 endif()
 
 if (TILEDB_HDFS)
-  message(DEPRECATION "The HDFS storage backend is deprecated and untested. It will be removed in TileDB 2.28.")
+  message(DEPRECATION "The HDFS storage backend is deprecated and receiving build-only official validation. It will be removed in TileDB 2.28.")
 endif()
 
 # enable assertions by default for debug builds


### PR DESCRIPTION
[SC-49481](https://app.shortcut.com/tiledb-inc/story/49481/disable-testing-hdfs-in-nightlies)
[SC-49482](https://app.shortcut.com/tiledb-inc/story/49482/add-deprecation-warning-when-configuring-with-hdfs-enabled)

This PR disables testing HDFS in nightlies. The runs have been very brittle for years when more tests were added in and with the recent addition of many tests to all VFSes, it is now impossible to get a successful run. As we are planning to fully remove support for HDFS in TileDB version 2.28, we have made the decision to not investigate the failures. The Core will still be built with HDFS enabled to catch build-time regressions.

Furthermore, the build script was updated to emit a warning when configuring with `-DTILEDB_HDFS=ON`.

---
TYPE: DEPRECATION
DESC: The HDFS backend is no longer officially tested by TileDB. As announced before, it is scheduled to be removed in version 2.28, to be released in Q4 2024.