### PR TITLE
Add CODEOWNERS file to flag configuration changes for documentation follow-up

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Flag all PR configuration changes for documentation follow-up.
 /tiledb/sm/cpp_api/config.h   @TileDB-Inc/tiledb-docs
+/tiledb/api/c_api/config/config_api_external.h  @TileDB-Inc/tiledb-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Flag all PR configuration changes for documentation follow-up.
+/tiledb/sm/cpp_api/config.h   @tiledb-docs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Flag all PR configuration changes for documentation follow-up.
-/tiledb/sm/cpp_api/config.h   @tiledb-docs
+/tiledb/sm/cpp_api/config.h   @TileDB-Inc/tiledb-docs


### PR DESCRIPTION
Add CODEOWNERS file to flag configuration changes for documentation follow-up

[sc-49693]

---
TYPE: NO_HISTORY