### PR TITLE
Create rectangle object library from reworked utils code.

### DIFF
--- a/test/src/cpp-integration-query-condition.cc
+++ b/test/src/cpp-integration-query-condition.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include <test/support/src/vfs_helpers.h>
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
 

--- a/test/src/unit-arrow.cc
+++ b/test/src/unit-arrow.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB Inc.
+ * @copyright Copyright (c) 2020-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,6 @@
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <pybind11/embed.h>
 #include <pybind11/pybind11.h>

--- a/test/src/unit-average-cell-size.cc
+++ b/test/src/unit-average-cell-size.cc
@@ -40,7 +40,6 @@
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/fragment/fragment_identifier.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <numeric>
 

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -5,8 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,7 +50,6 @@
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::test;
 

--- a/test/src/unit-capi-attributes.cc
+++ b/test/src/unit-capi-attributes.cc
@@ -45,7 +45,6 @@
 #endif
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <chrono>
 #include <iostream>

--- a/test/src/unit-capi-dense_neg.cc
+++ b/test/src/unit-capi-dense_neg.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-dense_vector.cc
+++ b/test/src/unit-capi-dense_vector.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -46,7 +46,6 @@
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +37,6 @@
 #include "tiledb/api/c_api/vfs/vfs_api_internal.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/enums/array_type.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <optional>

--- a/test/src/unit-capi-object_mgmt.cc
+++ b/test/src/unit-capi-object_mgmt.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,6 @@
 #endif
 
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-query.cc
+++ b/test/src/unit-capi-query.cc
@@ -5,8 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +48,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::test;
 

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -5,8 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +45,6 @@
 #include "test/support/src/helpers.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/enums/encryption_type.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/rest/rest_client.h"
 
 #include <array>

--- a/test/src/unit-capi-smoke-test.cc
+++ b/test/src/unit-capi-smoke-test.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,6 @@
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/encryption_type.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <optional>

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -5,8 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +48,6 @@
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/enums/encryption_type.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include "test/support/src/helpers.h"
 

--- a/test/src/unit-capi-sparse_heter.cc
+++ b/test/src/unit-capi-sparse_heter.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,6 @@
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-sparse_neg.cc
+++ b/test/src/unit-capi-sparse_neg.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-sparse_neg_2.cc
+++ b/test/src/unit-capi-sparse_neg_2.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-sparse_real.cc
+++ b/test/src/unit-capi-sparse_real.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-sparse_real_2.cc
+++ b/test/src/unit-capi-sparse_real_2.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/posix.h"
 #endif
 #include "tiledb/sm/c_api/tiledb.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,6 @@
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/c_api/tiledb_serialization.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <chrono>
 #include <iostream>

--- a/test/src/unit-capi-vfs.cc
+++ b/test/src/unit-capi-vfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/platform/platform.h"
 #include "tiledb/sm/c_api/tiledb.h"
 #include "tiledb/sm/filesystem/uri.h"
-#include "tiledb/sm/misc/utils.h"
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/path_win.h"
 #include "tiledb/sm/filesystem/win.h"

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -39,7 +39,6 @@
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
 

--- a/test/src/unit-cppapi-datetimes.cc
+++ b/test/src/unit-cppapi-datetimes.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
 

--- a/test/src/unit-cppapi-dense-qc-coords-mode.cc
+++ b/test/src/unit-cppapi-dense-qc-coords-mode.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,6 @@
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <numeric>
 

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,6 @@
 #include "tiledb/sm/cpp_api/group.h"
 #include "tiledb/sm/enums/encryption_type.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <sstream>

--- a/test/src/unit-cppapi-max-fragment-size.cc
+++ b/test/src/unit-cppapi-max-fragment-size.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +37,6 @@
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <numeric>
 

--- a/test/src/unit-cppapi-nullable.cc
+++ b/test/src/unit-cppapi-nullable.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,6 @@
 #include "test/support/src/helpers.h"
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/sm/cpp_api/tiledb"
-#include "tiledb/sm/misc/utils.h"
 
 #include <iostream>
 #include <vector>

