### PR TITLE
Include missing `<random>` and `numeric` headers.

### DIFF
--- a/experimental/tiledb/common/dag/data_block/test/unit_blocks_and_ports.cc
+++ b/experimental/tiledb/common/dag/data_block/test/unit_blocks_and_ports.cc
@@ -32,6 +32,7 @@
  */
 
 #include <future>
+#include <numeric>
 
 #include "unit_data_block.h"
 

--- a/experimental/tiledb/common/dag/data_block/test/unit_data_block.cc
+++ b/experimental/tiledb/common/dag/data_block/test/unit_data_block.cc
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <forward_list>
 #include <list>
+#include <numeric>
 
 /**
  * @todo Use proper checks for preprocessor directives to selectively include

--- a/experimental/tiledb/common/dag/edge/test/unit_edge.cc
+++ b/experimental/tiledb/common/dag/edge/test/unit_edge.cc
@@ -41,6 +41,7 @@
 #include "unit_edge.h"
 
 #include <future>
+#include <numeric>
 
 #include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/ports/ports.h"

--- a/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
@@ -31,10 +31,10 @@
 
 #include <numeric>
 
-#include "unit_duffs.h"
 #include "../duffs.h"
 #include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "unit_duffs.h"
 
 using namespace tiledb::common;
 

--- a/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_duffs.cc
@@ -29,6 +29,8 @@
  *
  */
 
+#include <numeric>
+
 #include "unit_duffs.h"
 #include "../duffs.h"
 #include "experimental/tiledb/common/dag/edge/edge.h"

--- a/experimental/tiledb/common/dag/execution/test/unit_frugal.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_frugal.cc
@@ -36,6 +36,7 @@
 #include <cassert>
 #include <iostream>
 #include <map>
+#include <numeric>
 #include <tiledb/stdx/stop_token>
 #include <type_traits>
 

--- a/experimental/tiledb/common/dag/execution/test/unit_scheduler.cc
+++ b/experimental/tiledb/common/dag/execution/test/unit_scheduler.cc
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <iostream>
 #include <map>
+#include <numeric>
 #include <type_traits>
 
 #include "unit_scheduler.h"

--- a/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
@@ -28,6 +28,8 @@
  * @section DESCRIPTION
  */
 
+#include <numeric>
+
 #include "unit_taskgraph.h"
 #include "experimental/tiledb/common/dag/execution/duffs.h"
 #include "experimental/tiledb/common/dag/graph/taskgraph.h"

--- a/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
+++ b/experimental/tiledb/common/dag/graph/test/unit_taskgraph.cc
@@ -30,10 +30,10 @@
 
 #include <numeric>
 
-#include "unit_taskgraph.h"
 #include "experimental/tiledb/common/dag/execution/duffs.h"
 #include "experimental/tiledb/common/dag/graph/taskgraph.h"
 #include "experimental/tiledb/common/dag/nodes/segmented_nodes.h"
+#include "unit_taskgraph.h"
 
 using namespace tiledb::common;
 

--- a/experimental/tiledb/common/dag/nodes/generators.h
+++ b/experimental/tiledb/common/dag/nodes/generators.h
@@ -33,6 +33,7 @@
 #ifndef TILEDB_DAG_GENERATOR_H
 #define TILEDB_DAG_GENERATOR_H
 
+#include <random>
 #include <tiledb/stdx/stop_token>
 
 #include "experimental/tiledb/common/dag/ports/ports.h"

--- a/experimental/tiledb/common/dag/nodes/test/unit_general_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_general_nodes.cc
@@ -32,6 +32,7 @@
 
 #include "unit_general_nodes.h"
 #include <future>
+#include <numeric>
 
 #include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/nodes/detail/simple/mimo.h"

--- a/experimental/tiledb/common/dag/nodes/test/unit_segmented_mimo_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_segmented_mimo_nodes.cc
@@ -32,6 +32,8 @@
  * @todo: Need to get better syntax for Edge with shared_ptr
  */
 
+#include <numeric>
+
 #include "unit_segmented_mimo_nodes.h"
 
 #include "experimental/tiledb/common/dag/edge/edge.h"

--- a/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_simple_nodes.cc
@@ -32,6 +32,7 @@
 
 #include "unit_simple_nodes.h"
 #include <future>
+#include <numeric>
 #include <type_traits>
 #include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/nodes/generators.h"

--- a/experimental/tiledb/common/dag/nodes/test/unit_stop_source.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_stop_source.cc
@@ -32,6 +32,7 @@
 
 #include <atomic>
 #include <future>
+#include <numeric>
 
 #include "unit_stop_source.h"
 

--- a/experimental/tiledb/common/dag/nodes/test/unit_util_functions.cc
+++ b/experimental/tiledb/common/dag/nodes/test/unit_util_functions.cc
@@ -33,6 +33,7 @@
 
 #include "unit_util_functions.h"
 #include <future>
+#include <numeric>
 #include "experimental/tiledb/common/dag/edge/edge.h"
 #include "experimental/tiledb/common/dag/nodes/generators.h"
 #include "experimental/tiledb/common/dag/nodes/nodes.h"

--- a/experimental/tiledb/common/dag/ports/test/unit_ports.cc
+++ b/experimental/tiledb/common/dag/ports/test/unit_ports.cc
@@ -32,6 +32,7 @@
 
 #include "unit_ports.h"
 #include <future>
+#include <numeric>
 #include "experimental/tiledb/common/dag/ports/ports.h"
 #include "experimental/tiledb/common/dag/state_machine/policies.h"
 #include "experimental/tiledb/common/dag/state_machine/test/types.h"

--- a/experimental/tiledb/common/dag/utility/test/unit_bounded_buffer.cc
+++ b/experimental/tiledb/common/dag/utility/test/unit_bounded_buffer.cc
@@ -32,6 +32,7 @@
 
 #include "experimental/tiledb/common/dag/utility/test/unit_bounded_buffer.h"
 #include <future>
+#include <numeric>
 #include <type_traits>
 #include <vector>
 #include "experimental/tiledb/common/dag/utility/bounded_buffer.h"

--- a/test/src/unit-cppapi-query-condition-enumerations.cc
+++ b/test/src/unit-cppapi-query-condition-enumerations.cc
@@ -31,6 +31,7 @@
  */
 
 #include <limits>
+#include <numeric>
 #include <ostream>
 #include <random>
 

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -30,6 +30,7 @@
  * Tests the C++ API for enumeration related functions.
  */
 
+#include <numeric>
 #include <sstream>
 
 #include "test/support/src/mem_helpers.h"

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -44,6 +44,7 @@
 #endif
 
 #include <test/support/tdb_catch.h>
+#include <numeric>
 
 using namespace tiledb;
 using namespace tiledb::test;

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -46,6 +46,7 @@
 #endif
 
 #include <test/support/tdb_catch.h>
+#include <numeric>
 
 using namespace tiledb::sm;
 using namespace tiledb::test;


### PR DESCRIPTION
Fixes #5244.

---
TYPE: NO_HISTORY