### PR TITLE
Add support for custom headers for REST via config.

### DIFF
--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -138,7 +138,8 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  auto& extra_headers = resources.rest_client()->extra_headers());
+  // We copy because the [] operator is not const-qualified.
+  auto extra_headers = resources.rest_client()->extra_headers();
   CHECK(extra_headers.size() == 2);
   CHECK(extra_headers["abc"] == "def");
   CHECK(extra_headers["ghi"] == "jkl");

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -43,14 +43,6 @@
 
 using namespace tiledb::sm;
 
-class tiledb::sm::WhiteboxRestClient {
- public:
-  static std::unordered_map<std::string, std::string> get_extra_headers(
-      const RestClient& rest_client) {
-    return rest_client.extra_headers_;
-  }
-};
-
 TEST_CASE("CURL: Test curl's header parsing callback", "[curl]") {
   // Initialize data that in real life scenario would be initialized by
   // RestClient
@@ -146,8 +138,7 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  auto extra_headers =
-      WhiteboxRestClient::get_extra_headers(*resources.rest_client());
+  auto& extra_headers = resources.rest_client()->extra_headers());
   CHECK(extra_headers.size() == 2);
   CHECK(extra_headers["abc"] == "def");
   CHECK(extra_headers["ghi"] == "jkl");

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -709,6 +709,10 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `rest.capnp_traversal_limit` <br>
  *    CAPNP traversal limit used in the deserialization of messages(bytes) <br>
  *    **Default**: 536870912 (512MB)
+ * - `rest.custom_headers.*` <br>
+ *    (Optional) Prefix for custom headers on REST requests. For each custom
+ *    header, use "rest.custom_headers.header_key" = "header_value" <br>
+ *    **Optional. No Default**
  * - `filestore.buffer_size` <br>
  *    Specifies the size in bytes of the internal buffers used in the filestore
  *    API. The size should be bigger than the minimum tile size filestore

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -889,6 +889,10 @@ class Config {
    *    CAPNP traversal limit used in the deserialization of messages(bytes)
    * <br>
    *    **Default**: 536870912 (512MB)
+   * - `rest.custom_headers.*` <br>
+   *    (Optional) Prefix for custom headers on REST requests. For each custom
+   *    header, use "rest.custom_headers.header_key" = "header_value" <br>
+   *    **Optional. No Default**
    * - `filestore.buffer_size` <br>
    *    Specifies the size in bytes of the internal buffers used in the
    *    filestore API. The size should be bigger than the minimum tile size

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -773,6 +773,9 @@ const unsigned concurrent_attr_reads = 2;
 /** The redirection header key in REST response. */
 extern const std::string redirection_header_key = "location";
 
+/** The config key prefix for REST custom headers. */
+const std::string rest_header_prefix = "rest.custom_headers.";
+
 /** String describing MIME_AUTODETECT. */
 const std::string mime_autodetect_str = "AUTODETECT";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -760,6 +760,9 @@ const void* fill_value(Datatype type);
 /** The redirection header key in REST response. */
 extern const std::string redirection_header_key;
 
+/** The REST custom headers config key prefix. */
+extern const std::string rest_header_prefix;
+
 /** Delimiter for lists passed as config parameter */
 extern const std::string config_delimiter;
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1674,7 +1674,6 @@ void RestClient::load_headers(const Config& cfg) {
     }
     extra_headers_[key] = iter.value();
   }
-  return ret;
 }
 
 #else

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -149,7 +149,7 @@ Status RestClient::init(
   RETURN_NOT_OK(config_->get<bool>(
       "rest.resubmit_incomplete", &resubmit_incomplete_, &found));
 
-  extra_headers_ = load_headers(*config_);
+  load_headers(*config_);
 
   return Status::Ok();
 }
@@ -1664,8 +1664,7 @@ RestClient::post_consolidation_plan_from_rest(
       serialization_type_, returned_data);
 }
 
