### PR TITLE
[Backport release-2.23] Remove pin to MSVC toolset version in CI. (#5047)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -131,10 +131,6 @@ jobs:
         uses: TheMrMilchmann/setup-msvc-dev@v3
         with:
           arch: x64
-          # By default Visual Studio 2022 chooses the earliest installed toolset
-          # version for the main build and vcpkg chooses the latest. Force it to
-          # use the latest (14.39 currently).
-          toolset: ${{ matrix.os == 'windows-2022' && '14.39' || '' }}
       # This must happen after checkout, because checkout would remove the directory.
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@v4

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -25,7 +25,16 @@ jobs:
 
       - name: 'Homebrew setup'
         run: brew install automake pkg-config
-        if: ${{ startsWith(matrix.os, 'macos-') == true }}
+        if: ${{ startsWith(matrix.os, 'macos-') }}
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v4
+
+      - name: Setup MSVC toolset
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        if: ${{ startsWith(matrix.os, 'windows-') }}
+        with:
+          arch: x64
 
       # Configure required environment variables for vcpkg to use
       # GitHub's Action Cache


### PR DESCRIPTION
Backport 94a2d982964a4b896014678fd565577fc74ae3b1 from #5047.

---
TYPE: NO_HISTORY
