### PR TITLE
Synchronize configuration parameters to Academy

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -658,7 +658,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    `config_files` (forces SDK to only consider options found in aws
  *    config files),
  *    `sts_profile_with_web_identity` (force SDK to consider assume roles/sts
- * from config files with support for web tokens, commonly used by EKS/ECS).
+ *    from config files with support for web tokens, commonly used by EKS/ECS).
  *    **Default**: auto
  *    <br>
  * - `vfs.s3.install_sigpipe_handler` <br>

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -180,7 +180,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `sm.consolidation.steps` <br>
  *    The number of consolidation steps to be performed when executing
  *    the consolidation algorithm.<br>
- *    **Default**: 1
+ *    **Default**: UINT32_MAX
  * - `sm.consolidation.purge_deleted_cells` <br>
  *    **Experimental** <br>
  *    Purge deleted cells from the consolidated fragment or not.<br>
@@ -207,6 +207,25 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    `sm.consolidation.timestamp_start` and this value (inclusive). <br>
  *    Only for `fragments` and `array_meta` consolidation mode. <br>
  *    **Default**: UINT64_MAX
+ * - `sm.encryption_key` <br>
+ *    The key for encrypted arrays. <br>
+ *    **Default**: ""
+ * - `sm.encryption_type` <br>
+ *    The type of encryption used for encrypted arrays. <br>
+ *    **Default**: "NO_ENCRYPTION"
+ * - `sm.enumerations_max_size` <br>
+ *    Maximum in memory size for an enumeration. If the enumeration is <br>
+ *    var sized, the size will include the data and the offsets. <br>
+ *    **Default**: 10MB
+ * - `sm.enumerations_max_total_size` <br>
+ *    Maximum in memory size for all enumerations. If the enumeration <br>
+ *    is var sized, the size will include the data and the offsets. <br>
+ *    **Default**: 50MB
+ * - `sm.max_tile_overlap_size` <br>
+ *    Maximum size for the tile overlap structure which holds <br>
+ *    information about which tiles are covered by ranges. Only used <br>
+ *    in dense reads and legacy reads. <br>
+ *    **Default**: 300MB
  * - `sm.memory_budget` <br>
  *    The memory budget for tiles of fixed-sized attributes (or offsets for
  *    var-sized attributes) to be fetched during reads.<br>
@@ -230,14 +249,21 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `sm.query.dense.reader` <br>
  *    Which reader to use for dense queries. "refactored" or "legacy".<br>
  *    **Default**: refactored
+ * - `sm.query.dense.qc_coords_mode` <br>
+ *    Dense configuration that allows to only return the coordinates of <br>
+ *    the cells that match a query condition without any attribute data. <br>
+ *    **Default**: "false"
  * - `sm.query.sparse_global_order.reader` <br>
  *    Which reader to use for sparse global order queries. "refactored"
  *    or "legacy".<br>
- *    **Default**: legacy
+ *    **Default**: refactored
  * - `sm.query.sparse_unordered_with_dups.reader` <br>
  *    Which reader to use for sparse unordered with dups queries.
  *    "refactored" or "legacy".<br>
  *    **Default**: refactored
+ * - `sm.skip_checksum_validation` <br>
+ *    Skip checksum validation on reads for the md5 and sha256 filters. <br>
+ *    **Default**: "false"
  * - `sm.mem.malloc_trim` <br>
  *    Should malloc_trim be called on context and query destruction? This might
  *    reduce residual memory usage. <br>
@@ -270,6 +296,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    `sm.mem.consolidation.reader_weight` and
  *    `sm.mem.consolidation.writer_weight`. <br>
  *    **Default**: 3
+ * - `sm.mem.consolidation.writer_weight` <br>
  *    Weight used to split `sm.mem.total_budget` and assign to the
  *    writer query. The budget is split across 3 values,
  *    `sm.mem.consolidation.buffers_weight`,
@@ -352,7 +379,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: 10MB
  * - `vfs.max_batch_size` <br>
  *    The maximum number of bytes in a VFS read operation<br>
- *    **Default**: UINT64_MAX
+ *    **Default**: 100MB
  * - `vfs.min_batch_size` <br>
  *    The minimum number of bytes in a VFS read operation<br>
  *    **Default**: 20MB
@@ -533,7 +560,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: ""
  * - `vfs.s3.connect_timeout_ms` <br>
  *    The connection timeout in ms. Any `long` value is acceptable. <br>
- *    **Default**: 3000
+ *    **Default**: 10800
  * - `vfs.s3.connect_max_tries` <br>
  *    The maximum tries for a connection. Any `long` value is acceptable. <br>
  *    **Default**: 5
