### PR TITLE
Unpin the manylinux image in the Release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: arm64-osx-release
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.manylinux && 'quay.io/pypa/manylinux2014_x86_64:2023-11-13-f6b0c51' || '' }}
+    container: ${{ matrix.manylinux && 'quay.io/pypa/manylinux2014_x86_64' || '' }}
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'


### PR DESCRIPTION
[SC-50383](https://app.shortcut.com/tiledb-inc/story/50383/failures-in-the-release-workflow)

Because CentOS 7 went out of support recently, its package repository URL has changed to `vault.centos.org`. The manylinux image [has been updated](https://github.com/pypa/manylinux/commit/7beb9ae220bcf3da425d323817709c1a1e2bd35d) accordingly, but this update was not caught by the Release workflow, because the manylinux image tag is pinned. This PR unpins the image.

---
TYPE: NO_HISTORY