### PR TITLE
Reset vcpkg _deps folder if it doesn't exist

### DIFF
--- a/cmake/Options/TileDBToolchain.cmake
+++ b/cmake/Options/TileDBToolchain.cmake
@@ -27,7 +27,8 @@
 # TileDB Toolchain Setup
 ############################################################
 
-if (NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+if (NOT DEFINED CMAKE_TOOLCHAIN_FILE
+    OR DEFINED CMAKE_TOOLCHAIN_FILE AND NOT EXISTS ${vcpkg_SOURCE_DIR})
     if(DEFINED ENV{VCPKG_ROOT})
         set(CMAKE_TOOLCHAIN_FILE
             "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"


### PR DESCRIPTION
This allows removal of `$BUILD_DIR/_deps` to fix inconsistent state issues. If `_deps` does not exist, the FetchContent bootstrap step will be rerun.

---
TYPE: BUILD
DESC: Reset vcpkg _deps folder if it doesn't exist
