### PR TITLE
Fix dangling memory tracker references in the buffer and buffer list C API handles et. al.

### DIFF
--- a/test/src/test-cppapi-consolidation-plan.cc
+++ b/test/src/test-cppapi-consolidation-plan.cc
@@ -188,17 +188,9 @@ tiledb::sm::ConsolidationPlan CppConsolidationPlanFx::call_handler(
     const Array& array,
     tiledb::sm::SerializationType stype) {
   auto req_buf = tiledb_buffer_handle_t::make_handle(
-      ctx_.ptr()
-          .get()
-          ->resources()
-          .serialization_memory_tracker()
-          ->get_resource(tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx_.ptr().get()->resources().serialization_memory_tracker());
   auto resp_buf = tiledb_buffer_handle_t::make_handle(
-      ctx_.ptr()
-          .get()
-          ->resources()
-          .serialization_memory_tracker()
-          ->get_resource(tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx_.ptr().get()->resources().serialization_memory_tracker());
 
   tiledb::sm::serialization::serialize_consolidation_plan_request(
       fragment_size, cfg_.ptr()->config(), stype, req_buf->buffer());

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -214,11 +214,9 @@ TEST_CASE_METHOD(
   auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
   auto stype = TILEDB_CAPNP;
   auto req_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
   auto resp_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
 
   auto rval = tiledb_handle_load_array_schema_request(
       nullptr,
@@ -325,11 +323,9 @@ TEST_CASE_METHOD(
   auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
   auto stype = TILEDB_CAPNP;
   auto req_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
   auto resp_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
 
   auto rval = tiledb_handle_query_plan_request(
       nullptr,
@@ -374,11 +370,9 @@ TEST_CASE_METHOD(
   auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
   auto stype = TILEDB_CAPNP;
   auto req_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
   auto resp_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
 
   auto rval = tiledb_handle_consolidation_plan_request(
       nullptr,
@@ -536,11 +530,9 @@ HandleLoadArraySchemaRequestFx::call_handler(
   auto ctx = tiledb::Context();
   auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
   auto req_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
   auto resp_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
 
   serialization::serialize_load_array_schema_request(
       cfg_, req, stype, req_buf->buffer());
@@ -591,11 +583,9 @@ QueryPlan HandleQueryPlanRequestFx::call_handler(
   auto ctx = tiledb::Context();
   auto array = tiledb::Array(ctx, uri_.to_string(), TILEDB_READ);
   auto req_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
   auto resp_buf = tiledb_buffer_handle_t::make_handle(
-      ctx.ptr()->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx.ptr()->resources().serialization_memory_tracker());
 
   serialization::serialize_query_plan_request(
       cfg_, query, stype, req_buf->buffer());

--- a/test/src/unit.cc
+++ b/test/src/unit.cc
@@ -17,6 +17,16 @@ int store_g_vfs(std::string&& vfs, std::vector<std::string> vfs_fs);
 }  // namespace tiledb
 
 int main(const int argc, char** const argv) {
+#if defined(_MSC_VER)
+  // We disable the following events on abort in CI environments:
+  // _WRITE_ABORT_MSG: Display message box with Abort, Retry, Ignore
+  // _CALL_REPORTFAULT: Send an error report to Microsoft
+  // The second parameter specifies which flags to change, and the first
+  // the value of these flags.
+  if (std::getenv("CI") != nullptr) {
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+  }
+#endif
   Catch::Session session;
 
   // Define acceptable VFS values.

--- a/tiledb/api/c_api/buffer/buffer_api.cc
+++ b/tiledb/api/c_api/buffer/buffer_api.cc
@@ -44,8 +44,7 @@ capi_return_t tiledb_buffer_alloc(
   ensure_context_is_valid(ctx);
   ensure_output_pointer_is_valid(buffer);
   *buffer = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
   return TILEDB_OK;
 }
 

--- a/tiledb/api/c_api/buffer_list/buffer_list_api.cc
+++ b/tiledb/api/c_api/buffer_list/buffer_list_api.cc
@@ -75,7 +75,7 @@ capi_return_t tiledb_buffer_list_get_buffer(
 
   // Create a non-owning wrapper of the underlying buffer
   *buffer = tiledb_buffer_handle_t::make_handle(
-      b.data(), b.size(), buffer_list->buffer_list().get_allocator());
+      b.data(), b.size(), buffer_list->memory_tracker());
 
   return TILEDB_OK;
 }
@@ -89,18 +89,14 @@ capi_return_t tiledb_buffer_list_get_total_size(
 }
 
 capi_return_t tiledb_buffer_list_flatten(
-    tiledb_ctx_handle_t* ctx,
-    tiledb_buffer_list_t* buffer_list,
-    tiledb_buffer_t** buffer) {
+    tiledb_buffer_list_t* buffer_list, tiledb_buffer_t** buffer) {
   ensure_buffer_list_is_valid(buffer_list);
   ensure_output_pointer_is_valid(buffer);
 
   // Create a serialization buffer
   const auto nbytes = buffer_list->buffer_list().total_size();
   *buffer = tiledb_buffer_t::make_handle(
-      buffer_list->buffer_list().total_size(),
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      buffer_list->buffer_list().total_size(), buffer_list->memory_tracker());
 
   try {
     // Read all into the dest buffer
@@ -164,6 +160,6 @@ CAPI_INTERFACE(
     tiledb_ctx_t* ctx,
     tiledb_buffer_list_t* buffer_list,
     tiledb_buffer_t** buffer) {
-  return api_entry_with_context<tiledb::api::tiledb_buffer_list_flatten>(
+  return api_entry_context<tiledb::api::tiledb_buffer_list_flatten>(
       ctx, buffer_list, buffer);
 }

--- a/tiledb/api/c_api/buffer_list/buffer_list_api_internal.h
+++ b/tiledb/api/c_api/buffer_list/buffer_list_api_internal.h
@@ -34,8 +34,10 @@
 #define TILEDB_CAPI_BUFFER_LIST_API_INTERNAL_H
 
 #include "../../c_api_support/handle/handle.h"
+#include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/buffer/buffer_list.h"
+
 struct tiledb_buffer_list_handle_t
     : public tiledb::api::CAPIHandle<tiledb_buffer_list_handle_t> {
   /**
@@ -44,11 +46,14 @@ struct tiledb_buffer_list_handle_t
   static constexpr std::string_view object_type_name{"buffer list"};
 
  private:
+  shared_ptr<tiledb::sm::MemoryTracker> memory_tracker_;
   tiledb::sm::BufferList buffer_list_;
 
  public:
-  explicit tiledb_buffer_list_handle_t(auto&&... args)
-      : buffer_list_(std::forward<decltype(args)>(args)...) {
+  explicit tiledb_buffer_list_handle_t(
+      shared_ptr<tiledb::sm::MemoryTracker> memory_tracker)
+      : memory_tracker_(std::move(memory_tracker))
+      , buffer_list_(memory_tracker_) {
   }
 
   [[nodiscard]] inline tiledb::sm::BufferList& buffer_list() {
@@ -57,6 +62,11 @@ struct tiledb_buffer_list_handle_t
 
   [[nodiscard]] inline const tiledb::sm::BufferList& buffer_list() const {
     return buffer_list_;
+  }
+
+  [[nodiscard]] inline const shared_ptr<tiledb::sm::MemoryTracker>
+  memory_tracker() const {
+    return memory_tracker_;
   }
 };
 

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -415,8 +415,7 @@ capi_return_t tiledb_serialize_group(
 
   // ALERT: Conditional Handle Construction
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   // We're not using throw_if_not_ok here because we have to
   // clean up our allocated buffer if serialization fails.
@@ -461,8 +460,7 @@ capi_return_t tiledb_serialize_group_metadata(
 
   // ALERT: Conditional Handle Construction
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   // Get metadata to serialize, this will load it if it does not exist
   auto metadata = group->group().metadata();

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2344,8 +2344,7 @@ int32_t tiledb_serialize_array(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2436,8 +2435,7 @@ int32_t tiledb_serialize_array_schema(
 
   // Create buffer
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2491,8 +2489,7 @@ int32_t tiledb_serialize_array_open(
   }
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2579,8 +2576,7 @@ int32_t tiledb_serialize_array_schema_evolution(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2798,8 +2794,7 @@ int32_t tiledb_serialize_array_nonempty_domain(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2856,8 +2851,7 @@ int32_t tiledb_serialize_array_non_empty_domain_all_dimensions(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -2905,8 +2899,7 @@ int32_t tiledb_serialize_array_max_buffer_sizes(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   // Serialize
   if (SAVE_ERROR_CATCH(
@@ -2990,8 +2983,7 @@ int32_t tiledb_serialize_array_metadata(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   // Get metadata to serialize, this will load it if it does not exist
   sm::Metadata* metadata = nullptr;
@@ -3052,8 +3044,7 @@ int32_t tiledb_serialize_query_est_result_sizes(
     return TILEDB_ERR;
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -3103,8 +3094,7 @@ int32_t tiledb_serialize_config(
   api::ensure_config_is_valid(config);
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -3166,8 +3156,7 @@ int32_t tiledb_serialize_fragment_info_request(
   }
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   if (SAVE_ERROR_CATCH(
           ctx,
@@ -3224,8 +3213,7 @@ int32_t tiledb_serialize_fragment_info(
   }
 
   auto buf = tiledb_buffer_handle_t::make_handle(
-      ctx->resources().serialization_memory_tracker()->get_resource(
-          tiledb::sm::MemoryType::SERIALIZATION_BUFFER));
+      ctx->resources().serialization_memory_tracker());
 
   // Serialize
   if (SAVE_ERROR_CATCH(


### PR DESCRIPTION
[SC-55087](https://app.shortcut.com/tiledb-inc/story/55087/do-not-show-message-dialog-on-debug-assertion-failures-in-tiledb-unit-on-windows-ci)

Fixes #5295

Several tests allocate a `tiledb_buffer_t*` but never free it. When the context that created the buffer gets freed, the buffer's memory tracker gets freed, which causes a debug assertion to fail because that tracker had some outstanding memory allocated.

This PR fixes it by adding a `shared_ptr<MemoryTracker>` field in `tiledb_buffer(_list)_handle_t`, ensuring the memory tracker does not outlive the C API handles.

While the assertion failures could be avoided by patching the buffer handle leaks, freeing a buffer handle (or any kind of handle) after its context should not fail unless in extreme cases. Memory leaks in test code will be addressed in a subsequent PR (opened SC-55086 to track this work).

I also updated `tiledb_unit` to not display a message box on assertion failures when running on Windows CI, which caused timeouts similar to #4250. We should eventually do this to all Catch2 tests.

---
TYPE: NO_HISTORY