### PR TITLE
Remove `rest.ignore_ssl_validation` config option.

### DIFF
--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -711,9 +711,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    If true, incomplete queries received from server are automatically
  *    resubmitted before returning to user control. <br>
  *    **Default**: "true"
- * - `rest.ignore_ssl_validation` <br>
- *    Have curl ignore ssl peer and host validation for REST server. <br>
- *    **Default**: false
  * - `rest.creation_access_credentials_name` <br>
  *    The name of the registered access key to use for creation of the REST
  *    server. <br>

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -885,9 +885,6 @@ class Config {
    *    If true, incomplete queries received from server are automatically
    *    resubmitted before returning to user control. <br>
    *    **Default**: "true"
-   * - `rest.ignore_ssl_validation` <br>
-   *    Have curl ignore ssl peer and host validation for REST server. <br>
-   *    **Default**: false
    * - `rest.creation_access_credentials_name` <br>
    *    The name of the registered access key to use for creation of the REST
    *    server. <br>

--- a/tiledb/sm/filesystem/ssl_config.cc
+++ b/tiledb/sm/filesystem/ssl_config.cc
@@ -109,20 +109,4 @@ S3SSLConfig::S3SSLConfig(const Config& cfg)
   }
 }
 
-RestSSLConfig::RestSSLConfig(const Config& cfg)
-    : SSLConfig(cfg) {
-  // Only override what was found in `ssl.verify` if
-  // `rest.ignore_ssl_verification` is non-default (i.e., true, the naming here
-  // is backwards from all the other ssl verification key names)
-  auto skip_verify = cfg.get<bool>("rest.ignore_ssl_validation");
-  if (skip_verify.has_value() && skip_verify.value()) {
-    LOG_WARN(
-        "The 'rest.ignore_ssl_validation = false' configuration option "
-        "has been replaced with 'ssl.verify = true'. Make sure that you update "
-        "your configuration because 'rest.ignore_ssl_validation' will "
-        "eventually be removed.");
-    verify_ = false;
-  }
-}
-
 }  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/ssl_config.h
+++ b/tiledb/sm/filesystem/ssl_config.h
@@ -73,11 +73,6 @@ class S3SSLConfig : public SSLConfig {
   S3SSLConfig(const Config& cfg);
 };
 
-class RestSSLConfig : public SSLConfig {
- public:
-  RestSSLConfig(const Config& cfg);
-};
-
 }  // namespace tiledb::sm
 
 #endif  // TILEDB_SSL_CONFIG_H

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -277,7 +277,7 @@ Status Curl::init(
     return LOG_STATUS(Status_RestError(
         "Error initializing libcurl; failed to set CURLOPT_HEADERDATA"));
 
-  SSLConfig ssl_cfg = RestSSLConfig(*config_);
+  SSLConfig ssl_cfg(*config_);
 
   if (ssl_cfg.verify() == false) {
     curl_easy_setopt(curl_.get(), CURLOPT_SSL_VERIFYHOST, 0);


### PR DESCRIPTION
[SC-50444](https://app.shortcut.com/tiledb-inc/story/50444/remove-rest-ignore-ssl-validation-config-option)

The `rest.ignore_ssl_validation` config option has been deprecated for more than a year and superseded by the uniform `ssl.verify` (#4087). This PR removes it. Setting `rest.ignore_ssl_validation` will no longer have any effect.

---
TYPE: CONFIG
DESC: The deprecated `rest.ignore_ssl_validation` config option is no longer supported. It is superseded by `ssl.verify` which applies to all network requests.