### PR TITLE
Add current domain API examples.

### DIFF
--- a/examples/c_api/current_domain.c
+++ b/examples/c_api/current_domain.c
@@ -173,9 +173,9 @@ void expand_current_domain() {
   tiledb_array_schema_evolution_t* schema_evolution;
   tiledb_array_schema_evolution_alloc(ctx, &schema_evolution);
 
-  // Create current domain
-  tiledb_current_domain_t* current_domain;
-  tiledb_current_domain_create(ctx, &current_domain);
+  // Create the new current domain
+  tiledb_current_domain_t* new_current_domain;
+  tiledb_current_domain_create(ctx, &new_current_domain);
 
   // Create an n-dimensional rectangle
   tiledb_ndrectangle_t* ndrect;
@@ -191,18 +191,18 @@ void expand_current_domain() {
   tiledb_ndrectangle_set_range_for_name(ctx, ndrect, "d1", &range);
 
   // Set the rectangle to the current domain
-  tiledb_current_domain_set_ndrectangle(current_domain, ndrect);
+  tiledb_current_domain_set_ndrectangle(new_current_domain, ndrect);
 
   // Expand the current domain
   tiledb_array_schema_evolution_expand_current_domain(
-      ctx, schema_evolution, current_domain);
+      ctx, schema_evolution, new_current_domain);
 
   // Evolve the array
   tiledb_array_evolve(ctx, array_name, schema_evolution);
 
   // Clean up
   tiledb_ndrectangle_free(&ndrect);
-  tiledb_current_domain_free(&current_domain);
+  tiledb_current_domain_free(&new_current_domain);
   tiledb_array_schema_evolution_free(&schema_evolution);
   tiledb_domain_free(&domain);
   tiledb_array_schema_free(&array_schema);

--- a/examples/c_api/current_domain.c
+++ b/examples/c_api/current_domain.c
@@ -1,0 +1,203 @@
+/**
+ * @file   current_domain.c
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * When run, this program will create a simple 1D sparse array, print its
+ * current domain, expand it and print it agaon.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <tiledb/tiledb.h>
+#include <tiledb/tiledb_experimental.h>
+
+// Name of array.
+const char* array_name = "current_domain_array";
+
+void create_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // The array will be 1000x1 with dimension "d1", with domain [1,1000].
+  int dim_domain[] = {1, 1000};
+  int tile_extent = 50;
+  tiledb_dimension_t* d1;
+  tiledb_dimension_alloc(
+      ctx, "d1", TILEDB_INT32, &dim_domain[0], &tile_extent, &d1);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  tiledb_domain_alloc(ctx, &domain);
+  tiledb_domain_add_dimension(ctx, domain, d1);
+
+  // Create a single attribute "a" so each cell can store an integer
+  tiledb_attribute_t* a;
+  tiledb_attribute_alloc(ctx, "a", TILEDB_INT32, &a);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+  tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  tiledb_array_schema_add_attribute(ctx, array_schema, a);
+
+  // Create array
+  tiledb_array_create(ctx, array_name, array_schema);
+
+  // Clean up
+  tiledb_attribute_free(&a);
+  tiledb_dimension_free(&d1);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+void print_current_domain() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Load array schema
+  tiledb_array_schema_t* array_schema;
+  tiledb_array_schema_load(ctx, array_name, &array_schema);
+
+  // Get current domain
+  tiledb_current_domain_t* current_domain;
+  tiledb_array_schema_get_current_domain(ctx, array_schema, &current_domain);
+
+  // Check if current domain is empty
+  uint32_t is_empty;
+  tiledb_current_domain_get_is_empty(current_domain, &is_empty);
+
+  if (is_empty) {
+    printf("Current domain: empty\n");
+  } else {
+    // Get current domain type
+    tiledb_current_domain_type_t current_domain_type;
+    tiledb_current_domain_get_type(current_domain, &current_domain_type);
+
+    if (current_domain_type == TILEDB_NDRECTANGLE) {
+      printf("Current domain type: NDRECTANGLE\n");
+
+      // Get the ND rectangle
+      tiledb_ndrectangle_t* ndrect;
+      tiledb_current_domain_get_ndrectangle(current_domain, &ndrect);
+
+      tiledb_range_t range;
+      tiledb_ndrectangle_get_range_from_name(ctx, ndrect, "d1", &range);
+
+      printf(
+          "Current domain range: [%d, %d]\n",
+          *(int*)range.min,
+          *(int*)range.max);
+
+      // Clean up
+      tiledb_ndrectangle_free(&ndrect);
+    } else {
+      printf("Current domain type: unknown\n");
+    }
+  }
+
+  // Clean up
+  tiledb_current_domain_free(&current_domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+void expand_current_domain() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Load array schema
+  tiledb_array_schema_t* array_schema;
+  tiledb_array_schema_load(ctx, array_name, &array_schema);
+
+  // Get domain
+  tiledb_domain_t* domain;
+  tiledb_array_schema_get_domain(ctx, array_schema, &domain);
+
+  // Create schema evolution
+  tiledb_array_schema_evolution_t* schema_evolution;
+  tiledb_array_schema_evolution_alloc(ctx, &schema_evolution);
+
+  // Create current domain
+  tiledb_current_domain_t* current_domain;
+  tiledb_current_domain_create(ctx, &current_domain);
+
+  // Create an n-dimensional rectangle
+  tiledb_ndrectangle_t* ndrect;
+  tiledb_ndrectangle_alloc(ctx, domain, &ndrect);
+
+  // Assign a range to the rectangle
+  int32_t expanded_current_domain[] = {1, 200};
+  tiledb_range_t range = {
+      &expanded_current_domain[0],
+      sizeof(expanded_current_domain[0]),
+      &expanded_current_domain[1],
+      sizeof(expanded_current_domain[1])};
+  tiledb_ndrectangle_set_range_for_name(ctx, ndrect, "d1", &range);
+
+  // Set the rectangle to the current domain
+  tiledb_current_domain_set_ndrectangle(current_domain, ndrect);
+
+  // Expand the current domain
+  tiledb_array_schema_evolution_expand_current_domain(
+      ctx, schema_evolution, current_domain);
+
+  // Evolve the array
+  tiledb_array_evolve(ctx, array_name, schema_evolution);
+
+  // Clean up
+  tiledb_ndrectangle_free(&ndrect);
+  tiledb_current_domain_free(&current_domain);
+  tiledb_array_schema_evolution_free(&schema_evolution);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+int main() {
+  // Get object type
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+  tiledb_object_t type;
+  tiledb_object_type(ctx, array_name, &type);
+  tiledb_ctx_free(&ctx);
+
+  if (type != TILEDB_ARRAY) {
+    create_array();
+    print_current_domain();
+    expand_current_domain();
+  }
+
+  print_current_domain();
+  return 0;
+}

--- a/examples/cpp_api/current_domain.cc
+++ b/examples/cpp_api/current_domain.cc
@@ -125,8 +125,8 @@ void expand_current_domain(Context& ctx) {
   // Create an ArraySchemaEvolution object
   ArraySchemaEvolution schema_evolution(ctx);
 
-  // Create a CurrentDomain object
-  CurrentDomain current_domain(ctx);
+  // Create the new CurrentDomain object
+  CurrentDomain new_current_domain(ctx);
 
   // Create an NDRectangle object
   NDRectangle ndrect(ctx, domain);
@@ -135,10 +135,10 @@ void expand_current_domain(Context& ctx) {
   ndrect.set_range<int32_t>("d1", 1, 200);
 
   // Set the NDRectangle to the CurrentDomain
-  current_domain.set_ndrectangle(ndrect);
+  new_current_domain.set_ndrectangle(ndrect);
 
   // Set the current domain to the array schema evolution
-  schema_evolution.expand_current_domain(current_domain);
+  schema_evolution.expand_current_domain(new_current_domain);
 
   // Evolve the array
   schema_evolution.array_evolve(array_name);

--- a/examples/cpp_api/current_domain.cc
+++ b/examples/cpp_api/current_domain.cc
@@ -1,0 +1,148 @@
+/**
+ * @file   current_domain.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * When run, this program will create a simple 1D sparse array, print its
+ * current domain, expand it and print it agaon.
+ */
+
+#include <iostream>
+#include <numeric>
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
+using namespace tiledb;
+
+// Name of array.
+std::string array_name("current_domain_example_array");
+
+void create_array(Context& ctx, const std::string& array_uri) {
+  // Create a TileDB domain
+  Domain domain(ctx);
+
+  // Add a dimension to the domain
+  auto d1 = Dimension::create<int>(ctx, "d1", {{1, 1000}}, 50);
+  domain.add_dimension(d1);
+
+  // Create and set a TileDB sparse array schema
+  ArraySchema schema(ctx, TILEDB_SPARSE);
+  schema.set_domain(domain)
+      .set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}})
+      .set_capacity(100)
+      .set_cell_order(TILEDB_ROW_MAJOR)
+      .set_tile_order(TILEDB_ROW_MAJOR);
+
+  // Create a single attribute
+  schema.add_attribute(Attribute::create<int>(ctx, "a"));
+
+  // Create the (empty) array on disk
+  Array::create(array_uri, schema);
+}
+
+void print_current_domain(Context& ctx) {
+  // Get array schema
+  ArraySchema schema(ctx, array_name);
+
+  // Get current domain
+  CurrentDomain current_domain =
+      ArraySchemaExperimental::current_domain(ctx, schema);
+
+  // Check if the current domain is empty
+  if (current_domain.is_empty()) {
+    std::cout << "Current domain: empty" << std::endl;
+    return;
+  }
+
+  // Get the current domain type
+  tiledb_current_domain_type_t current_domain_type = current_domain.type();
+
+  // Check the current domain type
+  if (current_domain_type != TILEDB_NDRECTANGLE) {
+    std::cout << "Current domain type: unknown" << std::endl;
+    return;
+  }
+
+  std::cout << "Current domain type: NDRECTANGLE" << std::endl;
+
+  // Get the current domain's NDRectangle
+  NDRectangle ndrect = current_domain.ndrectangle();
+
+  // Get the range of the rectangle's first dimension
+  std::array<int32_t, 2> range = ndrect.range<int32_t>("d1");
+
+  // Print the range
+  std::cout << "Current domain range: [" << range[0] << ", " << range[1] << "]"
+            << std::endl;
+}
+
+void expand_current_domain(Context& ctx) {
+  // Get the array schema
+  ArraySchema schema(ctx, array_name);
+
+  // Get the domain
+  Domain domain = schema.domain();
+
+  // Create an ArraySchemaEvolution object
+  ArraySchemaEvolution schema_evolution(ctx);
+
+  // Create a CurrentDomain object
+  CurrentDomain current_domain(ctx);
+
+  // Create an NDRectangle object
+  NDRectangle ndrect(ctx, domain);
+
+  // Set the range of the NDRectangle's first dimension
+  ndrect.set_range<int32_t>("d1", 1, 200);
+
+  // Set the NDRectangle to the CurrentDomain
+  current_domain.set_ndrectangle(ndrect);
+
+  // Set the current domain to the array schema evolution
+  schema_evolution.expand_current_domain(current_domain);
+
+  // Evolve the array
+  schema_evolution.array_evolve(array_name);
+}
+
+int main() {
+  Context ctx;
+
+  // Create a new simple array
+  create_array(ctx, array_name);
+
+  // Print the current domain
+  print_current_domain(ctx);
+
+  // Expand the current domain
+  expand_current_domain(ctx);
+
+  // Print the current domain again
+  print_current_domain(ctx);
+
+  return 0;
+}

