### PR TITLE
Remove StorageManager from stats dumps.

### DIFF
--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -1156,8 +1156,7 @@ void CppAggregatesFx<T>::validate_data_var(
 
 uint64_t get_stat(std::string name, std::string& stats) {
   // Parse num_tiles_read from the stats.
-  std::string to_find =
-      "\"Context.Query.Reader." + name + "\": ";
+  std::string to_find = "\"Context.Query.Reader." + name + "\": ";
   auto start_pos = stats.find(to_find);
 
   if (start_pos != std::string::npos) {

--- a/test/src/test-cppapi-aggregates.cc
+++ b/test/src/test-cppapi-aggregates.cc
@@ -1157,7 +1157,7 @@ void CppAggregatesFx<T>::validate_data_var(
 uint64_t get_stat(std::string name, std::string& stats) {
   // Parse num_tiles_read from the stats.
   std::string to_find =
-      "\"Context.StorageManager.Query.Reader." + name + "\": ";
+      "\"Context.Query.Reader." + name + "\": ";
   auto start_pos = stats.find(to_find);
 
   if (start_pos != std::string::npos) {

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -102,7 +102,7 @@ struct SerializationFx {
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto loop_num =
-        counters->find("Context.StorageManager.Query.Reader.loop_num");
+        counters->find("Context.Query.Reader.loop_num");
     REQUIRE((loop_num != counters->end()));
     REQUIRE(loop_num->second > 0);
   }
@@ -113,7 +113,7 @@ struct SerializationFx {
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto loop_num =
-        counters->find("Context.StorageManager.Query.Writer.attr_num");
+        counters->find("Context.Query.Writer.attr_num");
     REQUIRE((loop_num != counters->end()));
     REQUIRE(loop_num->second > 0);
   }
@@ -125,11 +125,11 @@ struct SerializationFx {
     // Note: if these checks fail, use Stats::dump(stdout) to validate counters
     CHECK(
         stats.find(
-            "\"Context.StorageManager.subSubarray.add_range_dim_0\": " +
+            "\"Context.subSubarray.add_range_dim_0\": " +
             std::to_string(dim0_expected)) != std::string::npos);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.subSubarray.add_range_dim_1\": " +
+            "\"Context.subSubarray.add_range_dim_1\": " +
             std::to_string(dim1_expected)) != std::string::npos);
     Stats::disable();
   }
@@ -140,7 +140,7 @@ struct SerializationFx {
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto dowork_num = counters->find(
-        "Context.StorageManager.Query.Deletes.dowork.timer_count");
+        "Context.Query.Deletes.dowork.timer_count");
     REQUIRE((dowork_num != counters->end()));
     REQUIRE(dowork_num->second > 0);
   }

--- a/test/src/unit-capi-serialized_queries.cc
+++ b/test/src/unit-capi-serialized_queries.cc
@@ -101,8 +101,7 @@ struct SerializationFx {
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto loop_num =
-        counters->find("Context.Query.Reader.loop_num");
+    auto loop_num = counters->find("Context.Query.Reader.loop_num");
     REQUIRE((loop_num != counters->end()));
     REQUIRE(loop_num->second > 0);
   }
@@ -112,8 +111,7 @@ struct SerializationFx {
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto loop_num =
-        counters->find("Context.Query.Writer.attr_num");
+    auto loop_num = counters->find("Context.Query.Writer.attr_num");
     REQUIRE((loop_num != counters->end()));
     REQUIRE(loop_num->second > 0);
   }
@@ -139,8 +137,8 @@ struct SerializationFx {
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto dowork_num = counters->find(
-        "Context.Query.Deletes.dowork.timer_count");
+    auto dowork_num =
+        counters->find("Context.Query.Deletes.dowork.timer_count");
     REQUIRE((dowork_num != counters->end()));
     REQUIRE(dowork_num->second > 0);
   }

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1698,12 +1698,12 @@ TEST_CASE(
   // cpp_unit_array/__meta
   // cpp_unit_array/__fragment_meta
   CHECK(
-      stats.find("\"Context.StorageManager.VFS.read_ops_num\": 5") !=
+      stats.find("\"Context.VFS.read_ops_num\": 5") !=
       std::string::npos);
 
   // Expect file_size on the fragment.
   CHECK(
-      stats.find("\"Context.StorageManager.VFS.file_size_num\": 1") !=
+      stats.find("\"Context.VFS.file_size_num\": 1") !=
       std::string::npos);
 }
 
@@ -1758,12 +1758,12 @@ TEST_CASE(
   // cpp_unit_array/__meta
   // cpp_unit_array/__fragment_meta
   CHECK(
-      stats.find("\"Context.StorageManager.VFS.read_ops_num\": 5") !=
+      stats.find("\"Context.VFS.read_ops_num\": 5") !=
       std::string::npos);
 
   // Expect file_size on the fragment.
   CHECK(
-      stats.find("\"Context.StorageManager.VFS.file_size_num\": 1") !=
+      stats.find("\"Context.VFS.file_size_num\": 1") !=
       std::string::npos);
 }
 

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -1697,14 +1697,10 @@ TEST_CASE(
   // cpp_unit_array/__schema
   // cpp_unit_array/__meta
   // cpp_unit_array/__fragment_meta
-  CHECK(
-      stats.find("\"Context.VFS.read_ops_num\": 5") !=
-      std::string::npos);
+  CHECK(stats.find("\"Context.VFS.read_ops_num\": 5") != std::string::npos);
 
   // Expect file_size on the fragment.
-  CHECK(
-      stats.find("\"Context.VFS.file_size_num\": 1") !=
-      std::string::npos);
+  CHECK(stats.find("\"Context.VFS.file_size_num\": 1") != std::string::npos);
 }
 
 TEST_CASE(
@@ -1757,14 +1753,10 @@ TEST_CASE(
   // cpp_unit_array/__schema
   // cpp_unit_array/__meta
   // cpp_unit_array/__fragment_meta
-  CHECK(
-      stats.find("\"Context.VFS.read_ops_num\": 5") !=
-      std::string::npos);
+  CHECK(stats.find("\"Context.VFS.read_ops_num\": 5") != std::string::npos);
 
   // Expect file_size on the fragment.
-  CHECK(
-      stats.find("\"Context.VFS.file_size_num\": 1") !=
-      std::string::npos);
+  CHECK(stats.find("\"Context.VFS.file_size_num\": 1") != std::string::npos);
 }
 
 TEST_CASE(

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -652,8 +652,7 @@ TEST_CASE_METHOD(
 
   // Make sure there was an internal loop on the reader.
   CHECK(
-      stats.find(
-          "\"Context.Query.Reader.internal_loop_num\": 2") !=
+      stats.find("\"Context.Query.Reader.internal_loop_num\": 2") !=
       std::string::npos);
 
   remove_sparse_array();
@@ -705,8 +704,7 @@ TEST_CASE_METHOD(
 
   // Make sure there was an internal loop on the reader.
   CHECK(
-      stats.find(
-          "\"Context.Query.Reader.internal_loop_num\": 2") !=
+      stats.find("\"Context.Query.Reader.internal_loop_num\": 2") !=
       std::string::npos);
 
   remove_sparse_array();
@@ -1476,8 +1474,7 @@ TEST_CASE_METHOD(
     // partially overlaps with the first 1:3 consolidated fragment.
     read_sparse(a, dim1, dim2, stats, layout, 2);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 4") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 4") !=
         std::string::npos);
 
     // Same but skip timestamps: 4 - 1 = 3, since 0:4 array fully overlaps with
@@ -1485,8 +1482,7 @@ TEST_CASE_METHOD(
     // cells.
     read_sparse(a, dim1, dim2, stats, layout, 4);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 3") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 3") !=
         std::string::npos);
 
     // Read 2 tiles for dim1, dim2, attr a1 and 1 for timestamps: 3 * 2 + 1 = 7
@@ -1494,24 +1490,21 @@ TEST_CASE_METHOD(
     // overlaps with the second 5:7 consolidated fragment.
     read_sparse(a, dim1, dim2, stats, layout, 6);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 7") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 7") !=
         std::string::npos);
 
     // Read 2 tiles for dim1, dim2, attr a1 and skip timestamps: 3 * 2, since
     // 0:8 array fully overlaps with both consolidateded fragments 1:3 and 5:7.
     read_sparse(a, dim1, dim2, stats, layout, 8);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 6") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 6") !=
         std::string::npos);
 
     // Read 2 tiles for dim1, dim2, attr a1 and timestamps: 4 * 2, since 3:5
     // array partially overlaps with both consolidateded fragments 1:3 and 5:7.
     reopen_sparse(a, dim1, dim2, stats, layout, 3, 5);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 8") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 8") !=
         std::string::npos);
   }
 
