### PR TITLE
Add documentation for the `ssl.*` config options.

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -324,6 +324,24 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    If `true` tile offsets can be partially loaded and unloaded by the
  *    readers. <br>
  *    **Default**: false
+ * - `ssl.ca_file` <br>
+ *    The path to CA certificate to use when validating server certificates.
+ *    Applies to all SSL/TLS connections. <br>
+ *    This option might be ignored on platforms that have native certificate
+ *    stores like Windows. <br>
+ *    **Default**: ""
+ * - `ssl.ca_path` <br>
+ *    The path to a directory with CA certificates to use when validating
+ *    server certificates. Applies to all SSL/TLS connections. <br>
+ *    This option might be ignored on platforms that have native certificate
+ *    stores like Windows. <br>
+ *    **Default**: ""
+ * - `ssl.verify` <br>
+ *    Whether to verify the server's certificate. Applies to all SSL/TLS
+ *    connections. <br>
+ *    Disabling verification is insecure and should only used for testing
+ *    purposes. <br>
+ *    **Default**: true
  * - `vfs.read_ahead_cache_size` <br>
  *    The the total maximum size of the read-ahead cache, which is an LRU. <br>
  *    **Default**: 10485760

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -498,6 +498,24 @@ class Config {
    *    If `true` tile offsets can be partially loaded and unloaded by the
    *    readers. <br>
    *    **Default**: false
+   * - `ssl.ca_file` <br>
+   *    The path to CA certificate to use when validating server certificates.
+   *    Applies to all SSL/TLS connections. <br>
+   *    This option might be ignored on platforms that have native certificate
+   *    stores like Windows. <br>
+   *    **Default**: ""
+   * - `ssl.ca_path` <br>
+   *    The path to a directory with CA certificates to use when validating
+   *    server certificates. Applies to all SSL/TLS connections. <br>
+   *    This option might be ignored on platforms that have native certificate
+   *    stores like Windows. <br>
+   *    **Default**: ""
+   * - `ssl.verify` <br>
+   *    Whether to verify the server's certificate. Applies to all SSL/TLS
+   *    connections. <br>
+   *    Disabling verification is insecure and should only used for testing
+   *    purposes. <br>
+   *    **Default**: true
    * -  `vfs.read_ahead_cache_size` <br>
    *    The the total maximum size of the read-ahead cache, which is an LRU.
    *    <br>


### PR DESCRIPTION
[SC-50966](https://app.shortcut.com/tiledb-inc/story/50966/document-ssl-config-options)

This adds documentation for the ssl certificate options that was previously undocumented.

---
TYPE: NO_HISTORY