### PR TITLE
Pass AWS client configuration to the default credentials provider chain.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -192,6 +192,9 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/posix.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3_thread_pool_executor.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/AwsCredentialsProviderChain.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/STSProfileWithWebIdentityCredentialsProvider.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/ssl_config.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/uri.cc

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -192,7 +192,7 @@ set(TILEDB_CORE_SOURCES
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/posix.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3_thread_pool_executor.cc
-  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/AwsCredentialsProviderChain.cc
+  ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
   ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/filesystem/s3/STSProfileWithWebIdentityCredentialsProvider.cc

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -1409,6 +1409,7 @@ Status S3::init_client() const {
         credentials_provider_ = make_shared<
             tiledb::sm::filesystem::s3::DefaultAWSCredentialsProviderChain>(
             HERE(), client_config_);
+        break;
       case 1:
       case 2:
         throw S3Exception(

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -355,13 +355,6 @@ class TileDBS3Client : public Aws::S3::S3Client {
  public:
   TileDBS3Client(
       const S3Parameters& s3_params,
-      const Aws::S3::S3ClientConfiguration& client_config)
-      : Aws::S3::S3Client(client_config)
-      , params_(s3_params) {
-  }
-
-  TileDBS3Client(
-      const S3Parameters& s3_params,
       const std::shared_ptr<Aws::Auth::AWSCredentialsProvider>& creds,
       const Aws::S3::S3ClientConfiguration& client_config)
       : Aws::S3::S3Client(

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -55,7 +55,6 @@
 
 #undef GetObject
 #include <aws/core/Aws.h>
-#include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/http/HttpClient.h>

--- a/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
+++ b/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
@@ -40,6 +40,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#ifdef HAVE_S3
+
 #include "tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h"
 
 #include "tiledb/common/common.h"
@@ -160,3 +162,5 @@ DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(
   }
 }
 }  // namespace tiledb::sm::filesystem::s3
+
+#endif  // HAVE_S3

--- a/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
+++ b/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
@@ -1,92 +1,137 @@
 /**
+ * @file   AWSCredentialsProviderChain.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a vendored copy of the
+ * Aws::Auth::DefaultAWSCredentialsProviderChain class, updated to support
+ * getting a client configuration object.
+ *
+ * Changes made should be contributed upstream to the AWS SDK for C++ and when
+ * that happens, the vendored copy should be removed.
+ */
+
+/**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include "tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h"
+
+#include "tiledb/common/common.h"
+#include "tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h"
+#include "tiledb/sm/filesystem/s3/STSCredentialsProvider.h"
+
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
-#include <aws/core/auth/STSCredentialsProvider.h>
 #include <aws/core/auth/SSOCredentialsProvider.h>
 #include <aws/core/platform/Environment.h>
-#include <aws/core/utils/memory/AWSMemory.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/memory/AWSMemory.h>
 
 using namespace Aws::Auth;
 using namespace Aws::Utils::Threading;
 
+namespace tiledb::sm::filesystem::s3 {
 static const char AWS_EC2_METADATA_DISABLED[] = "AWS_EC2_METADATA_DISABLED";
-static const char DefaultCredentialsProviderChainTag[] = "DefaultAWSCredentialsProviderChain";
+static const char DefaultCredentialsProviderChainTag[] =
+    "DefaultAWSCredentialsProviderChain";
 
-AWSCredentials AWSCredentialsProviderChain::GetAWSCredentials()
-{
-    ReaderLockGuard lock(m_cachedProviderLock);
-    if (m_cachedProvider) {
-      AWSCredentials credentials = m_cachedProvider->GetAWSCredentials();
-      if (!credentials.GetAWSAccessKeyId().empty() && !credentials.GetAWSSecretKey().empty())
-      {
-        return credentials;
-      }
+DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain()
+    : AWSCredentialsProviderChain() {
+  AddProvider(make_shared<EnvironmentAWSCredentialsProvider>(HERE()));
+  AddProvider(make_shared<ProfileConfigFileAWSCredentialsProvider>(HERE()));
+  AddProvider(make_shared<ProcessCredentialsProvider>(HERE()));
+  AddProvider(make_shared<STSAssumeRoleWebIdentityCredentialsProvider>(HERE()));
+  AddProvider(make_shared<SSOCredentialsProvider>(HERE()));
+
+  // General HTTP Credentials (prev. known as ECS TaskRole credentials) only
+  // available when ENVIRONMENT VARIABLE is set
+  const auto relativeUri = Aws::Environment::GetEnv(
+      GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
+  AWS_LOGSTREAM_DEBUG(
+      DefaultCredentialsProviderChainTag,
+      "The environment variable value "
+          << GeneralHTTPCredentialsProvider::
+                 AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+          << " is " << relativeUri);
+
+  const auto absoluteUri = Aws::Environment::GetEnv(
+      GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI);
+  AWS_LOGSTREAM_DEBUG(
+      DefaultCredentialsProviderChainTag,
+      "The environment variable value "
+          << GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI
+          << " is " << absoluteUri);
+
+  const auto ec2MetadataDisabled =
+      Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
+  AWS_LOGSTREAM_DEBUG(
+      DefaultCredentialsProviderChainTag,
+      "The environment variable value " << AWS_EC2_METADATA_DISABLED << " is "
+                                        << ec2MetadataDisabled);
+
+  if (!relativeUri.empty() || !absoluteUri.empty()) {
+    const Aws::String token = Aws::Environment::GetEnv(
+        GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN);
+    const Aws::String tokenPath = Aws::Environment::GetEnv(
+        GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE);
+
+    auto genProvider = make_shared<GeneralHTTPCredentialsProvider>(
+        HERE(), relativeUri, absoluteUri, token, tokenPath);
+    if (genProvider && genProvider->IsValid()) {
+      AddProvider(std::move(genProvider));
+      auto& uri = !relativeUri.empty() ? relativeUri : absoluteUri;
+      AWS_LOGSTREAM_INFO(
+          DefaultCredentialsProviderChainTag,
+          "Added General HTTP / ECS credentials provider with ur: ["
+              << uri << "] to the provider chain with a"
+              << ((token.empty() && tokenPath.empty()) ? "n empty " :
+                                                         " non-empty ")
+              << "authorization token.");
+    } else {
+      AWS_LOGSTREAM_ERROR(
+          DefaultCredentialsProviderChainTag,
+          "Unable to create GeneralHTTPCredentialsProvider");
     }
-    lock.UpgradeToWriterLock();
-    for (auto&& credentialsProvider : m_providerChain)
-    {
-        AWSCredentials credentials = credentialsProvider->GetAWSCredentials();
-        if (!credentials.GetAWSAccessKeyId().empty() && !credentials.GetAWSSecretKey().empty())
-        {
-            m_cachedProvider = credentialsProvider;
-            return credentials;
-        }
-    }
-    return AWSCredentials();
+  } else if (
+      Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true") {
+    AddProvider(make_shared<InstanceProfileCredentialsProvider>(HERE()));
+    AWS_LOGSTREAM_INFO(
+        DefaultCredentialsProviderChainTag,
+        "Added EC2 metadata service credentials provider to the provider "
+        "chain.");
+  }
 }
 
-DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain() : AWSCredentialsProviderChain()
-{
-    AddProvider(Aws::MakeShared<EnvironmentAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
-    AddProvider(Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
-    AddProvider(Aws::MakeShared<ProcessCredentialsProvider>(DefaultCredentialsProviderChainTag));
-    AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag));
-    AddProvider(Aws::MakeShared<SSOCredentialsProvider>(DefaultCredentialsProviderChainTag));
-    
-    // General HTTP Credentials (prev. known as ECS TaskRole credentials) only available when ENVIRONMENT VARIABLE is set
-    const auto relativeUri = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
-    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
-            << " is " << relativeUri);
-
-    const auto absoluteUri = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI);
-    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI
-            << " is " << absoluteUri);
-
-    const auto ec2MetadataDisabled = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
-    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << AWS_EC2_METADATA_DISABLED
-            << " is " << ec2MetadataDisabled);
-
-    if (!relativeUri.empty() || !absoluteUri.empty())
-    {
-        const Aws::String token = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN);
-        const Aws::String tokenPath = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE);
-
-        auto genProvider = Aws::MakeShared<GeneralHTTPCredentialsProvider>(DefaultCredentialsProviderChainTag,
-                                                                           relativeUri, absoluteUri, token, tokenPath);
-        if (genProvider && genProvider->IsValid()) {
-            AddProvider(std::move(genProvider));
-            auto& uri = !relativeUri.empty() ? relativeUri : absoluteUri;
-            AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added General HTTP / ECS credentials provider with ur: ["
-                << uri << "] to the provider chain with a" << ((token.empty() && tokenPath.empty()) ? "n empty " : " non-empty ")
-                << "authorization token.");
-        } else {
-            AWS_LOGSTREAM_ERROR(DefaultCredentialsProviderChainTag, "Unable to create GeneralHTTPCredentialsProvider");
-        }
-    }
-    else if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true")
-    {
-        AddProvider(Aws::MakeShared<InstanceProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
-        AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added EC2 metadata service credentials provider to the provider chain.");
-    }
+DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(
+    const DefaultAWSCredentialsProviderChain& chain) {
+  for (const auto& provider : chain.GetProviders()) {
+    AddProvider(provider);
+  }
 }
-
-DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(const DefaultAWSCredentialsProviderChain& chain) {
-    for (const auto& provider: chain.GetProviders()) {
-        AddProvider(provider);
-    }
-}
+}  // namespace tiledb::sm::filesystem::s3

--- a/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
+++ b/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.cc
@@ -1,0 +1,92 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/auth/STSCredentialsProvider.h>
+#include <aws/core/auth/SSOCredentialsProvider.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/utils/memory/AWSMemory.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/logging/LogMacros.h>
+
+using namespace Aws::Auth;
+using namespace Aws::Utils::Threading;
+
+static const char AWS_EC2_METADATA_DISABLED[] = "AWS_EC2_METADATA_DISABLED";
+static const char DefaultCredentialsProviderChainTag[] = "DefaultAWSCredentialsProviderChain";
+
+AWSCredentials AWSCredentialsProviderChain::GetAWSCredentials()
+{
+    ReaderLockGuard lock(m_cachedProviderLock);
+    if (m_cachedProvider) {
+      AWSCredentials credentials = m_cachedProvider->GetAWSCredentials();
+      if (!credentials.GetAWSAccessKeyId().empty() && !credentials.GetAWSSecretKey().empty())
+      {
+        return credentials;
+      }
+    }
+    lock.UpgradeToWriterLock();
+    for (auto&& credentialsProvider : m_providerChain)
+    {
+        AWSCredentials credentials = credentialsProvider->GetAWSCredentials();
+        if (!credentials.GetAWSAccessKeyId().empty() && !credentials.GetAWSSecretKey().empty())
+        {
+            m_cachedProvider = credentialsProvider;
+            return credentials;
+        }
+    }
+    return AWSCredentials();
+}
+
+DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain() : AWSCredentialsProviderChain()
+{
+    AddProvider(Aws::MakeShared<EnvironmentAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<ProfileConfigFileAWSCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<ProcessCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<STSAssumeRoleWebIdentityCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    AddProvider(Aws::MakeShared<SSOCredentialsProvider>(DefaultCredentialsProviderChainTag));
+    
+    // General HTTP Credentials (prev. known as ECS TaskRole credentials) only available when ENVIRONMENT VARIABLE is set
+    const auto relativeUri = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
+    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+            << " is " << relativeUri);
+
+    const auto absoluteUri = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI);
+    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI
+            << " is " << absoluteUri);
+
+    const auto ec2MetadataDisabled = Aws::Environment::GetEnv(AWS_EC2_METADATA_DISABLED);
+    AWS_LOGSTREAM_DEBUG(DefaultCredentialsProviderChainTag, "The environment variable value " << AWS_EC2_METADATA_DISABLED
+            << " is " << ec2MetadataDisabled);
+
+    if (!relativeUri.empty() || !absoluteUri.empty())
+    {
+        const Aws::String token = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN);
+        const Aws::String tokenPath = Aws::Environment::GetEnv(GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE);
+
+        auto genProvider = Aws::MakeShared<GeneralHTTPCredentialsProvider>(DefaultCredentialsProviderChainTag,
+                                                                           relativeUri, absoluteUri, token, tokenPath);
+        if (genProvider && genProvider->IsValid()) {
+            AddProvider(std::move(genProvider));
+            auto& uri = !relativeUri.empty() ? relativeUri : absoluteUri;
+            AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added General HTTP / ECS credentials provider with ur: ["
+                << uri << "] to the provider chain with a" << ((token.empty() && tokenPath.empty()) ? "n empty " : " non-empty ")
+                << "authorization token.");
+        } else {
+            AWS_LOGSTREAM_ERROR(DefaultCredentialsProviderChainTag, "Unable to create GeneralHTTPCredentialsProvider");
+        }
+    }
+    else if (Aws::Utils::StringUtils::ToLower(ec2MetadataDisabled.c_str()) != "true")
+    {
+        AddProvider(Aws::MakeShared<InstanceProfileCredentialsProvider>(DefaultCredentialsProviderChainTag));
+        AWS_LOGSTREAM_INFO(DefaultCredentialsProviderChainTag, "Added EC2 metadata service credentials provider to the provider chain.");
+    }
+}
+
+DefaultAWSCredentialsProviderChain::DefaultAWSCredentialsProviderChain(const DefaultAWSCredentialsProviderChain& chain) {
+    for (const auto& provider: chain.GetProviders()) {
+        AddProvider(provider);
+    }
+}

--- a/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h
+++ b/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h
@@ -1,0 +1,72 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <memory>
+
+namespace Aws
+{
+    namespace Auth
+    {
+        /**
+         * Abstract class for providing chains of credentials providers. When a credentials provider in the chain returns empty credentials,
+         * We go on to the next provider until we have either exhausted the installed providers in the chain or something returns non-empty credentials.
+         */
+        class AWS_CORE_API AWSCredentialsProviderChain : public AWSCredentialsProvider
+        {
+        public:
+            virtual ~AWSCredentialsProviderChain() = default;
+
+            /**
+             * When a credentials provider in the chain returns empty credentials,
+             * We go on to the next provider until we have either exhausted the installed providers in the chain or something returns non-empty credentials.
+             */
+            virtual AWSCredentials GetAWSCredentials();
+
+            /**
+             * Gets all providers stored in this chain.
+             */
+            const Aws::Vector<std::shared_ptr<AWSCredentialsProvider>>& GetProviders() const { return m_providerChain; }
+
+        protected:
+            /**
+             * This class is only allowed to be initialized by subclasses.
+             */
+            AWSCredentialsProviderChain() = default;
+
+            /**
+             * Adds a provider to the back of the chain.
+             */
+            void AddProvider(const std::shared_ptr<AWSCredentialsProvider>& provider) { m_providerChain.push_back(provider); }
+
+
+        private:
+            Aws::Vector<std::shared_ptr<AWSCredentialsProvider> > m_providerChain;
+            std::shared_ptr<AWSCredentialsProvider> m_cachedProvider;
+            mutable Aws::Utils::Threading::ReaderWriterLock m_cachedProviderLock;
+        };
+
+        /**
+         * Creates an AWSCredentialsProviderChain which uses in order EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
+         * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider.
+         */
+        class AWS_CORE_API DefaultAWSCredentialsProviderChain : public AWSCredentialsProviderChain
+        {
+        public:
+            /**
+             * Initializes the provider chain with EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
+             * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider in that order.
+             */
+            DefaultAWSCredentialsProviderChain();
+
+            DefaultAWSCredentialsProviderChain(const DefaultAWSCredentialsProviderChain& chain);
+        };
+
+    } // namespace Auth
+} // namespace Aws

--- a/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h
+++ b/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h
@@ -1,72 +1,72 @@
 /**
+ * @file   AWSCredentialsProviderChain.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a vendored copy of the
+ * Aws::Auth::DefaultAWSCredentialsProviderChain class, updated to support
+ * getting a client configuration object.
+ *
+ * Changes made should be contributed upstream to the AWS SDK for C++ and when
+ * that happens, the vendored copy should be removed.
+ */
+
+/**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
 
 #pragma once
 
-#include <aws/core/Core_EXPORTS.h>
-#include <aws/core/utils/memory/stl/AWSVector.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/utils/memory/stl/AWSVector.h>
 #include <memory>
 
-namespace Aws
-{
-    namespace Auth
-    {
-        /**
-         * Abstract class for providing chains of credentials providers. When a credentials provider in the chain returns empty credentials,
-         * We go on to the next provider until we have either exhausted the installed providers in the chain or something returns non-empty credentials.
-         */
-        class AWS_CORE_API AWSCredentialsProviderChain : public AWSCredentialsProvider
-        {
-        public:
-            virtual ~AWSCredentialsProviderChain() = default;
+namespace tiledb::sm::filesystem::s3 {
+/**
+ * Creates an AWSCredentialsProviderChain which uses in order
+ * EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
+ * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and
+ * SSOCredentialsProvider.
+ */
+class DefaultAWSCredentialsProviderChain
+    : public Aws::Auth::AWSCredentialsProviderChain {
+ public:
+  /**
+   * Initializes the provider chain with EnvironmentAWSCredentialsProvider,
+   * ProfileConfigFileAWSCredentialsProvider, ProcessCredentialsProvider,
+   * STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider in
+   * that order.
+   */
+  DefaultAWSCredentialsProviderChain();
 
-            /**
-             * When a credentials provider in the chain returns empty credentials,
-             * We go on to the next provider until we have either exhausted the installed providers in the chain or something returns non-empty credentials.
-             */
-            virtual AWSCredentials GetAWSCredentials();
+  DefaultAWSCredentialsProviderChain(
+      const DefaultAWSCredentialsProviderChain& chain);
+};
 
-            /**
-             * Gets all providers stored in this chain.
-             */
-            const Aws::Vector<std::shared_ptr<AWSCredentialsProvider>>& GetProviders() const { return m_providerChain; }
-
-        protected:
-            /**
-             * This class is only allowed to be initialized by subclasses.
-             */
-            AWSCredentialsProviderChain() = default;
-
-            /**
-             * Adds a provider to the back of the chain.
-             */
-            void AddProvider(const std::shared_ptr<AWSCredentialsProvider>& provider) { m_providerChain.push_back(provider); }
-
-
-        private:
-            Aws::Vector<std::shared_ptr<AWSCredentialsProvider> > m_providerChain;
-            std::shared_ptr<AWSCredentialsProvider> m_cachedProvider;
-            mutable Aws::Utils::Threading::ReaderWriterLock m_cachedProviderLock;
-        };
-
-        /**
-         * Creates an AWSCredentialsProviderChain which uses in order EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
-         * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider.
-         */
-        class AWS_CORE_API DefaultAWSCredentialsProviderChain : public AWSCredentialsProviderChain
-        {
-        public:
-            /**
-             * Initializes the provider chain with EnvironmentAWSCredentialsProvider, ProfileConfigFileAWSCredentialsProvider,
-             * ProcessCredentialsProvider, STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider in that order.
-             */
-            DefaultAWSCredentialsProviderChain();
-
-            DefaultAWSCredentialsProviderChain(const DefaultAWSCredentialsProviderChain& chain);
-        };
-
-    } // namespace Auth
-} // namespace Aws
+}  // namespace tiledb::sm::filesystem::s3

