### PR TITLE
Include algorithm header for gcc 14.

### DIFF
--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -47,12 +47,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <fstream>
 #include <future>
 #include <iostream>
 #include <queue>
 #include <sstream>
-#include <algorithm>
 
 using namespace tiledb::common;
 using filesystem::directory_entry;

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -52,6 +52,7 @@
 #include <iostream>
 #include <queue>
 #include <sstream>
+#include <algorithm>
 
 using namespace tiledb::common;
 using filesystem::directory_entry;


### PR DESCRIPTION
<long description>

There is a compilation error on gcc 14.
```
tiledb/sm/filesystem/posix.cc: In static member function ‘static void tiledb::sm::Posix::adjacent_slashes_dedup(std::string*)’:
tiledb/sm/filesystem/posix.cc:384:12: error: ‘unique’ is not a member of ‘std’
  384 |       std::unique(
      |            ^~~~~~
```
This patch will fix this issue.

---
TYPE: NO_HISTORY
DESC: Include <algorithm> header for gcc 14.
