### PR TITLE
Add specification for delta filter encoding et al.

### DIFF
--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -26,15 +26,33 @@ The filter has internal format:
 
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |
-| Filter type | `uint8_t` | Type of filter \(e.g. `TILEDB_FILTER_BZIP2`\) |
-| Filter options size | `uint32_t` | Number of bytes in filter options — may be 0. |
+| Filter type | `uint8_t` | Type of filter \(e.g. `TILEDB_FILTER_BZIP2`\) – see below for values |
+| Filter options size | `uint32_t` | Number of bytes in filter options – may be 0. |
 | Filter options | [Filter Options](#filter-options) | Filter options, specific to each filter. E.g. compression level for compression filters. |
 
-TileDB supports the following filters:
-* [Float Scaling Filter](./filters/float_scale.md)
-* [XOR Filter](./filters/xor.md)
-* [Dictionary Encoding Filter](./filters/dictionary_encoding.md)
-* [WEBP Filter](./filters/webp.md)
+TileDB supports the following filters. Each filter has a type, which also corresponds to a constant in the C API:
+* [Compression](./tile.md#compression-filters)
+    * [Gzip](https://www.gnu.org/software/gzip/) – `TILEDB_FILTER_GZIP` (1)
+    * [Zstandard](https://facebook.github.io/zstd/) – `TILEDB_FILTER_ZSTD` (2)
+    * [LZ4](https://lz4.org/) – `TILEDB_FILTER_LZ4` (3)
+    * Run-length encoding – `TILEDB_FILTER_RLE` (4)
+    * [BZip2](http://sourceware.org/bzip2/) – `TILEDB_FILTER_BZIP2` (5)
+    * [Double-delta](filters/double_delta.md) – `TILEDB_FILTER_DOUBLE_DELTA` (6)
+    * [Dictionary](filters/dictionary_encoding.md) – `TILEDB_FILTER_DICTIONARY` (14)
+    * [Delta](filters/delta.md) – `TILEDB_FILTER_DELTA` (19)
+* [Bit-width Reduction](./tile.md#bit-width-reduction-filter) – `TILEDB_FILTER_BIT_WIDTH_REDUCTION` (7)
+* [Bit Shuffle](./tile.md#byteshuffle-filter) – `TILEDB_FILTER_BITSHUFFLE` (8)
+* [Byte Shuffle](./tile.md#bitshuffle-filter) – `TILEDB_FILTER_BYTESHUFFLE` (9)
+* [Positive Delta](./tile.md#positive-delta-encoding-filter) – `TILEDB_FILTER_POSITIVE_DELTA` (10)
+* [Encryption](./tile.md#encryption-filters) – _not a publicly exposed and user-configurable filter_
+    * [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) (11)
+* [Checksum](./tile.md#checksum-filters)
+    * [MD5](https://en.wikipedia.org/wiki/MD5) – `TILEDB_FILTER_CHECKSUM_MD5` (12)
+    * [SHA-256](https://en.wikipedia.org/wiki/SHA-2) – `TILEDB_FILTER_CHECKSUM_SHA256` (13)
+* [Dictionary Encoding](./filters/dictionary_encoding.md) – `TILEDB_FILTER_DICTIONARY` (14)
+* [Float Scale](./filters/float_scale.md) – `TILEDB_FILTER_SCALE_FLOAT` (15)
+* [XOR](./filters/xor.md) – `TILEDB_FILTER_XOR` (16)
+* [WEBP](./filters/webp.md) – `TILEDB_FILTER_WEBP` (18)
 
 ## Filter Options
 

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -44,8 +44,8 @@ TileDB supports the following filters. Each filter has a type, which also corres
 * [Bit Shuffle](./tile.md#byteshuffle-filter) – `TILEDB_FILTER_BITSHUFFLE` (8)
 * [Byte Shuffle](./tile.md#bitshuffle-filter) – `TILEDB_FILTER_BYTESHUFFLE` (9)
 * [Positive Delta](./tile.md#positive-delta-encoding-filter) – `TILEDB_FILTER_POSITIVE_DELTA` (10)
-* [Encryption](./tile.md#encryption-filters) – _not a publicly exposed and user-configurable filter_
-    * [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) (11)
+* [Encryption](./tile.md#encryption-filters)
+    * [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) – (11)
 * [Checksum](./tile.md#checksum-filters)
     * [MD5](https://en.wikipedia.org/wiki/MD5) – `TILEDB_FILTER_CHECKSUM_MD5` (12)
     * [SHA-256](https://en.wikipedia.org/wiki/SHA-2) – `TILEDB_FILTER_CHECKSUM_SHA256` (13)
@@ -53,6 +53,9 @@ TileDB supports the following filters. Each filter has a type, which also corres
 * [Float Scale](./filters/float_scale.md) – `TILEDB_FILTER_SCALE_FLOAT` (15)
 * [XOR](./filters/xor.md) – `TILEDB_FILTER_XOR` (16)
 * [WEBP](./filters/webp.md) – `TILEDB_FILTER_WEBP` (18)
+
+> [!NOTE]
+> Encryption is internally implemented as a filter at the end of the pipeline, but the encryption filter is not directly selectable by the user. The presence of the encryption filter in a pipeline is used to indicate that the data is encrypted.
 
 ## Filter Options
 

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -27,8 +27,8 @@ The filter has internal format:
 | **Field** | **Type** | **Description** |
 | :--- | :--- | :--- |
 | Filter type | `uint8_t` | Type of filter \(e.g. `TILEDB_FILTER_BZIP2`\) |
-| Filter metadata size | `uint32_t` | Number of bytes in filter metadata — may be 0. |
-| Filter metadata | [Filter Metadata](#filter-metadata) | Filter metadata, specific to each filter. E.g. compression level for compression filters. |
+| Filter options size | `uint32_t` | Number of bytes in filter options — may be 0. |
+| Filter options | [Filter Options](#filter-options) | Filter options, specific to each filter. E.g. compression level for compression filters. |
 
 TileDB supports the following filters:
 * [Float Scaling Filter](./filters/float_scale.md)

--- a/format_spec/filter_pipeline.md
+++ b/format_spec/filter_pipeline.md
@@ -45,7 +45,7 @@ TileDB supports the following filters. Each filter has a type, which also corres
 * [Byte Shuffle](./tile.md#bitshuffle-filter) – `TILEDB_FILTER_BYTESHUFFLE` (9)
 * [Positive Delta](./tile.md#positive-delta-encoding-filter) – `TILEDB_FILTER_POSITIVE_DELTA` (10)
 * [Encryption](./tile.md#encryption-filters)
-    * [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode) – (11)
+    * [AES-256-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode)
 * [Checksum](./tile.md#checksum-filters)
     * [MD5](https://en.wikipedia.org/wiki/MD5) – `TILEDB_FILTER_CHECKSUM_MD5` (12)
     * [SHA-256](https://en.wikipedia.org/wiki/SHA-2) – `TILEDB_FILTER_CHECKSUM_SHA256` (13)
@@ -55,7 +55,7 @@ TileDB supports the following filters. Each filter has a type, which also corres
 * [WEBP](./filters/webp.md) – `TILEDB_FILTER_WEBP` (18)
 
 > [!NOTE]
-> Encryption is internally implemented as a filter at the end of the pipeline, but the encryption filter is not directly selectable by the user. The presence of the encryption filter in a pipeline is used to indicate that the data is encrypted.
+> Encryption is implemented as a filter at the end of the pipeline, but the encryption filter is not directly selectable by the user, and does not appear in filter pipelines serialized to storage.
 
 ## Filter Options
 

--- a/format_spec/filters/delta.md
+++ b/format_spec/filters/delta.md
@@ -1,0 +1,23 @@
+---
+title: Delta Filter
+---
+
+## Delta Filter
+
+The delta filter transforms integer type data by computing and storing the delta between consecutive elements.
+
+### Filter Enum Value
+
+The filter enum value for the delta filter is `19` (`TILEDB_FILTER_DELTA` enum).
+
+### Input and Output Layout
+
+The input data layout will be an array of integer numbers. Their type (henceforth known as `input_t`) is inferred from the output type of the previous filter, or the tile's datatype if this is the first filter in the pipeline, but can be overriden by the [_Reinterpret datatype_ field](../filter_pipeline.md#delta-compressor-options) in the filter options.
+
+The output data layout consists of the following fields:
+
+|Field|Type|Description|
+|:---|:---|:---|
+|`n`|`uint64_t`|Number of values in the input data.|
+|`in_0`|`input_t`|First input value.|
+|`delta_1`|`input_t`|Value of `in_1 - in_0`.|

--- a/format_spec/filters/delta.md
+++ b/format_spec/filters/delta.md
@@ -12,7 +12,7 @@ The filter enum value for the delta filter is `19` (`TILEDB_FILTER_DELTA` enum).
 
 ### Input and Output Layout
 
-The input data layout will be an array of integer numbers. Their type (henceforth known as `input_t`) is inferred from the output type of the previous filter, or the tile's datatype if this is the first filter in the pipeline, but can be overriden by the [_Reinterpret datatype_ field](../filter_pipeline.md#delta-compressor-options) in the filter options.
+The input data layout will be an array of integer numbers (each known as `in_{n}`, with `n` starting from 0). Their type (henceforth known as `input_t`) is inferred from the output type of the previous filter, or the tile's datatype if this is the first filter in the pipeline, but can be overriden by the [_Reinterpret datatype_ field](../filter_pipeline.md#delta-compressor-options) in the filter options.
 
 The output data layout consists of the following fields:
 
@@ -21,3 +21,4 @@ The output data layout consists of the following fields:
 |`n`|`uint64_t`|Number of values in the input data.|
 |`in_0`|`input_t`|First input value.|
 |`delta_1`|`input_t`|Value of `in_1 - in_0`.|
+|`delta_n`|`input_t`|Value of `in_n - in_{n - 1}`.|

--- a/format_spec/tile.md
+++ b/format_spec/tile.md
@@ -185,7 +185,7 @@ The filter metadata for `TILEDB_FILTER_CHECKSUM_{MD5,SHA256}` has internal forma
 
 ### Encryption Filters
 
-If the array is **encrypted**, TileDB uses an extra internal filter `INTERNAL_FILTER_AES_256_GCM` for AES encryption.
+If the array is **encrypted**, TileDB uses an extra internal filter at the end of the pipeline for AES encryption.
 
 The encryption filter metadata have the following on-disk format:
 

--- a/tiledb/sm/compressors/delta_compressor.cc
+++ b/tiledb/sm/compressors/delta_compressor.cc
@@ -52,8 +52,6 @@ class DeltaCompressorException : public StatusException {
   }
 };
 
-const uint64_t Delta::OVERHEAD = 17;
-
 /* ****************************** */
 /*               API              */
 /* ****************************** */

--- a/tiledb/sm/compressors/delta_compressor.h
+++ b/tiledb/sm/compressors/delta_compressor.h
@@ -49,10 +49,9 @@ enum class Datatype : uint8_t;
 class Delta {
  public:
   /**
-   * Constant overhead (equal to 1 byte for the bitsize, 8 bytes for
-   * the number of cells, and 8 bytes for a potential extra 64-bit chunk).
+   * Constant overhead (equal to 8 bytes for the number of cells).
    */
-  static const uint64_t OVERHEAD;
+  static constexpr uint64_t OVERHEAD = sizeof(uint64_t);
 
   /* ****************************** */
   /*               API              */
@@ -67,11 +66,9 @@ class Delta {
    *
    * The output buffer will contain the following after compression:
    *
-   * bitsize | n | in_0 | in_1 - in_0 | in_2 - in_1 | ... | in_n - in_{n-1}
+   * n | in_0 | in_1 - in_0 | in_2 - in_1 | ... | in_n - in_{n-1}
    *
    * where:
-   *  - *bitsize* (char) is the minimum number of bits required to represent
-   *    any abs(dd_i).
    *  - *n* (uint64_t) is the number of values in the input buffer.
    *
    * @param type The type of the input values.

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -696,6 +696,8 @@ uint64_t CompressionFilter::overhead(
       return BZip::overhead(nbytes);
     case Compressor::DOUBLE_DELTA:
       return DoubleDelta::overhead(nbytes);
+    case Compressor::DELTA:
+      return Delta::OVERHEAD;
     case Compressor::DICTIONARY_ENCODING:
     default:
       // No compression


### PR DESCRIPTION
[SC-49777](https://app.shortcut.com/tiledb-inc/story/49777/delta-filter-storage-format-is-undocumented)

This PR adds the encoding of the delta filter to the filter specification. The specification was based on the filter class' [implementation](https://github.com/TileDB-Inc/TileDB/blob/6a9918a6caf33967dc3201016ecb51eb62a45d3c/tiledb/sm/compressors/delta_compressor.cc#L225-L245).

The class' documentation had some errors which I fixed. I also fixed the definition of the delta filter's overhead, and plumbed it to the `CompressionFilter::overhead` function, and added to the storage format specification a list of all supported filters.

---
TYPE: NO_HISTORY
DESC: Added specification for the encoding of the delta filter, and a list of all filters supported by TileDB.