### PR TITLE
Add config option to override the payer namespace for REST requests.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -615,6 +615,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.load_enumerations_on_array_open"] = "false";
   all_param_values["rest.use_refactored_array_open"] = "true";
   all_param_values["rest.use_refactored_array_open_and_query_submit"] = "true";
+  all_param_values["rest.payer_namespace"] = "";
   all_param_values["sm.allow_separate_attribute_writes"] = "false";
   all_param_values["sm.allow_updates_experimental"] = "false";
   all_param_values["sm.encryption_key"] = "";

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -75,7 +75,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 69);
+  CHECK(names.size() == 70);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -75,7 +75,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 70);
+  CHECK(names.size() == 69);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -138,11 +138,10 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  // We copy because the [] operator is not const-qualified.
-  auto extra_headers = resources.rest_client()->extra_headers();
+  const auto& extra_headers = resources.rest_client()->extra_headers();
   CHECK(extra_headers.size() == 2);
-  CHECK(extra_headers["abc"] == "def");
-  CHECK(extra_headers["ghi"] == "jkl");
+  CHECK(extra_headers.at("abc") == "def");
+  CHECK(extra_headers.at("ghi") == "jkl");
 }
 
 TEST_CASE(
@@ -153,6 +152,6 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  auto extra_headers = resources.rest_client()->extra_headers();
-  CHECK(extra_headers["X-Payer"] == "foo");
+  const auto& extra_headers = resources.rest_client()->extra_headers();
+  CHECK(extra_headers.at("X-Payer") == "foo");
 }

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -138,7 +138,8 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  auto& extra_headers = resources.rest_client()->extra_headers());
+  // We copy because the [] operator is not const-qualified.
+  auto extra_headers = resources.rest_client()->extra_headers();
   CHECK(extra_headers.size() == 2);
   CHECK(extra_headers["abc"] == "def");
   CHECK(extra_headers["ghi"] == "jkl");

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -139,7 +139,6 @@ TEST_CASE(
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
   const auto& extra_headers = resources.rest_client()->extra_headers();
-  CHECK(extra_headers.size() == 2);
   CHECK(extra_headers.at("abc") == "def");
   CHECK(extra_headers.at("ghi") == "jkl");
 }

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -154,6 +154,5 @@ TEST_CASE(
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
   auto extra_headers = resources.rest_client()->extra_headers();
-  CHECK(extra_headers.size() == 1);
   CHECK(extra_headers["X-Payer"] == "foo");
 }

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -43,6 +43,14 @@
 
 using namespace tiledb::sm;
 