@@ -549,7 +576,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    The AWS SDK logging level. This is a process-global setting. The
  *    configuration of the most recently constructed context will set
  *    process state. Log files are written to the process working directory.
- *    **Default**: ""
+ *    **Default**: "Off"
  * - `vfs.s3.request_timeout_ms` <br>
  *    The request timeout in ms. Any `long` value is acceptable. <br>
  *    **Default**: 3000
@@ -693,7 +720,7 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    **Default**: "503"
  * - `rest.retry_count` <br>
  *    Number of times to retry failed REST requests <br>
- *    **Default**: 3
+ *    **Default**: 25
  * - `rest.retry_initial_delay_ms` <br>
  *    Initial delay in milliseconds to wait until retrying a REST request <br>
  *    **Default**: 500

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -272,7 +272,7 @@ class Config {
    *    **Default**: false
    * - `sm.dedup_coords` <br>
    *    If `true`, cells with duplicate coordinates will be removed during
-   * sparse fragment writes. Note that ties during deduplication are broken
+   *    sparse fragment writes. Note that ties during deduplication are broken
    *    arbitrarily. Also note that this check means that it will take longer to
    *    perform the write operation. <br>
    *    **Default**: false
@@ -281,7 +281,7 @@ class Config {
    *    If `true`, an error will be thrown if there are cells with duplicate
    *    coordinates during sparse fragmnet writes. If `false` and there are
    *    duplicates, the duplicates will be written without errors. Note that
-   * this check is much ligher weight than the coordinate deduplication check
+   *    this check is much ligher weight than the coordinate deduplication check
    *    enabled by `sm.dedup_coords`. <br>
    *    **Default**: true
    * - `sm.check_coord_oob` <br>
@@ -605,7 +605,7 @@ class Config {
    *    The block size (in bytes) used in Azure blob block list writes.
    *    Any `uint64_t` value is acceptable. Note:
    *    `vfs.azure.block_list_block_size vfs.azure.max_parallel_ops` bytes will
-   * be buffered before issuing block uploads in parallel. <br>
+   *    be buffered before issuing block uploads in parallel. <br>
    *    **Default**: "5242880"
    * - `vfs.azure.max_parallel_ops` <br>
    *    The maximum number of Azure backend parallel operations. <br>
@@ -832,7 +832,8 @@ class Config {
    *    `config_files` (forces SDK to only consider options found in aws
    *    config files),
    *    `sts_profile_with_web_identity` (force SDK to consider assume roles/sts
-   * from config files with support for web tokens, commonly used by EKS/ECS).
+   *    from config files with support for web tokens, commonly used by
+   *    EKS/ECS).
    *    **Default**: auto
    *    <br>
    * - `vfs.s3.install_sigpipe_handler` <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -262,9 +262,6 @@ class Config {
   }
 
   /** Sets a config parameter.
-   *
-   * **Parameters**
-   *
    * - `sm.allow_separate_attribute_writes` <br>
    *    **Experimental** <br>
    *    Allow separate attribute write queries.<br>
@@ -274,8 +271,8 @@ class Config {
    *    Allow update queries. Experimental for testing purposes, do not use.<br>
    *    **Default**: false
    * - `sm.dedup_coords` <br>
-   *    If `true`, cells with duplicate coordinates will be removed during
-   *    sparse fragment writes. Note that ties during deduplication are broken
+   *    If `true`, cells with duplicate coordinates will be removed during sparse
+   *    fragment writes. Note that ties during deduplication are broken
    *    arbitrarily. Also note that this check means that it will take longer to
    *    perform the write operation. <br>
    *    **Default**: false
@@ -283,34 +280,33 @@ class Config {
    *    This is applicable only if `sm.dedup_coords` is `false`.
    *    If `true`, an error will be thrown if there are cells with duplicate
    *    coordinates during sparse fragmnet writes. If `false` and there are
-   *    duplicates, the duplicates will be written without errors. Note that
-   *    this check is much ligher weight than the coordinate deduplication check
+   *    duplicates, the duplicates will be written without errors. Note that this
+   *    check is much ligher weight than the coordinate deduplication check
    *    enabled by `sm.dedup_coords`. <br>
+   *    **Default**: true
    * - `sm.check_coord_oob` <br>
    *    If `true`, an error will be thrown if there are cells with coordinates
-   *    falling outside the array domain during sparse fragment writes. <br>
+   *    lying outside the domain during sparse fragment writes.  <br>
    *    **Default**: true
-   *    `sm.read_range_oob` <br>
+   * - `sm.read_range_oob` <br>
    *    If `error`, this will check ranges for read with out-of-bounds on the
-   *    dimension domain's and error. If `warn`, the ranges will be capped at
-   *    the dimension's domain and a warning logged. <br>
+   *    dimension domain's. If `warn`, the ranges will be capped at the
+   *    dimension's domain and a warning logged. <br>
    *    **Default**: warn
    * - `sm.check_global_order` <br>
    *    Checks if the coordinates obey the global array order. Applicable only
    *    to sparse writes in global order.
    *    **Default**: true
    * - `sm.merge_overlapping_ranges_experimental` <br>
-   *    **Experimental** <br>
    *    If `true`, merge overlapping Subarray ranges. Else, overlapping ranges
    *    will not be merged and multiplicities will be returned.
    *    Experimental for testing purposes, do not use.<br>
    *    **Default**: true
    * - `sm.enable_signal_handlers` <br>
-   *    Whether or not TileDB will install signal handlers. <br>
+   *    Determines whether or not TileDB will install signal handlers. <br>
    *    **Default**: true
    * - `sm.compute_concurrency_level` <br>
-   *    Upper-bound on number of threads to allocate for compute-bound tasks.
-   * <br>
+   *    Upper-bound on number of threads to allocate for compute-bound tasks. <br>
    *    **Default*: # cores
    * - `sm.io_concurrency_level` <br>
    *    Upper-bound on number of threads to allocate for IO-bound tasks. <br>
@@ -323,14 +319,14 @@ class Config {
    *    `array_meta` (remove only consolidated array metadata files), or
    *    `group_meta` (remove only consolidate group metadata only).
    *    <br>
-   *    **Default**: "fragments"
+   *    **Default**: fragments
    * - `sm.consolidation.mode` <br>
    *    The consolidation mode, one of
    *    `commits` (consolidate all commit files),
    *    `fragments` (consolidate all fragments),
    *    `fragment_meta` (consolidate only fragment metadata footers to a single
-   * file), `array_meta` (consolidate array metadata only), or `group_meta`
-   * (consolidate group metadata only). <br>
+   *    file), `array_meta` (consolidate array metadata only), or `group_meta`
+   *    (consolidate group metadata only). <br>
    *    **Default**: "fragments"
    * - `sm.consolidation.amplification` <br>
    *    The factor by which the size of the dense fragment resulting
@@ -339,7 +335,7 @@ class Config {
    *    the union of the non-empty domains of the fragments to be
    *    consolidated have a lot of empty cells, which the consolidated
    *    fragment will have to fill with the special fill value
-   *    (since the resulting fragments is dense). <br>
+   *    (since the resulting fragment is dense). <br>
    *    **Default**: 1.0
    * - `sm.consolidation.buffer_size` <br>
    *    **Deprecated**
@@ -349,14 +345,13 @@ class Config {
    * - `sm.consolidation.max_fragment_size` <br>
    *    **Experimental** <br>
    *    The size (in bytes) of the maximum on-disk fragment size that will be
-   *    created by consolidation. When it is reached, consolidation will
-   *    continue the operation in a new fragment. The result will be a multiple
-   *    fragments, but with seperate MBRs. <br>
-   *    **Default**: UINT64_MAX
+   *    created by consolidation. When it is reached, consolidation will continue
+   *    the operation in a new fragment. The result will be a multiple fragments,
+   *    but with seperate MBRs. <br>
    * - `sm.consolidation.steps` <br>
    *    The number of consolidation steps to be performed when executing
    *    the consolidation algorithm.<br>
-   *    **Default**: 1
+   *    **Default**: UINT32_MAX
    * - `sm.consolidation.purge_deleted_cells` <br>
    *    **Experimental** <br>
    *    Purge deleted cells from the consolidated fragment or not.<br>
@@ -383,6 +378,25 @@ class Config {
    *    `sm.consolidation.timestamp_start` and this value (inclusive). <br>
    *    Only for `fragments` and `array_meta` consolidation mode. <br>
    *    **Default**: UINT64_MAX
+   * - `sm.encryption_key` <br>
+   *    The key for encrypted arrays. <br>
+   *    **Default**: ""
+   * - `sm.encryption_type` <br>
+   *    The type of encryption used for encrypted arrays. <br>
+   *    **Default**: "NO_ENCRYPTION"
+   * - `sm.enumerations_max_size` <br>
+   *    Maximum in memory size for an enumeration. If the enumeration is <br>
+   *    var sized, the size will include the data and the offsets. <br>
+   *    **Default**: 10MB
+   * - `sm.enumerations_max_total_size` <br>
+   *    Maximum in memory size for all enumerations. If the enumeration <br>
+   *    is var sized, the size will include the data and the offsets. <br>
+   *    **Default**: 50MB
+   * - `sm.max_tile_overlap_size` <br>
+   *    Maximum size for the tile overlap structure which holds <br>
+   *    information about which tiles are covered by ranges. Only used <br>
+   *    in dense reads and legacy reads. <br>
+   *    **Default**: 300MB
    * - `sm.memory_budget` <br>
    *    The memory budget for tiles of fixed-sized attributes (or offsets for
    *    var-sized attributes) to be fetched during reads.<br>
@@ -403,35 +417,39 @@ class Config {
    *    The offsets format (`bytes` or `elements`) to be used for
    *    var-sized attributes.<br>
    *    **Default**: bytes
-   * - `sm.query.dense.qc_coords_mode` <br>
-   *    **Experimental** <br>
-   *    Reads only the coordinates of the dense query that matched the query
-   *    condition.<br>
-   *    **Default**: false
    * - `sm.query.dense.reader` <br>
    *    Which reader to use for dense queries. "refactored" or "legacy".<br>
    *    **Default**: refactored
+   * - `sm.query.dense.qc_coords_mode` <br>
+   *    Dense configuration that allows to only return the coordinates of <br>
+   *    the cells that match a query condition without any attribute data. <br>
+   *    **Default**: "false"
    * - `sm.query.sparse_global_order.reader` <br>
    *    Which reader to use for sparse global order queries. "refactored"
    *    or "legacy".<br>
-   *    **Default**: legacy
+   *    **Default**: refactored
    * - `sm.query.sparse_unordered_with_dups.reader` <br>
    *    Which reader to use for sparse unordered with dups queries.
    *    "refactored" or "legacy".<br>
    *    **Default**: refactored
+   * - `sm.skip_checksum_validation` <br>
+   *    Skip checksum validation on reads for the md5 and sha256 filters. <br>
+   *    **Default**: "false"
    * - `sm.mem.malloc_trim` <br>
-   *    Should malloc_trim be called on context and query destruction? This
-   *    might reduce residual memory usage. <br>
+   *    Should malloc_trim be called on context and query destruction? This might
+   *    reduce residual memory usage. <br>
    *    **Default**: true
    * - `sm.mem.tile_upper_memory_limit` <br>
    *    **Experimental** <br>
-   *    This is the upper memory limit that is used when loading tiles. For now
-   *    it is only used in the dense reader but will be eventually used by all
+   *    This is the upper memory limit that is used when loading tiles. For now it
+   *    is only used in the dense reader but will be eventually used by all
    *    readers. The readers using this value will use it as a way to limit the
    *    amount of tile data that is brought into memory at once so that we don't
    *    incur performance penalties during memory movement operations. It is a
-   *    soft limit that we might go over if a single tile doesn't fit into
-   *    memory, we will allow to load that tile if it still fits within
+   *    soft limit that we might go over if a single tile doesn't fit into memory,
+   *    we will allow to load that tile if it still fits within
+   *    `sm.mem.total_budget`. <br>
+   *    **Default**: 1GB
    * - `sm.mem.total_budget` <br>
    *    Memory budget for readers and writers. <br>
    *    **Default**: 10GB
@@ -449,6 +467,7 @@ class Config {
    *    `sm.mem.consolidation.reader_weight` and
    *    `sm.mem.consolidation.writer_weight`. <br>
    *    **Default**: 3
+   * - `sm.mem.consolidation.writer_weight` <br>
    *    Weight used to split `sm.mem.total_budget` and assign to the
    *    writer query. The budget is split across 3 values,
    *    `sm.mem.consolidation.buffers_weight`,
@@ -488,12 +507,17 @@ class Config {
    *    The end timestamp used for opening the group. <br>
    *    Also used for the write timestamp if set. <br>
    *    **Default**: UINT64_MAX
+   * -  `sm.partial_tile_offsets_loading`
+   *    **Experimental** <br>
+   *    If `true` tile offsets can be partially loaded and unloaded by the
+   *    readers. <br>
+   *    **Default**: false
    * - `sm.fragment_info.preload_mbrs` <br>
    *    If `true` MBRs will be loaded at the same time as the rest of fragment
-   *    info, otherwise they will be loaded lazily when some info related to
-   *    MBRs is requested by the user. <br>
+   *    info, otherwise they will be loaded lazily when some info related to MBRs
+   *    is requested by the user. <br>
    *    **Default**: false
-   * -  `sm.partial_tile_offsets_loading`
+   * - `sm.partial_tile_offset_loading`
    *    **Experimental** <br>
    *    If `true` tile offsets can be partially loaded and unloaded by the
    *    readers. <br>
@@ -516,18 +540,17 @@ class Config {
    *    Disabling verification is insecure and should only used for testing
    *    purposes. <br>
    *    **Default**: true
-   * -  `vfs.read_ahead_cache_size` <br>
-   *    The the total maximum size of the read-ahead cache, which is an LRU.
-   *    <br>
+   * - `vfs.read_ahead_cache_size` <br>
+   *    The the total maximum size of the read-ahead cache, which is an LRU. <br>
    *    **Default**: 10485760
    * - `vfs.min_parallel_size` <br>
    *    The minimum number of bytes in a parallel VFS operation
    *    (except parallel S3 writes, which are controlled by
-   *    `vfs.s3.multipart_part_size`.) <br>
+   *    `vfs.s3.multipart_part_size`). <br>
    *    **Default**: 10MB
    * - `vfs.max_batch_size` <br>
    *    The maximum number of bytes in a VFS read operation<br>
-   *    **Default**: UINT64_MAX
+   *    **Default**: 100MB
    * - `vfs.min_batch_size` <br>
    *    The minimum number of bytes in a VFS read operation<br>
    *    **Default**: 20MB
@@ -552,10 +575,10 @@ class Config {
    *         increased log verbosity.</li>
    *   </ul>
    * - `vfs.file.posix_file_permissions` <br>
-   *    permissions to use for posix file system with file or dir creation.<br>
+   *    Permissions to use for posix file system with file creation.<br>
    *    **Default**: 644
    * - `vfs.file.posix_directory_permissions` <br>
-   *    permissions to use for posix file system with file or dir creation.<br>
+   *    Permissions to use for posix file system with directory creation.<br>
    *    **Default**: 755
    * - `vfs.azure.storage_account_name` <br>
    *    Set the name of the Azure Storage account to use. <br>
@@ -578,9 +601,9 @@ class Config {
    *    **Default**: ""
    * - `vfs.azure.block_list_block_size` <br>
    *    The block size (in bytes) used in Azure blob block list writes.
-   *    Any `uint64_t` value is acceptable. Note:
-   *    `vfs.azure.block_list_block_size * vfs.azure.max_parallel_ops` bytes
-   *    will be buffered before issuing block uploads in parallel. <br>
+   *    Any `uint64_t` value is acceptable. Note: `vfs.azure.block_list_block_size
+   *    vfs.azure.max_parallel_ops` bytes will be buffered before issuing block
+   *    uploads in parallel. <br>
    *    **Default**: "5242880"
    * - `vfs.azure.max_parallel_ops` <br>
    *    The maximum number of Azure backend parallel operations. <br>
@@ -619,8 +642,8 @@ class Config {
    * - `vfs.gcs.impersonate_service_account` <br>
    *    **Experimental** <br>
    *    Set the GCS service account to impersonate. A chain of impersonated
-   *    accounts can be formed by specifying many service accounts, separated by
-   *    a comma. <br>
+   *    accounts can be formed by specifying many service accounts, separated by a
+   *    comma. <br>
    *    **Default**: ""
    * - `vfs.gcs.multi_part_size` <br>
    *    The part size (in bytes) used in GCS multi part writes.
@@ -708,12 +731,12 @@ class Config {
    *    **Default**: ""
    * - `vfs.s3.connect_timeout_ms` <br>
    *    The connection timeout in ms. Any `long` value is acceptable. <br>
-   *    **Default**: 3000
+   *    **Default**: 10800
    * - `vfs.s3.connect_max_tries` <br>
    *    The maximum tries for a connection. Any `long` value is acceptable. <br>
    *    **Default**: 5
    * - `vfs.s3.connect_scale_factor` <br>
-   *    The scale factor for exponential backofff when connecting to S3.
+   *    The scale factor for exponential backoff when connecting to S3.
    *    Any `long` value is acceptable. <br>
    *    **Default**: 25
    * - `vfs.s3.custom_headers.*` <br>
@@ -724,7 +747,7 @@ class Config {
    *    The AWS SDK logging level. This is a process-global setting. The
    *    configuration of the most recently constructed context will set
    *    process state. Log files are written to the process working directory.
-   *    **Default**: "off"
+   *    **Default**: "Off"
    * - `vfs.s3.request_timeout_ms` <br>
    *    The request timeout in ms. Any `long` value is acceptable. <br>
    *    **Default**: 3000
@@ -732,25 +755,25 @@ class Config {
    *    The requester pays for the S3 access charges. <br>
    *    **Default**: false
    * - `vfs.s3.proxy_host` <br>
-   *    The proxy host. <br>
+   *    The S3 proxy host. <br>
    *    **Default**: ""
    * - `vfs.s3.proxy_port` <br>
-   *    The proxy port. <br>
+   *    The S3 proxy port. <br>
    *    **Default**: 0
    * - `vfs.s3.proxy_scheme` <br>
-   *    The proxy scheme. <br>
+   *    The S3 proxy scheme. <br>
    *    **Default**: "http"
    * - `vfs.s3.proxy_username` <br>
-   *    The proxy username. Note: this parameter is not serialized by
+   *    The S3 proxy username. Note: this parameter is not serialized by
    *    `tiledb_config_save_to_file`. <br>
    *    **Default**: ""
    * - `vfs.s3.proxy_password` <br>
-   *    The proxy password. Note: this parameter is not serialized by
+   *    The S3 proxy password. Note: this parameter is not serialized by
    *    `tiledb_config_save_to_file`. <br>
    *    **Default**: ""
    * - `vfs.s3.verify_ssl` <br>
    *    Enable HTTPS certificate verification. <br>
-   *    **Default**: true
+   *    **Default**: true""
    * - `vfs.s3.no_sign_request` <br>
    *    Make unauthenticated requests to s3. <br>
    *    **Default**: false
@@ -764,8 +787,7 @@ class Config {
    *    **Default**: ""
    * - `vfs.s3.storage_class` <br>
    *    The storage class to use for the newly uploaded S3 objects. The set of
-   *    accepted values is found in the Aws::S3::Model::StorageClass
-   *    enumeration.
+   *    accepted values is found in the Aws::S3::Model::StorageClass enumeration.
    *    "NOT_SET"
    *    "STANDARD"
    *    "REDUCED_REDUNDANCY"
@@ -814,7 +836,7 @@ class Config {
    *    When set to `true`, the S3 SDK uses a handler that ignores SIGPIPE
    *    signals.
    *    **Default**: "true"
-   * - `vfs.hdfs.name_node_uri"` <br>
+   * - `vfs.hdfs.name_node_uri` <br>
    *    Name node for HDFS. <br>
    *    **Default**: ""
    * - `vfs.hdfs.username` <br>
@@ -863,20 +885,19 @@ class Config {
    *    The name of the registered access key to use for creation of the REST
    *    server. <br>
    *    **Default**: no default set
-   * -  `rest.retry_http_codes` <br>
+   * - `rest.retry_http_codes` <br>
    *    CSV list of http status codes to automatically retry a REST request for
    *    <br>
    *    **Default**: "503"
    * - `rest.retry_count` <br>
    *    Number of times to retry failed REST requests <br>
-   *    **Default**: 3
+   *    **Default**: 25
    * - `rest.retry_initial_delay_ms` <br>
-   *    Initial delay in milliseconds to wait until retrying a REST request
-   *    <br>
+   *    Initial delay in milliseconds to wait until retrying a REST request <br>
    *    **Default**: 500
    * - `rest.retry_delay_factor` <br>
-   *    The delay factor to exponentially wait until further retries of a
-   *    failed REST request <br>
+   *    The delay factor to exponentially wait until further retries of a failed
+   *    REST request <br>
    *    **Default**: 1.25
    * - `rest.curl.verbose` <br>
    *    Set curl to run in verbose mode for REST requests <br>
@@ -887,16 +908,14 @@ class Config {
    *    the open array <br>
    *    **Default**: true
    * - `rest.load_non_empty_domain_on_array_open` <br>
-   *    If true, array non empty domain will be loaded and sent to server
-   *    together with the open array <br>
+   *    If true, array non empty domain will be loaded and sent to server together
+   *    with the open array <br>
    *    **Default**: true
    * - `rest.use_refactored_array_open` <br>
-   *    **Experimental** <br>
    *    If true, the new, experimental REST routes and APIs for opening an array
    *    will be used <br>
    *    **Default**: false
    * - `rest.use_refactored_array_open_and_query_submit` <br>
-   *    **Experimental** <br>
    *    If true, the new, experimental REST routes and APIs for opening an array
    *    and submitting a query will be used <br>
    *    **Default**: false
@@ -904,8 +923,7 @@ class Config {
    *    Set curl buffer size for REST requests <br>
    *    **Default**: 524288 (512KB)
    * - `rest.capnp_traversal_limit` <br>
-   *    CAPNP traversal limit used in the deserialization of messages(bytes)
-   * <br>
+   *    CAPNP traversal limit used in the deserialization of messages(bytes) <br>
    *    **Default**: 536870912 (512MB)
    * - `rest.custom_headers.*` <br>
    *    (Optional) Prefix for custom headers on REST requests. For each custom
@@ -915,9 +933,9 @@ class Config {
    *    The namespace that should be charged for the request. <br>
    *    **Default**: no default set
    * - `filestore.buffer_size` <br>
-   *    Specifies the size in bytes of the internal buffers used in the
-   *    filestore API. The size should be bigger than the minimum tile size
-   *    filestore currently supports, that is currently 1024bytes. <br>
+   *    Specifies the size in bytes of the internal buffers used in the filestore
+   *    API. The size should be bigger than the minimum tile size filestore
+   *    currently supports, that is currently 1024bytes. <br>
    *    **Default**: 100MB
    */
   Config& set(const std::string& param, const std::string& value) {

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -271,8 +271,8 @@ class Config {
    *    Allow update queries. Experimental for testing purposes, do not use.<br>
    *    **Default**: false
    * - `sm.dedup_coords` <br>
-   *    If `true`, cells with duplicate coordinates will be removed during sparse
-   *    fragment writes. Note that ties during deduplication are broken
+   *    If `true`, cells with duplicate coordinates will be removed during
+   * sparse fragment writes. Note that ties during deduplication are broken
    *    arbitrarily. Also note that this check means that it will take longer to
    *    perform the write operation. <br>
    *    **Default**: false
@@ -280,8 +280,8 @@ class Config {
    *    This is applicable only if `sm.dedup_coords` is `false`.
    *    If `true`, an error will be thrown if there are cells with duplicate
    *    coordinates during sparse fragmnet writes. If `false` and there are
-   *    duplicates, the duplicates will be written without errors. Note that this
-   *    check is much ligher weight than the coordinate deduplication check
+   *    duplicates, the duplicates will be written without errors. Note that
+   * this check is much ligher weight than the coordinate deduplication check
    *    enabled by `sm.dedup_coords`. <br>
    *    **Default**: true
    * - `sm.check_coord_oob` <br>
@@ -306,7 +306,8 @@ class Config {
    *    Determines whether or not TileDB will install signal handlers. <br>
    *    **Default**: true
    * - `sm.compute_concurrency_level` <br>
-   *    Upper-bound on number of threads to allocate for compute-bound tasks. <br>
+   *    Upper-bound on number of threads to allocate for compute-bound tasks.
+   *    <br>
    *    **Default*: # cores
    * - `sm.io_concurrency_level` <br>
    *    Upper-bound on number of threads to allocate for IO-bound tasks. <br>
@@ -345,9 +346,9 @@ class Config {
    * - `sm.consolidation.max_fragment_size` <br>
    *    **Experimental** <br>
    *    The size (in bytes) of the maximum on-disk fragment size that will be
-   *    created by consolidation. When it is reached, consolidation will continue
-   *    the operation in a new fragment. The result will be a multiple fragments,
-   *    but with seperate MBRs. <br>
+   *    created by consolidation. When it is reached, consolidation will
+   *    continue the operation in a new fragment. The result will be a multiple
+   *    fragments, but with seperate MBRs. <br>
    * - `sm.consolidation.steps` <br>
    *    The number of consolidation steps to be performed when executing
    *    the consolidation algorithm.<br>
@@ -436,18 +437,18 @@ class Config {
    *    Skip checksum validation on reads for the md5 and sha256 filters. <br>
    *    **Default**: "false"
    * - `sm.mem.malloc_trim` <br>
-   *    Should malloc_trim be called on context and query destruction? This might
-   *    reduce residual memory usage. <br>
+   *    Should malloc_trim be called on context and query destruction? This
+   *    might reduce residual memory usage. <br>
    *    **Default**: true
    * - `sm.mem.tile_upper_memory_limit` <br>
    *    **Experimental** <br>
-   *    This is the upper memory limit that is used when loading tiles. For now it
-   *    is only used in the dense reader but will be eventually used by all
+   *    This is the upper memory limit that is used when loading tiles. For now
+   *    it is only used in the dense reader but will be eventually used by all
    *    readers. The readers using this value will use it as a way to limit the
    *    amount of tile data that is brought into memory at once so that we don't
    *    incur performance penalties during memory movement operations. It is a
-   *    soft limit that we might go over if a single tile doesn't fit into memory,
-   *    we will allow to load that tile if it still fits within
+   *    soft limit that we might go over if a single tile doesn't fit into
+   *    memory, we will allow to load that tile if it still fits within
    *    `sm.mem.total_budget`. <br>
    *    **Default**: 1GB
    * - `sm.mem.total_budget` <br>
@@ -514,8 +515,8 @@ class Config {
    *    **Default**: false
    * - `sm.fragment_info.preload_mbrs` <br>
    *    If `true` MBRs will be loaded at the same time as the rest of fragment
-   *    info, otherwise they will be loaded lazily when some info related to MBRs
-   *    is requested by the user. <br>
+   *    info, otherwise they will be loaded lazily when some info related to
+   *    MBRs is requested by the user. <br>
    *    **Default**: false
    * - `sm.partial_tile_offset_loading`
    *    **Experimental** <br>
@@ -541,7 +542,8 @@ class Config {
    *    purposes. <br>
    *    **Default**: true
    * - `vfs.read_ahead_cache_size` <br>
-   *    The the total maximum size of the read-ahead cache, which is an LRU. <br>
+   *    The the total maximum size of the read-ahead cache, which is an LRU.
+   *    <br>
    *    **Default**: 10485760
    * - `vfs.min_parallel_size` <br>
    *    The minimum number of bytes in a parallel VFS operation
@@ -601,9 +603,9 @@ class Config {
    *    **Default**: ""
    * - `vfs.azure.block_list_block_size` <br>
    *    The block size (in bytes) used in Azure blob block list writes.
-   *    Any `uint64_t` value is acceptable. Note: `vfs.azure.block_list_block_size
-   *    vfs.azure.max_parallel_ops` bytes will be buffered before issuing block
-   *    uploads in parallel. <br>
+   *    Any `uint64_t` value is acceptable. Note:
+   *    `vfs.azure.block_list_block_size vfs.azure.max_parallel_ops` bytes will
+   * be buffered before issuing block uploads in parallel. <br>
    *    **Default**: "5242880"
    * - `vfs.azure.max_parallel_ops` <br>
    *    The maximum number of Azure backend parallel operations. <br>
@@ -642,8 +644,8 @@ class Config {
    * - `vfs.gcs.impersonate_service_account` <br>
    *    **Experimental** <br>
    *    Set the GCS service account to impersonate. A chain of impersonated
-   *    accounts can be formed by specifying many service accounts, separated by a
-   *    comma. <br>
+   *    accounts can be formed by specifying many service accounts, separated by
+   *    a comma. <br>
    *    **Default**: ""
    * - `vfs.gcs.multi_part_size` <br>
    *    The part size (in bytes) used in GCS multi part writes.
@@ -787,7 +789,8 @@ class Config {
    *    **Default**: ""
    * - `vfs.s3.storage_class` <br>
    *    The storage class to use for the newly uploaded S3 objects. The set of
-   *    accepted values is found in the Aws::S3::Model::StorageClass enumeration.
+   *    accepted values is found in the Aws::S3::Model::StorageClass
+   *    enumeration.
    *    "NOT_SET"
    *    "STANDARD"
    *    "REDUCED_REDUNDANCY"
@@ -908,8 +911,8 @@ class Config {
    *    the open array <br>
    *    **Default**: true
    * - `rest.load_non_empty_domain_on_array_open` <br>
-   *    If true, array non empty domain will be loaded and sent to server together
-   *    with the open array <br>
+   *    If true, array non empty domain will be loaded and sent to server
+   *    together with the open array <br>
    *    **Default**: true
    * - `rest.use_refactored_array_open` <br>
    *    If true, the new, experimental REST routes and APIs for opening an array
@@ -923,7 +926,8 @@ class Config {
    *    Set curl buffer size for REST requests <br>
    *    **Default**: 524288 (512KB)
    * - `rest.capnp_traversal_limit` <br>
-   *    CAPNP traversal limit used in the deserialization of messages(bytes) <br>
+   *    CAPNP traversal limit used in the deserialization of messages(bytes)
+   *    <br>
    *    **Default**: 536870912 (512MB)
    * - `rest.custom_headers.*` <br>
    *    (Optional) Prefix for custom headers on REST requests. For each custom
@@ -933,9 +937,9 @@ class Config {
    *    The namespace that should be charged for the request. <br>
    *    **Default**: no default set
    * - `filestore.buffer_size` <br>
-   *    Specifies the size in bytes of the internal buffers used in the filestore
-   *    API. The size should be bigger than the minimum tile size filestore
-   *    currently supports, that is currently 1024bytes. <br>
+   *    Specifies the size in bytes of the internal buffers used in the
+   *    filestore API. The size should be bigger than the minimum tile size
+   *    filestore currently supports, that is currently 1024bytes. <br>
    *    **Default**: 100MB
    */
   Config& set(const std::string& param, const std::string& value) {


### PR DESCRIPTION
I was tasked with documenting all configuration parameters in Academy. The information I was given to document those parameters was out of date. I have since compiled the responses from the rest of the core team about the missing configuration parameters and compiled it here. Note the following parameters have been left undocumented:

- `sm.skip_est_size_partitioning`
- `sm.skip_unary_partitioning_budget_check`
- `sm.merge_overlapping_ranges_experimental`
- `vfs.gcs.endpoint`

---
TYPE: NO_HISTORY
DESC: Update all configuration parameters to reflect what's available in 2.24.1
