### PR TITLE
Add dim num support for ndrectangle.

### DIFF
--- a/examples/c_api/current_domain.c
+++ b/examples/c_api/current_domain.c
@@ -155,6 +155,11 @@ void print_current_domain() {
       tiledb_datatype_to_str(dtype, &dtype_str);
       printf("Range 0 dtype by name: %s\n", dtype_str);
 
+      // Get dim num
+      uint32_t ndim;
+      tiledb_ndrectangle_get_dim_num(ctx, ndrect, &ndim);
+      printf("Range 0 dtype by name: %d\n", ndim);
+
       // Clean up
       tiledb_ndrectangle_free(&ndrect);
     } else {

--- a/examples/cpp_api/current_domain.cc
+++ b/examples/cpp_api/current_domain.cc
@@ -121,6 +121,9 @@ void print_current_domain(Context& ctx) {
   // Print datatype of range d1
   std::cout << "Current domain range 0 datatype: "
             << tiledb::impl::type_to_str(ndrect.range_dtype("d1")) << std::endl;
+
+  // Print dim num
+  std::cout << "Current domain dim num: " << ndrect.dim_num() << std::endl;
 }
 
 void expand_current_domain(Context& ctx) {

--- a/test/src/test-cppapi-current-domain.cc
+++ b/test/src/test-cppapi-current-domain.cc
@@ -98,9 +98,12 @@ TEST_CASE_METHOD(
   CHECK(range[0] == 30);
   CHECK(range[1] == 40);
 
-  // CHECK range dtype
+  // Check range dtype
   CHECK(ndrect.range_dtype(0) == TILEDB_INT32);
   CHECK(ndrect.range_dtype("x") == TILEDB_INT32);
+
+  // Check ndim api
+  CHECK(ndrect.dim_num() == 2);
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
@@ -191,6 +191,17 @@ capi_return_t tiledb_ndrectangle_get_dtype_from_name(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_ndrectangle_get_dim_num(
+    tiledb_ctx_t* ctx, tiledb_ndrectangle_t* ndr, uint32_t* ndim) {
+  ensure_context_is_valid(ctx);
+  ensure_handle_is_valid(ndr);
+  ensure_output_pointer_is_valid(ndim);
+
+  *ndim = ndr->ndrectangle()->domain()->dim_num();
+
+  return TILEDB_OK;
+}
+
 }  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
@@ -269,4 +280,13 @@ CAPI_INTERFACE(
   return api_entry_with_context<
       tiledb::api::tiledb_ndrectangle_get_dtype_from_name>(
       ctx, ndr, name, type);
+}
+
+CAPI_INTERFACE(
+    ndrectangle_get_dim_num,
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    uint32_t* ndim) {
+  return api_entry_with_context<tiledb::api::tiledb_ndrectangle_get_dim_num>(
+      ctx, ndr, ndim);
 }

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
@@ -245,6 +245,27 @@ TILEDB_EXPORT capi_return_t tiledb_ndrectangle_get_dtype_from_name(
     const char* name,
     tiledb_datatype_t* type) TILEDB_NOEXCEPT;
 
+/**
+ * Get the the number of dimensions of
+ * the N-dimensional rectangle passed as argument
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint32_t ndim;
+ * tiledb_ndrectangle_get_dim_num(ctx, ndr, &ndim);
+ * @endcode
+ *
+ * @param ctx The TileDB context
+ * @param ndr The n-dimensional rectangle to be queried
+ * @param ndim The number of dimensions to be returned
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_ndrectangle_get_dim_num(
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    uint32_t* ndim) TILEDB_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/api/c_api/ndrectangle/test/unit_capi_ndrectangle.cc
+++ b/tiledb/api/c_api/ndrectangle/test/unit_capi_ndrectangle.cc
@@ -165,6 +165,12 @@ TEST_CASE_METHOD(
       tiledb_ndrectangle_get_dtype_from_name(ctx, ndr, "doesntexist", &dtype) ==
       TILEDB_ERR);
 
+  CHECK(
+      tiledb_ndrectangle_get_dim_num(nullptr, nullptr, nullptr) ==
+      TILEDB_INVALID_CONTEXT);
+  CHECK(tiledb_ndrectangle_get_dim_num(ctx, nullptr, nullptr) == TILEDB_ERR);
+  CHECK(tiledb_ndrectangle_get_dim_num(ctx, ndr, nullptr) == TILEDB_ERR);
+
   REQUIRE(tiledb_ndrectangle_free(&ndr) == TILEDB_OK);
 }
 
@@ -214,6 +220,10 @@ TEST_CASE_METHOD(
       tiledb_ndrectangle_get_dtype_from_name(ctx, ndr, "d1", &dtype) ==
       TILEDB_OK);
   CHECK(dtype == TILEDB_UINT64);
+
+  uint32_t ndim;
+  REQUIRE(tiledb_ndrectangle_get_dim_num(ctx, ndr, &ndim) == TILEDB_OK);
+  CHECK(ndim == 2);
 
   REQUIRE(tiledb_ndrectangle_free(&ndr) == TILEDB_OK);
 }

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -284,6 +284,7 @@ class NDRectangle {
 
     return dtype;
   }
+
   /**
    * Get the data type of the range by name
    *
@@ -298,6 +299,21 @@ class NDRectangle {
         ctx.ptr().get(), ndrect_.get(), dim_name.c_str(), &dtype));
 
     return dtype;
+  }
+
+  /**
+   * Get the number of dimensions associated with the NDRectangle.
+   *
+   * @return The number of dimensions.
+   */
+  uint32_t dim_num() {
+    auto& ctx = ctx_.get();
+
+    uint32_t ndim;
+    ctx.handle_error(
+        tiledb_ndrectangle_get_dim_num(ctx.ptr().get(), ndrect_.get(), &ndim));
+
+    return ndim;
   }
 
  private:


### PR DESCRIPTION
This PR adds capi and cppapi support for querying the number of slots/dimensions/axes of a current domain ndrectangle.

Depends on #5229 to be merged first.

---
TYPE: FEATURE
DESC: Add dim num support for ndrectangle.
