### PR TITLE
[Backport release-2.23] Fix `google-cloud-cpp` build failures on CMake 3.30. (#5167)

### DIFF
--- a/ports/README.md
+++ b/ports/README.md
@@ -35,3 +35,4 @@ After copying the port, add an entry to the table below. You should also contrib
 |`pcre2`|To be removed alongside libmagic.|
 |`azure-storage-common-cpp`|Patching to disable default features on libxml2 (https://github.com/Azure/azure-sdk-for-cpp/pull/5221).|
 |`vcpkg-cmake-config`|Patching to fix build issues with CMake 3.29.1. (https://github.com/microsoft/vcpkg/pull/38017)|
+|`google-cloud-cpp`|Patching to remove dependency on GMock. (https://github.com/microsoft/vcpkg/pull/39802)|

--- a/ports/google-cloud-cpp/portfile.cmake
+++ b/ports/google-cloud-cpp/portfile.cmake
@@ -1,0 +1,86 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO googleapis/google-cloud-cpp
+    REF "v${VERSION}"
+    SHA512 a392da19ac353409ecbf30e390803b2e34670552fd54466a08ee554a77c893d447289b30d5841c7f79b2a23244a269d8ecac8f7fbd8a34dda45ce2d8b1d46817
+    HEAD_REF main
+    PATCHES
+        support_absl_cxx17.patch
+        remove_gmock.patch
+)
+
+if ("grpc-common" IN_LIST FEATURES)
+    vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/grpc")
+endif ()
+
+set(GOOGLE_CLOUD_CPP_ENABLE "${FEATURES}")
+list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "core")
+# This feature does not exist, but allows us to simplify the vcpkg.json
+# file.
+list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "grpc-common")
+list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "rest-common")
+list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "googleapis")
+# google-cloud-cpp uses dialogflow_cx and dialogflow_es. Underscores
+# are invalid in `vcpkg` features, we use dashes (`-`) as a separator
+# for the `vcpkg` feature name, and convert it here to something that
+# `google-cloud-cpp` would like.
+if ("dialogflow-cx" IN_LIST FEATURES)
+    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-cx")
+    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_cx")
+endif ()
+if ("dialogflow-es" IN_LIST FEATURES)
+    list(REMOVE_ITEM GOOGLE_CLOUD_CPP_ENABLE "dialogflow-es")
+    list(APPEND GOOGLE_CLOUD_CPP_ENABLE "dialogflow_es")
+endif ()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
+    OPTIONS
+        "-DGOOGLE_CLOUD_CPP_ENABLE=${GOOGLE_CLOUD_CPP_ENABLE}"
+        -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF
+        -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+        -DGOOGLE_CLOUD_CPP_ENABLE_CCACHE=OFF
+        -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF
+        -DBUILD_TESTING=OFF
+        # This is needed by the `experimental-storage-grpc` feature until vcpkg
+        # gets Protobuf >= 4.23.0.  It has no effect for other features, so
+        # it is simpler to just always turn it on.
+        -DGOOGLE_CLOUD_CPP_ENABLE_CTYPE_CORD_WORKAROUND=ON
+)
+
+vcpkg_cmake_install()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+foreach(feature IN LISTS FEATURES)
+    set(config_path "lib/cmake/google_cloud_cpp_${feature}")
+    # Most features get their own package in `google-cloud-cpp`.
+    # The exceptions are captured by this `if()` command, basically
+    # things like `core` and `experimental-storage-grpc` are skipped.
+    if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
+        continue()
+    endif()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "google_cloud_cpp_${feature}"
+                             CONFIG_PATH "${config_path}"
+                             DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
+# These packages are automatically installed depending on what features are
+# enabled.
+foreach(suffix common compute_protos googleapis grpc_utils iam_v2 logging_type rest_internal rest_protobuf_internal dialogflow_cx dialogflow_es)
+    set(config_path "lib/cmake/google_cloud_cpp_${suffix}")
+    if(NOT IS_DIRECTORY "${CURRENT_PACKAGES_DIR}/${config_path}")
+        continue()
+    endif()
+    vcpkg_cmake_config_fixup(PACKAGE_NAME "google_cloud_cpp_${suffix}"
+                             CONFIG_PATH "${config_path}"
+                             DO_NOT_DELETE_PARENT_CONFIG_PATH)
+endforeach()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/lib/cmake"
+                    "${CURRENT_PACKAGES_DIR}/debug/share")
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/ports/google-cloud-cpp/remove_gmock.patch
+++ b/ports/google-cloud-cpp/remove_gmock.patch
@@ -1,0 +1,28 @@
+diff --git a/google/cloud/google_cloud_cpp_common.cmake b/google/cloud/google_cloud_cpp_common.cmake
+index 1a14c77..4e8058e 100644
+--- a/google/cloud/google_cloud_cpp_common.cmake
++++ b/google/cloud/google_cloud_cpp_common.cmake
+@@ -271,9 +271,6 @@ set(google_cloud_cpp_mocks_hdrs
+     mocks/mock_stream_range.h)
+ export_list_to_bazel("google_cloud_cpp_mocks.bzl" "google_cloud_cpp_mocks_hdrs"
+                      YEAR "2022")
+-target_link_libraries(
+-    google_cloud_cpp_mocks INTERFACE google-cloud-cpp::common GTest::gmock_main
+-                                     GTest::gmock GTest::gtest)
+ set_target_properties(google_cloud_cpp_mocks PROPERTIES EXPORT_NAME
+                                                         google-cloud-cpp::mocks)
+ target_include_directories(
+diff --git a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+index a12bb20..eb3182f 100644
+--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
++++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+@@ -219,9 +219,6 @@ set(google_cloud_cpp_storage_grpc_mocks_hdrs
+     mocks/mock_async_writer_connection.h)
+ export_list_to_bazel("google_cloud_cpp_storage_grpc_mocks.bzl"
+                      "google_cloud_cpp_storage_grpc_mocks_hdrs" YEAR "2023")
+-target_link_libraries(
+-    google_cloud_cpp_storage_grpc_mocks
+-    INTERFACE google-cloud-cpp::experimental-storage_grpc GTest::gmock)
+ set_target_properties(
+     google_cloud_cpp_storage_grpc_mocks
+     PROPERTIES EXPORT_NAME "google-cloud-cpp::experimental-storage_grpc_mocks")

--- a/ports/google-cloud-cpp/support_absl_cxx17.patch
+++ b/ports/google-cloud-cpp/support_absl_cxx17.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3fb0564..b4a251b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,6 +29,14 @@ if (NOT "${PROJECT_VERSION_PRE_RELEASE}" STREQUAL "")
+     set(PROJECT_VERSION "${PROJECT_VERSION}-${PROJECT_VERSION_PRE_RELEASE}")
+ endif ()
+ 
++find_package(absl CONFIG REQUIRED)
++
++# Use CMAKE_CXX_STANDARD=17 if ABSL_USE_CXX17 is set
++if (ABSL_USE_CXX17)
++    message(STATUS "Found absl uses CXX17, enable CXX17 feature.")
++    set(CMAKE_CXX_STANDARD 17)
++endif ()
++
+ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.3)
+         message(

--- a/ports/google-cloud-cpp/vcpkg.json
+++ b/ports/google-cloud-cpp/vcpkg.json
@@ -1,0 +1,1509 @@
+{
+    "name": "google-cloud-cpp",
+    "version": "2.19.0",
+    "description": "C++ Client Libraries for Google Cloud Platform APIs.",
+    "homepage": "https://github.com/googleapis/google-cloud-cpp",
+    "license": "Apache-2.0",
+    "supports": "!uwp",
+    "dependencies": [
+      "abseil",
+      "openssl",
+      {
+        "name": "vcpkg-cmake",
+        "host": true
+      },
+      {
+        "name": "vcpkg-cmake-config",
+        "host": true
+      }
+    ],
+    "default-features": [
+      "bigquery",
+      "bigtable",
+      "iam",
+      "pubsub",
+      "spanner",
+      "storage"
+    ],
+    "features": {
+      "accessapproval": {
+        "description": "Access Approval API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "accesscontextmanager": {
+        "description": "Access Context Manager API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "advisorynotifications": {
+        "description": "Advisory Notifications API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "alloydb": {
+        "description": "Alloy DB API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "apigateway": {
+        "description": "API Gateway API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "apigeeconnect": {
+        "description": "Apigee Connect API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "apikeys": {
+        "description": "API Keys API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "appengine": {
+        "description": "App Engine Admin API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "artifactregistry": {
+        "description": "Artifact Registry API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "asset": {
+        "description": "Cloud Asset API C++ Client Library",
+        "supports": "!windows",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "accesscontextmanager",
+              "grpc-common",
+              "osconfig"
+            ]
+          }
+        ]
+      },
+      "assuredworkloads": {
+        "description": "Assured Workloads API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "automl": {
+        "description": "Cloud AutoML API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "baremetalsolution": {
+        "description": "Bare Metal Solution API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "batch": {
+        "description": "Batch API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "beyondcorp": {
+        "description": "BeyondCorp API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "bigquery": {
+        "description": "The Google Cloud BigQuery C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "bigtable": {
+        "description": "The Google Cloud Bigtable C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "billing": {
+        "description": "Cloud Billing Budget API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "binaryauthorization": {
+        "description": "Binary Authorization API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grafeas",
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "certificatemanager": {
+        "description": "Certificate Manager API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "channel": {
+        "description": "Cloud Channel API C++ Client Library",
+        "supports": "!windows",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "cloudbuild": {
+        "description": "Cloud Build API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "commerce": {
+        "description": "Cloud Commerce C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "composer": {
+        "description": "Cloud Composer C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "compute": {
+        "description": "Compute Engine C++ Client Library",
+        "supports": "!windows",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common",
+              "rest-common"
+            ]
+          }
+        ]
+      },
+      "confidentialcomputing": {
+        "description": "Confidential Computing API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "config": {
+        "description": "Infrastructure Manager API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "connectors": {
+        "description": "Connectors API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "contactcenterinsights": {
+        "description": "Contact Center AI Insights API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "container": {
+        "description": "Kubernetes Engine API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "containeranalysis": {
+        "description": "Container Analysis API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grafeas",
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "datacatalog": {
+        "description": "Google Cloud Data Catalog API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "datafusion": {
+        "description": "Cloud Data Fusion API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "datamigration": {
+        "description": "Database Migration API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "dataplex": {
+        "description": "Cloud Dataplex API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "dataproc": {
+        "description": "Cloud Dataproc API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "datastore": {
+        "description": "Cloud Datastore API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "datastream": {
+        "description": "Datastream API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "deploy": {
+        "description": "Google Cloud Deploy API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "dialogflow-cx": {
+        "description": "Cloud Dialogflow CX API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "dialogflow-es": {
+        "description": "Cloud Dialogflow ES API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "discoveryengine": {
+        "description": "Discovery Engine API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "dlp": {
+        "description": "Cloud Data Loss Prevention (DLP) API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "documentai": {
+        "description": "Cloud Document AI API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "edgecontainer": {
+        "description": "Distributed Cloud Edge Container API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "edgenetwork": {
+        "description": "Distributed Cloud Edge Network API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "eventarc": {
+        "description": "Eventarc API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "experimental-storage-grpc": {
+        "description": "The GCS+gRPC plugin",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common",
+              "storage"
+            ]
+          }
+        ]
+      },
+      "filestore": {
+        "description": "Cloud Filestore API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "functions": {
+        "description": "Cloud Functions API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "gkehub": {
+        "description": "GKE Hub C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "gkemulticloud": {
+        "description": "Anthos Multi-Cloud C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "grafeas": {
+        "description": "Protocol buffers implementing the 'Grafeas API' (metadata about software artifacts)",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "grpc-common": {
+        "description": "Dependencies used by all gRPC-based libraries",
+        "dependencies": [
+          "grpc",
+          {
+            "name": "grpc",
+            "host": true
+          },
+          "protobuf",
+          {
+            "name": "protobuf",
+            "host": true
+          }
+        ]
+      },
+      "iam": {
+        "description": "The Google Cloud IAM C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "iap": {
+        "description": "Cloud Identity-Aware Proxy API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "ids": {
+        "description": "Cloud IDS API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "kms": {
+        "description": "Cloud Key Management Service (KMS) API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "language": {
+        "description": "Cloud Natural Language API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "logging": {
+        "description": "Google Cloud Logging C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "managedidentities": {
+        "description": "Managed Service for Microsoft Active Directory API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "memcache": {
+        "description": "Cloud Memorystore for Memcached API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "metastore": {
+        "description": "Dataproc Metastore API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "migrationcenter": {
+        "description": "Migration Center API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "monitoring": {
+        "description": "Cloud Monitoring API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "netapp": {
+        "description": "NetApp API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "networkconnectivity": {
+        "description": "Network Connectivity API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "networkmanagement": {
+        "description": "Network Management API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "networksecurity": {
+        "description": "Secure Web Proxy API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "notebooks": {
+        "description": "Notebooks API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "oauth2": {
+        "description": "OAuth2 Access Token Generation Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "rest-common"
+            ]
+          }
+        ]
+      },
+      "opentelemetry": {
+        "description": "OpenTelemetry C++ GCP Exporter Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "rest-common",
+              "trace"
+            ]
+          },
+          "opentelemetry-cpp"
+        ]
+      },
+      "optimization": {
+        "description": "Cloud Optimization API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "orgpolicy": {
+        "description": "Organization Policy API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "osconfig": {
+        "description": "Cloud OS Config API C++ Client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "oslogin": {
+        "description": "Cloud OS Login API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "policysimulator": {
+        "description": "Policy Simulator API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "policytroubleshooter": {
+        "description": "Policy Troubleshooter API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "privateca": {
+        "description": "Certificate Authority API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "profiler": {
+        "description": "Cloud Profiler API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "pubsub": {
+        "description": "The Google Cloud Bigtable C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "rapidmigrationassessment": {
+        "description": "Rapid Migration Assessment C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "recommender": {
+        "description": "Recommender C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "redis": {
+        "description": "Google Cloud Memorystore for Redis API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "resourcemanager": {
+        "description": "Cloud Resource Manager API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "resourcesettings": {
+        "description": "Resource Settings API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "rest-common": {
+        "description": "Dependencies used by all REST-based libraries",
+        "dependencies": [
+          {
+            "name": "curl",
+            "features": [
+              "ssl"
+            ]
+          },
+          "nlohmann-json"
+        ]
+      },
+      "retail": {
+        "description": "Retail API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "run": {
+        "description": "Cloud Run Admin API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "scheduler": {
+        "description": "Cloud Scheduler API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "secretmanager": {
+        "description": "The Google Cloud Secret Manager C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "securesourcemanager": {
+        "description": "Secure Source Manager API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "securitycenter": {
+        "description": "Security Command Center API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "servicecontrol": {
+        "description": "Service Control API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "servicedirectory": {
+        "description": "Service Directory API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "servicemanagement": {
+        "description": "Service Management API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "serviceusage": {
+        "description": "Service Usage API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "shell": {
+        "description": "Cloud Shell API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "spanner": {
+        "description": "The Google Cloud Spanner C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "speech": {
+        "description": "The Google Cloud Speech-to-Text C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "sql": {
+        "description": "The Google Cloud SQL Admin C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "rest-common"
+            ]
+          }
+        ]
+      },
+      "storage": {
+        "description": "The Google Cloud Storage C++ client library",
+        "dependencies": [
+          "crc32c",
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "rest-common"
+            ]
+          }
+        ]
+      },
+      "storageinsights": {
+        "description": "Storage Insights API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "storagetransfer": {
+        "description": "Storage Transfer API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "support": {
+        "description": "Cloud Support API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "talent": {
+        "description": "Cloud Talent Solution API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "tasks": {
+        "description": "The Google Cloud Tasks C++ client library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "telcoautomation": {
+        "description": "Cloud Telco Automation API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "texttospeech": {
+        "description": "Cloud Text-to-Speech API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "tpu": {
+        "description": "Cloud TPU API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "trace": {
+        "description": "Stackdriver Trace API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "translate": {
+        "description": "Cloud Translation API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "video": {
+        "description": "Video Services C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "videointelligence": {
+        "description": "Cloud Video Intelligence API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "vision": {
+        "description": "Cloud Vision API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "vmmigration": {
+        "description": "VM Migration API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "vmwareengine": {
+        "description": "VMware Engine API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "vpcaccess": {
+        "description": "Serverless VPC Access API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "webrisk": {
+        "description": "Web Risk API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "websecurityscanner": {
+        "description": "Web Security Scanner API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "workflows": {
+        "description": "Workflow Executions API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      },
+      "workstations": {
+        "description": "Workstations API C++ Client Library",
+        "dependencies": [
+          {
+            "name": "google-cloud-cpp",
+            "default-features": false,
+            "features": [
+              "grpc-common"
+            ]
+          }
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
Backport 4c768575cbfbd723d8b5fb67e10cec9da60e1598 from #5167.

---
TYPE: NO_HISTORY