--- a/test/src/unit-cppapi-query.cc
+++ b/test/src/unit-cppapi-query.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
 

--- a/test/src/unit-cppapi-subarray.cc
+++ b/test/src/unit-cppapi-subarray.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,6 @@
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
 using namespace tiledb::test;

--- a/test/src/unit-cppapi-time.cc
+++ b/test/src/unit-cppapi-time.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB Inc.
+ * @copyright Copyright (c) 2021-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/cpp_api/tiledb"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb;
 

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -39,7 +39,6 @@
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/cpp_api/tiledb_experimental"
 #include "tiledb/sm/enums/encryption_type.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/update_value.h"
 
 using namespace tiledb;

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@ using namespace Catch::Matchers;
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/readers/ordered_dim_label_reader.h"
 
 #include <numeric>

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -237,10 +237,10 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/mgc_dict.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/parse_argument.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/rectangle.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/tdb_math.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/tdb_time.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/types.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/utils.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/misc/win_constants.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/object/object.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/object/object_iter.cc

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -52,7 +52,6 @@
 #include "tiledb/sm/global_state/unit_test_config.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/object/object.h"
 #include "tiledb/sm/object/object_mutex.h"
 #include "tiledb/sm/query/deletes_and_updates/serialization.h"

--- a/tiledb/sm/array_schema/domain.cc
+++ b/tiledb/sm/array_schema/domain.cc
@@ -41,7 +41,6 @@
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/type/apply_with_type.h"
 #include "tiledb/type/range/range.h"
 

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -36,7 +36,6 @@
 #include "tiledb/sm/enums/query_type.h"
 #include "tiledb/sm/fragment/fragment_identifier.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/generic_tile_io.h"

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,6 @@
 #include "tiledb/sm/filesystem/azure.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 
 static std::shared_ptr<::Azure::Core::Http::HttpTransport> create_transport(
     const tiledb::sm::SSLConfig& ssl_cfg);
