### PR TITLE
Install pybind from pip.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Prevent vcpkg from building debug variants
         run: python $env:GITHUB_WORKSPACE/scripts/ci/patch_vcpkg_triplets.py
       - name: Install dependencies from pip
-        run: python -m pip install pybind11
+        run: python -m pip install pybind11[global]
 
       - name: Configure TileDB
         shell: pwsh

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -136,6 +136,8 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Prevent vcpkg from building debug variants
         run: python $env:GITHUB_WORKSPACE/scripts/ci/patch_vcpkg_triplets.py
+      - name: Install dependencies from pip
+        run: python -m pip install pybind11
 
       - name: Configure TileDB
         shell: pwsh

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           set -e pipefail
           python -m pip install --upgrade pip virtualenv
-          pip install pyarrow pybind11[global] numpy
+          pip install pyarrow pybind11 numpy
 
       - name: 'Brew setup on macOS' # x-ref c8e49ba8f8b9ce
         if: ${{ startsWith(matrix.os, 'macos-') == true }}

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -148,7 +148,7 @@ jobs:
         run: |
           set -e pipefail
           python -m pip install --upgrade pip virtualenv
-          pip install pyarrow pybind11 numpy
+          pip install pyarrow pybind11[global] numpy
 
       - name: 'Brew setup on macOS' # x-ref c8e49ba8f8b9ce
         if: ${{ startsWith(matrix.os, 'macos-') == true }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,8 +53,8 @@ if (${TILEDB_ARROW_TESTS})
 
   message(STATUS "Configuring Apache Arrow integration test with Python ${Python_VERSION} (${Python_EXECUTABLE})")
 
-  # file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
-  # target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
+  file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
+  target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
 endif()
 
 # Include TileDB core header directories

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,33 +53,6 @@ if (${TILEDB_ARROW_TESTS})
 
   message(STATUS "Configuring Apache Arrow integration test with Python ${Python_VERSION} (${Python_EXECUTABLE})")
 
-  # If we can't find the pybind11 cmake config (not available in pypi yet)
-  # try to find with the current executable.
-  if (NOT ${pybind11_FOUND})
-    # Get the include arguments from the python executable (has "-I" compiler option)
-    execute_process(COMMAND  ${Python_EXECUTABLE} -m pybind11 --includes
-                    OUTPUT_VARIABLE CMD_PYBIND11_INCLUDE
-                    RESULT_VARIABLE CMD_PYBIND11_RESULT
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if (${CMD_PYBIND11_RESULT})
-      message(FATAL_ERROR "Unable to find pybind11 via cmake or 'python3 -m pybind11 --includes'")
-    endif()
-
-    # Convert args to list
-    separate_arguments(CMD_PARSED_INCLUDES NATIVE_COMMAND ${CMD_PYBIND11_INCLUDE})
-    # Remove the "-I" from each include
-    foreach(INCL_PATH IN LISTS CMD_PARSED_INCLUDES)
-      string(REPLACE "-I" "" INCL_PATH ${INCL_PATH})
-      list(APPEND PYBIND11_INCLUDE_DIRECTORIES ${INCL_PATH})
-    endforeach()
-
-    file(TO_CMAKE_PATH "${Python_SITELIB}" SAFE_Python_SITELIB)
-    set(pybind11_FOUND TRUE CACHE BOOL "pybind11 include path found")
-    add_library(pybind11::embed INTERFACE IMPORTED)
-    target_include_directories(pybind11::embed INTERFACE ${PYBIND11_INCLUDE_DIRECTORIES})
-    target_link_libraries(pybind11::embed INTERFACE Python::Python)
-    target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_SITELIB_PATH="${SAFE_Python_SITELIB}")
-  endif()
   file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
   target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,12 +49,12 @@ if (${TILEDB_ARROW_TESTS})
   # Tell CMake to prefer Python from the PATH
   set(Python_FIND_STRATEGY "LOCATION")
   find_package(Python COMPONENTS Interpreter Development REQUIRED)
-  find_package(pybind11)
+  find_package(pybind11 REQUIRED)
 
   message(STATUS "Configuring Apache Arrow integration test with Python ${Python_VERSION} (${Python_EXECUTABLE})")
 
-  file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
-  target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
+  # file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
+  # target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
 endif()
 
 # Include TileDB core header directories

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,10 +49,37 @@ if (${TILEDB_ARROW_TESTS})
   # Tell CMake to prefer Python from the PATH
   set(Python_FIND_STRATEGY "LOCATION")
   find_package(Python COMPONENTS Interpreter Development REQUIRED)
-  find_package(pybind11 REQUIRED)
+  find_package(pybind11)
 
   message(STATUS "Configuring Apache Arrow integration test with Python ${Python_VERSION} (${Python_EXECUTABLE})")
 
+  # If we can't find the pybind11 cmake config (not available in pypi yet)
+  # try to find with the current executable.
+  if (NOT ${pybind11_FOUND})
+    # Get the include arguments from the python executable (has "-I" compiler option)
+    execute_process(COMMAND  ${Python_EXECUTABLE} -m pybind11 --includes
+            OUTPUT_VARIABLE CMD_PYBIND11_INCLUDE
+            RESULT_VARIABLE CMD_PYBIND11_RESULT
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (${CMD_PYBIND11_RESULT})
+      message(FATAL_ERROR "Unable to find pybind11 via cmake or 'python3 -m pybind11 --includes'")
+    endif()
+
+    # Convert args to list
+    separate_arguments(CMD_PARSED_INCLUDES NATIVE_COMMAND ${CMD_PYBIND11_INCLUDE})
+    # Remove the "-I" from each include
+    foreach(INCL_PATH IN LISTS CMD_PARSED_INCLUDES)
+      string(REPLACE "-I" "" INCL_PATH ${INCL_PATH})
+      list(APPEND PYBIND11_INCLUDE_DIRECTORIES ${INCL_PATH})
+    endforeach()
+
+    file(TO_CMAKE_PATH "${Python_SITELIB}" SAFE_Python_SITELIB)
+    set(pybind11_FOUND TRUE CACHE BOOL "pybind11 include path found")
+    add_library(pybind11::embed INTERFACE IMPORTED)
+    target_include_directories(pybind11::embed INTERFACE ${PYBIND11_INCLUDE_DIRECTORIES})
+    target_link_libraries(pybind11::embed INTERFACE Python::Python)
+    target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_SITELIB_PATH="${SAFE_Python_SITELIB}")
+  endif()
   file(TO_CMAKE_PATH ${CMAKE_CURRENT_BINARY_DIR} SAFE_CURRENT_BINARY_DIR)
   target_compile_definitions(pybind11::embed INTERFACE -DTILEDB_PYTHON_UNIT_PATH="${SAFE_CURRENT_BINARY_DIR}")
 endif()


### PR DESCRIPTION
This installs pybind11 from PIP so that the windows builds can find it. It is a workaround that will be properly fixed but for now this will unblock the 2.26 release and allow us to merge PRs.

[sc-52966]

---
TYPE: NO_HISTORY
DESC: Use pybind11 from pip.
