### PR TITLE
Remove some extraneous capnp dereferences.

### DIFF
--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -105,8 +105,9 @@ Status metadata_from_capnp(
 
   for (size_t i = 0; i < num_entries; i++) {
     auto entry_reader = entries_reader[i];
-    auto key = std::string{std::string_view{
-        entry_reader.getKey().cStr(), entry_reader.getKey().size()}};
+    auto entry_key = entry_reader.getKey();
+    auto key =
+        std::string{std::string_view{entry_key.cStr(), entry_key.size()}};
     Datatype type = datatype_enum(entry_reader.getType());
     uint32_t value_num = entry_reader.getValueNum();
 

--- a/tiledb/sm/serialization/capnp_utils.h
+++ b/tiledb/sm/serialization/capnp_utils.h
@@ -498,21 +498,19 @@ std::pair<Status, std::optional<NDRange>> deserialize_non_empty_domain_rv(
       (capnp::NonEmptyDomainList::Reader)reader;
 
   NDRange ndRange;
-  if (r.hasNonEmptyDomains() && r.getNonEmptyDomains().size() > 0) {
-    auto nonEmptyDomains = r.getNonEmptyDomains();
-
-    for (uint32_t i = 0; i < nonEmptyDomains.size(); i++) {
-      auto nonEmptyDomainObj = nonEmptyDomains[i];
+  if (r.hasNonEmptyDomains()) {
+    auto non_empty_domains = r.getNonEmptyDomains();
+    for (auto non_empty_domain : non_empty_domains) {
       // We always store nonEmptyDomain as uint8 lists for the heterogeneous/var
       // length version
-      auto list = nonEmptyDomainObj.getNonEmptyDomain().getUint8();
+      auto list = non_empty_domain.getNonEmptyDomain().getUint8();
       std::vector<uint8_t> vec(list.size());
       for (uint32_t index = 0; index < list.size(); index++) {
         vec[index] = list[index];
       }
 
-      if (nonEmptyDomainObj.hasSizes()) {
-        auto sizes = nonEmptyDomainObj.getSizes();
+      if (non_empty_domain.hasSizes()) {
+        auto sizes = non_empty_domain.getSizes();
         ndRange.emplace_back(vec.data(), vec.size(), sizes[0]);
       } else {
         ndRange.emplace_back(vec.data(), vec.size());

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -59,54 +59,58 @@ void generic_tile_offsets_from_capnp(
     FragmentMetadata::GenericTileOffsets& gt_offsets) {
   gt_offsets.rtree_ = gt_reader.getRtree();
   if (gt_reader.hasTileOffsets()) {
-    gt_offsets.tile_offsets_.reserve(gt_reader.getTileOffsets().size());
-    for (const auto& tile_offset : gt_reader.getTileOffsets()) {
+    auto tile_offsets = gt_reader.getTileOffsets();
+    gt_offsets.tile_offsets_.reserve(tile_offsets.size());
+    for (const auto& tile_offset : tile_offsets) {
       gt_offsets.tile_offsets_.emplace_back(tile_offset);
     }
   }
   if (gt_reader.hasTileVarOffsets()) {
-    gt_offsets.tile_var_offsets_.reserve(gt_reader.getTileVarOffsets().size());
-    for (const auto& tile_var_offset : gt_reader.getTileVarOffsets()) {
+    auto tile_var_offsets = gt_reader.getTileVarOffsets();
+    gt_offsets.tile_var_offsets_.reserve(tile_var_offsets.size());
+    for (const auto& tile_var_offset : tile_var_offsets) {
       gt_offsets.tile_var_offsets_.emplace_back(tile_var_offset);
     }
   }
   if (gt_reader.hasTileVarSizes()) {
-    gt_offsets.tile_var_sizes_.reserve(gt_reader.getTileVarSizes().size());
-    for (const auto& tile_var_size : gt_reader.getTileVarSizes()) {
+    auto tile_var_sizes = gt_reader.getTileVarSizes();
+    gt_offsets.tile_var_sizes_.reserve(tile_var_sizes.size());
+    for (const auto& tile_var_size : tile_var_sizes) {
       gt_offsets.tile_var_sizes_.emplace_back(tile_var_size);
     }
   }
   if (gt_reader.hasTileValidityOffsets()) {
-    gt_offsets.tile_validity_offsets_.reserve(
-        gt_reader.getTileValidityOffsets().size());
-    for (const auto& tile_validity_offset :
-         gt_reader.getTileValidityOffsets()) {
+    auto tile_validity_offsets = gt_reader.getTileValidityOffsets();
+    gt_offsets.tile_validity_offsets_.reserve(tile_validity_offsets.size());
+    for (const auto& tile_validity_offset : tile_validity_offsets) {
       gt_offsets.tile_validity_offsets_.emplace_back(tile_validity_offset);
     }
   }
   if (gt_reader.hasTileMinOffsets()) {
-    gt_offsets.tile_min_offsets_.reserve(gt_reader.getTileMinOffsets().size());
-    for (const auto& tile_min_offset : gt_reader.getTileMinOffsets()) {
+    auto tile_min_offsets = gt_reader.getTileMinOffsets();
+    gt_offsets.tile_min_offsets_.reserve(tile_min_offsets.size());
+    for (const auto& tile_min_offset : tile_min_offsets) {
       gt_offsets.tile_min_offsets_.emplace_back(tile_min_offset);
     }
   }
   if (gt_reader.hasTileMaxOffsets()) {
-    gt_offsets.tile_max_offsets_.reserve(gt_reader.getTileMaxOffsets().size());
-    for (const auto& tile_max_offset : gt_reader.getTileMaxOffsets()) {
+    auto tile_max_offsets = gt_reader.getTileMaxOffsets();
+    gt_offsets.tile_max_offsets_.reserve(tile_max_offsets.size());
+    for (const auto& tile_max_offset : tile_max_offsets) {
       gt_offsets.tile_max_offsets_.emplace_back(tile_max_offset);
     }
   }
   if (gt_reader.hasTileSumOffsets()) {
-    gt_offsets.tile_sum_offsets_.reserve(gt_reader.getTileSumOffsets().size());
-    for (const auto& tile_sum_offset : gt_reader.getTileSumOffsets()) {
+    auto tile_sum_offsets = gt_reader.getTileSumOffsets();
+    gt_offsets.tile_sum_offsets_.reserve(tile_sum_offsets.size());
+    for (const auto& tile_sum_offset : tile_sum_offsets) {
       gt_offsets.tile_sum_offsets_.emplace_back(tile_sum_offset);
     }
   }
   if (gt_reader.hasTileNullCountOffsets()) {
-    gt_offsets.tile_null_count_offsets_.reserve(
-        gt_reader.getTileNullCountOffsets().size());
-    for (const auto& tile_null_count_offset :
-         gt_reader.getTileNullCountOffsets()) {
+    auto tile_null_count_offsets = gt_reader.getTileNullCountOffsets();
+    gt_offsets.tile_null_count_offsets_.reserve(tile_null_count_offsets.size());
+    for (const auto& tile_null_count_offset : tile_null_count_offsets) {
       gt_offsets.tile_null_count_offsets_.emplace_back(tile_null_count_offset);
     }
   }
@@ -362,9 +366,9 @@ Status fragment_metadata_from_capnp(
 
   frag_meta->version() = frag_meta_reader.getVersion();
   if (frag_meta_reader.hasTimestampRange()) {
-    frag_meta->timestamp_range() = std::make_pair(
-        frag_meta_reader.getTimestampRange()[0],
-        frag_meta_reader.getTimestampRange()[1]);
+    auto timestamp_range = frag_meta_reader.getTimestampRange();
+    frag_meta->timestamp_range() =
+        std::make_pair(timestamp_range[0], timestamp_range[1]);
   }
   frag_meta->last_tile_cell_num() = frag_meta_reader.getLastTileCellNum();
 


### PR DESCRIPTION
[sc-48746]

We need to be conservative and follow the CAPNP guidelines on what's best practice when reading messages: only call `reader.getXYZ` once and reuse that value so that the traversal counter is not increased and we don't hit the limit earlier than needed. [Tips and best practices here: https://capnproto.org/cxx.html]

---
TYPE: NO_HISTORY
DESC: Remove some extraneous capnp dereferences.
