### PR TITLE
Install missing dependency in the Release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
     needs: Publish-Release
     if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
     steps:
+      # The open-issue action requires to clone the repository.
+      - name: Checkout TileDB
+        uses: actions/checkout@v4
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
         if: matrix.manylinux
         run: |
           set -e pipefail
-          yum install -y redhat-lsb-core centos-release-scl devtoolset-7
+          yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
           echo "source /opt/rh/devtoolset-7/enable" >> ~/.bashrc
       - name: Configure TileDB
         run: |


### PR DESCRIPTION
[SC-51175](https://app.shortcut.com/tiledb-inc/story/51175/failures-in-the-release-workflow-after-openssl-3-update)

Fixes [failures](https://github.com/TileDB-Inc/TileDB/actions/runs/9970526664/job/27549618574#step:8:209) after updating to OpenSSL 3.

Also fixes failures in the `Create-Issue-On-Fail` step.

---
TYPE: NO_HISTORY