### PR TITLE
Add memory tracking for `DenseTileSubarray`.

### DIFF
--- a/tiledb/common/memory_tracker.cc
+++ b/tiledb/common/memory_tracker.cc
@@ -54,6 +54,8 @@ std::string memory_type_to_str(MemoryType type) {
       return "Attributes";
     case MemoryType::CONSOLIDATION_BUFFERS:
       return "ConsolidationBuffers";
+    case MemoryType::DENSE_TILE_SUBARRAY:
+      return "DenseTileSubarray";
     case MemoryType::DIMENSION_LABELS:
       return "DimensionLabels";
     case MemoryType::DIMENSIONS:

--- a/tiledb/common/memory_tracker.h
+++ b/tiledb/common/memory_tracker.h
@@ -110,6 +110,7 @@ namespace tiledb::sm {
 enum class MemoryType {
   ATTRIBUTES,
   CONSOLIDATION_BUFFERS,
+  DENSE_TILE_SUBARRAY,
   DIMENSION_LABELS,
   DIMENSIONS,
   DOMAINS,

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -388,7 +388,8 @@ Status DenseReader::dense_read() {
             subarray,
             t_start,
             t_end,
-            std::move(result_space_tiles));
+            std::move(result_space_tiles),
+            *query_memory_tracker_);
 
     // Add the number of cells to process to subarray_end_cell.
     for (uint64_t t = t_start; t < t_end; t++) {

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -36,6 +36,7 @@
 #include <atomic>
 
 #include "tiledb/common/common.h"
+#include "tiledb/common/pmr.h"
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/misc/types.h"
@@ -68,10 +69,14 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
         Subarray& subarray,
         uint64_t t_start,
         uint64_t t_end,
-        std::map<const DimType*, ResultSpaceTile<DimType>>&& result_space_tiles)
+        std::map<const DimType*, ResultSpaceTile<DimType>>&& result_space_tiles,
+        MemoryTracker& memory_tracker)
         : t_start_(t_start)
         , t_end_(t_end)
-        , tile_subarrays_(t_end - t_start, subarray.dim_num())
+        , tile_subarrays_(
+              t_end - t_start,
+              subarray.dim_num(),
+              memory_tracker.get_resource(MemoryType::DENSE_TILE_SUBARRAY))
         , result_space_tiles_(std::move(result_space_tiles)) {
       auto& tile_coords = subarray.tile_coords();
       throw_if_not_ok(
@@ -123,7 +128,7 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
     uint64_t t_end_;
 
     /** Tile subarrays. */
-    std::vector<DenseTileSubarray<DimType>> tile_subarrays_;
+    tdb::pmr::vector<DenseTileSubarray<DimType>> tile_subarrays_;
 
     /** Result space tiles. */
     std::map<const DimType*, ResultSpaceTile<DimType>> result_space_tiles_;

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -36,6 +36,7 @@
 #include <atomic>
 
 #include "tiledb/common/common.h"
+#include "tiledb/common/pmr.h"
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/config/config.h"
@@ -117,32 +118,65 @@ class DenseTileSubarray {
     }
   };
 
+  /** The type of the allocator. Required to make the type allocator-aware.
+   *
+   * uint8_t was arbitrarily chosen and does not matter; allocators can convert
+   * between any types.
+   */
+  using allocator_type = tdb::pmr::polymorphic_allocator<uint8_t>;
+
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
   DenseTileSubarray() = delete;
 
-  DenseTileSubarray(unsigned dim_num)
-      : ranges_(dim_num) {
+  DenseTileSubarray(unsigned dim_num, const allocator_type& alloc = {})
+      : original_range_idx_(alloc)
+      , ranges_(dim_num, alloc) {
   }
+
+  /** Default copy constructor. */
+  DenseTileSubarray(const DenseTileSubarray&) = default;
+  /** Default move constructor. */
+  DenseTileSubarray(DenseTileSubarray&&) = default;
+
+  /** Allocator-aware copy constructor. */
+  DenseTileSubarray(const DenseTileSubarray& other, const allocator_type& alloc)
+      : original_range_idx_(other.original_range_idx_, alloc)
+      , ranges_(other.ranges_, alloc) {
+  }
+
+  /** Allocator-aware move constructor. */
+  DenseTileSubarray(DenseTileSubarray&& other, const allocator_type& alloc)
+      : original_range_idx_(std::move(other.original_range_idx_), alloc)
+      , ranges_(std::move(other.ranges_), alloc) {
+  }
+
+  /** Default copy-assign operator. */
+  DenseTileSubarray& operator=(const DenseTileSubarray&) = default;
+  /** Default move-assign operator. */
+  DenseTileSubarray& operator=(DenseTileSubarray&&) = default;
 
   /* ********************************* */
   /*                 API               */
   /* ********************************* */
 
   /** Returns the orignal range indexes. */
-  inline const std::vector<std::vector<uint64_t>>& original_range_idx() const {
+  inline const tdb::pmr::vector<tdb::pmr::vector<uint64_t>>&
+  original_range_idx() const {
     return original_range_idx_;
   }
 
   /** Returns the ranges. */
-  inline const std::vector<std::vector<DenseTileRange>>& ranges() const {
+  inline const tdb::pmr::vector<tdb::pmr::vector<DenseTileRange>>& ranges()
+      const {
     return ranges_;
   }
 
   /** Returns the orignal range indexes to be modified. */
-  inline std::vector<std::vector<uint64_t>>& original_range_idx_unsafe() {
+  inline tdb::pmr::vector<tdb::pmr::vector<uint64_t>>&
+  original_range_idx_unsafe() {
     return original_range_idx_;
   }
 
@@ -160,10 +194,10 @@ class DenseTileSubarray {
   /* ********************************* */
 
   /** Stores a vector of 1D ranges per dimension. */
-  std::vector<std::vector<uint64_t>> original_range_idx_;
+  tdb::pmr::vector<tdb::pmr::vector<uint64_t>> original_range_idx_;
 
   /** Stores the ranges per dimension. */
-  std::vector<std::vector<DenseTileRange>> ranges_;
+  tdb::pmr::vector<tdb::pmr::vector<DenseTileRange>> ranges_;
 };
 
 /**

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -118,7 +118,8 @@ class DenseTileSubarray {
     }
   };
 
-  /** The type of the allocator. Required to make the type allocator-aware.
+  /**
+   * The type of the allocator. Required to make the type allocator-aware.
    *
    * uint8_t was arbitrarily chosen and does not matter; allocators can convert
    * between any types.

--- a/tiledb/sm/subarray/tile_cell_slab_iter.h
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.h
@@ -139,7 +139,7 @@ class TileCellSlabIter {
   uint64_t num_ranges_;
 
   /** Original range indexes. */
-  const std::vector<std::vector<uint64_t>>& original_range_idx_;
+  const tdb::pmr::vector<tdb::pmr::vector<uint64_t>>& original_range_idx_;
 
   /** Range info. */
   const std::vector<RangeInfo<T>>& range_info_;
@@ -191,8 +191,8 @@ class TileCellSlabIter {
    * ranges, after appropriately splitting them so that no range crosses
    * more that one tile.
    */
-  const std::vector<std::vector<typename DenseTileSubarray<T>::DenseTileRange>>&
-      ranges_;
+  const tdb::pmr::vector<
+      tdb::pmr::vector<typename DenseTileSubarray<T>::DenseTileRange>>& ranges_;
 
   /** Saved multiplication of tile extents in cell order. */
   std::vector<uint64_t> mult_extents_;


### PR DESCRIPTION
This adds memory tracking for the dense tile subarray structures so that we can make sure they are properly accounted for when estimating memory usage for dense reads.

[SC-48176](https://app.shortcut.com/tiledb-inc/story/48176/memory-tracking-for-tilesubarrays-in-dense-reader)

---
TYPE: NO_HISTORY