--- a/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h
+++ b/tiledb/sm/filesystem/s3/AWSCredentialsProviderChain.h
@@ -62,8 +62,12 @@ class DefaultAWSCredentialsProviderChain
    * ProfileConfigFileAWSCredentialsProvider, ProcessCredentialsProvider,
    * STSAssumeRoleWebIdentityCredentialsProvider and SSOCredentialsProvider in
    * that order.
+   *
+   * @param clientConfig Optional client configuration to use.
    */
-  DefaultAWSCredentialsProviderChain();
+  DefaultAWSCredentialsProviderChain(
+      std::shared_ptr<const Aws::Client::ClientConfiguration> clientConfig =
+          nullptr);
 
   DefaultAWSCredentialsProviderChain(
       const DefaultAWSCredentialsProviderChain& chain);

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
@@ -41,6 +41,7 @@
  */
 
 #include "tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h"
+#include "tiledb/common/common.h"
 
 #include <aws/core/platform/Environment.h>
 #include <aws/core/utils/json/JsonSerializer.h>
@@ -208,6 +209,35 @@ bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(
 
   // both relativeUri and absoluteUri are empty
   return false;
+}
+
+GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(
+    const Aws::Client::ClientConfiguration& clientConfig,
+    const Aws::String& relativeUri,
+    const Aws::String& absoluteUri,
+    const Aws::String& authToken,
+    const Aws::String& authTokenFilePath,
+    long refreshRateMs,
+    ShouldCreateFunc shouldCreateFunc)
+    : m_authTokenFilePath(authTokenFilePath)
+    , m_loadFrequencyMs(refreshRateMs) {
+  if (shouldCreateFunc(relativeUri, absoluteUri, authToken)) {
+    AWS_LOGSTREAM_INFO(
+        GEN_HTTP_LOG_TAG,
+        "Creating GeneralHTTPCredentialsProvider with refresh rate "
+            << refreshRateMs);
+    if (!relativeUri.empty()) {
+      m_ecsCredentialsClient = make_shared<Aws::Internal::ECSCredentialsClient>(
+          HERE(),
+          clientConfig,
+          relativeUri.c_str(),
+          AWS_ECS_CONTAINER_HOST,
+          authToken.c_str());
+    } else if (!absoluteUri.empty()) {
+      m_ecsCredentialsClient = make_shared<Aws::Internal::ECSCredentialsClient>(
+          HERE(), clientConfig, "", absoluteUri.c_str(), authToken.c_str());
+    }
+  }
 }
 
 GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
@@ -40,6 +40,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#ifdef HAVE_S3
+
 #include "tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h"
 #include "tiledb/common/common.h"
 
@@ -383,3 +385,5 @@ void GeneralHTTPCredentialsProvider::RefreshIfExpired() {
   Reload();
 }
 }  // namespace tiledb::sm::filesystem::s3
