### PR TITLE
Improvements in the `tiledb::sm::Range` class.

### DIFF
--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -163,8 +163,8 @@ class Range {
 
   /** Constructs a range and sets variable data. */
   Range(
-      const std::string_view& s1,
-      const std::string_view& s2,
+      const std::string_view s1,
+      const std::string_view s2,
       const allocator_type& alloc = {})
       : Range(alloc) {
     set_str_range(s1, s2);
@@ -243,7 +243,7 @@ class Range {
   }
 
   /** Sets a string range. */
-  void set_str_range(const std::string_view& s1, const std::string_view& s2) {
+  void set_str_range(const std::string_view s1, const std::string_view s2) {
     auto size = s1.size() + s2.size();
     if (size == 0) {
       range_.clear();

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -451,42 +451,52 @@ Status check_range_is_subset(const Range& superset, const Range& range) {
  *
  * @param range The range to check.
  */
-template <
-    typename T,
-    typename std::enable_if_t<
-        std::is_arithmetic_v<T> || std::is_same_v<T, std::string_view>>* =
-        nullptr>
-void check_range_is_valid(const Range& range) {
+template <class T>
+void check_range_is_valid(const Range& range)
+  requires(std::is_arithmetic_v<T>)
+{
   // Check has data.
   if (range.empty())
     throw std::invalid_argument("Range is empty");
 
-  // Compare string views
-  if constexpr (std::is_same_v<T, std::string_view>) {
-    auto start = range.start_str();
-    auto end = range.end_str();
-    // Check range bounds
-    if (start > end)
-      throw std::invalid_argument(
-          "Lower range bound " + std::string(start) +
-          " cannot be larger than the higher bound " + std::string(end));
-  } else {
-    if (range.size() != 2 * sizeof(T))
-      throw std::invalid_argument(
-          "Range size " + std::to_string(range.size()) +
-          " does not match the expected size " + std::to_string(2 * sizeof(T)));
-    auto r = (const T*)range.data();
-    // Check for NaN
-    if constexpr (std::is_floating_point_v<T>) {
-      if (std::isnan(r[0]) || std::isnan(r[1]))
-        throw std::invalid_argument("Range contains NaN");
-    }
-    // Check range bounds
-    if (r[0] > r[1])
-      throw std::invalid_argument(
-          "Lower range bound " + std::to_string(r[0]) +
-          " cannot be larger than the higher bound " + std::to_string(r[1]));
+  if (range.size() != 2 * sizeof(T))
+    throw std::invalid_argument(
+        "Range size " + std::to_string(range.size()) +
+        " does not match the expected size " + std::to_string(2 * sizeof(T)));
+  auto r = (const T*)range.data();
+  // Check for NaN
+  if constexpr (std::is_floating_point_v<T>) {
+    if (std::isnan(r[0]) || std::isnan(r[1]))
+      throw std::invalid_argument("Range contains NaN");
   }
+  // Check range bounds
+  if (r[0] > r[1])
+    throw std::invalid_argument(
+        "Lower range bound " + std::to_string(r[0]) +
+        " cannot be larger than the higher bound " + std::to_string(r[1]));
+};
+
+/**
+ * Performs correctness checks for a valid range. If any validity checks fail
+ * an exception is thrown.
+ *
+ * @param range The range to check.
+ */
+template <class T>
+void check_range_is_valid(const Range& range)
+  requires(std::same_as<T, std::string_view>)
+{
+  // Check has data.
+  if (range.empty())
+    throw std::invalid_argument("Range is empty");
+
+  auto start = range.start_str();
+  auto end = range.end_str();
+  // Check range bounds
+  if (start > end)
+    throw std::invalid_argument(
+        "Lower range bound " + std::string(start) +
+        " cannot be larger than the higher bound " + std::string(end));
 };
 
 /**

--- a/tiledb/type/range/range.h
+++ b/tiledb/type/range/range.h
@@ -163,8 +163,8 @@ class Range {
 
   /** Constructs a range and sets variable data. */
   Range(
-      const std::string& s1,
-      const std::string& s2,
+      const std::string_view& s1,
+      const std::string_view& s2,
       const allocator_type& alloc = {})
       : Range(alloc) {
     set_str_range(s1, s2);
@@ -179,6 +179,7 @@ class Range {
    */
   template <class T>
   Range(Tag<T>, T first, T second, const allocator_type& alloc = {})
+    requires(std::is_arithmetic_v<T>)
       : Range(2 * sizeof(T), alloc) {
     auto d{reinterpret_cast<T*>(range_.data())};
     d[0] = first;
@@ -242,7 +243,7 @@ class Range {
   }
 
   /** Sets a string range. */
-  void set_str_range(const std::string& s1, const std::string& s2) {
+  void set_str_range(const std::string_view& s1, const std::string_view& s2) {
     auto size = s1.size() + s2.size();
     if (size == 0) {
       range_.clear();

--- a/tiledb/type/range/test/unit_check_range_is_valid.cc
+++ b/tiledb/type/range/test/unit_check_range_is_valid.cc
@@ -173,3 +173,22 @@ TEMPLATE_TEST_CASE(
     REQUIRE_THROWS(check_range_is_valid<TestType>(range));
   }
 }
+
+TEST_CASE("RangeOperations: Test is_valid_range for string_view", "[range]") {
+  SECTION("Test single point range is valid") {
+    Range range{"a", "a"};
+    REQUIRE_NOTHROW(check_range_is_valid<std::string_view>(range));
+  }
+  SECTION("Test standard range is valid") {
+    Range range{"abc", "def"};
+    REQUIRE_NOTHROW(check_range_is_valid<std::string_view>(range));
+  }
+  SECTION("Test empty range is invalid") {
+    Range range;
+    REQUIRE_THROWS(check_range_is_valid<std::string_view>(range));
+  }
+  SECTION("Test lower bound larger than upper bound is invalid") {
+    Range range{"def", "abc"};
+    REQUIRE_THROWS(check_range_is_valid<std::string_view>(range));
+  }
+}


### PR DESCRIPTION
[SC-50345](https://app.shortcut.com/tiledb-inc/story/50345/improvements-in-the-tiledb-sm-range-class)

This PR:

* Decomposes `check_range_is_valid` into two functions, for fixed-size and variable-size ranges. We use C++ 20's `requires()` to make sure the two functions don't collide. (https://github.com/TileDB-Inc/TileDB/pull/5144#discussion_r1665784869)
* Restricts the template argument in the fixed-size constructor of `Range` to be an arithmetic type, and updates the variable-size constructor to accept `string_view` instead of `string` (we don't actually need to accept strings, and matches what the `start_str()` and `end_str()` functions return).
* Adds test coverage for variable-size ranges in `unit_check_range_is_valid.cc`.

---
TYPE: NO_HISTORY