### PR TITLE
Do not show message dialog on debug assertion failures in the standalone tests on Windows CI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,9 +433,9 @@ if(TILEDB_TESTS)
   # Add custom Catch2 entry point that suppresses message boxes on debug assertion
   # failures on Windows CI.
   find_package(Catch2 REQUIRED)
-  add_library(tdb_Catch2WithMain STATIC
+  add_library(tiledb_Catch2WithMain STATIC
     test/support/src/tdb_catch_main.cc)
-  target_link_libraries(tdb_Catch2WithMain PUBLIC Catch2::Catch2)
+  target_link_libraries(tiledb_Catch2WithMain PUBLIC Catch2::Catch2)
 endif()
 
 # -------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,6 +429,15 @@ target_include_directories(local_install INTERFACE ${CMAKE_SOURCE_DIR})
 # Enable testing
 enable_testing()
 
+if(TILEDB_TESTS)
+  # Add custom Catch2 entry point that suppresses message boxes on debug assertion
+  # failures on Windows CI.
+  find_package(Catch2 REQUIRED)
+  add_library(tdb_Catch2WithMain STATIC
+    test/support/src/tdb_catch_main.cc)
+  target_link_libraries(tdb_Catch2WithMain PUBLIC Catch2::Catch2)
+endif()
+
 # -------------------------------------------------------
 # Accumulators for object libraries and unit tests
 # -------------------------------------------------------

--- a/cmake/unit_test.cmake
+++ b/cmake/unit_test.cmake
@@ -167,7 +167,7 @@ macro(TileDB_Environment_unit_test_end)
     target_sources(${TileDB_Environment_unit_test_end_Unit_Test} PRIVATE ${TileDB_Environment_unit_test_end_Sources})
     # Catch2 is always a dependency of our unit tests
     find_package(Catch2 REQUIRED)
-    target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC tdb_Catch2WithMain)
+    target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC tiledb_Catch2WithMain)
     foreach(Object_Library IN LISTS TileDB_Environment_unit_test_end_OL_Dependencies)
         target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC ${Object_Library})
     endforeach()

--- a/cmake/unit_test.cmake
+++ b/cmake/unit_test.cmake
@@ -167,7 +167,7 @@ macro(TileDB_Environment_unit_test_end)
     target_sources(${TileDB_Environment_unit_test_end_Unit_Test} PRIVATE ${TileDB_Environment_unit_test_end_Sources})
     # Catch2 is always a dependency of our unit tests
     find_package(Catch2 REQUIRED)
-    target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC Catch2::Catch2WithMain)
+    target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC tdb_Catch2WithMain)
     foreach(Object_Library IN LISTS TileDB_Environment_unit_test_end_OL_Dependencies)
         target_link_libraries(${TileDB_Environment_unit_test_end_Unit_Test} PUBLIC ${Object_Library})
     endforeach()

--- a/experimental/tiledb/common/dag/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/CMakeLists.txt
@@ -64,7 +64,7 @@ macro (dag_add_header_only_unit_test TESTNAME)
     #
     # Required libraries
     #
-    target_link_libraries(unit_${TESTNAME} PUBLIC tdb_Catch2WithMain)
+    target_link_libraries(unit_${TESTNAME} PUBLIC tiledb_Catch2WithMain)
     #
     # Define sources for test
     #

--- a/experimental/tiledb/common/dag/CMakeLists.txt
+++ b/experimental/tiledb/common/dag/CMakeLists.txt
@@ -64,7 +64,7 @@ macro (dag_add_header_only_unit_test TESTNAME)
     #
     # Required libraries
     #
-    target_link_libraries(unit_${TESTNAME} PUBLIC Catch2::Catch2WithMain)
+    target_link_libraries(unit_${TESTNAME} PUBLIC tdb_Catch2WithMain)
     #
     # Define sources for test
     #

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,8 +26,6 @@
 # THE SOFTWARE.
 #
 
-find_package(Catch2 REQUIRED)
-
 # Include TileDB core header directories
 set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 # Include the C API directory so that the C++ 'tiledb' file can directly
