### PR TITLE
Support cross-compiling in the libmagic vcpkg port overlay.

### DIFF
--- a/ports/libmagic/CMakeLists.txt
+++ b/ports/libmagic/CMakeLists.txt
@@ -7,6 +7,7 @@ unset(CONFIGURE_AC_CONTENT)
 project(file VERSION ${CMAKE_MATCH_1})
 
 option(FILE_TESTS "Enable file tests" OFF)
+set(FILE_COMMAND "file" CACHE PATH "Path to the file command to generate magic.mgc. Should be set for cross-compiling scenarios.")
 
 # Get library directory for multiarch linux distros
 include(GNUInstallDirs)
@@ -133,7 +134,7 @@ foreach(MAGIC_FRAGMENT ${MAGIC_FRAGMENTS})
 endforeach()
 
 add_custom_command(OUTPUT magic.mgc
-  COMMAND file -C -m magic
+  COMMAND ${FILE_COMMAND} -C -m magic
   COMMENT "Compiling magic file"
 )
 

--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -31,11 +31,19 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-libmagic-config.cmake.in" DESTIN
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/magic.def" DESTINATION "${SOURCE_PATH}/src")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/config.h" DESTINATION "${SOURCE_PATH}/src")
 
+if(VCPKG_CROSSCOMPILING)
+    set(FILE_COMMAND_OPT "-DFILE_COMMAND=${CURRENT_HOST_INSTALLED_DIR}/tools/libmagic/file${VCPKG_HOST_EXECUTABLE_SUFFIX}")
+elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(EXTRA_ARGS "ADD_BIN_TO_PATH")
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        ${FILE_COMMAND_OPT}
 )
 
-vcpkg_cmake_install()
+vcpkg_cmake_install(${EXTRA_ARGS})
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_tools(TOOL_NAMES file AUTO_CLEAN)
@@ -46,12 +54,6 @@ vcpkg_cmake_config_fixup(
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/man5")
-
-if(VCPKG_CROSSCOMPILING)
-    vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/libmagic/bin")
-elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    set(EXTRA_ARGS "ADD_BIN_TO_PATH")
-endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -6,6 +6,10 @@
   "homepage": "https://github.com/file/file",
   "dependencies": [
     {
+      "name": "libmagic",
+      "host": true
+    },
+    {
       "name": "vcpkg-cmake",
       "host": true
     },


### PR DESCRIPTION
Fixes TileDB-Inc/conda-forge-nightly-controller#145.

This PR adds support for cross-compiling our custom vcpkg port overlay for libmagic. This is accomplished by installing libmagic as a host dependency, and using the host's `file.exe` to build `magic.mgc` in cross-compiled builds.

Validated locally by successfully cross compiling the Core for Windows-ARM64 (with cloud storage and serialization disabled because these dependencies are not yet compatible).

---
TYPE: BUILD
DESC: Fixed cross-compiling support in the libmagic vcpkg port overlay.