### PR TITLE
Update unit tests to use v11 array helpers.

### DIFF
--- a/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
@@ -70,13 +70,11 @@ struct ConsolidationWithTimestampsFx {
   // Functions.
   void set_legacy();
   void create_sparse_array(bool allows_dups = false);
-  void create_sparse_array_v11();
   void write_sparse(
       std::vector<int> a1,
       std::vector<uint64_t> dim1,
       std::vector<uint64_t> dim2,
       uint64_t timestamp);
-  void write_sparse_v11(uint64_t timestamp);
   void consolidate_sparse(bool vacuum = false);
   void consolidate_sparse(
       uint64_t start_time, uint64_t end_time, bool vacuum = false);
@@ -160,18 +158,6 @@ void ConsolidationWithTimestampsFx::create_sparse_array(bool allows_dups) {
   Array::create(SPARSE_ARRAY_NAME, schema);
 }
 
-void ConsolidationWithTimestampsFx::create_sparse_array_v11() {
-  // Get the v11 sparse array.
-  std::string v11_arrays_dir =
-      std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays/sparse_array_v11";
-  REQUIRE(
-      tiledb_vfs_copy_dir(
-          ctx_.ptr().get(),
-          vfs_.ptr().get(),
-          v11_arrays_dir.c_str(),
-          SPARSE_ARRAY_NAME) == TILEDB_OK);
-}
-
 void ConsolidationWithTimestampsFx::write_sparse(
     std::vector<int> a1,
     std::vector<uint64_t> dim1,
@@ -186,37 +172,6 @@ void ConsolidationWithTimestampsFx::write_sparse(
   query.set_data_buffer("a1", a1);
   query.set_data_buffer("d1", dim1);
   query.set_data_buffer("d2", dim2);
-
-  // Submit/finalize the query.
-  query.submit();
-  query.finalize();
-
-  // Close array.
-  array.close();
-}
-
-void ConsolidationWithTimestampsFx::write_sparse_v11(uint64_t timestamp) {
-  // Prepare cell buffers.
-  std::vector<int> buffer_a1{0, 1, 2, 3};
-  std::vector<uint64_t> buffer_a2{0, 1, 3, 6};
-  std::string buffer_var_a2("abbcccdddd");
-  std::vector<float> buffer_a3{0.1f, 0.2f, 1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f};
-  std::vector<uint64_t> buffer_coords_dim1{1, 1, 1, 2};
-  std::vector<uint64_t> buffer_coords_dim2{1, 2, 4, 3};
-
-  // Open array.
-  Array array(ctx_, SPARSE_ARRAY_NAME, TILEDB_WRITE, timestamp);
-
-  // Create query.
-  Query query(ctx_, array, TILEDB_WRITE);
-  query.set_layout(TILEDB_GLOBAL_ORDER);
-  query.set_data_buffer("a1", buffer_a1);
-  query.set_data_buffer(
-      "a2", (void*)buffer_var_a2.c_str(), buffer_var_a2.size());
-  query.set_offsets_buffer("a2", buffer_a2);
-  query.set_data_buffer("a3", buffer_a3);
-  query.set_data_buffer("d1", buffer_coords_dim1);
-  query.set_data_buffer("d2", buffer_coords_dim2);
 
   // Submit/finalize the query.
   query.submit();

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -80,14 +80,12 @@ struct DeletesFx {
   void create_dir(const std::string& path);
   void create_simple_array(const std::string& path);
   void create_sparse_array(bool allows_dups = false, bool encrypt = false);
-  void create_sparse_array_v11();
   void write_sparse(
       std::vector<int> a1,
       std::vector<uint64_t> dim1,
       std::vector<uint64_t> dim2,
       uint64_t timestamp,
       bool encrypt = false);
-  void write_sparse_v11(uint64_t timestamp);
   std::vector<tiledb::Object> read_group(const tiledb::Group& group) const;
   void read_sparse(
       std::vector<int>& a1,
@@ -248,52 +246,6 @@ void DeletesFx::write_sparse(
 
   // Close array.
   array->close();
-}
-
-void DeletesFx::create_sparse_array_v11() {
-  // Get the v11 sparse array.
-  std::string v11_arrays_dir =
-      std::string(TILEDB_TEST_INPUTS_DIR) + "/arrays/sparse_array_v11";
-  REQUIRE(
-      tiledb_vfs_copy_dir(
-          ctx_.ptr().get(),
-          vfs_.ptr().get(),
-          v11_arrays_dir.c_str(),
-          array_name_.c_str()) == TILEDB_OK);
-}
-
-void DeletesFx::write_sparse_v11(uint64_t timestamp) {
-  // Prepare cell buffers.
-  std::vector<int> buffer_a1{0, 1, 2, 3};
-  std::vector<uint64_t> buffer_a2{0, 1, 3, 6};
-  std::string buffer_var_a2("abbcccdddd");
-  std::vector<float> buffer_a3{0.1f, 0.2f, 1.1f, 1.2f, 2.1f, 2.2f, 3.1f, 3.2f};
-  std::vector<uint64_t> buffer_coords_dim1{1, 1, 1, 2};
-  std::vector<uint64_t> buffer_coords_dim2{1, 2, 4, 3};
-
-  // Open array.
-  Array array(
-      ctx_,
-      array_name_.c_str(),
-      TILEDB_WRITE,
-      tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp));
-
-  // Create query.
-  Query query(ctx_, array, TILEDB_WRITE);
-  query.set_layout(TILEDB_GLOBAL_ORDER);
-  query.set_data_buffer("a1", buffer_a1);
-  query.set_data_buffer(
-      "a2", (void*)buffer_var_a2.c_str(), buffer_var_a2.size());
-  query.set_offsets_buffer("a2", buffer_a2);
-  query.set_data_buffer("a3", buffer_a3);
-  query.set_data_buffer("d1", buffer_coords_dim1);
-  query.set_data_buffer("d2", buffer_coords_dim2);
-
-  // Submit/finalize the query.
-  query.submit_and_finalize();
-
-  // Close array.
-  array.close();
 }
 
 std::vector<tiledb::Object> DeletesFx::read_group(
@@ -1661,12 +1613,12 @@ TEST_CASE_METHOD(
   }
 
   remove_sparse_array();
-  create_sparse_array_v11();
+  test::create_sparse_array_v11(ctx_.ptr().get(), array_name_);
   // Write first fragment.
-  write_sparse_v11(1);
+  test::write_sparse_v11(ctx_.ptr().get(), array_name_, 1);
 
   // Write second fragment.
-  write_sparse_v11(3);
+  test::write_sparse_v11(ctx_.ptr().get(), array_name_, 3);
 
   // Consolidate.
   consolidate_sparse();
@@ -1947,8 +1899,8 @@ TEST_CASE_METHOD(
   auto array_name = array_name_ + "/";
 
   // Write to v11 array
-  create_sparse_array_v11();
-  write_sparse_v11(1);
+  test::create_sparse_array_v11(ctx_.ptr().get(), array_name_);
+  test::write_sparse_v11(ctx_.ptr().get(), array_name_, 1);
   std::string extraneous_file_path = array_name + "extraneous_file";
   vfs_.touch(extraneous_file_path);
 


### PR DESCRIPTION
Follow up for #5135, which relocated some fixture member functions to `test/support/src/helpers.h` for use across unit tests.

[sc-51730]

---
TYPE: NO_HISTORY
DESC: Update unit tests to use v11 array helpers.
