### PR TITLE
Fix fragment consolidation to allow using absolute URIs.

### DIFF
--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -7197,9 +7197,17 @@ TEST_CASE_METHOD(
   REQUIRE(err == nullptr);
 
   // Consolidate
-  const char* uris[2] = {strrchr(uri, '/') + 1, strrchr(uri2, '/') + 1};
-  rc = tiledb_array_consolidate_fragments(
-      ctx_, dense_array_uri_.c_str(), uris, 2, cfg);
+  SECTION("Relative URIs") {
+    const char* uris[2] = {strrchr(uri, '/') + 1, strrchr(uri2, '/') + 1};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, dense_array_uri_.c_str(), uris, 2, cfg);
+  }
+
+  SECTION("Absolute URIs") {
+    const char* uris[2] = {uri, uri2};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, dense_array_uri_.c_str(), uris, 2, cfg);
+  }
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&cfg);
 
@@ -7273,9 +7281,17 @@ TEST_CASE_METHOD(
   REQUIRE(err == nullptr);
 
   // Consolidate
-  const char* uris[2] = {strrchr(uri, '/') + 1, strrchr(uri2, '/') + 1};
-  rc = tiledb_array_consolidate_fragments(
-      ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+  SECTION("Relative URIs") {
+    const char* uris[2] = {strrchr(uri, '/') + 1, strrchr(uri2, '/') + 1};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+  }
+
+  SECTION("Absolute URIs") {
+    const char* uris[2] = {uri, uri2};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+  }
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&cfg);
 

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -7303,6 +7303,17 @@ TEST_CASE_METHOD(
     rc = tiledb_array_consolidate_fragments(
         ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
   }
+
+  SECTION("Invalid URIs") {
+    std::string frag1(strrchr(uri, '/') + 1), frag2(strrchr(uri, '/') + 1);
+    frag1 = "/some/array/__fragments/" + frag1;
+    frag2 = "/some/array/__fragments/" + frag2;
+    const char* uris[2] = {frag1.c_str(), frag2.c_str()};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+    CHECK(rc == TILEDB_ERR);
+    return;
+  }
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&cfg);
 
@@ -7394,6 +7405,17 @@ TEST_CASE_METHOD(
     const char* uris[2] = {uri, uri2};
     rc = tiledb_array_consolidate_fragments(
         ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+  }
+
+  SECTION("Invalid URIs") {
+    std::string frag1(strrchr(uri, '/') + 1), frag2(strrchr(uri, '/') + 1);
+    frag1 = "/some/array/" + frag1;
+    frag2 = "/some/array/" + frag2;
+    const char* uris[2] = {frag1.c_str(), frag2.c_str()};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+    CHECK(rc == TILEDB_ERR);
+    return;
   }
   CHECK(rc == TILEDB_OK);
   tiledb_config_free(&cfg);

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -7334,10 +7334,18 @@ TEST_CASE_METHOD(
   remove_sparse_array();
 }
 
+#ifndef _WIN32
 TEST_CASE_METHOD(
     ConsolidationFx,
     "C API: Test consolidation v11 array, split fragments",
     "[capi][consolidation][split-fragments][non-rest]") {
+  // vfs_copy_dir is only supported on Posix and S3.
+  // Experimental builds throw when attempting to write to an array with
+  // previous format version.
+  if (!vfs_test_setup_.is_local() || is_experimental_build) {
+    return;
+  }
+
   remove_sparse_array();
   create_sparse_array_v11(ctx_, sparse_array_uri_);
   write_sparse_v11(ctx_, sparse_array_uri_, 0);
@@ -7429,6 +7437,7 @@ TEST_CASE_METHOD(
   // Clean up
   remove_sparse_array();
 }
+#endif
 
 TEST_CASE_METHOD(
     ConsolidationFx,

--- a/test/src/unit-capi-consolidation.cc
+++ b/test/src/unit-capi-consolidation.cc
@@ -167,6 +167,7 @@ struct ConsolidationFx {
   static int get_wrt_num(const char* path, void* data);
   static int get_ignore_num(const char* path, void* data);
   static int get_ok_num(const char* path, void* data);
+  static int get_vac_num(const char* path, void* data);
   static int get_array_meta_files_callback(const char* path, void* data);
   static int get_array_meta_vac_files_callback(const char* path, void* data);
   static int get_vac_files_callback(const char* path, void* data);
@@ -4863,6 +4864,16 @@ int ConsolidationFx::get_ok_num(const char* path, void* data) {
   return 1;
 }
 
+int ConsolidationFx::get_vac_num(const char* path, void* data) {
+  auto data_struct = (ConsolidationFx::get_num_struct*)data;
+  if (tiledb::sm::utils::parse::ends_with(
+          path, tiledb::sm::constants::vacuum_file_suffix)) {
+    ++data_struct->num;
+  }
+
+  return 1;
+}
+
 int ConsolidationFx::get_array_meta_files_callback(
     const char* path, void* data) {
   auto vec = static_cast<std::vector<std::string>*>(data);
@@ -7318,6 +7329,102 @@ TEST_CASE_METHOD(
       ctx_, vfs_, sparse_array_frag_dir_.c_str(), &get_dir_num, &data);
   CHECK(rc == TILEDB_OK);
   CHECK(data.num == 3);
+
+  // Clean up
+  remove_sparse_array();
+}
+
+TEST_CASE_METHOD(
+    ConsolidationFx,
+    "C API: Test consolidation v11 array, split fragments",
+    "[capi][consolidation][split-fragments][non-rest]") {
+  remove_sparse_array();
+  create_sparse_array_v11(ctx_, sparse_array_uri_);
+  write_sparse_v11(ctx_, sparse_array_uri_, 0);
+  write_sparse_v11(ctx_, sparse_array_uri_, 1);
+  write_sparse_v11(ctx_, sparse_array_uri_, 2);
+  write_sparse_v11(ctx_, sparse_array_uri_, 3);
+
+  // Create fragment info object
+  tiledb_fragment_info_t* fragment_info = nullptr;
+  int rc = tiledb_fragment_info_alloc(
+      ctx_, sparse_array_uri_.c_str(), &fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Load fragment info
+  rc = tiledb_fragment_info_load(ctx_, fragment_info);
+  CHECK(rc == TILEDB_OK);
+
+  // Get fragment URIs
+  const char* uri;
+  rc = tiledb_fragment_info_get_fragment_uri(ctx_, fragment_info, 1, &uri);
+  CHECK(rc == TILEDB_OK);
+  const char* uri2;
+  rc = tiledb_fragment_info_get_fragment_uri(ctx_, fragment_info, 3, &uri2);
+  CHECK(rc == TILEDB_OK);
+
+  // Set consolidation buffer size
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+
+  rc = tiledb_config_alloc(&cfg, &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  rc = tiledb_config_set(cfg, "sm.consolidation.buffer_size", "10000", &err);
+  REQUIRE(rc == TILEDB_OK);
+  REQUIRE(err == nullptr);
+
+  // Consolidate
+  SECTION("Relative URIs") {
+    const char* uris[2] = {strrchr(uri, '/') + 1, strrchr(uri2, '/') + 1};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+  }
+
+  SECTION("Absolute URIs") {
+    const char* uris[2] = {uri, uri2};
+    rc = tiledb_array_consolidate_fragments(
+        ctx_, sparse_array_uri_.c_str(), uris, 2, cfg);
+  }
+  CHECK(rc == TILEDB_OK);
+  tiledb_config_free(&cfg);
+
+  tiledb_fragment_info_free(&fragment_info);
+
+  // Check for 1 vacuum file after consolidation.
+  get_num_struct data = {ctx_, vfs_, 0};
+  rc =
+      tiledb_vfs_ls(ctx_, vfs_, sparse_array_uri_.c_str(), &get_vac_num, &data);
+  CHECK(rc == TILEDB_OK);
+  CHECK(data.num == 1);
+
+  // Check for 5 fragments comitted: 4 writes and 1 consolidation.
+  data = {ctx_, vfs_, 0};
+  rc = tiledb_vfs_ls(ctx_, vfs_, sparse_array_uri_.c_str(), &get_ok_num, &data);
+  CHECK(rc == TILEDB_OK);
+  CHECK(data.num == 5);
+
+  // Check reading after consolidation
+  read_sparse_v11(ctx_, sparse_array_uri_, UINT64_MAX);
+
+  // Vacuum
+  rc = tiledb_array_vacuum(ctx_, sparse_array_uri_.c_str(), NULL);
+  CHECK(rc == TILEDB_OK);
+  read_sparse_v11(ctx_, sparse_array_uri_, UINT64_MAX);
+
+  // Check for 3 comitted fragments after vacuum.
+  data = {ctx_, vfs_, 0};
+  rc = tiledb_vfs_ls(ctx_, vfs_, sparse_array_uri_.c_str(), &get_ok_num, &data);
+  CHECK(rc == TILEDB_OK);
+  CHECK(data.num == 3);
+
+  // Check for no vacuum file after vacuum.
+  data = {ctx_, vfs_, 0};
+  rc =
+      tiledb_vfs_ls(ctx_, vfs_, sparse_array_uri_.c_str(), &get_vac_num, &data);
+  CHECK(rc == TILEDB_OK);
+  CHECK(data.num == 0);
 
   // Clean up
   remove_sparse_array();

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1617,8 +1617,8 @@ void read_sparse_v11(
       buffer_coords_dim2_read,
       sizeof(buffer_coords_dim2_read)));
 
-  tiledb_free(array);
-  tiledb_free(query);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
 }
 
 template void check_subarray<int8_t>(

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1472,6 +1472,155 @@ sm::URI generate_fragment_uri(sm::Array* array) {
   return frag_dir_uri.join_path(new_fragment_str);
 }
 
+void create_sparse_array_v11(tiledb_ctx_t* ctx, const std::string& array_name) {
+  tiledb_config_t* config;
+  REQUIRE(tiledb_ctx_get_config(ctx, &config) == TILEDB_OK);
+  tiledb_vfs_t* vfs;
+  REQUIRE(tiledb_vfs_alloc(ctx, config, &vfs) == TILEDB_OK);
+  // Get the v11 sparse array.
+  std::string v11_arrays_dir =
+      std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays/sparse_array_v11";
+  REQUIRE(
+      tiledb_vfs_copy_dir(
+          ctx, vfs, v11_arrays_dir.c_str(), array_name.c_str()) == TILEDB_OK);
+}
+
+void write_sparse_v11(
+    tiledb_ctx_t* ctx, const std::string& array_name, uint64_t timestamp) {
+  // Prepare cell buffers.
+  std::vector<int> buffer_a1{0, 1, 2, 3};
+  std::vector<uint64_t> buffer_a2{0, 1, 3, 6};
+  std::string buffer_var_a2("abbcccdddd");
+  std::vector<float> buffer_a3{0.1f, 0.2f, 1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f};
+  std::vector<uint64_t> buffer_coords_dim1{1, 1, 1, 2};
+  std::vector<uint64_t> buffer_coords_dim2{1, 2, 4, 3};
+
+  // Open array.
+  tiledb_array_t* array;
+  REQUIRE(tiledb_array_alloc(ctx, array_name.c_str(), &array) == TILEDB_OK);
+  REQUIRE(
+      tiledb_array_set_open_timestamp_end(ctx, array, timestamp) == TILEDB_OK);
+  REQUIRE(tiledb_array_open(ctx, array, TILEDB_WRITE) == TILEDB_OK);
+
+  // Create query.
+  tiledb_query_t* query;
+  REQUIRE(tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query) == TILEDB_OK);
+  REQUIRE(
+      tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER) == TILEDB_OK);
+  uint64_t a1_size = buffer_a1.size() * sizeof(int);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "a1", buffer_a1.data(), &a1_size) == TILEDB_OK);
+  uint64_t a2_var_size = buffer_var_a2.size() * sizeof(char);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "a2", (void*)buffer_var_a2.c_str(), &a2_var_size) ==
+      TILEDB_OK);
+  uint64_t a2_size = buffer_a2.size() * sizeof(uint64_t);
+  REQUIRE(
+      tiledb_query_set_offsets_buffer(
+          ctx, query, "a2", buffer_a2.data(), &a2_size) == TILEDB_OK);
+  uint64_t a3_size = buffer_a3.size() * sizeof(float);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "a3", buffer_a3.data(), &a3_size) == TILEDB_OK);
+
+  uint64_t d1_size = buffer_coords_dim1.size() * sizeof(uint64_t);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "d1", buffer_coords_dim1.data(), &d1_size) == TILEDB_OK);
+  uint64_t d2_size = buffer_coords_dim2.size() * sizeof(uint64_t);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "d2", buffer_coords_dim2.data(), &d2_size) == TILEDB_OK);
+
+  // Submit/finalize the query.
+  REQUIRE(tiledb_query_submit_and_finalize(ctx, query) == TILEDB_OK);
+  // Close array.
+  REQUIRE(tiledb_array_close(ctx, array) == TILEDB_OK);
+
+  tiledb_free(array);
+  tiledb_free(query);
+}
+
+void read_sparse_v11(
+    tiledb_ctx_t* ctx, const std::string& array_name, uint64_t timestamp) {
+  // Prepare expected results for cell buffers.
+  std::vector<int> buffer_a1{0, 1, 2, 3};
+  std::vector<uint64_t> buffer_a2{0, 1, 3, 6};
+  std::string buffer_var_a2("abbcccdddd");
+  std::vector<float> buffer_a3{0.1f, 0.2f, 1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f};
+  std::vector<uint64_t> buffer_coords_dim1{1, 1, 1, 2};
+  std::vector<uint64_t> buffer_coords_dim2{1, 2, 4, 3};
+
+  int buffer_a1_read[4];
+  uint64_t buffer_a2_read[4];
+  char buffer_var_a2_read[10];
+  float buffer_a3_read[8];
+  uint64_t buffer_coords_dim1_read[4];
+  uint64_t buffer_coords_dim2_read[4];
+
+  // Open array.
+  tiledb_array_t* array;
+  REQUIRE(tiledb_array_alloc(ctx, array_name.c_str(), &array) == TILEDB_OK);
+  REQUIRE(
+      tiledb_array_set_open_timestamp_end(ctx, array, timestamp) == TILEDB_OK);
+  REQUIRE(tiledb_array_open(ctx, array, TILEDB_READ) == TILEDB_OK);
+
+  // Create query.
+  tiledb_query_t* query;
+  REQUIRE(tiledb_query_alloc(ctx, array, TILEDB_READ, &query) == TILEDB_OK);
+  REQUIRE(
+      tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER) == TILEDB_OK);
+  uint64_t a1_size = buffer_a1.size() * sizeof(int);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "a1", buffer_a1_read, &a1_size) == TILEDB_OK);
+  uint64_t a2_var_size = buffer_var_a2.size() * sizeof(char);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "a2", buffer_var_a2_read, &a2_var_size) == TILEDB_OK);
+  uint64_t a2_size = buffer_a2.size() * sizeof(uint64_t);
+  REQUIRE(
+      tiledb_query_set_offsets_buffer(
+          ctx, query, "a2", buffer_a2_read, &a2_size) == TILEDB_OK);
+  uint64_t a3_size = buffer_a3.size() * sizeof(float);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "a3", buffer_a3_read, &a3_size) == TILEDB_OK);
+
+  uint64_t d1_size = buffer_coords_dim1.size() * sizeof(uint64_t);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "d1", buffer_coords_dim1_read, &d1_size) == TILEDB_OK);
+  uint64_t d2_size = buffer_coords_dim2.size() * sizeof(uint64_t);
+  REQUIRE(
+      tiledb_query_set_data_buffer(
+          ctx, query, "d2", buffer_coords_dim2_read, &d2_size) == TILEDB_OK);
+
+  // Submit the query.
+  REQUIRE(tiledb_query_submit(ctx, query) == TILEDB_OK);
+  // Close array.
+  REQUIRE(tiledb_array_close(ctx, array) == TILEDB_OK);
+
+  CHECK(!memcmp(buffer_a1.data(), buffer_a1_read, sizeof(buffer_a1_read)));
+  CHECK(!memcmp(
+      buffer_var_a2.data(), buffer_var_a2_read, sizeof(buffer_var_a2_read)));
+  CHECK(!memcmp(buffer_a2.data(), buffer_a2_read, sizeof(buffer_a2_read)));
+  CHECK(!memcmp(buffer_a3.data(), buffer_a3_read, sizeof(buffer_a3_read)));
+  CHECK(!memcmp(
+      buffer_coords_dim1.data(),
+      buffer_coords_dim1_read,
+      sizeof(buffer_coords_dim1_read)));
+  CHECK(!memcmp(
+      buffer_coords_dim2.data(),
+      buffer_coords_dim2_read,
+      sizeof(buffer_coords_dim2_read)));
+
+  tiledb_free(array);
+  tiledb_free(query);
+}
+
 template void check_subarray<int8_t>(
     tiledb::sm::Subarray& subarray, const SubarrayRanges<int8_t>& ranges);
 template void check_subarray<uint8_t>(

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1539,8 +1539,8 @@ void write_sparse_v11(
   // Close array.
   REQUIRE(tiledb_array_close(ctx, array) == TILEDB_OK);
 
-  tiledb_free(array);
-  tiledb_free(query);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
 }
 
 void read_sparse_v11(

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -929,6 +929,34 @@ int deserialize_array_and_query(
  * @return A test fragment uri
  */
 sm::URI generate_fragment_uri(sm::Array* array);
+
+/**
+ * Helper function to create a sparse array using format version 11.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The name of the new array to create.
+ */
+void create_sparse_array_v11(tiledb_ctx_t* ctx, const std::string& array_name);
+
+/**
+ * Helper function to write data to a format version 11 sparse array.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The name of the array to write to.
+ * @param timestamp The timestamp to open the array for writing.
+ */
+void write_sparse_v11(
+    tiledb_ctx_t* ctx, const std::string& array_name, uint64_t timestamp);
+
+/**
+ * Helper function to validate data read from a format version 11 sparse array.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The name of the array to read from.
+ * @param timestamp The timestamp to open the array for reading.
+ */
+void read_sparse_v11(
+    tiledb_ctx_t* ctx, const std::string& array_name, uint64_t timestamp);
 }  // namespace tiledb::test
 
 #endif

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -371,21 +371,21 @@ Status FragmentConsolidator::consolidate_fragments(
       FragmentID frag_id(fragment_uri);
       std::string fragment = fragment_uri.last_path_part();
 
+      // Normalizes path separators for windows paths.
+      std::string array_uri = URI(array_name).to_string();
       // Check for valid URI based on array format version.
       if (frag_id.array_format_version() <= 11 &&
-          !fragment_uri.contains(std::string(array_name) + "/" + fragment)) {
+          !fragment_uri.contains(array_uri.append("/" + fragment))) {
         throw FragmentConsolidatorException(
             "Failed request to consolidate an invalid fragment URI '" +
-            fragment_uri.to_string() + "' for array at '" +
-            std::string(array_name) + "'");
+            fragment_uri.to_string() + "' for array at '" + array_uri + "'");
       } else if (
           frag_id.array_format_version() > 11 &&
           !fragment_uri.contains(
-              std::string(array_name) + "/__fragments/" + fragment)) {
+              array_uri.append("/__fragments/" + fragment))) {
         throw FragmentConsolidatorException(
             "Failed request to consolidate an invalid fragment URI '" +
-            fragment_uri.to_string() + "' for array at '" +
-            std::string(array_name) + "'");
+            fragment_uri.to_string() + "' for array at '" + array_uri + "'");
       }
       to_consolidate_set.emplace(fragment);
     }

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -373,7 +373,8 @@ Status FragmentConsolidator::consolidate_fragments(
       // Check for valid URI based on array format version.
       auto fragments_dir = array_for_reads->array_directory().get_fragments_dir(
           frag_id.array_format_version());
-      if (!fragment_uri.contains(fragments_dir)) {
+      if (fragment_uri !=
+          fragments_dir.join_path(fragment_uri.last_path_part().c_str())) {
         throw FragmentConsolidatorException(
             "Failed request to consolidate an invalid fragment URI '" +
             fragment_uri.to_string() + "' for array at '" +

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -375,15 +375,17 @@ Status FragmentConsolidator::consolidate_fragments(
       if (frag_id.array_format_version() <= 11 &&
           !fragment_uri.contains(std::string(array_name) + "/" + fragment)) {
         throw FragmentConsolidatorException(
-            "Failed request to consolidate an invalid fragment URI ('" +
-            fragment_uri.to_string() + "')");
+            "Failed request to consolidate an invalid fragment URI '" +
+            fragment_uri.to_string() + "' for array at '" +
+            std::string(array_name) + "'");
       } else if (
           frag_id.array_format_version() > 11 &&
           !fragment_uri.contains(
               std::string(array_name) + "/__fragments/" + fragment)) {
         throw FragmentConsolidatorException(
-            "Failed request to consolidate an invalid fragment URI ('" +
-            fragment_uri.to_string() + "')");
+            "Failed request to consolidate an invalid fragment URI '" +
+            fragment_uri.to_string() + "' for array at '" +
+            std::string(array_name) + "'");
       }
       to_consolidate_set.emplace(fragment);
     }

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -369,25 +369,17 @@ Status FragmentConsolidator::consolidate_fragments(
       // The fragment URI is absolute and should contain the correct array URI.
       URI fragment_uri(uri);
       FragmentID frag_id(fragment_uri);
-      std::string fragment = fragment_uri.last_path_part();
 
-      // Normalizes path separators for windows paths.
-      std::string array_uri = URI(array_name).to_string();
       // Check for valid URI based on array format version.
-      if (frag_id.array_format_version() <= 11 &&
-          !fragment_uri.contains(array_uri.append("/" + fragment))) {
+      auto fragments_dir = array_for_reads->array_directory().get_fragments_dir(
+          frag_id.array_format_version());
+      if (!fragment_uri.contains(fragments_dir)) {
         throw FragmentConsolidatorException(
             "Failed request to consolidate an invalid fragment URI '" +
-            fragment_uri.to_string() + "' for array at '" + array_uri + "'");
-      } else if (
-          frag_id.array_format_version() > 11 &&
-          !fragment_uri.contains(
-              array_uri.append("/__fragments/" + fragment))) {
-        throw FragmentConsolidatorException(
-            "Failed request to consolidate an invalid fragment URI '" +
-            fragment_uri.to_string() + "' for array at '" + array_uri + "'");
+            fragment_uri.to_string() + "' for array at '" +
+            URI(array_name).to_string() + "'");
       }
-      to_consolidate_set.emplace(fragment);
+      to_consolidate_set.emplace(fragment_uri.last_path_part());
     }
   }
 

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -362,7 +362,7 @@ Status FragmentConsolidator::consolidate_fragments(
   NDRange union_non_empty_domains;
   std::unordered_set<std::string> to_consolidate_set;
   for (auto& uri : fragment_uris) {
-    to_consolidate_set.emplace(uri);
+    to_consolidate_set.emplace(URI(uri).last_path_part());
   }
 
   // Make sure all fragments to consolidate are present
@@ -384,7 +384,8 @@ Status FragmentConsolidator::consolidate_fragments(
 
   if (count != fragment_uris.size()) {
     throw FragmentConsolidatorException(
-        "Cannot consolidate; Not all fragments could be found");
+        "Cannot consolidate; Found " + std::to_string(count) + " of " +
+        std::to_string(fragment_uris.size()) + " required fragments.");
   }
 
   FragmentConsolidationWorkspace cw(consolidator_memory_tracker_);


### PR DESCRIPTION
This fixes fragment consolidation to allow using absolute URIs. I ran into this while adding a TileDB-Go binding for `tiledb_array_consolidate_fragments` in [SC-49723](https://app.shortcut.com/tiledb-inc/story/49723/add-tiledb-go-binding-for-tiledb-array-consolidate-fragments) by passing URIs directly from the [FragmentInfo APIs.](https://github.com/TileDB-Inc/TileDB-Go/pull/322/files#diff-c37e5f4dd452918ab7c467ff243d69310dbd1b238b7b717a98871f80cf0fab70R156)

---
TYPE: BUG
DESC: Fix fragment consolidation to allow using absolute URIs.