### PR TITLE
Sleep for five seconds after starting the GCS emulator on Windows.

### DIFF
--- a/scripts/install-run-gcs-emu.ps1
+++ b/scripts/install-run-gcs-emu.ps1
@@ -56,4 +56,7 @@ $env:CLOUD_STORAGE_EMULATOR_ENDPOINT = "http://localhost:9000"
 $testbenchCmd = "start `"Google Cloud Storage Testbench`" /D `"$testbenchPath`" py testbench_run.py localhost 9000 10"
 cmd /c $testbenchCmd
 
+# Wait for the testbench to be prepared. This was added to fix failures in the windows-2019-gcs job.
+Start-Sleep -Seconds 5
+
 Write-Host "Finished."


### PR DESCRIPTION
[SC-54660](https://app.shortcut.com/tiledb-inc/story/54660/see-if-we-can-reproduce-intermittent-gcs-test-failure)

Maybe it fixes the intermittent failures in the Windows 2019 GCS job.

---
TYPE: NO_HISTORY