### PR TITLE
Fix missing header.

### DIFF
--- a/tiledb/sm/crypto/crypto_win32.cc
+++ b/tiledb/sm/crypto/crypto_win32.cc
@@ -35,6 +35,7 @@
 #include "tiledb/sm/crypto/crypto_win32.h"
 
 #include <algorithm>
+#include <array>
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/buffer/buffer.h"

--- a/tiledb/sm/crypto/test/unit_tiledb_crypto.cc
+++ b/tiledb/sm/crypto/test/unit_tiledb_crypto.cc
@@ -288,7 +288,7 @@ TEST_CASE("Crypto: Test AES-256-GCM", "[crypto][aes]") {
       }
     };
 
-    static constexpr auto tests = {
+    static auto tests = {
         TestCase(
             "1fded32d5999de4a76e0f8082108823aef60417e1896cf4218a2fa90f632ec8a",
             "1f3afa4711e9474f32e70462",


### PR DESCRIPTION
Fixes #5249.

Because the `<span>` header in MSVC does not include `<array>`, a simultaneous merging of #5233 which uses `<span>` with #3979 which used `std::array` in the Windows crypto code caused compile errors.

---
TYPE: NO_HISTORY