### PR TITLE
Skip caching redirect uri on array create

### DIFF
--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -85,6 +85,9 @@ struct HeaderCbData {
 
   /** A pointer to the lock attached to the shared resource of the cache map */
   std::mutex* redirect_uri_map_lock;
+
+  /** True if the uri should be stored in URI cache map, false if not */
+  bool should_cache_redirect;
 };
 
 /**
@@ -128,7 +131,8 @@ class Curl {
       const Config* config,
       const std::unordered_map<std::string, std::string>& extra_headers,
       std::unordered_map<std::string, std::string>* res_headers,
-      std::mutex* res_mtx);
+      std::mutex* res_mtx,
+      bool should_cache_redirect = true);
 
   /**
    * Escapes the given URL.

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -296,8 +296,12 @@ Status RestClientRemote::post_array_schema_to_rest(
   std::string array_ns, array_uri;
   RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
   const std::string cache_key = array_ns + ":" + array_uri;
-  RETURN_NOT_OK(
-      curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
+  // We don't want to cache the URI used for array creation as it will
+  // always be hardcoded to the default server. After creation the REST
+  // server knows the right region to direct the request to, so client
+  // side caching should start from then on.
+  RETURN_NOT_OK(curlc.init(
+      config_, extra_headers_, &redirect_meta_, &redirect_mtx_, false));
   auto deduced_url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns + "/" +
                      curlc.url_escape(array_uri);
   Buffer returned_data;


### PR DESCRIPTION
Currently we store a cache of the region redirection for all requests to the REST server in `redirect_uri_map`. However, when an array is first created, we don't know the region yet and we sent the request to the default region, so we shouldn't be caching this. After the array has been created, subsequent requests will be redirected by the server to the right region, and only then the rest client in Core should start caching in `redirect_uri_map`.

---
TYPE: IMPROVEMENT
DESC: Skip caching redirect uri on array create
