### PR TITLE
Break cycle between FragmentMetadata and LoadedFragmentMetadata classes

### DIFF
--- a/test/src/unit-tile-metadata.cc
+++ b/test/src/unit-tile-metadata.cc
@@ -332,13 +332,15 @@ struct CPPFixedTileMetadataFx {
 
           // Validate no min.
           CHECK_THROWS_WITH(
-              frag_meta[f]->get_tile_min_as<TestType>("d", tile_idx),
+              frag_meta[f]->loaded_metadata()->get_tile_min_as<TestType>(
+                  "d", tile_idx),
               "FragmentMetadata: Trying to access tile min metadata that's not "
               "present");
 
           // Validate no max.
           CHECK_THROWS_WITH(
-              frag_meta[f]->get_tile_max_as<TestType>("d", tile_idx),
+              frag_meta[f]->loaded_metadata()->get_tile_max_as<TestType>(
+                  "d", tile_idx),
               "FragmentMetadata: Trying to access tile max metadata that's not "
               "present");
 
@@ -348,7 +350,8 @@ struct CPPFixedTileMetadataFx {
           CHECK(*(int64_t*)sum == correct_sum);
 
           // Validate the tile metadata structure.
-          auto full_tile_data = frag_meta[f]->get_tile_metadata("d", tile_idx);
+          auto full_tile_data =
+              frag_meta[f]->loaded_metadata()->get_tile_metadata("d", tile_idx);
           CHECK(correct_min == full_tile_data.min_as<uint32_t>());
           CHECK(correct_max == full_tile_data.max_as<uint32_t>());
           CHECK(correct_sum == full_tile_data.sum_as<int64_t>());
@@ -463,13 +466,13 @@ struct CPPFixedTileMetadataFx {
     if constexpr (std::is_same<TestType, std::byte>::value) {
       // Validate no min.
       CHECK_THROWS_WITH(
-          frag_meta[f]->get_tile_min_as<TestType>("a", 0),
+          frag_meta[f]->loaded_metadata()->get_tile_min_as<TestType>("a", 0),
           "FragmentMetadata: Trying to access tile min metadata that's not "
           "present");
 
       // Validate no max.
       CHECK_THROWS_WITH(
-          frag_meta[f]->get_tile_max_as<TestType>("a", 0),
+          frag_meta[f]->loaded_metadata()->get_tile_max_as<TestType>("a", 0),
           "FragmentMetadata: Trying to access tile max metadata that's not "
           "present");
 
@@ -484,7 +487,9 @@ struct CPPFixedTileMetadataFx {
           for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
             // Validate min.
             const auto min =
-                frag_meta[f]->get_tile_min_as<std::string_view>("a", tile_idx);
+                frag_meta[f]
+                    ->loaded_metadata()
+                    ->get_tile_min_as<std::string_view>("a", tile_idx);
             CHECK(min.size() == cell_val_num);
 
             // For strings, the index is stored in a signed value, switch to
@@ -498,7 +503,9 @@ struct CPPFixedTileMetadataFx {
 
             // Validate max.
             const auto max =
-                frag_meta[f]->get_tile_max_as<std::string_view>("a", tile_idx);
+                frag_meta[f]
+                    ->loaded_metadata()
+                    ->get_tile_max_as<std::string_view>("a", tile_idx);
             CHECK(max.size() == cell_val_num);
 
             // For strings, the index is stored in a signed value, switch to
@@ -519,7 +526,8 @@ struct CPPFixedTileMetadataFx {
 
             // Validate the tile metadata structure.
             auto full_tile_data =
-                frag_meta[f]->get_tile_metadata("a", tile_idx);
+                frag_meta[f]->loaded_metadata()->get_tile_metadata(
+                    "a", tile_idx);
             CHECK(
                 string_ascii_[min_idx] ==
                 full_tile_data.min_as<std::string_view>());
@@ -532,7 +540,8 @@ struct CPPFixedTileMetadataFx {
           for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
             // Validate min.
             const auto min =
-                frag_meta[f]->get_tile_min_as<TestType>("a", tile_idx);
+                frag_meta[f]->loaded_metadata()->get_tile_min_as<TestType>(
+                    "a", tile_idx);
             CHECK(
                 0 ==
                 memcmp(
@@ -540,7 +549,8 @@ struct CPPFixedTileMetadataFx {
 
             // Validate max.
             const auto max =
-                frag_meta[f]->get_tile_max_as<TestType>("a", tile_idx);
+                frag_meta[f]->loaded_metadata()->get_tile_max_as<TestType>(
+                    "a", tile_idx);
             CHECK(
                 0 ==
                 memcmp(
@@ -548,7 +558,8 @@ struct CPPFixedTileMetadataFx {
 
             // Validate the tile metadata structure.
             auto full_tile_data =
-                frag_meta[f]->get_tile_metadata("a", tile_idx);
+                frag_meta[f]->loaded_metadata()->get_tile_metadata(
+                    "a", tile_idx);
             CHECK(
                 correct_tile_mins_[f][tile_idx] ==
                 full_tile_data.min_as<TestType>());
@@ -594,7 +605,8 @@ struct CPPFixedTileMetadataFx {
     if constexpr (!std::is_same<TestType, std::byte>::value) {
       // Validate the full tile data structure for null count
       for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
-        auto full_tile_data = frag_meta[f]->get_tile_metadata("a", tile_idx);
+        auto full_tile_data =
+            frag_meta[f]->loaded_metadata()->get_tile_metadata("a", tile_idx);
         if (nullable) {
           CHECK(
               full_tile_data.null_count() ==
@@ -883,13 +895,15 @@ struct CPPVarTileMetadataFx {
 
           // Validate no min.
           CHECK_THROWS_WITH(
-              frag_meta[f]->get_tile_min_as<uint32_t>("d", tile_idx),
+              frag_meta[f]->loaded_metadata()->get_tile_min_as<uint32_t>(
+                  "d", tile_idx),
               "FragmentMetadata: Trying to access tile min metadata that's not "
               "present");
 
           // Validate no max.
           CHECK_THROWS_WITH(
-              frag_meta[f]->get_tile_max_as<uint32_t>("d", tile_idx),
+              frag_meta[f]->loaded_metadata()->get_tile_max_as<uint32_t>(
+                  "d", tile_idx),
               "FragmentMetadata: Trying to access tile max metadata that's not "
               "present");
 
@@ -899,7 +913,8 @@ struct CPPVarTileMetadataFx {
           CHECK(*(int64_t*)sum == correct_sum);
 
           // Validate the tile metadata structure.
-          auto full_tile_data = frag_meta[f]->get_tile_metadata("d", tile_idx);
+          auto full_tile_data =
+              frag_meta[f]->loaded_metadata()->get_tile_metadata("d", tile_idx);
           CHECK(correct_min == full_tile_data.min_as<uint32_t>());
           CHECK(correct_max == full_tile_data.max_as<uint32_t>());
           CHECK(correct_sum == full_tile_data.sum_as<int64_t>());
@@ -962,7 +977,8 @@ struct CPPVarTileMetadataFx {
       for (uint64_t tile_idx = 0; tile_idx < num_tiles_; tile_idx++) {
         // Validate min.
         const auto min =
-            frag_meta[f]->get_tile_min_as<std::string_view>("a", tile_idx);
+            frag_meta[f]->loaded_metadata()->get_tile_min_as<std::string_view>(
+                "a", tile_idx);
         int min_idx = correct_tile_mins_[f][tile_idx];
         CHECK(min.size() == strings_[min_idx].size());
         CHECK(
@@ -973,7 +989,8 @@ struct CPPVarTileMetadataFx {
 
         // Validate max.
         const auto max =
-            frag_meta[f]->get_tile_max_as<std::string_view>("a", tile_idx);
+            frag_meta[f]->loaded_metadata()->get_tile_max_as<std::string_view>(
+                "a", tile_idx);
         int max_idx = correct_tile_maxs_[f][tile_idx];
         CHECK(max.size() == strings_[max_idx].size());
         CHECK(
@@ -989,7 +1006,8 @@ struct CPPVarTileMetadataFx {
             "present");
 
         // Validate the tile metadata structure.
-        auto full_tile_data = frag_meta[f]->get_tile_metadata("a", tile_idx);
+        auto full_tile_data =
+            frag_meta[f]->loaded_metadata()->get_tile_metadata("a", tile_idx);
         CHECK(strings_[min_idx] == full_tile_data.min_as<std::string_view>());
         CHECK(strings_[max_idx] == full_tile_data.max_as<std::string_view>());
       }
@@ -1208,11 +1226,13 @@ struct CPPFixedTileMetadataPartialFx {
     // Validate attribute metadta.
     for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
       // Validate min.
-      const auto min = frag_meta[0]->get_tile_min_as<double>("a", tile_idx);
+      const auto min = frag_meta[0]->loaded_metadata()->get_tile_min_as<double>(
+          "a", tile_idx);
       CHECK(0 == memcmp(&min, &correct_tile_mins[tile_idx], sizeof(double)));
 
       // Validate max.
-      const auto max = frag_meta[0]->get_tile_max_as<double>("a", tile_idx);
+      const auto max = frag_meta[0]->loaded_metadata()->get_tile_max_as<double>(
+          "a", tile_idx);
       CHECK(0 == memcmp(&max, &correct_tile_maxs[tile_idx], sizeof(double)));
 
       // Validate sum.
@@ -1220,7 +1240,8 @@ struct CPPFixedTileMetadataPartialFx {
       CHECK(*(double*)sum - correct_tile_sums[tile_idx] < 0.0001);
 
       // Validate the tile metadata structure.
-      auto full_tile_data = frag_meta[0]->get_tile_metadata("a", tile_idx);
+      auto full_tile_data =
+          frag_meta[0]->loaded_metadata()->get_tile_metadata("a", tile_idx);
       CHECK(correct_tile_mins[tile_idx] == full_tile_data.min_as<double>());
       CHECK(correct_tile_maxs[tile_idx] == full_tile_data.max_as<double>());
       CHECK(
@@ -1381,7 +1402,8 @@ struct CPPVarTileMetadataPartialFx {
     for (uint64_t tile_idx = 0; tile_idx < 4; tile_idx++) {
       // Validate min.
       const auto min =
-          frag_meta[0]->get_tile_min_as<std::string_view>("a", tile_idx);
+          frag_meta[0]->loaded_metadata()->get_tile_min_as<std::string_view>(
+              "a", tile_idx);
       CHECK(min.size() == correct_tile_mins[tile_idx].size());
       CHECK(
           0 ==
@@ -1389,14 +1411,16 @@ struct CPPVarTileMetadataPartialFx {
 
       // Validate max.
       const auto max =
-          frag_meta[0]->get_tile_max_as<std::string_view>("a", tile_idx);
+          frag_meta[0]->loaded_metadata()->get_tile_max_as<std::string_view>(
+              "a", tile_idx);
       CHECK(max.size() == correct_tile_maxs[tile_idx].size());
       CHECK(
           0 ==
           memcmp(max.data(), correct_tile_maxs[tile_idx].data(), max.size()));
 
       // Validate the tile metadata structure.
-      auto full_tile_data = frag_meta[0]->get_tile_metadata("a", tile_idx);
+      auto full_tile_data =
+          frag_meta[0]->loaded_metadata()->get_tile_metadata("a", tile_idx);
       CHECK(
           correct_tile_mins[tile_idx] ==
           full_tile_data.min_as<std::string_view>());
@@ -1562,24 +1586,30 @@ struct CPPTileMetadataStringDimFx {
         enc_key, names);
 
     // Validate min.
-    CHECK(frag_meta[0]->get_tile_min_as<double>("a", 0) == 4);
+    CHECK(
+        frag_meta[0]->loaded_metadata()->get_tile_min_as<double>("a", 0) == 4);
     CHECK_THROWS_WITH(
-        frag_meta[0]->get_tile_min_as<std::string_view>("d1", 0),
+        frag_meta[0]->loaded_metadata()->get_tile_min_as<std::string_view>(
+            "d1", 0),
         "FragmentMetadata: Trying to access tile min metadata that's not "
         "present");
     CHECK_THROWS_WITH(
-        frag_meta[0]->get_tile_min_as<std::string_view>("d2", 0),
+        frag_meta[0]->loaded_metadata()->get_tile_min_as<std::string_view>(
+            "d2", 0),
         "FragmentMetadata: Trying to access tile min metadata that's not "
         "present");
 
     // Validate max.
-    CHECK(frag_meta[0]->get_tile_max_as<double>("a", 0) == 7);
+    CHECK(
+        frag_meta[0]->loaded_metadata()->get_tile_max_as<double>("a", 0) == 7);
     CHECK_THROWS_WITH(
-        frag_meta[0]->get_tile_max_as<std::string_view>("d1", 0),
+        frag_meta[0]->loaded_metadata()->get_tile_max_as<std::string_view>(
+            "d1", 0),
         "FragmentMetadata: Trying to access tile max metadata that's not "
         "present");
     CHECK_THROWS_WITH(
-        frag_meta[0]->get_tile_max_as<std::string_view>("d2", 0),
+        frag_meta[0]->loaded_metadata()->get_tile_max_as<std::string_view>(
+            "d2", 0),
         "FragmentMetadata: Trying to access tile max metadata that's not "
         "present");
 
@@ -1588,16 +1618,19 @@ struct CPPTileMetadataStringDimFx {
         *(double*)frag_meta[0]->loaded_metadata()->get_tile_sum("a", 0) == 22);
 
     // Validate the tile metadata structure.
-    auto full_tile_data_a = frag_meta[0]->get_tile_metadata("a", 0);
+    auto full_tile_data_a =
+        frag_meta[0]->loaded_metadata()->get_tile_metadata("a", 0);
     CHECK(4 == full_tile_data_a.min_as<double>());
     CHECK(7 == full_tile_data_a.max_as<double>());
     CHECK(22 == full_tile_data_a.sum_as<double>());
 
-    auto full_tile_data_d1 = frag_meta[0]->get_tile_metadata("d1", 0);
+    auto full_tile_data_d1 =
+        frag_meta[0]->loaded_metadata()->get_tile_metadata("d1", 0);
     CHECK("a" == full_tile_data_d1.min_as<std::string_view>());
     CHECK("dddd" == full_tile_data_d1.max_as<std::string_view>());
 
-    auto full_tile_data_d2 = frag_meta[0]->get_tile_metadata("d2", 0);
+    auto full_tile_data_d2 =
+        frag_meta[0]->loaded_metadata()->get_tile_metadata("d2", 0);
     CHECK("a" == full_tile_data_d2.min_as<std::string_view>());
     CHECK("d" == full_tile_data_d2.max_as<std::string_view>());
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -985,6 +985,7 @@ Status Array::get_max_buffer_size(
 Status Array::get_max_buffer_size(
     const char* name,
     const void* subarray,
+
     uint64_t* buffer_off_size,
     uint64_t* buffer_val_size) {
   // Check if array is open

--- a/tiledb/sm/fragment/fragment_metadata.h
+++ b/tiledb/sm/fragment/fragment_metadata.h
@@ -402,36 +402,82 @@ class FragmentMetadata {
       const std::unordered_map<std::string, std::pair<Tile*, uint64_t>>&
           offsets);
 
-  /** Stores all the metadata to storage. */
-  void store(const EncryptionKey& encryption_key);
+  /**
+   * Writes the R-tree to a tile.
+   * @param loaded_metadata The loaded fragment metadata.
+   */
+  shared_ptr<WriterTile> write_rtree(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata);
+
+  /**
+   * Writes the R-tree to storage.
+   *
+   * @param loaded_metadata The loaded fragment metadata.
+   * @param encryption_key The encryption key.
+   * @param nbytes The total number of bytes written for the R-tree.
+   */
+  void store_rtree(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
+
+  /**
+   * Stores all the metadata to storage.
+   *
+   * @param loaded_metadata The loaded fragment metadata.
+   * @param encryption_key The encryption key.
+   */
+  void store(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key);
 
   /**
    * Stores all the metadata to storage.
    *
    * Applicable to format versions 7 to 10.
+   *
+   * @param loaded_metadata The loaded fragment metadata.
+   * @param encryption_key The encryption key.
    */
-  void store_v7_v10(const EncryptionKey& encryption_key);
+  void store_v7_v10(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key);
 
   /**
    * Stores all the metadata to storage.
    *
    * Applicable to format versions 11.
+   *
+   * @param loaded_metadata The loaded fragment metadata.
+   * @param encryption_key The encryption key.
    */
-  void store_v11(const EncryptionKey& encryption_key);
+  void store_v11(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key);
 
   /**
    * Stores all the metadata to storage.
    *
    * Applicable to format versions 12 or higher.
+   *
+   * @param loaded_metadata The loaded fragment metadata.
+   * @param encryption_key The encryption key.
    */
-  void store_v12_v14(const EncryptionKey& encryption_key);
+  void store_v12_v14(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key);
 
   /**
    * Stores all the metadata to storage.
    *
    * Applicable to format versions 15 or higher.
+   *
+   * @param loaded_metadata The loaded fragment metadata.
+   * @param encryption_key The encryption key.
    */
-  void store_v15_or_higher(const EncryptionKey& encryption_key);
+  void store_v15_or_higher(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key);
 
   /**
    * Simply sets the number of cells for the last tile.
@@ -440,15 +486,6 @@ class FragmentMetadata {
    * @return void
    */
   void set_last_tile_cell_num(uint64_t cell_num);
-
-  /**
-   * Sets the input tile's MBR in the fragment metadata. It also expands the
-   * non-empty domain of the fragment.
-   *
-   * @param tile The tile index whose MBR will be set.
-   * @param mbr The MBR to be set.
-   */
-  void set_mbr(uint64_t tile, const NDRange& mbr);
 
   /**
    * Resizes the per-tile metadata vectors for the given number of tiles. This
@@ -477,9 +514,14 @@ class FragmentMetadata {
    * @param tid The index of the tile for which the offset is set.
    * @param step This is essentially the step by which the previous
    *     offset will be expanded. It is practically the last tile size.
+   * @param tile_offsets The tile offsets to set.
    * @return void
    */
-  void set_tile_offset(const std::string& name, uint64_t tid, uint64_t step);
+  void set_tile_offset(
+      const std::string& name,
+      uint64_t tid,
+      uint64_t step,
+      tdb::pmr::vector<tdb::pmr::vector<uint64_t>>& tile_offsets);
 
   /**
    * Sets a variable tile offset for the input attribute or dimension.
@@ -488,10 +530,14 @@ class FragmentMetadata {
    * @param tid The index of the tile for which the offset is set.
    * @param step This is essentially the step by which the previous
    *     offset will be expanded. It is practically the last variable tile size.
+   * @param tile_var_offsets The variable tile offsets to set.
    * @return void
    */
   void set_tile_var_offset(
-      const std::string& name, uint64_t tid, uint64_t step);
+      const std::string& name,
+      uint64_t tid,
+      uint64_t step,
+      tdb::pmr::vector<tdb::pmr::vector<uint64_t>>& tile_var_offsets);
 
   /**
    * Sets a variable tile size for the input attribute or dimension.
@@ -499,9 +545,14 @@ class FragmentMetadata {
    * @param name The attribute/dimension for which the size is set.
    * @param tid The index of the tile for which the offset is set.
    * @param size The size to be appended.
+   * @param tile_var_sizes The variable tile sizes to set.
    * @return void
    */
-  void set_tile_var_size(const std::string& name, uint64_t tid, uint64_t size);
+  void set_tile_var_size(
+      const std::string& name,
+      uint64_t tid,
+      uint64_t size,
+      tdb::pmr::vector<tdb::pmr::vector<uint64_t>>& tile_var_sizes);
 
   /**
    * Sets a validity tile offset for the input attribute.
@@ -510,10 +561,14 @@ class FragmentMetadata {
    * @param tid The index of the tile for which the offset is set.
    * @param step This is essentially the step by which the previous
    *     offset will be expanded. It is practically the last tile size.
+   * @param tile_validity_offsets The validity tile offsets to set.
    * @return void
    */
   void set_tile_validity_offset(
-      const std::string& name, uint64_t tid, uint64_t step);
+      const std::string& name,
+      uint64_t tid,
+      uint64_t step,
+      tdb::pmr::vector<tdb::pmr::vector<uint64_t>>& tile_validity_offsets);
 
   /**
    * Sets a tile min for the fixed input attribute.
@@ -521,9 +576,14 @@ class FragmentMetadata {
    * @param name The attribute for which the min is set.
    * @param tid The index of the tile for which the min is set.
    * @param min The minimum.
+   * @param tile_min_buffer The tile min buffer.
    * @return void
    */
-  void set_tile_min(const std::string& name, uint64_t tid, const ByteVec& min);
+  void set_tile_min(
+      const std::string& name,
+      uint64_t tid,
+      const ByteVec& min,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_min_buffer);
 
   /**
    * Sets a tile min size for the var input attribute.
@@ -531,10 +591,14 @@ class FragmentMetadata {
    * @param name The attribute for which the min size is set.
    * @param tid The index of the tile for which the min is set.
    * @param size The size.
+   * @param tile_min_buffer The tile min buffer.
    * @return void
    */
   void set_tile_min_var_size(
-      const std::string& name, uint64_t tid, uint64_t size);
+      const std::string& name,
+      uint64_t tid,
+      uint64_t size,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_min_buffer);
 
   /**
    * Sets a tile min for the var input attribute.
@@ -542,10 +606,16 @@ class FragmentMetadata {
    * @param name The attribute for which the min is set.
    * @param tid The index of the tile for which the min is set.
    * @param min The minimum.
+   * @param tile_min_buffer The tile min buffer.
+   * @param tile_min_var_buffer The tile min var buffer.
    * @return void
    */
   void set_tile_min_var(
-      const std::string& name, uint64_t tid, const ByteVec& min);
+      const std::string& name,
+      uint64_t tid,
+      const ByteVec& min,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_min_buffer,
+      tdb::pmr::vector<tdb::pmr::vector<char>>& tile_min_var_buffer);
 
   /**
    * Sets a tile max for the input attribute.
@@ -553,9 +623,14 @@ class FragmentMetadata {
    * @param name The attribute for which the max is set.
    * @param tid The index of the tile for which the max is set.
    * @param max The maximum.
+   * @param tile_max_buffer The tile max buffer.
    * @return void
    */
-  void set_tile_max(const std::string& name, uint64_t tid, const ByteVec& max);
+  void set_tile_max(
+      const std::string& name,
+      uint64_t tid,
+      const ByteVec& max,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_max_buffer);
 
   /**
    * Sets a tile max for the var input attribute.
@@ -563,10 +638,14 @@ class FragmentMetadata {
    * @param name The attribute for which the min size is set.
    * @param tid The index of the tile for which the min is set.
    * @param size The size.
+   * @param tile_max_buffer The tile max buffer.
    * @return void
    */
   void set_tile_max_var_size(
-      const std::string& name, uint64_t tid, uint64_t size);
+      const std::string& name,
+      uint64_t tid,
+      uint64_t size,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_max_buffer);
 
   /**
    * Sets a tile max for the var input attribute.
@@ -574,18 +653,33 @@ class FragmentMetadata {
    * @param name The attribute for which the min is set.
    * @param tid The index of the tile for which the min is set.
    * @param max The maximum.
+   * @param tile_max_buffer The tile max buffer.
+   * @param tile_max_var_buffer The tile max var buffer.
    * @return void
    */
   void set_tile_max_var(
-      const std::string& name, uint64_t tid, const ByteVec& max);
+      const std::string& name,
+      uint64_t tid,
+      const ByteVec& max,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_max_buffer,
+      tdb::pmr::vector<tdb::pmr::vector<char>>& tile_max_var_buffer);
 
   /**
    * Converts min/max sizes to offsets.
    *
    * @param name The attribute for which the offsets are converted
+   * @param tile_min_var_buffer The tile min var buffer.
+   * @param tile_min_buffer The tile min buffer.
+   * @param tile_max_var_buffer The tile max var buffer.
+   * @param tile_max_buffer The tile max buffer.
    * @return void
    */
-  void convert_tile_min_max_var_sizes_to_offsets(const std::string& name);
+  void convert_tile_min_max_var_sizes_to_offsets(
+      const std::string& name,
+      tdb::pmr::vector<tdb::pmr::vector<char>>& tile_min_var_buffer,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_min_buffer,
+      tdb::pmr::vector<tdb::pmr::vector<char>>& tile_max_var_buffer,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_max_buffer);
 
   /**
    * Sets a tile sum for the input attribute.
@@ -593,9 +687,14 @@ class FragmentMetadata {
    * @param name The attribute for which the sum is set.
    * @param tid The index of the tile for which the sum is set.
    * @param sum The sum.
+   * @param tile_sums The tile sums to set.
    * @return void
    */
-  void set_tile_sum(const std::string& name, uint64_t tid, const ByteVec& sum);
+  void set_tile_sum(
+      const std::string& name,
+      uint64_t tid,
+      const ByteVec& sum,
+      tdb::pmr::vector<tdb::pmr::vector<uint8_t>>& tile_sums);
 
   /**
    * Sets a tile null count for the input attribute.
@@ -603,15 +702,14 @@ class FragmentMetadata {
    * @param name The attribute for which the null count is set.
    * @param tid The index of the tile for which the null count is set.
    * @param sum The null count.
+   * @param tile_null_counts The tile null counts to set.
    * @return void
    */
   void set_tile_null_count(
-      const std::string& name, uint64_t tid, uint64_t null_count);
-
-  /**
-   * Compute fragment min, max, sum, null count for all dimensions/attributes.
-   */
-  void compute_fragment_min_max_sum_null_count();
+      const std::string& name,
+      uint64_t tid,
+      uint64_t null_count,
+      tdb::pmr::vector<tdb::pmr::vector<uint64_t>>& tile_null_counts);
 
   /**
    * Sets array schema pointer.
@@ -644,12 +742,6 @@ class FragmentMetadata {
 
   uint64_t footer_size() const;
 
-  /** Returns the MBR of the input tile. */
-  const NDRange& mbr(uint64_t tile_idx) const;
-
-  /** Returns all the MBRs of all tiles in the fragment. */
-  const tdb::pmr::vector<NDRange>& mbrs() const;
-
   /**
    * Returns the (uncompressed) tile size for a given attribute or dimension
    * and tile index. If the attribute/dimension is var-sized, this will return
@@ -660,47 +752,6 @@ class FragmentMetadata {
    * @return The tile size.
    */
   uint64_t tile_size(const std::string& name, uint64_t tile_idx) const;
-
-  /**
-   * Retrieves the tile min value for a given attribute or dimension and tile
-   * index.
-   *
-   * @param name The input attribute/dimension.
-   * @param tile_idx The index of the tile in the metadata.
-   * @return Value.
-   */
-  template <typename T>
-  T get_tile_min_as(const std::string& name, uint64_t tile_idx) const;
-
-  /**
-   * Retrieves the tile max value for a given attribute or dimension and tile
-   * index.
-   *
-   * @tparam Type to return the data as.
-   * @param name The input attribute/dimension.
-   * @param tile_idx The index of the tile in the metadata.
-   * @return Value.
-   */
-  template <typename T>
-  T get_tile_max_as(const std::string& name, uint64_t tile_idx) const;
-
-  /**
-   * Returns the tile metadata for a tile.
-   *
-   * @param name Name of the attribute to get the data for.
-   * @param tile_idx Tile index.
-   */
-  TileMetadata get_tile_metadata(
-      const std::string& name, const uint64_t tile_idx) const;
-
-  /**
-   * Set the processed conditions. The processed conditions is the list
-   * of delete/update conditions that have already been applied for this
-   * fragment and don't need to be applied again.
-   *
-   * @param processed_conditions The processed conditions.
-   */
-  void set_processed_conditions(std::vector<std::string>& processed_conditions);
 
   /** Returns the first timestamp of the fragment timestamp range. */
   uint64_t first_timestamp() const;
@@ -1189,19 +1240,8 @@ class FragmentMetadata {
    */
   void write_has_delete_meta(Serializer& serializer) const;
 
-  /**
-   * Writes the R-tree to storage.
-   *
-   * @param encryption_key The encryption key.
-   * @param nbytes The total number of bytes written for the R-tree.
-   */
-  void store_rtree(const EncryptionKey& encryption_key, uint64_t* nbytes);
-
   /** Stores a footer with the basic information. */
   void store_footer(const EncryptionKey& encryption_key);
-
-  /** Writes the R-tree to a tile. */
-  shared_ptr<WriterTile> write_rtree();
 
   /** Writes the non-empty domain to the input buffer. */
   void write_non_empty_domain(Serializer& serializer) const;
@@ -1209,172 +1249,211 @@ class FragmentMetadata {
   /**
    * Writes the tile offsets of the input attribute or dimension to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute or dimension.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the tile offsets.
    */
   void store_tile_offsets(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the tile offsets of the input attribute or dimension idx to the
    * input buffer.
    */
-  void write_tile_offsets(unsigned idx, Serializer& serializer);
+  void write_tile_offsets(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the variable tile offsets of the input attribute or dimension
    * to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute or dimension.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the tile var offsets.
    */
   void store_tile_var_offsets(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the variable tile offsets of the input attribute or dimension idx
    * to the buffer.
    */
-  void write_tile_var_offsets(unsigned idx, Serializer& serializer);
+  void write_tile_var_offsets(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the variable tile sizes for the input attribute or dimension to
    * the buffer.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute or dimension.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the tile var sizes.
    */
   void store_tile_var_sizes(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the variable tile sizes for the input attribute or dimension
    * to storage.
    */
-  void write_tile_var_sizes(unsigned idx, Serializer& serializer);
+  void write_tile_var_sizes(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the validity tile offsets of the input attribute to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the validity tile
    * offsets.
    */
   void store_tile_validity_offsets(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the validity tile offsets of the input attribute idx to the
    * input buffer.
    */
-  void write_tile_validity_offsets(unsigned idx, Serializer& serializer);
+  void write_tile_validity_offsets(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the mins of the input attribute to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the mins.
    */
   void store_tile_mins(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the mins of the input attribute idx to the input buffer.
    */
-  void write_tile_mins(unsigned idx, Serializer& serializer);
+  void write_tile_mins(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the maxs of the input attribute to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the maxs.
    */
   void store_tile_maxs(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the maxs of the input attribute idx to the input buffer.
    */
-  void write_tile_maxs(unsigned idx, Serializer& serializer);
+  void write_tile_maxs(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the sums of the input attribute to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the sums.
    */
   void store_tile_sums(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the sums of the input attribute idx to the input buffer.
    */
-  void write_tile_sums(unsigned idx, Serializer& serializer);
+  void write_tile_sums(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the null counts of the input attribute to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param idx The index of the attribute.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written for the null counts.
    */
   void store_tile_null_counts(
-      unsigned idx, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the null counts of the input attribute idx to the input buffer.
    */
-  void write_tile_null_counts(unsigned idx, Serializer& serializer);
+  void write_tile_null_counts(
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      unsigned idx,
+      Serializer& serializer);
 
   /**
    * Writes the fragment min, max, sum and null count to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param num The number of attributes.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written.
    */
   void store_fragment_min_max_sum_null_count(
-      uint64_t num, const EncryptionKey& encryption_key, uint64_t* nbytes);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      uint64_t num,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /**
    * Writes the processed conditions to storage.
    *
+   * @param loaded_metadata The loaded fragment metadata.
    * @param encryption_key The encryption key.
    * @param nbytes The total number of bytes written.
    */
   void store_processed_conditions(
-      const EncryptionKey& encryption_key, uint64_t* nbytes);
-
-  /**
-   * Compute the fragment min, max and sum values.
-   *
-   * @param name The attribute/dimension name.
-   */
-  template <class T>
-  void compute_fragment_min_max_sum(const std::string& name);
-
-  /**
-   * Compute the fragment sum value.
-   *
-   * @param idx The attribute/dimension index.
-   * @param nullable Is the attribute/dimension nullable.
-   */
-  template <class SumT>
-  void compute_fragment_sum(const uint64_t idx, const bool nullable);
-
-  /**
-   * Compute the fragment min and max values for var sized attributes.
-   *
-   * @param name The attribute/dimension name.
-   */
-  void min_max_var(const std::string& name);
+      shared_ptr<LoadedFragmentMetadata> loaded_metadata,
+      const EncryptionKey& encryption_key,
+      uint64_t* nbytes);
 
   /** Writes the format version to the buffer. */
   void write_version(Serializer& serializer) const;

--- a/tiledb/sm/fragment/loaded_fragment_metadata.h
+++ b/tiledb/sm/fragment/loaded_fragment_metadata.h
@@ -588,6 +588,94 @@ class LoadedFragmentMetadata {
     return processed_conditions_set_;
   }
 
+  /**
+   * Sets the input tile's MBR in the fragment metadata.
+   *
+   * @param tile The tile index whose MBR will be set.
+   * @param mbr The MBR to be set.
+   */
+  void set_mbr(uint64_t tile, const NDRange& mbr);
+
+  /** Returns the MBR of the input tile. */
+  const NDRange& LoadedFragmentMetadata::mbr(uint64_t tile_idx) const {
+    return rtree().leaf(tile_idx);
+  }
+
+  /** Returns all the MBRs of all tiles in the fragment. */
+  const tdb::pmr::vector<NDRange>& LoadedFragmentMetadata::mbrs() const {
+    return rtree().leaves();
+  }
+
+  /**
+   * Retrieves the tile min value for a given attribute or dimension and tile
+   * index.
+   *
+   * @param name The input attribute/dimension.
+   * @param tile_idx The index of the tile in the metadata.
+   * @return Value.
+   */
+  template <typename T>
+  T get_tile_min_as(const std::string& name, uint64_t tile_idx) const;
+
+  /**
+   * Returns the tile metadata for a tile.
+   *
+   * @param name Name of the attribute to get the data for.
+   * @param tile_idx Tile index.
+   */
+  TileMetadata get_tile_metadata(
+      const std::string& name, const uint64_t tile_idx) const;
+
+  /**
+   * Retrieves the tile max value for a given attribute or dimension and tile
+   * index.
+   *
+   * @tparam Type to return the data as.
+   * @param name The input attribute/dimension.
+   * @param tile_idx The index of the tile in the metadata.
+   * @return Value.
+   */
+  template <typename T>
+  T get_tile_max_as(const std::string& name, uint64_t tile_idx) const;
+
+  /**
+   * Set the processed conditions. The processed conditions is the list
+   * of delete/update conditions that have already been applied for this
+   * fragment and don't need to be applied again.
+   *
+   * @param processed_conditions The processed conditions.
+   */
+  void set_processed_conditions(std::vector<std::string>& processed_conditions);
+
+  /**
+   * Compute fragment min, max, sum, null count for all dimensions/attributes.
+   */
+  void compute_fragment_min_max_sum_null_count();
+
+  /**
+   * Compute the fragment min, max and sum values.
+   *
+   * @param name The attribute/dimension name.
+   */
+  template <class T>
+  void compute_fragment_min_max_sum(const std::string& name);
+
+  /**
+   * Compute the fragment sum value.
+   *
+   * @param idx The attribute/dimension index.
+   * @param nullable Is the attribute/dimension nullable.
+   */
+  template <class SumT>
+  void compute_fragment_sum(const uint64_t idx, const bool nullable);
+
+  /**
+   * Compute the fragment min and max values for var sized attributes.
+   *
+   * @param name The attribute/dimension name.
+   */
+  void min_max_var(const std::string& name);
+
  protected:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/query/legacy/reader.cc
+++ b/tiledb/sm/query/legacy/reader.cc
@@ -2122,7 +2122,8 @@ Status Reader::add_extra_offset() {
 
 bool Reader::sparse_tile_overwritten(
     unsigned frag_idx, uint64_t tile_idx) const {
-  const auto& mbr = fragment_metadata_[frag_idx]->mbr(tile_idx);
+  const auto& mbr =
+      fragment_metadata_[frag_idx]->loaded_metadata()->mbr(tile_idx);
   assert(!mbr.empty());
   auto fragment_num = (unsigned)fragment_metadata_.size();
   auto& domain{array_schema_.domain()};

--- a/tiledb/sm/query/readers/attribute_order_validator.h
+++ b/tiledb/sm/query/readers/attribute_order_validator.h
@@ -297,12 +297,14 @@ class AttributeOrderValidator {
           // Increasing data: The first value on f is the minimum on f. Check
           // that it is greater than the last (maximum) value in the proceeding
           // tile on f2.
-          auto value = fragment_metadata[f]->get_tile_min_as<AttributeType>(
-              attribute_name_, 0);
+          auto value = fragment_metadata[f]
+                           ->loaded_metadata()
+                           ->get_tile_min_as<AttributeType>(attribute_name_, 0);
 
-          auto value_previous =
-              fragment_metadata[f2]->get_tile_max_as<AttributeType>(
-                  attribute_name_, f2_tile_idx);
+          auto value_previous = fragment_metadata[f2]
+                                    ->loaded_metadata()
+                                    ->get_tile_max_as<AttributeType>(
+                                        attribute_name_, f2_tile_idx);
 
           if (value_previous >= value) {
             throw AttributeOrderValidatorStatusException(
@@ -312,12 +314,14 @@ class AttributeOrderValidator {
           // Decreasing data: The first value on f is the maximum of f. Check
           // that is is less than the last (minimum) value in the proceeding
           // tile on f2.
-          auto value = fragment_metadata[f]->get_tile_max_as<AttributeType>(
-              attribute_name_, 0);
+          auto value = fragment_metadata[f]
+                           ->loaded_metadata()
+                           ->get_tile_max_as<AttributeType>(attribute_name_, 0);
 
-          auto value_previous =
-              fragment_metadata[f2]->get_tile_min_as<AttributeType>(
-                  attribute_name_, f2_tile_idx);
+          auto value_previous = fragment_metadata[f2]
+                                    ->loaded_metadata()
+                                    ->get_tile_min_as<AttributeType>(
+                                        attribute_name_, f2_tile_idx);
 
           if (value_previous <= value) {
             throw AttributeOrderValidatorStatusException(
@@ -359,11 +363,14 @@ class AttributeOrderValidator {
           // Increasing data: The last value on f is the maximum on f. Check
           // that is less than the first (minimum) value on the following
           // tile in f2.
-          auto value = fragment_metadata[f]->get_tile_max_as<AttributeType>(
-              attribute_name_, max_tile_idx);
-          auto value_next =
-              fragment_metadata[f2]->get_tile_min_as<AttributeType>(
-                  attribute_name_, f2_tile_idx);
+          auto value = fragment_metadata[f]
+                           ->loaded_metadata()
+                           ->get_tile_max_as<AttributeType>(
+                               attribute_name_, max_tile_idx);
+          auto value_next = fragment_metadata[f2]
+                                ->loaded_metadata()
+                                ->get_tile_min_as<AttributeType>(
+                                    attribute_name_, f2_tile_idx);
           if (value_next <= value) {
             throw AttributeOrderValidatorStatusException(
                 "Attribute out of order");
@@ -373,11 +380,14 @@ class AttributeOrderValidator {
           // Decreasinging data: The last value on f is the minimum on f. Check
           // that is greater than the first (maximum) value on the following
           // tile in f2.
-          auto value = fragment_metadata[f]->get_tile_min_as<AttributeType>(
-              attribute_name_, max_tile_idx);
-          auto value_next =
-              fragment_metadata[f2]->get_tile_max_as<AttributeType>(
-                  attribute_name_, f2_tile_idx);
+          auto value = fragment_metadata[f]
+                           ->loaded_metadata()
+                           ->get_tile_min_as<AttributeType>(
+                               attribute_name_, max_tile_idx);
+          auto value_next = fragment_metadata[f2]
+                                ->loaded_metadata()
+                                ->get_tile_max_as<AttributeType>(
+                                    attribute_name_, f2_tile_idx);
           if (value_next >= value) {
             throw AttributeOrderValidatorStatusException(
                 "Attribute out of order");
@@ -422,8 +432,9 @@ class AttributeOrderValidator {
 
     if (!val_data.min_validated_) {
       // Get the min of the current fragment.
-      auto value = fragment_metadata[f]->get_tile_min_as<AttributeType>(
-          attribute_name_, 0);
+      auto value = fragment_metadata[f]
+                       ->loaded_metadata()
+                       ->get_tile_min_as<AttributeType>(attribute_name_, 0);
 
       // Get the previous value from the loaded tile.
       auto rt = min_tile_to_compare_against(f);
@@ -454,8 +465,10 @@ class AttributeOrderValidator {
     if (!val_data.max_validated_) {
       // Get the min of the current fragment.
       auto max_tile_idx = fragment_metadata[f]->tile_num() - 1;
-      auto value = fragment_metadata[f]->get_tile_max_as<AttributeType>(
-          attribute_name_, max_tile_idx);
+      auto value =
+          fragment_metadata[f]
+              ->loaded_metadata()
+              ->get_tile_max_as<AttributeType>(attribute_name_, max_tile_idx);
 
       // Get the previous value from the loaded tile.
       auto rt = max_tile_to_compare_against(f);

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -1472,7 +1472,8 @@ Status DenseReader::process_aggregates(
             auto& rt = result_space_tile.single_result_tile();
             auto tile_idx = rt.tile_idx();
             auto& frag_md = fragment_metadata_[rt.frag_idx()];
-            auto md = frag_md->get_tile_metadata(name, tile_idx);
+            auto md =
+                frag_md->loaded_metadata()->get_tile_metadata(name, tile_idx);
             auto& aggregates = aggregates_[name];
             for (auto& aggregate : aggregates) {
               aggregate->aggregate_tile_with_frag_md(md);

--- a/tiledb/sm/query/readers/ordered_dim_label_reader.cc
+++ b/tiledb/sm/query/readers/ordered_dim_label_reader.cc
@@ -346,9 +346,11 @@ OrderedDimLabelReader::get_array_tile_indexes_for_range(
 
   if (increasing_labels_) {
     const auto min =
-        fragment_metadata_[f]->get_tile_min_as<LabelType>(label_name_, 0);
-    const auto max = fragment_metadata_[f]->get_tile_max_as<LabelType>(
-        label_name_, tile_num - 1);
+        fragment_metadata_[f]->loaded_metadata()->get_tile_min_as<LabelType>(
+            label_name_, 0);
+    const auto max =
+        fragment_metadata_[f]->loaded_metadata()->get_tile_max_as<LabelType>(
+            label_name_, tile_num - 1);
 
     if (start_range < min) {
       start_val_type = IndexValueType::LT;
@@ -362,10 +364,12 @@ OrderedDimLabelReader::get_array_tile_indexes_for_range(
       end_val_type = IndexValueType::GT;
     }
   } else {
-    const auto min = fragment_metadata_[f]->get_tile_min_as<LabelType>(
-        label_name_, tile_num - 1);
+    const auto min =
+        fragment_metadata_[f]->loaded_metadata()->get_tile_min_as<LabelType>(
+            label_name_, tile_num - 1);
     const auto max =
-        fragment_metadata_[f]->get_tile_max_as<LabelType>(label_name_, 0);
+        fragment_metadata_[f]->loaded_metadata()->get_tile_max_as<LabelType>(
+            label_name_, 0);
     if (start_range > max) {
       start_val_type = IndexValueType::LT;
     } else if (start_range < min) {
@@ -383,16 +387,20 @@ OrderedDimLabelReader::get_array_tile_indexes_for_range(
   if (start_val_type == IndexValueType::CONTAINED) {
     if (increasing_labels_) {
       for (; start_index < tile_num; start_index++) {
-        const auto max = fragment_metadata_[f]->get_tile_max_as<LabelType>(
-            label_name_, start_index);
+        const auto max =
+            fragment_metadata_[f]
+                ->loaded_metadata()
+                ->get_tile_max_as<LabelType>(label_name_, start_index);
         if (max >= start_range) {
           break;
         }
       }
     } else {
       for (;; start_index--) {
-        const auto max = fragment_metadata_[f]->get_tile_max_as<LabelType>(
-            label_name_, start_index);
+        const auto max =
+            fragment_metadata_[f]
+                ->loaded_metadata()
+                ->get_tile_max_as<LabelType>(label_name_, start_index);
         if (start_index == 0 || max >= start_range) {
           break;
         }
@@ -404,16 +412,20 @@ OrderedDimLabelReader::get_array_tile_indexes_for_range(
   if (end_val_type == IndexValueType::CONTAINED) {
     if (increasing_labels_) {
       for (;; end_index--) {
-        const auto min = fragment_metadata_[f]->get_tile_min_as<LabelType>(
-            label_name_, end_index);
+        const auto min =
+            fragment_metadata_[f]
+                ->loaded_metadata()
+                ->get_tile_min_as<LabelType>(label_name_, end_index);
         if (end_index == 0 || min <= end_range) {
           break;
         }
       }
     } else {
       for (; end_index < tile_num; end_index++) {
-        const auto min = fragment_metadata_[f]->get_tile_min_as<LabelType>(
-            label_name_, end_index);
+        const auto min =
+            fragment_metadata_[f]
+                ->loaded_metadata()
+                ->get_tile_min_as<LabelType>(label_name_, end_index);
         if (min <= end_range) {
           break;
         }

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -2130,8 +2130,9 @@ void SparseGlobalOrderReader<BitmapType>::process_aggregates(
         if (can_aggregate_tile_with_frag_md(result_cell_slabs[i])) {
           if (range_thread_idx == 0) {
             auto rt = result_cell_slabs[i].tile_;
-            auto md = fragment_metadata_[rt->frag_idx()]->get_tile_metadata(
-                name, rt->tile_idx());
+            auto md = fragment_metadata_[rt->frag_idx()]
+                          ->loaded_metadata()
+                          ->get_tile_metadata(name, rt->tile_idx());
             for (auto& aggregate : aggregates) {
               aggregate->aggregate_tile_with_frag_md(md);
             }

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -632,7 +632,8 @@ void SparseIndexReaderBase::compute_tile_bitmaps(
 
         // Get the MBR for this tile.
         const auto& mbr =
-            fragment_metadata_[rt->frag_idx()]->mbr(rt->tile_idx());
+            fragment_metadata_[rt->frag_idx()]->loaded_metadata()->mbr(
+                rt->tile_idx());
 
         // Compute bitmaps one dimension at a time.
         for (unsigned d = 0; d < dim_num; d++) {

--- a/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
+++ b/tiledb/sm/query/readers/sparse_unordered_with_dups_reader.cc
@@ -1938,8 +1938,9 @@ void SparseUnorderedWithDupsReader<BitmapType>::process_aggregates(
         if (can_aggregate_tile_with_frag_md(rt)) {
           if (range_thread_idx == 0) {
             auto t = rt->tile_idx();
-            auto md =
-                fragment_metadata_[rt->frag_idx()]->get_tile_metadata(name, t);
+            auto md = fragment_metadata_[rt->frag_idx()]
+                          ->loaded_metadata()
+                          ->get_tile_metadata(name, t);
             for (auto& aggregate : aggregates) {
               aggregate->aggregate_tile_with_frag_md(md);
             }

--- a/tools/src/commands/info_command.cc
+++ b/tools/src/commands/info_command.cc
@@ -228,7 +228,7 @@ void InfoCommand::write_svg_mbrs() const {
          max_y = std::numeric_limits<double>::min();
   auto fragment_metadata = array.fragment_metadata();
   for (const auto& f : fragment_metadata) {
-    const auto& mbrs = f->mbrs();
+    const auto& mbrs = f->loaded_metadata()->mbrs();
     for (const auto& mbr : mbrs) {
       auto tup = get_mbr(mbr, schema.domain());
       min_x = std::min(min_x, std::get<0>(tup));
@@ -296,7 +296,7 @@ void InfoCommand::write_text_mbrs() const {
   std::stringstream text;
   for (const auto& f : fragment_metadata) {
     f->loaded_metadata()->load_rtree(*encryption_key);
-    const auto& mbrs = f->mbrs();
+    const auto& mbrs = f->loaded_metadata()->mbrs();
     for (const auto& mbr : mbrs) {
       auto str_mbr = mbr_to_string(mbr, schema.domain());
       for (unsigned i = 0; i < dim_num; i++) {


### PR DESCRIPTION
More context at: https://app.shortcut.com/tiledb-inc/story/54416/break-cycle-between-loadedfragmentmetadata-and-fragmentmetadata

---
TYPE: NO_HISTORY | IMPROVEMENT
DESC: Break cycle between FragmentMetadata and LoadedFragmentMetadata classes
