### PR TITLE
Bug fix: update range end when merging overlapping subarray ranges.

### DIFF
--- a/test/regression/targets/sc-53970.cc
+++ b/test/regression/targets/sc-53970.cc
@@ -78,7 +78,7 @@ TEST_CASE(
 
   // The expected result are a single matching cell of (0, 1507468.6)
   REQUIRE(dim[0] == 0);
-  REQUIRE(abs(attr[0] - 1507468.6) < 0.00000005);
+  REQUIRE(abs(attr[0] - 1507468.6f) < 0.00000005);
 
   // Check we didn't get any extra results
   REQUIRE(dim[1] == -1);

--- a/test/regression/targets/sc-53970.cc
+++ b/test/regression/targets/sc-53970.cc
@@ -41,7 +41,7 @@ static void write_array(const std::string& array_uri);
 
 TEST_CASE(
     "Subarray range expansion bug",
-    "[bug][sc53970][subarray-range-expansion][!shouldfail]") {
+    "[bug][sc53970][subarray-range-expansion]") {
   std::string array_uri = "test_array_schema_dump";
 
   // Test setup

--- a/tiledb/sm/subarray/range_subset.h
+++ b/tiledb/sm/subarray/range_subset.h
@@ -170,7 +170,7 @@ struct MergeStrategy<
 
       if (can_merge) {
         // Only update the end if the merging end is greater.
-        if (tail->end_fixed() > head->end_fixed()) {
+        if (tail->end_as<T>() > head->end_as<T>()) {
           head->set_end_fixed(tail->end_fixed());
         }
         merged_cells++;

--- a/tiledb/sm/subarray/range_subset.h
+++ b/tiledb/sm/subarray/range_subset.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -169,7 +169,10 @@ struct MergeStrategy<
           tail->start_as<T>() <= head_end;
 
       if (can_merge) {
-        head->set_end_fixed(tail->end_fixed());
+        // Only update the end if the merging end is greater.
+        if (tail->end_fixed() > head->end_fixed()) {
+          head->set_end_fixed(tail->end_fixed());
+        }
         merged_cells++;
       } else {
         head++;


### PR DESCRIPTION
Bug fix: update range end when merging overlapping subarray ranges.

Previously, when merging overlapping ranges, the new range end would _always_ be updated to that of the merged range. This was a _clear_ issue if one range was fully encompassed within another. For example, if range `{3, 4}` were merged into `{1, 10}`, the old behavior would produce a new range of `{1, 4}`. This PR fixes the bug simply, taking the larger of the two range ends on merge. 

[sc-53970]

---
TYPE: BUG
DESC: Update range end when merging overlapping subarray ranges.