+
+#endif  // HAVE_S3

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
@@ -1,266 +1,355 @@
 /**
+ * @file   GeneralHTTPCredentialsProvider.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a vendored copy of the
+ * Aws::Auth::GeneralHTTPCredentialsProvider class, updated to support
+ * getting a client configuration object.
+ *
+ * Changes made should be contributed upstream to the AWS SDK for C++ and when
+ * that happens, the vendored copy should be removed.
+ */
+
+/**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include "tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h"
 
-#include <aws/core/auth/GeneralHTTPCredentialsProvider.h>
-
-#include <aws/crt/Api.h>
 #include <aws/core/platform/Environment.h>
-#include <aws/core/utils/logging/LogMacros.h>
 #include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/crt/Api.h>
 #include <fstream>
 
 using namespace Aws::Auth;
 
+namespace tiledb::sm::filesystem::s3 {
 static const char GEN_HTTP_LOG_TAG[] = "GeneralHTTPCredentialsProvider";
 
-const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[] = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
-const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
-const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI[]     = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
-const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN[]      = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+const char
+    GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[] =
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+const char
+    GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[] =
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+const char
+    GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI[] =
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN[] =
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN";
 
-const char GeneralHTTPCredentialsProvider::AWS_ECS_CONTAINER_HOST[]      = "169.254.170.2";
-const char GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST[]      = "169.254.170.23";
-const char GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST_IPV6[] = "fd00:ec2::23";
+const char GeneralHTTPCredentialsProvider::AWS_ECS_CONTAINER_HOST[] =
+    "169.254.170.2";
+const char GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST[] =
+    "169.254.170.23";
+const char GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST_IPV6[] =
+    "fd00:ec2::23";
 
+bool IsAllowedIp(const Aws::String& authority) {
+  // address is an ECS / EKS container host
+  if (authority ==
+      GeneralHTTPCredentialsProvider::AWS_ECS_CONTAINER_HOST)  // ECS container
+                                                               // host
+  {
+    return true;
+  } else if (
+      authority == GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST ||
+      authority == GeneralHTTPCredentialsProvider::
+                       AWS_EKS_CONTAINER_HOST_IPV6) {  // EKS container host
+    return true;
+  }
 
-bool IsAllowedIp(const Aws::String& authority)
-{
-    // address is an ECS / EKS container host
-    if (authority == GeneralHTTPCredentialsProvider::AWS_ECS_CONTAINER_HOST) // ECS container host
-    {
-        return true;
-    } else if (authority == GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST ||
-               authority == GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST_IPV6) { // EKS container host
-        return true;
+  // address is within the loop back
+  // IPv4
+  if (authority.rfind(Aws::String("127.0.0."), 0) == 0 &&
+      authority.size() > 8 && authority.size() <= 11) {
+    Aws::String octet = authority.substr(8);
+    if ((octet.find_first_not_of("0123456789") != Aws::String::npos) ||
+        (Aws::Utils::StringUtils::ConvertToInt32(octet.c_str()) > 255)) {
+      AWS_LOGSTREAM_WARN(
+          GEN_HTTP_LOG_TAG,
+          "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_FULL_URI "
+          "ip address is malformed: "
+              << authority);
+      return false;
+    } else {
+      return true;
     }
+  }
 
-    // address is within the loop back
-    // IPv4
-    if (authority.rfind(Aws::String("127.0.0."), 0) == 0 && authority.size() > 8 && authority.size() <= 11)
-    {
-        Aws::String octet = authority.substr(8);
-        if ((octet.find_first_not_of("0123456789") != Aws::String::npos) ||
-            (Aws::Utils::StringUtils::ConvertToInt32(octet.c_str()) > 255)) {
-            AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_FULL_URI ip address is malformed: " << authority);
-            return false;
-        } else {
-            return true;
-        }
-    }
+  // IPv6
+  if (authority == "::1" || authority == "0:0:0:0:0:0:0:1" ||
+      authority == "[::1]" || authority == "[0:0:0:0:0:0:0:1]") {
+    return true;
+  }
 
-    // IPv6
-    if (authority == "::1" || authority == "0:0:0:0:0:0:0:1" || authority == "[::1]" || authority == "[0:0:0:0:0:0:0:1]")
-    {
-        return true;
-    }
-
-    return false;
+  return false;
 }
 
-bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(const Aws::String& relativeUri, const Aws::String& absoluteUri, const Aws::String authToken)
-{
-    if (authToken.find("\r\n") != Aws::String::npos)
+bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(
+    const Aws::String& relativeUri,
+    const Aws::String& absoluteUri,
+    const Aws::String authToken) {
+  if (authToken.find("\r\n") != Aws::String::npos) {
+    AWS_LOGSTREAM_WARN(
+        GEN_HTTP_LOG_TAG,
+        "Can't use General HTTP Provider: AWS_CONTAINER_AUTHORIZATION_TOKEN "
+        "env value contains invalid characters (\\r\\n)");
+    return false;
+  }
+
+  if (!relativeUri.empty()) {
+    // The provider MAY choose to assert syntactical validity of the resulting
+    // URI perform very basic check here
+    if (relativeUri[0] != '/') {
+      AWS_LOGSTREAM_WARN(
+          GEN_HTTP_LOG_TAG,
+          "Can't use General HTTP Provider: "
+          "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI does not begin with /");
+      return false;
+    } else {
+      // full URI is not used in case of a relative one present
+      return true;
+    }
+  }
+
+  if (!absoluteUri.empty()) {
+    // If the resolved URI’s scheme is HTTPS, its hostname may be used in the
+    // request
+    if (Aws::Utils::StringUtils::ToLower(absoluteUri.c_str())
+            .rfind(Aws::String("https://"), 0) == 0)  // if starts_with
     {
-        AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_AUTHORIZATION_TOKEN env value contains invalid characters (\\r\\n)");
-        return false;
+      return true;
     }
 
-    if (!relativeUri.empty())
-    {
-        // The provider MAY choose to assert syntactical validity of the resulting URI
-        // perform very basic check here
-        if (relativeUri[0] != '/') {
-          AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI does not begin with /");
-          return false;
-        } else {
-          // full URI is not used in case of a relative one present
-          return true;
-        }
+    Aws::Http::URI absUri(absoluteUri);
+    const Aws::String& authority = absUri.GetAuthority();
+
+    // Otherwise, implementations MUST fail to resolve when the URI hostname
+    // does not satisfy any of the following conditions
+    if (IsAllowedIp(authority)) {
+      return true;
     }
 
-    if (!absoluteUri.empty())
-    {
-        // If the resolved URI’s scheme is HTTPS, its hostname may be used in the request
-        if (Aws::Utils::StringUtils::ToLower(absoluteUri.c_str()).rfind(Aws::String("https://"), 0) == 0) // if starts_with
-        {
-            return true;
-        }
-
-        Aws::Http::URI absUri(absoluteUri);
-        const Aws::String& authority = absUri.GetAuthority();
-
-        // Otherwise, implementations MUST fail to resolve when the URI hostname does not satisfy any of the following conditions
-        if (IsAllowedIp(authority))
-        {
-            return true;
-        }
-
-        Aws::Crt::Io::HostResolver* pHostResolver = Aws::Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver();
-        if (pHostResolver)
-        {
-          bool shouldAllow = false;
-          bool hostResolved = false;
-          std::mutex hostResolverMutex;
-          std::condition_variable hostResolverCV;
-          auto onHostResolved = [&shouldAllow, &hostResolved, &hostResolverCV, &hostResolverMutex](Aws::Crt::Io::HostResolver &resolver, const Aws::Crt::Vector<Aws::Crt::Io::HostAddress> &addresses, int errorCode)
-            {
-              AWS_UNREFERENCED_PARAM(resolver);
-              if (AWS_ERROR_SUCCESS == errorCode)
-              {
-                for(const auto& address : addresses)
-                {
-                  if (!IsAllowedIp(Aws::String((const char*) address.address->bytes, address.address->len)))
-                  {
-                    return;
-                  }
+    Aws::Crt::Io::HostResolver* pHostResolver =
+        Aws::Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver();
+    if (pHostResolver) {
+      bool shouldAllow = false;
+      bool hostResolved = false;
+      std::mutex hostResolverMutex;
+      std::condition_variable hostResolverCV;
+      auto onHostResolved =
+          [&shouldAllow, &hostResolved, &hostResolverCV, &hostResolverMutex](
+              Aws::Crt::Io::HostResolver& resolver,
+              const Aws::Crt::Vector<Aws::Crt::Io::HostAddress>& addresses,
+              int errorCode) {
+            AWS_UNREFERENCED_PARAM(resolver);
+            if (AWS_ERROR_SUCCESS == errorCode) {
+              for (const auto& address : addresses) {
+                if (!IsAllowedIp(Aws::String(
+                        (const char*)address.address->bytes,
+                        address.address->len))) {
+                  return;
                 }
-                std::unique_lock<std::mutex> lock(hostResolverMutex);
-                shouldAllow = !addresses.empty();
-                hostResolved = true;
-                hostResolverCV.notify_one();
               }
-              else
-              {
-                std::unique_lock<std::mutex> lock(hostResolverMutex);
-                hostResolverCV.notify_one();
-              }
-            };
-          pHostResolver->ResolveHost(authority.c_str(), onHostResolved);
-          std::unique_lock<std::mutex> lock(hostResolverMutex);
-          if (!hostResolved) {
-            hostResolverCV.wait_for(lock, std::chrono::milliseconds(1000));
-          }
-          if (shouldAllow)
-          {
-            return true;
-          }
-        }
-
-        AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_FULL_URI is not HTTPS and is not within loop back CIDR: " << authority);
-        return false;
+              std::unique_lock<std::mutex> lock(hostResolverMutex);
+              shouldAllow = !addresses.empty();
+              hostResolved = true;
+              hostResolverCV.notify_one();
+            } else {
+              std::unique_lock<std::mutex> lock(hostResolverMutex);
+              hostResolverCV.notify_one();
+            }
+          };
+      pHostResolver->ResolveHost(authority.c_str(), onHostResolved);
+      std::unique_lock<std::mutex> lock(hostResolverMutex);
+      if (!hostResolved) {
+        hostResolverCV.wait_for(lock, std::chrono::milliseconds(1000));
+      }
+      if (shouldAllow) {
+        return true;
+      }
     }
 
-    // both relativeUri and absoluteUri are empty
+    AWS_LOGSTREAM_WARN(
+        GEN_HTTP_LOG_TAG,
+        "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_FULL_URI "
+        "is not HTTPS and is not within loop back CIDR: "
+            << authority);
     return false;
-}
+  }
 
-GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
-                                                               const Aws::String& absoluteUri,
-                                                               const Aws::String& authToken,
-                                                               const Aws::String& authTokenFilePath,
-                                                               long refreshRateMs,
-                                                               ShouldCreateFunc shouldCreateFunc) :
-    m_authTokenFilePath(authTokenFilePath),
-    m_loadFrequencyMs(refreshRateMs)
-{
-    if (shouldCreateFunc(relativeUri, absoluteUri, authToken))
-    {
-        AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Creating GeneralHTTPCredentialsProvider with refresh rate " << refreshRateMs);
-        if (!relativeUri.empty()) {
-            m_ecsCredentialsClient = Aws::MakeShared<Aws::Internal::ECSCredentialsClient>(GEN_HTTP_LOG_TAG, relativeUri.c_str(), AWS_ECS_CONTAINER_HOST, authToken.c_str());
-        } else if (!absoluteUri.empty()) {
-            m_ecsCredentialsClient = Aws::MakeShared<Aws::Internal::ECSCredentialsClient>(GEN_HTTP_LOG_TAG, "", absoluteUri.c_str(), authToken.c_str());
-        }
-    }
+  // both relativeUri and absoluteUri are empty
+  return false;
 }
 
 GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(
-        const std::shared_ptr<Aws::Internal::ECSCredentialsClient>& client, long refreshRateMs) :
-    m_ecsCredentialsClient(client),
-    m_loadFrequencyMs(refreshRateMs)
-{
-    AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Creating GeneralHTTPCredentialsProvider with a pre-allocated client " << refreshRateMs);
-}
-
-AWSCredentials GeneralHTTPCredentialsProvider::GetAWSCredentials()
-{
-    RefreshIfExpired();
-    Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    return m_credentials;
-}
-
-bool GeneralHTTPCredentialsProvider::ExpiresSoon() const
-{
-    return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
-}
-
-Aws::String GeneralHTTPCredentialsProvider::LoadTokenFromFile() const
-{
-      Aws::IFStream tokenFile(m_authTokenFilePath.c_str());
-      if (tokenFile.is_open() && tokenFile.good())
-      {
-          Aws::StringStream memoryStream;
-          std::copy(std::istreambuf_iterator<char>(tokenFile), std::istreambuf_iterator<char>(), std::ostreambuf_iterator<char>(memoryStream));
-          Aws::String tokenFileStr = memoryStream.str();
-          if (tokenFileStr.find("\r\n") != Aws::String::npos)
-          {
-              AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Unable to retrieve credentials: file in AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE contains invalid characters (\\r\\n)");
-              return {};
-          }
-          return tokenFileStr;
-      } else {
-          AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Unable to retrieve credentials: failed to open Auth Token file .");
-          return {};
-      }
-}
-
-void GeneralHTTPCredentialsProvider::Reload()
-{
-    AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Credentials have expired or will expire, attempting to re-pull from ECS IAM Service.");
-    if (!m_ecsCredentialsClient)
-    {
-        AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Unable to retrieve credentials: ECS Credentials client is not initialized.");
-        return;
+    const Aws::String& relativeUri,
+    const Aws::String& absoluteUri,
+    const Aws::String& authToken,
+    const Aws::String& authTokenFilePath,
+    long refreshRateMs,
+    ShouldCreateFunc shouldCreateFunc)
+    : m_authTokenFilePath(authTokenFilePath)
+    , m_loadFrequencyMs(refreshRateMs) {
+  if (shouldCreateFunc(relativeUri, absoluteUri, authToken)) {
+    AWS_LOGSTREAM_INFO(
+        GEN_HTTP_LOG_TAG,
+        "Creating GeneralHTTPCredentialsProvider with refresh rate "
+            << refreshRateMs);
+    if (!relativeUri.empty()) {
+      m_ecsCredentialsClient = make_shared<Aws::Internal::ECSCredentialsClient>(
+          HERE(),
+          relativeUri.c_str(),
+          AWS_ECS_CONTAINER_HOST,
+          authToken.c_str());
+    } else if (!absoluteUri.empty()) {
+      m_ecsCredentialsClient = make_shared<Aws::Internal::ECSCredentialsClient>(
+          HERE(), "", absoluteUri.c_str(), authToken.c_str());
     }
-
-    if (!m_authTokenFilePath.empty())
-    {
-        Aws::String token = LoadTokenFromFile();
-        m_ecsCredentialsClient->SetToken(std::move(token));
-    }
-
-    auto credentialsStr = m_ecsCredentialsClient->GetECSCredentials();
-    if (credentialsStr.empty()) return;
-
-    Aws::Utils::Json::JsonValue credentialsDoc(credentialsStr);
-    if (!credentialsDoc.WasParseSuccessful())
-    {
-        AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Failed to parse output from ECSCredentialService.");
-        return;
-    }
-
-    Aws::String accessKey, secretKey, token;
-    Utils::Json::JsonView credentialsView(credentialsDoc);
-    accessKey = credentialsView.GetString("AccessKeyId");
-    secretKey = credentialsView.GetString("SecretAccessKey");
-    token = credentialsView.GetString("Token");
-    AWS_LOGSTREAM_DEBUG(GEN_HTTP_LOG_TAG, "Successfully pulled credentials from metadata service with access key " << accessKey);
-
-    m_credentials.SetAWSAccessKeyId(accessKey);
-    m_credentials.SetAWSSecretKey(secretKey);
-    m_credentials.SetSessionToken(token);
-    m_credentials.SetExpiration(Aws::Utils::DateTime(credentialsView.GetString("Expiration"), Aws::Utils::DateFormat::ISO_8601));
-    AWSCredentialsProvider::Reload();
+  }
 }
 
-void GeneralHTTPCredentialsProvider::RefreshIfExpired()
-{
-    AWS_LOGSTREAM_DEBUG(GEN_HTTP_LOG_TAG, "Checking if latest credential pull has expired.");
-    Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    if (!m_credentials.IsEmpty() && !IsTimeToRefresh(m_loadFrequencyMs) && !ExpiresSoon())
-    {
-        return;
-    }
-
-    guard.UpgradeToWriterLock();
-
-    if (!m_credentials.IsEmpty() && !IsTimeToRefresh(m_loadFrequencyMs) && !ExpiresSoon())
-    {
-        return;
-    }
-
-    Reload();
+GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(
+    const std::shared_ptr<Aws::Internal::ECSCredentialsClient>& client,
+    long refreshRateMs)
+    : m_ecsCredentialsClient(client)
+    , m_loadFrequencyMs(refreshRateMs) {
+  AWS_LOGSTREAM_INFO(
+      GEN_HTTP_LOG_TAG,
+      "Creating GeneralHTTPCredentialsProvider with a pre-allocated client "
+          << refreshRateMs);
 }
+
+AWSCredentials GeneralHTTPCredentialsProvider::GetAWSCredentials() {
+  RefreshIfExpired();
+  Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+  return m_credentials;
+}
+
+bool GeneralHTTPCredentialsProvider::ExpiresSoon() const {
+  return (
+      (m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() <
+      AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
+}
+
+Aws::String GeneralHTTPCredentialsProvider::LoadTokenFromFile() const {
+  Aws::IFStream tokenFile(m_authTokenFilePath.c_str());
+  if (tokenFile.is_open() && tokenFile.good()) {
+    Aws::StringStream memoryStream;
+    std::copy(
+        std::istreambuf_iterator<char>(tokenFile),
+        std::istreambuf_iterator<char>(),
+        std::ostreambuf_iterator<char>(memoryStream));
+    Aws::String tokenFileStr = memoryStream.str();
+    if (tokenFileStr.find("\r\n") != Aws::String::npos) {
+      AWS_LOGSTREAM_ERROR(
+          GEN_HTTP_LOG_TAG,
+          "Unable to retrieve credentials: file in "
+          "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE contains invalid characters "
+          "(\\r\\n)");
+      return {};
+    }
+    return tokenFileStr;
+  } else {
+    AWS_LOGSTREAM_ERROR(
+        GEN_HTTP_LOG_TAG,
+        "Unable to retrieve credentials: failed to open Auth Token file .");
+    return {};
+  }
+}
+
+void GeneralHTTPCredentialsProvider::Reload() {
+  AWS_LOGSTREAM_INFO(
+      GEN_HTTP_LOG_TAG,
+      "Credentials have expired or will expire, attempting to re-pull from ECS "
+      "IAM Service.");
+  if (!m_ecsCredentialsClient) {
+    AWS_LOGSTREAM_ERROR(
+        GEN_HTTP_LOG_TAG,
+        "Unable to retrieve credentials: ECS Credentials client is not "
+        "initialized.");
+    return;
+  }
+
+  if (!m_authTokenFilePath.empty()) {
+    Aws::String token = LoadTokenFromFile();
+    m_ecsCredentialsClient->SetToken(std::move(token));
+  }
+
+  auto credentialsStr = m_ecsCredentialsClient->GetECSCredentials();
+  if (credentialsStr.empty())
+    return;
+
+  Aws::Utils::Json::JsonValue credentialsDoc(credentialsStr);
+  if (!credentialsDoc.WasParseSuccessful()) {
+    AWS_LOGSTREAM_ERROR(
+        GEN_HTTP_LOG_TAG, "Failed to parse output from ECSCredentialService.");
+    return;
+  }
+
+  Aws::String accessKey, secretKey, token;
+  Aws::Utils::Json::JsonView credentialsView(credentialsDoc);
+  accessKey = credentialsView.GetString("AccessKeyId");
+  secretKey = credentialsView.GetString("SecretAccessKey");
+  token = credentialsView.GetString("Token");
+  AWS_LOGSTREAM_DEBUG(
+      GEN_HTTP_LOG_TAG,
+      "Successfully pulled credentials from metadata service with access key "
+          << accessKey);
+
+  m_credentials.SetAWSAccessKeyId(accessKey);
+  m_credentials.SetAWSSecretKey(secretKey);
+  m_credentials.SetSessionToken(token);
+  m_credentials.SetExpiration(Aws::Utils::DateTime(
+      credentialsView.GetString("Expiration"),
+      Aws::Utils::DateFormat::ISO_8601));
+  AWSCredentialsProvider::Reload();
+}
+
+void GeneralHTTPCredentialsProvider::RefreshIfExpired() {
+  AWS_LOGSTREAM_DEBUG(
+      GEN_HTTP_LOG_TAG, "Checking if latest credential pull has expired.");
+  Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+  if (!m_credentials.IsEmpty() && !IsTimeToRefresh(m_loadFrequencyMs) &&
+      !ExpiresSoon()) {
+    return;
+  }
+
+  guard.UpgradeToWriterLock();
+
+  if (!m_credentials.IsEmpty() && !IsTimeToRefresh(m_loadFrequencyMs) &&
+      !ExpiresSoon()) {
+    return;
+  }
+
+  Reload();
+}
+}  // namespace tiledb::sm::filesystem::s3

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.cc
@@ -1,0 +1,266 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+
+#include <aws/core/auth/GeneralHTTPCredentialsProvider.h>
+
+#include <aws/crt/Api.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/json/JsonSerializer.h>
+#include <fstream>
+
+using namespace Aws::Auth;
+
+static const char GEN_HTTP_LOG_TAG[] = "GeneralHTTPCredentialsProvider";
+
+const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[] = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[] = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI";
+const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_CREDENTIALS_FULL_URI[]     = "AWS_CONTAINER_CREDENTIALS_FULL_URI";
+const char GeneralHTTPCredentialsProvider::AWS_CONTAINER_AUTHORIZATION_TOKEN[]      = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
+
+const char GeneralHTTPCredentialsProvider::AWS_ECS_CONTAINER_HOST[]      = "169.254.170.2";
+const char GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST[]      = "169.254.170.23";
+const char GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST_IPV6[] = "fd00:ec2::23";
+
+
+bool IsAllowedIp(const Aws::String& authority)
+{
+    // address is an ECS / EKS container host
+    if (authority == GeneralHTTPCredentialsProvider::AWS_ECS_CONTAINER_HOST) // ECS container host
+    {
+        return true;
+    } else if (authority == GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST ||
+               authority == GeneralHTTPCredentialsProvider::AWS_EKS_CONTAINER_HOST_IPV6) { // EKS container host
+        return true;
+    }
+
+    // address is within the loop back
+    // IPv4
+    if (authority.rfind(Aws::String("127.0.0."), 0) == 0 && authority.size() > 8 && authority.size() <= 11)
+    {
+        Aws::String octet = authority.substr(8);
+        if ((octet.find_first_not_of("0123456789") != Aws::String::npos) ||
+            (Aws::Utils::StringUtils::ConvertToInt32(octet.c_str()) > 255)) {
+            AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_FULL_URI ip address is malformed: " << authority);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    // IPv6
+    if (authority == "::1" || authority == "0:0:0:0:0:0:0:1" || authority == "[::1]" || authority == "[0:0:0:0:0:0:0:1]")
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool GeneralHTTPCredentialsProvider::ShouldCreateGeneralHTTPProvider(const Aws::String& relativeUri, const Aws::String& absoluteUri, const Aws::String authToken)
+{
+    if (authToken.find("\r\n") != Aws::String::npos)
+    {
+        AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_AUTHORIZATION_TOKEN env value contains invalid characters (\\r\\n)");
+        return false;
+    }
+
+    if (!relativeUri.empty())
+    {
+        // The provider MAY choose to assert syntactical validity of the resulting URI
+        // perform very basic check here
+        if (relativeUri[0] != '/') {
+          AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI does not begin with /");
+          return false;
+        } else {
+          // full URI is not used in case of a relative one present
+          return true;
+        }
+    }
+
+    if (!absoluteUri.empty())
+    {
+        // If the resolved URI’s scheme is HTTPS, its hostname may be used in the request
+        if (Aws::Utils::StringUtils::ToLower(absoluteUri.c_str()).rfind(Aws::String("https://"), 0) == 0) // if starts_with
+        {
+            return true;
+        }
+
+        Aws::Http::URI absUri(absoluteUri);
+        const Aws::String& authority = absUri.GetAuthority();
+
+        // Otherwise, implementations MUST fail to resolve when the URI hostname does not satisfy any of the following conditions
+        if (IsAllowedIp(authority))
+        {
+            return true;
+        }
+
+        Aws::Crt::Io::HostResolver* pHostResolver = Aws::Crt::ApiHandle::GetOrCreateStaticDefaultHostResolver();
+        if (pHostResolver)
+        {
+          bool shouldAllow = false;
+          bool hostResolved = false;
+          std::mutex hostResolverMutex;
+          std::condition_variable hostResolverCV;
+          auto onHostResolved = [&shouldAllow, &hostResolved, &hostResolverCV, &hostResolverMutex](Aws::Crt::Io::HostResolver &resolver, const Aws::Crt::Vector<Aws::Crt::Io::HostAddress> &addresses, int errorCode)
+            {
+              AWS_UNREFERENCED_PARAM(resolver);
+              if (AWS_ERROR_SUCCESS == errorCode)
+              {
+                for(const auto& address : addresses)
+                {
+                  if (!IsAllowedIp(Aws::String((const char*) address.address->bytes, address.address->len)))
+                  {
+                    return;
+                  }
+                }
+                std::unique_lock<std::mutex> lock(hostResolverMutex);
+                shouldAllow = !addresses.empty();
+                hostResolved = true;
+                hostResolverCV.notify_one();
+              }
+              else
+              {
+                std::unique_lock<std::mutex> lock(hostResolverMutex);
+                hostResolverCV.notify_one();
+              }
+            };
+          pHostResolver->ResolveHost(authority.c_str(), onHostResolved);
+          std::unique_lock<std::mutex> lock(hostResolverMutex);
+          if (!hostResolved) {
+            hostResolverCV.wait_for(lock, std::chrono::milliseconds(1000));
+          }
+          if (shouldAllow)
+          {
+            return true;
+          }
+        }
+
+        AWS_LOGSTREAM_WARN(GEN_HTTP_LOG_TAG, "Can't use General HTTP Provider: AWS_CONTAINER_CREDENTIALS_FULL_URI is not HTTPS and is not within loop back CIDR: " << authority);
+        return false;
+    }
+
+    // both relativeUri and absoluteUri are empty
+    return false;
+}
+
+GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
+                                                               const Aws::String& absoluteUri,
+                                                               const Aws::String& authToken,
+                                                               const Aws::String& authTokenFilePath,
+                                                               long refreshRateMs,
+                                                               ShouldCreateFunc shouldCreateFunc) :
+    m_authTokenFilePath(authTokenFilePath),
+    m_loadFrequencyMs(refreshRateMs)
+{
+    if (shouldCreateFunc(relativeUri, absoluteUri, authToken))
+    {
+        AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Creating GeneralHTTPCredentialsProvider with refresh rate " << refreshRateMs);
+        if (!relativeUri.empty()) {
+            m_ecsCredentialsClient = Aws::MakeShared<Aws::Internal::ECSCredentialsClient>(GEN_HTTP_LOG_TAG, relativeUri.c_str(), AWS_ECS_CONTAINER_HOST, authToken.c_str());
+        } else if (!absoluteUri.empty()) {
+            m_ecsCredentialsClient = Aws::MakeShared<Aws::Internal::ECSCredentialsClient>(GEN_HTTP_LOG_TAG, "", absoluteUri.c_str(), authToken.c_str());
+        }
+    }
+}
+
+GeneralHTTPCredentialsProvider::GeneralHTTPCredentialsProvider(
+        const std::shared_ptr<Aws::Internal::ECSCredentialsClient>& client, long refreshRateMs) :
+    m_ecsCredentialsClient(client),
+    m_loadFrequencyMs(refreshRateMs)
+{
+    AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Creating GeneralHTTPCredentialsProvider with a pre-allocated client " << refreshRateMs);
+}
+
+AWSCredentials GeneralHTTPCredentialsProvider::GetAWSCredentials()
+{
+    RefreshIfExpired();
+    Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+    return m_credentials;
+}
+
+bool GeneralHTTPCredentialsProvider::ExpiresSoon() const
+{
+    return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < AWS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
+}
+
+Aws::String GeneralHTTPCredentialsProvider::LoadTokenFromFile() const
+{
+      Aws::IFStream tokenFile(m_authTokenFilePath.c_str());
+      if (tokenFile.is_open() && tokenFile.good())
+      {
+          Aws::StringStream memoryStream;
+          std::copy(std::istreambuf_iterator<char>(tokenFile), std::istreambuf_iterator<char>(), std::ostreambuf_iterator<char>(memoryStream));
+          Aws::String tokenFileStr = memoryStream.str();
+          if (tokenFileStr.find("\r\n") != Aws::String::npos)
+          {
+              AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Unable to retrieve credentials: file in AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE contains invalid characters (\\r\\n)");
+              return {};
+          }
+          return tokenFileStr;
+      } else {
+          AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Unable to retrieve credentials: failed to open Auth Token file .");
+          return {};
+      }
+}
+
+void GeneralHTTPCredentialsProvider::Reload()
+{
+    AWS_LOGSTREAM_INFO(GEN_HTTP_LOG_TAG, "Credentials have expired or will expire, attempting to re-pull from ECS IAM Service.");
+    if (!m_ecsCredentialsClient)
+    {
+        AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Unable to retrieve credentials: ECS Credentials client is not initialized.");
+        return;
+    }
+
+    if (!m_authTokenFilePath.empty())
+    {
+        Aws::String token = LoadTokenFromFile();
+        m_ecsCredentialsClient->SetToken(std::move(token));
+    }
+
+    auto credentialsStr = m_ecsCredentialsClient->GetECSCredentials();
+    if (credentialsStr.empty()) return;
+
+    Aws::Utils::Json::JsonValue credentialsDoc(credentialsStr);
+    if (!credentialsDoc.WasParseSuccessful())
+    {
+        AWS_LOGSTREAM_ERROR(GEN_HTTP_LOG_TAG, "Failed to parse output from ECSCredentialService.");
+        return;
+    }
+
+    Aws::String accessKey, secretKey, token;
+    Utils::Json::JsonView credentialsView(credentialsDoc);
+    accessKey = credentialsView.GetString("AccessKeyId");
+    secretKey = credentialsView.GetString("SecretAccessKey");
+    token = credentialsView.GetString("Token");
+    AWS_LOGSTREAM_DEBUG(GEN_HTTP_LOG_TAG, "Successfully pulled credentials from metadata service with access key " << accessKey);
+
+    m_credentials.SetAWSAccessKeyId(accessKey);
+    m_credentials.SetAWSSecretKey(secretKey);
+    m_credentials.SetSessionToken(token);
+    m_credentials.SetExpiration(Aws::Utils::DateTime(credentialsView.GetString("Expiration"), Aws::Utils::DateFormat::ISO_8601));
+    AWSCredentialsProvider::Reload();
+}
+
+void GeneralHTTPCredentialsProvider::RefreshIfExpired()
+{
+    AWS_LOGSTREAM_DEBUG(GEN_HTTP_LOG_TAG, "Checking if latest credential pull has expired.");
+    Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
+    if (!m_credentials.IsEmpty() && !IsTimeToRefresh(m_loadFrequencyMs) && !ExpiresSoon())
+    {
+        return;
+    }
+
+    guard.UpgradeToWriterLock();
+
+    if (!m_credentials.IsEmpty() && !IsTimeToRefresh(m_loadFrequencyMs) && !ExpiresSoon())
+    {
+        return;
+    }
+
+    Reload();
+}

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h
@@ -1,0 +1,120 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+
+#pragma once
+
+#include <aws/core/auth/AWSCredentialsProvider.h>
+
+namespace Aws
+{
+    namespace Auth
+    {
+        /**
+        * General HTTP Credentials Provider (previously known as ECS credentials provider)
+        * implementation that loads credentials from an arbitrary HTTP(S) endpoint specified by the environment
+        * or loop back / Amazon ECS / Amazon EKS container host metadata services by default.
+        */
+        class AWS_CORE_API GeneralHTTPCredentialsProvider : public AWSCredentialsProvider
+        {
+        private:
+            static bool ShouldCreateGeneralHTTPProvider(const Aws::String& relativeUri, const Aws::String& absoluteUri, const Aws::String authToken);
+        public:
+            using ShouldCreateFunc = std::function<bool(const Aws::String& relativeUri, const Aws::String& absoluteUri, const Aws::String authToken)>;
+
+            /**
+             * Initializes the provider to retrieve credentials from a general http provided endpoint every 5 minutes or before it
+             * expires.
+             * @param relativeUri A path appended to the metadata service endpoint. OR
+             * @param absoluteUri The full URI to resolve to get credentials.
+             * @param authTokenFilePath A path to a file with optional authorization token passed to the URI via the 'Authorization' HTTP header.
+             * @param authToken An optional authorization token passed to the URI via the 'Authorization' HTTP header.
+             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
+             * @param ShouldCreateFunc
+             */
+            GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
+                                           const Aws::String& absoluteUri,
+                                           const Aws::String& authTokenFilePath = "",
+                                           const Aws::String& authToken = "",
+                                           long refreshRateMs = REFRESH_THRESHOLD,
+                                           ShouldCreateFunc shouldCreateFunc = ShouldCreateGeneralHTTPProvider);
+
+            /**
+             * Check if GeneralHTTPCredentialsProvider was initialized with allowed configuration
+             * @return true if provider configuration is valid
+             */
+            bool IsValid() const
+            {
+                if (!m_ecsCredentialsClient)
+                    return false;
+                if (!m_authTokenFilePath.empty())
+                    return !LoadTokenFromFile().empty();
+                return true;
+            }
+
+            /**
+             * Initializes the provider to retrieve credentials from the ECS metadata service every 5 minutes,
+             * or before it expires.
+             * @param resourcePath A path appended to the metadata service endpoint.
+             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
+             */
+            // TODO: 1.12: AWS_DEPRECATED("This c-tor is deprecated, please use one above.")
+            GeneralHTTPCredentialsProvider(const char* resourcePath, long refreshRateMs = REFRESH_THRESHOLD)
+              : GeneralHTTPCredentialsProvider(resourcePath, "", "", "", refreshRateMs)
+            {}
+
+            /**
+             * Initializes the provider to retrieve credentials from a provided endpoint every 5 minutes or before it
+             * expires.
+             * @param endpoint The full URI to resolve to get credentials.
+             * @param token An optional authorization token passed to the URI via the 'Authorization' HTTP header.
+             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
+             */
+            // TODO: 1.12: AWS_DEPRECATED("This c-tor is deprecated, please use one above.")
+            GeneralHTTPCredentialsProvider(const char* endpoint, const char* token, long refreshRateMs = REFRESH_THRESHOLD)
+              : GeneralHTTPCredentialsProvider("", endpoint, token, "", refreshRateMs)
+            {}
+
+            /**
+             * Initializes the provider to retrieve credentials using the provided client.
+             * @param client The ECSCredentialsClient instance to use when retrieving credentials.
+             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
+             */
+            GeneralHTTPCredentialsProvider(const std::shared_ptr<Aws::Internal::ECSCredentialsClient>& client,
+                    long refreshRateMs = REFRESH_THRESHOLD);
+            /**
+            * Retrieves the credentials if found, otherwise returns empty credential set.
+            */
+            AWSCredentials GetAWSCredentials() override;
+
+            static const char AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[];
+            static const char AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[];
+            static const char AWS_CONTAINER_CREDENTIALS_FULL_URI[];
+            static const char AWS_CONTAINER_AUTHORIZATION_TOKEN[];
+
+            static const char AWS_ECS_CONTAINER_HOST[];
+            static const char AWS_EKS_CONTAINER_HOST[];
+            static const char AWS_EKS_CONTAINER_HOST_IPV6[];
+
+        protected:
+            void Reload() override;
+
+        private:
+            bool ExpiresSoon() const;
+            void RefreshIfExpired();
+
+            Aws::String LoadTokenFromFile() const;
+
+            std::shared_ptr<Aws::Internal::ECSCredentialsClient> m_ecsCredentialsClient;
+            Aws::String m_authTokenFilePath;
+
+            long m_loadFrequencyMs = REFRESH_THRESHOLD;
+            Aws::Auth::AWSCredentials m_credentials;
+        };
+
+        // GeneralHTTPCredentialsProvider was previously known as TaskRoleCredentialsProvider or "ECS credentials provider"
+        using TaskRoleCredentialsProvider = GeneralHTTPCredentialsProvider;
+    } // namespace Auth
+} // namespace Aws

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h
@@ -1,120 +1,179 @@
 /**
+ * @file   GeneralHTTPCredentialsProvider.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a vendored copy of the
+ * Aws::Auth::GeneralHTTPCredentialsProvider class, updated to support
+ * getting a client configuration object.
+ *
+ * Changes made should be contributed upstream to the AWS SDK for C++ and when
+ * that happens, the vendored copy should be removed.
+ */
+
+/**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-
 
 #pragma once
 
 #include <aws/core/auth/AWSCredentialsProvider.h>
 
-namespace Aws
-{
-    namespace Auth
-    {
-        /**
-        * General HTTP Credentials Provider (previously known as ECS credentials provider)
-        * implementation that loads credentials from an arbitrary HTTP(S) endpoint specified by the environment
-        * or loop back / Amazon ECS / Amazon EKS container host metadata services by default.
-        */
-        class AWS_CORE_API GeneralHTTPCredentialsProvider : public AWSCredentialsProvider
-        {
-        private:
-            static bool ShouldCreateGeneralHTTPProvider(const Aws::String& relativeUri, const Aws::String& absoluteUri, const Aws::String authToken);
-        public:
-            using ShouldCreateFunc = std::function<bool(const Aws::String& relativeUri, const Aws::String& absoluteUri, const Aws::String authToken)>;
+namespace tiledb::sm::filesystem::s3 {
+/**
+ * General HTTP Credentials Provider (previously known as ECS credentials
+ * provider) implementation that loads credentials from an arbitrary HTTP(S)
+ * endpoint specified by the environment or loop back / Amazon ECS / Amazon EKS
+ * container host metadata services by default.
+ */
+class GeneralHTTPCredentialsProvider
+    : public Aws::Auth::AWSCredentialsProvider {
+ private:
+  static bool ShouldCreateGeneralHTTPProvider(
+      const Aws::String& relativeUri,
+      const Aws::String& absoluteUri,
+      const Aws::String authToken);
 
-            /**
-             * Initializes the provider to retrieve credentials from a general http provided endpoint every 5 minutes or before it
-             * expires.
-             * @param relativeUri A path appended to the metadata service endpoint. OR
-             * @param absoluteUri The full URI to resolve to get credentials.
-             * @param authTokenFilePath A path to a file with optional authorization token passed to the URI via the 'Authorization' HTTP header.
-             * @param authToken An optional authorization token passed to the URI via the 'Authorization' HTTP header.
-             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
-             * @param ShouldCreateFunc
-             */
-            GeneralHTTPCredentialsProvider(const Aws::String& relativeUri,
-                                           const Aws::String& absoluteUri,
-                                           const Aws::String& authTokenFilePath = "",
-                                           const Aws::String& authToken = "",
-                                           long refreshRateMs = REFRESH_THRESHOLD,
-                                           ShouldCreateFunc shouldCreateFunc = ShouldCreateGeneralHTTPProvider);
+ public:
+  using ShouldCreateFunc = std::function<bool(
+      const Aws::String& relativeUri,
+      const Aws::String& absoluteUri,
+      const Aws::String authToken)>;
 
-            /**
-             * Check if GeneralHTTPCredentialsProvider was initialized with allowed configuration
-             * @return true if provider configuration is valid
-             */
-            bool IsValid() const
-            {
-                if (!m_ecsCredentialsClient)
-                    return false;
-                if (!m_authTokenFilePath.empty())
-                    return !LoadTokenFromFile().empty();
-                return true;
-            }
+  /**
+   * Initializes the provider to retrieve credentials from a general http
+   * provided endpoint every 5 minutes or before it expires.
+   * @param relativeUri A path appended to the metadata service endpoint. OR
+   * @param absoluteUri The full URI to resolve to get credentials.
+   * @param authTokenFilePath A path to a file with optional authorization token
+   * passed to the URI via the 'Authorization' HTTP header.
+   * @param authToken An optional authorization token passed to the URI via the
+   * 'Authorization' HTTP header.
+   * @param refreshRateMs The number of milliseconds after which the credentials
+   * will be fetched again.
+   * @param ShouldCreateFunc
+   */
+  GeneralHTTPCredentialsProvider(
+      const Aws::String& relativeUri,
+      const Aws::String& absoluteUri,
+      const Aws::String& authTokenFilePath = "",
+      const Aws::String& authToken = "",
+      long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD,
+      ShouldCreateFunc shouldCreateFunc = ShouldCreateGeneralHTTPProvider);
 
-            /**
-             * Initializes the provider to retrieve credentials from the ECS metadata service every 5 minutes,
-             * or before it expires.
-             * @param resourcePath A path appended to the metadata service endpoint.
-             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
-             */
-            // TODO: 1.12: AWS_DEPRECATED("This c-tor is deprecated, please use one above.")
-            GeneralHTTPCredentialsProvider(const char* resourcePath, long refreshRateMs = REFRESH_THRESHOLD)
-              : GeneralHTTPCredentialsProvider(resourcePath, "", "", "", refreshRateMs)
-            {}
+  /**
+   * Check if GeneralHTTPCredentialsProvider was initialized with allowed
+   * configuration
+   * @return true if provider configuration is valid
+   */
+  bool IsValid() const {
+    if (!m_ecsCredentialsClient)
+      return false;
+    if (!m_authTokenFilePath.empty())
+      return !LoadTokenFromFile().empty();
+    return true;
+  }
 
-            /**
-             * Initializes the provider to retrieve credentials from a provided endpoint every 5 minutes or before it
-             * expires.
-             * @param endpoint The full URI to resolve to get credentials.
-             * @param token An optional authorization token passed to the URI via the 'Authorization' HTTP header.
-             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
-             */
-            // TODO: 1.12: AWS_DEPRECATED("This c-tor is deprecated, please use one above.")
-            GeneralHTTPCredentialsProvider(const char* endpoint, const char* token, long refreshRateMs = REFRESH_THRESHOLD)
-              : GeneralHTTPCredentialsProvider("", endpoint, token, "", refreshRateMs)
-            {}
+  /**
+   * Initializes the provider to retrieve credentials from the ECS metadata
+   * service every 5 minutes, or before it expires.
+   * @param resourcePath A path appended to the metadata service endpoint.
+   * @param refreshRateMs The number of milliseconds after which the credentials
+   * will be fetched again.
+   */
+  // TODO: 1.12: AWS_DEPRECATED("This c-tor is deprecated, please use one
+  // above.")
+  GeneralHTTPCredentialsProvider(
+      const char* resourcePath,
+      long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD)
+      : GeneralHTTPCredentialsProvider(
+            resourcePath, "", "", "", refreshRateMs) {
+  }
 
-            /**
-             * Initializes the provider to retrieve credentials using the provided client.
-             * @param client The ECSCredentialsClient instance to use when retrieving credentials.
-             * @param refreshRateMs The number of milliseconds after which the credentials will be fetched again.
-             */
-            GeneralHTTPCredentialsProvider(const std::shared_ptr<Aws::Internal::ECSCredentialsClient>& client,
-                    long refreshRateMs = REFRESH_THRESHOLD);
-            /**
-            * Retrieves the credentials if found, otherwise returns empty credential set.
-            */
-            AWSCredentials GetAWSCredentials() override;
+  /**
+   * Initializes the provider to retrieve credentials from a provided endpoint
+   * every 5 minutes or before it expires.
+   * @param endpoint The full URI to resolve to get credentials.
+   * @param token An optional authorization token passed to the URI via the
+   * 'Authorization' HTTP header.
+   * @param refreshRateMs The number of milliseconds after which the credentials
+   * will be fetched again.
+   */
+  // TODO: 1.12: AWS_DEPRECATED("This c-tor is deprecated, please use one
+  // above.")
+  GeneralHTTPCredentialsProvider(
+      const char* endpoint,
+      const char* token,
+      long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD)
+      : GeneralHTTPCredentialsProvider("", endpoint, token, "", refreshRateMs) {
+  }
 
-            static const char AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[];
-            static const char AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[];
-            static const char AWS_CONTAINER_CREDENTIALS_FULL_URI[];
-            static const char AWS_CONTAINER_AUTHORIZATION_TOKEN[];
+  /**
+   * Initializes the provider to retrieve credentials using the provided client.
+   * @param client The ECSCredentialsClient instance to use when retrieving
+   * credentials.
+   * @param refreshRateMs The number of milliseconds after which the credentials
+   * will be fetched again.
+   */
+  GeneralHTTPCredentialsProvider(
+      const std::shared_ptr<Aws::Internal::ECSCredentialsClient>& client,
+      long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD);
+  /**
+   * Retrieves the credentials if found, otherwise returns empty credential set.
+   */
+  Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
-            static const char AWS_ECS_CONTAINER_HOST[];
-            static const char AWS_EKS_CONTAINER_HOST[];
-            static const char AWS_EKS_CONTAINER_HOST_IPV6[];
+  static const char AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE[];
+  static const char AWS_CONTAINER_CREDENTIALS_RELATIVE_URI[];
+  static const char AWS_CONTAINER_CREDENTIALS_FULL_URI[];
+  static const char AWS_CONTAINER_AUTHORIZATION_TOKEN[];
 
-        protected:
-            void Reload() override;
+  static const char AWS_ECS_CONTAINER_HOST[];
+  static const char AWS_EKS_CONTAINER_HOST[];
+  static const char AWS_EKS_CONTAINER_HOST_IPV6[];
 
-        private:
-            bool ExpiresSoon() const;
-            void RefreshIfExpired();
+ protected:
+  void Reload() override;
 
-            Aws::String LoadTokenFromFile() const;
+ private:
+  bool ExpiresSoon() const;
+  void RefreshIfExpired();
 
-            std::shared_ptr<Aws::Internal::ECSCredentialsClient> m_ecsCredentialsClient;
-            Aws::String m_authTokenFilePath;
+  Aws::String LoadTokenFromFile() const;
 
-            long m_loadFrequencyMs = REFRESH_THRESHOLD;
-            Aws::Auth::AWSCredentials m_credentials;
-        };
+  std::shared_ptr<Aws::Internal::ECSCredentialsClient> m_ecsCredentialsClient;
+  Aws::String m_authTokenFilePath;
 
-        // GeneralHTTPCredentialsProvider was previously known as TaskRoleCredentialsProvider or "ECS credentials provider"
-        using TaskRoleCredentialsProvider = GeneralHTTPCredentialsProvider;
-    } // namespace Auth
-} // namespace Aws
+  long m_loadFrequencyMs = Aws::Auth::REFRESH_THRESHOLD;
+  Aws::Auth::AWSCredentials m_credentials;
+};
+
+// GeneralHTTPCredentialsProvider was previously known as
+// TaskRoleCredentialsProvider or "ECS credentials provider"
+using TaskRoleCredentialsProvider = GeneralHTTPCredentialsProvider;
+}  // namespace tiledb::sm::filesystem::s3

