### PR TITLE
Fix ASAN nightlies with failure in unit_query.

### DIFF
--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -4591,6 +4591,7 @@ TEST_CASE(
     offsets.push_back(curr_offset);
     curr_offset += elem.size();
   }
+  offsets.push_back(curr_offset);
 
   // Initialize the result tile.
   ResultTile::TileSizes tile_sizes(


### PR DESCRIPTION
After moving more tests to run in the ASAN nightlies, we encountered an issue in unit_query where it doesn't properly setup a test offset buffer with an extra offset and tries to read the extra offset when copying over to the tile.

[sc-49797]

---
TYPE: NO_HISTORY
DESC: Fix ASAN nightlies with failure in unit_query.
