### PR TITLE
Document sentinel values for array open end timestamps.

### DIFF
--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2402,9 +2402,16 @@ TILEDB_EXPORT int32_t tiledb_array_set_open_timestamp_start(
 
 /**
  * Sets the ending timestamp to use when opening (and reopening) the array.
- * This is an inclusive bound. The UINT64_MAX timestamp is a reserved timestamp
- * that will be interpretted as the current timestamp when an array is opened.
- * The default value is `UINT64_MAX`.
+ * This is an inclusive bound. The default value is `UINT64_MAX`.
+ *
+ * When opening the array for reads, this value will be used to determine the
+ * ending timestamp of fragments to load. A value of `UINT64_MAX` will be
+ * translated to the current timestamp at the time the array is opened.
+ *
+ * When opening the array for writes, this value will be used to determine the
+ * timestamp to write new fragments. A value of `UINT64_MAX` will use the
+ * current timestamp at the time the array is opened. A value of 0 will use the
+ * current timestamp at the time the fragment is written.
  *
  * **Example:**
  *

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -2406,12 +2406,12 @@ TILEDB_EXPORT int32_t tiledb_array_set_open_timestamp_start(
  *
  * When opening the array for reads, this value will be used to determine the
  * ending timestamp of fragments to load. A value of `UINT64_MAX` will be
- * translated to the current timestamp at the time the array is opened.
+ * translated to the current timestamp at which the array is opened.
  *
  * When opening the array for writes, this value will be used to determine the
  * timestamp to write new fragments. A value of `UINT64_MAX` will use the
- * current timestamp at the time the array is opened. A value of 0 will use the
- * current timestamp at the time the fragment is written.
+ * current timestamp at which the array is opened. A value of 0 will use the
+ * current timestamp at which the fragment is written.
  *
  * **Example:**
  *


### PR DESCRIPTION
[SC-49672](https://app.shortcut.com/tiledb-inc/story/49672/document-sentinel-values-for-array-open-timestamps)

This PR updates the documentation of `tiledb_array_set_open_timestamp_end` to mention the sentinel values of `0` and `UINT64_MAX`. Documentation was taken from the internal `Array::set_timestamps` method. https://github.com/TileDB-Inc/TileDB/blob/3d73cf616c1f1e6f1ec541ad2ecf3759727277a9/tiledb/sm/array/array.h#L716-L732

---
TYPE: NO_HISTORY
DESC: Update the documentation of `tiledb_array_set_open_timestamp_end` to mention the sentinel values of `0` and `UINT64_MAX`.