--- a/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/GeneralHTTPCredentialsProvider.h
@@ -68,6 +68,30 @@ class GeneralHTTPCredentialsProvider
   /**
    * Initializes the provider to retrieve credentials from a general http
    * provided endpoint every 5 minutes or before it expires.
+   * @param clientConfig The client configuration to use when performing
+   * requests.
+   * @param relativeUri A path appended to the metadata service endpoint. OR
+   * @param absoluteUri The full URI to resolve to get credentials.
+   * @param authTokenFilePath A path to a file with optional authorization token
+   * passed to the URI via the 'Authorization' HTTP header.
+   * @param authToken An optional authorization token passed to the URI via the
+   * 'Authorization' HTTP header.
+   * @param refreshRateMs The number of milliseconds after which the credentials
+   * will be fetched again.
+   * @param ShouldCreateFunc
+   */
+  GeneralHTTPCredentialsProvider(
+      const Aws::Client::ClientConfiguration& clientConfig,
+      const Aws::String& relativeUri,
+      const Aws::String& absoluteUri,
+      const Aws::String& authTokenFilePath = "",
+      const Aws::String& authToken = "",
+      long refreshRateMs = Aws::Auth::REFRESH_THRESHOLD,
+      ShouldCreateFunc shouldCreateFunc = ShouldCreateGeneralHTTPProvider);
+
+  /**
+   * Initializes the provider to retrieve credentials from a general http
+   * provided endpoint every 5 minutes or before it expires.
    * @param relativeUri A path appended to the metadata service endpoint. OR
    * @param absoluteUri The full URI to resolve to get credentials.
    * @param authTokenFilePath A path to a file with optional authorization token

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
@@ -40,6 +40,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#ifdef HAVE_S3
+
 #include "tiledb/sm/filesystem/s3/STSCredentialsProvider.h"
 #include "tiledb/common/common.h"
 
@@ -227,3 +229,5 @@ void STSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
   Reload();
 }
 }  // namespace tiledb::sm::filesystem::s3
+
+#endif

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
@@ -1,24 +1,60 @@
 /**
+ * @file   STSCredentialsProvider.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a vendored copy of the
+ * Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider class, updated to
+ * support getting a client configuration object.
+ *
+ * Changes made should be contributed upstream to the AWS SDK for C++ and when
+ * that happens, the vendored copy should be removed.
+ */
+
+/**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include "tiledb/sm/filesystem/s3/STSCredentialsProvider.h"
+#include "tiledb/common/common.h"
 
-#include <aws/core/auth/STSCredentialsProvider.h>
+#include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/config/AWSProfileConfigLoader.h>
 #include <aws/core/platform/Environment.h>
 #include <aws/core/platform/FileSystem.h>
-#include <aws/core/utils/logging/LogMacros.h>
-#include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/FileSystemUtils.h>
-#include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
 #include <aws/core/utils/StringUtils.h>
 #include <aws/core/utils/UUID.h>
-#include <cstdlib>
-#include <fstream>
+#include <aws/core/utils/logging/LogMacros.h>
 #include <string.h>
 #include <climits>
-
+#include <cstdlib>
+#include <fstream>
 
 using namespace Aws::Utils;
 using namespace Aws::Utils::Logging;
@@ -29,142 +65,165 @@ using namespace Aws::Client;
 using Aws::Utils::Threading::ReaderLockGuard;
 using Aws::Utils::Threading::WriterLockGuard;
 
-static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] = "STSAssumeRoleWithWebIdentityCredentialsProvider";
+static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] =
+    "STSAssumeRoleWithWebIdentityCredentialsProvider";
 static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 5 * 1000;
 
-STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentialsProvider() :
-    m_initialized(false)
-{
-    // check environment variables
-    Aws::String tmpRegion = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
-    m_roleArn = Aws::Environment::GetEnv("AWS_ROLE_ARN");
-    m_tokenFile = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
-    m_sessionName = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
+namespace tiledb::sm::filesystem::s3 {
+STSAssumeRoleWebIdentityCredentialsProvider::
+    STSAssumeRoleWebIdentityCredentialsProvider()
+    : m_initialized(false) {
+  // check environment variables
+  Aws::String tmpRegion = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
+  m_roleArn = Aws::Environment::GetEnv("AWS_ROLE_ARN");
+  m_tokenFile = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
+  m_sessionName = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
 
-    // check profile_config if either m_roleArn or m_tokenFile is not loaded from environment variable
-    // region source is not enforced, but we need it to construct sts endpoint, if we can't find from environment, we should check if it's set in config file.
-    if (m_roleArn.empty() || m_tokenFile.empty() || tmpRegion.empty())
-    {
-        auto profile = Aws::Config::GetCachedConfigProfile(Aws::Auth::GetConfigProfileName());
-        if (tmpRegion.empty())
-        {
-            tmpRegion = profile.GetRegion();
-        }
-        // If either of these two were not found from environment, use whatever found for all three in config file
-        if (m_roleArn.empty() || m_tokenFile.empty())
-        {
-            m_roleArn = profile.GetRoleArn();
-            m_tokenFile = profile.GetValue("web_identity_token_file");
-            m_sessionName = profile.GetValue("role_session_name");
-        }
+  // check profile_config if either m_roleArn or m_tokenFile is not loaded from
+  // environment variable region source is not enforced, but we need it to
+  // construct sts endpoint, if we can't find from environment, we should check
+  // if it's set in config file.
+  if (m_roleArn.empty() || m_tokenFile.empty() || tmpRegion.empty()) {
+    auto profile =
+        Aws::Config::GetCachedConfigProfile(Aws::Auth::GetConfigProfileName());
+    if (tmpRegion.empty()) {
+      tmpRegion = profile.GetRegion();
     }
+    // If either of these two were not found from environment, use whatever
+    // found for all three in config file
+    if (m_roleArn.empty() || m_tokenFile.empty()) {
+      m_roleArn = profile.GetRoleArn();
+      m_tokenFile = profile.GetValue("web_identity_token_file");
+      m_sessionName = profile.GetValue("role_session_name");
+    }
+  }
 
-    if (m_tokenFile.empty())
-    {
-        AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Token file must be specified to use STS AssumeRole web identity creds provider.");
-        return; // No need to do further constructing
-    }
-    else
-    {
-        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved token_file from profile_config or environment variable to be " << m_tokenFile);
-    }
+  if (m_tokenFile.empty()) {
+    AWS_LOGSTREAM_WARN(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Token file must be specified to use STS AssumeRole web identity creds "
+        "provider.");
+    return;  // No need to do further constructing
+  } else {
+    AWS_LOGSTREAM_DEBUG(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Resolved token_file from profile_config or environment variable to be "
+            << m_tokenFile);
+  }
 
-    if (m_roleArn.empty())
-    {
-        AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "RoleArn must be specified to use STS AssumeRole web identity creds provider.");
-        return; // No need to do further constructing
-    }
-    else
-    {
-        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved role_arn from profile_config or environment variable to be " << m_roleArn);
-    }
+  if (m_roleArn.empty()) {
+    AWS_LOGSTREAM_WARN(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "RoleArn must be specified to use STS AssumeRole web identity creds "
+        "provider.");
+    return;  // No need to do further constructing
+  } else {
+    AWS_LOGSTREAM_DEBUG(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Resolved role_arn from profile_config or environment variable to be "
+            << m_roleArn);
+  }
 
-    if (tmpRegion.empty())
-    {
-        tmpRegion = Aws::Region::US_EAST_1;
-    }
-    else
-    {
-        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved region from profile_config or environment variable to be " << tmpRegion);
-    }
+  if (tmpRegion.empty()) {
+    tmpRegion = Aws::Region::US_EAST_1;
+  } else {
+    AWS_LOGSTREAM_DEBUG(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Resolved region from profile_config or environment variable to be "
+            << tmpRegion);
+  }
 
-    if (m_sessionName.empty())
-    {
-        m_sessionName = Aws::Utils::UUID::PseudoRandomUUID();
-    }
-    else
-    {
-        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved session_name from profile_config or environment variable to be " << m_sessionName);
-    }
+  if (m_sessionName.empty()) {
+    m_sessionName = Aws::Utils::UUID::PseudoRandomUUID();
+  } else {
+    AWS_LOGSTREAM_DEBUG(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Resolved session_name from profile_config or environment variable to "
+        "be "
+            << m_sessionName);
+  }
 
-    Aws::Client::ClientConfiguration config;
-    config.scheme = Aws::Http::Scheme::HTTPS;
-    config.region = tmpRegion;
+  Aws::Client::ClientConfiguration config;
+  config.scheme = Aws::Http::Scheme::HTTPS;
+  config.region = tmpRegion;
 
-    Aws::Vector<Aws::String> retryableErrors;
-    retryableErrors.push_back("IDPCommunicationError");
-    retryableErrors.push_back("InvalidIdentityToken");
+  Aws::Vector<Aws::String> retryableErrors;
+  retryableErrors.push_back("IDPCommunicationError");
+  retryableErrors.push_back("InvalidIdentityToken");
 
-    config.retryStrategy = Aws::MakeShared<SpecifiedRetryableErrorsRetryStrategy>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3/*maxRetries*/);
+  config.retryStrategy = make_shared<SpecifiedRetryableErrorsRetryStrategy>(
+      HERE(), retryableErrors, 3 /*maxRetries*/);
 
