### PR TITLE
Implement actualize for alt_var_length_view

### DIFF
--- a/tiledb/common/util/alt_var_length_view.h
+++ b/tiledb/common/util/alt_var_length_view.h
@@ -351,4 +351,41 @@ alt_var_length_view(R, R, J, I, I, K)
 template <class R, class I, class J, class K, class L>
 alt_var_length_view(R, R, J, I, I, K, L)
     -> alt_var_length_view<std::ranges::subrange<R>, std::ranges::subrange<I>>;
+
+
+
+/**
+ * Actually reorder the data underlying an alt_var_length_view (un-virtualize
+ * the permutation).  Upon return, data will have the sorted data, offsets will
+ * have the SIZES of each subrange, and the subranges will be "in order"
+ * @tparam S Type of the subranges
+ * @tparam R Type of the data range
+ * @tparam I Type of the index / offset / size range
+ * @tparam B Type of the scratch buffer
+ * @param subranges The alt_var_length_view
+ * @param data The data range underlying the alt_var_length_view
+ * @param offsets The offsets range to be written to
+ * @param buffer Scratch space used for reordering, must have enough space to
+ * hold all of the data
+ * @return
+ *
+ * @todo Make this a member of alt_var_length_view
+ */
+template <
+    std::ranges::forward_range S,
+    std::ranges::forward_range R,
+    std::ranges::forward_range I,
+    std::ranges::random_access_range B>
+auto actualize(S& subranges, R& data, I& offsets, B& buffer) {
+  auto x = buffer.begin();
+  auto o = offsets.begin();
+  for (auto& s : subranges) {
+    std::ranges::copy(s.begin(), s.end(), x);
+    auto n = s.size();
+    s = std::ranges::subrange(x, x + n);
+    x += n;
+    *o++ = n;  // x - buffer.begin();
+  }
+  std::ranges::copy(buffer.begin(), buffer.begin() + data.size(), data.begin());
+}
 #endif  // TILEDB_ALT_VAR_LENGTH_VIEW_H

--- a/tiledb/common/util/alt_var_length_view.h
+++ b/tiledb/common/util/alt_var_length_view.h
@@ -352,8 +352,6 @@ template <class R, class I, class J, class K, class L>
 alt_var_length_view(R, R, J, I, I, K, L)
     -> alt_var_length_view<std::ranges::subrange<R>, std::ranges::subrange<I>>;
 
-
-
 /**
  * Actually reorder the data underlying an alt_var_length_view (un-virtualize
  * the permutation).  Upon return, data will have the sorted data, offsets will

--- a/tiledb/common/util/test/unit_alt_var_length_view.cc
+++ b/tiledb/common/util/test/unit_alt_var_length_view.cc
@@ -603,3 +603,51 @@ TEST_CASE("alt_var_length_view: Sort", "[alt_var_length_view]") {
     }
   }
 }
+
+
+TEST_CASE("alt_var_length_view: Sort and actualize", "[alt_var_length_view]") {
+  std::vector<double> r = {
+      1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
+  std::vector<double> s(r);
+  std::vector<size_t> o = {0, 3, 6, 10, 12};
+  alt_var_length_view<std::vector<double>, std::vector<size_t>> v(r, o);
+
+  SECTION("Sort by size, ascending") {
+    std::vector<std::vector<double>> expected = {
+        {11.0, 12.0},
+        {1.0, 2.0, 3.0},
+        {4.0, 5.0, 6.0},
+        {7.0, 8.0, 9.0, 10.0},
+    };
+
+    std::sort(v.begin(), v.end(), [](auto& a, auto& b) {
+      return a.size() < b.size();
+    });
+
+    CHECK(v.begin()->size() == 2);
+    CHECK((v.begin() + 1)->size() == 3);
+    CHECK((v.begin() + 2)->size() == 3);
+    CHECK((v.begin() + 3)->size() == 4);
+
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+
+    // Check the underlying data has not changed even though sorted
+    CHECK(std::ranges::equal(r, s));
+    std::vector<double> scratch(size(r));
+
+    actualize(v, r, o, scratch);
+
+    // Check the underlying data has changed to the expected sorted order
+    CHECK(std::ranges::equal(r, std::vector<double>{11.0, 12.0, 1.0, 2.0, 3.0,
+                                                    4.0, 5.0, 6.0, 7.0, 8.0,
+                                                    9.0, 10.0}));
+
+    // The alt_var_length_view should still "look" the same
+    CHECK(std::ranges::equal(o, std::vector<size_t>{2, 3, 3, 4, 12}));
+    for (auto&& i : v) {
+      CHECK(std::ranges::equal(i, expected[&i - &*v.begin()]));
+    }
+  }
+}

--- a/tiledb/common/util/test/unit_alt_var_length_view.cc
+++ b/tiledb/common/util/test/unit_alt_var_length_view.cc
@@ -604,7 +604,6 @@ TEST_CASE("alt_var_length_view: Sort", "[alt_var_length_view]") {
   }
 }
 
-
 TEST_CASE("alt_var_length_view: Sort and actualize", "[alt_var_length_view]") {
   std::vector<double> r = {
       1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0};
@@ -640,9 +639,10 @@ TEST_CASE("alt_var_length_view: Sort and actualize", "[alt_var_length_view]") {
     actualize(v, r, o, scratch);
 
     // Check the underlying data has changed to the expected sorted order
-    CHECK(std::ranges::equal(r, std::vector<double>{11.0, 12.0, 1.0, 2.0, 3.0,
-                                                    4.0, 5.0, 6.0, 7.0, 8.0,
-                                                    9.0, 10.0}));
+    CHECK(std::ranges::equal(
+        r,
+        std::vector<double>{
+            11.0, 12.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}));
 
     // The alt_var_length_view should still "look" the same
     CHECK(std::ranges::equal(o, std::vector<size_t>{2, 3, 3, 4, 12}));

--- a/tiledb/common/util/var_length_view.h
+++ b/tiledb/common/util/var_length_view.h
@@ -1,5 +1,5 @@
 /**
- * @file   tiledb/common/util/var_length_view.h
+ * @file   tiledb/common/util/              var_length_view.h
  *
  * @section LICENSE
  *

--- a/tiledb/common/util/var_length_view.h
+++ b/tiledb/common/util/var_length_view.h
@@ -1,5 +1,5 @@
 /**
- * @file   tiledb/common/util/              var_length_view.h
+ * @file   tiledb/common/util/var_length_view.h
  *
  * @section LICENSE
  *


### PR DESCRIPTION
This PR implements a function `actualize` that
* orders the underlying data of an `alt_var_length_view` according to the permuted subranges
* sets the subranges in the `alt_var_length_view` to delimit the new var-length element
* stores the size of each subrange in an index argument

After calling `actualize`, the `alt_var_length_view` will "look" exactly the same, i.e., iterating through it before and after will give exactly the same results (even though the underlying data range has been reordered).

Actually ordered (instead of virtually ordered) var-length data, along with an array of the corresponding sizes, will be needed for saving phase I data to a temporary array.

[sc-49496]

---
TYPE: FEATURE
DESC: Implement actualize function that orders data underlying `alt_var_length_view`
