### PR TITLE
Support setting of schema-creation timestamp [WIP]

### DIFF
--- a/test/src/unit-capi-enumerations.cc
+++ b/test/src/unit-capi-enumerations.cc
@@ -117,3 +117,5 @@ TEST_CASE(
   rc = tiledb_array_get_enumeration(ctx, array, nullptr, &enmr);
   REQUIRE(rc == TILEDB_ERR);
 }
+
+// XXX TOUCH

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -750,3 +750,5 @@ void CPPEnumerationFx::rm_array() {
     vfs_.remove_dir(uri_);
   }
 }
+
+// XXX TOUCH

--- a/test/src/unit-rest-enumerations.cc
+++ b/test/src/unit-rest-enumerations.cc
@@ -206,3 +206,5 @@ void RESTEnumerationFx::create_array(const std::string& array_name) {
   query.finalize();
   array.close();
 }
+
+// XXX TOUCH

--- a/tiledb/api/c_api/array_schema/array_schema_api.cc
+++ b/tiledb/api/c_api/array_schema/array_schema_api.cc
@@ -98,9 +98,9 @@ capi_return_t tiledb_array_schema_alloc(
 capi_return_t tiledb_array_schema_alloc_at_timestamp(
     tiledb_ctx_t* ctx,
     tiledb_array_type_t array_type,
-    tiledb_array_schema_t** array_schema,
     uint64_t t1,
-    uint64_t t2) {
+    uint64_t t2,
+    tiledb_array_schema_t** array_schema) {
   ensure_output_pointer_is_valid(array_schema);
 
   // Create ArraySchema object
@@ -480,12 +480,12 @@ CAPI_INTERFACE(
     array_schema_alloc_at_timestamp,
     tiledb_ctx_t* ctx,
     tiledb_array_type_t array_type,
-    tiledb_array_schema_t** array_schema,
     uint64_t t1,
-    uint64_t t2) {
+    uint64_t t2,
+    tiledb_array_schema_t** array_schema) {
   return api_entry_with_context<
       tiledb::api::tiledb_array_schema_alloc_at_timestamp>(
-      ctx, array_type, array_schema, t1, t2);
+      ctx, array_type, t1, t2, array_schema);
 }
 
 CAPI_INTERFACE_VOID(array_schema_free, tiledb_array_schema_t** array_schema) {

--- a/tiledb/api/c_api/array_schema/array_schema_api.cc
+++ b/tiledb/api/c_api/array_schema/array_schema_api.cc
@@ -95,6 +95,28 @@ capi_return_t tiledb_array_schema_alloc(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_array_schema_alloc_at_timestamp(
+    tiledb_ctx_t* ctx,
+    tiledb_array_type_t array_type,
+    tiledb_array_schema_t** array_schema,
+    uint64_t t1,
+    uint64_t t2) {
+  ensure_output_pointer_is_valid(array_schema);
+
+  // Create ArraySchema object
+  auto memory_tracker = ctx->resources().create_memory_tracker();
+  memory_tracker->set_type(MemoryTrackerType::ARRAY_CREATE);
+  auto timestamp_range = std::make_pair(t1, t2);
+  auto opt_range =
+      std::optional<std::pair<uint64_t, uint64_t>>(timestamp_range);
+  *array_schema = tiledb_array_schema_t::make_handle(
+      static_cast<tiledb::sm::ArrayType>(array_type),
+      memory_tracker,
+      opt_range);
+
+  return TILEDB_OK;
+}
+
 void tiledb_array_schema_free(tiledb_array_schema_t** array_schema) {
   ensure_output_pointer_is_valid(array_schema);
   ensure_array_schema_is_valid(*array_schema);
@@ -452,6 +474,18 @@ CAPI_INTERFACE(
     tiledb_array_schema_t** array_schema) {
   return api_entry_with_context<tiledb::api::tiledb_array_schema_alloc>(
       ctx, array_type, array_schema);
+}
+
+CAPI_INTERFACE(
+    array_schema_alloc_at_timestamp,
+    tiledb_ctx_t* ctx,
+    tiledb_array_type_t array_type,
+    tiledb_array_schema_t** array_schema,
+    uint64_t t1,
+    uint64_t t2) {
+  return api_entry_with_context<
+      tiledb::api::tiledb_array_schema_alloc_at_timestamp>(
+      ctx, array_type, array_schema, t1, t2);
 }
 
 CAPI_INTERFACE_VOID(array_schema_free, tiledb_array_schema_t** array_schema) {

--- a/tiledb/api/c_api/array_schema/array_schema_api_external.h
+++ b/tiledb/api/c_api/array_schema/array_schema_api_external.h
@@ -122,6 +122,31 @@ TILEDB_EXPORT capi_return_t tiledb_array_schema_alloc(
     tiledb_array_schema_t** array_schema) TILEDB_NOEXCEPT;
 
 /**
+ * Creates a TileDB array schema object with specified creation time.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_schema_t* array_schema;
+ * uint64_t t1 = 10;
+ * uint64_t t2 = 20;
+ * tiledb_array_schema_alloc_at_timestamp(ctx, TILEDB_DENSE, &array_schema, t1,
+ * t2);
+ * @endcode
+ *
+ * @param[in] ctx The TileDB context.
+ * @param[in] array_type The array type.
+ * @param[out] array_schema The TileDB array schema to be created.
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_array_schema_alloc_at_timestamp(
+    tiledb_ctx_t* ctx,
+    tiledb_array_type_t array_type,
+    tiledb_array_schema_t** array_schema,
+    uint64_t t1,
+    uint64_t t2);
+
+/**
  * Destroys an array schema, freeing associated memory.
  *
  * **Example:**

--- a/tiledb/api/c_api/array_schema/array_schema_api_external.h
+++ b/tiledb/api/c_api/array_schema/array_schema_api_external.h
@@ -130,8 +130,8 @@ TILEDB_EXPORT capi_return_t tiledb_array_schema_alloc(
  * tiledb_array_schema_t* array_schema;
  * uint64_t t1 = 10;
  * uint64_t t2 = 20;
- * tiledb_array_schema_alloc_at_timestamp(ctx, TILEDB_DENSE, &array_schema, t1,
- * t2);
+ * tiledb_array_schema_alloc_at_timestamp(ctx, TILEDB_DENSE, t1, t2,
+ * &array_schema);
  * @endcode
  *
  * @param[in] ctx The TileDB context.
@@ -142,9 +142,9 @@ TILEDB_EXPORT capi_return_t tiledb_array_schema_alloc(
 TILEDB_EXPORT capi_return_t tiledb_array_schema_alloc_at_timestamp(
     tiledb_ctx_t* ctx,
     tiledb_array_type_t array_type,
-    tiledb_array_schema_t** array_schema,
     uint64_t t1,
-    uint64_t t2);
+    uint64_t t2,
+    tiledb_array_schema_t** array_schema) TILEDB_NOEXCEPT;
 
 /**
  * Destroys an array schema, freeing associated memory.

--- a/tiledb/api/c_api/enumeration/test/unit_capi_enumeration.cc
+++ b/tiledb/api/c_api/enumeration/test/unit_capi_enumeration.cc
@@ -469,3 +469,5 @@ TEST_CASE(
     REQUIRE(rc == TILEDB_ERR);
   }
 }
+
+// XXX TOUCH

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -203,7 +203,7 @@ void Array::create(
 
   std::lock_guard<std::mutex> lock{object_mtx};
   array_schema->set_array_uri(array_uri);
-  array_schema->generate_uri();
+  array_schema->generate_uri(array_schema->timestamp_range());
   array_schema->check(resources.config());
 
   // Check current domain is specified correctly if set

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -80,13 +80,20 @@ class ArraySchemaException : public StatusException {
 /* ****************************** */
 
 ArraySchema::ArraySchema(
-    ArrayType array_type, shared_ptr<MemoryTracker> memory_tracker)
+    ArrayType array_type,
+    shared_ptr<MemoryTracker> memory_tracker,
+    std::optional<std::pair<uint64_t, uint64_t>> timestamp_range)
     : memory_tracker_(memory_tracker)
     , uri_(URI())
     , array_uri_(URI())
     , version_(constants::format_version)
-    , timestamp_range_(std::make_pair(
-          utils::time::timestamp_now_ms(), utils::time::timestamp_now_ms()))
+    , timestamp_range_(
+          timestamp_range.has_value() ? std::make_pair(
+                                            timestamp_range.value().first,
+                                            timestamp_range.value().second) :
+                                        std::make_pair(
+                                            utils::time::timestamp_now_ms(),
+                                            utils::time::timestamp_now_ms()))
     , name_("")
     , array_type_(array_type)
     , allows_dups_(false)
@@ -121,7 +128,7 @@ ArraySchema::ArraySchema(
       Datatype::UINT8));
 
   // Generate URI and name for ArraySchema
-  generate_uri();
+  generate_uri(timestamp_range);
 }
 
 ArraySchema::ArraySchema(

--- a/tiledb/sm/array_schema/array_schema.h
+++ b/tiledb/sm/array_schema/array_schema.h
@@ -99,7 +99,11 @@ class ArraySchema {
    * @param memory_tracker The memory tracker of the array this fragment
    *     metadata corresponds to.
    */
-  ArraySchema(ArrayType array_type, shared_ptr<MemoryTracker> memory_tracker);
+  ArraySchema(
+      ArrayType array_type,
+      shared_ptr<MemoryTracker> memory_tracker,
+      std::optional<std::pair<uint64_t, uint64_t>> timestamp_range =
+          std::nullopt);
 
   /** Constructor with std::vector attributes.
    * @param uri The URI of the array schema file.

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -107,10 +107,23 @@ class ArraySchema : public Schema {
    * @param ctx TileDB context
    * @param type Array type, sparse or dense.
    */
-  explicit ArraySchema(const Context& ctx, tiledb_array_type_t type)
+  explicit ArraySchema(
+      const Context& ctx,
+      tiledb_array_type_t type,
+      std::optional<std::pair<int64_t, int64_t>> timestamp_range = std::nullopt)
       : Schema(ctx) {
     tiledb_array_schema_t* schema;
-    ctx.handle_error(tiledb_array_schema_alloc(ctx.ptr().get(), type, &schema));
+    if (timestamp_range.has_value()) {
+      ctx.handle_error(tiledb_array_schema_alloc_at_timestamp(
+          ctx.ptr().get(),
+          type,
+          &schema,
+          timestamp_range.value().first,
+          timestamp_range.value().second));
+    } else {
+      ctx.handle_error(
+          tiledb_array_schema_alloc(ctx.ptr().get(), type, &schema));
+    }
     schema_ = std::shared_ptr<tiledb_array_schema_t>(schema, deleter_);
   }
 

--- a/tiledb/sm/cpp_api/array_schema.h
+++ b/tiledb/sm/cpp_api/array_schema.h
@@ -117,9 +117,9 @@ class ArraySchema : public Schema {
       ctx.handle_error(tiledb_array_schema_alloc_at_timestamp(
           ctx.ptr().get(),
           type,
-          &schema,
           timestamp_range.value().first,
-          timestamp_range.value().second));
+          timestamp_range.value().second,
+          &schema));
     } else {
       ctx.handle_error(
           tiledb_array_schema_alloc(ctx.ptr().get(), type, &schema));


### PR DESCRIPTION
Long description to be typed up.

See also:

* https://github.com/single-cell-data/TileDB-SOMA/issues/2920
* https://github.com/single-cell-data/TileDB-SOMA/pull/2895
* [[sc-47660]](https://app.shortcut.com/tiledb-inc/story/47660/core-c-c-api-support-to-set-initial-array-schema-timestamp#activity-53864)

Clean and tested against tiledbsoma acceptance cases as a patch on 2.25.0; iterating on clean patch against tip of `dev`.

Unit-test cases upcoming.

---
TYPE: FEATURE
DESC: to be typed up