### PR TITLE
Remove unnecessary manual retrieval of AWS credentials.

### DIFF
--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -1342,9 +1342,6 @@ class S3 : FilesystemBase {
    */
   mutable shared_ptr<TileDBS3Client> client_;
 
-  /** The AWS credetial provider. */
-  mutable shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider_;
-
   /**
    * Mutex protecting client initialization. This is mutable so that nominally
    * const functions can call init_client().


### PR DESCRIPTION
[SC-54624](https://app.shortcut.com/tiledb-inc/story/54624/remove-unnecessary-credentials-retrieval-from-the-s3-vfs)

At the start of `S3::init_client()`, we try to acquire AWS credentials and fail if they are empty or have expired. This does not make much sense to do because the credentials provider is responsible for refreshing expired credentials, and this PR removes this check. After that, the `S3::credentials_provider_` field was removed from the class and became a local variable because of a lack of uses.

---
TYPE: NO_HISTORY