### PR TITLE
Fix ASAN nightlies with failure in unit_cppapi_string.

### DIFF
--- a/tiledb/api/cpp_api_support/test/CMakeLists.txt
+++ b/tiledb/api/cpp_api_support/test/CMakeLists.txt
@@ -30,3 +30,7 @@ commence(unit_test cppapi_string)
     this_target_sources(unit_cppapi_string.cc)
     this_target_object_libraries(capi_string)
 conclude(unit_test)
+
+if(TILEDB_SANITIZER)
+    target_compile_definitions(unit_cppapi_string PRIVATE -DHAVE_SANITIZER)
+endif()

--- a/tiledb/api/cpp_api_support/test/unit_cppapi_string.cc
+++ b/tiledb/api/cpp_api_support/test/unit_cppapi_string.cc
@@ -71,6 +71,7 @@ TEST_CASE(
   REQUIRE(result == test_string);
 }
 
+#ifndef HAVE_SANITIZER
 TEST_CASE(
     "CAPIString: Test that accessing freed handle fails",
     "[capi_string][freed_handle]") {
@@ -82,6 +83,7 @@ TEST_CASE(
   size_t length = 0;
   REQUIRE(tiledb_string_view(handle_copy, &chars, &length) == TILEDB_ERR);
 }
+#endif
 
 TEST_CASE(
     "CAPIString: Test convert_to_string with null handle", "[capi_string]") {

--- a/tiledb/sm/array_schema/test/unit_current_domain.cc
+++ b/tiledb/sm/array_schema/test/unit_current_domain.cc
@@ -1,5 +1,5 @@
 /**
- * @file unit-current_domain.cc
+ * @file unit_current_domain.cc
  *
  * @section LICENSE
  *


### PR DESCRIPTION
After moving more tests to run in the ASAN nightlies, we encountered an issue in unit_cppapi_string where a handle is used after being freed. This test is doing this by design so this PR disables the test when ASAN is enabled.

[sc-49797]

---
TYPE: NO_HISTORY
DESC: Fix ASAN nightlies with failure in unit_cppapi_string.
