### PR TITLE
Add an additional C API example "aggregates_string" which demonstrates running min/max on string dimension and emitting coordinates from the same query

### DIFF
--- a/examples/c_api/aggregates_string.c
+++ b/examples/c_api/aggregates_string.c
@@ -1,0 +1,288 @@
+/**
+ * @file   aggregates_string.c
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2018-2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * When run, this program will create a 2D sparse array with one dimension a
+ * string type, and the other an integer. This models closely what a dataframe
+ * looks like. The program will write some data to it, and compute the min
+ * and max values of the string dimension using aggregates.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <tiledb/tiledb.h>
+#include <tiledb/tiledb_experimental.h>
+
+#include "tiledb_examples.h"
+
+// Name of array.
+const char* array_name = "aggregates_string_array";
+
+void create_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // The array will be 2d array with dimensions "rows" and "cols"
+  // "rows" is a string dimension type, so the domain and extent is null
+  int dim_domain[] = {1, 4};
+  int tile_extents[] = {4};
+  tiledb_dimension_t* d1;
+  tiledb_dimension_alloc(ctx, "rows", TILEDB_STRING_ASCII, NULL, NULL, &d1);
+  tiledb_dimension_t* d2;
+  tiledb_dimension_alloc(
+      ctx, "cols", TILEDB_INT32, &dim_domain[0], &tile_extents[0], &d2);
+
+  // Create domain
+  tiledb_domain_t* domain;
+  tiledb_domain_alloc(ctx, &domain);
+  tiledb_domain_add_dimension(ctx, domain, d1);
+  tiledb_domain_add_dimension(ctx, domain, d2);
+
+  // Create a single attribute "a" so each (i,j) cell can store an integer
+  tiledb_attribute_t* a;
+  tiledb_attribute_alloc(ctx, "a", TILEDB_INT32, &a);
+
+  // Create array schema
+  tiledb_array_schema_t* array_schema;
+  tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &array_schema);
+  tiledb_array_schema_set_cell_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_tile_order(ctx, array_schema, TILEDB_ROW_MAJOR);
+  tiledb_array_schema_set_domain(ctx, array_schema, domain);
+  tiledb_array_schema_add_attribute(ctx, array_schema, a);
+
+  // Create array
+  tiledb_array_create(ctx, array_name, array_schema);
+
+  // Clean up
+  tiledb_attribute_free(&a);
+  tiledb_dimension_free(&d1);
+  tiledb_dimension_free(&d2);
+  tiledb_domain_free(&domain);
+  tiledb_array_schema_free(&array_schema);
+  tiledb_ctx_free(&ctx);
+}
+
+void write_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Open array for writing
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, array_name, &array);
+  tiledb_array_open(ctx, array, TILEDB_WRITE);
+
+  // Prepare data for first write
+  char coords_rows_1[] = {"barbazcorgefoo"};
+  uint64_t coords_rows_size_1 = sizeof(coords_rows_1);
+  uint64_t coords_rows_offsets_1[] = {0, 3, 6, 11};
+  uint64_t coords_rows_offsets_size_1 = sizeof(coords_rows_offsets_1);
+  int coords_cols_1[] = {1, 2, 3, 4};
+  uint64_t coords_cols_size_1 = sizeof(coords_cols_1);
+  int data_1[] = {10, 20, 30, 40};
+  uint64_t data_size_1 = sizeof(data_1);
+
+  // Create first query
+  tiledb_query_t* query;
+  tiledb_query_alloc(ctx, array, TILEDB_WRITE, &query);
+
+  // Global order enables writes in stages to a single fragment
+  // but requires input to match global order
+  tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER);
+
+  // Prepare data for first write
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "a", data_1, &data_size_1));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(
+          ctx, query, "rows", coords_rows_1, &coords_rows_size_1));
+  TRY(ctx,
+      tiledb_query_set_offsets_buffer(
+          ctx,
+          query,
+          "rows",
+          coords_rows_offsets_1,
+          &coords_rows_offsets_size_1));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(
+          ctx, query, "cols", coords_cols_1, &coords_cols_size_1));
+
+  // Submit first query
+  TRY(ctx, tiledb_query_submit(ctx, query));
+
+  // Prepare data for second write
+  char coords_rows_2[] = {"garplygraultgubquux"};
+  uint64_t coords_rows_size_2 = sizeof(coords_rows_2);
+  uint64_t coords_rows_offsets_2[] = {0, 6, 12, 15};
+  uint64_t coords_rows_offsets_size_2 = sizeof(coords_rows_offsets_2);
+  int coords_cols_2[] = {1, 2, 3, 4};
+  uint64_t coords_cols_size_2 = sizeof(coords_cols_2);
+  int data_2[] = {50, 60, 70, 80};
+  uint64_t data_size_2 = sizeof(data_2);
+
+  // Reset buffers
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "a", data_2, &data_size_2));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(
+          ctx, query, "rows", coords_rows_2, &coords_rows_size_2));
+  TRY(ctx,
+      tiledb_query_set_offsets_buffer(
+          ctx,
+          query,
+          "rows",
+          coords_rows_offsets_2,
+          &coords_rows_offsets_size_2));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(
+          ctx, query, "cols", coords_cols_2, &coords_cols_size_2));
+
+  // Submit second query
+  TRY(ctx, tiledb_query_submit(ctx, query));
+
+  // Finalize query (IMPORTANT)
+  TRY(ctx, tiledb_query_finalize(ctx, query));
+
+  // Close array
+  tiledb_array_close(ctx, array);
+
+  // Clean up
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
+}
+
+void read_array() {
+  // Create TileDB context
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  // Open array for reading
+  tiledb_array_t* array;
+  tiledb_array_alloc(ctx, array_name, &array);
+  tiledb_array_open(ctx, array, TILEDB_READ);
+
+  // Read entire array - no subarray
+
+  // Calculate maximum buffer sizes
+  uint64_t max_size = 64;  // variable-length result has unknown size
+  uint64_t max_offsets_size = sizeof(uint64_t);
+  uint64_t min_size = 64;  // variable-length result has unknown size
+  uint64_t min_offsets_size = sizeof(uint64_t);
+
+  // Result buffers (1 cell each of unknown size)
+  char* max = (char*)malloc(max_size);
+  uint64_t max_offsets[1];
+  char* min = (char*)malloc(min_size);
+  uint64_t min_offsets[1];
+
+  // Create query
+  tiledb_query_t* query;
+  tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
+
+  // Get the default channel from the query
+  tiledb_query_channel_t* default_channel;
+  tiledb_query_get_default_channel(ctx, query, &default_channel);
+
+  // Apply min aggregate
+  const tiledb_channel_operator_t* operator_min;
+  tiledb_channel_operation_t* min_rows;
+  TRY(ctx, tiledb_channel_operator_min_get(ctx, &operator_min));
+  TRY(ctx,
+      tiledb_create_unary_aggregate(
+          ctx, query, operator_min, "rows", &min_rows));
+  TRY(ctx,
+      tiledb_channel_apply_aggregate(
+          ctx, default_channel, "Min(rows)", min_rows));
+
+  // Apply max aggregate
+  const tiledb_channel_operator_t* operator_max;
+  tiledb_channel_operation_t* max_rows;
+  TRY(ctx, tiledb_channel_operator_max_get(ctx, &operator_max));
+  TRY(ctx,
+      tiledb_create_unary_aggregate(
+          ctx, query, operator_max, "rows", &max_rows));
+  TRY(ctx,
+      tiledb_channel_apply_aggregate(
+          ctx, default_channel, "Max(rows)", max_rows));
+
+  TRY(ctx, tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(ctx, query, "Min(rows)", min, &min_size));
+  TRY(ctx,
+      tiledb_query_set_offsets_buffer(
+          ctx, query, "Min(rows)", min_offsets, &min_offsets_size));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(ctx, query, "Max(rows)", max, &max_size));
+  TRY(ctx,
+      tiledb_query_set_offsets_buffer(
+          ctx, query, "Max(rows)", max_offsets, &max_offsets_size));
+
+  // Submit query
+  tiledb_query_submit(ctx, query);
+
+  // Close array
+  tiledb_array_close(ctx, array);
+
+  // Print out the results.
+  printf(
+      "Min has data %.*s\n",
+      (int)(min_size - min_offsets[0]),
+      &min[min_offsets[0]]);
+  printf(
+      "Max has data %.*s\n",
+      (int)(max_size - max_offsets[0]),
+      &max[max_offsets[0]]);
+
+  // Clean up
+  free((void*)min);
+  free((void*)max);
+  tiledb_aggregate_free(ctx, &min_rows);
+  tiledb_aggregate_free(ctx, &max_rows);
+  tiledb_query_channel_free(ctx, &default_channel);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
+  tiledb_ctx_free(&ctx);
+}
+
+int main() {
+  // Get object type
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+  tiledb_object_t type;
+  tiledb_object_type(ctx, array_name, &type);
+  tiledb_ctx_free(&ctx);
+
+  if (type != TILEDB_ARRAY) {
+    create_array();
+    write_array();
+  }
+
+  read_array();
+  return 0;
+}
+

--- a/examples/c_api/aggregates_string.c
+++ b/examples/c_api/aggregates_string.c
@@ -28,9 +28,9 @@
  * @section DESCRIPTION
  *
  * When run, this program will create a 2D sparse array with one dimension a
- * string type, and the other an integer. This models closely what a dataframe
- * looks like. The program will write some data to it, and compute the min
- * and max values of the string dimension using aggregates.
+ * string type, and the other an integer. The program will write some data to
+ * it, and run a query to select coordinates and compute the min and max values
+ * of the string dimension using aggregates.
  */
 
 #include <stdio.h>
