### PR TITLE
Use a dedicated label for release workflow failure issues.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,5 +208,5 @@ jobs:
         uses: TileDB-Inc/github-actions/open-issue@main
         with:
           name: Release failed
-          label: bug
+          label: release
           assignee: KiterLuc,teo-tsirpanis,davisp


### PR DESCRIPTION
[SC-52392](https://app.shortcut.com/tiledb-inc/story/52392/release-workflow-failures-are-printed-to-very-old-issues)

Fixes release workflow failure messages being printed to very old issues (https://github.com/TileDB-Inc/TileDB/issues/1446#issuecomment-2269131941).

---
TYPE: NO_HISTORY