### PR TITLE
Shrink storage_manager_stub

### DIFF
--- a/tiledb/api/c_api/context/CMakeLists.txt
+++ b/tiledb/api/c_api/context/CMakeLists.txt
@@ -35,7 +35,6 @@ gather_sources(${SOURCES})
 list(APPEND OTHER_SOURCES
     # We need to recompile sources that depend on StorageManager to use the stub
     ../../../sm/storage_manager/context.cc
-    ../../../sm/storage_manager/context_resources.cc
     )
 
 commence(object_library capi_context_stub)
@@ -43,7 +42,7 @@ commence(object_library capi_context_stub)
   this_target_link_libraries(export)
   this_target_object_libraries(capi_config_stub)
   this_target_object_libraries(storage_manager_stub)
-  this_target_object_libraries(rest_client stats thread_pool vfs)
+  this_target_object_libraries(context_resources)
 conclude(object_library)
 
 add_test_subdirectory()


### PR DESCRIPTION
With the recent change to `RestClient`, it's possible to use the object library `context_resources` now in the specification for the object library `storage_manager_stub`. This removes independent compilation, allowing CMake's duplicate object detection to function.

---
TYPE: NO_HISTORY
DESC: Shrink storage_manager_stub
