### PR TITLE
Fix crash in current domain triggered by incorrect function selection.

### DIFF
--- a/test/src/test-cppapi-current-domain.cc
+++ b/test/src/test-cppapi-current-domain.cc
@@ -118,10 +118,10 @@ TEST_CASE_METHOD(
   ndrect.set_range(1, std::string("b"), std::string("db"));
 
   // Get and check ranges
-  std::array<std::string, 2> range = ndrect.range(0);
+  std::array<std::string, 2> range = ndrect.range<std::string>(0);
   CHECK(range[0] == "a");
   CHECK(range[1] == "c");
-  range = ndrect.range(1);
+  range = ndrect.range<std::string>(1);
   CHECK(range[0] == "b");
   CHECK(range[1] == "db");
 
@@ -134,10 +134,10 @@ TEST_CASE_METHOD(
   auto rect = current_domain.ndrectangle();
 
   // Get and check ranges
-  range = ndrect.range(0);
+  range = ndrect.range<std::string>(0);
   CHECK(range[0] == "a");
   CHECK(range[1] == "c");
-  range = ndrect.range(1);
+  range = ndrect.range<std::string>(1);
   CHECK(range[0] == "b");
   CHECK(range[1] == "db");
 }

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -47,15 +47,6 @@
 namespace tiledb {
 
 class NDRectangle {
-  template <class K, class Y = void>
-  struct tuple_ret {
-    using type = std::array<K, 2>;
-  };
-  template <class Y>
-  struct tuple_ret<std::string, Y> {
-    using type = std::array<std::string, 2>;
-  };
-
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -263,8 +254,8 @@ class NDRectangle {
    * @param dim_name The dimension name.
    * @return A duplex of the form (start, end).
    */
-  template <class T, class Y = void>
-  typename tuple_ret<T>::type range(const std::string& dim_name) {
+  template <class T>
+  std::array<T, 2> range(const std::string& dim_name) {
     auto& ctx = ctx_.get();
     tiledb_range_t range;
     ctx.handle_error(tiledb_ndrectangle_get_range_from_name(
@@ -323,10 +314,9 @@ class NDRectangle {
  * @param range_idx The range index.
  * @return A pair of the form (start, end).
  */
-
 template <>
-inline NDRectangle::tuple_ret<std::string>::type
-NDRectangle::range<std::string>(const std::string& dim_name) {
+inline std::array<std::string, 2> NDRectangle::range<std::string>(
+    const std::string& dim_name) {
   auto& ctx = ctx_.get();
   tiledb_range_t range;
   ctx.handle_error(tiledb_ndrectangle_get_range_from_name(

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -323,9 +323,10 @@ class NDRectangle {
  * @param range_idx The range index.
  * @return A pair of the form (start, end).
  */
-inline template <>
-NDRectangle::tuple_ret<std::string>::type NDRectangle::range<std::string>(
-    const std::string& dim_name) {
+
+template <>
+inline NDRectangle::tuple_ret<std::string>::type
+NDRectangle::range<std::string>(const std::string& dim_name) {
   auto& ctx = ctx_.get();
   tiledb_range_t range;
   ctx.handle_error(tiledb_ndrectangle_get_range_from_name(

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -323,7 +323,7 @@ class NDRectangle {
  * @param range_idx The range index.
  * @return A pair of the form (start, end).
  */
-template <>
+inline template <>
 NDRectangle::tuple_ret<std::string>::type NDRectangle::range<std::string>(
     const std::string& dim_name) {
   auto& ctx = ctx_.get();

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -263,7 +263,7 @@ class NDRectangle {
    * @param dim_name The dimension name.
    * @return A duplex of the form (start, end).
    */
-  template <class T>
+  template <class T, class Y = void>
   typename tuple_ret<T>::type range(const std::string& dim_name) {
     auto& ctx = ctx_.get();
     tiledb_range_t range;
@@ -271,27 +271,6 @@ class NDRectangle {
         ctx.ptr().get(), ndrect_.get(), dim_name.c_str(), &range));
 
     return {*(const T*)range.min, *(const T*)range.max};
-  }
-
-  /**
-   * Retrieves a range for a given variable length string dimension index and
-   * range id.
-   *
-   * @param dim_name The dimension name.
-   * @param range_idx The range index.
-   * @return A pair of the form (start, end).
-   */
-  template <>
-  tuple_ret<std::string>::type range<std::string>(const std::string& dim_name) {
-    auto& ctx = ctx_.get();
-    tiledb_range_t range;
-    ctx.handle_error(tiledb_ndrectangle_get_range_from_name(
-        ctx.ptr().get(), ndrect_.get(), dim_name.c_str(), &range));
-
-    std::string start_str(static_cast<const char*>(range.min), range.min_size);
-    std::string end_str(static_cast<const char*>(range.max), range.max_size);
-
-    return {std::move(start_str), std::move(end_str)};
   }
 
   /**
@@ -335,6 +314,28 @@ class NDRectangle {
   /** An auxiliary deleter. */
   impl::Deleter deleter_;
 };
+
+/**
+ * Retrieves a range for a given variable length string dimension index and
+ * range id.
+ *
+ * @param dim_name The dimension name.
+ * @param range_idx The range index.
+ * @return A pair of the form (start, end).
+ */
+template <>
+NDRectangle::tuple_ret<std::string>::type NDRectangle::range<std::string>(
+    const std::string& dim_name) {
+  auto& ctx = ctx_.get();
+  tiledb_range_t range;
+  ctx.handle_error(tiledb_ndrectangle_get_range_from_name(
+      ctx.ptr().get(), ndrect_.get(), dim_name.c_str(), &range));
+
+  std::string start_str(static_cast<const char*>(range.min), range.min_size);
+  std::string end_str(static_cast<const char*>(range.max), range.max_size);
+
+  return {std::move(start_str), std::move(end_str)};
+}
 
 }  // namespace tiledb
 

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -47,6 +47,15 @@
 namespace tiledb {
 
 class NDRectangle {
+  template <class K, class Y = void>
+  struct tuple_ret {
+    using type = std::array<K, 2>;
+  };
+  template <class Y>
+  struct tuple_ret<std::string, Y> {
+    using type = std::array<std::string, 2>;
+  };
+
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -245,15 +254,6 @@ class NDRectangle {
 
     return {std::move(start_str), std::move(end_str)};
   }
-
-  template <class K>
-  struct tuple_ret {
-    using type = std::array<K, 2>;
-  };
-  template <>
-  struct tuple_ret<std::string> {
-    using type = std::array<std::string, 2>;
-  };
 
   /**
    * Retrieves a range for a given dimension name. The template datatype must be

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -226,27 +226,6 @@ class NDRectangle {
   }
 
   /**
-   * Retrieves a range for a given variable length string dimension index and
-   * range id.
-   *
-   * @param dim_idx The dimension index.
-   * @param range_idx The range index.
-   * @return A pair of the form (start, end).
-   */
-  std::array<std::string, 2> range(unsigned dim_idx) {
-    auto& ctx = ctx_.get();
-    tiledb_range_t range;
-
-    ctx.handle_error(tiledb_ndrectangle_get_range(
-        ctx.ptr().get(), ndrect_.get(), dim_idx, &range));
-
-    std::string start_str(static_cast<const char*>(range.min), range.min_size);
-    std::string end_str(static_cast<const char*>(range.max), range.max_size);
-
-    return {std::move(start_str), std::move(end_str)};
-  }
-
-  /**
    * Retrieves a range for a given dimension name. The template datatype must be
    * the same as that of the underlying array.
    *
@@ -321,6 +300,28 @@ inline std::array<std::string, 2> NDRectangle::range<std::string>(
   tiledb_range_t range;
   ctx.handle_error(tiledb_ndrectangle_get_range_from_name(
       ctx.ptr().get(), ndrect_.get(), dim_name.c_str(), &range));
+
+  std::string start_str(static_cast<const char*>(range.min), range.min_size);
+  std::string end_str(static_cast<const char*>(range.max), range.max_size);
+
+  return {std::move(start_str), std::move(end_str)};
+}
+
+/**
+ * Retrieves a range for a given variable length string dimension index and
+ * range id.
+ *
+ * @param dim_idx The dimension index.
+ * @param range_idx The range index.
+ * @return A pair of the form (start, end).
+ */
+template <>
+inline std::array<std::string, 2> NDRectangle::range(unsigned dim_idx) {
+  auto& ctx = ctx_.get();
+  tiledb_range_t range;
+
+  ctx.handle_error(tiledb_ndrectangle_get_range(
+      ctx.ptr().get(), ndrect_.get(), dim_idx, &range));
 
   std::string start_str(static_cast<const char*>(range.min), range.min_size);
   std::string end_str(static_cast<const char*>(range.max), range.max_size);


### PR DESCRIPTION
Fix crash in current domain triggered by incorrect function selection for range() in the cpp api
`range<std::string>` now selects the correct specialization.

[[sc-51234]](https://app.shortcut.com/tiledb-inc/story/51234)

---
TYPE: NO_HISTORY
DESC: Fix crash in current domain triggered by incorrect function selection.