+class tiledb::sm::WhiteboxRestClient {
+ public:
+  static std::unordered_map<std::string, std::string> get_extra_headers(
+      const RestClient& rest_client) {
+    return rest_client.extra_headers_;
+  }
+};
+
 TEST_CASE("CURL: Test curl's header parsing callback", "[curl]") {
   // Initialize data that in real life scenario would be initialized by
   // RestClient
@@ -138,8 +146,8 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  // We copy because the [] operator is not const-qualified.
-  auto extra_headers = resources.rest_client()->extra_headers();
+  auto extra_headers =
+      WhiteboxRestClient::get_extra_headers(*resources.rest_client());
   CHECK(extra_headers.size() == 2);
   CHECK(extra_headers["abc"] == "def");
   CHECK(extra_headers["ghi"] == "jkl");

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -43,14 +43,6 @@
 
 using namespace tiledb::sm;
 
-class tiledb::sm::WhiteboxRestClient {
- public:
-  static std::unordered_map<std::string, std::string> get_extra_headers(
-      const RestClient& rest_client) {
-    return rest_client.extra_headers_;
-  }
-};
-
 TEST_CASE("CURL: Test curl's header parsing callback", "[curl]") {
   // Initialize data that in real life scenario would be initialized by
   // RestClient
@@ -146,8 +138,7 @@ TEST_CASE(
 
   ContextResources resources(
       cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
-  auto extra_headers =
-      WhiteboxRestClient::get_extra_headers(*resources.rest_client());
+  auto& extra_headers = resources.rest_client()->extra_headers());
   CHECK(extra_headers.size() == 2);
   CHECK(extra_headers["abc"] == "def");
   CHECK(extra_headers["ghi"] == "jkl");

--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -144,3 +144,16 @@ TEST_CASE(
   CHECK(extra_headers["abc"] == "def");
   CHECK(extra_headers["ghi"] == "jkl");
 }
+
+TEST_CASE(
+    "RestClient: Ensure payer namespace is set",
+    "[rest-client][payer-namespace]") {
+  tiledb::sm::Config cfg;
+  REQUIRE(cfg.set("rest.payer_namespace", "foo").ok());
+
+  ContextResources resources(
+      cfg, tiledb::test::g_helper_logger(), 1, 1, "test");
+  auto extra_headers = resources.rest_client()->extra_headers();
+  CHECK(extra_headers.size() == 1);
+  CHECK(extra_headers["X-Payer"] == "foo");
+}

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -713,6 +713,9 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    (Optional) Prefix for custom headers on REST requests. For each custom
  *    header, use "rest.custom_headers.header_key" = "header_value" <br>
  *    **Optional. No Default**
+ * - `rest.payer_namespace` <br>
+ *    The namespace that should be charged for the request. <br>
+ *    **Default**: no default set
  * - `filestore.buffer_size` <br>
  *    Specifies the size in bytes of the internal buffers used in the filestore
  *    API. The size should be bigger than the minimum tile size filestore

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -96,6 +96,7 @@ const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_USE_REFACTORED_ARRAY_OPEN = "false";
 const std::string Config::REST_USE_REFACTORED_QUERY_SUBMIT = "false";
+const std::string Config::REST_PAYER_NAMESPACE = "";
 const std::string Config::SM_ALLOW_SEPARATE_ATTRIBUTE_WRITES = "false";
 const std::string Config::SM_ALLOW_UPDATES_EXPERIMENTAL = "false";
 const std::string Config::SM_ENCRYPTION_KEY = "";
@@ -270,6 +271,7 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "rest.use_refactored_array_open_and_query_submit",
         Config::REST_USE_REFACTORED_QUERY_SUBMIT),
+    std::make_pair("rest.payer_namespace", Config::REST_PAYER_NAMESPACE),
     std::make_pair(
         "config.env_var_prefix", Config::CONFIG_ENVIRONMENT_VARIABLE_PREFIX),
     std::make_pair("config.logging_level", Config::CONFIG_LOGGING_LEVEL),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -125,6 +125,9 @@ class Config {
   /** Refactored query submit is disabled by default */
   static const std::string REST_USE_REFACTORED_QUERY_SUBMIT;
 
+  /** The namespace that should be charged for the request. */
+  static const std::string REST_PAYER_NAMESPACE;
+
   /** The prefix to use for checking for parameter environmental variables. */
   static const std::string CONFIG_ENVIRONMENT_VARIABLE_PREFIX;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -893,6 +893,9 @@ class Config {
    *    (Optional) Prefix for custom headers on REST requests. For each custom
    *    header, use "rest.custom_headers.header_key" = "header_value" <br>
    *    **Optional. No Default**
+   * - `rest.payer_namespace` <br>
+   *    The namespace that should be charged for the request. <br>
+   *    **Default**: no default set
    * - `filestore.buffer_size` <br>
    *    Specifies the size in bytes of the internal buffers used in the
    *    filestore API. The size should be bigger than the minimum tile size

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -151,6 +151,11 @@ Status RestClient::init(
 
   load_headers(*config_);
 
+  RETURN_NOT_OK(config_->get("rest.payer_namespace", &c_str));
+  if (c_str != nullptr) {
+    extra_headers_["X-Payer"] = std::string(c_str);
+  }
+
   return Status::Ok();
 }
 

--- a/tiledb/sm/rest/rest_client.cc
+++ b/tiledb/sm/rest/rest_client.cc
@@ -151,9 +151,10 @@ Status RestClient::init(
 
   load_headers(*config_);
 
-  RETURN_NOT_OK(config_->get("rest.payer_namespace", &c_str));
-  if (c_str != nullptr) {
-    extra_headers_["X-Payer"] = std::string(c_str);
+  if (auto payer =
+          config_->get<std::string>("rest.payer_namespace", Config::must_find);
+      !payer.empty()) {
+    extra_headers_["X-Payer"] = std::move(payer);
   }
 
   return Status::Ok();

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -58,11 +58,6 @@ class WhiteboxRestClient;
 enum class SerializationType : uint8_t;
 
 class RestClient {
-  /**
-   * WhiteboxRestClient makes available internals of RestClient for testing.
-   */
-  friend class WhiteboxRestClient;
-
  public:
   /** Constructor. */
   RestClient();

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -53,10 +53,16 @@ class FragmentInfo;
 class Query;
 class MemoryTracker;
 class QueryPlan;
+class WhiteboxRestClient;
 
 enum class SerializationType : uint8_t;
 
 class RestClient {
+  /**
+   * WhiteboxRestClient makes available internals of RestClient for testing.
+   */
+  friend class WhiteboxRestClient;
+
  public:
   /** Constructor. */
   RestClient();

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -574,7 +574,7 @@ class RestClient {
    */
   Status ensure_json_null_delimited_string(Buffer* buffer);
 
-  /** Load all custom headers from the given config.  */
+  /** Load all custom headers from the given config. */
   void load_headers(const Config& cfg);
 };
 

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -53,7 +53,6 @@ class FragmentInfo;
 class Query;
 class MemoryTracker;
 class QueryPlan;
-class WhiteboxRestClient;
 
 enum class SerializationType : uint8_t;
 


### PR DESCRIPTION
[SC-49142](https://app.shortcut.com/tiledb-inc/story/49142/add-support-for-rest-x-payer-via-config)

This PR introduces a new config option that allows users to set the namespace to charge for REST requests when it cannot be automatically determined or when the user needs to set a specific override.

Big thanks to @Shelnutt2 for implementing this. I added a test and made some small changes on top of it.

---
TYPE: CONFIG
DESC: Add `rest.payer_namespace` config option to set the namespace to be charged for REST requests.