-std::unordered_map<std::string, std::string> RestClient::load_headers(
-    const Config& cfg) {
+void RestClient::load_headers(const Config& cfg) {
   std::unordered_map<std::string, std::string> ret;
   for (auto iter = ConfigIter(cfg, constants::rest_header_prefix); !iter.end();
        iter.next()) {
@@ -1673,7 +1672,7 @@ std::unordered_map<std::string, std::string> RestClient::load_headers(
     if (key.size() == 0) {
       continue;
     }
-    ret[key] = iter.value();
+    extra_headers_[key] = iter.value();
   }
   return ret;
 }
@@ -1849,8 +1848,7 @@ RestClient::post_consolidation_plan_from_rest(
   throw RestClientDisabledException();
 }
 
-std::unordered_map<std::string, std::string> RestClient::load_headers(
-    const Config&) {
+void RestClient::load_headers(const Config&) {
   throw RestClientDisabledException();
 }
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1667,8 +1667,8 @@ RestClient::post_consolidation_plan_from_rest(
 std::unordered_map<std::string, std::string> RestClient::load_headers(
     const Config& cfg) {
   std::unordered_map<std::string, std::string> ret;
-  auto iter = ConfigIter(cfg, constants::rest_header_prefix);
-  for (; !iter.end(); iter.next()) {
+  for (auto iter = ConfigIter(cfg, constants::rest_header_prefix); !iter.end();
+       iter.next()) {
     auto key = iter.param();
     if (key.size() == 0) {
       continue;
@@ -1850,7 +1850,7 @@ RestClient::post_consolidation_plan_from_rest(
 }
 
 std::unordered_map<std::string, std::string> RestClient::load_headers(
-    const Config& cfg) {
+    const Config&) {
   throw RestClientDisabledException();
 }
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -1665,7 +1665,6 @@ RestClient::post_consolidation_plan_from_rest(
 }
 
 void RestClient::load_headers(const Config& cfg) {
-  std::unordered_map<std::string, std::string> ret;
   for (auto iter = ConfigIter(cfg, constants::rest_header_prefix); !iter.end();
        iter.next()) {
     auto key = iter.param();

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -53,10 +53,16 @@ class FragmentInfo;
 class Query;
 class MemoryTracker;
 class QueryPlan;
+class WhiteboxRestClient;
 
 enum class SerializationType : uint8_t;
 
 class RestClient {
+  /**
+   * WhiteboxRestClient makes available internals of RestClient for testing.
+   */
+  friend class WhiteboxRestClient;
+
  public:
   /** Constructor. */
   RestClient();

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -567,12 +567,14 @@ class RestClient {
    * @return Status
    */
   Status ensure_json_null_delimited_string(Buffer* buffer);
+
   /**
    * Constant accessor to `extra_headers_` member variable.
    */
   const std::unordered_map<std::string, std::string>& extra_headers() const {
     return extra_headers_;
   }
+
   /** Load all custom headers from the given config.  */
   void load_headers(const Config& cfg);
 };

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -58,11 +58,6 @@ class WhiteboxRestClient;
 enum class SerializationType : uint8_t;
 
 class RestClient {
-  /**
-   * WhiteboxRestClient makes available internals of RestClient for testing.
-   */
-  friend class WhiteboxRestClient;
-
  public:
   /** Constructor. */
   RestClient();
@@ -572,10 +567,14 @@ class RestClient {
    * @return Status
    */
   Status ensure_json_null_delimited_string(Buffer* buffer);
-
+  /**
+   * Constant accessor to `extra_headers_` member variable.
+   */
+  const std::unordered_map<std::string, std::string>& extra_headers() const {
+    return extra_headers_;
+  }
   /** Load all custom headers from the given config.  */
-  static std::unordered_map<std::string, std::string> load_headers(
-      const Config& cfg);
+  void load_headers(const Config& cfg);
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -566,6 +566,10 @@ class RestClient {
    * @return Status
    */
   Status ensure_json_null_delimited_string(Buffer* buffer);
+
+  /** Load all custom headers from the given config.  */
+  static std::unordered_map<std::string, std::string> load_headers(
+      const Config& cfg);
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -419,6 +419,13 @@ class RestClient {
   std::vector<std::vector<std::string>> post_consolidation_plan_from_rest(
       const URI& uri, const Config& config, uint64_t fragment_size);
 
+  /**
+   * Constant accessor to `extra_headers_` member variable.
+   */
+  const std::unordered_map<std::string, std::string>& extra_headers() const {
+    return extra_headers_;
+  }
+
  private:
   /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */
@@ -567,13 +574,6 @@ class RestClient {
    * @return Status
    */
   Status ensure_json_null_delimited_string(Buffer* buffer);
-
-  /**
-   * Constant accessor to `extra_headers_` member variable.
-   */
-  const std::unordered_map<std::string, std::string>& extra_headers() const {
-    return extra_headers_;
-  }
 
   /** Load all custom headers from the given config.  */
   void load_headers(const Config& cfg);

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -53,7 +53,6 @@ class FragmentInfo;
 class Query;
 class MemoryTracker;
 class QueryPlan;
-class WhiteboxRestClient;
 
 enum class SerializationType : uint8_t;
 


### PR DESCRIPTION
[SC-49141](https://app.shortcut.com/tiledb-inc/story/49141/add-support-for-custom-rest-headers-via-config)

Similar to S3 custom header support (#4400) this PR adds support for custom headers in REST request. This allows users to set header via a config parameter instead of the current `tildb_context_set_tag`. The context set tag does not work in all cases because its not always possible to use the same context, i.e SOMA and VCF python APIs can't pass a TileDB-Py ctx to their respective C++ code.

Big thanks to @Shelnutt2 for implementing this. I added a test and documentation.

---
TYPE: CONFIG
DESC: Add `rest.custom_headers.*` config option to set custom headers on REST requests.