@@ -1519,8 +1512,7 @@ TEST_CASE_METHOD(
     std::vector<uint64_t> timestamps(16);
     read_sparse(a, dim1, dim2, stats, layout, 4, &timestamps);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 4") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 4") !=
         std::string::npos);
   }
 
@@ -1538,8 +1530,7 @@ TEST_CASE_METHOD(
     consolidate_sparse(vacuum);
     read_sparse(a, dim1, dim2, stats, layout, 4);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 4") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 4") !=
         std::string::npos);
   }
 
@@ -1557,8 +1548,7 @@ TEST_CASE_METHOD(
     // have any.
     read_sparse(a, dim1, dim2, stats, layout, 2);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 3") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 3") !=
         std::string::npos);
 
     // Request timestamps - expect no timestamps getting read since fragment
@@ -1566,8 +1556,7 @@ TEST_CASE_METHOD(
     std::vector<uint64_t> timestamps(16);
     read_sparse(a, dim1, dim2, stats, layout, 4, &timestamps);
     CHECK(
-        stats.find(
-            "\"Context.Query.Reader.num_tiles_read\": 6") !=
+        stats.find("\"Context.Query.Reader.num_tiles_read\": 6") !=
         std::string::npos);
   }
 

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -653,7 +653,7 @@ TEST_CASE_METHOD(
   // Make sure there was an internal loop on the reader.
   CHECK(
       stats.find(
-          "\"Context.StorageManager.Query.Reader.internal_loop_num\": 2") !=
+          "\"Context.Query.Reader.internal_loop_num\": 2") !=
       std::string::npos);
 
   remove_sparse_array();
