### PR TITLE
[Backport release-2.25] Fix fragment consolidation to allow using absolute URIs. (#5135)

### DIFF
--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -929,6 +929,34 @@ int deserialize_array_and_query(
  * @return A test fragment uri
  */
 sm::URI generate_fragment_uri(sm::Array* array);
+
+/**
+ * Helper function to create a sparse array using format version 11.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The name of the new array to create.
+ */
+void create_sparse_array_v11(tiledb_ctx_t* ctx, const std::string& array_name);
+
+/**
+ * Helper function to write data to a format version 11 sparse array.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The name of the array to write to.
+ * @param timestamp The timestamp to open the array for writing.
+ */
+void write_sparse_v11(
+    tiledb_ctx_t* ctx, const std::string& array_name, uint64_t timestamp);
+
+/**
+ * Helper function to validate data read from a format version 11 sparse array.
+ *
+ * @param ctx TileDB context.
+ * @param array_name The name of the array to read from.
+ * @param timestamp The timestamp to open the array for reading.
+ */
+void read_sparse_v11(
+    tiledb_ctx_t* ctx, const std::string& array_name, uint64_t timestamp);
 }  // namespace tiledb::test
 
 #endif

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -362,7 +362,26 @@ Status FragmentConsolidator::consolidate_fragments(
   NDRange union_non_empty_domains;
   std::unordered_set<std::string> to_consolidate_set;
   for (auto& uri : fragment_uris) {
-    to_consolidate_set.emplace(uri);
+    if (uri.find('/') == std::string::npos) {
+      // The fragment URI is relative and does not contain the array URI.
+      to_consolidate_set.emplace(uri);
+    } else {
+      // The fragment URI is absolute and should contain the correct array URI.
+      URI fragment_uri(uri);
+      FragmentID frag_id(fragment_uri);
+
+      // Check for valid URI based on array format version.
+      auto fragments_dir = array_for_reads->array_directory().get_fragments_dir(
+          frag_id.array_format_version());
+      if (fragment_uri !=
+          fragments_dir.join_path(fragment_uri.last_path_part().c_str())) {
+        throw FragmentConsolidatorException(
+            "Failed request to consolidate an invalid fragment URI '" +
+            fragment_uri.to_string() + "' for array at '" +
+            URI(array_name).to_string() + "'");
+      }
+      to_consolidate_set.emplace(fragment_uri.last_path_part());
+    }
   }
 
   // Make sure all fragments to consolidate are present
@@ -384,7 +403,8 @@ Status FragmentConsolidator::consolidate_fragments(
 
   if (count != fragment_uris.size()) {
     throw FragmentConsolidatorException(
-        "Cannot consolidate; Not all fragments could be found");
+        "Cannot consolidate; Found " + std::to_string(count) + " of " +
+        std::to_string(fragment_uris.size()) + " required fragments.");
   }
 
   FragmentConsolidationWorkspace cw(consolidator_memory_tracker_);


### PR DESCRIPTION
Backport a7e2a07d6c74208f691ec8d3c94be17c9de12ab8 from #5135

---
TYPE: NO_HISTORY