### PR TITLE
Support the `ssl.ca_path` config option on Azure.

### DIFF
--- a/test/src/unit-ssl-config.cc
+++ b/test/src/unit-ssl-config.cc
@@ -116,10 +116,7 @@ TEST_CASE("Azure - CAPATH - ssl.ca_path", "[ssl_config][azure]") {
   auto cfg = azure_base_config();
   REQUIRE(cfg.set("ssl.verify_ssl", "true").ok());
   REQUIRE(cfg.set("ssl.ca_path", get_test_ca_path()).ok());
-
-  // The Azure client does not support setting the CAPATH in libcurl so
-  // this is an expected failure.
-  check_failure(Filesystem::AZURE, cfg);
+  check_success(Filesystem::AZURE, cfg);
 }
 
 Config gcs_base_config() {

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1289,9 +1289,7 @@ std::shared_ptr<::Azure::Core::Http::HttpTransport> create_transport(
   }
 
   if (!ssl_cfg.ca_path().empty()) {
-    LOG_WARN(
-        "Azure ignores the `ssl.ca_path` configuration key, "
-        "use `ssl.ca_file` instead");
+    transport_opts.CAPath = ssl_cfg.ca_path();
   }
 
   if (ssl_cfg.verify() == false) {


### PR DESCRIPTION
[SC-34861](https://app.shortcut.com/tiledb-inc/story/34861/support-ssl-ca-path-on-azure)

Now that we depend on an updated Azure SDK, this PR passes the `ssl.ca_path` config option to the newly introduced `CurlTransportOptions::CAPath` field, enabling support for setting the `CAPath` in Azure (previously we supported only `CAInfo`).

Tests were updated.

---
TYPE: FEATURE
DESC: Added support for the `ssl.ca_path` config option on Azure.