@@ -706,7 +706,7 @@ TEST_CASE_METHOD(
   // Make sure there was an internal loop on the reader.
   CHECK(
       stats.find(
-          "\"Context.StorageManager.Query.Reader.internal_loop_num\": 2") !=
+          "\"Context.Query.Reader.internal_loop_num\": 2") !=
       std::string::npos);
 
   remove_sparse_array();
@@ -1477,7 +1477,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 2);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 4") !=
+            "\"Context.Query.Reader.num_tiles_read\": 4") !=
         std::string::npos);
 
     // Same but skip timestamps: 4 - 1 = 3, since 0:4 array fully overlaps with
@@ -1486,7 +1486,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 4);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 3") !=
+            "\"Context.Query.Reader.num_tiles_read\": 3") !=
         std::string::npos);
 
     // Read 2 tiles for dim1, dim2, attr a1 and 1 for timestamps: 3 * 2 + 1 = 7
@@ -1495,7 +1495,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 6);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 7") !=
+            "\"Context.Query.Reader.num_tiles_read\": 7") !=
         std::string::npos);
 
     // Read 2 tiles for dim1, dim2, attr a1 and skip timestamps: 3 * 2, since
@@ -1503,7 +1503,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 8);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 6") !=
+            "\"Context.Query.Reader.num_tiles_read\": 6") !=
         std::string::npos);
 
     // Read 2 tiles for dim1, dim2, attr a1 and timestamps: 4 * 2, since 3:5
@@ -1511,7 +1511,7 @@ TEST_CASE_METHOD(
     reopen_sparse(a, dim1, dim2, stats, layout, 3, 5);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 8") !=
+            "\"Context.Query.Reader.num_tiles_read\": 8") !=
         std::string::npos);
   }
 
@@ -1520,7 +1520,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 4, &timestamps);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 4") !=
+            "\"Context.Query.Reader.num_tiles_read\": 4") !=
         std::string::npos);
   }
 
@@ -1539,7 +1539,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 4);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 4") !=
+            "\"Context.Query.Reader.num_tiles_read\": 4") !=
         std::string::npos);
   }
 
@@ -1558,7 +1558,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 2);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 3") !=
+            "\"Context.Query.Reader.num_tiles_read\": 3") !=
         std::string::npos);
 
     // Request timestamps - expect no timestamps getting read since fragment
@@ -1567,7 +1567,7 @@ TEST_CASE_METHOD(
     read_sparse(a, dim1, dim2, stats, layout, 4, &timestamps);
     CHECK(
         stats.find(
-            "\"Context.StorageManager.Query.Reader.num_tiles_read\": 6") !=
+            "\"Context.Query.Reader.num_tiles_read\": 6") !=
         std::string::npos);
   }
 

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -532,7 +532,7 @@ void CDenseFx::read(
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto loop_num =
-        counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+        counters->find("Context.Query.Reader.internal_loop_num");
     CHECK(2 == loop_num->second);
   }
 
@@ -661,7 +661,7 @@ void CDenseFx::read_strings(
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto loop_num =
-        counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+        counters->find("Context.Query.Reader.internal_loop_num");
     CHECK(2 == loop_num->second);
   }
 
@@ -841,7 +841,7 @@ void CDenseFx::read_fixed_strings(
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto loop_num =
-        counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+        counters->find("Context.Query.Reader.internal_loop_num");
     CHECK(expected_num_loops == loop_num->second);
   }
 

--- a/test/src/unit-dense-reader.cc
+++ b/test/src/unit-dense-reader.cc
@@ -531,8 +531,7 @@ void CDenseFx::read(
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto loop_num =
-        counters->find("Context.Query.Reader.internal_loop_num");
+    auto loop_num = counters->find("Context.Query.Reader.internal_loop_num");
     CHECK(2 == loop_num->second);
   }
 
