### PR TITLE
Replace backport workflow.

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,30 +1,26 @@
 name: Backport
 on:
-  pull_request_target:
-    types:
-      - closed
-      - labeled
-    paths-ignore:
-      - '_quarto.yml'
-      - 'quarto-materials/*'
-      - '**/.md'
+  issue_comment:
+    types: [created]
+  schedule:
+    # once a day at 13:00 UTC to cleanup old runs
+    - cron: '0 13 * * *'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  actions: write
 
 jobs:
   backport:
-    name: Backport
-    runs-on: ubuntu-22.04
-    if: >
-      github.event.pull_request.merged &&
-      (
-        github.event.action == 'closed' ||
-        (
-          github.event.action == 'labeled' &&
-          contains(github.event.label.name, 'backport')
-        )
-      )
-    steps:
-      - name: Backport
-        uses: zephyrproject-rtos/action-backport@7e74f601d11eaca577742445e87775b5651a965f #tag=v2.0.3-3
-        with:
-          issue_labels: Backport
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@aa70f3a7a494063952307a9b1df7ca0ab67bce13
+    with:
+      pr_title_template: '[Backport %target_branch%] %source_pr_title% (#%source_pr_number%)'
+      pr_description_template: |
+        Backport of #%source_pr_number% to %target_branch%
+
+        ---
+        TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
+        DESC: <short description>
+      repository_owners: TileDB-Inc


### PR DESCRIPTION
[SC-49830](https://app.shortcut.com/tiledb-inc/story/49830/the-backport-workflow-consistently-fails-to-run)

Due to [longstanding issues with the backport workflow](https://github.com/TileDB-Inc/TileDB/issues?q=is%3Aissue+failed+to+backport), it is time to move away from it, and this PR replaces it with the battle-tested backport workflow used by the .NET project. This has been made possible by dotnet/arcade#14034 which adds support for the workflow to be used from repositories outside of the `dotnet` or `microsoft` organizations.

One significant difference lies within the workflow's triggering method. Whereas the old workflow triggers by adding a `backport` label in a closed pull request, the new workflow triggers by commenting `/backport to <branch>` in the pull request. I personally consider this to be better, since posting a comment is a more explicit action that applying a label, and we can still use the labels for reminding ourselves.

To validate that only authorized users can trigger it, the workflow requires that those using it have their `TileDB-Inc` organization membership set to public. You can change that from [the organization's members page](https://github.com/orgs/TileDB-Inc/people).

If backporting fails, the new workflow will post a comment on the PR instead of opening a new issue.

---
TYPE: NO_HISTORY