### PR TITLE
Improve error message of `apply_with_type`.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -2616,7 +2616,7 @@ TEMPLATE_LIST_TEST_CASE(
   QueryChannel default_channel = QueryExperimental::get_default_channel(query);
   REQUIRE_THROWS_WITH(
       QueryExperimental::create_unary_aggregate<SumOperator>(query, "a"),
-      Catch::Matchers::ContainsSubstring("not a valid Datatype"));
+      Catch::Matchers::ContainsSubstring("not a supported Datatype"));
 
   // Clean up.
   array.close();

--- a/tiledb/type/apply_with_type.h
+++ b/tiledb/type/apply_with_type.h
@@ -116,7 +116,7 @@ inline auto apply_with_type(Fn&& f, Datatype type, Args&&... args) {
     }
     default: {
       throw std::logic_error(
-          "Datatype::" + datatype_str(type) + " is not a valid Datatype");
+          "Datatype::" + datatype_str(type) + " is not a supported Datatype");
     }
   }
 }


### PR DESCRIPTION
[SC-53336](https://app.shortcut.com/tiledb-inc/story/53336/improve-error-messages-for-unsupported-datatypes-in-aggregate-queries)

If `apply_with_type` (used for aggregates among other things) encounters an unsupported data type (like non-ASCII strings), it would fail with a message saying that the type is "not valid". This PR updates it to the more clear "not supported".

---
TYPE: IMPROVEMENT
DESC: Improve error messages for unsupported data types in aggregates.