### PR TITLE
Fix schema timestamps used when loading enumerations from REST.

### DIFF
--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -51,7 +51,6 @@ struct CPPEnumerationFx {
   void check_dump(const T& val);
 
   void create_array(bool with_empty_enumeration = false);
-  void rm_array();
 
   tiledb::test::VFSTestSetup vfs_test_setup_;
   std::string uri_;
@@ -347,7 +346,7 @@ TEST_CASE_METHOD(
   // Evolve once to add an enumeration.
   ArraySchemaEvolution ase(ctx_);
   std::vector<std::string> var_values{"one", "two", "three"};
-  auto var_enmr = tiledb::Enumeration::create(ctx_, "ase_var_enmr", var_values);
+  auto var_enmr = Enumeration::create(ctx_, "ase_var_enmr", var_values);
   ase.add_enumeration(var_enmr);
   auto attr4 = Attribute::create<uint16_t>(ctx_, "attr4");
   AttributeExperimental::set_enumeration_name(ctx_, attr4, "ase_var_enmr");
@@ -744,9 +743,6 @@ TEST_CASE_METHOD(
 CPPEnumerationFx::CPPEnumerationFx()
     : uri_(vfs_test_setup_.array_uri("enumeration_test_array"))
     , vfs_(vfs_test_setup_.ctx()) {
-  if (!vfs_test_setup_.is_rest()) {
-    rm_array();
-  }
 }
 
 template <typename T>
@@ -820,10 +816,4 @@ void CPPEnumerationFx::create_array(bool with_empty_enumeration) {
   CHECK_NOTHROW(query.submit());
   query.finalize();
   array.close();
-}
-
-void CPPEnumerationFx::rm_array() {
-  if (vfs_.is_dir(uri_)) {
-    vfs_.remove_dir(uri_);
-  }
 }

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -403,6 +403,51 @@ TEST_CASE_METHOD(
   CHECK(
       all_schemas[schema_name_3]->is_enumeration_loaded("ase_var_enmr") ==
       true);
+
+  // Evolve a third time to add an enumeration with a name equal to a previously
+  // dropped enumeration.
+  ArraySchemaEvolution ase3(ctx_);
+  auto old_enmr = Enumeration::create(ctx_, "an_enumeration", var_values);
+  ase3.add_enumeration(old_enmr);
+  auto attr5 = Attribute::create<uint16_t>(ctx_, "attr5");
+  AttributeExperimental::set_enumeration_name(ctx_, attr5, "an_enumeration");
+  ase.add_attribute(attr5);
+  CHECK_NOTHROW(ase3.array_evolve(uri_));
+
+  // Apply evolution to the array and reopen.
+  CHECK_NOTHROW(array.close());
+  CHECK_NOTHROW(array.open(TILEDB_READ));
+  ArrayExperimental::load_all_enumerations(ctx_, array);
+  all_schemas = array.ptr()->array_->array_schemas_all();
+  schema = array.load_schema(ctx_, uri_);
+  std::string schema_name_4 = schema.ptr()->array_schema()->name();
+
+  // Check all schemas.
+  CHECK(all_schemas[schema_name_1]->has_enumeration("an_enumeration") == true);
+  CHECK(
+      all_schemas[schema_name_1]->is_enumeration_loaded("an_enumeration") ==
+      true);
+  CHECK(all_schemas[schema_name_2]->has_enumeration("an_enumeration") == true);
+  CHECK(
+      all_schemas[schema_name_2]->is_enumeration_loaded("an_enumeration") ==
+      true);
+  CHECK(all_schemas[schema_name_2]->has_enumeration("ase_var_enmr") == true);
+  CHECK(
+      all_schemas[schema_name_2]->is_enumeration_loaded("ase_var_enmr") ==
+      true);
+  CHECK(all_schemas[schema_name_3]->has_enumeration("an_enumeration") == false);
+  CHECK(all_schemas[schema_name_3]->has_enumeration("ase_var_enmr") == true);
+  CHECK(
+      all_schemas[schema_name_3]->is_enumeration_loaded("ase_var_enmr") ==
+      true);
+  CHECK(all_schemas[schema_name_4]->has_enumeration("an_enumeration") == true);
+  CHECK(
+      all_schemas[schema_name_4]->is_enumeration_loaded("an_enumeration") ==
+      true);
+  CHECK(all_schemas[schema_name_4]->has_enumeration("ase_var_enmr") == true);
+  CHECK(
+      all_schemas[schema_name_4]->is_enumeration_loaded("ase_var_enmr") ==
+      true);
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/api/c_api/array_schema/array_schema_api.cc
+++ b/tiledb/api/c_api/array_schema/array_schema_api.cc
@@ -88,7 +88,7 @@ capi_return_t tiledb_array_schema_alloc(
 
   // Create ArraySchema object
   auto memory_tracker = ctx->resources().create_memory_tracker();
-  memory_tracker->set_type(MemoryTrackerType::ARRAY_CREATE);
+  memory_tracker->set_type(tiledb::sm::MemoryTrackerType::ARRAY_CREATE);
   *array_schema = tiledb_array_schema_t::make_handle(
       static_cast<tiledb::sm::ArrayType>(array_type), memory_tracker);
 

--- a/tiledb/api/c_api/array_schema/array_schema_api_internal.h
+++ b/tiledb/api/c_api/array_schema/array_schema_api_internal.h
@@ -41,8 +41,6 @@
 #include "tiledb/sm/enums/array_type.h"
 #include "tiledb/sm/enums/layout.h"
 
-using namespace tiledb::sm;
-
 /** Handle `struct` for API ArraySchema objects. */
 struct tiledb_array_schema_handle_t
     : public tiledb::api::CAPIHandle<tiledb_array_schema_handle_t> {
@@ -50,18 +48,20 @@ struct tiledb_array_schema_handle_t
   static constexpr std::string_view object_type_name{"array_schema"};
 
  private:
-  using array_schema_type = shared_ptr<ArraySchema>;
+  using array_schema_type = shared_ptr<tiledb::sm::ArraySchema>;
   array_schema_type array_schema_;
 
  public:
   template <class... Args>
   explicit tiledb_array_schema_handle_t(Args... args)
-      : array_schema_{
-            make_shared<ArraySchema>(HERE(), std::forward<Args>(args)...)} {
+      : array_schema_{make_shared<tiledb::sm::ArraySchema>(
+            HERE(), std::forward<Args>(args)...)} {
   }
 
-  explicit tiledb_array_schema_handle_t(const ArraySchema& array_schema)
-      : array_schema_{make_shared<ArraySchema>(HERE(), array_schema)} {
+  explicit tiledb_array_schema_handle_t(
+      const tiledb::sm::ArraySchema& array_schema)
+      : array_schema_{
+            make_shared<tiledb::sm::ArraySchema>(HERE(), array_schema)} {
   }
 
   /**
@@ -76,21 +76,21 @@ struct tiledb_array_schema_handle_t
   }
 
   Status add_attribute(
-      shared_ptr<const Attribute> attr, bool check_special = true) {
+      shared_ptr<const tiledb::sm::Attribute> attr, bool check_special = true) {
     return array_schema_->add_attribute(attr, check_special);
   }
 
   void add_dimension_label(
-      ArraySchema::dimension_size_type dim_id,
+      tiledb::sm::ArraySchema::dimension_size_type dim_id,
       const std::string& name,
-      DataOrder label_order,
-      Datatype label_type,
+      tiledb::sm::DataOrder label_order,
+      tiledb::sm::Datatype label_type,
       bool check_name = true) {
     array_schema_->add_dimension_label(
         dim_id, name, label_order, label_type, check_name);
   }
 
-  void add_enumeration(shared_ptr<const Enumeration> enmr) {
+  void add_enumeration(shared_ptr<const tiledb::sm::Enumeration> enmr) {
     return array_schema_->add_enumeration(enmr);
   }
 
@@ -98,15 +98,15 @@ struct tiledb_array_schema_handle_t
     return array_schema_->allows_dups();
   }
 
-  ArrayType array_type() const {
+  tiledb::sm::ArrayType array_type() const {
     return array_schema_->array_type();
   }
 
-  const URI& array_uri() const {
+  const tiledb::sm::URI& array_uri() const {
     return array_schema_->array_uri();
   }
 
-  ArraySchema::attribute_size_type attribute_num() const {
+  tiledb::sm::ArraySchema::attribute_size_type attribute_num() const {
     return array_schema_->attribute_num();
   }
 
@@ -114,48 +114,50 @@ struct tiledb_array_schema_handle_t
     return array_schema_->capacity();
   }
 
-  Layout cell_order() const {
+  tiledb::sm::Layout cell_order() const {
     return array_schema_->cell_order();
   }
 
-  const FilterPipeline& cell_validity_filters() const {
+  const tiledb::sm::FilterPipeline& cell_validity_filters() const {
     return array_schema_->cell_validity_filters();
   }
 
-  const FilterPipeline& cell_var_offsets_filters() const {
+  const tiledb::sm::FilterPipeline& cell_var_offsets_filters() const {
     return array_schema_->cell_var_offsets_filters();
   }
 
-  void check(const Config& cfg) const {
+  void check(const tiledb::sm::Config& cfg) const {
     array_schema_->check(cfg);
   }
 
-  const FilterPipeline& coords_filters() const {
+  const tiledb::sm::FilterPipeline& coords_filters() const {
     return array_schema_->coords_filters();
   }
 
-  const DimensionLabel& dimension_label(
-      ArraySchema::dimension_label_size_type i) const {
+  const tiledb::sm::DimensionLabel& dimension_label(
+      tiledb::sm::ArraySchema::dimension_label_size_type i) const {
     return array_schema_->dimension_label(i);
   }
 
-  const DimensionLabel& dimension_label(const std::string& name) const {
+  const tiledb::sm::DimensionLabel& dimension_label(
+      const std::string& name) const {
     return array_schema_->dimension_label(name);
   }
 
-  const Dimension* dimension_ptr(ArraySchema::dimension_size_type i) const {
+  const tiledb::sm::Dimension* dimension_ptr(
+      tiledb::sm::ArraySchema::dimension_size_type i) const {
     return array_schema_->dimension_ptr(i);
   }
 
-  const Dimension* dimension_ptr(const std::string& name) const {
+  const tiledb::sm::Dimension* dimension_ptr(const std::string& name) const {
     return array_schema_->dimension_ptr(name);
   }
 
-  ArraySchema::dimension_label_size_type dim_label_num() const {
+  tiledb::sm::ArraySchema::dimension_label_size_type dim_label_num() const {
     return array_schema_->dim_label_num();
   }
 
-  shared_ptr<CurrentDomain> get_current_domain() const {
+  shared_ptr<tiledb::sm::CurrentDomain> get_current_domain() const {
     return array_schema_->get_current_domain();
   }
 
@@ -175,61 +177,67 @@ struct tiledb_array_schema_handle_t
     array_schema_->set_capacity(capacity);
   }
 
-  void set_current_domain(shared_ptr<CurrentDomain> current_domain) {
+  void set_current_domain(
+      shared_ptr<tiledb::sm::CurrentDomain> current_domain) {
     array_schema_->set_current_domain(current_domain);
   }
 
   void set_dimension_label_filter_pipeline(
-      const std::string& label_name, const FilterPipeline& pipeline) {
+      const std::string& label_name,
+      const tiledb::sm::FilterPipeline& pipeline) {
     array_schema_->set_dimension_label_filter_pipeline(label_name, pipeline);
   }
 
   void set_dimension_label_tile_extent(
       const std::string& label_name,
-      const Datatype type,
+      const tiledb::sm::Datatype type,
       const void* tile_extent) {
     array_schema_->set_dimension_label_tile_extent(
         label_name, type, tile_extent);
   }
 
-  Status set_domain(shared_ptr<Domain> domain) {
+  Status set_domain(shared_ptr<tiledb::sm::Domain> domain) {
     return array_schema_->set_domain(domain);
   }
 
-  Status set_cell_order(Layout cell_order) {
+  Status set_cell_order(tiledb::sm::Layout cell_order) {
     return array_schema_->set_cell_order(cell_order);
   }
 
-  Status set_cell_validity_filter_pipeline(const FilterPipeline& pipeline) {
+  Status set_cell_validity_filter_pipeline(
+      const tiledb::sm::FilterPipeline& pipeline) {
     return array_schema_->set_cell_validity_filter_pipeline(pipeline);
   }
 
-  Status set_cell_var_offsets_filter_pipeline(const FilterPipeline& pipeline) {
+  Status set_cell_var_offsets_filter_pipeline(
+      const tiledb::sm::FilterPipeline& pipeline) {
     return array_schema_->set_cell_var_offsets_filter_pipeline(pipeline);
   }
 
-  Status set_coords_filter_pipeline(const FilterPipeline& pipeline) {
+  Status set_coords_filter_pipeline(
+      const tiledb::sm::FilterPipeline& pipeline) {
     return array_schema_->set_coords_filter_pipeline(pipeline);
   }
 
-  Status set_tile_order(Layout tile_order) {
+  Status set_tile_order(tiledb::sm::Layout tile_order) {
     return array_schema_->set_tile_order(tile_order);
   }
 
-  shared_ptr<const Attribute> shared_attribute(
-      ArraySchema::attribute_size_type id) const {
+  shared_ptr<const tiledb::sm::Attribute> shared_attribute(
+      tiledb::sm::ArraySchema::attribute_size_type id) const {
     return array_schema_->shared_attribute(id);
   }
 
-  shared_ptr<const Attribute> shared_attribute(const std::string& name) const {
+  shared_ptr<const tiledb::sm::Attribute> shared_attribute(
+      const std::string& name) const {
     return array_schema_->shared_attribute(name);
   }
 
-  shared_ptr<Domain> shared_domain() const {
+  shared_ptr<tiledb::sm::Domain> shared_domain() const {
     return array_schema_->shared_domain();
   }
 
-  Layout tile_order() const {
+  tiledb::sm::Layout tile_order() const {
     return array_schema_->tile_order();
   }
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -860,8 +860,8 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
 
       loaded = rest_client->post_enumerations_from_rest(
           array_uri_,
-          array_dir_timestamp_start_,
-          array_dir_timestamp_end_,
+          schema->timestamp_range().first,
+          schema->timestamp_range().second,
           this,
           names_to_load,
           memory_tracker_);

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -823,6 +823,9 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
   // Dedupe requested names and filter out anything already loaded.
   std::unordered_set<std::string> enmrs_to_load;
   for (auto& enmr_name : enumeration_names) {
+    if (!schema->has_enumeration(enmr_name)) {
+      continue;
+    }
     if (schema->is_enumeration_loaded(enmr_name)) {
       continue;
     }
@@ -831,7 +834,7 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
 
   // Only attempt to load enumerations if we have at least one Enumeration
   // to load.
-  if (enmrs_to_load.size() > 0) {
+  if (!enmrs_to_load.empty()) {
     std::vector<shared_ptr<const Enumeration>> loaded;
 
     if (remote_) {
@@ -873,9 +876,12 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
   }
 
   // Return the requested list of enumerations
-  std::vector<shared_ptr<const Enumeration>> ret(enumeration_names.size());
-  for (size_t i = 0; i < enumeration_names.size(); i++) {
-    ret[i] = schema->get_enumeration(enumeration_names[i]);
+  std::vector<shared_ptr<const Enumeration>> ret(enmrs_to_load.size());
+  for (size_t i = 0; const auto& name : enmrs_to_load) {
+    if (!schema->has_enumeration(name)) {
+      continue;
+    }
+    ret[i++] = schema->get_enumeration(name);
   }
   return ret;
 }


### PR DESCRIPTION
This fixes a bug loading enumerations after a REST request was made using [array directory timestamp ranges](https://github.com/TileDB-Inc/TileDB/blob/dev/tiledb/sm/array/array.cc#L849-L855). The response from the request gives the enumerations on the latest schema in that range, which can result in attempting to store enumerations on a schema where they no longer exist after being dropped in a previous array schema evolution.

Thanks @johnkerl for reporting, in the end I found the exact error from your issue was thrown because the enumeration happened to have the same name as a previously dropped enumeration. I was able to reproduce your error in the test case I added here by evolving the schema a third time to add back an enumeration with an identical name of one that was previously dropped. 

---
TYPE: BUG
DESC: Fix schema timestamps used when loading enumerations from REST.
