### PR TITLE
Remove extraneous `StorageManager` objects from tests

### DIFF
--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -51,7 +51,7 @@ struct ConsolidationWithTimestampsFx {
   // TileDB context.
   Context ctx_;
   VFS vfs_;
-  sm::StorageManager* sm_;
+  sm::ContextResources* resources_;
 
   // Constructors/destructors.
   ConsolidationWithTimestampsFx();
@@ -99,7 +99,7 @@ ConsolidationWithTimestampsFx::ConsolidationWithTimestampsFx()
   Config config;
   config.set("sm.consolidation.buffer_size", "1000");
   ctx_ = Context(config);
-  sm_ = ctx_.ptr().get()->storage_manager();
+  resources_ = &ctx_.ptr().get()->resources();
   vfs_ = VFS(ctx_);
 }
 
@@ -113,7 +113,7 @@ void ConsolidationWithTimestampsFx::set_legacy() {
   config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
 
   ctx_ = Context(config);
-  sm_ = ctx_.ptr().get()->storage_manager();
+  resources_ = &ctx_.ptr().get()->resources();
   vfs_ = VFS(ctx_);
 }
 
@@ -419,7 +419,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(sm_->resources(), array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
 
     // Check that only the consolidated fragment is visible.
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);
@@ -437,7 +437,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(sm_->resources(), array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
 
     // Check that no fragment is visible
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);
@@ -1274,7 +1274,7 @@ TEST_CASE_METHOD(
   cfg["sm.mem.consolidation.reader_weight"] = "5000";
   cfg["sm.mem.consolidation.writer_weight"] = "5000";
   ctx_ = Context(cfg);
-  sm_ = ctx_.ptr().get()->storage_manager();
+  resources_ = &ctx_.ptr().get()->resources();
   vfs_ = VFS(ctx_);
 
   // Write first fragment.

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -525,7 +525,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(sm_->resources(), array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
 
     // Check that only the first fragment is visible on an old array.
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);
@@ -543,7 +543,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(sm_->resources(), array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
 
     // Check that no fragment is visible
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -419,7 +419,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(*resources_, array_uri, ts[0], ts[1]);
 
     // Check that only the consolidated fragment is visible.
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);
@@ -437,7 +437,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(*resources_, array_uri, ts[0], ts[1]);
 
     // Check that no fragment is visible
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -525,7 +525,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(*resources_, array_uri, ts[0], ts[1]);
 
     // Check that only the first fragment is visible on an old array.
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);
@@ -543,7 +543,7 @@ TEST_CASE_METHOD(
   };
 
   for (auto& ts : test_timestamps) {
-    sm::ArrayDirectory array_dir(resources_, array_uri, ts[0], ts[1]);
+    sm::ArrayDirectory array_dir(*resources_, array_uri, ts[0], ts[1]);
 
     // Check that no fragment is visible
     auto filtered_fragment_uris = array_dir.filtered_fragment_uris(false);

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -59,7 +59,6 @@ struct DeletesFx {
   VFSTestSetup vfs_test_setup_;
   Context ctx_;
   VFS vfs_;
-  sm::StorageManager* sm_;
 
   const std::string array_name_;
   // to be used for direct VFS operations in [rest] testcases where array_name_
@@ -126,7 +125,6 @@ DeletesFx::DeletesFx()
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
   vfs_ = VFS(ctx_);
-  sm_ = ctx_.ptr().get()->storage_manager();
 }
 
 void DeletesFx::set_purge_deleted_cells() {
@@ -136,7 +134,6 @@ void DeletesFx::set_purge_deleted_cells() {
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
   vfs_ = VFS(ctx_);
-  sm_ = ctx_.ptr().get()->storage_manager();
 }
 
 void DeletesFx::set_legacy() {
@@ -147,7 +144,6 @@ void DeletesFx::set_legacy() {
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
   vfs_ = VFS(ctx_);
-  sm_ = ctx_.ptr().get()->storage_manager();
 }
 
 void DeletesFx::create_dir(const std::string& path) {
@@ -184,7 +180,6 @@ void DeletesFx::create_sparse_array(bool allows_dups, bool encrypt) {
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
   vfs_ = VFS(ctx_);
-  sm_ = ctx_.ptr().get()->storage_manager();
 
   // Create dimensions.
   auto d1 = Dimension::create<uint64_t>(ctx_, "d1", {{1, 4}}, 2);

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -51,7 +51,6 @@ struct UpdatesFx {
   // TileDB context.
   Context ctx_;
   VFS vfs_;
-  sm::StorageManager* sm_;
 
   std::string key_ = "0123456789abcdeF0123456789abcdeF";
   const tiledb_encryption_type_t enc_type_ = TILEDB_AES_256_GCM;
@@ -84,7 +83,6 @@ UpdatesFx::UpdatesFx()
   config.set("sm.consolidation.buffer_size", "1000");
   config["sm.allow_updates_experimental"] = "true";
   ctx_ = Context(config);
-  sm_ = ctx_.ptr().get()->storage_manager();
   vfs_ = VFS(ctx_);
 }
 


### PR DESCRIPTION
This PR removes some `StorageManager` objects from tests. In some cases these objects were not used at all anymore. In others they were replaced with `ContextResources` objects, which is all the tests needed.

[sc-50127]

---
TYPE: NO_HISTORY
DESC: Remove extraneous `StorageManager` objects from tests
