### PR TITLE
Hold a shared pointer to the query memory tracker in `IterationTileData`.

### DIFF
--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -388,7 +388,7 @@ Status DenseReader::dense_read() {
             t_start,
             t_end,
             std::move(result_space_tiles),
-            *query_memory_tracker_);
+            query_memory_tracker_);
 
     // Add the number of cells to process to subarray_end_cell.
     for (uint64_t t = t_start; t < t_end; t++) {

--- a/tiledb/sm/query/readers/dense_reader.h
+++ b/tiledb/sm/query/readers/dense_reader.h
@@ -70,13 +70,14 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
         uint64_t t_start,
         uint64_t t_end,
         std::map<const DimType*, ResultSpaceTile<DimType>>&& result_space_tiles,
-        MemoryTracker& memory_tracker)
+        shared_ptr<MemoryTracker> memory_tracker)
         : t_start_(t_start)
         , t_end_(t_end)
+        , memory_tracker_(memory_tracker)
         , tile_subarrays_(
               t_end - t_start,
               subarray.dim_num(),
-              memory_tracker.get_resource(MemoryType::DENSE_TILE_SUBARRAY))
+              memory_tracker_->get_resource(MemoryType::DENSE_TILE_SUBARRAY))
         , result_space_tiles_(std::move(result_space_tiles)) {
       auto& tile_coords = subarray.tile_coords();
       throw_if_not_ok(
@@ -126,6 +127,9 @@ class DenseReader : public ReaderBase, public IQueryStrategy {
 
     /** End tile to process. */
     uint64_t t_end_;
+
+    /** Memory tracker. */
+    shared_ptr<MemoryTracker> memory_tracker_;
 
     /** Tile subarrays. */
     tdb::pmr::vector<DenseTileSubarray<DimType>> tile_subarrays_;


### PR DESCRIPTION
[SC-52008](https://app.shortcut.com/tiledb-inc/story/52008/fix-nightlies-after-dense-reader-memory-tracking-merge)

Fixes #5217

Recent nightly builds fail consistently on ASAN, because the memory tracker used by `DenseTileSubarray`s gets used after being freed. I am still not sure why this happens, but keeping a shared pointer to the tracker in `IterationTileData` (not in `DenseTileSubarray` to reduce size overhead) will likely fix the problem.

Big thanks to @davisp for helping me come up with this.

---
TYPE: NO_HISTORY