@@ -660,8 +659,7 @@ void CDenseFx::read_strings(
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto loop_num =
-        counters->find("Context.Query.Reader.internal_loop_num");
+    auto loop_num = counters->find("Context.Query.Reader.internal_loop_num");
     CHECK(2 == loop_num->second);
   }
 
@@ -840,8 +838,7 @@ void CDenseFx::read_fixed_strings(
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto loop_num =
-        counters->find("Context.Query.Reader.internal_loop_num");
+    auto loop_num = counters->find("Context.Query.Reader.internal_loop_num");
     CHECK(expected_num_loops == loop_num->second);
   }
 

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -1079,7 +1079,7 @@ TEST_CASE_METHOD(
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
   auto loop_num =
-      counters->find("Context.StorageManager.Query.Reader.loop_num");
+      counters->find("Context.Query.Reader.loop_num");
   CHECK(2 == loop_num->second);
 }
 

--- a/test/src/unit-ordered-dim-label-reader.cc
+++ b/test/src/unit-ordered-dim-label-reader.cc
@@ -1078,8 +1078,7 @@ TEST_CASE_METHOD(
   REQUIRE(stats != nullptr);
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
-  auto loop_num =
-      counters->find("Context.Query.Reader.loop_num");
+  auto loop_num = counters->find("Context.Query.Reader.loop_num");
   CHECK(2 == loop_num->second);
 }
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -823,8 +823,7 @@ TEST_CASE_METHOD(
   REQUIRE(stats != nullptr);
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
-  auto loop_num =
-      counters->find("Context.Query.Reader.internal_loop_num");
+  auto loop_num = counters->find("Context.Query.Reader.internal_loop_num");
   CHECK(5 == loop_num->second);
 
   // Check incomplete query status.

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -824,7 +824,7 @@ TEST_CASE_METHOD(
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
   auto loop_num =
-      counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+      counters->find("Context.Query.Reader.internal_loop_num");
   CHECK(5 == loop_num->second);
 
   // Check incomplete query status.

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1060,7 +1060,7 @@ TEST_CASE_METHOD(
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
     auto loop_num =
-        counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+        counters->find("Context.Query.Reader.internal_loop_num");
 
     if (one_frag) {
       CHECK(1 == loop_num->second);
@@ -1175,7 +1175,7 @@ TEST_CASE_METHOD(
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
   auto loop_num =
-      counters->find("Context.StorageManager.Query.Reader.internal_loop_num");
+      counters->find("Context.Query.Reader.internal_loop_num");
   CHECK(uint64_t(num_frags * 3) == loop_num->second);
 
   // Check query status.

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1059,8 +1059,7 @@ TEST_CASE_METHOD(
     REQUIRE(stats != nullptr);
     auto counters = stats->counters();
     REQUIRE(counters != nullptr);
-    auto loop_num =
-        counters->find("Context.Query.Reader.internal_loop_num");
+    auto loop_num = counters->find("Context.Query.Reader.internal_loop_num");
 
     if (one_frag) {
       CHECK(1 == loop_num->second);
@@ -1174,8 +1173,7 @@ TEST_CASE_METHOD(
   REQUIRE(stats != nullptr);
   auto counters = stats->counters();
   REQUIRE(counters != nullptr);
-  auto loop_num =
-      counters->find("Context.Query.Reader.internal_loop_num");
+  auto loop_num = counters->find("Context.Query.Reader.internal_loop_num");
   CHECK(uint64_t(num_frags * 3) == loop_num->second);
 
   // Check query status.

--- a/tiledb/sm/stats/global_stats.h
+++ b/tiledb/sm/stats/global_stats.h
@@ -71,7 +71,7 @@
  * As mentioned above, the Stats objects used under a Context form a tree.
  * Each Stats object mentains a list of children Stats and a pointer to the
  * parent Stats object.
- * The Stats object created by ContextResources(named "Context.StorageManager")
+ * The Stats object created by ContextResources(named "Context")
  * is the only Stats constructed in a standalone fashion using the Stats
  * constructor, all the other objects under this root Stats are created via
  * the Stats::create_child API.

--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -65,10 +65,7 @@ Context::Context(const Config& config)
           logger_,
           get_compute_thread_count(config),
           get_io_thread_count(config),
-          // TODO: Remove `.StorageManager` from statistic names
-          // We're sticking with `Context.StorageManager` here because
-          // it is part of the public facing API.
-          "Context.StorageManager")
+          "Context")
     , storage_manager_{resources_, logger_, config} {
   /*
    * Logger class is not yet C.41-compliant


### PR DESCRIPTION
This PR removes the deprecated ```StorageManager``` word from the stats dump. 

[sc-53952]

---
TYPE: IMPROVEMENT
DESC: Remove StorageManager from stats dumps.
