### PR TITLE
Deny altering current domain on dense arrays

### DIFF
--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -1821,8 +1821,14 @@ void ArraySchema::expand_current_domain(
         "The argument specified for current domain expansion is nullptr.");
   }
 
+  if (this->dense()) {
+    throw ArraySchemaException(
+        "Expanding the current domain on a TileDB dense array is not "
+        "supported.");
+  }
+
   // Check that the new current domain expands the existing one and not shrinks
-  // it Every current domain covers an empty current domain.
+  // it. Every current domain covers an empty current domain.
   if (!current_domain_->empty() &&
       !current_domain_->covered(new_current_domain)) {
     throw ArraySchemaException(
@@ -1845,6 +1851,10 @@ void ArraySchema::set_current_domain(shared_ptr<CurrentDomain> current_domain) {
     throw ArraySchemaException(
         "The argument specified for setting the current domain on the "
         "schema is nullptr.");
+  }
+  if (this->dense()) {
+    throw ArraySchemaException(
+        "Setting a current domain on a TileDB dense array is not supported.");
   }
 
   current_domain_ = current_domain;


### PR DESCRIPTION
Setting a current domain on a dense array throws.
Also expanding the current domain via schema evolution on a dense array throws.

[sc-50500]

---
TYPE: NO_HISTORY
DESC:  Deny altering current domain on dense arrays.
