### PR TITLE
Add ContextResources param to the StrategyParams constructor.

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -170,6 +170,7 @@ TEST_CASE_METHOD(
   Subarray subarray(&array, &g_helper_stats, g_helper_logger());
   DefaultChannelAggregates default_channel_aggregates;
   auto params = StrategyParams(
+      context.resources(),
       array.memory_tracker(),
       tracker_,
       context.storage_manager(),

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -52,7 +52,6 @@
 #include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/readers/aggregators/tile_metadata.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"

--- a/tiledb/sm/group/group_details_v1.h
+++ b/tiledb/sm/group/group_details_v1.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,13 +41,11 @@
 #include "tiledb/sm/group/group_details.h"
 #include "tiledb/sm/group/group_member.h"
 #include "tiledb/sm/metadata/metadata.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/storage_format/serialization/serializers.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class GroupDetails;
 
@@ -79,7 +77,6 @@ class GroupDetailsV1 : public GroupDetails {
   /* Format version for class. */
   inline static const format_version_t format_version_ = 1;
 };
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_GROUP_DETAILS_V1_H

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -48,7 +48,6 @@
 #include "tiledb/sm/query/readers/result_tile.h"
 #include "tiledb/sm/query/update_value.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/subarray/cell_slab.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/type/apply_with_type.h"
@@ -110,10 +109,6 @@ Reader::Reader(
     bool remote_query)
     : ReaderBase(stats, logger->clone("Reader", ++logger_id_), params) {
   // Sanity checks
-  if (storage_manager_ == nullptr) {
-    throw ReaderException("Cannot initialize reader; Storage manager not set");
-  }
-
   if (!params.default_channel_aggregates().empty()) {
     throw ReaderException(
         "Cannot initialize reader; Reader cannot process aggregates");
@@ -595,9 +590,9 @@ Status Reader::compute_range_result_coords(
               range_result_coords[r].end(),
               range_result_coords[r].size(),
               sort_layout));
-          this->throw_if_cancelled();
+          throw_if_cancelled();
           throw_if_not_ok(dedup_result_coords(range_result_coords[r]));
-          this->throw_if_cancelled();
+          throw_if_cancelled();
         }
 
         return Status::Ok();

--- a/tiledb/sm/query/legacy/reader.h
+++ b/tiledb/sm/query/legacy/reader.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,13 +45,11 @@
 #include "tiledb/sm/query/readers/reader_base.h"
 #include "tiledb/sm/query/readers/result_cell_slab.h"
 #include "tiledb/sm/query/readers/result_coords.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 #include "tiledb/sm/subarray/subarray_partitioner.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 class Tile;
@@ -869,7 +867,6 @@ class Reader : public ReaderBase, public IQueryStrategy {
       std::vector<uint64_t>& offsets) const;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_READER_H

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1777,6 +1777,7 @@ bool Query::is_aggregate(std::string output_field_name) const {
 
 Status Query::create_strategy(bool skip_checks_serialization) {
   auto params = StrategyParams(
+      resources_,
       array_->memory_tracker(),
       query_memory_tracker_,
       storage_manager_,

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -35,22 +35,21 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 #ifndef RETURN_CANCEL_OR_ERROR
 /**
  * Returns an error status if the given Status is not Status::Ok, or
  * if the StorageManager that owns this Query has requested cancellation.
  */
-#define RETURN_CANCEL_OR_ERROR(s)                              \
-  do {                                                         \
-    Status _s = (s);                                           \
-    if (!_s.ok()) {                                            \
-      return _s;                                               \
-    } else if (storage_manager_->cancellation_in_progress()) { \
-      return Status_QueryError("Query cancelled.");            \
-    }                                                          \
+#define RETURN_CANCEL_OR_ERROR(s) \
+  do {                            \
+    Status _s = (s);              \
+    if (!_s.ok()) {               \
+      return _s;                  \
+    } else {                      \
+      throw_if_cancelled();       \
+    }                             \
   } while (false)
 #endif
 
@@ -59,55 +58,17 @@ namespace sm {
  * Returns an error status if the given Status is not Status::Ok, or
  * if the StorageManager that owns this Query has requested cancellation.
  */
-#define RETURN_CANCEL_OR_ERROR_TUPLE(s)                             \
-  do {                                                              \
-    Status _s = (s);                                                \
-    if (!_s.ok()) {                                                 \
-      return {_s, std::nullopt};                                    \
-    } else if (storage_manager_->cancellation_in_progress()) {      \
-      return {Status_QueryError("Query cancelled."), std::nullopt}; \
-    }                                                               \
+#define RETURN_CANCEL_OR_ERROR_TUPLE(s) \
+  do {                                  \
+    Status _s = (s);                    \
+    if (!_s.ok()) {                     \
+      return {_s, std::nullopt};        \
+    } else {                            \
+      throw_if_cancelled();             \
+    }                                   \
   } while (false)
 #endif
 
-#ifndef RETURN_CANCEL_OR_ERROR_ELSE
-/**
- * Returns an error status if the given Status is not Status::Ok, or
- * if the StorageManager that owns this Query has requested cancellation.
- * If an error status is returned, also execute the 'else' code.
- */
-#define RETURN_CANCEL_OR_ERROR_ELSE(s, _else)                  \
-  do {                                                         \
-    Status _s = (s);                                           \
-    if (!_s.ok()) {                                            \
-      _else;                                                   \
-      return _s;                                               \
-    } else if (storage_manager_->cancellation_in_progress()) { \
-      _else;                                                   \
-      return Status_QueryError("Query cancelled.");            \
-    }                                                          \
-  } while (false)
-#endif
-
-#ifndef BREAK_CANCEL_OR_ERROR
-/**
- * If the given status 's' is not Status::Ok, sets the Status variable
- * 'outer_st' to 's' and breaks the containing loop.
- */
-#define BREAK_CANCEL_OR_ERROR(outer_st, s)                     \
-  do {                                                         \
-    Status _s = (s);                                           \
-    if (!_s.ok()) {                                            \
-      outer_st = _s;                                           \
-      break;                                                   \
-    } else if (storage_manager_->cancellation_in_progress()) { \
-      outer_st = Status_QueryError("Query cancelled.");        \
-      break;                                                   \
-    }                                                          \
-  } while (false)
-#endif
-
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_QUERY_MACROS_H

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -42,14 +42,14 @@ namespace tiledb::sm {
  * Returns an error status if the given Status is not Status::Ok, or
  * if the StorageManager that owns this Query has requested cancellation.
  */
-#define RETURN_CANCEL_OR_ERROR(s) \
-  do {                            \
-    Status _s = (s);              \
-    if (!_s.ok()) {               \
-      return _s;                  \
-    } else {                      \
-      throw_if_cancelled();       \
-    }                             \
+#define RETURN_CANCEL_OR_ERROR(s)                              \
+  do {                                                         \
+    Status _s = (s);                                           \
+    if (!_s.ok()) {                                            \
+      return _s;                                               \
+    } else if (storage_manager_->cancellation_in_progress()) { \
+      return Status_QueryError("Query cancelled.");            \
+    }                                                          \
   } while (false)
 #endif
 
@@ -58,14 +58,14 @@ namespace tiledb::sm {
  * Returns an error status if the given Status is not Status::Ok, or
  * if the StorageManager that owns this Query has requested cancellation.
  */
-#define RETURN_CANCEL_OR_ERROR_TUPLE(s) \
-  do {                                  \
-    Status _s = (s);                    \
-    if (!_s.ok()) {                     \
-      return {_s, std::nullopt};        \
-    } else {                            \
-      throw_if_cancelled();             \
-    }                                   \
+#define RETURN_CANCEL_OR_ERROR_TUPLE(s)                             \
+  do {                                                              \
+    Status _s = (s);                                                \
+    if (!_s.ok()) {                                                 \
+      return {_s, std::nullopt};                                    \
+    } else if (storage_manager_->cancellation_in_progress()) {      \
+      return {Status_QueryError("Query cancelled."), std::nullopt}; \
+    }                                                               \
   } while (false)
 #endif
 

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,13 +42,11 @@
 #include "tiledb/sm/query/iquery_strategy.h"
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/reader_base.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 #include "tiledb/sm/subarray/tile_cell_slab_iter.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 
@@ -603,7 +601,6 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
       std::vector<uint64_t>& offsets) const;
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_DENSE_READER

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.h
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,12 +42,10 @@
 #include "tiledb/sm/query/iquery_strategy.h"
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/readers/reader_base.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 
@@ -513,9 +511,8 @@ class OrderedDimLabelReader : public ReaderBase, public IQueryStrategy {
    */
   template <typename IndexType>
   void compute_and_copy_range_indexes(uint64_t buffer_offset, uint64_t r);
-};  // namespace sm
+};
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_ORDERED_DIM_LABEL_READER

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -46,7 +46,6 @@
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/readers/result_tile.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/subarray/subarray.h"
 
 using namespace tiledb;
@@ -55,9 +54,9 @@ using namespace tiledb::sm::stats;
 
 namespace tiledb::sm {
 
-class SparseGlobalOrderReaderStatusException : public StatusException {
+class SparseGlobalOrderReaderException : public StatusException {
  public:
-  explicit SparseGlobalOrderReaderStatusException(const std::string& message)
+  explicit SparseGlobalOrderReaderException(const std::string& message)
       : StatusException("SparseGlobalOrderReader", message) {
   }
 };
@@ -249,7 +248,7 @@ void SparseGlobalOrderReader<BitmapType>::load_all_tile_offsets() {
         tile_offsets_size(subarray_.relevant_fragments());
     uint64_t available_memory = array_memory_tracker_->get_memory_available();
     if (total_tile_offset_usage > available_memory) {
-      throw SparseGlobalOrderReaderStatusException(
+      throw SparseGlobalOrderReaderException(
           "Cannot load tile offsets, computed size (" +
           std::to_string(total_tile_offset_usage) +
           ") is larger than available memory (" +
@@ -385,7 +384,7 @@ SparseGlobalOrderReader<BitmapType>::create_result_tiles(
 
                 if (result_tiles[f].empty()) {
                   auto tiles_size = get_coord_tiles_size(dim_num, f, t);
-                  throw SparseGlobalOrderReaderStatusException(
+                  throw SparseGlobalOrderReaderException(
                       "Cannot load a single tile for fragment, increase "
                       "memory "
                       "budget, tile size : " +
@@ -1711,7 +1710,7 @@ SparseGlobalOrderReader<BitmapType>::respect_copy_memory_budget(
       }));
 
   if (max_cs_idx == 0) {
-    throw SparseGlobalOrderReaderStatusException(
+    throw SparseGlobalOrderReaderException(
         "Unable to copy one slab with current budget/buffers");
   }
 
@@ -1948,7 +1947,7 @@ void SparseGlobalOrderReader<BitmapType>::process_slabs(
       if (aggregates_.count(name) != 0) {
         for (auto& aggregates : aggregates_[name]) {
           if (aggregates->need_recompute_on_overflow()) {
-            throw SparseGlobalOrderReaderStatusException(
+            throw SparseGlobalOrderReaderException(
                 "Overflow happened after aggregate was computed, aggregate "
                 "recompute pass is not yet implemented");
           }

--- a/tiledb/sm/query/readers/sparse_global_order_reader.h
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,12 +45,10 @@
 #include "tiledb/sm/query/readers/result_cell_slab.h"
 #include "tiledb/sm/query/readers/result_coords.h"
 #include "tiledb/sm/query/readers/sparse_index_reader_base.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 
@@ -628,7 +626,6 @@ class SparseGlobalOrderReader : public SparseIndexReaderBase,
   void end_iteration(std::vector<ResultTilesList>& result_tiles);
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_SPARSE_GLOBAL_ORDER_READER

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -51,9 +51,9 @@
 
 namespace tiledb::sm {
 
-class SparseIndexReaderBaseStatusException : public StatusException {
+class SparseIndexReaderBaseException : public StatusException {
  public:
-  explicit SparseIndexReaderBaseStatusException(const std::string& message)
+  explicit SparseIndexReaderBaseException(const std::string& message)
       : StatusException("SparseIndexReaderBase", message) {
   }
 };
@@ -78,14 +78,9 @@ SparseIndexReaderBase::SparseIndexReaderBase(
           buffers_.count(constants::delete_timestamps) != 0)
     , partial_tile_offsets_loading_(false) {
   // Sanity checks
-  if (storage_manager_ == nullptr) {
-    throw SparseIndexReaderBaseStatusException(
-        "Cannot initialize reader; Storage manager not set");
-  }
-
   if (!params.skip_checks_serialization() && buffers_.empty() &&
       aggregate_buffers_.empty()) {
-    throw SparseIndexReaderBaseStatusException(
+    throw SparseIndexReaderBaseException(
         "Cannot initialize reader; Buffers not set");
   }
 
@@ -96,7 +91,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
   offsets_format_mode_ =
       config_.get<std::string>("sm.var_offsets.mode", Config::must_find);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    throw SparseIndexReaderBaseStatusException(
+    throw SparseIndexReaderBaseException(
         "Cannot initialize reader; Unsupported offsets format in "
         "configuration");
   }
@@ -108,7 +103,7 @@ SparseIndexReaderBase::SparseIndexReaderBase(
   offsets_bitsize_ =
       config_.get<uint32_t>("sm.var_offsets.bitsize", Config::must_find);
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    throw SparseIndexReaderBaseStatusException(
+    throw SparseIndexReaderBaseException(
         "Cannot initialize reader; Unsupported offsets bitsize in "
         "configuration");
   }
@@ -389,7 +384,7 @@ Status SparseIndexReaderBase::load_initial_data() {
   if (subarray_.is_set()) {
     // At this point, full memory budget is available.
     if (!array_memory_tracker_->set_budget(memory_budget_.total_budget())) {
-      throw SparseIndexReaderBaseStatusException(
+      throw SparseIndexReaderBaseException(
           "Cannot set array memory budget, already over limit.");
     }
 
@@ -454,7 +449,7 @@ Status SparseIndexReaderBase::load_initial_data() {
   // Set a limit to the array memory.
   if (!array_memory_tracker_->set_budget(
           memory_budget_.total_budget() * memory_budget_.ratio_array_data())) {
-    throw SparseIndexReaderBaseStatusException(
+    throw SparseIndexReaderBaseException(
         "Cannot set array memory budget, already over limit.");
   }
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,10 +40,8 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/query/readers/result_cell_slab.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 class ArraySchema;
@@ -788,7 +786,6 @@ class SparseIndexReaderBase : public ReaderBase {
   void add_extra_offset();
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_SPARSE_INDEX_READER_BASE_H

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -43,7 +43,6 @@
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/readers/result_tile.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/subarray/subarray.h"
 
 using namespace tiledb;
@@ -52,10 +51,9 @@ using namespace tiledb::sm::stats;
 
 namespace tiledb::sm {
 
-class SparseUnorderedWithDupsReaderStatusException : public StatusException {
+class SparseUnorderedWithDupsReaderException : public StatusException {
  public:
-  explicit SparseUnorderedWithDupsReaderStatusException(
-      const std::string& message)
+  explicit SparseUnorderedWithDupsReaderException(const std::string& message)
       : StatusException("SparseUnorderedWithDupsReader", message) {
   }
 };
@@ -83,7 +81,7 @@ SparseUnorderedWithDupsReader<BitmapType>::SparseUnorderedWithDupsReader(
                &partial_tile_offsets_loading_,
                &found)
            .ok()) {
-    throw SparseUnorderedWithDupsReaderStatusException("Cannot get setting");
+    throw SparseUnorderedWithDupsReaderException("Cannot get setting");
   }
   assert(found);
 }
@@ -262,7 +260,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::load_tile_offsets_data() {
       // tile offsets data.
       uint64_t total_tile_offset_usage = tile_offsets_size(relevant_fragments);
       if (total_tile_offset_usage > available_memory) {
-        throw SparseUnorderedWithDupsReaderStatusException(
+        throw SparseUnorderedWithDupsReaderException(
             "Cannot load tile offsets, computed size (" +
             std::to_string(total_tile_offset_usage) +
             ") is larger than available memory (" +
@@ -312,7 +310,7 @@ void SparseUnorderedWithDupsReader<BitmapType>::load_tile_offsets_data() {
 
       // Make sure plan to load tile offsets for at least one fragment.
       if (tile_offsets_min_frag_idx_ == tile_offsets_max_frag_idx_) {
-        throw SparseUnorderedWithDupsReaderStatusException(
+        throw SparseUnorderedWithDupsReaderException(
             "Cannot load tile offsets for only one fragment. Offsets size for "
             "the fragment (" +
             std::to_string(
@@ -388,7 +386,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::add_result_tile(
 
       // Make sure we can add at least one tile.
       if (result_tiles.empty()) {
-        throw SparseUnorderedWithDupsReaderStatusException(
+        throw SparseUnorderedWithDupsReaderException(
             "Cannot load a single tile, increase memory budget");
       }
 
@@ -1512,7 +1510,7 @@ SparseUnorderedWithDupsReader<BitmapType>::respect_copy_memory_budget(
       }));
 
   if (max_rt_idx == 0) {
-    throw SparseUnorderedWithDupsReaderStatusException(
+    throw SparseUnorderedWithDupsReaderException(
         "Unable to copy one tile with current budget/buffers");
   }
 
@@ -1696,7 +1694,7 @@ bool SparseUnorderedWithDupsReader<BitmapType>::process_tiles(
       if (aggregates_.count(name) != 0) {
         for (auto& aggregates : aggregates_[name]) {
           if (aggregates->need_recompute_on_overflow()) {
-            throw SparseUnorderedWithDupsReaderStatusException(
+            throw SparseUnorderedWithDupsReaderException(
                 "Overflow happened after aggregate was computed, aggregate "
                 "recompute pass is not yet implemented");
           }

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,12 +45,10 @@
 #include "tiledb/sm/query/readers/result_cell_slab.h"
 #include "tiledb/sm/query/readers/result_coords.h"
 #include "tiledb/sm/query/readers/sparse_index_reader_base.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class Array;
 
@@ -552,7 +550,6 @@ class SparseUnorderedWithDupsReader : public SparseIndexReaderBase,
   void end_iteration(ResultTilesList& result_tiles);
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_SPARSE_UNORDERED_WITH_DUPS_READER

--- a/tiledb/sm/query/strategy_base.cc
+++ b/tiledb/sm/query/strategy_base.cc
@@ -102,7 +102,7 @@ void StrategyBase::get_dim_attr_stats() const {
   }
 }
 
-void StrategyBase::throw_if_cancellation_requested() const {
+void StrategyBase::throw_if_cancelled() const {
   if (storage_manager_->cancellation_in_progress()) {
     throw QueryException("Query was cancelled");
   }

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -65,6 +65,7 @@ class StrategyParams {
   /* ********************************* */
 
   StrategyParams(
+      ContextResources& resources,
       shared_ptr<MemoryTracker> array_memory_tracker,
       shared_ptr<MemoryTracker> query_memory_tracker,
       StorageManager* storage_manager,
@@ -78,7 +79,7 @@ class StrategyParams {
       std::optional<QueryCondition>& condition,
       DefaultChannelAggregates& default_channel_aggregates,
       bool skip_checks_serialization)
-      : resources_(storage_manager->resources())
+      : resources_(resources)
       , array_memory_tracker_(array_memory_tracker)
       , query_memory_tracker_(query_memory_tracker)
       , storage_manager_(storage_manager)
@@ -340,9 +341,9 @@ class StrategyBase {
   void get_dim_attr_stats() const;
 
   /**
-   * Throws an exception if the query is canceled.
+   * Throws an exception if the query is cancelled.
    */
-  void throw_if_cancellation_requested() const;
+  void throw_if_cancelled() const;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -60,9 +60,9 @@ using namespace tiledb::sm::stats;
 
 namespace tiledb::sm {
 
-class GlobalOrderWriterStatusException : public StatusException {
+class GlobalOrderWriterException : public StatusException {
  public:
-  explicit GlobalOrderWriterStatusException(const std::string& message)
+  explicit GlobalOrderWriterException(const std::string& message)
       : StatusException("GlobalOrderWriter", message) {
   }
 };
@@ -96,14 +96,14 @@ GlobalOrderWriter::GlobalOrderWriter(
     , current_fragment_size_(0) {
   // Check the layout is global order.
   if (layout_ != Layout::GLOBAL_ORDER) {
-    throw GlobalOrderWriterStatusException(
+    throw GlobalOrderWriterException(
         "Failed to initialize global order writer. Layout " +
         layout_str(layout_) + " is not global order.");
   }
 
   // Check no ordered attributes.
   if (array_schema_.has_ordered_attributes()) {
-    throw GlobalOrderWriterStatusException(
+    throw GlobalOrderWriterException(
         "Failed to initialize global order writer. Global order writes to "
         "ordered attributes are not yet supported.");
   }
@@ -797,7 +797,7 @@ Status GlobalOrderWriter::global_write() {
     frag_meta->set_num_tiles(new_num_tiles);
 
     if (new_num_tiles == 0) {
-      throw GlobalOrderWriterStatusException(
+      throw GlobalOrderWriterException(
           "Fragment size is too small to write a single tile");
     }
 
@@ -873,7 +873,7 @@ Status GlobalOrderWriter::prepare_full_tiles(
     std::advance(buff_it, i);
     const auto& name = buff_it->first;
     throw_if_not_ok(prepare_full_tiles(name, coord_dups, &tiles->at(name)));
-    this->throw_if_cancellation_requested();
+    this->throw_if_cancelled();
     return Status::Ok();
   });
 

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -48,7 +48,6 @@
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"
@@ -186,8 +185,7 @@ Status GlobalOrderWriter::alloc_global_write_state() {
   // Alloc FragmentMetadata object
   global_write_state_->frag_meta_ = this->create_fragment_metadata();
   // Used in serialization when FragmentMetadata is built from ground up
-  global_write_state_->frag_meta_->set_context_resources(
-      &storage_manager_->resources());
+  global_write_state_->frag_meta_->set_context_resources(&resources_);
 
   return Status::Ok();
 }
@@ -873,7 +871,7 @@ Status GlobalOrderWriter::prepare_full_tiles(
     std::advance(buff_it, i);
     const auto& name = buff_it->first;
     throw_if_not_ok(prepare_full_tiles(name, coord_dups, &tiles->at(name)));
-    this->throw_if_cancelled();
+    throw_if_cancelled();
     return Status::Ok();
   });
 

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -48,7 +48,6 @@
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -48,7 +48,6 @@
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"
@@ -170,7 +169,7 @@ Status UnorderedWriter::alloc_frag_meta() {
   // Alloc FragmentMetadata object.
   frag_meta_ = this->create_fragment_metadata();
   // Used in serialization when FragmentMetadata is built from ground up.
-  frag_meta_->set_context_resources(&storage_manager_->resources());
+  frag_meta_->set_context_resources(&resources_);
 
   return Status::Ok();
 }
@@ -388,7 +387,7 @@ Status UnorderedWriter::prepare_tiles(
         auto tiles_it = tiles->begin();
         std::advance(tiles_it, i);
         throw_if_not_ok(prepare_tiles(tiles_it->first, &(tiles_it->second)));
-        this->throw_if_cancelled();
+        throw_if_cancelled();
         return Status::Ok();
       });
 

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -388,7 +388,7 @@ Status UnorderedWriter::prepare_tiles(
         auto tiles_it = tiles->begin();
         std::advance(tiles_it, i);
         throw_if_not_ok(prepare_tiles(tiles_it->first, &(tiles_it->second)));
-        this->throw_if_cancellation_requested();
+        this->throw_if_cancelled();
         return Status::Ok();
       });
 

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -50,7 +50,6 @@
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 #include "tiledb/sm/tile/tile_metadata_generator.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"
@@ -62,9 +61,9 @@ using namespace tiledb::sm::stats;
 
 namespace tiledb::sm {
 
-class WriterBaseStatusException : public StatusException {
+class WriterBaseException : public StatusException {
  public:
-  explicit WriterBaseStatusException(const std::string& message)
+  explicit WriterBaseException(const std::string& message)
       : StatusException("WriterBase", message) {
   }
 };
@@ -92,21 +91,15 @@ WriterBase::WriterBase(
     , written_fragment_info_(written_fragment_info)
     , remote_query_(remote_query) {
   // Sanity checks
-  if (storage_manager_ == nullptr) {
-    throw WriterBaseStatusException(
-        "Cannot initialize query; Storage manager not set");
-  }
-
   if (!params.skip_checks_serialization() && buffers_.empty()) {
-    throw WriterBaseStatusException(
-        "Cannot initialize writer; Buffers not set");
+    throw WriterBaseException("Cannot initialize writer; Buffers not set");
   }
 
   if (array_schema_.dense() &&
       (layout_ == Layout::ROW_MAJOR || layout_ == Layout::COL_MAJOR)) {
     for (const auto& b : buffers_) {
       if (array_schema_.is_dim(b.first)) {
-        throw WriterBaseStatusException(
+        throw WriterBaseException(
             "Cannot initialize writer; Sparse coordinates for dense arrays "
             "cannot be provided if the query layout is ROW_MAJOR or COL_MAJOR");
       }
@@ -117,19 +110,19 @@ WriterBase::WriterBase(
   const char *check_coord_dups, *check_coord_oob, *check_global_order;
   const char* dedup_coords;
   if (!config_.get("sm.check_coord_dups", &check_coord_dups).ok()) {
-    throw WriterBaseStatusException("Cannot get setting");
+    throw WriterBaseException("Cannot get setting");
   }
 
   if (!config_.get("sm.check_coord_oob", &check_coord_oob).ok()) {
-    throw WriterBaseStatusException("Cannot get setting");
+    throw WriterBaseException("Cannot get setting");
   }
 
   if (!config_.get("sm.check_global_order", &check_global_order).ok()) {
-    throw WriterBaseStatusException("Cannot get setting");
+    throw WriterBaseException("Cannot get setting");
   }
 
   if (!config_.get("sm.dedup_coords", &dedup_coords).ok()) {
-    throw WriterBaseStatusException("Cannot get setting");
+    throw WriterBaseException("Cannot get setting");
   }
 
   assert(check_coord_dups != nullptr && dedup_coords != nullptr);
@@ -144,7 +137,7 @@ WriterBase::WriterBase(
   offsets_format_mode_ = config_.get("sm.var_offsets.mode", &found);
   assert(found);
   if (offsets_format_mode_ != "bytes" && offsets_format_mode_ != "elements") {
-    throw WriterBaseStatusException(
+    throw WriterBaseException(
         "Cannot initialize writer; Unsupported offsets format in "
         "configuration");
   }
@@ -152,19 +145,19 @@ WriterBase::WriterBase(
            .get<bool>(
                "sm.var_offsets.extra_element", &offsets_extra_element_, &found)
            .ok()) {
-    throw WriterBaseStatusException("Cannot get setting");
+    throw WriterBaseException("Cannot get setting");
   }
   assert(found);
 
   if (!config_
            .get<uint32_t>("sm.var_offsets.bitsize", &offsets_bitsize_, &found)
            .ok()) {
-    throw WriterBaseStatusException("Cannot get setting");
+    throw WriterBaseException("Cannot get setting");
   }
   assert(found);
 
   if (offsets_bitsize_ != 32 && offsets_bitsize_ != 64) {
-    throw WriterBaseStatusException(
+    throw WriterBaseException(
         "Cannot initialize writer; Unsupported offsets bitsize in "
         "configuration");
   }
@@ -172,12 +165,12 @@ WriterBase::WriterBase(
   // Check subarray is valid for strategy is set or set it to default if unset.
   if (subarray_.is_set()) {
     if (!array_schema_.dense()) {
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "Cannot initialize write; Non-default subarray are not supported in "
           "sparse writes");
     }
     if (subarray_.range_num() > 1) {
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "Cannot initialize writer; Multi-range dense writes are not "
           "supported");
     }
@@ -270,7 +263,7 @@ void WriterBase::check_var_attr_offsets() const {
     // Allow the initial offset to be equal to the size, this indicates
     // the first and only value in the buffer is to be empty
     if (prev_offset > *buffer_val_size) {
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "Invalid offsets for attribute " + attr + "; offset " +
           std::to_string(prev_offset) + " specified for buffer of size " +
           std::to_string(*buffer_val_size));
@@ -279,7 +272,7 @@ void WriterBase::check_var_attr_offsets() const {
     for (uint64_t i = 1; i < num_offsets; i++) {
       uint64_t cur_offset = get_offset_buffer_element(buffer_off, i);
       if (cur_offset < prev_offset)
-        throw WriterBaseStatusException(
+        throw WriterBaseException(
             "Invalid offsets for attribute " + attr +
             "; offsets must be given in "
             "strictly ascending order.");
@@ -291,7 +284,7 @@ void WriterBase::check_var_attr_offsets() const {
            get_offset_buffer_element(
                buffer_off, (i < num_offsets - 1 ? i + 1 : i)) !=
                *buffer_val_size))
-        throw WriterBaseStatusException(
+        throw WriterBaseException(
             "Invalid offsets for attribute " + attr + "; offset " +
             std::to_string(cur_offset) + " specified at index " +
             std::to_string(i) + " for buffer of size " +
@@ -383,7 +376,7 @@ void WriterBase::check_buffer_sizes() const {
               "given for ";
         ss << "attribute '" << attr << "'";
         ss << " (" << expected_validity_num << " != " << cell_num << ")";
-        throw WriterBaseStatusException(ss.str());
+        throw WriterBaseException(ss.str());
       }
     } else {
       if (expected_cell_num != cell_num) {
@@ -391,7 +384,7 @@ void WriterBase::check_buffer_sizes() const {
         ss << "Buffer sizes check failed; Invalid number of cells given for ";
         ss << "attribute '" << attr << "'";
         ss << " (" << expected_cell_num << " != " << cell_num << ")";
-        throw WriterBaseStatusException(ss.str());
+        throw WriterBaseException(ss.str());
       }
     }
   }
@@ -445,12 +438,11 @@ Status WriterBase::check_coord_oob() const {
 void WriterBase::check_subarray() const {
   if (array_schema_.dense()) {
     if (subarray_.range_num() != 1) {
-      throw WriterBaseStatusException(
-          "Multi-range dense writes are not supported");
+      throw WriterBaseException("Multi-range dense writes are not supported");
     }
 
     if (layout_ == Layout::GLOBAL_ORDER && !subarray_.coincides_with_tiles()) {
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "Cannot initialize query; In global writes for dense arrays, the "
           "subarray must coincide with the tile bounds");
     }
@@ -529,7 +521,7 @@ bool is_sorted_buffer(
                  buffer.is_sorted_str<std::less_equal<std::string_view>>() :
                  buffer.is_sorted_str<std::greater_equal<std::string_view>>();
     default:
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "Unexpected datatype '" + datatype_str(type) +
           "' for an ordered attribute.");
   }
@@ -556,7 +548,7 @@ void WriterBase::check_attr_order() const {
     // Check the attribute sort. This assumes all ordered attributes are fixed
     // except STRING_ASCII which is assumed to always be variable.
     if (!is_sorted_buffer(buffer, attr->type(), increasing)) {
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "The data for attribute '" + name +
           "' is not in the expected order.");
     }
@@ -810,7 +802,7 @@ Status WriterBase::filter_tiles(
         auto tiles_it = tiles->begin();
         std::advance(tiles_it, i);
         throw_if_not_ok(filter_tiles(tiles_it->first, &tiles_it->second));
-        this->throw_if_cancelled();
+        throw_if_cancelled();
         return Status::Ok();
       });
 
@@ -982,7 +974,7 @@ void WriterBase::check_extra_element() {
         get_offset_buffer_element(buffer_off, num_offsets - 1);
 
     if (last_offset != max_offset) {
-      throw WriterBaseStatusException(
+      throw WriterBaseException(
           "Invalid offsets for attribute " + attr +
           "; the last offset: " + std::to_string(last_offset) +
           " is not equal to the size of the data buffer: " +

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -810,7 +810,7 @@ Status WriterBase::filter_tiles(
         auto tiles_it = tiles->begin();
         std::advance(tiles_it, i);
         throw_if_not_ok(filter_tiles(tiles_it->first, &tiles_it->second));
-        this->throw_if_cancellation_requested();
+        this->throw_if_cancelled();
         return Status::Ok();
       });
 


### PR DESCRIPTION
Add a `ContextResources&` param to the `StrategyParams` constructor. 
Rename `StrategyBase::throw_if_cancellation_requested` -> `StrategyBase::throw_if_cancelled`. 
Rename `ReaderStatusException` -> `ReaderException`.
Rename `GlobalOrderWriterStatusException` -> `GlobalOrderWriterException`. 

[sc-49624]

---
TYPE: NO_HISTORY
DESC: Add a `ContextResources&` param to the `StrategyParams` constructor. 