@@ -309,7 +307,7 @@ if (TILEDB_ARROW_TESTS)
     PUBLIC
       TILEDB_CORE_OBJECTS_ILIB
       TILEDB_CORE_OBJECTS
-      Catch2::Catch2WithMain
+      tdb_Catch2WithMain
       pybind11::embed
       tiledb_test_support_lib
       configuration_definitions

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -307,7 +307,7 @@ if (TILEDB_ARROW_TESTS)
     PUBLIC
       TILEDB_CORE_OBJECTS_ILIB
       TILEDB_CORE_OBJECTS
-      tdb_Catch2WithMain
+      tiledb_Catch2WithMain
       pybind11::embed
       tiledb_test_support_lib
       configuration_definitions

--- a/test/ci/CMakeLists.txt
+++ b/test/ci/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(test_assert
     Catch2::Catch2
 )
 
-target_link_libraries(test_assert PUBLIC tdb_Catch2WithMain)
+target_link_libraries(test_assert PUBLIC tiledb_Catch2WithMain)
 
 if (TILEDB_ASSERTIONS)
   target_compile_definitions(

--- a/test/ci/CMakeLists.txt
+++ b/test/ci/CMakeLists.txt
@@ -1,7 +1,5 @@
 include(TileDBAssertions)
 
-find_package(Catch2 REQUIRED)
-
 add_executable(
   test_assert
   test_assert.cc
@@ -13,7 +11,7 @@ target_include_directories(test_assert
     Catch2::Catch2
 )
 
-target_link_libraries(test_assert PUBLIC Catch2::Catch2WithMain)
+target_link_libraries(test_assert PUBLIC tdb_Catch2WithMain)
 
 if (TILEDB_ASSERTIONS)
   target_compile_definitions(

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -26,8 +26,6 @@
 # THE SOFTWARE.
 #
 
-find_package(Catch2 REQUIRED)
-
 # These options not exposed in bootstrap script.
 option(TILEDB_TESTS_AWS_S3_CONFIG "Use an S3 config appropriate for AWS in tests" OFF)
 
@@ -74,7 +72,7 @@ target_include_directories(
 target_link_libraries(tiledb_explore_msys_handle_leakage
   PUBLIC
     TILEDB_CORE_OBJECTS_ILIB
-    Catch2::Catch2WithMain
+    tdb_Catch2WithMain
     tiledb_test_support_lib
 )
 

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -72,7 +72,7 @@ target_include_directories(
 target_link_libraries(tiledb_explore_msys_handle_leakage
   PUBLIC
     TILEDB_CORE_OBJECTS_ILIB
-    tdb_Catch2WithMain
+    tiledb_Catch2WithMain
     tiledb_test_support_lib
 )
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 target_link_libraries(tiledb_regression
   PUBLIC
-    Catch2::Catch2WithMain
+    tdb_Catch2WithMain
     local_install
     tiledb
 )

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 target_link_libraries(tiledb_regression
   PUBLIC
-    tdb_Catch2WithMain
+    tiledb_Catch2WithMain
     local_install
     tiledb
 )

--- a/test/support/src/tdb_catch_main.cc
+++ b/test/support/src/tdb_catch_main.cc
@@ -1,0 +1,52 @@
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+#include <catch2/catch_session.hpp>
+#include <catch2/internal/catch_compiler_capabilities.hpp>
+#include <catch2/internal/catch_config_wchar.hpp>
+#include <catch2/internal/catch_leak_detector.hpp>
+#include <catch2/internal/catch_platform.hpp>
+
+#include <cstdlib>
+
+namespace Catch {
+CATCH_INTERNAL_START_WARNINGS_SUPPRESSION
+CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS
+static LeakDetector leakDetector;
+CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
+}  // namespace Catch
+
+// Allow users of amalgamated .cpp file to remove our main and provide their
+// own.
+#if !defined(CATCH_AMALGAMATED_CUSTOM_MAIN)
+
+#if defined(CATCH_CONFIG_WCHAR) && defined(CATCH_PLATFORM_WINDOWS) && \
+    defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
+// Standard C/C++ Win32 Unicode wmain entry point
+extern "C" int __cdecl wmain(int argc, wchar_t* argv[], wchar_t*[]) {
+#else
+// Standard C/C++ main entry point
+int main(int argc, char* argv[]) {
+#endif
+#if defined(_MSC_VER)
+  // We disable the following events on abort in CI environments:
+  // _WRITE_ABORT_MSG: Display message box with Abort, Retry, Ignore
+  // _CALL_REPORTFAULT: Send an error report to Microsoft
+  // The second parameter specifies which flags to change, and the first
+  // the value of these flags.
+  if (std::getenv("CI") != nullptr) {
+    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+  }
+#endif
+
+  // We want to force the linker not to discard the global variable
+  // and its constructor, as it (optionally) registers leak detector
+  (void)&Catch::leakDetector;
+
+  return Catch::Session().run(argc, argv);
+}
+
+#endif  // !defined(CATCH_AMALGAMATED_CUSTOM_MAIN

--- a/tiledb/api/c_api_support/handle/test/CMakeLists.txt
+++ b/tiledb/api/c_api_support/handle/test/CMakeLists.txt
@@ -25,8 +25,7 @@
 #
 
 add_executable(unit_capi_handle EXCLUDE_FROM_ALL)
-find_package(Catch2 REQUIRED)
-target_link_libraries(unit_capi_handle PUBLIC Catch2::Catch2WithMain)
+target_link_libraries(unit_capi_handle PUBLIC tdb_Catch2WithMain)
 
 # Sources for code under test
 target_link_libraries(unit_capi_handle PUBLIC handle)

--- a/tiledb/api/c_api_support/handle/test/CMakeLists.txt
+++ b/tiledb/api/c_api_support/handle/test/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 add_executable(unit_capi_handle EXCLUDE_FROM_ALL)
-target_link_libraries(unit_capi_handle PUBLIC tdb_Catch2WithMain)
+target_link_libraries(unit_capi_handle PUBLIC tiledb_Catch2WithMain)
 
 # Sources for code under test
 target_link_libraries(unit_capi_handle PUBLIC handle)

--- a/tiledb/common/governor/CMakeLists.txt
+++ b/tiledb/common/governor/CMakeLists.txt
@@ -31,7 +31,7 @@ if (FALSE AND TILEDB_TESTS) # reserved for later
     find_package(Catch2 REQUIRED)
 
     add_executable(unit_governor EXCLUDE_FROM_ALL)
-    target_link_libraries(unit_governor PUBLIC Catch2::Catch2WithMain)
+    target_link_libraries(unit_governor PUBLIC tdb_Catch2WithMain)
 
     # Sources for code under test
     target_sources(unit_dynamic_memory PUBLIC

--- a/tiledb/common/governor/CMakeLists.txt
+++ b/tiledb/common/governor/CMakeLists.txt
@@ -31,7 +31,7 @@ if (FALSE AND TILEDB_TESTS) # reserved for later
     find_package(Catch2 REQUIRED)
 
     add_executable(unit_governor EXCLUDE_FROM_ALL)
-    target_link_libraries(unit_governor PUBLIC tdb_Catch2WithMain)
+    target_link_libraries(unit_governor PUBLIC tiledb_Catch2WithMain)
 
     # Sources for code under test
     target_sources(unit_dynamic_memory PUBLIC


### PR DESCRIPTION
[SC-55089](https://app.shortcut.com/tiledb-inc/story/55089/do-not-show-message-dialog-on-debug-assertion-failures-in-the-standalone-tests-on-windows-ci)

This PR replaces uses of the `Catch2::Catch2WithMain` CMake target with a new `tdb_Catch2WithMain`, that calls `_set_abort_behavior` to suppress showing a message dialog on debug assertion failures on Windows CI, extending what was done in #5305 for `tiledb_unit` to all other test executables.

---
TYPE: NO_HISTORY