### PR TITLE
Fix array latest schema selection for same MS timestamps schemas.

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -1229,7 +1229,6 @@ URI ArrayDirectory::select_latest_array_schema_uri() {
   }
 
   optional<URI> latest_uri = nullopt;
-  uint64_t latest_ts = 0;
 
   for (auto& uri : array_schema_uris_) {
     FragmentID fragment_id{uri};
@@ -1239,9 +1238,8 @@ URI ArrayDirectory::select_latest_array_schema_uri() {
     }
 
     auto ts_range{fragment_id.timestamp_range()};
-    if (ts_range.second > latest_ts && ts_range.second <= timestamp_end_) {
+    if (ts_range.second <= timestamp_end_) {
       latest_uri = uri;
-      latest_ts = ts_range.second;
     }
   }
 


### PR DESCRIPTION
PR #4549 attempted to fix the latest array schema selection. Unfortunately, it didn't take into account that some array schemas might have the same timestamps. This change uses the fact that array schema URIs are lexicographically sorted (names generated in the same timestamps use extra sorting bits in the UUID) to chose the latest array URI whilst keeping the original intent of #4549 and checking against the end timestamp.

[sc-49806]

---
TYPE: BUG
DESC: Fix array latest schema selection for same MS timestamps schemas.
