### PR TITLE
Remove extraneous StorageManager objects from serialization

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -3777,7 +3777,7 @@ int32_t tiledb_deserialize_query_and_array(
       buffer->buffer(),
       (tiledb::sm::SerializationType)serialize_type,
       *(*array)->array_,
-      ctx->storage_manager(),
+      ctx->resources(),
       memory_tracker));
 
   // Create query struct

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2296,11 +2296,7 @@ Status array_from_query_deserialize(
         capnp::Query::Reader query_reader = query_builder.asReader();
         // Deserialize array instance.
         array_from_capnp(
-            query_reader.getArray(),
-            resources,
-            &array,
-            false,
-            memory_tracker);
+            query_reader.getArray(), resources, &array, false, memory_tracker);
         break;
       }
       case SerializationType::CAPNP: {
@@ -2328,11 +2324,7 @@ Status array_from_query_deserialize(
         capnp::Query::Reader query_reader = reader.getRoot<capnp::Query>();
         // Deserialize array instance.
         array_from_capnp(
-            query_reader.getArray(),
-            resources,
-            &array,
-            false,
-            memory_tracker);
+            query_reader.getArray(), resources, &array, false, memory_tracker);
         break;
       }
       default:

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -2280,7 +2280,7 @@ Status array_from_query_deserialize(
     const Buffer& serialized_buffer,
     SerializationType serialize_type,
     Array& array,
-    StorageManager* storage_manager,
+    ContextResources& resources,
     shared_ptr<MemoryTracker> memory_tracker) {
   try {
     switch (serialize_type) {
@@ -2297,7 +2297,7 @@ Status array_from_query_deserialize(
         // Deserialize array instance.
         array_from_capnp(
             query_reader.getArray(),
-            storage_manager->resources(),
+            resources,
             &array,
             false,
             memory_tracker);
@@ -2310,8 +2310,7 @@ Status array_from_query_deserialize(
               "Could not deserialize query; buffer is not 8-byte aligned."));
 
         // Set traversal limit from config
-        uint64_t limit = storage_manager->resources()
-                             .config()
+        uint64_t limit = resources.config()
                              .get<uint64_t>("rest.capnp_traversal_limit")
                              .value();
         ::capnp::ReaderOptions readerOptions;
@@ -2330,7 +2329,7 @@ Status array_from_query_deserialize(
         // Deserialize array instance.
         array_from_capnp(
             query_reader.getArray(),
-            storage_manager->resources(),
+            resources,
             &array,
             false,
             memory_tracker);
@@ -3198,7 +3197,7 @@ Status array_from_query_deserialize(
     const Buffer&,
     SerializationType,
     Array&,
-    StorageManager*,
+    ContextResources&,
     shared_ptr<MemoryTracker>) {
   return LOG_STATUS(Status_SerializationError(
       "Cannot deserialize; serialization not enabled."));

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -142,7 +142,7 @@ Status array_from_query_deserialize(
     const Buffer& serialized_buffer,
     SerializationType serialize_type,
     Array& array,
-    StorageManager* storage_manager,
+    ContextResources& resources,
     shared_ptr<MemoryTracker> memory_tracker);
 
 /**

--- a/tiledb/sm/serialization/query.h
+++ b/tiledb/sm/serialization/query.h
@@ -52,6 +52,7 @@ namespace tiledb::sm {
 class Array;
 class Buffer;
 class BufferList;
+class ContextResources;
 class Query;
 class GlobalOrderWriter;
 class UnorderedWriter;


### PR DESCRIPTION
This PR removes the last occurrence of `StorageManager` from serialization code.

---
TYPE: NO_HISTORY
DESC: Remove extraneous StorageManager objects from serialization