-    m_client = Aws::MakeUnique<Aws::Internal::STSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
-    m_initialized = true;
-    AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
+  m_client = tdb_unique_ptr<Aws::Internal::STSCredentialsClient>(tdb_new(
+      Aws::Internal::STSCredentialsClient,
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+      config));
+  m_initialized = true;
+  AWS_LOGSTREAM_INFO(
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+      "Creating STS AssumeRole with web identity creds provider.");
 }
 
-AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials()
-{
-    // A valid client means required information like role arn and token file were constructed correctly.
-    // We can use this provider to load creds, otherwise, we can just return empty creds.
-    if (!m_initialized)
-    {
-        return Aws::Auth::AWSCredentials();
-    }
-    RefreshIfExpired();
-    ReaderLockGuard guard(m_reloadLock);
-    return m_credentials;
+AWSCredentials
+STSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials() {
+  // A valid client means required information like role arn and token file were
+  // constructed correctly. We can use this provider to load creds, otherwise,
+  // we can just return empty creds.
+  if (!m_initialized) {
+    return Aws::Auth::AWSCredentials();
+  }
+  RefreshIfExpired();
+  ReaderLockGuard guard(m_reloadLock);
+  return m_credentials;
 }
 
-void STSAssumeRoleWebIdentityCredentialsProvider::Reload()
-{
-    AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Credentials have expired, attempting to renew from STS.");
+void STSAssumeRoleWebIdentityCredentialsProvider::Reload() {
+  AWS_LOGSTREAM_INFO(
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+      "Credentials have expired, attempting to renew from STS.");
 
-    Aws::IFStream tokenFile(m_tokenFile.c_str());
-    if(tokenFile)
-    {
-        Aws::String token((std::istreambuf_iterator<char>(tokenFile)), std::istreambuf_iterator<char>());
-        m_token = token;
-    }
-    else
-    {
-        AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
-        return;
-    }
-    STSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request {m_sessionName, m_roleArn, m_token};
+  Aws::IFStream tokenFile(m_tokenFile.c_str());
+  if (tokenFile) {
+    Aws::String token(
+        (std::istreambuf_iterator<char>(tokenFile)),
+        std::istreambuf_iterator<char>());
+    m_token = token;
+  } else {
+    AWS_LOGSTREAM_ERROR(
+        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+        "Can't open token file: " << m_tokenFile);
+    return;
+  }
+  STSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{
+      m_sessionName, m_roleArn, m_token};
 
-    auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
-    AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Successfully retrieved credentials with AWS_ACCESS_KEY: " << result.creds.GetAWSAccessKeyId());
-    m_credentials = result.creds;
+  auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
+  AWS_LOGSTREAM_TRACE(
+      STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+      "Successfully retrieved credentials with AWS_ACCESS_KEY: "
+          << result.creds.GetAWSAccessKeyId());
+  m_credentials = result.creds;
 }
 
-bool STSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() const
-{
-  return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
+bool STSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() const {
+  return (
+      (m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() <
+      STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
 }
 
-void STSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired()
-{
-    ReaderLockGuard guard(m_reloadLock);
-    if (!m_credentials.IsEmpty() && !ExpiresSoon())
-    {
-       return;
-    }
+void STSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired() {
+  ReaderLockGuard guard(m_reloadLock);
+  if (!m_credentials.IsEmpty() && !ExpiresSoon()) {
+    return;
+  }
 
-    guard.UpgradeToWriterLock();
-    if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) // double-checked lock to avoid refreshing twice
-    {
-        return;
-    }
+  guard.UpgradeToWriterLock();
+  if (!m_credentials.IsExpiredOrEmpty() &&
+      !ExpiresSoon())  // double-checked lock to avoid refreshing twice
+  {
+    return;
+  }
 
-    Reload();
+  Reload();
 }
+}  // namespace tiledb::sm::filesystem::s3

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
@@ -77,21 +77,15 @@ STSAssumeRoleWebIdentityCredentialsProvider::
         Aws::Client::ClientConfiguration config)
     : m_initialized(false) {
   // check environment variables
-  Aws::String tmpRegion = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
   m_roleArn = Aws::Environment::GetEnv("AWS_ROLE_ARN");
   m_tokenFile = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
   m_sessionName = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
 
   // check profile_config if either m_roleArn or m_tokenFile is not loaded from
-  // environment variable region source is not enforced, but we need it to
-  // construct sts endpoint, if we can't find from environment, we should check
-  // if it's set in config file.
-  if (m_roleArn.empty() || m_tokenFile.empty() || tmpRegion.empty()) {
+  // environment variable
+  if (m_roleArn.empty() || m_tokenFile.empty()) {
     auto profile =
         Aws::Config::GetCachedConfigProfile(Aws::Auth::GetConfigProfileName());
-    if (tmpRegion.empty()) {
-      tmpRegion = profile.GetRegion();
-    }
     // If either of these two were not found from environment, use whatever
     // found for all three in config file
     if (m_roleArn.empty() || m_tokenFile.empty()) {
@@ -125,18 +119,6 @@ STSAssumeRoleWebIdentityCredentialsProvider::
         STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
         "Resolved role_arn from profile_config or environment variable to be "
             << m_roleArn);
-  }
-
-  if (config.region.empty()) {
-    if (tmpRegion.empty()) {
-      tmpRegion = Aws::Region::US_EAST_1;
-    } else {
-      AWS_LOGSTREAM_DEBUG(
-          STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-          "Resolved region from profile_config or environment variable to be "
-              << tmpRegion);
-    }
-    config.region = tmpRegion;
   }
 
   if (m_sessionName.empty()) {

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
@@ -127,13 +127,16 @@ STSAssumeRoleWebIdentityCredentialsProvider::
             << m_roleArn);
   }
 
-  if (tmpRegion.empty()) {
-    tmpRegion = Aws::Region::US_EAST_1;
-  } else {
-    AWS_LOGSTREAM_DEBUG(
-        STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
-        "Resolved region from profile_config or environment variable to be "
-            << tmpRegion);
+  if (config.region.empty()) {
+    if (tmpRegion.empty()) {
+      tmpRegion = Aws::Region::US_EAST_1;
+    } else {
+      AWS_LOGSTREAM_DEBUG(
+          STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG,
+          "Resolved region from profile_config or environment variable to be "
+              << tmpRegion);
+    }
+    config.region = tmpRegion;
   }
 
   if (m_sessionName.empty()) {
@@ -147,7 +150,6 @@ STSAssumeRoleWebIdentityCredentialsProvider::
   }
 
   config.scheme = Aws::Http::Scheme::HTTPS;
-  config.region = tmpRegion;
 
   if (!config.retryStrategy) {
     Aws::Vector<Aws::String> retryableErrors;

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.cc
@@ -1,0 +1,170 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+
+#include <aws/core/auth/STSCredentialsProvider.h>
+#include <aws/core/config/AWSProfileConfigLoader.h>
+#include <aws/core/platform/Environment.h>
+#include <aws/core/platform/FileSystem.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/FileSystemUtils.h>
+#include <aws/core/client/SpecifiedRetryableErrorsRetryStrategy.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/core/utils/UUID.h>
+#include <cstdlib>
+#include <fstream>
+#include <string.h>
+#include <climits>
+
+
+using namespace Aws::Utils;
+using namespace Aws::Utils::Logging;
+using namespace Aws::Auth;
+using namespace Aws::Internal;
+using namespace Aws::FileSystem;
+using namespace Aws::Client;
+using Aws::Utils::Threading::ReaderLockGuard;
+using Aws::Utils::Threading::WriterLockGuard;
+
+static const char STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG[] = "STSAssumeRoleWithWebIdentityCredentialsProvider";
+static const int STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD = 5 * 1000;
+
+STSAssumeRoleWebIdentityCredentialsProvider::STSAssumeRoleWebIdentityCredentialsProvider() :
+    m_initialized(false)
+{
+    // check environment variables
+    Aws::String tmpRegion = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
+    m_roleArn = Aws::Environment::GetEnv("AWS_ROLE_ARN");
+    m_tokenFile = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
+    m_sessionName = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
+
+    // check profile_config if either m_roleArn or m_tokenFile is not loaded from environment variable
+    // region source is not enforced, but we need it to construct sts endpoint, if we can't find from environment, we should check if it's set in config file.
+    if (m_roleArn.empty() || m_tokenFile.empty() || tmpRegion.empty())
+    {
+        auto profile = Aws::Config::GetCachedConfigProfile(Aws::Auth::GetConfigProfileName());
+        if (tmpRegion.empty())
+        {
+            tmpRegion = profile.GetRegion();
+        }
+        // If either of these two were not found from environment, use whatever found for all three in config file
+        if (m_roleArn.empty() || m_tokenFile.empty())
+        {
+            m_roleArn = profile.GetRoleArn();
+            m_tokenFile = profile.GetValue("web_identity_token_file");
+            m_sessionName = profile.GetValue("role_session_name");
+        }
+    }
+
+    if (m_tokenFile.empty())
+    {
+        AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Token file must be specified to use STS AssumeRole web identity creds provider.");
+        return; // No need to do further constructing
+    }
+    else
+    {
+        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved token_file from profile_config or environment variable to be " << m_tokenFile);
+    }
+
+    if (m_roleArn.empty())
+    {
+        AWS_LOGSTREAM_WARN(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "RoleArn must be specified to use STS AssumeRole web identity creds provider.");
+        return; // No need to do further constructing
+    }
+    else
+    {
+        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved role_arn from profile_config or environment variable to be " << m_roleArn);
+    }
+
+    if (tmpRegion.empty())
+    {
+        tmpRegion = Aws::Region::US_EAST_1;
+    }
+    else
+    {
+        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved region from profile_config or environment variable to be " << tmpRegion);
+    }
+
+    if (m_sessionName.empty())
+    {
+        m_sessionName = Aws::Utils::UUID::PseudoRandomUUID();
+    }
+    else
+    {
+        AWS_LOGSTREAM_DEBUG(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Resolved session_name from profile_config or environment variable to be " << m_sessionName);
+    }
+
+    Aws::Client::ClientConfiguration config;
+    config.scheme = Aws::Http::Scheme::HTTPS;
+    config.region = tmpRegion;
+
+    Aws::Vector<Aws::String> retryableErrors;
+    retryableErrors.push_back("IDPCommunicationError");
+    retryableErrors.push_back("InvalidIdentityToken");
+
+    config.retryStrategy = Aws::MakeShared<SpecifiedRetryableErrorsRetryStrategy>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, retryableErrors, 3/*maxRetries*/);
+
+    m_client = Aws::MakeUnique<Aws::Internal::STSCredentialsClient>(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, config);
+    m_initialized = true;
+    AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Creating STS AssumeRole with web identity creds provider.");
+}
+
+AWSCredentials STSAssumeRoleWebIdentityCredentialsProvider::GetAWSCredentials()
+{
+    // A valid client means required information like role arn and token file were constructed correctly.
+    // We can use this provider to load creds, otherwise, we can just return empty creds.
+    if (!m_initialized)
+    {
+        return Aws::Auth::AWSCredentials();
+    }
+    RefreshIfExpired();
+    ReaderLockGuard guard(m_reloadLock);
+    return m_credentials;
+}
+
+void STSAssumeRoleWebIdentityCredentialsProvider::Reload()
+{
+    AWS_LOGSTREAM_INFO(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Credentials have expired, attempting to renew from STS.");
+
+    Aws::IFStream tokenFile(m_tokenFile.c_str());
+    if(tokenFile)
+    {
+        Aws::String token((std::istreambuf_iterator<char>(tokenFile)), std::istreambuf_iterator<char>());
+        m_token = token;
+    }
+    else
+    {
+        AWS_LOGSTREAM_ERROR(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Can't open token file: " << m_tokenFile);
+        return;
+    }
+    STSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request {m_sessionName, m_roleArn, m_token};
+
+    auto result = m_client->GetAssumeRoleWithWebIdentityCredentials(request);
+    AWS_LOGSTREAM_TRACE(STS_ASSUME_ROLE_WEB_IDENTITY_LOG_TAG, "Successfully retrieved credentials with AWS_ACCESS_KEY: " << result.creds.GetAWSAccessKeyId());
+    m_credentials = result.creds;
+}
+
+bool STSAssumeRoleWebIdentityCredentialsProvider::ExpiresSoon() const
+{
+  return ((m_credentials.GetExpiration() - Aws::Utils::DateTime::Now()).count() < STS_CREDENTIAL_PROVIDER_EXPIRATION_GRACE_PERIOD);
+}
+
+void STSAssumeRoleWebIdentityCredentialsProvider::RefreshIfExpired()
+{
+    ReaderLockGuard guard(m_reloadLock);
+    if (!m_credentials.IsEmpty() && !ExpiresSoon())
+    {
+       return;
+    }
+
+    guard.UpgradeToWriterLock();
+    if (!m_credentials.IsExpiredOrEmpty() && !ExpiresSoon()) // double-checked lock to avoid refreshing twice
+    {
+        return;
+    }
+
+    Reload();
+}

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+
+#pragma once
+
+#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/internal/AWSHttpResourceClient.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <memory>
+
+namespace Aws
+{
+    namespace Auth
+    {
+        /**
+         * To support retrieving credentials of STS AssumeRole with web identity.
+         * Note that STS accepts request with protocol of queryxml. Calling GetAWSCredentials() will trigger (if expired)
+         * a query request using AWSHttpResourceClient under the hood.
+         */
+        class AWS_CORE_API STSAssumeRoleWebIdentityCredentialsProvider : public AWSCredentialsProvider
+        {
+        public:
+            STSAssumeRoleWebIdentityCredentialsProvider();
+
+            /**
+             * Retrieves the credentials if found, otherwise returns empty credential set.
+             */
+            AWSCredentials GetAWSCredentials() override;
+
+        protected:
+            void Reload() override;
+
+        private:
+            void RefreshIfExpired();
+            Aws::String CalculateQueryString() const;
+
+            Aws::UniquePtr<Aws::Internal::STSCredentialsClient> m_client;
+            Aws::Auth::AWSCredentials m_credentials;
+            Aws::String m_roleArn;
+            Aws::String m_tokenFile;
+            Aws::String m_sessionName;
+            Aws::String m_token;
+            bool m_initialized;
+            bool ExpiresSoon() const;
+        };
+    } // namespace Auth
+} // namespace Aws

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.h
@@ -1,52 +1,85 @@
 /**
+ * @file   STSCredentialsProvider.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines a vendored copy of the
+ * Aws::Auth::STSAssumeRoleWebIdentityCredentialsProvider class, updated to
+ * support getting a client configuration object.
+ *
+ * Changes made should be contributed upstream to the AWS SDK for C++ and when
+ * that happens, the vendored copy should be removed.
+ */
+
+/**
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-
 #pragma once
 
-#include <aws/core/Core_EXPORTS.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/internal/AWSHttpResourceClient.h>
 #include <aws/core/utils/DateTime.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
-#include <aws/core/internal/AWSHttpResourceClient.h>
-#include <aws/core/auth/AWSCredentialsProvider.h>
 #include <memory>
+#include "tiledb/common/common.h"
 
-namespace Aws
-{
-    namespace Auth
-    {
-        /**
-         * To support retrieving credentials of STS AssumeRole with web identity.
-         * Note that STS accepts request with protocol of queryxml. Calling GetAWSCredentials() will trigger (if expired)
-         * a query request using AWSHttpResourceClient under the hood.
-         */
-        class AWS_CORE_API STSAssumeRoleWebIdentityCredentialsProvider : public AWSCredentialsProvider
-        {
-        public:
-            STSAssumeRoleWebIdentityCredentialsProvider();
+namespace tiledb::sm::filesystem::s3 {
+/**
+ * To support retrieving credentials of STS AssumeRole with web identity.
+ * Note that STS accepts request with protocol of queryxml. Calling
+ * GetAWSCredentials() will trigger (if expired) a query request using
+ * AWSHttpResourceClient under the hood.
+ */
+class STSAssumeRoleWebIdentityCredentialsProvider
+    : public Aws::Auth::AWSCredentialsProvider {
+ public:
+  STSAssumeRoleWebIdentityCredentialsProvider();
 
-            /**
-             * Retrieves the credentials if found, otherwise returns empty credential set.
-             */
-            AWSCredentials GetAWSCredentials() override;
+  /**
+   * Retrieves the credentials if found, otherwise returns empty credential set.
+   */
+  Aws::Auth::AWSCredentials GetAWSCredentials() override;
 
-        protected:
-            void Reload() override;
+ protected:
+  void Reload() override;
 
-        private:
-            void RefreshIfExpired();
-            Aws::String CalculateQueryString() const;
+ private:
+  void RefreshIfExpired();
+  Aws::String CalculateQueryString() const;
 
-            Aws::UniquePtr<Aws::Internal::STSCredentialsClient> m_client;
-            Aws::Auth::AWSCredentials m_credentials;
-            Aws::String m_roleArn;
-            Aws::String m_tokenFile;
-            Aws::String m_sessionName;
-            Aws::String m_token;
-            bool m_initialized;
-            bool ExpiresSoon() const;
-        };
-    } // namespace Auth
-} // namespace Aws
+  tdb_unique_ptr<Aws::Internal::STSCredentialsClient> m_client;
+  Aws::Auth::AWSCredentials m_credentials;
+  Aws::String m_roleArn;
+  Aws::String m_tokenFile;
+  Aws::String m_sessionName;
+  Aws::String m_token;
+  bool m_initialized;
+  bool ExpiresSoon() const;
+};
+}  // namespace tiledb::sm::filesystem::s3

--- a/tiledb/sm/filesystem/s3/STSCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/STSCredentialsProvider.h
@@ -59,7 +59,9 @@ namespace tiledb::sm::filesystem::s3 {
 class STSAssumeRoleWebIdentityCredentialsProvider
     : public Aws::Auth::AWSCredentialsProvider {
  public:
-  STSAssumeRoleWebIdentityCredentialsProvider();
+  STSAssumeRoleWebIdentityCredentialsProvider(
+      Aws::Client::ClientConfiguration clientConfig =
+          Aws::Client::ClientConfiguration());
 
   /**
    * Retrieves the credentials if found, otherwise returns empty credential set.
@@ -71,7 +73,6 @@ class STSAssumeRoleWebIdentityCredentialsProvider
 
  private:
   void RefreshIfExpired();
-  Aws::String CalculateQueryString() const;
 
   tdb_unique_ptr<Aws::Internal::STSCredentialsClient> m_client;
   Aws::Auth::AWSCredentials m_credentials;

--- a/tiledb/sm/filesystem/s3/STSProfileWithWebIdentityCredentialsProvider.h
+++ b/tiledb/sm/filesystem/s3/STSProfileWithWebIdentityCredentialsProvider.h
@@ -1,5 +1,5 @@
 /**
- * @file   STSProfileWithWebIdentityCredentialsProvider.g
+ * @file   STSProfileWithWebIdentityCredentialsProvider.h
  *
  * @section LICENSE
  *


### PR DESCRIPTION
[SC-55378](https://app.shortcut.com/tiledb-inc/story/55378/ensure-all-aws-clients-and-credentials-providers-are-being-passed-client-configuration)

This PR applies a similar fix to #4641, but for the `DefaultAWSCredentialsProviderChain` which was being implicitly used when we don't pass any credentials provider to `S3Client` (it's now explicitly used).

Because `DefaultAWSCredentialsProviderChain` does not accept a `ClientConfiguration`, I copied its sources, as well as the sources of all applicable credentials providers and updated them to accept a `ClientConfiguration`. This is a temporary measure until the changes to the providers are upstreamed to the AWS SDK.

You are encouraged to review this PR by looking at each commit individually.

---
TYPE: BUG
DESC: Fix HTTP requests for AWS default credentials provider chain not honoring config options.