### PR TITLE
Prevent consolidation with fragment list in dense arrays if it could result in data loss.

### DIFF
--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -295,6 +295,24 @@ TEST_CASE(
     fragment_name2 = fragment_info.fragment_uri(3);
   }
 
+  SECTION("Throws exception because of overlap in extended domain") {
+    throws = true;
+    create_array_2d(array_name);
+    // order matters
+    write_array(array_name, {2, 4, 2, 3}, {1, 2, 3, 4, 5, 6});
+    write_array(array_name, {10, 10, 4, 4}, {16});
+    write_array(array_name, {7, 9, 6, 8}, {7, 8, 9, 10, 11, 12, 13, 14, 15});
+
+    number_of_fragments_before_consolidation =
+        tiledb::test::num_fragments(array_name);
+    CHECK(number_of_fragments_before_consolidation == 3);
+
+    FragmentInfo fragment_info(ctx, array_name);
+    fragment_info.load();
+    fragment_name1 = fragment_info.fragment_uri(0);
+    fragment_name2 = fragment_info.fragment_uri(2);
+  }
+
   SECTION("Does not throw exception") {
     create_array_2d(array_name);
     // order matters

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -280,6 +280,12 @@ TEST_CASE(
     throws = true;
     create_array_2d(array_name);
     // order matters
+    // In this case we request to consolidate frag2 and frag4. We can see that
+    // frag1 has been created prior to frag3 so the first condition to abort
+    // the consolidation is satisfied. Additionally, frag1's
+    // domain intersects with the union of the domains of the
+    // selected fragments for consolidation(frag2, frag4), so the second
+    // condition is also satisfied. An exception is expected.
     write_array(array_name, {1, 3, 7, 9}, {1, 2, 3, 4, 5, 6, 7, 8, 9});
     write_array(array_name, {2, 4, 2, 3}, {10, 11, 12, 13, 14, 15});
     write_array(array_name, {3, 5, 4, 5}, {16, 17, 18, 19, 20, 21});
@@ -299,6 +305,13 @@ TEST_CASE(
     throws = true;
     create_array_2d(array_name);
     // order matters
+    // In this case we request to consolidate frag1 and frag3. We can see that
+    // frag2 has been created prior to frag3 so the first condition to abort
+    // the consolidation is satisfied. Additionally, even though frag2's
+    // domain does not directly intersect with the union of the domains of the
+    // selected fragments for consolidation(frag1, frag3), it intersects with
+    // their expanded domain(Full tiles) because the tile extend is set to 2 and
+    // the domain range is 1-10.
     write_array(array_name, {2, 4, 2, 3}, {1, 2, 3, 4, 5, 6});
     write_array(array_name, {10, 10, 4, 4}, {16});
     write_array(array_name, {7, 9, 6, 8}, {7, 8, 9, 10, 11, 12, 13, 14, 15});
@@ -316,9 +329,14 @@ TEST_CASE(
   SECTION("Does not throw exception") {
     create_array_2d(array_name);
     // order matters
+    // In this case we request to consolidate frag1 and frag2. We can see that
+    // frag3 has not been created prior to frag3 so the first condition to abort
+    // the consolidation is not satisfied. Frag3's domain intersects with the
+    // union of the domains of the selected fragments for consolidation(frag1,
+    // frag2), so the second condition is satisfied. An exception is expected.
     write_array(array_name, {2, 4, 2, 3}, {10, 11, 12, 13, 14, 15});
     write_array(array_name, {7, 9, 6, 8}, {22, 23, 24, 25, 26, 27, 28, 29, 30});
-    write_array(array_name, {7, 8, 3, 4}, {31, 32, 33, 34});  // this is ok
+    write_array(array_name, {7, 8, 3, 4}, {31, 32, 33, 34});
 
     number_of_fragments_before_consolidation =
         tiledb::test::num_fragments(array_name);

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -265,7 +265,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test consolidation with wrong fragment list",
-    "[cppapi][consolidation][dstara]") {
+    "[cppapi][consolidation][fragment_list_consolidation]") {
   std::string array_name = "cppapi_consolidation";
   remove_array(array_name);
 
@@ -339,8 +339,10 @@ TEST_CASE(
       short_fragment_name1.c_str(), short_fragment_name2.c_str()};
 
   if (throws) {
-    REQUIRE_THROWS(
-        Array::consolidate(ctx, array_name, fragment_uris, 2, &config));
+    REQUIRE_THROWS_WITH(
+        Array::consolidate(ctx, array_name, fragment_uris, 2, &config),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot consolidate; The non-empty domain of the fragment"));
   } else {
     REQUIRE_NOTHROW(
         Array::consolidate(ctx, array_name, fragment_uris, 2, &config));

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -279,7 +279,6 @@ TEST_CASE(
   SECTION("Throws exception") {
     throws = true;
     create_array_2d(array_name);
-    // order matters
     // In this case we request to consolidate frag2 and frag4. We can see that
     // frag1 has been created prior to frag3 so the first condition to abort
     // the consolidation is satisfied. Additionally, frag1's
@@ -304,7 +303,6 @@ TEST_CASE(
   SECTION("Throws exception because of overlap in extended domain") {
     throws = true;
     create_array_2d(array_name);
-    // order matters
     // In this case we request to consolidate frag1 and frag3. We can see that
     // frag2 has been created prior to frag3 so the first condition to abort
     // the consolidation is satisfied. Additionally, even though frag2's
@@ -331,7 +329,6 @@ TEST_CASE(
       "fragment") {
     throws = true;
     create_array_2d(array_name);
-    // order matters
     // In this case we request to consolidate frag1 and frag3. Before this main
     // consolidation we run another secondary consolidation between frag2 and
     // frag4. The consolidated frag2_frag4 has been created after frag3 but its
@@ -371,7 +368,6 @@ TEST_CASE(
 
   SECTION("Does not throw exception") {
     create_array_2d(array_name);
-    // order matters
     // In this case we request to consolidate frag1 and frag2. We can see that
     // frag3 has not been created prior to frag3 so the first condition to abort
     // the consolidation is not satisfied. Frag3's domain intersects with the

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -265,7 +265,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C++ API: Test consolidation with wrong fragment list",
-    "[cppapi][consolidation][fragment_list_consolidation]") {
+    "[cppapi][consolidation][fragment-list-consolidation]") {
   std::string array_name = "cppapi_consolidation";
   remove_array(array_name);
 

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1772,7 +1772,6 @@ int32_t tiledb_array_consolidate_fragments(
     const char** fragment_uris,
     const uint64_t num_fragments,
     tiledb_config_t* config) {
-
   // Convert the list of fragments to a vector
   std::vector<std::string> uris;
   uris.reserve(num_fragments);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1772,7 +1772,6 @@ int32_t tiledb_array_consolidate_fragments(
     const char** fragment_uris,
     const uint64_t num_fragments,
     tiledb_config_t* config) {
-  // Sanity checks
 
   // Convert the list of fragments to a vector
   std::vector<std::string> uris;

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -430,9 +430,13 @@ Status FragmentConsolidator::consolidate_fragments(
         continue;
       }
 
+      // Expand domain to full tiles
+      auto expanded_non_empty_domain = union_non_empty_domains;
+      domain.expand_to_tiles(&expanded_non_empty_domain);
+
       // Check domain and timestamp overlap
       if (domain.overlap(
-              union_non_empty_domains, frag_info.non_empty_domain())) {
+              expanded_non_empty_domain, frag_info.non_empty_domain())) {
         auto timestamp_range{frag_info.timestamp_range()};
         bool timestamp_before = !(timestamp_range.first > max_timestamp);
         if (timestamp_before) {

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -407,6 +407,14 @@ Status FragmentConsolidator::consolidate_fragments(
         std::to_string(fragment_uris.size()) + " required fragments.");
   }
 
+  // In case we have a dense Array check that the fragments can be consolidated without data loss
+  if (array_for_reads->array_schema_latest().array_type() == ArrayType::DENSE) {
+    // pseudocode
+  // search every other fragment in this array
+    // if any of them overlaps in ranges AND its timestamp range falls between the range of the fragments to consolidate
+    // throw descriptive error
+  } 
+
   FragmentConsolidationWorkspace cw(consolidator_memory_tracker_);
 
   // Consolidate the selected fragments

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -33,6 +33,7 @@
 #include "tiledb/sm/consolidator/fragment_consolidator.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/datatype.h"
 #include "tiledb/sm/enums/query_status.h"
 #include "tiledb/sm/enums/query_type.h"

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -422,7 +422,8 @@ Status FragmentConsolidator::consolidate_fragments(
     // ranges and its timestamp range falls between the range of the fragments
     // to consolidate throw error
 
-    // First calculate the timestamp bounds
+    // First calculate the max timestamp among the fragments which are selected
+    // for consolidation and use it as an upper bound.
     uint64_t max_timestamp = std::numeric_limits<uint64_t>::min();
     for (const auto& item : to_consolidate) {
       const auto& range = item.timestamp_range();
@@ -442,7 +443,9 @@ Status FragmentConsolidator::consolidate_fragments(
       auto expanded_non_empty_domain = union_non_empty_domains;
       domain.expand_to_tiles(&expanded_non_empty_domain);
 
-      // Check domain and timestamp overlap
+      // Check domain and timestamp overlap. Do timestamp check first as it is
+      // cheaper. We compare the current fragment's start timestamp against the
+      // upper bound we calculated previously.
       auto timestamp_range{frag_info.timestamp_range()};
       bool timestamp_before = !(timestamp_range.first > max_timestamp);
       if (timestamp_before &&

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -440,8 +440,8 @@ Status FragmentConsolidator::consolidate_fragments(
       }
 
       // Expand domain to full tiles
-      auto expanded_non_empty_domain = union_non_empty_domains;
-      domain.expand_to_tiles(&expanded_non_empty_domain);
+      auto expanded_union_non_empty_domains = union_non_empty_domains;
+      domain.expand_to_tiles(&expanded_union_non_empty_domains);
 
       // Check domain and timestamp overlap. Do timestamp check first as it is
       // cheaper. We compare the current fragment's start timestamp against the
@@ -450,7 +450,7 @@ Status FragmentConsolidator::consolidate_fragments(
       bool timestamp_before = !(timestamp_range.first > max_timestamp);
       if (timestamp_before &&
           domain.overlap(
-              expanded_non_empty_domain, frag_info.non_empty_domain())) {
+              expanded_union_non_empty_domains, frag_info.non_empty_domain())) {
         throw FragmentConsolidatorException(
             "Cannot consolidate; The non-empty domain of the fragment with "
             "URI: " +

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -420,10 +420,6 @@ Status FragmentConsolidator::consolidate_fragments(
     max_timestamp = std::max(max_timestamp, range.second);
   }
 
-  // Output the results
-  std::cout << "Minimum timestamp: " << min_timestamp << "\n";
-  std::cout << "Maximum timestamp: " << max_timestamp << "\n";
-
   // In case we have a dense Array check that the fragments can be consolidated
   // without data loss
   if (array_for_reads->array_schema_latest().array_type() == ArrayType::DENSE) {
@@ -444,7 +440,13 @@ Status FragmentConsolidator::consolidate_fragments(
         bool timestamp_before = !(timestamp_range.first > max_timestamp);
         if (timestamp_before) {
           throw FragmentConsolidatorException(
-              "Cannot consolidate; Invalid fragments");
+              "Cannot consolidate; The non-empty domain of the fragment with "
+              "URI: " +
+              uri +
+              " overlaps with the union of the non-empty domains of the "
+              "fragments selected for consolidation and was created before "
+              "these fragments. For more information refer to our "
+              "documentation on consolidation for Dense arrays.");
         }
       }
     }

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -408,7 +408,15 @@ Status FragmentConsolidator::consolidate_fragments(
   }
 
   // In case we have a dense Array check that the fragments can be consolidated
-  // without data loss
+  // without data loss. More specifically, if the union of the non-empty domains
+  // of the fragments which are selected for consolidation (which is equal to
+  // the non-empty domain of the resulting consolidated fragment) overlaps with
+  // any fragment created prior to this subset, then the subset is marked as
+  // non-consolidatable. Recall that the fragment that results from
+  // consolidating a subset of fragments containing at least one dense fragment
+  // is always a dense fragment. Therefore, empty regions in the non-emtpy
+  // domain of the consolidated fragment will be filled with special values.
+  // Those values may erroneously overwrite older valid cell values
   if (array_for_reads->array_schema_latest().array_type() == ArrayType::DENSE) {
     // Search every other fragment in this array if any of them overlaps in
     // ranges and its timestamp range falls between the range of the fragments

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -407,7 +407,7 @@ Status FragmentConsolidator::consolidate_fragments(
         std::to_string(fragment_uris.size()) + " required fragments.");
   }
 
-  // In case we have a dense Array check that the fragments can be consolidated
+  // In case we have a dense array check that the fragments can be consolidated
   // without data loss. More specifically, if the union of the non-empty domains
   // of the fragments which are selected for consolidation (which is equal to
   // the non-empty domain of the resulting consolidated fragment) overlaps with
@@ -416,7 +416,7 @@ Status FragmentConsolidator::consolidate_fragments(
   // consolidating a subset of fragments containing at least one dense fragment
   // is always a dense fragment. Therefore, empty regions in the non-emtpy
   // domain of the consolidated fragment will be filled with special values.
-  // Those values may erroneously overwrite older valid cell values
+  // Those values may erroneously overwrite older valid cell values.
   if (array_for_reads->array_schema_latest().array_type() == ArrayType::DENSE) {
     // Search every other fragment in this array if any of them overlaps in
     // ranges and its timestamp range falls between the range of the fragments
@@ -443,20 +443,19 @@ Status FragmentConsolidator::consolidate_fragments(
       domain.expand_to_tiles(&expanded_non_empty_domain);
 
       // Check domain and timestamp overlap
-      if (domain.overlap(
+      auto timestamp_range{frag_info.timestamp_range()};
+      bool timestamp_before = !(timestamp_range.first > max_timestamp);
+      if (timestamp_before &&
+          domain.overlap(
               expanded_non_empty_domain, frag_info.non_empty_domain())) {
-        auto timestamp_range{frag_info.timestamp_range()};
-        bool timestamp_before = !(timestamp_range.first > max_timestamp);
-        if (timestamp_before) {
-          throw FragmentConsolidatorException(
-              "Cannot consolidate; The non-empty domain of the fragment with "
-              "URI: " +
-              uri +
-              " overlaps with the union of the non-empty domains of the "
-              "fragments selected for consolidation and was created before "
-              "these fragments. For more information refer to our "
-              "documentation on consolidation for Dense arrays.");
-        }
+        throw FragmentConsolidatorException(
+            "Cannot consolidate; The non-empty domain of the fragment with "
+            "URI: " +
+            uri +
+            " overlaps with the union of the non-empty domains of the "
+            "fragments selected for consolidation and was created before "
+            "these fragments. For more information refer to our "
+            "documentation on consolidation for Dense arrays.");
       }
     }
   }

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -40,6 +40,7 @@
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
 #include "tiledb/sm/misc/types.h"
+#include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -39,8 +39,8 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
-#include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/enums/array_type.h"
+#include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"
 

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -39,7 +39,6 @@
 #include "tiledb/common/status.h"
 #include "tiledb/sm/array/array.h"
 #include "tiledb/sm/consolidator/consolidator.h"
-#include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/misc/types.h"
 #include "tiledb/sm/storage_manager/context_resources.h"
 #include "tiledb/sm/storage_manager/storage_manager_declaration.h"


### PR DESCRIPTION
When using fragment list consolidation with dense arrays, there is a possibility that consolidating some fragments would lead to data loss (see https://docs.tiledb.com/main/background/internal-mechanics/consolidation#algorithm for more details). This PR fixes this issue.

---
TYPE: IMPROVEMENT
DESC: Prevent consolidation with fragment list in dense arrays if it could result in data loss.
