### PR TITLE
Disable unsupported consolidation options for dense arrays.

### DIFF
--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -7157,8 +7157,8 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     ConsolidationFx,
-    "C API: Test consolidation, dense split fragments",
-    "[capi][consolidation][dense][split-fragments][non-rest]") {
+    "C API: Test consolidation, dense split fragments error",
+    "[capi][consolidation][dense][split-fragments][non-rest][error]") {
   remove_dense_array();
   create_dense_array();
   write_dense_subarray(1, 2, 1, 2);
@@ -7200,32 +7200,10 @@ TEST_CASE_METHOD(
   const char* uris[2] = {strrchr(uri, '/') + 1, strrchr(uri2, '/') + 1};
   rc = tiledb_array_consolidate_fragments(
       ctx_, dense_array_uri_.c_str(), uris, 2, cfg);
-  CHECK(rc == TILEDB_OK);
+  CHECK(rc != TILEDB_OK);
   tiledb_config_free(&cfg);
 
   tiledb_fragment_info_free(&fragment_info);
-
-  // Check number of fragments
-  get_num_struct data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(
-      ctx_, vfs_, dense_array_frag_dir_.c_str(), &get_dir_num, &data);
-  CHECK(rc == TILEDB_OK);
-  CHECK(data.num == 5);
-
-  // Check reading after consolidation
-  read_dense_four_tiles();
-
-  // Vacuum
-  rc = tiledb_array_vacuum(ctx_, dense_array_uri_.c_str(), NULL);
-  CHECK(rc == TILEDB_OK);
-  read_dense_four_tiles();
-
-  // Check number of fragments
-  data = {ctx_, vfs_, 0};
-  rc = tiledb_vfs_ls(
-      ctx_, vfs_, dense_array_frag_dir_.c_str(), &get_dir_num, &data);
-  CHECK(rc == TILEDB_OK);
-  CHECK(data.num == 3);
 
   // Clean up
   remove_dense_array();

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -240,12 +240,10 @@ TEST_CASE(
   const char* fragment_uris[2] = {
       short_fragment_name1.c_str(), short_fragment_name2.c_str()};
 
-  REQUIRE_NOTHROW(
-      Array::consolidate(ctx, array_name, fragment_uris, 2, &config));
-  CHECK(tiledb::test::num_fragments(array_name) == 3);
-
-  read_array(array_name, {1, 3}, {1, 2, 3});
-
+  REQUIRE_THROWS_WITH(
+      Array::consolidate(ctx, array_name, fragment_uris, 2, &config),
+      Catch::Matchers::ContainsSubstring(
+          "Fragment list consolidation is not supported for dense arrays."));
   remove_array(array_name);
 }
 

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -504,3 +504,50 @@ TEST_CASE(
 
   array.close();
 }
+
+TEST_CASE_METHOD(
+    CPPMaxFragmentSizeFx,
+    "C++ API: Max fragment size, dense array error",
+    "[cppapi][max-frag-size][dense][error]") {
+  {
+    // Create a schema with one dimension and one int attribute.
+    Domain domain(ctx_);
+    auto d1 = Dimension::create<int>(ctx_, "d1", {{1, max_domain}}, 2);
+    domain.add_dimensions(d1);
+
+    auto a1 = Attribute::create<int>(ctx_, "a1");
+
+    ArraySchema schema(ctx_, TILEDB_DENSE);
+    schema.set_domain(domain);
+    schema.add_attributes(a1);
+    schema.set_capacity(10);
+
+    Array::create(array_name, schema);
+  }
+
+  // Write 2 fragments in different places.
+  {
+    Array array(ctx_, array_name, TILEDB_WRITE);
+    for (int i = 0; i < 2; i++) {
+      Query query(ctx_, array, TILEDB_WRITE);
+
+      std::vector<int> data{1, 2, 3, 4};
+
+      Subarray subarray(ctx_, array);
+      subarray.add_range(0, 4 * i + 1, 4 * i + 4);
+
+      query.set_layout(TILEDB_GLOBAL_ORDER)
+          .set_data_buffer("a1", data)
+          .set_subarray(subarray);
+
+      query.submit_and_finalize();
+    }
+  }
+
+  // Run fragment consolidation and vacuum.
+  CHECK_THROWS_WITH(
+      consolidate_fragments(10000),
+      Catch::Matchers::ContainsSubstring(
+          "Consolidation with a max fragment size limit is not supported for "
+          "dense arrays."));
+}

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -177,6 +177,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    created by consolidation. When it is reached, consolidation will continue
  *    the operation in a new fragment. The result will be a multiple fragments,
  *    but with seperate MBRs. <br>
+ *    This option is not supported for dense arrays. <br>
  * - `sm.consolidation.steps` <br>
  *    The number of consolidation steps to be performed when executing
  *    the consolidation algorithm.<br>

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -677,7 +677,8 @@ TILEDB_EXPORT capi_return_t tiledb_ctx_alloc_with_error(
  * Note: This API needs to be used with caution until we implement
  * consolidation with timestamps. For now, if the non-empty domain of the
  * consolidated fragments overlap anything in the fragments that come in
- * between, this could lead to unpredictable behavior.
+ * between, this could lead to unpredictable behavior. This API is also not
+ * supported for dense arrays.
  *
  * **Example:**
  *
@@ -902,6 +903,8 @@ TILEDB_EXPORT int32_t tiledb_fragment_info_get_total_cell_num(
 
 /**
  * Creates a consolidation plan object.
+ *
+ * Creating a consolidation plan is not supported for dense arrays.
  *
  * **Example:**
  *

--- a/tiledb/sm/consolidation_plan/consolidation_plan.cc
+++ b/tiledb/sm/consolidation_plan/consolidation_plan.cc
@@ -107,6 +107,13 @@ std::string ConsolidationPlan::dump() const {
 /* ********************************* */
 
 void ConsolidationPlan::generate(shared_ptr<Array> array) {
+  // It is very tricky to properly make fragments that will not lead to
+  // inconsistencies for dense when consolidating.
+  if (array->array_schema_latest().dense()) {
+    throw ConsolidationPlanStatusException(
+        "Creating a consolidation plan is not supported for dense arrays.");
+  }
+
   // Start with the plan being a single fragment per node.
   std::list<PlanNode> plan;
   for (unsigned f = 0;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -352,6 +352,7 @@ class Config {
    *    created by consolidation. When it is reached, consolidation will
    *    continue the operation in a new fragment. The result will be a multiple
    *    fragments, but with seperate MBRs. <br>
+   *    This option is not supported for dense arrays. <br>
    *    **Default**: UINT64_MAX
    * - `sm.consolidation.steps` <br>
    *    The number of consolidation steps to be performed when executing

--- a/tiledb/sm/cpp_api/consolidation_plan_experimental.h
+++ b/tiledb/sm/cpp_api/consolidation_plan_experimental.h
@@ -43,6 +43,8 @@ class ConsolidationPlan {
    * Constructor. This creates the consolidation plan for an array with the
    * given desired maximum fragment size.
    *
+   * Creating a consolidation plan is not supported for dense arrays.
+   *
    * @param ctx TileDB context.
    * @param array The array.
    * @param fragment_size The desired fragment size.


### PR DESCRIPTION
[SC-49509](https://app.shortcut.com/tiledb-inc/story/49509/disable-consolidation-plan-max-fragment-size-and-fragment-list-consolidation-for-dense)

It is very tricky to properly make fragments that will not lead to inconsistencies for dense when consolidating. The following features can all lead to inconsistencies and this PR changes them to fail when used in dense arrays:

* The consolidation plan API.
* Setting a max fragment size with the `sm.consolidation.max_fragment_size` option.
* Performing consolidation on specific fragments with the `tiledb_array_consolidate_fragments` API.

Tests were added, and the fragment list consolidation test was updated to check for failure on dense arrays.

---
TYPE: BREAKING_BEHAVIOR
DESC: Due to potential for data corruption, creating a consolidation plan, and performing consolidation with a fragment list or a custom max fragment size are no longer supported for dense arrays.