### PR TITLE
Remove dead code in `StorageManager` and `Query`

### DIFF
--- a/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
+++ b/tiledb/api/c_api_test_support/storage_manager_stub/storage_manager_override.h
@@ -38,15 +38,10 @@
 #include "tiledb/sm/storage_manager/context_resources.h"
 
 namespace tiledb::common {
-class ThreadPool;
 class Logger;
 }  // namespace tiledb::common
-namespace tiledb::stats {
-class Stats;
-}
 namespace tiledb::sm {
 class Config;
-class VFS;
 
 class StorageManagerStub {
   Config config_;
@@ -54,14 +49,13 @@ class StorageManagerStub {
  public:
   static constexpr bool is_overriding_class = true;
   StorageManagerStub(
-      ContextResources&, std::shared_ptr<common::Logger>, const Config& config)
+      ContextResources&,
+      const std::shared_ptr<common::Logger>&,
+      const Config& config)
       : config_(config) {
   }
 
   inline Status cancel_all_tasks() {
-    return Status{};
-  }
-  inline Status set_tag(const std::string&, const std::string&) {
     return Status{};
   }
 };

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1638,24 +1638,6 @@ Status Query::submit() {
   return Status::Ok();
 }
 
-Status Query::submit_async(
-    std::function<void(void*)> callback, void* callback_data) {
-  // Do not resubmit completed reads.
-  if (type_ == QueryType::READ && status_ == QueryStatus::COMPLETED) {
-    callback(callback_data);
-    return Status::Ok();
-  }
-  init();
-  if (array_->is_remote())
-    return logger_->status(
-        Status_QueryError("Error in async query submission; async queries not "
-                          "supported for remote arrays."));
-
-  callback_ = callback;
-  callback_data_ = callback_data;
-  return storage_manager_->query_submit_async(this);
-}
-
 QueryStatus Query::status() const {
   return status_;
 }

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -705,14 +705,6 @@ class Query {
   /** Submits the query to the storage manager. */
   Status submit();
 
-  /**
-   * Submits the query to the storage manager. The query will be
-   * processed asynchronously (i.e., in a non-blocking manner).
-   * Once the query is completed, the input callback function will
-   * be executed using the input callback data.
-   */
-  Status submit_async(std::function<void(void*)> callback, void* callback_data);
-
   /** Returns the query status. */
   QueryStatus status() const;
 

--- a/tiledb/sm/storage_manager/storage_manager_canonical.h
+++ b/tiledb/sm/storage_manager/storage_manager_canonical.h
@@ -61,16 +61,11 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 
-class Array;
-class ArrayDirectory;
-class ArraySchema;
-class Consolidator;
-class EncryptionKey;
 class Query;
 
 enum class EncryptionType : uint8_t;
 
-/** The storage manager that manages pretty much everything in TileDB. */
+/** The storage manager that manages pretty much nothing in TileDB. */
 class StorageManagerCanonical {
  public:
   /* ********************************* */
@@ -80,23 +75,17 @@ class StorageManagerCanonical {
   /**
    * Complete, C.41-compliant constructor
    *
+   * The `resources` argument is only used for its `vfs()` member function. This
+   * is the VFS instance that's waited on in `cancel_all_tasks`.
+   *
+   *
+   * @param resources Resource object from associated context
    * @param config The configuration parameters.
    */
   StorageManagerCanonical(
       ContextResources& resources,
-      shared_ptr<Logger> logger,
+      const shared_ptr<Logger>& logger,
       const Config& config);
-
- private:
-  /**
-   * Initializes the storage manager. Only used in the constructor.
-   *
-   * TODO: Integrate what this function does into the constructor directly.
-   * TODO: Eliminate this function.
-   *
-   * @return Status
-   */
-  Status init();
 
  public:
   /** Destructor. */
@@ -109,14 +98,6 @@ class StorageManagerCanonical {
   /*                API                */
   /* ********************************* */
 
-  /**
-   * Pushes an async query to the queue.
-   *
-   * @param query The async query.
-   * @return Status
-   */
-  Status async_push_query(Query* query);
-
   /** Cancels all background tasks. */
   Status cancel_all_tasks();
 
@@ -125,18 +106,6 @@ class StorageManagerCanonical {
 
   /** Submits a query for (sync) execution. */
   Status query_submit(Query* query);
-
-  /**
-   * Submits a query for async execution.
-   *
-   * @param query The query to submit.
-   * @return Status
-   */
-  Status query_submit_async(Query* query);
-
-  [[nodiscard]] inline ContextResources& resources() const {
-    return resources_;
-  }
 
  private:
   /* ********************************* */
@@ -177,11 +146,10 @@ class StorageManagerCanonical {
   /*        PRIVATE ATTRIBUTES         */
   /* ********************************* */
 
-  /** Context create resources object. */
-  ContextResources& resources_;
-
-  /** The class logger. */
-  shared_ptr<Logger> logger_;
+  /**
+   * VFS instance used in `cancel_all_tasks`.
+   */
+  VFS& vfs_;
 
   /** Set to true when tasks are being cancelled. */
   bool cancellation_in_progress_;
@@ -200,10 +168,6 @@ class StorageManagerCanonical {
 
   /** Guards queries_in_progress_ counter. */
   std::condition_variable queries_in_progress_cv_;
-
-  /** Tracks all scheduled tasks that can be safely cancelled before execution.
-   */
-  CancelableTasks cancelable_tasks_;
 
   /* ********************************* */
   /*         PRIVATE METHODS           */


### PR DESCRIPTION
With the removal of deprecated function in #5146, the opportunity arises to remove asynchronous query submission, which the C API no longer has any reference to. Alongside this, there is other dead code in `StorageManager` in need of pruning. This PR simplifies its constructor a bit and removes unused members variables.

[SC-50038]

---
TYPE: NO_HISTORY
DESC: Remove dead code in `StorageManager` and `Query`
