### PR TITLE
Rework query cancellation

### DIFF
--- a/test/src/unit-Reader.cc
+++ b/test/src/unit-Reader.cc
@@ -158,6 +158,7 @@ TEST_CASE_METHOD(
   uint64_t tmp_size = 0;
   Config config;
   Context context(config);
+  LocalQueryStateMachine lq_state_machine{LocalQueryState::uninitialized};
   std::unordered_map<std::string, tiledb::sm::QueryBuffer> buffers;
   buffers.emplace(
       "a", tiledb::sm::QueryBuffer(nullptr, nullptr, &tmp_size, &tmp_size));
@@ -173,7 +174,8 @@ TEST_CASE_METHOD(
       context.resources(),
       array.memory_tracker(),
       tracker_,
-      context.storage_manager(),
+      lq_state_machine,
+      CancellationSource(context.storage_manager()),
       array.opened_array(),
       config,
       nullopt,

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -2398,10 +2398,18 @@ TEST_CASE_METHOD(
   auto qc1 = create_qc("attr1", (int)2, QueryConditionOp::EQ);
   qc1.set_use_enumeration(false);
 
-  Query q1(ctx_.resources(), ctx_.storage_manager(), array);
+  Query q1(
+      ctx_.resources(),
+      ctx_.cancellation_source(),
+      ctx_.storage_manager(),
+      array);
   throw_if_not_ok(q1.set_condition(qc1));
 
-  Query q2(ctx_.resources(), ctx_.storage_manager(), array);
+  Query q2(
+      ctx_.resources(),
+      ctx_.cancellation_source(),
+      ctx_.storage_manager(),
+      array);
   ser_des_query(&q1, &q2, client_side, ser_type);
 
   auto qc2 = q2.condition();
@@ -2434,10 +2442,18 @@ TEST_CASE_METHOD(
 
   throw_if_not_ok(qc1.combine(qc2, QueryConditionCombinationOp::OR, &qc3));
 
-  Query q1(ctx_.resources(), ctx_.storage_manager(), array);
+  Query q1(
+      ctx_.resources(),
+      ctx_.cancellation_source(),
+      ctx_.storage_manager(),
+      array);
   throw_if_not_ok(q1.set_condition(qc3));
 
-  Query q2(ctx_.resources(), ctx_.storage_manager(), array);
+  Query q2(
+      ctx_.resources(),
+      ctx_.cancellation_source(),
+      ctx_.storage_manager(),
+      array);
   ser_des_query(&q1, &q2, client_side, ser_type);
 
   auto qc4 = q2.condition();

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -261,6 +261,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_condition.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_remote_buffer_storage.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/query_state.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/count_aggregator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/min_max_aggregator.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/query/readers/aggregators/operation.cc
@@ -301,6 +302,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/serialization/vacuum.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/global_stats.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/stats/stats.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/cancellation_source.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/context_resources.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/storage_manager/storage_manager.cc

--- a/tiledb/api/c_api/context/context_api_internal.h
+++ b/tiledb/api/c_api/context/context_api_internal.h
@@ -36,6 +36,7 @@
 #include "../../c_api_support/handle/handle.h"
 #include "../config/config_api_internal.h"
 #include "../error/error_api_internal.h"
+#include "tiledb/sm/storage_manager/cancellation_source.h"
 #include "tiledb/sm/storage_manager/context.h"
 
 struct tiledb_ctx_handle_t
@@ -69,6 +70,10 @@ struct tiledb_ctx_handle_t
 
   inline tiledb::sm::StorageManager* storage_manager() {
     return ctx_.storage_manager();
+  }
+
+  inline tiledb::sm::CancellationSource cancellation_source() {
+    return ctx_.cancellation_source();
   }
 
   inline optional<std::string> last_error() {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1028,7 +1028,10 @@ int32_t tiledb_query_alloc(
 
   // Create query
   (*query)->query_ = new (std::nothrow) tiledb::sm::Query(
-      ctx->resources(), ctx->storage_manager(), array->array_);
+      ctx->resources(),
+      ctx->cancellation_source(),
+      ctx->storage_manager(),
+      array->array_);
   if ((*query)->query_ == nullptr) {
     auto st = Status_Error(
         "Failed to allocate TileDB query object; Memory allocation failed");
@@ -3792,7 +3795,10 @@ int32_t tiledb_deserialize_query_and_array(
 
   // Create query
   (*query)->query_ = new (std::nothrow) tiledb::sm::Query(
-      ctx->resources(), ctx->storage_manager(), (*array)->array_);
+      ctx->resources(),
+      ctx->cancellation_source(),
+      ctx->storage_manager(),
+      (*array)->array_);
   if ((*query)->query_ == nullptr) {
     auto st = Status_Error(
         "Failed to allocate TileDB query object; Memory allocation failed");
@@ -4371,7 +4377,10 @@ capi_return_t tiledb_handle_query_plan_request(
   api::ensure_buffer_is_valid(response);
 
   tiledb::sm::Query query(
-      ctx->resources(), ctx->storage_manager(), array->array_);
+      ctx->resources(),
+      ctx->cancellation_source(),
+      ctx->storage_manager(),
+      array->array_);
   tiledb::sm::serialization::deserialize_query_plan_request(
       static_cast<tiledb::sm::SerializationType>(serialization_type),
       request->buffer(),

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -275,7 +275,10 @@ int32_t tiledb_filestore_uri_import(
       get_buffer_size_from_config(context.resources().config(), tile_extent);
 
   tiledb::sm::Query query(
-      context.resources(), context.storage_manager(), array);
+      context.resources(),
+      context.cancellation_source(),
+      context.storage_manager(),
+      array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::GLOBAL_ORDER));
   std::vector<std::byte> buffer(buffer_size);
 
@@ -298,7 +301,10 @@ int32_t tiledb_filestore_uri_import(
 
   auto tiledb_cloud_fix = [&](uint64_t start, uint64_t end) {
     tiledb::sm::Query query(
-        context.resources(), context.storage_manager(), array);
+        context.resources(),
+        context.cancellation_source(),
+        context.storage_manager(),
+        array);
     throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
     tiledb::sm::Subarray subarray_cloud_fix(
         array.get(), nullptr, context.resources().logger(), true);
@@ -432,7 +438,10 @@ int32_t tiledb_filestore_uri_export(
     subarray.add_range(0, std::move(subarray_range));
 
     tiledb::sm::Query query(
-        context.resources(), context.storage_manager(), array);
+        context.resources(),
+        context.cancellation_source(),
+        context.storage_manager(),
+        array);
     throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
     query.set_subarray(subarray);
 
@@ -536,7 +545,10 @@ int32_t tiledb_filestore_buffer_import(
       "");
 
   tiledb::sm::Query query(
-      context.resources(), context.storage_manager(), array);
+      context.resources(),
+      context.cancellation_source(),
+      context.storage_manager(),
+      array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
 
   tiledb::sm::Subarray subarray(
@@ -606,7 +618,10 @@ int32_t tiledb_filestore_buffer_export(
   subarray.add_range(0, std::move(subarray_range));
 
   tiledb::sm::Query query(
-      context.resources(), context.storage_manager(), array);
+      context.resources(),
+      context.cancellation_source(),
+      context.storage_manager(),
+      array);
   throw_if_not_ok(query.set_layout(tiledb::sm::Layout::ROW_MAJOR));
   query.set_subarray(subarray);
   uint64_t size_tmp = size;

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -670,6 +670,7 @@ Status FragmentConsolidator::create_queries(
   query_r = tdb_unique_ptr<Query>(tdb_new(
       Query,
       resources_,
+      CancellationSource(storage_manager_),
       storage_manager_,
       array_for_reads,
       nullopt,
@@ -701,6 +702,7 @@ Status FragmentConsolidator::create_queries(
   query_w = tdb_unique_ptr<Query>(tdb_new(
       Query,
       resources_,
+      CancellationSource(storage_manager_),
       storage_manager_,
       array_for_writes,
       fragment_name,

--- a/tiledb/sm/query/dimension_label/dimension_label_query.cc
+++ b/tiledb/sm/query/dimension_label/dimension_label_query.cc
@@ -58,7 +58,12 @@ DimensionLabelQuery::DimensionLabelQuery(
     const QueryBuffer& label_buffer,
     const QueryBuffer& index_buffer,
     optional<std::string> fragment_name)
-    : Query(resources, storage_manager, dim_label, fragment_name)
+    : Query(
+          resources,
+          CancellationSource(storage_manager),
+          storage_manager,
+          dim_label,
+          fragment_name)
     , dim_label_name_{dim_label_ref.name()} {
   switch (dim_label->get_query_type()) {
     case (QueryType::READ):
@@ -113,7 +118,12 @@ DimensionLabelQuery::DimensionLabelQuery(
     shared_ptr<Array> dim_label,
     const DimensionLabel& dim_label_ref,
     const std::vector<Range>& label_ranges)
-    : Query(resources, storage_manager, dim_label, nullopt)
+    : Query(
+          resources,
+          CancellationSource(storage_manager),
+          storage_manager,
+          dim_label,
+          nullopt)
     , dim_label_name_{dim_label_ref.name()}
     , index_data_{IndexDataCreate::make_index_data(
           array_schema().dimension_ptr(0)->type(),

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -83,6 +83,7 @@ static uint64_t get_effective_memory_budget(
 
 Query::Query(
     ContextResources& resources,
+    CancellationSource cancellation_source,
     StorageManager* storage_manager,
     shared_ptr<Array> array,
     optional<std::string> fragment_name,
@@ -105,6 +106,7 @@ Query::Query(
           (type_ == QueryType::READ || array_schema_->dense()) ?
               Layout::ROW_MAJOR :
               Layout::UNORDERED)
+    , cancellation_source_(cancellation_source)
     , storage_manager_(storage_manager)
     , dim_label_queries_(nullptr)
     , has_coords_buffer_(false)
@@ -764,9 +766,13 @@ const std::vector<UpdateValue>& Query::update_values() const {
   return update_values_;
 }
 
-Status Query::cancel() {
+void Query::cancel() {
+  local_state_machine_.event(LocalQueryEvent::cancel);
   status_ = QueryStatus::FAILED;
-  return Status::Ok();
+}
+
+bool Query::cancelled() {
+  return local_state_machine_.is_cancelled();
 }
 
 Status Query::process() {
@@ -1782,7 +1788,8 @@ Status Query::create_strategy(bool skip_checks_serialization) {
       resources_,
       array_->memory_tracker(),
       query_memory_tracker_,
-      storage_manager_,
+      local_state_machine_,
+      cancellation_source_,
       opened_array_,
       config_,
       memory_budget_,

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -49,12 +49,13 @@
 #include "tiledb/sm/query/query_buffer.h"
 #include "tiledb/sm/query/query_condition.h"
 #include "tiledb/sm/query/query_remote_buffer_storage.h"
+#include "tiledb/sm/query/query_state.h"
 #include "tiledb/sm/query/readers/aggregators/iaggregator.h"
 #include "tiledb/sm/query/readers/aggregators/query_channel.h"
 #include "tiledb/sm/query/update_value.h"
 #include "tiledb/sm/query/validity_vector.h"
 #include "tiledb/sm/rest/rest_client.h"
-#include "tiledb/sm/storage_manager/storage_manager_declaration.h"
+#include "tiledb/sm/storage_manager/cancellation_source.h"
 #include "tiledb/sm/subarray/subarray.h"
 
 using namespace tiledb::common;
@@ -138,15 +139,18 @@ class Query {
    * case the query will be used as writes and the given URI should be used
    * for the name of the new fragment to be created.
    *
-   * This is a transitional constructor in the sense that we are working
-   * on removing the dependency of the Query class on StorageManager.
-   * For now, we still need to keep the storage_manager argument, but once the
-   * dependency is gone, the signature will be
-   * Query(ContextResources&, shared_ptr<Array>, ...).
+   * @section Maturity
    *
-   * @note Array must be a properly opened array.
+   * This is a transitional constructor. There is still a `StorageManager`
+   * argument, and there is also a vestige of it with the `CancellationSource`
+   * argument. These argument now only pertain to job control of query with
+   * respect to its context. Once this facility is rewritten, these constructor
+   * argument may be dropped.
+   *
+   * @pre Array must be a properly opened array.
    *
    * @param resources The context resources.
+   * @param cancellation_source A source of external cancellation events
    * @param storage_manager Storage manager object.
    * @param array The array that is being queried.
    * @param fragment_uri The full URI for the new fragment. Only used for
@@ -158,6 +162,7 @@ class Query {
    */
   Query(
       ContextResources& resources,
+      CancellationSource cancellation_source,
       StorageManager* storage_manager,
       shared_ptr<Array> array,
       optional<std::string> fragment_name = nullopt,
@@ -314,12 +319,17 @@ class Query {
   QueryBuffer buffer(const std::string& name) const;
 
   /**
-   * Marks a query that has not yet been started as failed. This should not be
-   * called asynchronously to cancel an in-progress query; for that use the
-   * parent StorageManager's cancellation mechanism.
-   * @return Status
+   * Cancel a query.
+   *
+   * This does not immediately halt processing of a query, but does so at the
+   * first point where it checks in to see if it should continue processing.
    */
-  Status cancel();
+  void cancel();
+
+  /**
+   * Predicate function whether the query has been cancelled.
+   */
+  bool cancelled();
 
   /**
    * Finalizes the query, flushing all internal state.
@@ -933,6 +943,14 @@ class Query {
   /** The query memory tracker. */
   shared_ptr<MemoryTracker> query_memory_tracker_;
 
+  /**
+   * The state machine for processing local queries.
+   *
+   * At present this class combines both local and remote queries. This member
+   * variable is essentially unused for remote queries.
+   */
+  LocalQueryStateMachine local_state_machine_{LocalQueryState::uninitialized};
+
   /** A smart pointer to the array the query is associated with.
    * Ensures that the Array object exists as long as the Query object exists. */
   shared_ptr<Array> array_shared_;
@@ -969,6 +987,12 @@ class Query {
 
   /** The query status. */
   QueryStatus status_;
+
+  /**
+   * The cancellation source. This will be the last vestige of the storage
+   * manager.
+   */
+  CancellationSource cancellation_source_;
 
   /** The storage manager. */
   StorageManager* storage_manager_;

--- a/tiledb/sm/query/query_macros.h
+++ b/tiledb/sm/query/query_macros.h
@@ -42,14 +42,16 @@ namespace tiledb::sm {
  * Returns an error status if the given Status is not Status::Ok, or
  * if the StorageManager that owns this Query has requested cancellation.
  */
-#define RETURN_CANCEL_OR_ERROR(s)                              \
-  do {                                                         \
-    Status _s = (s);                                           \
-    if (!_s.ok()) {                                            \
-      return _s;                                               \
-    } else if (storage_manager_->cancellation_in_progress()) { \
-      return Status_QueryError("Query cancelled.");            \
-    }                                                          \
+#define RETURN_CANCEL_OR_ERROR(s)                   \
+  do {                                              \
+    Status _s = (s);                                \
+    if (!_s.ok()) {                                 \
+      return _s;                                    \
+    }                                               \
+    process_external_cancellation();                \
+    if (cancelled()) {                              \
+      return Status_QueryError("Query cancelled."); \
+    }                                               \
   } while (false)
 #endif
 
@@ -63,7 +65,9 @@ namespace tiledb::sm {
     Status _s = (s);                                                \
     if (!_s.ok()) {                                                 \
       return {_s, std::nullopt};                                    \
-    } else if (storage_manager_->cancellation_in_progress()) {      \
+    }                                                               \
+    process_external_cancellation();                                \
+    if (cancelled()) {                                              \
       return {Status_QueryError("Query cancelled."), std::nullopt}; \
     }                                                               \
   } while (false)

--- a/tiledb/sm/query/query_state.cc
+++ b/tiledb/sm/query/query_state.cc
@@ -1,0 +1,138 @@
+/**
+ * @file query_state.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a state machine for processing local queries.
+ */
+
+#include "query_state.h"
+
+#include "tiledb/common/exception/exception.h"
+
+namespace tiledb::sm {
+
+class QueryStateException : public tiledb::common::StatusException {
+ public:
+  QueryStateException(std::string_view s)
+      : StatusException("QueryState", std::string(s)) {
+  }
+};
+
+LocalQueryStateMachine::LocalQueryStateMachine(LocalQueryState s)
+    : state_(s) {
+  if (!is_initial()) {
+    throw QueryStateException("Argument is not an initial state");
+  }
+}
+
+/**
+ * A row in the transition table is a state indexed by events.
+ */
+using transition_table_row = LocalQueryState[n_local_query_events];
+/*
+ * A transition table is one row for each state.
+ */
+using transition_table = transition_table_row[n_local_query_states];
+
+using enum LocalQueryState;
+
+/**
+ * Transition table for `LocalQueryStateMachine`
+ */
+constexpr transition_table local_query_tt{
+    // uninitialized
+    {
+        everything_else,  // ready
+        success,    // finish. In due course this should be `error`, since it
+                    // should be impossible to complete a query without
+                    // initializing it.
+        aborted,    // abort,
+        cancelled,  // cancel
+    },
+    // everything_else
+    {
+        everything_else,  // ready
+        success,          // finish
+        aborted,          // abort,
+        cancelled,        // cancel
+    },
+    // success
+    {
+        success,  // ready
+        success,  // finish. Arguably this might be `error`, since it's already
+                  // finished once already.
+        error,    // abort. There should be no occasion where a successful query
+                  // aborts after completion.
+        success,  // cancel. Cancelling a successful query has no effect.
+                  // There's no longer any pending activity to cancel.
+    },
+    // aborted
+    {
+        aborted,  // ready
+        error,    // finish. It's an error to try to complete an aborted query.
+        aborted,  // abort. Self-transition is intentional
+        aborted,  // cancel. Cancelling an aborted query has no effect. There's
+                  // no longer any pending activity to cancel.
+    },
+    // cancelled
+    {
+        cancelled,  // ready
+        error,      // finish. You can't complete a cancelled query.
+        error,      // abort. A cancelled query shouldn't be doing anything that
+                    // would give rise to an `abort`.
+        cancelled,  // cancel
+    },
+    // error
+    {
+        error,  // ready
+        error,  // finish
+        error,  // abort,
+        error,  // cancel
+    },
+};
+
+/**
+ * @section Implementation Maturity
+ *
+ * This state machine at present is quite simple. All it does is to process the
+ * state transition. It does not have functions associated with events, nor with
+ * entering or leaving states. Such functions must be able to throw. The query
+ * processing code is not known to work correctly with exceptions in all cases,
+ * so such functions are currently not used.
+ */
+void LocalQueryStateMachine::event(LocalQueryEvent e) {
+  std::lock_guard<std::mutex> lg{m_};
+  state_ = local_query_tt[index_of(state_)][index_of(e)];
+}
+
+LocalQueryState LocalQueryStateMachine::state() const {
+  std::lock_guard<std::mutex> lg{m_};
+  return state_;
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/query_state.h
+++ b/tiledb/sm/query/query_state.h
@@ -1,0 +1,348 @@
+/**
+ * @file query_state.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares a state machine for processing local queries. This
+ * includes enumerations for the states and the events as well as the state
+ * machine class itself.
+ *
+ * @section Distinction between `LocalQueryState` and `QueryStatus`
+ *
+ * There are two basic distinctions
+ *   - `QueryStatus` is externally-visible, used for reporting summary status,
+ *     and `LocalQueryState` is internal-only, used for executing the query.
+ *   - `QueryStatus` applies to both local and remote queries. `LocalQueryState`
+ *     is only for local queries.
+ *
+ * As a point of development history, `QueryStatus` originally served both the
+ * internal implementation as well as the external interface. This was never a
+ * good idea, since externally-visible types are part of the API and should not
+ * change frequently. On the other hand, ordinary development periodically needs
+ * to change implementation details and should not be bound away from that
+ * because of a sticky API.
+ *
+ * Roughly speaking, there's a many-to-one relationship between internal states
+ * and external statuses. For example, there's only one "failed" status
+ * externally, but several possible internal states that map to "failed".
+ *
+ * @section State Machine
+ *
+ * This file contains a fully-encapsulated state machine that encapsulated the
+ * state. Direct assignment of the state is not possible; the state changes
+ * only as a result of events, which cause state transitions.
+ *
+ * @section C.41 concerns with `class Query`
+ *
+ * In the ideal world, `class Query` would be C.41 compliant and there would
+ * be a designated set of initial states depending on whether the query was new
+ * (never processed) or was resuming from suspension (in-progress but halted).
+ * This is not currently the case, so accommodations must be made. The
+ * accommodations take the form of additional mechanisms that supplement the
+ * ideal, rather than ones that require changing it. Thus we have the following
+ * design policy:
+ *   - All initial states for a C.41 compliant `class Query` are present in
+ *     the transitional state machine.
+ *   - `class QueryState` may only be constructed in an initial state.
+ *
+ * These are the accommodations:
+ *   - There is an additional event `ready`. The event does nothing on ordinary
+ *     states. Ordinary states are all those that will be present after C.41
+ *     compliance is achieved.
+ *   - There are extra states. Each initial state is doubled, representing a
+ *     fully-initialized state and a state that's not yet fully initialized.
+ *     - These not-fully-initialized states are not ordinary states, but they
+ *       are initial states.
+ *     - The `ready` event transitions a not-fully-initialized state to its
+ *       corresponding fully-initialized one.
+ *   - The assignment operator is defined. This is necessary as a transition
+ *     mechanism because at present initialization is done after construction.
+ *     There are no separate constructors at present for new vs. resumed
+ *     queries; once such constructors exist there will be no need for
+ *     assignment.
+ *
+ * By design, the `ready` event is redundant once C.41 compliance is achieved.
+ * As part of writing a C.41-compliant constructor, the ordinary initial state
+ * will be used directly; neither the extra, mirrored initial state will appear
+ * nor will assignment. Once `class Query` is entirely C.41 compliant, the
+ * `ready` event can be removed along with all the invocations of the event,
+ * as well as the extra states. At that point the assignment operator can be
+ * deleted.
+ *
+ * @section Maturity
+ *
+ * At present the state machine is incomplete. It's not yet complete enough
+ * even to properly have a map to externally-visible `QueryStatus`.
+ *
+ * The existing code in `class Query` is not yet ready to rely upon a state
+ * machine to manage its state; it will have to transition to it over time. The
+ * most glaring deficiency is that all the code does explicit state assignment.
+ * There is no notion of events or formal state transition.
+ *
+ * The current version of the state machine is written to support only a single
+ * purpose: to track the cancellation state of the query. At present the
+ * cancellation operation is inconsistent and unreliable. There are, indeed, two
+ * different kinds of cancellation that do not yield the same result.
+ *   - A function `Query::cancel`, which simply puts the query into the "failed"
+ *     status.
+ *   - A function `StorageManager::cancel_all_tasks`, which sets an internal
+ *     state retrievable through `StorageManager::cancellation_in_progress`.
+ * Cancellation processing happens through the macro `RETURN_CANCEL_OR_ERROR`,
+ * which internally calls `cancellation_in_progress`, which solely determines
+ * whether processing is interrupted. `RETURN_CANCEL_OR_ERROR` does not consult
+ * any local state, and thus `Query::cancel` cannot interrupt the processing of
+ * a query.
+ *
+ * Accordingly, with regard to cancellation, these are the immediate goals for
+ * the initial version of `class QueryState`:
+ *   - A sufficient number of states to distinguish between "cancelled" and
+ *     other states, to reject new operations on cancelled queries, and to
+ *     handle logic errors.
+ *   - A "cancel" event.
+ *   - A predicate function on the state that returns whether processing of a
+ *     query may proceed.
+ */
+
+#include <mutex>
+#include <type_traits>
+
+#ifndef TILEDB_QUERY_STATE_H
+#define TILEDB_QUERY_STATE_H
+
+namespace tiledb::sm {
+
+/**
+ * The set of life cycle states of a locally-processed query.
+ *
+ * Note that these states do not represent the states of a remotely-processed
+ * query.
+ *
+ * @section Initial States
+ *
+ * The only initial state at present is `uninitialized`. This name befits the
+ * C.41-noncompliance of the current `class Query`.
+ *
+ * @section Final States
+ *
+ * The final states follow the Tolstoy principle: "All happy families are alike;
+ * each unhappy family is unhappy in its own way." There is a single final state
+ * for a successfully completed query, and multiple final states for
+ * unsuccessful queries.
+ *
+ *   - Success. The query completed by returning all its results.
+ *     - `success`
+ *   - Failure. The query did not complete. If it returned partial results,
+ *     these results may or may not be all the results.
+ *     - External causes. These arise from causes external to the code.
+ *       - `aborted`: An error occurred because some external obstacle prevented
+ *         the query from completing successfully.
+ *       - `cancelled`: The query was directed to halt either by explicit
+ *         command, cancellation of all activity on a context, or shutdown of
+ *         the library
+ *     - Internal causes. These arise internally from a defect in the code.
+ *       - `error`. An event occurred in a state where it should not have
+ *         occurred.
+ *
+ * @section Maturity
+ *
+ * The current states do not make an attempt to model the full life cycle of
+ * a query.
+ */
+enum class LocalQueryState {
+  /**
+   * The state on construction of a C.41-noncompliant query object
+   *
+   * This is an initial state
+   */
+  uninitialized = 0,
+  /**
+   * All states not otherwise specified
+   */
+  everything_else,
+  /**
+   * The query has successfully completed and returned all its results.
+   *
+   * This is a final state.
+   */
+  success,
+  /**
+   * The query aborted during processing.
+   *
+   * This is a final state.
+   *
+   * The query need not have returned any results to enter this state. The
+   * "aborted" state represents external causes for failure to complete.
+   */
+  aborted,
+  /**
+   * The query was cancelled during processing, either directly or indirectly.
+   *
+   * This is a final state.
+   */
+  cancelled,
+  /**
+   * The query encountered a fault that caused the query to fail.
+   *
+   * This is a final state.
+   */
+  error
+};
+
+/**
+ * The number of local query states. This is the same as the number of
+ * enumeration constants defined in `LocalQueryState`.
+ */
+constexpr size_t n_local_query_states = 6;
+
+enum class LocalQueryEvent { ready, finish, abort, cancel };
+
+/**
+ * The number of local query states. This is the same as the number of
+ * enumeration constants defined in `LocalQueryState`.
+ */
+constexpr size_t n_local_query_events = 4;
+
+/**
+ * The state machine for local processing of queries.
+ *
+ * @section Design
+ *
+ * There is no way of manually changing states through assignment. The only way
+ * to get the state machine into a state is one of two ways:
+ *   - Construction of a state machine in a permissible initial state.
+ *   - Transitions in state caused by events.
+ */
+class LocalQueryStateMachine {
+  using enum LocalQueryState;
+  using enum LocalQueryEvent;
+
+  /**
+   * Mutex assure atomicity of state transition
+   *
+   * All accesses to `state`, even trivial ones, need to be serialized though
+   * the mutex.
+   */
+  mutable std::mutex m_{};
+
+  /**
+   * The current state of the machine.
+   */
+  LocalQueryState state_;
+
+  /**
+   * Conversion function from a query state to its integral representation
+   *
+   * This function is private because manipulation of the integers behind the
+   * state machine is solely the purview of the state machine. Outside code
+   * does not need this function, and if it thinks it does, it's defective.
+   */
+  static std::underlying_type_t<LocalQueryState> index_of(LocalQueryState s) {
+    return static_cast<std::underlying_type_t<LocalQueryState>>(s);
+  }
+
+  static std::underlying_type_t<LocalQueryEvent> index_of(LocalQueryEvent e) {
+    return static_cast<std::underlying_type_t<LocalQueryEvent>>(e);
+  }
+
+  /**
+   * The predicate function `is_initial` represented as an array.
+   */
+  static constexpr bool initials_[n_local_query_states]{
+      true, false, false, false, false, false};
+
+  /**
+   * The predicate function `is_final` represented as an array.
+   */
+  static constexpr bool finals_[n_local_query_states]{
+      false, false, true, true, true, true};
+
+ public:
+  /**
+   * The default constructor is deleted.
+   *
+   * Deleting this constructor is a design choice. We do not yet, but will need
+   * to, constructor objects in different initial states depending on whether
+   * they're new queries or queries resuming from suspension.
+   *
+   * @section Maturity
+   *
+   * There is only a single initial state at present. That's not a good argument
+   * for defining a default constructor. There will be multiple initial states;
+   * there's no need for self-inflicted harm by writing code known to need to
+   * change.
+   */
+  LocalQueryStateMachine() = delete;
+
+  /**
+   * Ordinary constructor at a given initial state.
+   */
+  LocalQueryStateMachine(LocalQueryState s);
+
+  /**
+   * Process an event on the state machine.
+   *
+   * @section Design
+   *
+   * This function is _not_ declared `noexcept`. At present, the implementation
+   * does not generate exceptions, but in the future it will. In particular,
+   * entering the `error` state (or self-transitioning in it) will throw an
+   * exception.
+   *
+   * @param e The event that will trigger a transition.
+   */
+  void event(LocalQueryEvent e);
+
+  /**
+   * Accessor for the internal state
+   */
+  LocalQueryState state() const;
+
+  /**
+   * Predicate that the machine is in an initial state
+   */
+  bool is_initial() const {
+    return initials_[index_of(state())];
+  }
+
+  /**
+   * Predicate that the machine is in a final state
+   */
+  bool is_final() const {
+    return finals_[index_of(state())];
+  }
+
+  /**
+   * Predicate that the machine is in a cancelled state
+   */
+  bool is_cancelled() const {
+    return state() == cancelled;
+  }
+};
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_QUERY_STATE_H

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -496,7 +496,7 @@ void ReaderBase::load_processed_conditions() {
 
 Status ReaderBase::read_and_unfilter_attribute_tiles(
     const std::vector<NameToLoad>& names,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<ResultTile*>& result_tiles) {
   // The filtered data here contains the memory allocations for all of the
   // filtered data that is read by `read_attribute_tiles`. To prevent
   // modifications to the filter pipeline at the moment, the `result_tiles`
@@ -523,7 +523,7 @@ Status ReaderBase::read_and_unfilter_attribute_tiles(
 
 Status ReaderBase::read_and_unfilter_coordinate_tiles(
     const std::vector<std::string>& names,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<ResultTile*>& result_tiles) {
   // See the comment in 'read_and_unfilter_attribute_tiles' to get more
   // information about the lifetime of this object.
   auto filtered_data{read_coordinate_tiles(names, result_tiles)};
@@ -767,7 +767,7 @@ Status ReaderBase::post_process_unfiltered_tile(
 Status ReaderBase::unfilter_tiles(
     const std::string& name,
     const bool validity_only,
-    const std::vector<ResultTile*>& result_tiles) const {
+    const std::vector<ResultTile*>& result_tiles) {
   const auto stat_type = (array_schema_.is_attr(name)) ? "unfilter_attr_tiles" :
                                                          "unfilter_coord_tiles";
 

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -508,7 +508,7 @@ class ReaderBase : public StrategyBase {
    */
   Status read_and_unfilter_attribute_tiles(
       const std::vector<NameToLoad>& names,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>& result_tiles);
 
   /**
    * Read and unfilter coordinate tiles.
@@ -520,7 +520,7 @@ class ReaderBase : public StrategyBase {
    */
   Status read_and_unfilter_coordinate_tiles(
       const std::vector<std::string>& names,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>& result_tiles);
 
   /**
    * Concurrently executes across each name in `names` and each result tile
@@ -583,7 +583,7 @@ class ReaderBase : public StrategyBase {
   Status unfilter_tiles(
       const std::string& name,
       const bool validity_only,
-      const std::vector<ResultTile*>& result_tiles) const;
+      const std::vector<ResultTile*>& result_tiles);
 
   /**
    * Unfilter a specific range of chunks in tile

--- a/tiledb/sm/query/strategy_base.h
+++ b/tiledb/sm/query/strategy_base.h
@@ -37,8 +37,8 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/storage_manager/cancellation_source.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
-#include "tiledb/sm/storage_manager/storage_manager.h"
 
 namespace tiledb::sm {
 
@@ -46,6 +46,7 @@ class OpenedArray;
 class ArraySchema;
 class IAggregator;
 enum class Layout : uint8_t;
+class LocalQueryStateMachine;
 class MemoryTracker;
 class Subarray;
 class QueryBuffer;
@@ -68,7 +69,8 @@ class StrategyParams {
       ContextResources& resources,
       shared_ptr<MemoryTracker> array_memory_tracker,
       shared_ptr<MemoryTracker> query_memory_tracker,
-      StorageManager* storage_manager,
+      LocalQueryStateMachine& query_state_machine,
+      CancellationSource cancellation_source,
       shared_ptr<OpenedArray> array,
       Config& config,
       optional<uint64_t> memory_budget,
@@ -82,7 +84,8 @@ class StrategyParams {
       : resources_(resources)
       , array_memory_tracker_(array_memory_tracker)
       , query_memory_tracker_(query_memory_tracker)
-      , storage_manager_(storage_manager)
+      , query_state_machine_(query_state_machine)
+      , cancellation_source_(cancellation_source)
       , array_(array)
       , config_(config)
       , memory_budget_(memory_budget)
@@ -115,10 +118,13 @@ class StrategyParams {
     return query_memory_tracker_;
   }
 
-  /** Return the storage manager. */
-  inline StorageManager* storage_manager() {
-    return storage_manager_;
-  };
+  inline LocalQueryStateMachine& query_state_machine() const {
+    return query_state_machine_;
+  }
+
+  inline CancellationSource cancellation_source() const {
+    return cancellation_source_;
+  }
 
   /** Return the array. */
   inline shared_ptr<OpenedArray> array() {
@@ -184,8 +190,11 @@ class StrategyParams {
   /** Query Memory tracker. */
   shared_ptr<MemoryTracker> query_memory_tracker_;
 
-  /** Storage manager. */
-  StorageManager* storage_manager_;
+  /** Query state machine */
+  LocalQueryStateMachine& query_state_machine_;
+
+  /** Cancellation source */
+  CancellationSource cancellation_source_;
 
   /** Array. */
   shared_ptr<OpenedArray> array_;
@@ -270,6 +279,11 @@ class StrategyBase {
   /** Sets the bitsize of offsets */
   Status set_offsets_bitsize(const uint32_t bitsize);
 
+  /**
+   * Cancel any ongoing processing at the next opportunity.
+   */
+  void cancel();
+
  protected:
   /* ********************************* */
   /*        PROTECTED ATTRIBUTES       */
@@ -312,8 +326,36 @@ class StrategyBase {
   /** The layout of the cells in the result of the subarray. */
   Layout layout_;
 
-  /** The storage manager. */
-  StorageManager* storage_manager_;
+  /**
+   * State machine of the query that under which this strategy is executing.
+   *
+   * Execution of query operation may be interrupted by asynchronous events that
+   * are tracked through the state machine. Operations should poll the state
+   * machine periodically and cease processing if the query has been cancelled,
+   * for example, or is otherwise not in a state where processing should
+   * proceed.
+   *
+   * @section Maturity
+   *
+   * At present the state machine cannot be declared `const` because the
+   * cancellation event must be generated at the same point where the
+   * cancellation source is checked. When the cancellation source goes away,
+   * query code will only need to check the state and will no longer need to
+   * generate events.
+   */
+  LocalQueryStateMachine& query_state_machine_;
+
+  /**
+   * The source for external cancellation events.
+   *
+   * @section Maturity
+   *
+   * This is a transitional member variable. It's required at present because
+   * the presence of a cancellation is held at the context level and must be
+   * polled for. When cancellation is pushed down from the top, there will no
+   * longer be a need for this variable.
+   */
+  CancellationSource cancellation_source_;
 
   /** The query subarray (initially the whole domain by default). */
   Subarray& subarray_;
@@ -344,6 +386,19 @@ class StrategyBase {
    * Throws an exception if the query is cancelled.
    */
   void throw_if_cancelled() const;
+
+  /**
+   * Predicate function whether the query has been cancelled.
+   */
+  bool cancelled() const;
+
+  /**
+   * Process any pending external cancellation order.
+   *
+   * If there's a pending external cancellation, this function generates a
+   * `cancel` event on the local state machine of the query being processed.
+   */
+  void process_external_cancellation();
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/storage_manager/cancellation_source.cc
+++ b/tiledb/sm/storage_manager/cancellation_source.cc
@@ -1,0 +1,50 @@
+/**
+ * @file cancellation_source.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines `class CancellationSource`.
+ */
+
+#include "cancellation_source.h"
+#include "storage_manager.h"
+
+namespace tiledb::sm {
+
+CancellationSource::CancellationSource(const StorageManager* sm)
+    : sm_(sm) {
+  if (sm_ == nullptr) {
+    throw std::invalid_argument(
+        "[CancellationSource] StorageManager argument may not be null");
+  }
+}
+
+bool CancellationSource::cancellation_in_progress() const {
+  return sm_->cancellation_in_progress();
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/storage_manager/cancellation_source.h
+++ b/tiledb/sm/storage_manager/cancellation_source.h
@@ -1,0 +1,54 @@
+/**
+ * @file cancellation_source
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares `class CancellationSource`.
+ */
+
+#ifndef TILEDB_CANCELLATION_SOURCE_H
+#define TILEDB_CANCELLATION_SOURCE_H
+
+#include "storage_manager_declaration.h"
+
+namespace tiledb::sm {
+
+/**
+ * The cancellation source is, at present, a wrapper around `StorageManager`
+ * with a very restricted interface.
+ */
+class CancellationSource {
+  const StorageManager* sm_;
+
+ public:
+  CancellationSource(const StorageManager* sm);
+
+  bool cancellation_in_progress() const;
+};
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_CANCELLATION_SOURCE_H

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -37,6 +37,7 @@
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/stats/global_stats.h"
+#include "tiledb/sm/storage_manager/cancellation_source.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 
@@ -101,6 +102,10 @@ class Context {
   /** Pointer to the underlying storage manager. */
   inline const StorageManager* storage_manager() const {
     return &storage_manager_;
+  }
+
+  inline CancellationSource cancellation_source() const {
+    return CancellationSource(storage_manager());
   }
 
   [[nodiscard]] inline ContextResources& resources() const {

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -143,7 +143,7 @@ Status StorageManagerCanonical::async_push_query(Query* query) {
         // Task was cancelled. This is safe to perform in a separate thread,
         // as we are guaranteed by the thread pool not to have entered
         // query->process() yet.
-        throw_if_not_ok(query->cancel());
+        query->cancel();
       });
 
   return Status::Ok();
@@ -177,7 +177,7 @@ Status StorageManagerCanonical::cancel_all_tasks() {
   return Status::Ok();
 }
 
-bool StorageManagerCanonical::cancellation_in_progress() {
+bool StorageManagerCanonical::cancellation_in_progress() const {
   std::unique_lock<std::mutex> lck(cancellation_in_progress_mtx_);
   return cancellation_in_progress_;
 }

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -122,7 +122,7 @@ class StorageManagerCanonical {
   Status cancel_all_tasks();
 
   /** Returns true while all tasks are being cancelled. */
-  bool cancellation_in_progress();
+  bool cancellation_in_progress() const;
 
   /** Returns the current map of any set tags. */
   const std::unordered_map<std::string, std::string>& tags() const;
@@ -202,7 +202,7 @@ class StorageManagerCanonical {
   bool cancellation_in_progress_;
 
   /** Mutex protecting cancellation_in_progress_. */
-  std::mutex cancellation_in_progress_mtx_;
+  mutable std::mutex cancellation_in_progress_mtx_;
 
   /** Stores the TileDB configuration parameters. */
   Config config_;


### PR DESCRIPTION
This PR begins the process of rationalizing the cancellation system for queries. The current system only has cancellation at the context level; this PR gives `class Query` its own cancellation state. The context-level cancellation is now encapsulated in `class CancellationSource`, which in this PR this is simply a restricted facade around `StorageManager`. `CancellationSource` is intended as a transient class, to be eliminated once cancellation orders at the context level propagates downward to individual queries.

---
TYPE: NO_HISTORY
DESC: Rework query cancellation
