### PR TITLE
Add ctx to CurrentDomain CAPI, adjust CPPAPI.

### DIFF
--- a/examples/c_api/current_domain.c
+++ b/examples/c_api/current_domain.c
@@ -74,7 +74,7 @@ void create_array() {
   tiledb_ndrectangle_set_range_for_name(ctx, ndrect, "d1", &range);
 
   // Assign the rectangle to the current domain
-  tiledb_current_domain_set_ndrectangle(current_domain, ndrect);
+  tiledb_current_domain_set_ndrectangle(ctx, current_domain, ndrect);
 
   // Create a single attribute "a" so each cell can store an integer
   tiledb_attribute_t* a;
@@ -119,21 +119,21 @@ void print_current_domain() {
 
   // Check if current domain is empty
   uint32_t is_empty;
-  tiledb_current_domain_get_is_empty(current_domain, &is_empty);
+  tiledb_current_domain_get_is_empty(ctx, current_domain, &is_empty);
 
   if (is_empty) {
     printf("Current domain: empty\n");
   } else {
     // Get current domain type
     tiledb_current_domain_type_t current_domain_type;
-    tiledb_current_domain_get_type(current_domain, &current_domain_type);
+    tiledb_current_domain_get_type(ctx, current_domain, &current_domain_type);
 
     if (current_domain_type == TILEDB_NDRECTANGLE) {
       printf("Current domain type: NDRECTANGLE\n");
 
       // Get the ND rectangle
       tiledb_ndrectangle_t* ndrect;
-      tiledb_current_domain_get_ndrectangle(current_domain, &ndrect);
+      tiledb_current_domain_get_ndrectangle(ctx, current_domain, &ndrect);
 
       tiledb_range_t range;
       tiledb_ndrectangle_get_range_from_name(ctx, ndrect, "d1", &range);
@@ -191,7 +191,7 @@ void expand_current_domain() {
   tiledb_ndrectangle_set_range_for_name(ctx, ndrect, "d1", &range);
 
   // Set the rectangle to the current domain
-  tiledb_current_domain_set_ndrectangle(new_current_domain, ndrect);
+  tiledb_current_domain_set_ndrectangle(ctx, new_current_domain, ndrect);
 
   // Expand the current domain
   tiledb_array_schema_evolution_expand_current_domain(

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -2503,7 +2503,8 @@ TEST_CASE_METHOD(
       tiledb_array_schema_get_current_domain(ctx_, schema, &crd) == TILEDB_OK);
 
   uint32_t is_empty = 0;
-  REQUIRE(tiledb_current_domain_get_is_empty(crd, &is_empty) == TILEDB_OK);
+  REQUIRE(
+      tiledb_current_domain_get_is_empty(ctx_, crd, &is_empty) == TILEDB_OK);
   CHECK(is_empty == 1);
 
   REQUIRE(tiledb_current_domain_free(&crd) == TILEDB_OK);
@@ -2537,7 +2538,7 @@ TEST_CASE_METHOD(
 
   tiledb_ndrectangle_t* ndr = nullptr;
   REQUIRE(tiledb_ndrectangle_alloc(ctx_, domain, &ndr) == TILEDB_OK);
-  REQUIRE(tiledb_current_domain_set_ndrectangle(crd, ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_set_ndrectangle(ctx_, crd, ndr) == TILEDB_OK);
 
   REQUIRE(
       tiledb_array_schema_set_current_domain(ctx_, schema, crd) == TILEDB_OK);
@@ -2604,7 +2605,7 @@ TEST_CASE_METHOD(
   REQUIRE(
       tiledb_array_schema_get_current_domain(ctx_, schema, &crd) == TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_get_ndrectangle(crd, &ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_get_ndrectangle(ctx_, crd, &ndr) == TILEDB_OK);
   tiledb_range_t outrange;
   REQUIRE(
       tiledb_ndrectangle_get_range_from_name(ctx_, ndr, "d1", &outrange) ==
@@ -2672,7 +2673,7 @@ TEST_CASE_METHOD(
   REQUIRE(
       tiledb_ndrectangle_set_range_for_name(ctx_, ndr, "d1", &range) ==
       TILEDB_OK);
-  REQUIRE(tiledb_current_domain_set_ndrectangle(crd, ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_set_ndrectangle(ctx_, crd, ndr) == TILEDB_OK);
   REQUIRE(
       tiledb_array_schema_set_current_domain(ctx_, schema, crd) == TILEDB_OK);
 
@@ -2712,7 +2713,7 @@ TEST_CASE_METHOD(
   REQUIRE(
       tiledb_ndrectangle_set_range_for_name(ctx_, ndr, "d1", &range) ==
       TILEDB_OK);
-  REQUIRE(tiledb_current_domain_set_ndrectangle(crd, ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_set_ndrectangle(ctx_, crd, ndr) == TILEDB_OK);
 
   REQUIRE(
       tiledb_array_schema_evolution_expand_current_domain(ctx_, evo, crd) ==
@@ -2752,7 +2753,7 @@ TEST_CASE_METHOD(
   REQUIRE(
       tiledb_array_schema_get_current_domain(ctx_, schema, &crd) == TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_get_ndrectangle(crd, &ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_get_ndrectangle(ctx_, crd, &ndr) == TILEDB_OK);
   tiledb_range_t outrange;
   REQUIRE(
       tiledb_ndrectangle_get_range_from_name(ctx_, ndr, "d1", &outrange) ==

--- a/test/src/unit-current-domain-rest.cc
+++ b/test/src/unit-current-domain-rest.cc
@@ -128,7 +128,7 @@ void RestCurrentDomainFx::create_sparse_array(const std::string& array_name) {
       tiledb_ndrectangle_set_range_for_name(ctx_c_, ndr, "d2", &range_var) ==
       TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_set_ndrectangle(crd, ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_set_ndrectangle(ctx_c_, crd, ndr) == TILEDB_OK);
   REQUIRE(
       tiledb_array_schema_set_current_domain(ctx_c_, array_schema, crd) ==
       TILEDB_OK);
@@ -169,7 +169,8 @@ TEST_CASE_METHOD(
       tiledb_array_schema_get_current_domain(ctx_c_, schema, &crd) ==
       TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_get_ndrectangle(crd, &ndr) == TILEDB_OK);
+  REQUIRE(
+      tiledb_current_domain_get_ndrectangle(ctx_c_, crd, &ndr) == TILEDB_OK);
   tiledb_range_t outrange;
   tiledb_range_t outrange_var;
   REQUIRE(
@@ -239,7 +240,7 @@ TEST_CASE_METHOD(
       tiledb_ndrectangle_set_range_for_name(ctx_c_, ndr, "d2", &range_var) ==
       TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_set_ndrectangle(crd, ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_set_ndrectangle(ctx_c_, crd, ndr) == TILEDB_OK);
   REQUIRE(
       tiledb_array_schema_evolution_expand_current_domain(ctx_c_, evo, crd) ==
       TILEDB_OK);
@@ -262,7 +263,8 @@ TEST_CASE_METHOD(
       tiledb_array_schema_get_current_domain(ctx_c_, schema, &crd) ==
       TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_get_ndrectangle(crd, &ndr) == TILEDB_OK);
+  REQUIRE(
+      tiledb_current_domain_get_ndrectangle(ctx_c_, crd, &ndr) == TILEDB_OK);
   tiledb_range_t outrange;
   REQUIRE(
       tiledb_ndrectangle_get_range_from_name(ctx_c_, ndr, "d1", &outrange) ==

--- a/tiledb/api/c_api/current_domain/current_domain_api.cc
+++ b/tiledb/api/c_api/current_domain/current_domain_api.cc
@@ -107,6 +107,7 @@ capi_return_t tiledb_current_domain_get_type(
 }  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
+using tiledb::api::api_entry_plain;
 using tiledb::api::api_entry_with_context;
 
 CAPI_INTERFACE(
@@ -117,12 +118,9 @@ CAPI_INTERFACE(
       ctx, current_domain);
 }
 
-CAPI_INTERFACE(
-    current_domain_free,
-    tiledb_ctx_t* ctx,
-    tiledb_current_domain_t** current_domain) {
-  return api_entry_context<tiledb::api::tiledb_current_domain_free>(
-      ctx, current_domain);
+CAPI_INTERFACE(current_domain_free, tiledb_current_domain_t** current_domain) {
+  return api_entry_plain<tiledb::api::tiledb_current_domain_free>(
+      current_domain);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/api/c_api/current_domain/current_domain_api.cc
+++ b/tiledb/api/c_api/current_domain/current_domain_api.cc
@@ -106,7 +106,7 @@ capi_return_t tiledb_current_domain_get_type(
 
 }  // namespace tiledb::api
 
-using tiledb::api::api_entry_plain;
+using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_with_context;
 
 CAPI_INTERFACE(
@@ -117,39 +117,46 @@ CAPI_INTERFACE(
       ctx, current_domain);
 }
 
-CAPI_INTERFACE(current_domain_free, tiledb_current_domain_t** current_domain) {
-  return api_entry_plain<tiledb::api::tiledb_current_domain_free>(
-      current_domain);
+CAPI_INTERFACE(
+    current_domain_free,
+    tiledb_ctx_t* ctx,
+    tiledb_current_domain_t** current_domain) {
+  return api_entry_context<tiledb::api::tiledb_current_domain_free>(
+      ctx, current_domain);
 }
 
 CAPI_INTERFACE(
     current_domain_set_ndrectangle,
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_ndrectangle_t* ndr) {
-  return api_entry_plain<tiledb::api::tiledb_current_domain_set_ndrectangle>(
-      current_domain, ndr);
+  return api_entry_context<tiledb::api::tiledb_current_domain_set_ndrectangle>(
+      ctx, current_domain, ndr);
 }
 
 CAPI_INTERFACE(
     current_domain_get_ndrectangle,
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_ndrectangle_t** ndr) {
-  return api_entry_plain<tiledb::api::tiledb_current_domain_get_ndrectangle>(
-      current_domain, ndr);
+  return api_entry_context<tiledb::api::tiledb_current_domain_get_ndrectangle>(
+      ctx, current_domain, ndr);
 }
 
 CAPI_INTERFACE(
     current_domain_get_is_empty,
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     uint32_t* is_empty) {
-  return api_entry_plain<tiledb::api::tiledb_current_domain_get_is_empty>(
-      current_domain, is_empty);
+  return api_entry_context<tiledb::api::tiledb_current_domain_get_is_empty>(
+      ctx, current_domain, is_empty);
 }
 
 CAPI_INTERFACE(
     current_domain_get_type,
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_current_domain_type_t* type) {
-  return api_entry_plain<tiledb::api::tiledb_current_domain_get_type>(
-      current_domain, type);
+  return api_entry_context<tiledb::api::tiledb_current_domain_get_type>(
+      ctx, current_domain, type);
 }

--- a/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h
+++ b/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h
@@ -59,7 +59,7 @@ typedef struct tiledb_current_domain_handle_t tiledb_current_domain_t;
  * @code{.c}
  * tiledb_current_domain_t *current_domain;
  * tiledb_current_domain_create(ctx, &current_domain);
- * tiledb_current_domain_free(&current_domain);
+ * tiledb_current_domain_free(ctx, &current_domain);
  * @endcode
  *
  * @param ctx The TileDB context
@@ -78,13 +78,15 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_create(
  * @code{.c}
  * tiledb_current_domain_t *current_domain;
  * tiledb_current_domain_create(ctx, &current_domain);
- * tiledb_current_domain_free(&current_domain);
+ * tiledb_current_domain_free(ctx, &current_domain);
  * @endcode
  *
+ * @param ctx The TileDB context
  * @param current_domain The current domain to be freed
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_current_domain_free(
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t** current_domain) TILEDB_NOEXCEPT;
 
 /**
@@ -106,17 +108,19 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_free(
  * range.max_size = sizeof(max);
  * tiledb_ndrectangle_set_range_for_name(ctx, ndr, "dim", &range);
  *
- * tiledb_current_domain_set_ndrectangle(current_domain, ndr);
+ * tiledb_current_domain_set_ndrectangle(ctx, current_domain, ndr);
  *
  * tiledb_ndrectangle_free(&ndr);
  * tiledb_current_domain_free(&current_domain);
  * @endcode
  *
+ * @param ctx A TileDB context
  * @param current_domain The current domain to modify
  * @param ndr The N-dimensional rectangle to be set
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_current_domain_set_ndrectangle(
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_ndrectangle_t* ndr) TILEDB_NOEXCEPT;
 
@@ -131,14 +135,16 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_set_ndrectangle(
  *
  * @code{.c}
  * tiledb_ndrectangle_t *ndr;
- * tiledb_current_domain_get_ndrectangle(current_domain, &ndr);
+ * tiledb_current_domain_get_ndrectangle(ctx, current_domain, &ndr);
  * @endcode
  *
+ * @param ctx A TileDB context
  * @param current_domain The current domain to query
  * @param ndr The N-dimensional rectangle of the current domain
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_current_domain_get_ndrectangle(
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_ndrectangle_t** ndr) TILEDB_NOEXCEPT;
 
@@ -149,14 +155,16 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_get_ndrectangle(
  *
  * @code{.c}
  * uint32_t empty = 0;
- * tiledb_current_domain_get_is_empty(current_domain, &empty);
+ * tiledb_current_domain_get_is_empty(ctx, current_domain, &empty);
  * @endcode
  *
+ * @param ctx A TileDB context
  * @param current_domain The current domain to query
  * @param is_empty True if nothing is set on the current domain
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_current_domain_get_is_empty(
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     uint32_t* is_empty) TILEDB_NOEXCEPT;
 
@@ -167,14 +175,16 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_get_is_empty(
  *
  * @code{.c}
  * tiledb_current_domain_type_t type;
- * tiledb_current_domain_get_type(current_domain, &type);
+ * tiledb_current_domain_get_type(ctx, current_domain, &type);
  * @endcode
  *
+ * @param ctx A TileDB context
  * @param current_domain The current domain to query
  * @param type The type of representation set on the current domain
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_current_domain_get_type(
+    tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_current_domain_type_t* type) TILEDB_NOEXCEPT;
 

--- a/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h
+++ b/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h
@@ -59,7 +59,7 @@ typedef struct tiledb_current_domain_handle_t tiledb_current_domain_t;
  * @code{.c}
  * tiledb_current_domain_t *current_domain;
  * tiledb_current_domain_create(ctx, &current_domain);
- * tiledb_current_domain_free(ctx, &current_domain);
+ * tiledb_current_domain_free(&current_domain);
  * @endcode
  *
  * @param ctx The TileDB context
@@ -78,15 +78,13 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_create(
  * @code{.c}
  * tiledb_current_domain_t *current_domain;
  * tiledb_current_domain_create(ctx, &current_domain);
- * tiledb_current_domain_free(ctx, &current_domain);
+ * tiledb_current_domain_free(&current_domain);
  * @endcode
  *
- * @param ctx The TileDB context
  * @param current_domain The current domain to be freed
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_current_domain_free(
-    tiledb_ctx_t* ctx,
     tiledb_current_domain_t** current_domain) TILEDB_NOEXCEPT;
 
 /**

--- a/tiledb/api/c_api/current_domain/test/compile_capi_current_domain_main.cc
+++ b/tiledb/api/c_api/current_domain/test/compile_capi_current_domain_main.cc
@@ -32,10 +32,10 @@
 int main() {
   tiledb_current_domain_create(nullptr, nullptr);
   tiledb_current_domain_free(nullptr);
-  tiledb_current_domain_set_ndrectangle(nullptr, nullptr);
-  tiledb_current_domain_get_ndrectangle(nullptr, nullptr);
-  tiledb_current_domain_get_is_empty(nullptr, nullptr);
-  tiledb_current_domain_get_type(nullptr, nullptr);
+  tiledb_current_domain_set_ndrectangle(nullptr, nullptr, nullptr);
+  tiledb_current_domain_get_ndrectangle(nullptr, nullptr, nullptr);
+  tiledb_current_domain_get_is_empty(nullptr, nullptr, nullptr);
+  tiledb_current_domain_get_type(nullptr, nullptr, nullptr);
 
   return 0;
 }

--- a/tiledb/api/c_api/current_domain/test/unit_capi_current_domain.cc
+++ b/tiledb/api/c_api/current_domain/test/unit_capi_current_domain.cc
@@ -100,17 +100,34 @@ TEST_CASE_METHOD(
   crd = nullptr;
   CHECK(tiledb_current_domain_create(ctx, &crd) == TILEDB_OK);
 
-  CHECK(tiledb_current_domain_set_ndrectangle(nullptr, nullptr) == TILEDB_ERR);
-  CHECK(tiledb_current_domain_set_ndrectangle(crd, nullptr) == TILEDB_ERR);
+  CHECK(
+      tiledb_current_domain_set_ndrectangle(nullptr, nullptr, nullptr) ==
+      TILEDB_INVALID_CONTEXT);
+  CHECK(
+      tiledb_current_domain_set_ndrectangle(ctx, nullptr, nullptr) ==
+      TILEDB_ERR);
+  CHECK(tiledb_current_domain_set_ndrectangle(ctx, crd, nullptr) == TILEDB_ERR);
 
-  CHECK(tiledb_current_domain_get_ndrectangle(nullptr, nullptr) == TILEDB_ERR);
-  CHECK(tiledb_current_domain_get_ndrectangle(crd, nullptr) == TILEDB_ERR);
+  CHECK(
+      tiledb_current_domain_get_ndrectangle(nullptr, nullptr, nullptr) ==
+      TILEDB_INVALID_CONTEXT);
+  CHECK(
+      tiledb_current_domain_get_ndrectangle(ctx, nullptr, nullptr) ==
+      TILEDB_ERR);
+  CHECK(tiledb_current_domain_get_ndrectangle(ctx, crd, nullptr) == TILEDB_ERR);
 
-  CHECK(tiledb_current_domain_get_is_empty(nullptr, nullptr) == TILEDB_ERR);
-  CHECK(tiledb_current_domain_get_is_empty(crd, nullptr) == TILEDB_ERR);
+  CHECK(
+      tiledb_current_domain_get_is_empty(nullptr, nullptr, nullptr) ==
+      TILEDB_INVALID_CONTEXT);
+  CHECK(
+      tiledb_current_domain_get_is_empty(ctx, nullptr, nullptr) == TILEDB_ERR);
+  CHECK(tiledb_current_domain_get_is_empty(ctx, crd, nullptr) == TILEDB_ERR);
 
-  CHECK(tiledb_current_domain_get_type(nullptr, nullptr) == TILEDB_ERR);
-  CHECK(tiledb_current_domain_get_type(crd, nullptr) == TILEDB_ERR);
+  CHECK(
+      tiledb_current_domain_get_type(nullptr, nullptr, nullptr) ==
+      TILEDB_INVALID_CONTEXT);
+  CHECK(tiledb_current_domain_get_type(ctx, nullptr, nullptr) == TILEDB_ERR);
+  CHECK(tiledb_current_domain_get_type(ctx, crd, nullptr) == TILEDB_ERR);
 
   tiledb_current_domain_free(&crd);
 }
@@ -126,22 +143,23 @@ TEST_CASE_METHOD(
   REQUIRE(tiledb_ndrectangle_alloc(ctx, domain_, &ndr) == TILEDB_OK);
 
   uint32_t is_empty = 0;
-  REQUIRE(tiledb_current_domain_get_is_empty(crd, &is_empty) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_get_is_empty(ctx, crd, &is_empty) == TILEDB_OK);
   CHECK(is_empty == 1);
 
   tiledb_current_domain_type_t type;
-  CHECK(tiledb_current_domain_get_type(crd, &type) == TILEDB_ERR);
+  CHECK(tiledb_current_domain_get_type(ctx, crd, &type) == TILEDB_ERR);
 
-  REQUIRE(tiledb_current_domain_set_ndrectangle(crd, ndr) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_set_ndrectangle(ctx, crd, ndr) == TILEDB_OK);
 
-  REQUIRE(tiledb_current_domain_get_is_empty(crd, &is_empty) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_get_is_empty(ctx, crd, &is_empty) == TILEDB_OK);
   CHECK(is_empty == 0);
 
-  REQUIRE(tiledb_current_domain_get_type(crd, &type) == TILEDB_OK);
+  REQUIRE(tiledb_current_domain_get_type(ctx, crd, &type) == TILEDB_OK);
   CHECK(type == TILEDB_NDRECTANGLE);
 
   tiledb_ndrectangle_t* out_ndr = nullptr;
-  REQUIRE(tiledb_current_domain_get_ndrectangle(crd, &out_ndr) == TILEDB_OK);
+  REQUIRE(
+      tiledb_current_domain_get_ndrectangle(ctx, crd, &out_ndr) == TILEDB_OK);
   CHECK(out_ndr != nullptr);
 
   // Verify that they point to the same tiledb::sm::NDRectangle instance.

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
@@ -176,9 +176,8 @@ CAPI_INTERFACE(
       ctx, domain, ndr);
 }
 
-CAPI_INTERFACE(
-    ndrectangle_free, tiledb_ctx_t* ctx, tiledb_ndrectangle_t** ndr) {
-  return api_entry_context<tiledb::api::tiledb_ndrectangle_free>(ctx, ndr);
+CAPI_INTERFACE(ndrectangle_free, tiledb_ndrectangle_t** ndr) {
+  return api_entry_plain<tiledb::api::tiledb_ndrectangle_free>(ndr);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
@@ -102,11 +102,7 @@ capi_return_t tiledb_ndrectangle_free(tiledb_ndrectangle_t** ndr) {
 }
 
 capi_return_t tiledb_ndrectangle_get_range_from_name(
-    tiledb_ctx_t* ctx,
-    tiledb_ndrectangle_t* ndr,
-    const char* name,
-    tiledb_range_t* range) {
-  ensure_context_is_valid(ctx);
+    tiledb_ndrectangle_t* ndr, const char* name, tiledb_range_t* range) {
   ensure_handle_is_valid(ndr);
   ensure_dim_name_is_valid(name);
   ensure_range_ptr_is_valid(range);
@@ -119,11 +115,7 @@ capi_return_t tiledb_ndrectangle_get_range_from_name(
 }
 
 capi_return_t tiledb_ndrectangle_get_range(
-    tiledb_ctx_t* ctx,
-    tiledb_ndrectangle_t* ndr,
-    uint32_t idx,
-    tiledb_range_t* range) {
-  ensure_context_is_valid(ctx);
+    tiledb_ndrectangle_t* ndr, uint32_t idx, tiledb_range_t* range) {
   ensure_handle_is_valid(ndr);
   ensure_range_ptr_is_valid(range);
 
@@ -134,11 +126,7 @@ capi_return_t tiledb_ndrectangle_get_range(
 }
 
 capi_return_t tiledb_ndrectangle_set_range_for_name(
-    tiledb_ctx_t* ctx,
-    tiledb_ndrectangle_t* ndr,
-    const char* name,
-    tiledb_range_t* range) {
-  ensure_context_is_valid(ctx);
+    tiledb_ndrectangle_t* ndr, const char* name, tiledb_range_t* range) {
   ensure_handle_is_valid(ndr);
   ensure_dim_name_is_valid(name);
   ensure_range_ptr_is_valid(range);
@@ -157,11 +145,7 @@ capi_return_t tiledb_ndrectangle_set_range_for_name(
 }
 
 capi_return_t tiledb_ndrectangle_set_range(
-    tiledb_ctx_t* ctx,
-    tiledb_ndrectangle_t* ndr,
-    uint32_t idx,
-    tiledb_range_t* range) {
-  ensure_context_is_valid(ctx);
+    tiledb_ndrectangle_t* ndr, uint32_t idx, tiledb_range_t* range) {
   ensure_handle_is_valid(ndr);
   ensure_range_ptr_is_valid(range);
 
@@ -179,6 +163,7 @@ capi_return_t tiledb_ndrectangle_set_range(
 
 }  // namespace tiledb::api
 
+using tiledb::api::api_entry_context;
 using tiledb::api::api_entry_plain;
 using tiledb::api::api_entry_with_context;
 
@@ -191,8 +176,9 @@ CAPI_INTERFACE(
       ctx, domain, ndr);
 }
 
-CAPI_INTERFACE(ndrectangle_free, tiledb_ndrectangle_t** ndr) {
-  return api_entry_plain<tiledb::api::tiledb_ndrectangle_free>(ndr);
+CAPI_INTERFACE(
+    ndrectangle_free, tiledb_ctx_t* ctx, tiledb_ndrectangle_t** ndr) {
+  return api_entry_context<tiledb::api::tiledb_ndrectangle_free>(ctx, ndr);
 }
 
 CAPI_INTERFACE(
@@ -201,8 +187,7 @@ CAPI_INTERFACE(
     tiledb_ndrectangle_t* ndr,
     const char* name,
     tiledb_range_t* range) {
-  return api_entry_with_context<
-      tiledb::api::tiledb_ndrectangle_get_range_from_name>(
+  return api_entry_context<tiledb::api::tiledb_ndrectangle_get_range_from_name>(
       ctx, ndr, name, range);
 }
 
@@ -212,7 +197,7 @@ CAPI_INTERFACE(
     tiledb_ndrectangle_t* ndr,
     uint32_t idx,
     tiledb_range_t* range) {
-  return api_entry_with_context<tiledb::api::tiledb_ndrectangle_get_range>(
+  return api_entry_context<tiledb::api::tiledb_ndrectangle_get_range>(
       ctx, ndr, idx, range);
 }
 
@@ -222,8 +207,7 @@ CAPI_INTERFACE(
     tiledb_ndrectangle_t* ndr,
     const char* name,
     tiledb_range_t* range) {
-  return api_entry_with_context<
-      tiledb::api::tiledb_ndrectangle_set_range_for_name>(
+  return api_entry_context<tiledb::api::tiledb_ndrectangle_set_range_for_name>(
       ctx, ndr, name, range);
 }
 
@@ -233,6 +217,6 @@ CAPI_INTERFACE(
     tiledb_ndrectangle_t* ndr,
     uint32_t idx,
     tiledb_range_t* range) {
-  return api_entry_with_context<tiledb::api::tiledb_ndrectangle_set_range>(
+  return api_entry_context<tiledb::api::tiledb_ndrectangle_set_range>(
       ctx, ndr, idx, range);
 }

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
@@ -62,7 +62,7 @@ typedef struct tiledb_ndrectangle_handle_t tiledb_ndrectangle_t;
  * @code{.c}
  * tiledb_ndrectangle_t *ndr;
  * tiledb_ndrectangle_alloc(ctx, domain, &ndr);
- * tiledb_ndrectangle_free(&ndr);
+ * tiledb_ndrectangle_free(ctx, &ndr);
  * @endcode
  *
  * @param ctx The TileDB context
@@ -83,14 +83,15 @@ TILEDB_EXPORT capi_return_t tiledb_ndrectangle_alloc(
  * @code{.c}
  * tiledb_ndrectangle_t *ndr;
  * tiledb_ndrectangle_alloc(ctx, domain, &ndr);
- * tiledb_ndrectangle_free(&ndr);
+ * tiledb_ndrectangle_free(ctx, &ndr);
  * @endcode
  *
+ * @param ctx The TileDB context
  * @param ndr The n-dimensional rectangle to be freed
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT capi_return_t tiledb_ndrectangle_free(tiledb_ndrectangle_t** ndr)
-    TILEDB_NOEXCEPT;
+TILEDB_EXPORT capi_return_t tiledb_ndrectangle_free(
+    tiledb_ctx_t* ctx, tiledb_ndrectangle_t** ndr) TILEDB_NOEXCEPT;
 
 /**
  * Get the range set on an N-dimensional rectangle for a dimension name

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
@@ -62,7 +62,7 @@ typedef struct tiledb_ndrectangle_handle_t tiledb_ndrectangle_t;
  * @code{.c}
  * tiledb_ndrectangle_t *ndr;
  * tiledb_ndrectangle_alloc(ctx, domain, &ndr);
- * tiledb_ndrectangle_free(ctx, &ndr);
+ * tiledb_ndrectangle_free(&ndr);
  * @endcode
  *
  * @param ctx The TileDB context
@@ -83,15 +83,15 @@ TILEDB_EXPORT capi_return_t tiledb_ndrectangle_alloc(
  * @code{.c}
  * tiledb_ndrectangle_t *ndr;
  * tiledb_ndrectangle_alloc(ctx, domain, &ndr);
- * tiledb_ndrectangle_free(ctx, &ndr);
+ * tiledb_ndrectangle_free(&ndr);
  * @endcode
  *
  * @param ctx The TileDB context
  * @param ndr The n-dimensional rectangle to be freed
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT capi_return_t tiledb_ndrectangle_free(
-    tiledb_ctx_t* ctx, tiledb_ndrectangle_t** ndr) TILEDB_NOEXCEPT;
+TILEDB_EXPORT capi_return_t tiledb_ndrectangle_free(tiledb_ndrectangle_t** ndr)
+    TILEDB_NOEXCEPT;
 
 /**
  * Get the range set on an N-dimensional rectangle for a dimension name

--- a/tiledb/sm/cpp_api/current_domain.h
+++ b/tiledb/sm/cpp_api/current_domain.h
@@ -111,8 +111,8 @@ class CurrentDomain {
   tiledb_current_domain_type_t type() const {
     tiledb_current_domain_type_t type;
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_current_domain_get_type(current_domain_.get(), &type));
+    ctx.handle_error(tiledb_current_domain_get_type(
+        ctx.ptr().get(), current_domain_.get(), &type));
     return type;
   }
 
@@ -126,7 +126,7 @@ class CurrentDomain {
   CurrentDomain& set_ndrectangle(const NDRectangle& ndrect) {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_current_domain_set_ndrectangle(
-        current_domain_.get(), ndrect.ptr().get()));
+        ctx.ptr().get(), current_domain_.get(), ndrect.ptr().get()));
 
     return *this;
   }
@@ -140,8 +140,8 @@ class CurrentDomain {
   NDRectangle ndrectangle() const {
     tiledb_ndrectangle_t* nd;
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_current_domain_get_ndrectangle(current_domain_.get(), &nd));
+    ctx.handle_error(tiledb_current_domain_get_ndrectangle(
+        ctx.ptr().get(), current_domain_.get(), &nd));
     return NDRectangle(ctx, nd);
   }
 
@@ -153,8 +153,8 @@ class CurrentDomain {
   bool is_empty() const {
     uint32_t ret;
     auto& ctx = ctx_.get();
-    ctx.handle_error(
-        tiledb_current_domain_get_is_empty(current_domain_.get(), &ret));
+    ctx.handle_error(tiledb_current_domain_get_is_empty(
+        ctx.ptr().get(), current_domain_.get(), &ret));
     return static_cast<bool>(ret);
   }
 

--- a/tiledb/sm/cpp_api/deleter.h
+++ b/tiledb/sm/cpp_api/deleter.h
@@ -118,11 +118,11 @@ class Deleter {
   }
 
   void operator()(tiledb_current_domain_t* p) const {
-    tiledb_current_domain_free(&p);
+    tiledb_current_domain_free(ctx_->ptr().get(), &p);
   }
 
   void operator()(tiledb_ndrectangle_t* p) const {
-    tiledb_ndrectangle_free(&p);
+    tiledb_ndrectangle_free(ctx_->ptr().get(), &p);
   }
 
   void operator()(tiledb_enumeration_t* p) const {

--- a/tiledb/sm/cpp_api/deleter.h
+++ b/tiledb/sm/cpp_api/deleter.h
@@ -118,11 +118,11 @@ class Deleter {
   }
 
   void operator()(tiledb_current_domain_t* p) const {
-    tiledb_current_domain_free(ctx_->ptr().get(), &p);
+    tiledb_current_domain_free(&p);
   }
 
   void operator()(tiledb_ndrectangle_t* p) const {
-    tiledb_ndrectangle_free(ctx_->ptr().get(), &p);
+    tiledb_ndrectangle_free(&p);
   }
 
   void operator()(tiledb_enumeration_t* p) const {


### PR DESCRIPTION
This adds a ctx parameter to all CurrentDomain CAPI calls so that internal exceptions are propagated correctly through the capi handle layer.
I also adjusted the CPP CurrentDomain API, the only current user of these calls.

---
TYPE: C_API | CPP_API
DESC: Add ctx to CurrentDomain CAPI, adjust CPPAPI.