@@ -54,8 +53,7 @@ static std::shared_ptr<::Azure::Core::Http::HttpTransport> create_transport(
 using namespace tiledb::common;
 using tiledb::common::filesystem::directory_entry;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Converts an Azure nullable value to an STL optional. */
 template <class T>
@@ -1257,8 +1255,7 @@ std::string Azure::BlockListUploadState::next_block_id() {
   return b64_block_id_str;
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #if defined(_WIN32)
 #include <azure/core/http/win_http_transport.hpp>

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,13 +55,11 @@
 #include "tiledb/sm/filesystem/gcs.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::common;
 using tiledb::common::filesystem::directory_entry;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -1379,7 +1377,6 @@ Status GCS::parse_gcs_uri(
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif

--- a/tiledb/sm/filesystem/hdfs_filesystem.cc
+++ b/tiledb/sm/filesystem/hdfs_filesystem.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,6 @@
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/misc/constants.h"
-#include "tiledb/sm/misc/utils.h"
 #include "uri.h"
 
 #include "hadoop/hdfs.h"
@@ -62,10 +61,7 @@
 using namespace tiledb::common;
 using tiledb::common::filesystem::directory_entry;
 
-namespace tiledb {
-namespace sm {
-
-namespace hdfs {
+namespace tiledb::sm::hdfs {
 
 Status close_library(void* handle) {
   if (dlclose(handle)) {
@@ -587,9 +583,6 @@ Status HDFS::file_size(const URI& uri, uint64_t* nbytes) {
   return Status::Ok();
 }
 
-}  // namespace hdfs
-
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::hdfs
 
 #endif  // HAVE_HDFS

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,14 +39,12 @@
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/filesystem/mem_filesystem.h"
-#include "tiledb/sm/misc/utils.h"
 #include "uri.h"
 
 using namespace tiledb::common;
 using tiledb::common::filesystem::directory_entry;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 class MemFilesystem::FSNode {
  public:
@@ -686,5 +684,4 @@ Status MemFilesystem::lookup_node(
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,6 @@
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "uri.h"
 
 #include <dirent.h>

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,6 @@
 #include "tiledb/sm/config/config_iter.h"
 #include "tiledb/sm/global_state/unit_test_config.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 
 #ifdef _WIN32
 #if !defined(NOMINMAX)

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/filesystem/vfs.h"
-#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/misc/constants.h"
 
 #ifdef _WIN32
 #include "tiledb/sm/filesystem/path_win.h"
@@ -44,8 +44,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -240,7 +239,7 @@ Status URI::get_rest_components(
 }
 
 std::optional<URI> URI::get_fragment_name() const {
-  auto to_find = "/" + sm::constants::array_fragments_dir_name + "/";
+  auto to_find = "/" + constants::array_fragments_dir_name + "/";
   auto pos = uri_.find(to_find);
   if (pos == std::string::npos) {
     // Unable to find '/__fragments/' anywhere.
@@ -361,5 +360,4 @@ bool URI::operator>(const URI& uri) const {
   return uri_ > uri.uri_;
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,6 @@
 #include "tiledb/sm/filesystem/hdfs_filesystem.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/tile/tile.h"
 

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -55,15 +55,13 @@
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "uri.h"
 #include "win.h"
 
 using namespace tiledb::common;
 using tiledb::common::filesystem::directory_entry;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 namespace {
 /** Returns the last Windows error message string. */
@@ -588,7 +586,6 @@ Status Win::write_at(
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // _WIN32

--- a/tiledb/sm/filter/bit_width_reduction_filter.cc
+++ b/tiledb/sm/filter/bit_width_reduction_filter.cc
@@ -36,7 +36,6 @@
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -47,13 +47,12 @@
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
+
 class CompressionFilterStatusException : public StatusException {
  public:
   explicit CompressionFilterStatusException(const std::string& msg)
@@ -737,5 +736,4 @@ Datatype CompressionFilter::output_datatype(Datatype datatype) const {
   }
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/filter/positive_delta_filter.cc
+++ b/tiledb/sm/filter/positive_delta_filter.cc
@@ -36,7 +36,6 @@
 #include "tiledb/sm/enums/filter_option.h"
 #include "tiledb/sm/enums/filter_type.h"
 #include "tiledb/sm/filter/filter_pipeline.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/tile/tile.h"
 
 using namespace tiledb::common;

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -42,7 +42,6 @@
 #include "tiledb/sm/fragment/fragment_identifier.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -50,7 +50,7 @@
 #include "tiledb/sm/fragment/v1v2preloaded_fragment_metadata.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/misc/rectangle.h"
 #include "tiledb/sm/query/readers/aggregators/tile_metadata.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
@@ -1814,7 +1814,7 @@ std::vector<uint64_t> FragmentMetadata::compute_overlapping_tile_ids(
   auto metadata_domain = (const T*)&temp[0];
 
   // Check if there is any overlap
-  if (!utils::geometry::overlap(subarray, metadata_domain, dim_num))
+  if (!rectangle::overlap(subarray, metadata_domain, dim_num))
     return tids;
 
   // Initialize subarray tile domain
@@ -1833,8 +1833,8 @@ std::vector<uint64_t> FragmentMetadata::compute_overlapping_tile_ids(
     tile_pos = domain.get_tile_pos(metadata_domain, tile_coords);
     tids.emplace_back(tile_pos);
     domain.get_next_tile_coords(subarray_tile_domain, tile_coords);
-  } while (utils::geometry::coords_in_rect(
-      tile_coords, subarray_tile_domain, dim_num));
+  } while (
+      rectangle::coords_in_rect(tile_coords, subarray_tile_domain, dim_num));
 
   // Clean up
   tdb_delete_array(subarray_tile_domain);
@@ -1862,7 +1862,7 @@ FragmentMetadata::compute_overlapping_tile_ids_cov(const T* subarray) const {
   auto metadata_domain = (const T*)&temp[0];
 
   // Check if there is any overlap
-  if (!utils::geometry::overlap(subarray, metadata_domain, dim_num))
+  if (!rectangle::overlap(subarray, metadata_domain, dim_num))
     return tids;
 
   // Initialize subarray tile domain
@@ -1884,15 +1884,15 @@ FragmentMetadata::compute_overlapping_tile_ids_cov(const T* subarray) const {
   uint64_t tile_pos;
   do {
     domain.get_tile_subarray(metadata_domain, tile_coords, tile_subarray);
-    utils::geometry::overlap(
+    rectangle::overlap(
         subarray, tile_subarray, dim_num, tile_overlap, &overlap);
     assert(overlap);
-    cov = utils::geometry::coverage(tile_overlap, tile_subarray, dim_num);
+    cov = rectangle::coverage(tile_overlap, tile_subarray, dim_num);
     tile_pos = domain.get_tile_pos(metadata_domain, tile_coords);
     tids.emplace_back(tile_pos, cov);
     domain.get_next_tile_coords(subarray_tile_domain, tile_coords);
-  } while (utils::geometry::coords_in_rect(
-      tile_coords, subarray_tile_domain, dim_num));
+  } while (
+      rectangle::coords_in_rect(tile_coords, subarray_tile_domain, dim_num));
 
   // Clean up
   tdb_delete_array(subarray_tile_domain);

--- a/tiledb/sm/global_state/global_state.cc
+++ b/tiledb/sm/global_state/global_state.cc
@@ -39,7 +39,6 @@
 #ifdef __linux__
 #include "tiledb/common/thread_pool/thread_pool.h"
 #include "tiledb/sm/filesystem/posix.h"
-#include "tiledb/sm/misc/utils.h"
 #endif
 
 #include <cassert>

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/fragment/fragment_identifier.h"
 #include "tiledb/sm/group/group_member.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::common;
 

--- a/tiledb/sm/misc/CMakeLists.txt
+++ b/tiledb/sm/misc/CMakeLists.txt
@@ -91,6 +91,14 @@ commence(object_library parse_argument)
 conclude(object_library)
 
 #
+# `rectangle` object library
+#
+commence(object_library rectangle)
+    this_target_sources(rectangle.cc)
+    this_target_object_libraries(baseline)
+conclude(object_library)
+
+#
 # `time` object library
 #
 commence(object_library time)

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -49,7 +49,7 @@
 #include "tiledb/sm/enums/compressor.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/misc/rectangle.h"
 
 namespace tiledb::sm::constants {
 

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -49,7 +49,6 @@
 #include "tiledb/sm/enums/compressor.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/serialization_type.h"
-#include "tiledb/sm/misc/rectangle.h"
 
 namespace tiledb::sm::constants {
 

--- a/tiledb/sm/misc/rectangle.cc
+++ b/tiledb/sm/misc/rectangle.cc
@@ -30,7 +30,13 @@
  * This file implements namespace rectangle.
  */
 
+#include <cmath>
+
 #include "tiledb/sm/misc/rectangle.h"
+
+#ifdef __linux__
+#include "tiledb/sm/filesystem/posix.h"
+#endif
 
 using namespace tiledb::common;
 

--- a/tiledb/sm/misc/rectangle.cc
+++ b/tiledb/sm/misc/rectangle.cc
@@ -1,12 +1,11 @@
 /**
- * @file   utils.cc
+ * @file   rectangle.cc
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,139 +27,14 @@
  *
  * @section DESCRIPTION
  *
- * This file implements useful (global) functions.
+ * This file implements namespace rectangle.
  */
 
-#include "tiledb/sm/misc/utils.h"
-#include "tiledb/common/logger.h"
-#include "tiledb/common/unreachable.h"
-#include "tiledb/sm/enums/datatype.h"
-#include "tiledb/sm/filesystem/uri.h"
-#include "tiledb/sm/misc/constants.h"
-
-#include <algorithm>
-#include <iostream>
-#include <set>
-#include <sstream>
-
-#ifdef __linux__
-#include "tiledb/sm/filesystem/posix.h"
-#endif
+#include "tiledb/sm/misc/rectangle.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
-
-namespace utils {
-
-/* ****************************** */
-/*         TYPE FUNCTIONS         */
-/* ****************************** */
-
-namespace datatype {
-
-template <>
-Status check_template_type_to_datatype<int8_t>(Datatype datatype) {
-  if (datatype == Datatype::INT8)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type int8_t but datatype is not Datatype::INT8");
-}
-template <>
-Status check_template_type_to_datatype<uint8_t>(Datatype datatype) {
-  if (datatype == Datatype::UINT8)
-    return Status::Ok();
-  else if (datatype == Datatype::STRING_ASCII)
-    return Status::Ok();
-  else if (datatype == Datatype::STRING_UTF8)
-    return Status::Ok();
-
-  return Status_Error(
-      "Template of type uint8_t but datatype is not Datatype::UINT8 nor "
-      "Datatype::STRING_ASCII nor atatype::STRING_UTF8");
-}
-template <>
-Status check_template_type_to_datatype<int16_t>(Datatype datatype) {
-  if (datatype == Datatype::INT16)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type int16_t but datatype is not Datatype::INT16");
-}
-template <>
-Status check_template_type_to_datatype<uint16_t>(Datatype datatype) {
-  if (datatype == Datatype::UINT16)
-    return Status::Ok();
-  else if (datatype == Datatype::STRING_UTF16)
-    return Status::Ok();
-  else if (datatype == Datatype::STRING_UCS2)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type uint16_t but datatype is not Datatype::UINT16 nor "
-      "Datatype::STRING_UTF16 nor Datatype::STRING_UCS2");
-}
-template <>
-Status check_template_type_to_datatype<int32_t>(Datatype datatype) {
-  if (datatype == Datatype::INT32)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type int32_t but datatype is not Datatype::INT32");
-}
-template <>
-Status check_template_type_to_datatype<uint32_t>(Datatype datatype) {
-  if (datatype == Datatype::UINT32)
-    return Status::Ok();
-  else if (datatype == Datatype::STRING_UTF32)
-    return Status::Ok();
-  else if (datatype == Datatype::STRING_UCS4)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type uint32_t but datatype is not Datatype::UINT32 nor "
-      "Datatype::STRING_UTF32 nor Datatype::STRING_UCS4");
-}
-template <>
-Status check_template_type_to_datatype<int64_t>(Datatype datatype) {
-  if (datatype == Datatype::INT64)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type int64_t but datatype is not Datatype::INT64");
-}
-template <>
-Status check_template_type_to_datatype<uint64_t>(Datatype datatype) {
-  if (datatype == Datatype::UINT64)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type uint64_t but datatype is not Datatype::UINT64");
-}
-template <>
-Status check_template_type_to_datatype<float>(Datatype datatype) {
-  if (datatype == Datatype::FLOAT32)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type float but datatype is not Datatype::FLOAT32");
-}
-template <>
-Status check_template_type_to_datatype<double>(Datatype datatype) {
-  if (datatype == Datatype::FLOAT64)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type double but datatype is not Datatype::FLOAT64");
-}
-template <>
-Status check_template_type_to_datatype<char>(Datatype datatype) {
-  if (datatype == Datatype::CHAR)
-    return Status::Ok();
-  return Status_Error(
-      "Template of type char but datatype is not Datatype::CHAR");
-}
-
-}  // namespace datatype
-
-/* ********************************* */
-/*        GEOMETRY FUNCTIONS         */
-/* ********************************* */
-
-namespace geometry {
+namespace tiledb::sm::rectangle {
 
 template <class T>
 inline bool coords_in_rect(
@@ -246,11 +120,7 @@ std::vector<std::array<T, 2>> intersection(
   return ret;
 }
 
-}  // namespace geometry
-
 // Explicit template instantiations
-
-namespace geometry {
 
 template bool coords_in_rect<int>(
     const int* corrds, const int* subarray, unsigned int dim_num);
@@ -431,7 +301,4 @@ template std::vector<std::array<uint64_t, 2>> intersection<uint64_t>(
     const std::vector<std::array<uint64_t, 2>>& r1,
     const std::vector<std::array<uint64_t, 2>>& r2);
 
-}  // namespace geometry
-}  // namespace utils
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::rectangle

--- a/tiledb/sm/misc/rectangle.h
+++ b/tiledb/sm/misc/rectangle.h
@@ -1,12 +1,11 @@
 /**
- * @file   utils.h
+ * @file   rectangle.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,83 +27,19 @@
  *
  * @section DESCRIPTION
  *
- * This file contains useful (global) functions.
+ * This file defines namespace rectangle.
  */
 
-#ifndef TILEDB_UTILS_H
-#define TILEDB_UTILS_H
+#ifndef TILEDB_RECTANGLE_H
+#define TILEDB_RECTANGLE_H
 
-#include <cassert>
-#include <cmath>
-#include <string>
-#include <type_traits>
 #include <vector>
 
-#include "constants.h"
 #include "tiledb/common/status.h"
-
-namespace tiledb {
-namespace sm {
 
 using namespace tiledb::common;
 
-class Posix;
-class URI;
-
-enum class Datatype : uint8_t;
-enum class SerializationType : uint8_t;
-
-namespace utils {
-
-/* ********************************* */
-/*          TYPE FUNCTIONS           */
-/* ********************************* */
-
-namespace datatype {
-
-/**
- * Check if a given type T is quivalent to the tiledb::sm::DataType
- * @tparam T
- * @param datatype to compare T to
- * @return Status indicating Ok() on equal data types else Status:Error()
- */
-template <class T>
-Status check_template_type_to_datatype(Datatype datatype);
-
-}  // namespace datatype
-
-/* ********************************* */
-/*        GEOMETRY FUNCTIONS         */
-/* ********************************* */
-
-namespace geometry {
-
-/**
- * Returns the number of cells in the input rectangle. Applicable
- * only to integers.
- *
- * @tparam T The rectangle domain type.
- * @param rect The input rectangle.
- * @param dim_num The number of dimensions of the rectangle.
- * @return The number of cells in the rectangle.
- */
-template <
-    class T,
-    typename std::enable_if<std::is_integral<T>::value, T>::type* = nullptr>
-uint64_t cell_num(const T* rect, unsigned dim_num) {
-  uint64_t ret = 1;
-  for (unsigned i = 0; i < dim_num; ++i)
-    ret *= rect[2 * i + 1] - rect[2 * i] + 1;
-  return ret;
-}
-
-/** Non-applicable to non-integers. */
-template <
-    class T,
-    typename std::enable_if<!std::is_integral<T>::value, T>::type* = nullptr>
-uint64_t cell_num(const T*, unsigned) {
-  throw std::logic_error("Invalid call to `cell_num` for non-integral type");
-}
+namespace tiledb::sm::rectangle {
 
 /**
  * Checks if `coords` are inside `rect`.
@@ -173,10 +108,6 @@ std::vector<std::array<T, 2>> intersection(
     const std::vector<std::array<T, 2>>& r1,
     const std::vector<std::array<T, 2>>& r2);
 
-}  // namespace geometry
+}  // namespace tiledb::sm::rectangle
 
-}  // namespace utils
-}  // namespace sm
-}  // namespace tiledb
-
-#endif  // TILEDB_UTILS_H
+#endif  // TILEDB_RECTANGLE_H

--- a/tiledb/sm/misc/test/compile_rectangle_main.cc
+++ b/tiledb/sm/misc/test/compile_rectangle_main.cc
@@ -1,0 +1,36 @@
+/**
+ * @file compile_rectangle_main.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "../rectangle.h"
+
+int main() {
+  const auto x = 0;
+  const auto y = 0;
+  (void)tiledb::sm::rectangle::overlap(&x, &y, 0);
+  return 0;
+}

--- a/tiledb/sm/misc/test/unit_math.cc
+++ b/tiledb/sm/misc/test/unit_math.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@
 
 #include <test/support/tdb_catch.h>
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 
 using namespace tiledb::sm::utils;
 

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -40,7 +40,6 @@
 #include "tiledb/sm/misc/hilbert.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/types.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/legacy/read_cell_slab_iter.h"
 #include "tiledb/sm/query/query_macros.h"

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -38,7 +38,6 @@
 #include "tiledb/sm/enums/query_condition_op.h"
 #include "tiledb/sm/fragment/fragment_identifier.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/readers/result_cell_slab.h"
 
 #include <algorithm>

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -38,7 +38,6 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/legacy/cell_slab_iter.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/readers/filtered_data.h"

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/legacy/cell_slab_iter.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/readers/filtered_data.h"

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -41,7 +41,6 @@
 #include "tiledb/sm/misc/hash.h"
 #include "tiledb/sm/misc/hilbert.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/readers/result_tile.h"

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -39,7 +39,6 @@
 #include "tiledb/sm/misc/comparators.h"
 #include "tiledb/sm/misc/hilbert.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/query/readers/result_tile.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/query/writers/dense_tiler.cc
+++ b/tiledb/sm/query/writers/dense_tiler.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -38,14 +38,13 @@
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/parallel_functions.h"
-#include "tiledb/sm/misc/utils.h"
+#include "tiledb/sm/misc/rectangle.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"
 
 using namespace tiledb::common;
 using namespace tiledb::sm::stats;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -115,7 +114,7 @@ const typename DenseTiler<T>::CopyPlan DenseTiler<T>::copy_plan(
 
   // Focus on the input tile
   auto tile_sub = this->tile_subarray(id);
-  auto sub_in_tile = utils::geometry::intersection<T>(sub, tile_sub);
+  auto sub_in_tile = rectangle::intersection<T>(sub, tile_sub);
 
   // Compute the starting element to copy from in the subarray, and
   // to copy to in the tile
@@ -651,5 +650,4 @@ template class DenseTiler<uint32_t>;
 template class DenseTiler<int64_t>;
 template class DenseTiler<uint64_t>;
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/query/writers/global_order_writer.cc
+++ b/tiledb/sm/query/writers/global_order_writer.cc
@@ -44,7 +44,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -44,7 +44,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -44,7 +44,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/hilbert_order.h"
 #include "tiledb/sm/query/query_macros.h"
 #include "tiledb/sm/stats/global_stats.h"

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -35,7 +35,6 @@
 #include "tiledb/sm/filesystem/ssl_config.h"
 #include "tiledb/sm/filesystem/uri.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 
 #include <algorithm>
@@ -49,8 +48,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /**
  * Wraps opaque user data to be invoked with a write callback.
@@ -453,9 +451,9 @@ CURLcode Curl::curl_easy_perform_instrumented(
     const char* const url, const uint8_t retry_number) const {
   CURL* curl = curl_.get();
   // Time the curl transfer
-  uint64_t t1 = tiledb::sm::utils::time::timestamp_now_ms();
+  uint64_t t1 = utils::time::timestamp_now_ms();
   auto curl_code = curl_easy_perform(curl);
-  uint64_t t2 = tiledb::sm::utils::time::timestamp_now_ms();
+  uint64_t t2 = utils::time::timestamp_now_ms();
   uint64_t dt = t2 - t1;
   long http_code = 0;
   if (curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code) != CURLE_OK) {
@@ -1030,5 +1028,5 @@ Status Curl::put_data_common(
 
   return Status::Ok();
 }
-}  // namespace sm
-}  // namespace tiledb
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/rtree/rtree.cc
+++ b/tiledb/sm/rtree/rtree.cc
@@ -37,7 +37,6 @@
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/storage_format/serialization/serializers.h"
 
 #include <cassert>
@@ -55,8 +54,7 @@ class RTreeException : public StatusException {
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -419,5 +417,4 @@ void RTree::deserialize_v5(Deserializer& deserializer, const Domain* domain) {
   domain_ = domain;
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm

--- a/tiledb/sm/stats/stats.cc
+++ b/tiledb/sm/stats/stats.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2021 TileDB, Inc.
+ * @copyright Copyright (c) 2021-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,16 +32,13 @@
 
 #include "tiledb/sm/stats/stats.h"
 #include "tiledb/common/stdx_string.h"
-#include "tiledb/sm/misc/utils.h"
 
 #include <algorithm>
 #include <cassert>
 #include <sstream>
 #include <vector>
 
-namespace tiledb {
-namespace sm {
-namespace stats {
+namespace tiledb::sm::stats {
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -301,6 +298,4 @@ void Stats::populate_with_data(const StatsData& data) {
   }
 }
 
-}  // namespace stats
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::stats

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -6,7 +6,6 @@
  * The MIT License
  *
  * @copyright Copyright (c) 2017-2024 TileDB, Inc.
- * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +56,6 @@
 #include "tiledb/sm/group/group.h"
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/misc/tdb_time.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/object/object.h"
 #include "tiledb/sm/object/object_mutex.h"
 #include "tiledb/sm/query/query.h"

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -49,9 +49,9 @@
 #include "tiledb/sm/fragment/fragment_metadata.h"
 #include "tiledb/sm/misc/hash.h"
 #include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/misc/rectangle.h"
 #include "tiledb/sm/misc/resource_pool.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/query/query.h"
 #include "tiledb/sm/query/readers/sparse_index_reader_base.h"
 #include "tiledb/sm/rest/rest_client.h"
@@ -841,7 +841,7 @@ uint64_t Subarray::tile_cell_num(const T* tile_coords) const {
     uint64_t cell_num_for_dim = 0;
     for (size_t r = 0; r < range_subset_[d].num_ranges(); ++r) {
       const auto& range = range_subset_[d][r];
-      utils::geometry::overlap(
+      rectangle::overlap(
           (const T*)range.data(),
           &tile_subarray[2 * d],
           1,
@@ -2691,7 +2691,7 @@ void Subarray::crop_to_tile_impl(const T* tile_coords, SubarrayT& ret) const {
     uint64_t i = 0;
     for (size_t r = 0; r < range_subset_[d].num_ranges(); ++r) {
       const auto& range = range_subset_[d][r];
-      utils::geometry::overlap(
+      rectangle::overlap(
           (const T*)range.data(),
           &tile_subarray[2 * d],
           1,

--- a/tiledb/sm/subarray/subarray_partitioner.cc
+++ b/tiledb/sm/subarray/subarray_partitioner.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,14 +40,13 @@
 #include "tiledb/sm/enums/layout.h"
 #include "tiledb/sm/misc/hilbert.h"
 #include "tiledb/sm/misc/tdb_math.h"
-#include "tiledb/sm/misc/utils.h"
 #include "tiledb/sm/stats/global_stats.h"
 
 #include <iomanip>
 
-class SubarrayPartitionerStatusException : public StatusException {
+class SubarrayPartitionerException : public StatusException {
  public:
-  explicit SubarrayPartitionerStatusException(const std::string& message)
+  explicit SubarrayPartitionerException(const std::string& message)
       : StatusException("SubarrayPartitioner", message) {
   }
 };
@@ -1159,7 +1158,7 @@ bool SubarrayPartitioner::must_split(Subarray* partition) {
          mem_size.variable_ > memory_budget_var_ ||
          mem_size.validity_ > memory_budget_validity_)) {
       if (partition->is_unary()) {
-        throw SubarrayPartitionerStatusException(
+        throw SubarrayPartitionerException(
             "Trying to partition a unary range because of memory budget, this "
             "will cause the query to run very slow. Increase "
             "`sm.memory_budget` and `sm.memory_budget_var` through the "


### PR DESCRIPTION
Create `rectangle` object library from reworked `utils` code.

* Rename `tiledb/sm/misc/utils.{h, cc}` to `rectangle`.
* Rename the namespace `tiledb::sm::utils::geometry` -> `tiledb::sm::rectangle`.
* Remove dead code from the file.
* Create a `rectangle` object library for future use. 

[sc-51145]

---
TYPE: NO_HISTORY
DESC: Create `rectangle` object library from reworked utils code.
