### PR TITLE
Add static linkage test nightly job.

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -110,7 +110,7 @@ jobs:
         run: cmake --install build --config Release --prefix dist
 
       - name: Configure CMake example
-        run: cmake -B examples/cmake_project/build -S examples/cmake_project -DCMAKE_PREFIX_PATH=$PWD.Path/dist;$PWD.Path/build/vcpkg_installed/${{ matrix.triplet }}
+        run: $ cmake -B examples/cmake_project/build -S examples/cmake_project "-DCMAKE_PREFIX_PATH=$($PWD.Path)/dist;$($PWD.Path)/build/vcpkg_installed/${{ matrix.triplet }}"
         shell: pwsh
 
       - name: Build CMake example

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v4
 
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v5
+
       - name: Configure TileDB CMake
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DTILEDB_WERROR=ON -DTILEDB_S3=ON -DTILEDB_GCS=ON -DTILEDB_AZURE=ON -DTILEDB_SERIALIZATION=ON -DTILEDB_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
@@ -110,15 +113,16 @@ jobs:
         run: cmake --install build --config Release --prefix dist
 
       - name: Configure CMake example
+        # Configure with Ninja to use a single-config generator and put the executable in the same path across platforms.
         run: |
-          & cmake -B examples/cmake_project/build -S examples/cmake_project "-DCMAKE_PREFIX_PATH=$($PWD.Path)/dist;$($PWD.Path)/build/vcpkg_installed/${{ matrix.triplet }}"
+          & cmake -G Ninja -B examples/cmake_project/build -S examples/cmake_project -DCMAKE_BUILD_TYPE=Release "-DCMAKE_PREFIX_PATH=$($PWD.Path)/dist;$($PWD.Path)/build/vcpkg_installed/${{ matrix.triplet }}"
         shell: pwsh
 
       - name: Build CMake example
-        run: cmake --build examples/cmake_project/build -j2 --config Release
+        run: cmake --build examples/cmake_project/build -j2
 
       - name: Run CMake example
-        run: examples/cmake_project/build/Release/tiledb_example
+        run: examples/cmake_project/build/tiledb_example
 
   create_issue_on_fail:
     permissions:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -110,7 +110,8 @@ jobs:
         run: cmake --install build --config Release --prefix dist
 
       - name: Configure CMake example
-        run: cmake -B examples/cmake_project/build -S examples/cmake_project -DCMAKE_PREFIX_PATH=./dist;./build/vcpkg_installed/${{ matrix.triplet }}
+        run: cmake -B examples/cmake_project/build -S examples/cmake_project -DCMAKE_PREFIX_PATH=$PWD.Path/dist;$PWD.Path/build/vcpkg_installed/${{ matrix.triplet }}
+        shell: pwsh
 
       - name: Build CMake example
         run: cmake --build examples/cmake_project/build -j2 --config Release

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -88,7 +88,7 @@ jobs:
           - os: macos-13
             triplet: x64-osx
           - os: macos-latest
-            triplet: x64-osx
+            triplet: arm64-osx
       fail-fast: false
     name: ${{ matrix.os }} - Static Linkage
 

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -127,7 +127,7 @@ jobs:
       - test
       - test_hdfs_build
       - test_static_linkage
-    if: failure() || cancelled()
+    if: github.event_name == 'schedule' && (failure() || cancelled())
     steps:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v3

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -101,15 +101,7 @@ jobs:
 
       - name: Configure TileDB CMake
         run: |
-          cmake -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DTILEDB_WERROR=ON \
-            -DTILEDB_S3=ON \
-            -DTILEDB_GCS=ON \
-            -DTILEDB_AZURE=ON \
-            -DTILEDB_SERIALIZATION=ON \
-            -DTILEDB_TESTS=OFF \
-            -DBUILD_SHARED_LIBS=OFF
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DTILEDB_WERROR=ON -DTILEDB_S3=ON -DTILEDB_GCS=ON -DTILEDB_AZURE=ON -DTILEDB_SERIALIZATION=ON -DTILEDB_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 
       - name: Build TileDB
         run: cmake --build build -j2 --config Release --target tiledb

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v4
 
