### PR TITLE
Create file array_operations.cc for I/O-oriented Array functions.

### DIFF
--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -37,6 +37,7 @@
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/array/array_operations.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/group.h"
 #include "tiledb/sm/cpp_api/tiledb"
@@ -436,15 +437,14 @@ void DeletesFx::check_delete_conditions(
   auto array_ptr = array->ptr()->array_;
 
   // Load delete conditions.
-  auto&& [st, delete_conditions, update_values] =
-      array_ptr->opened_array()->load_delete_and_update_conditions();
-  REQUIRE(st.ok());
-  REQUIRE(delete_conditions->size() == qcs.size());
+  auto&& [delete_conditions, update_values] = load_delete_and_update_conditions(
+      ctx_.ptr().get()->resources(), array_ptr->opened_array());
+  REQUIRE(delete_conditions.size() == qcs.size());
 
   for (uint64_t i = 0; i < qcs.size(); i++) {
     // Compare to negated condition.
     auto cmp = qcs[i].ptr()->query_condition_->negated_condition();
-    CHECK(tiledb::test::ast_equal(delete_conditions->at(i).ast(), cmp.ast()));
+    CHECK(tiledb::test::ast_equal(delete_conditions.at(i).ast(), cmp.ast()));
   }
 
   array->close();

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -438,7 +438,7 @@ void DeletesFx::check_delete_conditions(
 
   // Load delete conditions.
   auto&& [delete_conditions, update_values] = load_delete_and_update_conditions(
-      ctx_.ptr().get()->resources(), array_ptr->opened_array());
+      ctx_.ptr().get()->resources(), *array_ptr->opened_array().get());
   REQUIRE(delete_conditions.size() == qcs.size());
 
   for (uint64_t i = 0; i < qcs.size(); i++) {

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -35,6 +35,7 @@
 #include "test/support/src/helpers.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/array/array_operations.h"
 #include "tiledb/sm/c_api/tiledb_struct_def.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/cpp_api/tiledb_experimental"
@@ -205,16 +206,15 @@ void UpdatesFx::check_update_conditions(
   auto array_ptr = array->ptr()->array_;
 
   // Load delete conditions.
-  auto&& [st, conditions, update_values] =
-      array_ptr->opened_array()->load_delete_and_update_conditions();
-  REQUIRE(st.ok());
-  REQUIRE(conditions->size() == qcs.size());
+  auto&& [conditions, update_values] = load_delete_and_update_conditions(
+      ctx_.ptr().get()->resources(), array_ptr->opened_array());
+  REQUIRE(conditions.size() == qcs.size());
 
   for (uint64_t i = 0; i < qcs.size(); i++) {
     // Compare to negated condition.
     auto cmp = qcs[i].ptr()->query_condition_->negated_condition();
-    CHECK(tiledb::test::ast_equal(conditions->at(i).ast(), cmp.ast()));
-    auto& loaded_update_values = update_values->at(i);
+    CHECK(tiledb::test::ast_equal(conditions.at(i).ast(), cmp.ast()));
+    auto& loaded_update_values = update_values.at(i);
     for (uint64_t j = 0; j < uvs[i].size(); j++) {
       CHECK(uvs[i][j].field_name() == loaded_update_values[j].field_name());
     }

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -207,7 +207,7 @@ void UpdatesFx::check_update_conditions(
 
   // Load delete conditions.
   auto&& [conditions, update_values] = load_delete_and_update_conditions(
-      ctx_.ptr().get()->resources(), array_ptr->opened_array());
+      ctx_.ptr().get()->resources(), *array_ptr->opened_array().get());
   REQUIRE(conditions.size() == qcs.size());
 
   for (uint64_t i = 0; i < qcs.size(); i++) {

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -144,6 +144,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/platform/cert_file.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array_directory.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/array_operations.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array/consistency.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/array_schema/array_schema_evolution.cc

--- a/tiledb/sm/array/CMakeLists.txt
+++ b/tiledb/sm/array/CMakeLists.txt
@@ -28,6 +28,32 @@ include(common NO_POLICY_SCOPE)
 include(object_library)
 
 #
+# The data- and I/O-oriented operations of class `Array` have been
+# intentionally separated to support two _future_ standalone object libraries:
+#   - `array`: data-oriented
+#   - `array_operations`: I/O-oriented
+# 
+# This design eliminates cyclic dependencies in the build, as each module has
+# its own dependency chain.
+# 
+# Note that neither object library has been implemented at present. Rather,
+# class `Array` is getting segregated by functionality to prepare for this 
+# future work. 
+# 
+# Though there is currently an object library named `array`, it will soon be
+# aptly renamed `array_directory`.
+# 
+# The `array` object library will be added in the near future.
+#
+# The `array_operations` object library is very specifically blocked by 
+# `StrategyBase::throw_if_cancelled`. At present, this function relies on 
+# `StorageManagerCanonical`, which is slated for removal. The `Query` class is 
+# undergoing maintenance to remove all dependencies on class `StorageManager`. 
+# Once `StorageManager` is removed and a standalone `StrategyBase` object 
+# library can be added, so should the `array_operations` object library. 
+#
+
+#
 # `array` object library
 #
 commence(object_library array)

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -27,14 +27,19 @@
  *
  * @section DESCRIPTION
  *
- * This file implements class Array.
+ * This file implements the data-oriented operations on class Array.
+ *
+ * The data- and I/O-oriented operations of class `Array` have been
+ * intentionally separated to support two _standalone_ object libraries.
+ * This design eliminates cyclic dependencies in the build, as each module has
+ * its own dependency chain.
+ *
  */
 
 #include "tiledb/common/common.h"
 
 #include "tiledb/common/logger.h"
 #include "tiledb/common/memory_tracker.h"
-#include "tiledb/common/stdx_string.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/array_schema_evolution.h"
@@ -54,7 +59,6 @@
 #include "tiledb/sm/misc/tdb_time.h"
 #include "tiledb/sm/object/object.h"
 #include "tiledb/sm/object/object_mutex.h"
-#include "tiledb/sm/query/deletes_and_updates/serialization.h"
 #include "tiledb/sm/query/update_value.h"
 #include "tiledb/sm/rest/rest_client.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
@@ -108,60 +112,6 @@ Array::Array(
 /* ********************************* */
 /*                API                */
 /* ********************************* */
-
-tuple<
-    Status,
-    optional<std::vector<QueryCondition>>,
-    optional<std::vector<std::vector<UpdateValue>>>>
-OpenedArray::load_delete_and_update_conditions() {
-  auto& locations = array_directory().delete_and_update_tiles_location();
-  auto conditions = std::vector<QueryCondition>(locations.size());
-  auto update_values = std::vector<std::vector<UpdateValue>>(locations.size());
-
-  auto status = parallel_for(
-      &resources_.compute_tp(), 0, locations.size(), [&](size_t i) {
-        // Get condition marker.
-        auto& uri = locations[i].uri();
-
-        // Read the condition from storage.
-        auto tile = GenericTileIO::load(
-            resources_,
-            uri,
-            locations[i].offset(),
-            *(encryption_key()),
-            resources_.ephemeral_memory_tracker());
-
-        if (tiledb::sm::utils::parse::ends_with(
-                locations[i].condition_marker(),
-                tiledb::sm::constants::delete_file_suffix)) {
-          conditions[i] = tiledb::sm::deletes_and_updates::serialization::
-              deserialize_condition(
-                  i,
-                  locations[i].condition_marker(),
-                  tile->data(),
-                  tile->size());
-        } else if (tiledb::sm::utils::parse::ends_with(
-                       locations[i].condition_marker(),
-                       tiledb::sm::constants::update_file_suffix)) {
-          auto&& [cond, uvs] = tiledb::sm::deletes_and_updates::serialization::
-              deserialize_update_condition_and_values(
-                  i,
-                  locations[i].condition_marker(),
-                  tile->data(),
-                  tile->size());
-          conditions[i] = std::move(cond);
-          update_values[i] = std::move(uvs);
-        } else {
-          throw ArrayException("Unknown condition marker extension");
-        }
-
-        throw_if_not_ok(conditions[i].check(array_schema_latest()));
-        return Status::Ok();
-      });
-  throw_if_not_ok(status);
-
-  return {Status::Ok(), conditions, update_values};
-}
 
 void Array::evolve_array_schema(
     ContextResources& resources,

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -29,11 +29,6 @@
  *
  * This file implements the data-oriented operations on class Array.
  *
- * The data- and I/O-oriented operations of class `Array` have been
- * intentionally separated to support two _standalone_ object libraries.
- * This design eliminates cyclic dependencies in the build, as each module has
- * its own dependency chain.
- *
  */
 
 #include "tiledb/common/common.h"

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -215,17 +215,6 @@ class OpenedArray {
     return is_remote_;
   }
 
-  /**
-   * Loads the delete and update conditions from storage.
-   *
-   * @return Status, vector of the conditions, vector of the update values.
-   */
-  tuple<
-      Status,
-      optional<std::vector<QueryCondition>>,
-      optional<std::vector<std::vector<UpdateValue>>>>
-  load_delete_and_update_conditions();
-
  private:
   /** The context resources. */
   ContextResources& resources_;

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -55,8 +55,6 @@ class ArraySchemaEvolution;
 class SchemaEvolution;
 class FragmentMetadata;
 class MemoryTracker;
-class UpdateValue;
-class QueryCondition;
 enum class QueryType : uint8_t;
 
 /**

--- a/tiledb/sm/array/array_operations.cc
+++ b/tiledb/sm/array/array_operations.cc
@@ -1,0 +1,118 @@
+/**
+ * @file   array_operations.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file implements I/O operations which support the Array class.
+ *
+ * The data- and I/O-oriented operations of class `Array` have been
+ * intentionally separated to support two _standalone_ object libraries.
+ * This design eliminates cyclic dependencies in the build, as each module has
+ * its own dependency chain.
+ * Note that the `array_operations` object library will not be implemented
+ * until _after_ the `Query` object libraries on which it relies.
+ */
+
+#include "tiledb/sm/array/array_operations.h"
+#include "tiledb/common/stdx_string.h"
+#include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array/array_directory.h"
+#include "tiledb/sm/crypto/encryption_key.h"
+#include "tiledb/sm/misc/parallel_functions.h"
+#include "tiledb/sm/query/deletes_and_updates/serialization.h"
+#include "tiledb/sm/tile/generic_tile_io.h"
+
+#include <vector>
+
+namespace tiledb::sm {
+
+class ArrayOperationsException : public StatusException {
+ public:
+  explicit ArrayOperationsException(const std::string& message)
+      : StatusException("ArrayOperations", message) {
+  }
+};
+
+/* ********************************* */
+/*                API                */
+/* ********************************* */
+
+tuple<std::vector<QueryCondition>, std::vector<std::vector<UpdateValue>>>
+load_delete_and_update_conditions(
+    ContextResources& resources, const shared_ptr<OpenedArray>& opened_array) {
+  auto& locations =
+      opened_array->array_directory().delete_and_update_tiles_location();
+  auto conditions = std::vector<QueryCondition>(locations.size());
+  auto update_values = std::vector<std::vector<UpdateValue>>(locations.size());
+
+  auto status =
+      parallel_for(&resources.compute_tp(), 0, locations.size(), [&](size_t i) {
+        // Get condition marker.
+        auto& uri = locations[i].uri();
+
+        // Read the condition from storage.
+        auto tile = GenericTileIO::load(
+            resources,
+            uri,
+            locations[i].offset(),
+            *(opened_array->encryption_key()),
+            resources.ephemeral_memory_tracker());
+
+        if (tiledb::sm::utils::parse::ends_with(
+                locations[i].condition_marker(),
+                tiledb::sm::constants::delete_file_suffix)) {
+          conditions[i] = tiledb::sm::deletes_and_updates::serialization::
+              deserialize_condition(
+                  i,
+                  locations[i].condition_marker(),
+                  tile->data(),
+                  tile->size());
+        } else if (tiledb::sm::utils::parse::ends_with(
+                       locations[i].condition_marker(),
+                       tiledb::sm::constants::update_file_suffix)) {
+          auto&& [cond, uvs] = tiledb::sm::deletes_and_updates::serialization::
+              deserialize_update_condition_and_values(
+                  i,
+                  locations[i].condition_marker(),
+                  tile->data(),
+                  tile->size());
+          conditions[i] = std::move(cond);
+          update_values[i] = std::move(uvs);
+        } else {
+          throw ArrayOperationsException("Unknown condition marker extension");
+        }
+
+        throw_if_not_ok(
+            conditions[i].check(opened_array->array_schema_latest()));
+        return Status::Ok();
+      });
+  throw_if_not_ok(status);
+
+  return {conditions, update_values};
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/array/array_operations.cc
+++ b/tiledb/sm/array/array_operations.cc
@@ -46,8 +46,6 @@
 #include "tiledb/sm/query/deletes_and_updates/serialization.h"
 #include "tiledb/sm/tile/generic_tile_io.h"
 
-#include <vector>
-
 namespace tiledb::sm {
 
 class ArrayOperationsException : public StatusException {

--- a/tiledb/sm/array/array_operations.h
+++ b/tiledb/sm/array/array_operations.h
@@ -34,6 +34,8 @@
 #ifndef TILEDB_ARRAY_OPERATIONS_H
 #define TILEDB_ARRAY_OPERATIONS_H
 
+#include <vector>
+
 #include "tiledb/common/common.h"
 
 using namespace tiledb::common;

--- a/tiledb/sm/array/array_operations.h
+++ b/tiledb/sm/array/array_operations.h
@@ -1,0 +1,65 @@
+/**
+ * @file   array_operations.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines I/O operations which support class Array.
+ *
+ */
+
+#ifndef TILEDB_ARRAY_OPERATIONS_H
+#define TILEDB_ARRAY_OPERATIONS_H
+
+#include "tiledb/common/common.h"
+
+using namespace tiledb::common;
+
+namespace tiledb::sm {
+
+class ContextResources;
+class OpenedArray;
+class QueryCondition;
+class UpdateValue;
+
+/* ********************************* */
+/*                API                */
+/* ********************************* */
+
+/**
+ * Loads the delete and update conditions from storage.
+ *
+ * @param resources The context resources.
+ * @param opened_array The opened array whose conditions are getting loaded.
+ * @return vector of the conditions, vector of the update values.
+ */
+tuple<std::vector<QueryCondition>, std::vector<std::vector<UpdateValue>>>
+load_delete_and_update_conditions(
+    ContextResources& resources, const shared_ptr<OpenedArray>& opened_array);
+
+}  // namespace tiledb::sm
+
+#endif  // TILEDB_ARRAY_OPERATIONS_H

--- a/tiledb/sm/array/array_operations.h
+++ b/tiledb/sm/array/array_operations.h
@@ -47,10 +47,6 @@ class OpenedArray;
 class QueryCondition;
 class UpdateValue;
 
-/* ********************************* */
-/*                API                */
-/* ********************************* */
-
 /**
  * Loads the delete and update conditions from storage.
  *
@@ -60,7 +56,7 @@ class UpdateValue;
  */
 tuple<std::vector<QueryCondition>, std::vector<std::vector<UpdateValue>>>
 load_delete_and_update_conditions(
-    ContextResources& resources, const shared_ptr<OpenedArray>& opened_array);
+    ContextResources& resources, const OpenedArray& opened_array);
 
 }  // namespace tiledb::sm
 

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/query/legacy/reader.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array/array_operations.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
@@ -329,10 +330,9 @@ Status Reader::load_initial_data() {
   }
 
   // Load delete conditions.
-  auto&& [st, conditions, update_values] =
-      array_->load_delete_and_update_conditions();
-  RETURN_CANCEL_OR_ERROR(st);
-  delete_and_update_conditions_ = std::move(*conditions);
+  auto&& [conditions, update_values] =
+      load_delete_and_update_conditions(resources_, array_);
+  delete_and_update_conditions_ = conditions;
 
   // Set timestamps variables
   user_requested_timestamps_ = buffers_.count(constants::timestamps) != 0 ||

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -331,7 +331,7 @@ Status Reader::load_initial_data() {
 
   // Load delete conditions.
   auto&& [conditions, update_values] =
-      load_delete_and_update_conditions(resources_, array_);
+      load_delete_and_update_conditions(resources_, *array_.get());
   delete_and_update_conditions_ = conditions;
 
   // Set timestamps variables

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -342,7 +342,7 @@ Status SparseIndexReaderBase::load_initial_data() {
 
   // Load delete conditions.
   auto&& [conditions, update_values] =
-      load_delete_and_update_conditions(resources_, array_);
+      load_delete_and_update_conditions(resources_, *array_.get());
   delete_and_update_conditions_ = conditions;
   bool make_timestamped_conditions = need_timestamped_conditions();
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -34,6 +34,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/array/array.h"
+#include "tiledb/sm/array/array_operations.h"
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/fragment/fragment_metadata.h"
@@ -340,10 +341,9 @@ Status SparseIndexReaderBase::load_initial_data() {
   const auto dim_num = array_schema_.dim_num();
 
   // Load delete conditions.
-  auto&& [st, conditions, update_values] =
-      array_->load_delete_and_update_conditions();
-  RETURN_CANCEL_OR_ERROR(st);
-  delete_and_update_conditions_ = std::move(*conditions);
+  auto&& [conditions, update_values] =
+      load_delete_and_update_conditions(resources_, array_);
+  delete_and_update_conditions_ = conditions;
   bool make_timestamped_conditions = need_timestamped_conditions();
 
   if (make_timestamped_conditions) {


### PR DESCRIPTION
Create file `array_operations.cc` for I/O-oriented `Array` functions.
Migrate `OpenedArray::load_delete_and_update_conditions` from `array.cc` into `array_operations.cc`. 

[sc-51376]

---
TYPE: NO_HISTORY
DESC: Create file `array_operations.cc` for I/O-oriented `Array` functions.
