### PR TITLE
Improve dense read performance for small reads.

### DIFF
--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -3229,7 +3229,6 @@ TEST_CASE_METHOD(
   tiledb_vfs_free(&vfs_);
   // reallocate with input config
   vfs_test_init(fs_vec_, &ctx_, &vfs_, config).ok();
-  tiledb_config_free(&config);
 
   // Open array
   tiledb_array_t* array;
@@ -3276,6 +3275,8 @@ TEST_CASE_METHOD(
   REQUIRE(rc == TILEDB_OK);
   rc = tiledb_subarray_add_range(ctx_, subarray, 1, &s11[0], &s11[1], nullptr);
   REQUIRE(rc == TILEDB_OK);
+  rc = tiledb_subarray_set_config(ctx_, subarray, config);
+  REQUIRE(rc == TILEDB_OK);
   rc = tiledb_query_set_subarray_t(ctx_, query, subarray);
   CHECK(rc == TILEDB_OK);
 
@@ -3299,6 +3300,7 @@ TEST_CASE_METHOD(
   tiledb_query_free(&query);
   tiledb_array_free(&array);
   tiledb_subarray_free(&subarray);
+  tiledb_config_free(&config);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -1314,6 +1314,7 @@ TEST_CASE_METHOD(
   Subarray subarray(ctx_, array);
   subarray.add_range<uint64_t>(1, 2, 3);
   subarray.add_range<uint64_t>(1, 2, 3);
+  subarray.set_config(cfg);
   query.set_subarray(subarray);
 
   // Submit/finalize the query

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -388,6 +388,7 @@ TEST_CASE(
     subarray_r.add_range("d1", (int32_t)1, (int32_t)5);
     subarray_r.add_range("d2", (int32_t)1, (int32_t)3);
     subarray_r.add_range("d2", (int32_t)2, (int32_t)4);
+    subarray_r.set_config(cfg);
     query_r.set_subarray(subarray_r);
     query_r.set_layout(TILEDB_UNORDERED);
     // Submit query

--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -499,8 +499,10 @@ TEST_CASE(
     // Prepare the query
     Query query(ctx, array, TILEDB_READ);
     Subarray subarray(ctx, array);
+    subarray.set_config(cfg);
     subarray.add_range(0, 1, 4).add_range(0, 1, 4).add_range(1, 1, 4).add_range(
         1, 1, 4);
+    subarray.set_config(cfg);
     query.set_subarray(subarray)
         .set_layout(layout)
         .set_data_buffer("a", a_data)

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -1041,6 +1041,7 @@ TEST_CASE(
   subarray.add_range(0, row_range[0], row_range[1]);
   subarray.add_range(1, col_range0[0], col_range0[1]);
   subarray.add_range(1, col_range1[0], col_range1[1]);
+  subarray.set_config(cfg);
   query.set_subarray(subarray);
   query.set_layout(TILEDB_UNORDERED);
 
@@ -1174,6 +1175,7 @@ TEST_CASE(
       .set_data_buffer("a", data);
 
   // Submit query
+  subarray.set_config(cfg);
   query.set_subarray(subarray);
   auto st = query.submit();
   REQUIRE(st == tiledb::Query::Status::INCOMPLETE);

--- a/tiledb/sm/subarray/relevant_fragment_generator.cc
+++ b/tiledb/sm/subarray/relevant_fragment_generator.cc
@@ -98,57 +98,46 @@ RelevantFragments RelevantFragmentGenerator::compute_relevant_fragments(
   auto timer_se = stats_->start_timer("compute_relevant_frags");
   auto dim_num = array_->array_schema_latest().dim_num();
   auto fragment_num = array_->fragment_metadata().size();
+  const auto meta = array_->fragment_metadata();
 
   // Populate the fragment bytemap for each dimension in parallel.
-  throw_if_not_ok(parallel_for(compute_tp, 0, dim_num, [&](const uint32_t d) {
-    if (subarray_.is_default(d))
-      return Status::Ok();
+  throw_if_not_ok(parallel_for_2d(
+      compute_tp,
+      0,
+      dim_num,
+      0,
+      fragment_num,
+      [&](const uint32_t d, const uint64_t f) {
+        if (subarray_.is_default(d)) {
+          return Status::Ok();
+        }
 
-    return compute_relevant_fragments_for_dim(
-        compute_tp,
-        d,
-        fragment_num,
-        start_coords_,
-        end_coords_,
-        &fragment_bytemaps_[d]);
-  }));
+        // We're done when we have already determined fragment `f` to
+        // be relevant for this dimension.
+        if (fragment_bytemaps_[d][f] == 1) {
+          return Status::Ok();
+        }
+
+        auto dim{array_->array_schema_latest().dimension_ptr(d)};
+
+        // The fragment `f` is relevant to this dimension's fragment bytemap
+        // if it overlaps with any range between the start and end coordinates
+        // on this dimension.
+        const type::Range& frag_range = meta[f]->non_empty_domain()[d];
+        for (uint64_t r = start_coords_[d]; r <= end_coords_[d]; ++r) {
+          const type::Range& query_range = subarray_.ranges_for_dim(d)[r];
+
+          if (dim->overlap(frag_range, query_range)) {
+            fragment_bytemaps_[d][f] = 1;
+            break;
+          }
+        }
+
+        return Status::Ok();
+      }));
 
   // Recalculate relevant fragments.
   return RelevantFragments(dim_num, fragment_num, fragment_bytemaps_);
-}
-
-Status RelevantFragmentGenerator::compute_relevant_fragments_for_dim(
-    ThreadPool* const compute_tp,
-    const dimension_size_type dim_idx,
-    const size_t fragment_num,
-    const std::vector<uint64_t>& start_coords,
-    const std::vector<uint64_t>& end_coords,
-    std::vector<uint8_t>* const frag_bytemap) const {
-  const auto meta = array_->fragment_metadata();
-  auto dim{array_->array_schema_latest().dimension_ptr(dim_idx)};
-
-  return parallel_for(compute_tp, 0, fragment_num, [&](const uint64_t f) {
-    // We're done when we have already determined fragment `f` to
-    // be relevant for this dimension.
-    if ((*frag_bytemap)[f] == 1) {
-      return Status::Ok();
-    }
-
-    // The fragment `f` is relevant to this dimension's fragment bytemap
-    // if it overlaps with any range between the start and end coordinates
-    // on this dimension.
-    const type::Range& frag_range = meta[f]->non_empty_domain()[dim_idx];
-    for (uint64_t r = start_coords[dim_idx]; r <= end_coords[dim_idx]; ++r) {
-      const type::Range& query_range = subarray_.ranges_for_dim(dim_idx)[r];
-
-      if (dim->overlap(frag_range, query_range)) {
-        (*frag_bytemap)[f] = 1;
-        break;
-      }
-    }
-
-    return Status::Ok();
-  });
 }
 
 }  // namespace sm

--- a/tiledb/sm/subarray/relevant_fragment_generator.h
+++ b/tiledb/sm/subarray/relevant_fragment_generator.h
@@ -98,28 +98,6 @@ class RelevantFragmentGenerator {
 
  private:
   /* ********************************* */
-  /*          PRIVATE METHODS          */
-  /* ********************************* */
-
-  /**
-   * Computes the relevant fragment bytemap for a specific dimension.
-   *
-   * @param compute_tp The thread pool for compute-bound tasks.
-   * @param dim_idx The index of the dimension to compute on.
-   * @param fragment_num The number of fragments to compute on.
-   * @param start_coords The starting range coordinates to compute between.
-   * @param end_coords The ending range coordinates to compute between.
-   * @param frag_bytemap The fragment bytemap to mutate.
-   */
-  Status compute_relevant_fragments_for_dim(
-      ThreadPool* compute_tp,
-      dimension_size_type dim_idx,
-      size_t fragment_num,
-      const std::vector<uint64_t>& start_coords,
-      const std::vector<uint64_t>& end_coords,
-      std::vector<uint8_t>* frag_bytemap) const;
-
-  /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
 

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -88,7 +88,8 @@ Subarray::Subarray()
     , est_result_size_computed_(false)
     , relevant_fragments_(0)
     , coalesce_ranges_(true)
-    , ranges_sorted_(false) {
+    , ranges_sorted_(false)
+    , merge_overlapping_ranges_(true) {
 }
 
 Subarray::Subarray(
@@ -135,7 +136,8 @@ Subarray::Subarray(
     , est_result_size_computed_(false)
     , relevant_fragments_(opened_array->fragment_metadata().size())
     , coalesce_ranges_(coalesce_ranges)
-    , ranges_sorted_(false) {
+    , ranges_sorted_(false)
+    , merge_overlapping_ranges_(true) {
   add_default_ranges();
 }
 
@@ -513,17 +515,6 @@ void Subarray::add_range_var(
            .dimension_ptr(dim_idx)
            ->var_size()) {
     throw SubarrayException("Cannot add range; Range must be variable-sized");
-  }
-
-  // Get read_range_oob config setting
-  bool found = false;
-  std::string read_range_oob = config_.get("sm.read_range_oob", &found);
-  assert(found);
-
-  if (read_range_oob != "error" && read_range_oob != "warn") {
-    throw SubarrayException(
-        "Invalid value " + read_range_oob +
-        " for sm.read_range_obb. Acceptable values are 'error' or 'warn'.");
   }
 
   // Add range
@@ -1053,7 +1044,9 @@ void Subarray::set_layout(Layout layout) {
 }
 
 void Subarray::set_config(const QueryType query_type, const Config& config) {
-  config_.inherit(config);
+  merge_overlapping_ranges_ = config.get<bool>(
+      "sm.merge_overlapping_ranges_experimental", Config::MustFindMarker());
+
   if (query_type == QueryType::READ) {
     bool found = false;
     std::string read_range_oob_str = config.get("sm.read_range_oob", &found);
@@ -1065,10 +1058,6 @@ void Subarray::set_config(const QueryType query_type, const Config& config) {
     err_on_range_oob_ = read_range_oob_str == "error";
   }
 };
-
-const Config* Subarray::config() const {
-  return &config_;
-}
 
 void Subarray::set_coalesce_ranges(bool coalesce_ranges) {
   if (count_set_ranges()) {
@@ -1644,9 +1633,6 @@ void Subarray::sort_and_merge_ranges(ThreadPool* const compute_tp) {
   if (ranges_sorted_)
     return;
 
-  auto merge = config_.get<bool>(
-      "sm.merge_overlapping_ranges_experimental", Config::MustFindMarker());
-
   // Sort and conditionally merge ranges
   auto timer = stats_->start_timer("sort_and_merge_ranges");
   throw_if_not_ok(parallel_for(
@@ -1654,7 +1640,8 @@ void Subarray::sort_and_merge_ranges(ThreadPool* const compute_tp) {
       0,
       array_->array_schema_latest().dim_num(),
       [&](uint64_t dim_idx) {
-        range_subset_[dim_idx].sort_and_merge_ranges(compute_tp, merge);
+        range_subset_[dim_idx].sort_and_merge_ranges(
+            compute_tp, merge_overlapping_ranges_);
         return Status::Ok();
       }));
   ranges_sorted_ = true;
@@ -2354,6 +2341,7 @@ Subarray Subarray::clone() const {
   clone.est_result_size_ = est_result_size_;
   clone.max_mem_size_ = max_mem_size_;
   clone.original_range_idx_ = original_range_idx_;
+  clone.merge_overlapping_ranges_ = merge_overlapping_ranges_;
 
   return clone;
 }
@@ -2464,6 +2452,7 @@ void Subarray::swap(Subarray& subarray) {
   std::swap(est_result_size_, subarray.est_result_size_);
   std::swap(max_mem_size_, subarray.max_mem_size_);
   std::swap(original_range_idx_, subarray.original_range_idx_);
+  std::swap(merge_overlapping_ranges_, subarray.merge_overlapping_ranges_);
 }
 
 void Subarray::get_expanded_coordinates(
@@ -2566,45 +2555,39 @@ void Subarray::compute_relevant_fragment_tile_overlap(
 
   const auto& meta = array_->fragment_metadata();
 
-  auto status =
-      parallel_for(compute_tp, 0, relevant_fragments_.size(), [&](uint64_t i) {
-        const auto f = relevant_fragments_[i];
-        const auto dense = meta[f]->dense();
-        compute_relevant_fragment_tile_overlap(
-            meta[f], f, dense, compute_tp, tile_overlap, fn_ctx);
+  const auto num_threads = compute_tp->concurrency_level();
+  const auto ranges_per_thread =
+      (uint64_t)std::ceil((double)fn_ctx->range_len_ / num_threads);
+
+  auto status = parallel_for_2d(
+      compute_tp,
+      0,
+      relevant_fragments_.size(),
+      0,
+      num_threads,
+      [&](uint64_t i, uint64_t t) {
+        const auto frag_idx = relevant_fragments_[i];
+        const auto dense = meta[frag_idx]->dense();
+
+        const auto r_start =
+            fn_ctx->range_idx_offset_ + (t * ranges_per_thread);
+        const auto r_end =
+            fn_ctx->range_idx_offset_ +
+            std::min((t + 1) * ranges_per_thread - 1, fn_ctx->range_len_ - 1);
+        for (uint64_t r = r_start; r <= r_end; ++r) {
+          if (dense) {  // Dense fragment
+            *tile_overlap->at(frag_idx, r) = compute_tile_overlap(
+                r + tile_overlap->range_idx_start(), frag_idx);
+          } else {  // Sparse fragment
+            const auto& range =
+                this->ndrange(r + tile_overlap->range_idx_start());
+            meta[frag_idx]->loaded_metadata()->get_tile_overlap(
+                range, is_default_, tile_overlap->at(frag_idx, r));
+          }
+        }
+
         return Status::Ok();
       });
-  throw_if_not_ok(status);
-}
-
-void Subarray::compute_relevant_fragment_tile_overlap(
-    shared_ptr<FragmentMetadata> meta,
-    unsigned frag_idx,
-    bool dense,
-    ThreadPool* compute_tp,
-    SubarrayTileOverlap* tile_overlap,
-    ComputeRelevantTileOverlapCtx* fn_ctx) {
-  const auto num_threads = compute_tp->concurrency_level();
-  const auto range_num = fn_ctx->range_len_;
-
-  const auto ranges_per_thread =
-      (uint64_t)std::ceil((double)range_num / num_threads);
-  const auto status = parallel_for(compute_tp, 0, num_threads, [&](uint64_t t) {
-    const auto r_start = fn_ctx->range_idx_offset_ + (t * ranges_per_thread);
-    const auto r_end = fn_ctx->range_idx_offset_ +
-                       std::min((t + 1) * ranges_per_thread - 1, range_num - 1);
-    for (uint64_t r = r_start; r <= r_end; ++r) {
-      if (dense) {  // Dense fragment
-        *tile_overlap->at(frag_idx, r) =
-            compute_tile_overlap(r + tile_overlap->range_idx_start(), frag_idx);
-      } else {  // Sparse fragment
-        const auto& range = this->ndrange(r + tile_overlap->range_idx_start());
-        meta->loaded_metadata()->get_tile_overlap(
-            range, is_default_, tile_overlap->at(frag_idx, r));
-      }
-    }
-    return Status::Ok();
-  });
   throw_if_not_ok(status);
 }
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -436,12 +436,6 @@ class Subarray {
   void set_config(const QueryType query_type, const Config& config);
 
   /**
-   * Get the config of the writer
-   * @return Config
-   */
-  const Config* config() const;
-
-  /**
    * Sets the subarray using a pointer to raw range data that stores one range
    * per dimension.
    *
@@ -1509,9 +1503,6 @@ class Subarray {
   std::unordered_map<std::vector<uint8_t>, size_t, CoordsHasher>
       tile_coords_map_;
 
-  /** The config for query-level parameters only. */
-  Config config_;
-
   /** State of specific Config item needed from multiple locations. */
   bool err_on_range_oob_ = true;
 
@@ -1520,6 +1511,9 @@ class Subarray {
 
   /** Mutext to protect sorting ranges. */
   std::mutex ranges_sort_mtx_;
+
+  /** Merge overlapping ranges setting. */
+  bool merge_overlapping_ranges_;
 
   /* ********************************* */
   /*           PRIVATE METHODS         */
@@ -1594,25 +1588,6 @@ class Subarray {
    * invocations.
    */
   void compute_relevant_fragment_tile_overlap(
-      ThreadPool* compute_tp,
-      SubarrayTileOverlap* tile_overlap,
-      ComputeRelevantTileOverlapCtx* fn_ctx);
-
-  /**
-   * Computes the tile overlap for all ranges on the given relevant fragment.
-   *
-   * @param meta The fragment metadat to focus on.
-   * @param frag_idx The fragment id.
-   * @param dense Whether the fragment is dense or sparse.
-   * @param compute_tp The thread pool for compute-bound tasks.
-   * @param tile_overlap Mutated to store the computed tile overlap.
-   * @param fn_ctx An opaque context object to be used between successive
-   * invocations.
-   */
-  void compute_relevant_fragment_tile_overlap(
-      shared_ptr<FragmentMetadata> meta,
-      unsigned frag_idx,
-      bool dense,
       ThreadPool* compute_tp,
       SubarrayTileOverlap* tile_overlap,
       ComputeRelevantTileOverlapCtx* fn_ctx);


### PR DESCRIPTION
This improves a couples places that are easy gain when doing small dense reads. Running a small read in a loop (256K tile), I found out a few places where we can easily cut read times. 2 of those places were nested parallel fors that have been replaced by a parallel for 2d. The other was storing a full configuration class, which includes a map of ~148 configuration settings in the subarray. The subarray only uses two settings and those are now saved as member of the class, removing the need to generate a full configuration class when a subarray is constructed.

[sc-50178]

---
TYPE: IMPROVEMENT
DESC: Improve dense read performance for small reads.