@@ -363,4 +363,3 @@ int main() {
   read_array();
   return 0;
 }
-

--- a/examples/c_api/aggregates_string.c
+++ b/examples/c_api/aggregates_string.c
@@ -105,7 +105,7 @@ void write_array() {
   uint64_t coords_rows_offsets_size_1 = sizeof(coords_rows_offsets_1);
   int coords_cols_1[] = {1, 2, 3, 4};
   uint64_t coords_cols_size_1 = sizeof(coords_cols_1);
-  int data_1[] = {10, 20, 30, 40};
+  int data_1[] = {3, 3, 5, 3};
   uint64_t data_size_1 = sizeof(data_1);
 
   // Create first query
@@ -142,7 +142,7 @@ void write_array() {
   uint64_t coords_rows_offsets_size_2 = sizeof(coords_rows_offsets_2);
   int coords_cols_2[] = {1, 2, 3, 4};
   uint64_t coords_cols_size_2 = sizeof(coords_cols_2);
-  int data_2[] = {50, 60, 70, 80};
+  int data_2[] = {6, 6, 3, 4};
   uint64_t data_size_2 = sizeof(data_2);
 
   // Reset buffers
@@ -186,8 +186,6 @@ void read_array() {
   tiledb_array_alloc(ctx, array_name, &array);
   tiledb_array_open(ctx, array, TILEDB_READ);
 
-  // Read entire array - no subarray
-
   // Calculate maximum buffer sizes
   uint64_t max_size = 64;  // variable-length result has unknown size
   uint64_t max_offsets_size = sizeof(uint64_t);
@@ -203,6 +201,14 @@ void read_array() {
   // Create query
   tiledb_query_t* query;
   tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
+
+  // Query cells with a >= 4
+  tiledb_query_condition_t* qc;
+  tiledb_query_condition_alloc(ctx, &qc);
+  const int32_t a_lower_bound = 4;
+  tiledb_query_condition_init(
+      ctx, qc, "a", &a_lower_bound, sizeof(int32_t), TILEDB_GE);
+  tiledb_query_set_condition(ctx, query, qc);
 
   // Get the default channel from the query
   tiledb_query_channel_t* default_channel;

--- a/examples/c_api/tiledb_examples.h
+++ b/examples/c_api/tiledb_examples.h
@@ -1,0 +1,42 @@
+#ifndef TILEDB_EXAMPLES_H
+#define TILEDB_EXAMPLES_H
+
+#include <stdio.h>
+#include <tiledb/tiledb.h>
+
+static int try_print_error(int line, tiledb_ctx_t* ctx) {
+  // Retrieve the last error that occurred
+  tiledb_error_t* err = NULL;
+  tiledb_ctx_get_last_error(ctx, &err);
+
+  if (err == NULL) {
+    return TILEDB_OK;
+  }
+
+  const char* msg;
+  tiledb_error_message(err, &msg);
+  fprintf(stderr, "%d: %s\n", line, msg);
+
+  // Clean up
+  tiledb_error_free(&err);
+
+  return TILEDB_ERR;
+}
+
+#define IF_ERROR_EXIT(ctx)                               \
+  do {                                                   \
+    if (try_print_error(__LINE__, (ctx)) != TILEDB_OK) { \
+      exit(TILEDB_ERR);                                  \
+    }                                                    \
+  } while (0)
+
+#define TRY(ctx, capi_call)                  \
+  do {                                       \
+    const capi_return_t __ret = (capi_call); \
+    if (__ret != TILEDB_OK) {                \
+      IF_ERROR_EXIT(ctx);                    \
+    }                                        \
+  } while (0)
+
+#endif
+

--- a/examples/c_api/tiledb_examples.h
+++ b/examples/c_api/tiledb_examples.h
@@ -4,6 +4,15 @@
 #include <stdio.h>
 #include <tiledb/tiledb.h>
 
+/**
+ * Attempt to retrieve an error from the tiledb context
+ * and print to stderr if present.
+ *
+ * @param line the line number of the last API call
+ * @param ctx the context pointer
+ *
+ * @return TILEDB_OK if no error was found, TILEDB_ERR if one was.
+ */
 static int try_print_error(int line, tiledb_ctx_t* ctx) {
   // Retrieve the last error that occurred
   tiledb_error_t* err = NULL;
@@ -23,6 +32,10 @@ static int try_print_error(int line, tiledb_ctx_t* ctx) {
   return TILEDB_ERR;
 }
 
+/**
+ * Attempt to retrieve an error from the tiledb context.
+ * If present, print to stderr and exit.
+ */
 #define IF_ERROR_EXIT(ctx)                               \
   do {                                                   \
     if (try_print_error(__LINE__, (ctx)) != TILEDB_OK) { \
@@ -30,6 +43,9 @@ static int try_print_error(int line, tiledb_ctx_t* ctx) {
     }                                                    \
   } while (0)
 
+/**
+ * Run a tiledb API and then check for errors, exiting if one is found.
+ */
 #define TRY(ctx, capi_call)                  \
   do {                                       \
     const capi_return_t __ret = (capi_call); \
@@ -39,4 +55,3 @@ static int try_print_error(int line, tiledb_ctx_t* ctx) {
   } while (0)
 
 #endif
-


### PR DESCRIPTION
An example like this would have been a useful reference when building the query aggregate API in `tiledb-rs` (and in fact it shows that we did a few things wrong over there).

So, we combine the `quickstart_sparse_string.c` and `aggregates.c` examples into a new example which demonstrates the above.

I have also added `tiledb_examples.h` with some functions/macros to do error checking.  Whenever I have played with one of the examples to make a bug reproducer or learn a bit I am adding a bunch of error checks to see if I am doing anything wrong.  Error checking should be a standard part of the examples and this header provides a fairly non-intrusive way to do it.

---
TYPE: IMPROVEMENT
DESC: Add aggregates_string.c example and tiledb_examples.h for common example code
