### PR TITLE
Use unordered layout for aggregate-only read queries on sparse arrays.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -173,7 +173,7 @@ void CppAggregatesFx<T>::generate_test_params() {
     nullable_ = GENERATE(true, false);
     allow_dups_ = GENERATE(true, false);
     set_qc_values_ = {false};
-    layout_values_ = {TILEDB_UNORDERED};
+    layout_values_ = {TILEDB_ROW_MAJOR, TILEDB_UNORDERED};
     use_dim_values_ = {true, false};
     if (nullable_ || !std::is_same<T, uint64_t>::value) {
       use_dim_values_ = {false};
@@ -195,6 +195,11 @@ void CppAggregatesFx<T>::run_all_combinations(std::function<void()> fn) {
           for (bool set_qc : set_qc_values_) {
             set_qc_ = set_qc;
             for (tiledb_layout_t layout : layout_values_) {
+              // Filter invalid combination. The legacy reader does not support
+              // aggregates, and we cannot automatically switch to unordered
+              // reads if we are requesting both the aggregates and the data.
+              if (!dense_ && request_data && layout != TILEDB_UNORDERED)
+                continue;
               layout_ = layout;
               fn();
             }
@@ -1444,6 +1449,11 @@ TEST_CASE_METHOD(
       for (bool set_qc : set_qc_values_) {
         set_qc_ = set_qc;
         for (tiledb_layout_t layout : layout_values_) {
+          // Filter invalid combination. The legacy reader does not support
+          // aggregates, and we cannot automatically switch to unordered
+          // reads if we are requesting both the aggregates and the data.
+          if (!dense_ && request_data && layout != TILEDB_UNORDERED)
+            continue;
           layout_ = layout;
           Query query(ctx_, array, TILEDB_READ);
 
@@ -1824,6 +1834,11 @@ TEMPLATE_LIST_TEST_CASE(
       for (bool set_qc : fx.set_qc_values_) {
         fx.set_qc_ = set_qc;
         for (tiledb_layout_t layout : fx.layout_values_) {
+          // Filter invalid combination. The legacy reader does not support
+          // aggregates, and we cannot automatically switch to unordered
+          // reads if we are requesting both the aggregates and the data.
+          if (!fx.dense_ && request_data && layout != TILEDB_UNORDERED)
+            continue;
           fx.layout_ = layout;
           Query query(fx.ctx_, array, TILEDB_READ);
 
@@ -2048,6 +2063,11 @@ TEST_CASE_METHOD(
       for (bool set_qc : set_qc_values_) {
         set_qc_ = set_qc;
         for (tiledb_layout_t layout : layout_values_) {
+          // Filter invalid combination. The legacy reader does not support
+          // aggregates, and we cannot automatically switch to unordered
+          // reads if we are requesting both the aggregates and the data.
+          if (!dense_ && request_data && layout != TILEDB_UNORDERED)
+            continue;
           layout_ = layout;
           Query query(ctx_, array, TILEDB_READ);
 
@@ -2146,6 +2166,11 @@ TEST_CASE_METHOD(
     for (bool set_qc : set_qc_values_) {
       set_qc_ = set_qc;
       for (tiledb_layout_t layout : layout_values_) {
+        // Filter invalid combination. The legacy reader does not support
+        // aggregates, and we cannot automatically switch to unordered
+        // reads if we are requesting both the aggregates and the data.
+        if (!dense_ && layout != TILEDB_UNORDERED)
+          continue;
         layout_ = layout;
         Query query(ctx_, array, TILEDB_READ);
 
@@ -2285,6 +2310,11 @@ TEST_CASE_METHOD(
     for (bool set_qc : set_qc_values_) {
       set_qc_ = set_qc;
       for (tiledb_layout_t layout : layout_values_) {
+        // Filter invalid combination. The legacy reader does not support
+        // aggregates, and we cannot automatically switch to unordered
+        // reads if we are requesting both the aggregates and the data.
+        if (layout != TILEDB_UNORDERED)
+          continue;
         layout_ = layout;
         Query query(ctx_, array, TILEDB_READ);
 
@@ -2365,6 +2395,11 @@ TEMPLATE_LIST_TEST_CASE_METHOD(
     for (bool set_qc : CppAggregatesFx<T>::set_qc_values_) {
       CppAggregatesFx<T>::set_qc_ = set_qc;
       for (tiledb_layout_t layout : CppAggregatesFx<T>::layout_values_) {
+        // Filter invalid combination. The legacy reader does not support
+        // aggregates, and we cannot automatically switch to unordered
+        // reads if we are requesting both the aggregates and the data.
+        if (!CppAggregatesFx<T>::dense_ && layout != TILEDB_UNORDERED)
+          continue;
         CppAggregatesFx<T>::layout_ = layout;
         Query query(CppAggregatesFx<T>::ctx_, array, TILEDB_READ);
 

--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -198,8 +198,9 @@ void CppAggregatesFx<T>::run_all_combinations(std::function<void()> fn) {
               // Filter invalid combination. The legacy reader does not support
               // aggregates, and we cannot automatically switch to unordered
               // reads if we are requesting both the aggregates and the data.
-              if (!dense_ && request_data && layout != TILEDB_UNORDERED)
+              if (request_data && layout != TILEDB_UNORDERED) {
                 continue;
+              }
               layout_ = layout;
               fn();
             }
@@ -1452,8 +1453,9 @@ TEST_CASE_METHOD(
           // Filter invalid combination. The legacy reader does not support
           // aggregates, and we cannot automatically switch to unordered
           // reads if we are requesting both the aggregates and the data.
-          if (!dense_ && request_data && layout != TILEDB_UNORDERED)
+          if (request_data && layout != TILEDB_UNORDERED) {
             continue;
+          }
           layout_ = layout;
           Query query(ctx_, array, TILEDB_READ);
 
@@ -2066,8 +2068,9 @@ TEST_CASE_METHOD(
           // Filter invalid combination. The legacy reader does not support
           // aggregates, and we cannot automatically switch to unordered
           // reads if we are requesting both the aggregates and the data.
-          if (!dense_ && request_data && layout != TILEDB_UNORDERED)
+          if (request_data && layout != TILEDB_UNORDERED) {
             continue;
+          }
           layout_ = layout;
           Query query(ctx_, array, TILEDB_READ);
 
@@ -2169,8 +2172,9 @@ TEST_CASE_METHOD(
         // Filter invalid combination. The legacy reader does not support
         // aggregates, and we cannot automatically switch to unordered
         // reads if we are requesting both the aggregates and the data.
-        if (!dense_ && layout != TILEDB_UNORDERED)
+        if (layout != TILEDB_UNORDERED) {
           continue;
+        }
         layout_ = layout;
         Query query(ctx_, array, TILEDB_READ);
 

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -879,7 +879,7 @@ class Query {
   /**
    * Returns true if the query has any aggregates on any channels
    */
-  bool has_aggregates() {
+  bool has_aggregates() const {
     // We only need to check the default channel for now
     return !default_channel_aggregates_.empty();
   }
@@ -1148,6 +1148,15 @@ class Query {
   /* ********************************* */
   /*           PRIVATE METHODS         */
   /* ********************************* */
+
+  /**
+   * Return the layout that will be used to execute the query.
+   *
+   * This is usually set by the user but cen be overridden by TileDB in cases
+   * where the data order would not have an observable difference, like queries
+   * with only aggregates.
+   */
+  Layout effective_layout() const;
 
   /**
    * Create the strategy.

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -1152,7 +1152,7 @@ class Query {
   /**
    * Return the layout that will be used to execute the query.
    *
-   * This is usually set by the user but cen be overridden by TileDB in cases
+   * This is usually set by the user but can be overridden by TileDB in cases
    * where the data order would not have an observable difference, like queries
    * with only aggregates.
    */


### PR DESCRIPTION
[SC-53286](https://app.shortcut.com/tiledb-inc/story/53286/ignore-query-order-in-aggregate-only-queries)

If the user has not set a query layout, it will default to row-major, which will use the legacy reader on sparse arrays, and fail if aggregates were specified.

However, if only aggregates are specified and no regular data buffers, the layout doesn't matter and we can transparently switch to the much more efficient unordered layout.

---
TYPE: IMPROVEMENT
DESC: Fix read queries on sparse arrays where only aggregates are requested and no layout is specified.