### PR TITLE
Stop recognizing `sm.use_refactored_readers` config option.

### DIFF
--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1697,20 +1697,9 @@ bool Query::use_refactored_dense_reader(
     return false;
   }
 
-  // First check for legacy option
-  throw_if_not_ok(config_.get<bool>(
-      "sm.use_refactored_readers", &use_refactored_reader, &found));
-  // If the legacy/deprecated option is set use it over the new parameters
-  // This facilitates backwards compatibility
-  if (found) {
-    logger_->warn(
-        "sm.use_refactored_readers config option is deprecated.\nPlease use "
-        "'sm.query.dense.reader' with value of 'refactored' or 'legacy'");
-  } else {
-    const std::string& val = config_.get("sm.query.dense.reader", &found);
-    assert(found);
-    use_refactored_reader = val == "refactored";
-  }
+  const std::string& val = config_.get("sm.query.dense.reader", &found);
+  assert(found);
+  use_refactored_reader = val == "refactored";
 
   return use_refactored_reader && array_schema.dense() && all_dense;
 }
@@ -1725,22 +1714,10 @@ bool Query::use_refactored_sparse_global_order_reader(
     return false;
   }
 
-  // First check for legacy option
-  throw_if_not_ok(config_.get<bool>(
-      "sm.use_refactored_readers", &use_refactored_reader, &found));
-  // If the legacy/deprecated option is set use it over the new parameters
-  // This facilitates backwards compatibility
-  if (found) {
-    logger_->warn(
-        "sm.use_refactored_readers config option is deprecated.\nPlease use "
-        "'sm.query.sparse_global_order.reader' with value of 'refactored' or "
-        "'legacy'");
-  } else {
-    const std::string& val =
-        config_.get("sm.query.sparse_global_order.reader", &found);
-    assert(found);
-    use_refactored_reader = val == "refactored";
-  }
+  const std::string& val =
+      config_.get("sm.query.sparse_global_order.reader", &found);
+  assert(found);
+  use_refactored_reader = val == "refactored";
   return use_refactored_reader && !array_schema.dense() &&
          (layout == Layout::GLOBAL_ORDER || layout == Layout::UNORDERED);
 }
@@ -1755,22 +1732,10 @@ bool Query::use_refactored_sparse_unordered_with_dups_reader(
     return false;
   }
 
-  // First check for legacy option
-  throw_if_not_ok(config_.get<bool>(
-      "sm.use_refactored_readers", &use_refactored_reader, &found));
-  // If the legacy/deprecated option is set use it over the new parameters
-  // This facilitates backwards compatibility
-  if (found) {
-    logger_->warn(
-        "sm.use_refactored_readers config option is deprecated.\nPlease use "
-        "'sm.query.sparse_unordered_with_dups.reader' with value of "
-        "'refactored' or 'legacy'");
-  } else {
-    const std::string& val =
-        config_.get("sm.query.sparse_unordered_with_dups.reader", &found);
-    assert(found);
-    use_refactored_reader = val == "refactored";
-  }
+  const std::string& val =
+      config_.get("sm.query.sparse_unordered_with_dups.reader", &found);
+  assert(found);
+  use_refactored_reader = val == "refactored";
 
   return use_refactored_reader && !array_schema.dense() &&
          layout == Layout::UNORDERED && array_schema.allows_dups();

--- a/tiledb/sm/serialization/config.cc
+++ b/tiledb/sm/serialization/config.cc
@@ -84,8 +84,7 @@ Status config_from_capnp(
       auto key = std::string_view{kv.getKey().cStr(), kv.getKey().size()};
       auto value = std::string_view{kv.getValue().cStr(), kv.getValue().size()};
       RETURN_NOT_OK((*config)->set(std::string{key}, std::string{value}));
-      if (key == "sm.use_refactored_readers" ||
-          key == "sm.query.dense.reader" ||
+      if (key == "sm.query.dense.reader" ||
           key == "sm.query.sparse_global_order.reader" ||
           key == "sm.query.sparse_unordered_with_dups.reader")
         found_refactored_reader_config = true;


### PR DESCRIPTION
[SC-50445](https://app.shortcut.com/tiledb-inc/story/50445/remove-sm-use-refactored-readers-config-option)

This option has been deprecated and undocumented for a while and a warning was emitted if it is used. This PR removes all mentions of it from the codebase.

---
TYPE: CONFIG
DESC: The `sm.use_refactored_readers` config option is no longer recognized. Refactored readers are used by default. To use the legacy reader, set the `sm.query_(dense|sparse_global_order|sparse_unordered_with_dups)_reader` config option (depending on the reader you are using) to `legacy`.