### PR TITLE
Fix slow Azure test.

### DIFF
--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -740,6 +740,13 @@ TEST_CASE("VFS: Construct Azure Blob Storage endpoint URIs", "[azure][uri]") {
       config.set("vfs.azure.storage_account_name", "devstoreaccount1"));
   require_tiledb_ok(config.set("vfs.azure.blob_endpoint", custom_endpoint));
   require_tiledb_ok(config.set("vfs.azure.storage_sas_token", sas_token));
+  if (sas_token.empty()) {
+    // If the SAS token is empty, the VFS will try to connect to Microsoft Entra
+    // ID to obtain credentials, which can take a long time because of retries.
+    // Set a dummy access key (which won't be used because we are not going to
+    // perform any requests) to prevent Entra ID from being chosen.
+    require_tiledb_ok(config.set("vfs.azure.storage_account_key", "foobar"));
+  }
   tiledb::sm::Azure azure;
   ThreadPool thread_pool(1);
   require_tiledb_ok(azure.init(config, &thread_pool));

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -709,35 +709,33 @@ TEST_CASE(
 
 #ifdef HAVE_AZURE
 TEST_CASE("VFS: Construct Azure Blob Storage endpoint URIs", "[azure][uri]") {
+  // Test the construction of Azure Blob Storage URIs from account name and SAS
+  // token. We are not actually connecting to Azure Blob Storage in this test.
   std::string sas_token, custom_endpoint, expected_endpoint;
   SECTION("No SAS token") {
     sas_token = "";
-    expected_endpoint = "https://devstoreaccount1.blob.core.windows.net";
+    expected_endpoint = "https://exampleaccount.blob.core.windows.net";
   }
   SECTION("SAS token without leading question mark") {
     sas_token = "baz=qux&foo=bar";
     expected_endpoint =
-        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+        "https://exampleaccount.blob.core.windows.net?baz=qux&foo=bar";
   }
   SECTION("SAS token with leading question mark") {
     sas_token = "?baz=qux&foo=bar";
     expected_endpoint =
-        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+        "https://exampleaccount.blob.core.windows.net?baz=qux&foo=bar";
   }
   SECTION("SAS token in both endpoint and config option") {
     sas_token = "baz=qux&foo=bar";
     custom_endpoint =
-        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
+        "https://exampleaccount.blob.core.windows.net?baz=qux&foo=bar";
     expected_endpoint =
-        "https://devstoreaccount1.blob.core.windows.net?baz=qux&foo=bar";
-  }
-  SECTION("No SAS token") {
-    sas_token = "";
-    expected_endpoint = "https://devstoreaccount1.blob.core.windows.net";
+        "https://exampleaccount.blob.core.windows.net?baz=qux&foo=bar";
   }
   Config config;
   require_tiledb_ok(
-      config.set("vfs.azure.storage_account_name", "devstoreaccount1"));
+      config.set("vfs.azure.storage_account_name", "exampleaccount"));
   require_tiledb_ok(config.set("vfs.azure.blob_endpoint", custom_endpoint));
   require_tiledb_ok(config.set("vfs.azure.storage_sas_token", sas_token));
   if (sas_token.empty()) {


### PR DESCRIPTION
[SC-49913](https://app.shortcut.com/tiledb-inc/story/49913/azure-blob-storage-endpoint-uris-test-is-slow)

A test that merely checked that Azure Blob Storage endpoints and SAS tokens were properly concatenated was lagging because in a section where no SAS token was specified, it would try to authenticate with Microsoft Entra ID which took ten minutes in CI because of retries. For the cases when the SAS token is empty, we set a dummy shared key, which will prevent Microsoft Entra ID from being attempted.

I also removed a duplicate section and made it more clear that the endpoints are illustrative.

Validated locally.

---
TYPE: NO_HISTORY