--- a/examples/cpp_api/current_domain.cc
+++ b/examples/cpp_api/current_domain.cc
@@ -27,8 +27,8 @@
  *
  * @section DESCRIPTION
  *
- * When run, this program will create a simple 1D sparse array, print its
- * current domain, expand it and print it agaon.
+ * When run, this program will create a simple 1D sparse array with a current
+ * domain, print it, expand it with array schema evolution, and print it again.
  */
 
 #include <iostream>
@@ -49,7 +49,19 @@ void create_array(Context& ctx, const std::string& array_uri) {
   auto d1 = Dimension::create<int>(ctx, "d1", {{1, 1000}}, 50);
   domain.add_dimension(d1);
 
-  // Create and set a TileDB sparse array schema
+  // Create a CurrentDomain object
+  CurrentDomain current_domain(ctx);
+
+  // Create an NDRectangle object
+  NDRectangle ndrect(ctx, domain);
+
+  // Assign the range [1, 100] to the rectangle's first dimension
+  ndrect.set_range<int32_t>("d1", 1, 100);
+
+  // Assign the NDRectangle to the CurrentDomain
+  current_domain.set_ndrectangle(ndrect);
+
+  // Create a TileDB sparse array schema
   ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain)
       .set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}})
@@ -59,6 +71,9 @@ void create_array(Context& ctx, const std::string& array_uri) {
 
   // Create a single attribute
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
+
+  // Assign the current domain to the array schema
+  ArraySchemaExperimental::set_current_domain(ctx, schema, current_domain);
 
   // Create the (empty) array on disk
   Array::create(array_uri, schema);
@@ -116,7 +131,7 @@ void expand_current_domain(Context& ctx) {
   // Create an NDRectangle object
   NDRectangle ndrect(ctx, domain);
 
-  // Set the range of the NDRectangle's first dimension
+  // Assign the range [1, 200] to the rectangle's first dimension
   ndrect.set_range<int32_t>("d1", 1, 200);
 
   // Set the NDRectangle to the CurrentDomain


### PR DESCRIPTION
[SC-49732](https://app.shortcut.com/tiledb-inc/story/49732/current-domain-examples)

This PR adds examples in the C and C++ APIs, that create an array, print its current domain, expand it through array schema evolution, and print it again.

---
TYPE: NO_HISTORY