+      - name: Setup MSVC toolset
+        uses: TheMrMilchmann/setup-msvc-dev@v3
+        if: runner.os == 'Windows'
+        with:
+          arch: x64
+
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@v5
 
@@ -122,7 +128,7 @@ jobs:
         run: cmake --build examples/cmake_project/build -j2
 
       - name: Run CMake example
-        run: examples/cmake_project/build/tiledb_example
+        run: examples/cmake_project/build/ExampleExe
 
   create_issue_on_fail:
     permissions:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -110,7 +110,8 @@ jobs:
         run: cmake --install build --config Release --prefix dist
 
       - name: Configure CMake example
-        run: $ cmake -B examples/cmake_project/build -S examples/cmake_project "-DCMAKE_PREFIX_PATH=$($PWD.Path)/dist;$($PWD.Path)/build/vcpkg_installed/${{ matrix.triplet }}"
+        run: |
+          & cmake -B examples/cmake_project/build -S examples/cmake_project "-DCMAKE_PREFIX_PATH=$($PWD.Path)/dist;$($PWD.Path)/build/vcpkg_installed/${{ matrix.triplet }}"
         shell: pwsh
 
       - name: Build CMake example

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -76,6 +76,56 @@ jobs:
       build_only: true
       bootstrap_args: '--enable-hdfs --enable-static-tiledb --disable-werror'
 
+  test_static_linkage:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+          - os: windows-2019
+            triplet: x64-windows
+          - os: macos-13
+            triplet: x64-osx
+          - os: macos-latest
+            triplet: x64-osx
+      fail-fast: false
+    name: ${{ matrix.os }} - Static Linkage
+
+    steps:
+      - name: Print env
+        run: printenv
+
+      - name: Checkout TileDB `dev`
+        uses: actions/checkout@v4
+
+      - name: Configure TileDB CMake
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DTILEDB_WERROR=ON \
+            -DTILEDB_S3=ON \
+            -DTILEDB_GCS=ON \
+            -DTILEDB_AZURE=ON \
+            -DTILEDB_SERIALIZATION=ON \
+            -DTILEDB_TESTS=OFF \
+            -DBUILD_SHARED_LIBS=OFF
+
+      - name: Build TileDB
+        run: cmake --build build -j2 --config Release --target tiledb
+
+      - name: Install TileDB
+        run: cmake --install build --config Release --prefix dist
+
+      - name: Configure CMake example
+        run: cmake -B examples/cmake_project/build -S examples/cmake_project -DCMAKE_PREFIX_PATH=./dist;./build/vcpkg_installed/${{ matrix.triplet }}
+
+      - name: Build CMake example
+        run: cmake --build examples/cmake_project/build -j2 --config Release
+
+      - name: Run CMake example
+        run: examples/cmake_project/build/Release/tiledb_example
+
   create_issue_on_fail:
     permissions:
       issues: write
@@ -83,6 +133,7 @@ jobs:
     needs:
       - test
       - test_hdfs_build
+      - test_static_linkage
     if: failure() || cancelled()
     steps:
       - name: Checkout TileDB `dev`

--- a/examples/cmake_project/CMakeLists.txt
+++ b/examples/cmake_project/CMakeLists.txt
@@ -42,12 +42,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #   list(APPEND CMAKE_PREFIX_PATH "/path/to/TileDB-installation")
 find_package(TileDB 
   ${TILEDB_VERSION} EXACT
+  CONFIG
   REQUIRED
   )
 
 # Set up the example program.
 add_executable(ExampleExe "src/main.cc")
 
-# Link the example program with the TileDB shared library.
+# Link the example program with the TileDB library.
 # This also configures include paths to find the TileDB headers.
 target_link_libraries(ExampleExe TileDB::tiledb)


### PR DESCRIPTION
[SC-51503](https://app.shortcut.com/tiledb-inc/story/51503/add-static-linkage-example-and-test)

This PR adds a GitHub Actions job that builds TileDB as a static library with all features enabled, links it to the executable in `examples/cmake_project`, and runs it. The job runs in all four architecture-OS combinations we ship binaries from GitHub Releases.

Because library dependency gathering is more reliable compared to earlier times, the job was added to the nightly build workflow.

---
TYPE: NO_HISTORY