### PR TITLE
Downgrade Node.js version for manylinux jobs.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -82,6 +82,9 @@ env:
   bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'x64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
+  # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.
+  # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ inputs.manylinux && 'true' || 'false' }}
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ matrix.manylinux && 'true' || 'false' }}
 
     steps:
       - name: Checkout TileDB


### PR DESCRIPTION
[SC-50336](https://app.shortcut.com/tiledb-inc/story/50336/ci-failures-on-manylinux-due-to-node-js-forced-version-bump)

Apparently GitHub Actions has started forcing Node.js 20 for all jobs, which causes failures for manylinux jobs due to libc version incompatibilities.

This PR uses [an environment variable](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) to force GHA to use Node.js 16, fixing the failures until we cump manylinux in the 2.31 timeframe.

---
TYPE: NO_HISTORY