### PR TITLE
Add support for getting a dtype of ndrectangle,

### DIFF
--- a/examples/c_api/current_domain.c
+++ b/examples/c_api/current_domain.c
@@ -143,6 +143,18 @@ void print_current_domain() {
           *(int*)range.min,
           *(int*)range.max);
 
+      // Get datatype of range
+      tiledb_datatype_t dtype;
+      tiledb_ndrectangle_get_dtype(ctx, ndrect, 0, &dtype);
+      const char* dtype_str;
+      tiledb_datatype_to_str(dtype, &dtype_str);
+      printf("Range 0 dtype: %s\n", dtype_str);
+
+      // Get datatype of range by name
+      tiledb_ndrectangle_get_dtype_from_name(ctx, ndrect, "d1", &dtype);
+      tiledb_datatype_to_str(dtype, &dtype_str);
+      printf("Range 0 dtype by name: %s\n", dtype_str);
+
       // Clean up
       tiledb_ndrectangle_free(&ndrect);
     } else {

--- a/examples/cpp_api/current_domain.cc
+++ b/examples/cpp_api/current_domain.cc
@@ -113,6 +113,14 @@ void print_current_domain(Context& ctx) {
   // Print the range
   std::cout << "Current domain range: [" << range[0] << ", " << range[1] << "]"
             << std::endl;
+
+  // Print datatype of range 0
+  std::cout << "Current domain range 0 datatype: "
+            << tiledb::impl::type_to_str(ndrect.range_dtype(0)) << std::endl;
+
+  // Print datatype of range d1
+  std::cout << "Current domain range 0 datatype: "
+            << tiledb::impl::type_to_str(ndrect.range_dtype("d1")) << std::endl;
 }
 
 void expand_current_domain(Context& ctx) {

--- a/test/src/test-cppapi-current-domain.cc
+++ b/test/src/test-cppapi-current-domain.cc
@@ -97,6 +97,10 @@ TEST_CASE_METHOD(
   range = rect.range<int>(1);
   CHECK(range[0] == 30);
   CHECK(range[1] == 40);
+
+  // CHECK range dtype
+  CHECK(ndrect.range_dtype(0) == TILEDB_INT32);
+  CHECK(ndrect.range_dtype("x") == TILEDB_INT32);
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
@@ -177,6 +177,36 @@ capi_return_t tiledb_ndrectangle_set_range(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_ndrectangle_get_dtype(
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    uint32_t idx,
+    tiledb_datatype_t* type) {
+  ensure_context_is_valid(ctx);
+  ensure_handle_is_valid(ndr);
+  ensure_output_pointer_is_valid(type);
+
+  *type = static_cast<tiledb_datatype_t>(ndr->ndrectangle()->range_dtype(idx));
+
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_ndrectangle_get_dtype_from_name(
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    const char* name,
+    tiledb_datatype_t* type) {
+  ensure_context_is_valid(ctx);
+  ensure_handle_is_valid(ndr);
+  ensure_dim_name_is_valid(name);
+  ensure_output_pointer_is_valid(type);
+
+  *type = static_cast<tiledb_datatype_t>(
+      ndr->ndrectangle()->range_dtype_for_name(name));
+
+  return TILEDB_OK;
+}
+
 }  // namespace tiledb::api
 
 using tiledb::api::api_entry_plain;
@@ -235,4 +265,25 @@ CAPI_INTERFACE(
     tiledb_range_t* range) {
   return api_entry_with_context<tiledb::api::tiledb_ndrectangle_set_range>(
       ctx, ndr, idx, range);
+}
+
+CAPI_INTERFACE(
+    ndrectangle_get_dtype,
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    uint32_t idx,
+    tiledb_datatype_t* type) {
+  return api_entry_with_context<tiledb::api::tiledb_ndrectangle_get_dtype>(
+      ctx, ndr, idx, type);
+}
+
+CAPI_INTERFACE(
+    ndrectangle_get_dtype_from_name,
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    const char* name,
+    tiledb_datatype_t* type) {
+  return api_entry_with_context<
+      tiledb::api::tiledb_ndrectangle_get_dtype_from_name>(
+      ctx, ndr, name, type);
 }

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
@@ -198,6 +198,52 @@ TILEDB_EXPORT capi_return_t tiledb_ndrectangle_set_range(
     uint32_t idx,
     tiledb_range_t* range) TILEDB_NOEXCEPT;
 
+/**
+ * Get the TileDB datatype for dimension at idx from
+ * the N-dimensional rectangle passed as argument
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_datatype_t type;
+ * tiledb_ndrectangle_get_dtype(ctx, ndr, 1, &type);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param ndr The n-dimensional rectangle to be queried
+ * @param idx The index of the dimension
+ * @param type The datatype to be returned
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_ndrectangle_get_dtype(
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    uint32_t idx,
+    tiledb_datatype_t* type) TILEDB_NOEXCEPT;
+
+/**
+ * Get the TileDB datatype for dimension name from
+ * the N-dimensional rectangle passed as argument
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_datatype_t type;
+ * tiledb_ndrectangle_get_dtype_from_name(ctx, ndr, "dim1", &type);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param ndr The n-dimensional rectangle to be queried
+ * @param name The dimension name
+ * @param type The datatype to be returned
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_ndrectangle_get_dtype_from_name(
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    const char* name,
+    tiledb_datatype_t* type) TILEDB_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/api/c_api/ndrectangle/test/unit_capi_ndrectangle.cc
+++ b/tiledb/api/c_api/ndrectangle/test/unit_capi_ndrectangle.cc
@@ -144,6 +144,27 @@ TEST_CASE_METHOD(
       tiledb_ndrectangle_set_range_for_name(ctx, ndr, "doesntexist", &range) ==
       TILEDB_ERR);
 
+  CHECK(
+      tiledb_ndrectangle_get_dtype(nullptr, nullptr, 0, nullptr) ==
+      TILEDB_INVALID_CONTEXT);
+  CHECK(tiledb_ndrectangle_get_dtype(ctx, nullptr, 0, nullptr) == TILEDB_ERR);
+  CHECK(tiledb_ndrectangle_get_dtype(ctx, ndr, 0, nullptr) == TILEDB_ERR);
+  tiledb_datatype_t dtype;
+  CHECK(tiledb_ndrectangle_get_dtype(ctx, ndr, 2, &dtype) == TILEDB_ERR);
+
+  CHECK(
+      tiledb_ndrectangle_get_dtype_from_name(
+          nullptr, nullptr, "dim1", nullptr) == TILEDB_INVALID_CONTEXT);
+  CHECK(
+      tiledb_ndrectangle_get_dtype_from_name(ctx, nullptr, "dim1", nullptr) ==
+      TILEDB_ERR);
+  CHECK(
+      tiledb_ndrectangle_get_dtype_from_name(ctx, ndr, "dim1", nullptr) ==
+      TILEDB_ERR);
+  CHECK(
+      tiledb_ndrectangle_get_dtype_from_name(ctx, ndr, "doesntexist", &dtype) ==
+      TILEDB_ERR);
+
   REQUIRE(tiledb_ndrectangle_free(&ndr) == TILEDB_OK);
 }
 
@@ -185,6 +206,14 @@ TEST_CASE_METHOD(
   CHECK(range.min_size == out_range_d2.min_size);
   CHECK(std::memcmp(range.min, out_range_d2.min, range.min_size) == 0);
   CHECK(std::memcmp(range.max, out_range_d2.max, range.max_size) == 0);
+
+  tiledb_datatype_t dtype;
+  REQUIRE(tiledb_ndrectangle_get_dtype(ctx, ndr, 0, &dtype) == TILEDB_OK);
+  CHECK(dtype == TILEDB_UINT64);
+  REQUIRE(
+      tiledb_ndrectangle_get_dtype_from_name(ctx, ndr, "d1", &dtype) ==
+      TILEDB_OK);
+  CHECK(dtype == TILEDB_UINT64);
 
   REQUIRE(tiledb_ndrectangle_free(&ndr) == TILEDB_OK);
 }

--- a/tiledb/sm/array_schema/ndrectangle.cc
+++ b/tiledb/sm/array_schema/ndrectangle.cc
@@ -167,6 +167,20 @@ const Range& NDRectangle::get_range_for_name(const std::string& name) const {
   return get_range(idx);
 }
 
+Datatype NDRectangle::range_dtype(uint32_t idx) const {
+  if (idx >= range_data_.size()) {
+    throw std::logic_error(
+        "The index does not correspond to a valid dimension in the "
+        "NDRectangle");
+  }
+  return domain()->dimension_ptr(idx)->type();
+}
+
+Datatype NDRectangle::range_dtype_for_name(const std::string& name) const {
+  auto idx = domain()->get_dimension_index(name);
+  return range_dtype(idx);
+}
+
 }  // namespace tiledb::sm
 
 std::ostream& operator<<(std::ostream& os, const tiledb::sm::NDRectangle& ndr) {

--- a/tiledb/sm/array_schema/ndrectangle.h
+++ b/tiledb/sm/array_schema/ndrectangle.h
@@ -169,6 +169,7 @@ class NDRectangle {
   /**
    * Get the range for the dimension at idx
    *
+   * @param name The dimension index
    * @return The range of the dimension
    */
   const Range& get_range(uint32_t idx) const;
@@ -176,9 +177,26 @@ class NDRectangle {
   /**
    * Get the range for the dimension specified by name
    *
+   * @param name The name of the dimension
    * @return The range of the dimension
    */
   const Range& get_range_for_name(const std::string& name) const;
+
+  /**
+   * Get the data type of the range at idx
+   *
+   * @param idx The index of the range
+   * @return The range datatype
+   */
+  Datatype range_dtype(uint32_t idx) const;
+
+  /**
+   * Get the data type of the range at idx
+   *
+   * @param name The dimension name
+   * @return The range datatype
+   */
+  Datatype range_dtype_for_name(const std::string& name) const;
 
  private:
   /* ********************************* */

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -269,6 +269,36 @@ class NDRectangle {
   std::shared_ptr<tiledb_ndrectangle_t> ptr() const {
     return ndrect_;
   }
+  /**
+   * Get the data type of the range at idx
+   *
+   * @param dim_idx The dimension index.
+   * @return The datatype of the range.
+   */
+  tiledb_datatype_t range_dtype(unsigned dim_idx) {
+    auto& ctx = ctx_.get();
+
+    tiledb_datatype_t dtype;
+    ctx.handle_error(tiledb_ndrectangle_get_dtype(
+        ctx.ptr().get(), ndrect_.get(), dim_idx, &dtype));
+
+    return dtype;
+  }
+  /**
+   * Get the data type of the range by name
+   *
+   * @param dim_name The dimension name.
+   * @return The datatype of the range.
+   */
+  tiledb_datatype_t range_dtype(const std::string& dim_name) {
+    auto& ctx = ctx_.get();
+
+    tiledb_datatype_t dtype;
+    ctx.handle_error(tiledb_ndrectangle_get_dtype_from_name(
+        ctx.ptr().get(), ndrect_.get(), dim_name.c_str(), &dtype));
+
+    return dtype;
+  }
 
  private:
   /* ********************************* */


### PR DESCRIPTION
Users wrapping the current domain APIs are requesting:
`tiledb_datatype_t NDRectangle::range_dtype(const std::string& dim_name)` and 
`tiledb_datatype_t NDRectangle::range_dtype(uint32_t dim_idx)` (and the CAPI counterparts) 
so that the underlying TileDB datatype of a range/dimension can be queried closer to the
call site of functions like e.g. range<T> where a conversion from tiledb_datatype_t to static c++ type is most of the time needed.

[sc-52012]

---
TYPE: FEATURE
DESC: Add support for getting a dtype of ndrectangle,
