### PR TITLE
Avoid temporary `tiledb_array_t*` handle allocations in C API implementations.

### DIFF
--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1458,7 +1458,7 @@ capi_return_t tiledb_array_delete_fragments_v2(
     uint64_t timestamp_end) {
   auto uri = tiledb::sm::URI(uri_str);
   if (uri.is_invalid()) {
-    throw api::CAPIException("Failed to delete fragments; Invalid input uri");
+    throw CAPIException("Failed to delete fragments; Invalid input uri");
   }
 
   // Allocate an array object
@@ -1480,6 +1480,7 @@ capi_return_t tiledb_array_delete_fragments_v2(
     array->delete_fragments(uri, timestamp_start, timestamp_end);
   } catch (...) {
     throw_if_not_ok(array->close());
+    throw;
   }
 
   // Close and delete the array
@@ -1495,18 +1496,18 @@ capi_return_t tiledb_array_delete_fragments_list(
     const size_t num_fragments) {
   auto uri = tiledb::sm::URI(uri_str);
   if (uri.is_invalid()) {
-    throw api::CAPIException(
+    throw CAPIException(
         "Failed to delete_fragments_list; Invalid input uri");
   }
 
   if (num_fragments < 1) {
-    throw api::CAPIException(
+    throw CAPIException(
         "Failed to delete_fragments_list; Invalid input number of fragments");
   }
 
   for (size_t i = 0; i < num_fragments; i++) {
     if (tiledb::sm::URI(fragment_uris[i]).is_invalid()) {
-      throw api::CAPIException(
+      throw CAPIException(
           "Failed to delete_fragments_list; Invalid input fragment uri");
     }
   }
@@ -1533,6 +1534,7 @@ capi_return_t tiledb_array_delete_fragments_list(
     array->delete_fragments_list(uris);
   } catch (...) {
     throw_if_not_ok(array->close());
+    throw;
   }
 
   // Close the array

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1496,8 +1496,7 @@ capi_return_t tiledb_array_delete_fragments_list(
     const size_t num_fragments) {
   auto uri = tiledb::sm::URI(uri_str);
   if (uri.is_invalid()) {
-    throw CAPIException(
-        "Failed to delete_fragments_list; Invalid input uri");
+    throw CAPIException("Failed to delete_fragments_list; Invalid input uri");
   }
 
   if (num_fragments < 1) {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1487,7 +1487,8 @@ capi_return_t tiledb_array_delete_fragments_v2(
     array.delete_fragments(uri, timestamp_start, timestamp_end);
   } catch (...) {
     throw_if_not_ok(array.close());
-    throw api::CAPIStatusException("Failed to delete fragments");
+    std::throw_with_nested(
+        api::CAPIStatusException("Failed to delete fragments"));
   }
 
   // Close and delete the array
@@ -1541,7 +1542,8 @@ capi_return_t tiledb_array_delete_fragments_list(
     array.delete_fragments_list(uris);
   } catch (...) {
     throw_if_not_ok(array.close());
-    throw api::CAPIStatusException("Failed to delete fragments_list");
+    std::throw_with_nested(
+        api::CAPIStatusException("Failed to delete fragments_list"));
   }
 
   // Close the array

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1480,7 +1480,7 @@ capi_return_t tiledb_array_delete_fragments_v2(
     array->delete_fragments(uri, timestamp_start, timestamp_end);
   } catch (...) {
     throw_if_not_ok(array->close());
-    throw;
+    throw CAPIException("Failed to delete fragments");
   }
 
   // Close and delete the array
@@ -1533,7 +1533,7 @@ capi_return_t tiledb_array_delete_fragments_list(
     array->delete_fragments_list(uris);
   } catch (...) {
     throw_if_not_ok(array->close());
-    throw;
+    throw CAPIException("Failed to delete fragments_list");
   }
 
   // Close the array


### PR DESCRIPTION
[SC-53176](https://app.shortcut.com/tiledb-inc/story/53176/remove-unnecessarily-temporary-array-handle-allocations)

This PR replaces internal allocations of temporary `tiledb_array_t*` handles in the C API implementations, with `shared_ptr<tiledb::sm::Array>`. This simplifies error handling and memory management.

---
TYPE: NO_HISTORY