### PR TITLE
Add overload to `Array::create` that explicitly accepts a context.

### DIFF
--- a/examples/cpp_api/aggregates.cc
+++ b/examples/cpp_api/aggregates.cc
@@ -61,7 +61,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/array_metadata.cc
+++ b/examples/cpp_api/array_metadata.cc
@@ -56,7 +56,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array_metadata() {

--- a/examples/cpp_api/array_schema_evolution.cc
+++ b/examples/cpp_api/array_schema_evolution.cc
@@ -55,7 +55,7 @@ void create_array(const Context& ctx) {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 }
 
 void write_array(const Context& ctx) {

--- a/examples/cpp_api/axes_labels.cc
+++ b/examples/cpp_api/axes_labels.cc
@@ -71,7 +71,7 @@ void create_data_array(tiledb::Context& ctx, const std::string& array_uri) {
   schema.set_allows_dups(false);
 
   // Create the (empty) array on disk.
-  tiledb::Array::create(array_uri, schema);
+  tiledb::Array::create(ctx, array_uri, schema);
 }
 
 void create_axes_array(tiledb::Context& ctx, const std::string& array_uri) {
@@ -96,7 +96,7 @@ void create_axes_array(tiledb::Context& ctx, const std::string& array_uri) {
   schema.set_allows_dups(true);
 
   // Create the (empty) array on disk.
-  tiledb::Array::create(array_uri, schema);
+  tiledb::Array::create(ctx, array_uri, schema);
 }
 
 void write_axes_array(tiledb::Context& ctx, const std::string& array_uri) {

--- a/examples/cpp_api/consolidation_plan.cc
+++ b/examples/cpp_api/consolidation_plan.cc
@@ -61,7 +61,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_fragment(int min, int max) {

--- a/examples/cpp_api/current_domain.cc
+++ b/examples/cpp_api/current_domain.cc
@@ -76,7 +76,7 @@ void create_array(Context& ctx, const std::string& array_uri) {
   ArraySchemaExperimental::set_current_domain(ctx, schema, current_domain);
 
   // Create the (empty) array on disk
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 }
 
 void print_current_domain(Context& ctx) {

--- a/examples/cpp_api/deletes.cc
+++ b/examples/cpp_api/deletes.cc
@@ -56,7 +56,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/encryption.cc
+++ b/examples/cpp_api/encryption.cc
@@ -63,7 +63,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) encrypted array.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/enumerations.cc
+++ b/examples/cpp_api/enumerations.cc
@@ -79,7 +79,7 @@ void create_array() {
   // Finally, we add the attribute as per normal.
   schema.add_attribute(attr);
 
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/filters.cc
+++ b/examples/cpp_api/filters.cc
@@ -73,7 +73,7 @@ void create_array() {
   schema.add_attribute(a1).add_attribute(a2);
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/fragment_info.cc
+++ b/examples/cpp_api/fragment_info.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/fragments_consolidation.cc
+++ b/examples/cpp_api/fragments_consolidation.cc
@@ -58,7 +58,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array_1() {

--- a/examples/cpp_api/groups.cc
+++ b/examples/cpp_api/groups.cc
@@ -59,7 +59,7 @@ void create_array(const std::string& array_name, tiledb_array_type_t type) {
   ArraySchema schema(ctx, type);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void create_arrays_groups() {

--- a/examples/cpp_api/multi_attribute.cc
+++ b/examples/cpp_api/multi_attribute.cc
@@ -63,7 +63,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<float[2]>(ctx, "a2"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/multi_range_subarray.cc
+++ b/examples/cpp_api/multi_range_subarray.cc
@@ -56,7 +56,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/nullable_attribute.cc
+++ b/examples/cpp_api/nullable_attribute.cc
@@ -70,7 +70,7 @@ void create_array() {
   schema.add_attribute(a3);
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/object.cc
+++ b/examples/cpp_api/object.cc
@@ -98,7 +98,7 @@ void create_array(const std::string& array_name, tiledb_array_type_t type) {
   ArraySchema schema(ctx, type);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void move_remove_obj() {

--- a/examples/cpp_api/png_ingestion_webp.cc
+++ b/examples/cpp_api/png_ingestion_webp.cc
@@ -236,7 +236,7 @@ void create_array(
   schema.add_attribute(rgba);
 
   // Create the empty array on disk.
-  Array::create(array_path, schema);
+  Array::create(ctx, array_path, schema);
 }
 
 /**

--- a/examples/cpp_api/query_condition_dense.cc
+++ b/examples/cpp_api/query_condition_dense.cc
@@ -98,7 +98,7 @@ void create_array(Context& ctx) {
   schema.add_attribute(a).add_attribute(b).add_attribute(c).add_attribute(d);
 
   // Create the (empty) array.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 /**

--- a/examples/cpp_api/query_condition_sparse.cc
+++ b/examples/cpp_api/query_condition_sparse.cc
@@ -92,7 +92,7 @@ void create_array(Context& ctx) {
       .add_attribute(Attribute::create<float>(ctx, "d"));
 
   // Create the (empty) array.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 /**

--- a/examples/cpp_api/quickstart_dense.cc
+++ b/examples/cpp_api/quickstart_dense.cc
@@ -55,7 +55,7 @@ void create_array(const Context& ctx) {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name_, schema);
+  Array::create(ctx, array_name_, schema);
 }
 
 void write_array(const Context& ctx) {

--- a/examples/cpp_api/quickstart_dimension_labels.cc
+++ b/examples/cpp_api/quickstart_dimension_labels.cc
@@ -121,7 +121,7 @@ void create_array(const Context& ctx, const char* array_uri) {
       ctx, schema, 0, "y", TILEDB_INCREASING_DATA, TILEDB_FLOAT64);
   ArraySchemaExperimental::add_dimension_label(
       ctx, schema, 1, "timestamp", TILEDB_INCREASING_DATA, TILEDB_DATETIME_SEC);
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 }
 
 /**

--- a/examples/cpp_api/quickstart_sparse.cc
+++ b/examples/cpp_api/quickstart_sparse.cc
@@ -56,7 +56,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/quickstart_sparse_heter.cc
+++ b/examples/cpp_api/quickstart_sparse_heter.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int32_t>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/quickstart_sparse_string.cc
+++ b/examples/cpp_api/quickstart_sparse_string.cc
@@ -61,7 +61,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int32_t>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/reading_dense_layouts.cc
+++ b/examples/cpp_api/reading_dense_layouts.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/reading_incomplete.cc
+++ b/examples/cpp_api/reading_incomplete.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<std::string>(ctx, "a2"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/reading_sparse_layouts.cc
+++ b/examples/cpp_api/reading_sparse_layouts.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/using_tiledb_stats.cc
+++ b/examples/cpp_api/using_tiledb_stats.cc
@@ -56,7 +56,7 @@ void create_array(uint32_t row_tile_extent, uint32_t col_tile_extent) {
   schema.set_domain(dom);
   schema.add_attribute(Attribute::create<int32_t>(ctx, "a"));
 
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/variable_length.cc
+++ b/examples/cpp_api/variable_length.cc
@@ -59,7 +59,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<std::vector<int>>(ctx, "a2"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/writing_dense_global.cc
+++ b/examples/cpp_api/writing_dense_global.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/writing_dense_global_expansion.cc
+++ b/examples/cpp_api/writing_dense_global_expansion.cc
@@ -59,7 +59,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array_global() {

--- a/examples/cpp_api/writing_dense_multiple.cc
+++ b/examples/cpp_api/writing_dense_multiple.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array_1() {

--- a/examples/cpp_api/writing_dense_padding.cc
+++ b/examples/cpp_api/writing_dense_padding.cc
@@ -57,7 +57,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/writing_sparse_global.cc
+++ b/examples/cpp_api/writing_sparse_global.cc
@@ -60,7 +60,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/cpp_api/writing_sparse_multiple.cc
+++ b/examples/cpp_api/writing_sparse_multiple.cc
@@ -56,7 +56,7 @@ void create_array() {
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
   // Create the (empty) array on disk.
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 }
 
 void write_array() {

--- a/examples/png_ingestion/src/main.cc
+++ b/examples/png_ingestion/src/main.cc
@@ -189,7 +189,7 @@ void create_array(
       .add_attribute(Attribute::create<uint8_t>(ctx, "alpha"));
 
   // Create the (empty) array on disk.
-  Array::create(array_path, schema);
+  Array::create(ctx, array_path, schema);
 }
 
 /**

--- a/test/src/unit-cppapi-array.cc
+++ b/test/src/unit-cppapi-array.cc
@@ -75,7 +75,7 @@ struct CPPArrayFx {
     schema.add_attributes(a1, a2, a3, a4, a5);
 
     // set the array_uri so that it's deleted on cleanup
-    Array::create(array_uri_, schema);
+    Array::create(ctx, array_uri_, schema);
   }
 
   test::VFSTestSetup vfs_test_setup_;
@@ -135,7 +135,7 @@ TEST_CASE_METHOD(CPPArrayFx, "C++ API: Arrays", "[cppapi][basic][rest]") {
     schema.set_domain(domain);
     schema.add_attribute(a1);
 
-    Array::create(array_uri1, schema);
+    Array::create(ctx, array_uri1, schema);
     Array array(ctx1, array_uri1, TILEDB_READ);
 
     // Check that the config values are correct
@@ -473,7 +473,7 @@ TEST_CASE(
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<std::vector<int32_t>>(ctx, "a"));
   schema.add_attribute(Attribute::create<uint64_t>(ctx, "b"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   {
     Array array(ctx, array_uri, TILEDB_WRITE);
@@ -548,7 +548,7 @@ TEST_CASE("C++ API: Incorrect offsets", "[cppapi][invalid-offsets][rest]") {
   domain.add_dimension(Dimension::create<int32_t>(ctx, "d", {{0, 1000}}, 1001));
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<std::vector<int32_t>>(ctx, "a"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
   Array array(ctx, array_uri, TILEDB_WRITE);
 
   std::vector<int32_t> a, coord = {10, 20, 30};
@@ -594,7 +594,7 @@ TEST_CASE(
         ArraySchema schema(ctx, TILEDB_DENSE);
         schema.set_domain(domain).set_order({{tile_layout, cell_layout}});
         schema.add_attribute(Attribute::create<int>(ctx, "a"));
-        Array::create(array_name, schema);
+        Array::create(ctx, array_name, schema);
 
         // Write
         std::vector<int> data_w = {
@@ -650,7 +650,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 
   REQUIRE_NOTHROW(Array::consolidate(ctx, array_name));
 
@@ -680,7 +680,7 @@ TEST_CASE(
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
 
-  tiledb::Array::create(array_name, schema);
+  tiledb::Array::create(ctx, array_name, schema);
   auto array_w = tiledb::Array(ctx, array_name, TILEDB_WRITE);
   std::vector<int> data = {0, 1};
 
@@ -736,7 +736,7 @@ TEST_CASE("C++ API: Encrypted array", "[cppapi][encryption][non-rest]") {
 
   REQUIRE_THROWS_AS(
       Array::encryption_type(ctx, array_name), tiledb::TileDBError);
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
   REQUIRE(Array::encryption_type(ctx, array_name) == TILEDB_AES_256_GCM);
 
   ArraySchema schema_read(ctx, array_name);
@@ -827,7 +827,7 @@ TEST_CASE(
 
   REQUIRE_THROWS_AS(
       Array::encryption_type(ctx, array_name), tiledb::TileDBError);
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
   REQUIRE(Array::encryption_type(ctx, array_name) == TILEDB_AES_256_GCM);
 
   ArraySchema schema_read(ctx, array_name);
@@ -893,7 +893,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<int>(ctx, ""));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   Array array(ctx, array_uri, TILEDB_READ);
   auto reloaded_schema = array.schema();
@@ -914,7 +914,7 @@ TEST_CASE("C++ API: Open array at", "[cppapi][open-array-at][rest]") {
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write array
   Array array_w(ctx, array_uri, TILEDB_WRITE);
@@ -1023,7 +1023,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 
   // Write array
   Array array_w(ctx, array_name, TILEDB_WRITE);
@@ -1121,7 +1121,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   std::vector<int> data_w = {1};
@@ -1172,7 +1172,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create(ctx, "a", datatype));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   std::byte data_w{1};
@@ -1213,6 +1213,7 @@ TEST_CASE(
                   .set_filter_list(FilterList(ctx).add_filter(
                       Filter(ctx, TILEDB_FILTER_BZIP2)));
   Array::create(
+      ctx,
       array_uri,
       ArraySchema(ctx, TILEDB_SPARSE)
           .set_domain(Domain(ctx).add_dimension(
@@ -1271,7 +1272,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.add_attribute(a);
   schema.set_domain(dom);
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   Array array(ctx, array_uri, TILEDB_WRITE);
@@ -1333,7 +1334,7 @@ TEST_CASE(
   auto a = Attribute::create<int32_t>(ctx, "a");
   schema.add_attribute(a);
   schema.set_domain(dom);
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   Array array(ctx, array_uri, TILEDB_WRITE);
@@ -1465,7 +1466,7 @@ TEST_CASE(
   schema.set_tile_order(TILEDB_COL_MAJOR);
   schema.set_cell_order(TILEDB_COL_MAJOR);
   schema.set_domain(dom);
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   Array array(ctx, array_uri, TILEDB_WRITE);
@@ -1526,7 +1527,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   std::vector<int> data_w = {1};
@@ -1573,7 +1574,7 @@ TEST_CASE(
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
   schema.set_allows_dups(true);
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   std::vector<int> data_w = {1};
@@ -1619,7 +1620,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   std::vector<int> data_w = {
@@ -1667,7 +1668,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_uri, schema);
+  Array::create(ctx, array_uri, schema);
 
   // Write
   std::vector<int> data_w = {
@@ -1720,7 +1721,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_SPARSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 
   // Write
   std::vector<int> data_w = {1};
@@ -1771,7 +1772,7 @@ TEST_CASE(
   ArraySchema schema(ctx, TILEDB_DENSE);
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   schema.add_attribute(Attribute::create<int>(ctx, "a"));
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
 
   // Try writing on a non-process-global Context
   Context ctx_non_global;
@@ -1844,7 +1845,7 @@ TEST_CASE(
   schema.set_domain(domain).set_order({{TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR}});
   Attribute attr = Attribute::create<int>(ctx, "a");
   schema.add_attribute(attr);
-  Array::create(array_name, schema);
+  Array::create(ctx, array_name, schema);
   REQUIRE(vfs.ls(array_name).size() == 1);
 
   // Ensure the array can be opened and write to it
@@ -2039,7 +2040,7 @@ TEST_CASE("C++ API: Read empty array", "[cppapi][read-empty-array]") {
   schema.set_domain(domain);
   schema.add_attribute(Attribute::create<int32_t>(ctx, "a"));
   schema.set_allows_dups(dups);
-  Array::create(array_name_1d, schema);
+  Array::create(ctx, array_name_1d, schema);
   Array array(ctx, array_name_1d, TILEDB_READ);
 
   std::vector<int32_t> d(1);

--- a/tiledb/sm/cpp_api/array.h
+++ b/tiledb/sm/cpp_api/array.h
@@ -663,6 +663,30 @@ class Array {
    *
    * **Example:**
    * @code{.cpp}
+   * tiledb::Array::create(ctx, "s3://bucket-name/array-name", schema);
+   * @endcode
+   *
+   * @param ctx The TileDB context.
+   * @param uri URI where array will be created.
+   * @param schema The array schema.
+   */
+  static void create(
+      const Context& ctx, const std::string& uri, const ArraySchema& schema) {
+    tiledb_ctx_t* c_ctx = ctx.ptr().get();
+    ctx.handle_error(tiledb_array_schema_check(c_ctx, schema.ptr().get()));
+    ctx.handle_error(
+        tiledb_array_create(c_ctx, uri.c_str(), schema.ptr().get()));
+  }
+
+  /**
+   * Creates a new TileDB array given an input schema.
+   *
+   * To create the array, this function uses the context that was used to
+   * instantiate the schema. You are recommended to explicitly pass it with the
+   * overload that takes a context.
+   *
+   * **Example:**
+   * @code{.cpp}
    * tiledb::Array::create("s3://bucket-name/array-name", schema);
    * @endcode
    *
@@ -670,11 +694,7 @@ class Array {
    * @param schema The array schema.
    */
   static void create(const std::string& uri, const ArraySchema& schema) {
-    auto& ctx = schema.context();
-    tiledb_ctx_t* c_ctx = ctx.ptr().get();
-    ctx.handle_error(tiledb_array_schema_check(c_ctx, schema.ptr().get()));
-    ctx.handle_error(
-        tiledb_array_create(c_ctx, uri.c_str(), schema.ptr().get()));
+    create(schema.context(), uri, schema);
   }
 
   /**


### PR DESCRIPTION
[SC-42521](https://app.shortcut.com/tiledb-inc/story/42521/add-overload-to-the-array-create-c-function-that-explicitly-accepts-a-context)

The `Array::create` function uses the context that was used when creating its `ArraySchema`. This is unintuitive and inflexible, and this PR fixes it by adding an overload that explicitly accepts a context.

Per discussions the existing overload is not deprecated, but users are recommended to explicitly pass a context when creating an array whenever possible.

---
TYPE: CPP_API
DESC: Add overload to the `Array::create` function that explicitly accepts a context.