### PR TITLE
Add a ContextResources& parameter to the Query constructor.

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -2398,10 +2398,10 @@ TEST_CASE_METHOD(
   auto qc1 = create_qc("attr1", (int)2, QueryConditionOp::EQ);
   qc1.set_use_enumeration(false);
 
-  Query q1(ctx_.storage_manager(), array);
+  Query q1(ctx_.resources(), ctx_.storage_manager(), array);
   throw_if_not_ok(q1.set_condition(qc1));
 
-  Query q2(ctx_.storage_manager(), array);
+  Query q2(ctx_.resources(), ctx_.storage_manager(), array);
   ser_des_query(&q1, &q2, client_side, ser_type);
 
   auto qc2 = q2.condition();
@@ -2434,10 +2434,10 @@ TEST_CASE_METHOD(
 
   throw_if_not_ok(qc1.combine(qc2, QueryConditionCombinationOp::OR, &qc3));
 
-  Query q1(ctx_.storage_manager(), array);
+  Query q1(ctx_.resources(), ctx_.storage_manager(), array);
   throw_if_not_ok(q1.set_condition(qc3));
 
-  Query q2(ctx_.storage_manager(), array);
+  Query q2(ctx_.resources(), ctx_.storage_manager(), array);
   ser_des_query(&q1, &q2, client_side, ser_type);
 
   auto qc4 = q2.condition();

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -976,8 +976,8 @@ int32_t tiledb_query_alloc(
   }
 
   // Create query
-  (*query)->query_ = new (std::nothrow)
-      tiledb::sm::Query(ctx->storage_manager(), array->array_);
+  (*query)->query_ = new (std::nothrow) tiledb::sm::Query(
+      ctx->resources(), ctx->storage_manager(), array->array_);
   if ((*query)->query_ == nullptr) {
     auto st = Status_Error(
         "Failed to allocate TileDB query object; Memory allocation failed");
@@ -3742,8 +3742,8 @@ int32_t tiledb_deserialize_query_and_array(
   }
 
   // Create query
-  (*query)->query_ = new (std::nothrow)
-      tiledb::sm::Query(ctx->storage_manager(), (*array)->array_);
+  (*query)->query_ = new (std::nothrow) tiledb::sm::Query(
+      ctx->resources(), ctx->storage_manager(), (*array)->array_);
   if ((*query)->query_ == nullptr) {
     auto st = Status_Error(
         "Failed to allocate TileDB query object; Memory allocation failed");
@@ -4321,7 +4321,8 @@ capi_return_t tiledb_handle_query_plan_request(
   api::ensure_buffer_is_valid(request);
   api::ensure_buffer_is_valid(response);
 
-  tiledb::sm::Query query(ctx->storage_manager(), array->array_);
+  tiledb::sm::Query query(
+      ctx->resources(), ctx->storage_manager(), array->array_);
   tiledb::sm::serialization::deserialize_query_plan_request(
       static_cast<tiledb::sm::SerializationType>(serialization_type),
       request->buffer(),

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -274,7 +274,8 @@ int32_t tiledb_filestore_uri_import(
   auto buffer_size =
       get_buffer_size_from_config(context.resources().config(), tile_extent);
 
-  tiledb::sm::Query query(context.storage_manager(), array);
+  tiledb::sm::Query query(
+      context.resources(), context.storage_manager(), array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::GLOBAL_ORDER));
   std::vector<std::byte> buffer(buffer_size);
 
@@ -296,7 +297,8 @@ int32_t tiledb_filestore_uri_import(
   query.set_subarray(subarray);
 
   auto tiledb_cloud_fix = [&](uint64_t start, uint64_t end) {
-    tiledb::sm::Query query(context.storage_manager(), array);
+    tiledb::sm::Query query(
+        context.resources(), context.storage_manager(), array);
     throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
     tiledb::sm::Subarray subarray_cloud_fix(
         array.get(), nullptr, context.resources().logger(), true);
@@ -429,7 +431,8 @@ int32_t tiledb_filestore_uri_export(
         static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
     subarray.add_range(0, std::move(subarray_range));
 
-    tiledb::sm::Query query(context.storage_manager(), array);
+    tiledb::sm::Query query(
+        context.resources(), context.storage_manager(), array);
     throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
     query.set_subarray(subarray);
 
@@ -532,7 +535,8 @@ int32_t tiledb_filestore_buffer_import(
       static_cast<uint32_t>(0),
       "");
 
-  tiledb::sm::Query query(context.storage_manager(), array);
+  tiledb::sm::Query query(
+      context.resources(), context.storage_manager(), array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
 
   tiledb::sm::Subarray subarray(
@@ -601,7 +605,8 @@ int32_t tiledb_filestore_buffer_export(
       static_cast<void*>(subarray_range_arr), sizeof(uint64_t) * 2);
   subarray.add_range(0, std::move(subarray_range));
 
-  tiledb::sm::Query query(context.storage_manager(), array);
+  tiledb::sm::Query query(
+      context.resources(), context.storage_manager(), array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
   query.set_subarray(subarray);
   uint64_t size_tmp = size;

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -668,7 +668,12 @@ Status FragmentConsolidator::create_queries(
 
   // Create read query
   query_r = tdb_unique_ptr<Query>(tdb_new(
-      Query, storage_manager_, array_for_reads, nullopt, read_memory_budget));
+      Query,
+      resources_,
+      storage_manager_,
+      array_for_reads,
+      nullopt,
+      read_memory_budget));
   throw_if_not_ok(query_r->set_layout(Layout::GLOBAL_ORDER));
 
   // Dense consolidation will do a tile aligned read.
@@ -695,6 +700,7 @@ Status FragmentConsolidator::create_queries(
   // Create write query
   query_w = tdb_unique_ptr<Query>(tdb_new(
       Query,
+      resources_,
       storage_manager_,
       array_for_writes,
       fragment_name,

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.cc
@@ -50,13 +50,14 @@ using namespace tiledb::common;
 namespace tiledb::sm {
 
 ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
+    ContextResources& resources,
     StorageManager* storage_manager,
     Array* array,
     const Subarray& subarray,
     const std::unordered_map<std::string, QueryBuffer>& label_buffers,
     const std::unordered_map<std::string, QueryBuffer>& array_buffers,
     const optional<std::string>& fragment_name)
-    : resources_(storage_manager->resources())
+    : resources_(resources)
     , storage_manager_(storage_manager)
     , label_range_queries_by_dim_idx_(subarray.dim_num(), nullptr)
     , label_data_queries_by_dim_idx_(subarray.dim_num())
@@ -79,7 +80,7 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
       } else {
         // Cannot both read label ranges and write label data on the same write.
         if (subarray.has_label_ranges()) {
-          throw DimensionLabelQueryStatusException(
+          throw DimensionLabelQueryException(
               "Failed to add dimension label queries. Cannot set both label "
               "buffer and label range on a write query.");
         }
@@ -105,7 +106,7 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
     case (QueryType::UPDATE):
     case (QueryType::MODIFY_EXCLUSIVE):
       if (!label_buffers.empty() || subarray.has_label_ranges()) {
-        throw DimensionLabelQueryStatusException(
+        throw DimensionLabelQueryException(
             "Failed to add dimension label queries. Query type " +
             query_type_str(array->get_query_type()) +
             " is not supported for dimension labels.");
@@ -113,7 +114,7 @@ ArrayDimensionLabelQueries::ArrayDimensionLabelQueries(
       break;
 
     default:
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Failed to add dimension label queries. Unknown query type " +
           query_type_str(array->get_query_type()) + ".");
   }
@@ -132,7 +133,7 @@ bool ArrayDimensionLabelQueries::completed() const {
 DimensionLabelQuery* ArrayDimensionLabelQueries::get_range_query(
     ArrayDimensionLabelQueries::dimension_size_type dim_idx) const {
   if (!has_range_query(dim_idx)) {
-    throw DimensionLabelQueryStatusException(
+    throw DimensionLabelQueryException(
         "No dimension label range query for dimension at index " +
         std::to_string(dim_idx));
   }
@@ -142,7 +143,7 @@ DimensionLabelQuery* ArrayDimensionLabelQueries::get_range_query(
 std::vector<DimensionLabelQuery*> ArrayDimensionLabelQueries::get_data_query(
     ArrayDimensionLabelQueries::dimension_size_type dim_idx) const {
   if (!has_data_query(dim_idx)) {
-    throw DimensionLabelQueryStatusException(
+    throw DimensionLabelQueryException(
         "No dimension label data query for dimension at index " +
         std::to_string(dim_idx));
   }
@@ -161,7 +162,7 @@ void ArrayDimensionLabelQueries::process_data_queries() {
           throw_if_not_ok(query->process());
           return Status::Ok();
         } catch (const StatusException& err) {
-          throw DimensionLabelQueryStatusException(
+          throw DimensionLabelQueryException(
               "Failed to process data query for label '" +
               query->dim_label_name() + "'. " + err.what());
         }
@@ -182,7 +183,7 @@ void ArrayDimensionLabelQueries::process_range_queries(Query* parent_query) {
             range_query->init();
             throw_if_not_ok(range_query->process());
             if (!range_query->completed()) {
-              throw DimensionLabelQueryStatusException(
+              throw DimensionLabelQueryException(
                   "Range query for label '" + range_query->dim_label_name() +
                   "' failed to complete.");
             }
@@ -202,7 +203,7 @@ void ArrayDimensionLabelQueries::process_range_queries(Query* parent_query) {
           }
           return Status::Ok();
         } catch (const StatusException& err) {
-          throw DimensionLabelQueryStatusException(
+          throw DimensionLabelQueryException(
               "Failed to process and update index ranges for label '" +
               range_query->dim_label_name() + "'. " + err.what());
         }
@@ -249,13 +250,14 @@ void ArrayDimensionLabelQueries::add_read_queries(
       // Create the range query.
       range_queries_.emplace_back(tdb_new(
           DimensionLabelQuery,
+          resources_,
           storage_manager_,
           dim_label,
           dim_label_ref,
           label_ranges));
       label_range_queries_by_dim_idx_[dim_idx] = range_queries_.back().get();
     } catch (const StatusException& err) {
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Failed to initialize the query to read range data from label '" +
           label_name + "'. " + err.what());
     }
@@ -281,6 +283,7 @@ void ArrayDimensionLabelQueries::add_read_queries(
       // Create the data query.
       data_queries_.emplace_back(tdb_new(
           DimensionLabelQuery,
+          resources_,
           storage_manager_,
           dim_label,
           dim_label_ref,
@@ -291,7 +294,7 @@ void ArrayDimensionLabelQueries::add_read_queries(
       label_data_queries_by_dim_idx_[dim_label_ref.dimension_index()].push_back(
           data_queries_.back().get());
     } catch (const StatusException& err) {
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Failed to initialize the data query for label '" + label_name +
           "'. " + err.what());
     }
@@ -312,7 +315,7 @@ void ArrayDimensionLabelQueries::add_write_queries(
 
       // Verify that this subarray is not set to use labels.
       if (subarray.has_label_ranges(dim_label_ref.dimension_index())) {
-        throw DimensionLabelQueryStatusException(
+        throw DimensionLabelQueryException(
             "Cannot write label data when subarray is set by label range.");
       }
 
@@ -332,6 +335,7 @@ void ArrayDimensionLabelQueries::add_write_queries(
       // Create the dimension label query.
       data_queries_.emplace_back(tdb_new(
           DimensionLabelQuery,
+          resources_,
           storage_manager_,
           dim_label,
           dim_label_ref,
@@ -344,7 +348,7 @@ void ArrayDimensionLabelQueries::add_write_queries(
       label_data_queries_by_dim_idx_[dim_label_ref.dimension_index()].push_back(
           data_queries_.back().get());
     } catch (const StatusException& err) {
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Failed to initialize the data query for label '" + label_name +
           "'. " + err.what());
     }
@@ -358,8 +362,7 @@ shared_ptr<Array> ArrayDimensionLabelQueries::open_dimension_label(
     const QueryType& query_type) {
   // Create the dimension label.
   auto label_iter = dimension_labels_.try_emplace(
-      dim_label_name,
-      make_shared<Array>(HERE(), storage_manager_->resources(), dim_label_uri));
+      dim_label_name, make_shared<Array>(HERE(), resources_, dim_label_uri));
   const auto dim_label = label_iter.first->second;
 
   // Open the dimension label with the same timestamps and encryption as the

--- a/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
+++ b/tiledb/sm/query/dimension_label/array_dimension_label_queries.h
@@ -69,6 +69,13 @@ class ArrayDimensionLabelQueries {
   /**
    * Constructor.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of the Query class on StorageManager.
+   * For now, we still need to keep the storage_manager argument, but once the
+   * dependency is gone, the signature will be
+   * ArrayDimensionLabelQueries(ContextResources&, Array*, ...).
+   *
+   * @param resources The context resources.
    * @param storage_manager Storage manager object.
    * @param array Parent array the dimension labels are defined on.
    * @param subarray Subarray for the query on the parent array.
@@ -78,6 +85,7 @@ class ArrayDimensionLabelQueries {
    * @param fragment_name Optional fragment name for writing fragments.
    */
   ArrayDimensionLabelQueries(
+      ContextResources& resources,
       StorageManager* storage_manager,
       Array* array,
       const Subarray& subarray,

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +50,7 @@ using namespace tiledb::common;
 namespace tiledb::sm {
 
 DimensionLabelQuery::DimensionLabelQuery(
+    ContextResources& resources,
     StorageManager* storage_manager,
     shared_ptr<Array> dim_label,
     const DimensionLabel& dim_label_ref,
@@ -57,7 +58,7 @@ DimensionLabelQuery::DimensionLabelQuery(
     const QueryBuffer& label_buffer,
     const QueryBuffer& index_buffer,
     optional<std::string> fragment_name)
-    : Query(storage_manager, dim_label, fragment_name)
+    : Query(resources, storage_manager, dim_label, fragment_name)
     , dim_label_name_{dim_label_ref.name()} {
   switch (dim_label->get_query_type()) {
     case (QueryType::READ):
@@ -92,7 +93,7 @@ DimensionLabelQuery::DimensionLabelQuery(
 
         default:
           // Invalid label order type.
-          throw DimensionLabelQueryStatusException(
+          throw DimensionLabelQueryException(
               "Unrecognized label order " +
               data_order_str(dim_label_ref.label_order()));
       }
@@ -100,18 +101,19 @@ DimensionLabelQuery::DimensionLabelQuery(
     }
 
     default:
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Query type " + query_type_str(dim_label->get_query_type()) +
           " not supported for dimension label queries.");
   }
 }
 
 DimensionLabelQuery::DimensionLabelQuery(
+    ContextResources& resources,
     StorageManager* storage_manager,
     shared_ptr<Array> dim_label,
     const DimensionLabel& dim_label_ref,
     const std::vector<Range>& label_ranges)
-    : Query(storage_manager, dim_label, nullopt)
+    : Query(resources, storage_manager, dim_label, nullopt)
     , dim_label_name_{dim_label_ref.name()}
     , index_data_{IndexDataCreate::make_index_data(
           array_schema().dimension_ptr(0)->type(),
@@ -123,12 +125,12 @@ DimensionLabelQuery::DimensionLabelQuery(
     case (DataOrder::DECREASING_DATA):
       break;
     case (DataOrder::UNORDERED_DATA):
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Support for reading ranges from unordered labels is not yet "
           "implemented.");
     default:
       // Invalid label order type.
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "Unrecognized label order " +
           data_order_str(dim_label_ref.label_order()));
   }
@@ -194,7 +196,7 @@ void DimensionLabelQuery::initialize_ordered_write_query(
       Subarray subarray{*this->subarray()};
       subarray.set_ranges_for_dim(0, parent_subarray.ranges_for_dim(dim_idx));
       if (subarray.range_num() > 1) {
-        throw DimensionLabelQueryStatusException(
+        throw DimensionLabelQueryException(
             "Dimension label writes can only be set for a single range.");
       }
       set_subarray(subarray);
@@ -210,7 +212,7 @@ void DimensionLabelQuery::initialize_ordered_write_query(
     subarray.set_coalesce_ranges(true);
     subarray.add_point_ranges(0, index_buffer.buffer_, count);
     if (subarray.range_num() > 1) {
-      throw DimensionLabelQueryStatusException(
+      throw DimensionLabelQueryException(
           "The dimension data must contain consecutive points when writing to "
           "a dimension label.");
     }
@@ -231,7 +233,7 @@ void DimensionLabelQuery::initialize_unordered_write_query(
     if (!parent_subarray.is_default(dim_idx)) {
       const auto& ranges = parent_subarray.ranges_for_dim(dim_idx);
       if (ranges.size() != 1) {
-        throw DimensionLabelQueryStatusException(
+        throw DimensionLabelQueryException(
             "Dimension label writes can only be set for a single range.");
       }
     }

--- a/tiledb/sm/query/dimension_label/dimension_label_query.h
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,9 +50,9 @@ class QueryBuffer;
 class Subarray;
 
 /** Class for dimension label query status exceptions. */
-class DimensionLabelQueryStatusException : public StatusException {
+class DimensionLabelQueryException : public StatusException {
  public:
-  explicit DimensionLabelQueryStatusException(const std::string& msg)
+  explicit DimensionLabelQueryException(const std::string& msg)
       : StatusException("DimensionLabelQuery", msg) {
   }
 };
@@ -66,6 +66,13 @@ class DimensionLabelQuery : public Query {
   /**
    * Constructor for queries to read or write label data.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of the Query class on StorageManager.
+   * For now, we still need to keep the storage_manager argument, but once the
+   * dependency is gone, the signature will be
+   * DimensionLabelQuery(ContextResources&, shared_ptr<Array>, ...).
+   *
+   * @param resources The context resources.
    * @param storage_manager Storage manager object.
    * @param dim_label Opened dimension label for the query.
    * @param dim_label_ref Description of the dimension label.
@@ -76,6 +83,7 @@ class DimensionLabelQuery : public Query {
    * @param fragment_name Name to use when writing the fragment.
    */
   DimensionLabelQuery(
+      ContextResources& resources,
       StorageManager* storage_manager,
       shared_ptr<Array> dim_label,
       const DimensionLabel& dim_label_ref,
@@ -87,12 +95,20 @@ class DimensionLabelQuery : public Query {
   /**
    * Constructor for range queries.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of the Query class on StorageManager.
+   * For now, we still need to keep the storage_manager argument, but once the
+   * dependency is gone, the signature will be
+   * DimensionLabelQuery(ContextResources&, shared_ptr<Array>, ...).
+   *
+   * @param resources The context resources.
    * @param storage_manager Storage manager object.
    * @param dim_label Opened dimension label for the query.
    * @param dim_label_ref Description of the dimension label.
    * @param label_ranges Label ranges to read index ranges from.
    */
   DimensionLabelQuery(
+      ContextResources& resources,
       StorageManager* storage_manager,
       shared_ptr<Array> dim_label,
       const DimensionLabel& dim_label_ref,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -82,11 +82,12 @@ static uint64_t get_effective_memory_budget(
 /* ****************************** */
 
 Query::Query(
+    ContextResources& resources,
     StorageManager* storage_manager,
     shared_ptr<Array> array,
     optional<std::string> fragment_name,
     optional<uint64_t> memory_budget)
-    : resources_(storage_manager->resources())
+    : resources_(resources)
     , stats_(resources_.stats().create_child("Query"))
     , logger_(resources_.logger()->clone("Query", ++logger_id_))
     , query_memory_tracker_(resources_.memory_tracker_manager().create_tracker(
@@ -710,6 +711,7 @@ void Query::init() {
       // Initialize the dimension label queries.
       dim_label_queries_ = tdb_unique_ptr<ArrayDimensionLabelQueries>(tdb_new(
           ArrayDimensionLabelQueries,
+          resources_,
           storage_manager_,
           array_,
           subarray_,

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -138,8 +138,16 @@ class Query {
    * case the query will be used as writes and the given URI should be used
    * for the name of the new fragment to be created.
    *
+   * This is a transitional constructor in the sense that we are working
+   * on removing the dependency of the Query class on StorageManager.
+   * For now, we still need to keep the storage_manager argument, but once the
+   * dependency is gone, the signature will be
+   * Query(ContextResources&, shared_ptr<Array>, ...).
+   *
    * @note Array must be a properly opened array.
    *
+   * @param resources The context resources.
+   * @param storage_manager Storage manager object.
    * @param array The array that is being queried.
    * @param fragment_uri The full URI for the new fragment. Only used for
    * writes.
@@ -149,6 +157,7 @@ class Query {
    *     will be obtained from the sm.mem.total_budget config option.
    */
   Query(
+      ContextResources& resources,
       StorageManager* storage_manager,
       shared_ptr<Array> array,
       optional<std::string> fragment_name = nullopt,

--- a/tiledb/sm/query_plan/test/unit_query_plan.cc
+++ b/tiledb/sm/query_plan/test/unit_query_plan.cc
@@ -126,7 +126,7 @@ TEST_CASE_METHOD(QueryPlanFx, "Query plan dump_json", "[query_plan][dump]") {
   REQUIRE(st.ok());
 
   shared_ptr<Array> array_shared = std::move(array);
-  Query query(sm_.get(), array_shared);
+  Query query(resources_, sm_.get(), array_shared);
   REQUIRE(query.set_layout(Layout::ROW_MAJOR).ok());
 
   stats::Stats stats("foo");


### PR DESCRIPTION
Add a `ContextResources&` parameter to the `Query` constructor.
Add a `ContextResources&` parameter to the `DimensionLabelQuery` constructor.
Add a `ContextResources&` parameter to the `ArrayDimensionLabelQuery` constructor.
Update `DimensionLabelQueryStatusException` -> `DimensionLabelQueryException`.

[sc-49688]

---
TYPE: NO_HISTORY
DESC: Add a `ContextResources&` parameter to the `Query` constructor.
