### PR TITLE
Add the directory to the tiledb library on PATH in `tiledb_regression`.

### DIFF
--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -86,3 +86,8 @@ add_test(
   COMMAND $<TARGET_FILE:tiledb_regression> --durations=yes
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+if (BUILD_SHARED_LIBS)
+  # Add the location of the tiledb shared library to PATH, to help Windows find it.
+  set_property(TEST tiledb_regression PROPERTY ENVIRONMENT_MODIFICATION "PATH=path_list_append:$<TARGET_FILE_DIR:tiledb>")
+endif()


### PR DESCRIPTION
After https://github.com/TileDB-Inc/TileDB/pull/5054, `tiledb_regression` started to run in the nightlies. `tiledb_regression` directly links to the `tiledb` target, which on Windows when building a shared library, is not found by default. This PR updates the `tiledb_regression` CTest test to append the path to `tiledb.dll` to PATH so that we don't have issues running the nightlies anymore.

[SC-48054]

---
TYPE: NO_HISTORY