### PR TITLE
Fix task graph tests in nightlies.

### DIFF
--- a/experimental/tiledb/common/dag/edge/test/unit_edge.cc
+++ b/experimental/tiledb/common/dag/edge/test/unit_edge.cc
@@ -54,7 +54,7 @@ using namespace tiledb::common;
 /**
  * Attach an `Edge` to a `Source` and a `Sink`, two stage
  */
-TEST_CASE("Edge: Attach a Source and Sink with a two stage Edge", "[edge") {
+TEST_CASE("Edge: Attach a Source and Sink with a two stage Edge", "[edge]") {
   Source<NullMover2, size_t> left;
   Sink<NullMover2, size_t> right;
   Edge mid(left, right);
@@ -63,7 +63,7 @@ TEST_CASE("Edge: Attach a Source and Sink with a two stage Edge", "[edge") {
 /**
  * Attach an `Edge` to a `Source` and a `Sink`
  */
-TEST_CASE("Edge: Attach a Source and Sink with an Edge", "[edge") {
+TEST_CASE("Edge: Attach a Source and Sink with an Edge", "[edge]") {
   Source<NullMover3, size_t> left;
   Sink<NullMover3, size_t> right;
   Edge<NullMover3, size_t> mid(left, right);
@@ -72,7 +72,7 @@ TEST_CASE("Edge: Attach a Source and Sink with an Edge", "[edge") {
 /**
  * Attach an `Edge` to a `Source` and a `Sink, using CTAD`
  */
-TEST_CASE("Edge: Attach a Source and Sink with an Edge, using CTAD", "[edge") {
+TEST_CASE("Edge: Attach a Source and Sink with an Edge, using CTAD", "[edge]") {
   Source<NullMover3, size_t> left;
   Sink<NullMover3, size_t> right;
   Edge mid(left, right);
@@ -589,7 +589,7 @@ TEST_CASE("Edge: Async pass n integers", "[edge]") {
 /**
  * Attach an `Edge` to a `ProducerNode` and a `ConsumerNode`
  */
-TEST_CASE("Edge: Attach a Producer and Consumer with an Edge", "[edge") {
+TEST_CASE("Edge: Attach a Producer and Consumer with an Edge", "[edge]") {
   ProducerNode<NullMover3, size_t> left([]() { return 0UL; });
   ConsumerNode<NullMover3, size_t> right([](size_t) {});
 
@@ -600,7 +600,7 @@ TEST_CASE("Edge: Attach a Producer and Consumer with an Edge", "[edge") {
  * Attach an `Edge` to a `ProducerNode` and a `ConsumerNode, using CTAD`
  */
 TEST_CASE(
-    "Edge: Attach a Producer and Consumer with an Edge, using CTAD", "[edge") {
+    "Edge: Attach a Producer and Consumer with an Edge, using CTAD", "[edge]") {
   ProducerNode<NullMover3, size_t> left([]() { return 0UL; });
   ConsumerNode<NullMover3, size_t> right([](size_t) {});
 

--- a/experimental/tiledb/common/dag/execution/test/unit_scheduler_sieve.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_scheduler_sieve.cc
@@ -548,6 +548,9 @@ int main(int argc, char* argv[]) {
   size_t stages = 2;
   size_t trips = 2;
 
+  // This is unused until we migrate to catch2.
+  bool durations = false;
+
   auto cli = Opt(block_size, "block_size")["-b"]["--block_size"]("Block size") |
              Opt(width, "width")["-w"]["--width"]("Width") |
              Opt(number, "number")["-n"]["--number"]("Number") |
@@ -556,7 +559,8 @@ int main(int argc, char* argv[]) {
              Opt(scheduler, "scheduler")["-s"]["--scheduler"](
                  "Scheduler (bountiful, duffs, throw_catch, or frugal") |
              Opt(stages, "stages")["-t"]["--stages"]("Stages (2 or 3)") |
-             Opt(trips, "trips")["-p"]["--trips"]("Trips");
+             Opt(trips, "trips")["-p"]["--trips"]("Trips") |
+             Opt(durations, "durations")["-d"]["--durations"]("Durations");
 
   auto result = cli.parse(Args(argc, argv));
   if (!result) {

--- a/experimental/tiledb/common/dag/graph/test/unit_graph_sieve.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_graph_sieve.cc
@@ -533,6 +533,9 @@ int main(int argc, char* argv[]) {
   size_t stages = 2;
   size_t trips = 2;
 
+  // This is unused until we migrate to catch2.
+  bool durations = false;
+
   auto cli = Opt(block_size, "block_size")["-b"]["--block_size"]("Block size") |
              Opt(width, "width")["-w"]["--width"]("Width") |
              Opt(number, "number")["-n"]["--number"]("Number") |
@@ -541,7 +544,8 @@ int main(int argc, char* argv[]) {
              Opt(scheduler, "scheduler")["-s"]["--scheduler"](
                  "Scheduler (bountiful, duffs, throw_catch, or frugal") |
              Opt(stages, "stages")["-t"]["--stages"]("Stages (2 or 3)") |
-             Opt(trips, "trips")["-p"]["--trips"]("Trips");
+             Opt(trips, "trips")["-p"]["--trips"]("Trips") |
+             Opt(durations, "durations")["-d"]["--durations"]("Durations");
 
   auto result = cli.parse(Args(argc, argv));
   if (!result) {

--- a/experimental/tiledb/common/dag/nodes/test/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/nodes/test/CMakeLists.txt
@@ -57,7 +57,7 @@ target_sources(unit_nodes_sieve PUBLIC
 #
 add_test(
     NAME "unit_nodes_sieve"
-    COMMAND $<TARGET_FILE:unit_nodes_sieve> --durations=yes
+    COMMAND $<TARGET_FILE:unit_nodes_sieve>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_dependencies(all_unit_tests "unit_nodes_sieve")

--- a/experimental/tiledb/common/dag/ports/test/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/ports/test/CMakeLists.txt
@@ -52,7 +52,7 @@ target_sources(unit_ports_sieve PUBLIC
 #
 add_test(
     NAME "unit_ports_sieve"
-    COMMAND $<TARGET_FILE:unit_ports_sieve> --durations=yes
+    COMMAND $<TARGET_FILE:unit_ports_sieve>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_dependencies(all_unit_tests "unit_ports_sieve")

--- a/experimental/tiledb/common/dag/utility/test/unit_concurrent_map.cc
+++ b/experimental/tiledb/common/dag/utility/test/unit_concurrent_map.cc
@@ -1,5 +1,5 @@
 /**
- * @file   unit_concurrent_set.cc
+ * @file   unit_concurrent_map.cc
  *
  * @section LICENSE
  *

--- a/experimental/tiledb/common/dag/utility/test/unit_concurrent_set.cc
+++ b/experimental/tiledb/common/dag/utility/test/unit_concurrent_set.cc
@@ -39,10 +39,10 @@
 namespace tiledb::common {}
 using namespace tiledb::common;
 
-TEST_CASE("ConcurrentSet: Construct", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Construct", "[concurrent_set]") {
 }
 
-TEST_CASE("ConcurrentSet: Test empty", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test empty", "[concurrent_set]") {
   ConcurrentSet<int> numbers;
   CHECK(numbers.empty() == true);
 
@@ -51,19 +51,19 @@ TEST_CASE("ConcurrentSet: Test empty", "[concurrent_set") {
   CHECK(numbers.empty() == false);
 }
 
-TEST_CASE("ConcurrentSet: Test size", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test size", "[concurrent_set]") {
   ConcurrentSet<int> numbers{1, 3, 5, 7, 11};
   CHECK(numbers.size() == 5);
 }
 
-TEST_CASE("ConcurrentSet: Test clear", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test clear", "[concurrent_set]") {
   ConcurrentSet<int> numbers{1, 2, 3};
   CHECK(numbers.size() == 3);
   numbers.clear();
   CHECK(numbers.empty());
 }
 
-TEST_CASE("ConcurrentSet: Test insert", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test insert", "[concurrent_set]") {
   ConcurrentSet<int> set;
 
   auto result_1 = set.insert(3);
@@ -110,11 +110,11 @@ size_t set_emplace() {
   return set.size();
 }
 
-TEST_CASE("ConcurrentSet: Test emplace", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test emplace", "[concurrent_set]") {
   CHECK(set_emplace() == nof_operations * nof_operations * nof_operations);
 }
 
-TEST_CASE("ConcurrentSet: Test erase", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test erase", "[concurrent_set]") {
   ConcurrentSet<int> numbers = {1, 2, 3, 4, 1, 2, 3, 4};
 
   CHECK(numbers.size() == 4);
@@ -132,7 +132,7 @@ TEST_CASE("ConcurrentSet: Test erase", "[concurrent_set") {
   CHECK(numbers.erase(2) == 0);
 }
 
-TEST_CASE("ConcurrentSet: Test swap", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test swap", "[concurrent_set]") {
   {
     ConcurrentSet<int> a1{3, 1, 3, 2, 7}, a2{5, 4, 5};
 
@@ -178,7 +178,7 @@ TEST_CASE("ConcurrentSet: Test swap", "[concurrent_set") {
   }
 }
 
-TEST_CASE("ConcurrentSet: Test extract", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test extract", "[concurrent_set]") {
   ConcurrentSet<int> cont0{1, 2, 3};
   ConcurrentSet<int> cont1{1, 2, 3};
   ConcurrentSet<int> cont2{2, 3};
@@ -217,7 +217,7 @@ bool operator<(const FatKey& fk1, const FatKey& fk2) {
   return fk1.x < fk2.x;
 }
 
-TEST_CASE("ConcurrentSet: Test find", "[concurrent_set") {
+TEST_CASE("ConcurrentSet: Test find", "[concurrent_set]") {
   // simple comparison demo
   ConcurrentSet<int> example = {1, 2, 3, 4};
 


### PR DESCRIPTION
Some task graph tests now run in the nightlies and have been failing for two reasons. Some test cases were not closing tags properly and some tests were ran with --durations=yes when the executable doesn't support the option because they are not catch2 executables.

[sc-49724]

---
TYPE: NO_HISTORY
DESC: Fix task graph tests in nightlies.
