### PR TITLE
Add group member by type

### DIFF
--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -592,18 +592,34 @@ TEST_CASE_METHOD(
   rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
-  rc =
-      tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc =
-      tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc =
-      tiledb_group_add_member(ctx_, group2, array3_uri.c_str(), false, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc =
-      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, nullptr);
-  REQUIRE(rc == TILEDB_OK);
+  bool add_by_type = GENERATE(true, false);
+  if (add_by_type) {
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array1_uri.c_str(), false, nullptr, TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array2_uri.c_str(), false, nullptr, TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group2, array3_uri.c_str(), false, nullptr, TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, group2_uri.c_str(), false, nullptr, TILEDB_GROUP);
+    REQUIRE(rc == TILEDB_OK);
+  } else {
+    rc = tiledb_group_add_member(
+        ctx_, group1, array1_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, array2_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group2, array3_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, group2_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+  }
 
   // Close group from write mode
   rc = tiledb_group_close(ctx_, group1);
@@ -720,8 +736,16 @@ TEST_CASE_METHOD(
   rc = tiledb_group_open(ctx_, group1, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
-  rc = tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
-  REQUIRE(rc == TILEDB_OK);
+  bool add_by_type = GENERATE(true, false);
+  if (add_by_type) {
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array1_uri.c_str(), false, "one", TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+  } else {
+    rc =
+        tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
+    REQUIRE(rc == TILEDB_OK);
+  }
 
   // Close group from write mode
   rc = tiledb_group_close(ctx_, group1);
@@ -755,8 +779,15 @@ TEST_CASE_METHOD(
   rc = tiledb_group_remove_member(ctx_, group1, "one");
   REQUIRE(rc == TILEDB_OK);
   // Add one back with different URI
-  rc = tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "one");
-  REQUIRE(rc == TILEDB_OK);
+  if (add_by_type) {
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array2_uri.c_str(), false, "one", TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+  } else {
+    rc =
+        tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "one");
+    REQUIRE(rc == TILEDB_OK);
+  }
 
   // Close group
   rc = tiledb_group_close(ctx_, group1);
@@ -827,15 +858,34 @@ TEST_CASE_METHOD(
   rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
-  rc = tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "two");
-  REQUIRE(rc == TILEDB_OK);
-  rc =
-      tiledb_group_add_member(ctx_, group2, array3_uri.c_str(), false, "three");
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, "four");
-  REQUIRE(rc == TILEDB_OK);
+  bool add_by_type = GENERATE(true, false);
+  if (add_by_type) {
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array1_uri.c_str(), false, "one", TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array2_uri.c_str(), false, "two", TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group2, array3_uri.c_str(), false, "three", TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, group2_uri.c_str(), false, "four", TILEDB_GROUP);
+    REQUIRE(rc == TILEDB_OK);
+  } else {
+    rc =
+        tiledb_group_add_member(ctx_, group1, array1_uri.c_str(), false, "one");
+    REQUIRE(rc == TILEDB_OK);
+    rc =
+        tiledb_group_add_member(ctx_, group1, array2_uri.c_str(), false, "two");
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group2, array3_uri.c_str(), false, "three");
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, group2_uri.c_str(), false, "four");
+    REQUIRE(rc == TILEDB_OK);
+  }
 
   // Close group from write mode
   rc = tiledb_group_close(ctx_, group1);
@@ -1186,18 +1236,34 @@ TEST_CASE_METHOD(
   rc = tiledb_group_open(ctx_, group2, TILEDB_WRITE);
   REQUIRE(rc == TILEDB_OK);
 
-  rc = tiledb_group_add_member(
-      ctx_, group1, array1_relative_uri.c_str(), true, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_group_add_member(
-      ctx_, group1, array2_relative_uri.c_str(), true, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc = tiledb_group_add_member(
-      ctx_, group2, array3_relative_uri.c_str(), true, nullptr);
-  REQUIRE(rc == TILEDB_OK);
-  rc =
-      tiledb_group_add_member(ctx_, group1, group2_uri.c_str(), false, nullptr);
-  REQUIRE(rc == TILEDB_OK);
+  bool add_by_type = GENERATE(true, false);
+  if (add_by_type) {
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array1_relative_uri.c_str(), true, nullptr, TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, array2_relative_uri.c_str(), true, nullptr, TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group2, array3_relative_uri.c_str(), true, nullptr, TILEDB_ARRAY);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member_by_type(
+        ctx_, group1, group2_uri.c_str(), false, nullptr, TILEDB_GROUP);
+    REQUIRE(rc == TILEDB_OK);
+  } else {
+    rc = tiledb_group_add_member(
+        ctx_, group1, array1_relative_uri.c_str(), true, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, array2_relative_uri.c_str(), true, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group2, array3_relative_uri.c_str(), true, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+    rc = tiledb_group_add_member(
+        ctx_, group1, group2_uri.c_str(), false, nullptr);
+    REQUIRE(rc == TILEDB_OK);
+  }
 
   // Close group from write mode
   rc = tiledb_group_close(ctx_, group1);

--- a/tiledb/api/c_api/group/group_api.cc
+++ b/tiledb/api/c_api/group/group_api.cc
@@ -270,7 +270,30 @@ capi_return_t tiledb_group_add_member(
     name_optional = name;
   }
 
-  group->group().mark_member_for_addition(uri, relative, name_optional);
+  group->group().mark_member_for_addition(
+      uri, relative, name_optional, std::nullopt);
+
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_group_add_member_by_type(
+    tiledb_group_handle_t* group,
+    const char* group_uri,
+    const uint8_t relative,
+    const char* name,
+    tiledb_object_t type) {
+  ensure_group_is_valid(group);
+  ensure_group_uri_argument_is_valid(group_uri);
+
+  auto uri = tiledb::sm::URI(group_uri, !relative);
+
+  std::optional<std::string> name_optional = std::nullopt;
+  if (name != nullptr) {
+    name_optional = name;
+  }
+
+  group->group().mark_member_for_addition(
+      uri, relative, name_optional, static_cast<tiledb::sm::ObjectType>(type));
 
   return TILEDB_OK;
 }
@@ -657,6 +680,18 @@ CAPI_INTERFACE(
     const char* name) {
   return api_entry_context<tiledb::api::tiledb_group_add_member>(
       ctx, group, uri, relative, name);
+}
+
+CAPI_INTERFACE(
+    group_add_member_by_type,
+    tiledb_ctx_t* ctx,
+    tiledb_group_t* group,
+    const char* uri,
+    const uint8_t relative,
+    const char* name,
+    tiledb_object_t type) {
+  return api_entry_context<tiledb::api::tiledb_group_add_member_by_type>(
+      ctx, group, uri, relative, name, type);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/api/c_api/group/group_api_external.h
+++ b/tiledb/api/c_api/group/group_api_external.h
@@ -401,8 +401,8 @@ TILEDB_EXPORT capi_return_t tiledb_group_add_member(
  */
 TILEDB_EXPORT capi_return_t tiledb_group_add_member_by_type(
     tiledb_ctx_t* ctx,
-    tiledb_group_handle_t* group,
-    const char* group_uri,
+    tiledb_group_t* group,
+    const char* uri,
     const uint8_t relative,
     const char* name,
     tiledb_object_t type) TILEDB_NOEXCEPT;

--- a/tiledb/api/c_api/group/group_api_external.h
+++ b/tiledb/api/c_api/group/group_api_external.h
@@ -374,6 +374,39 @@ TILEDB_EXPORT capi_return_t tiledb_group_add_member(
     const char* name) TILEDB_NOEXCEPT;
 
 /**
+ * Add a member with a known type to a group
+ * The caller should make sure the correct type is provided for the member being
+ * added as this API will not check it for correctness in favor of efficiency
+ * and results can be undefined otherwise.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_group_t* group;
+ * tiledb_group_alloc(ctx, "s3://tiledb_bucket/my_group", &group);
+ * tiledb_group_open(ctx, group, TILEDB_WRITE);
+ * tiledb_group_add_member(ctx, group, "s3://tiledb_bucket/my_array",
+ * TILEDB_ARRAY); tiledb_group_add_member(ctx, group,
+ * "s3://tiledb_bucket/my_group_2", TILEDB_GROUP);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param group An group opened in WRITE mode.
+ * @param uri URI of member to add
+ * @param relative is the URI relative to the group
+ * @param name optional name group member can be given to be looked up by.
+ * Can be set to NULL.
+ *  @param type the type of the member getting added if known in advance.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_group_add_member_by_type(
+    tiledb_group_handle_t* group,
+    const char* group_uri,
+    const uint8_t relative,
+    const char* name,
+    tiledb_object_t type) TILEDB_NOEXCEPT;
+
+/**
  * Remove a member from a group
  *
  * * @code{.c}

--- a/tiledb/api/c_api/group/group_api_external.h
+++ b/tiledb/api/c_api/group/group_api_external.h
@@ -400,6 +400,7 @@ TILEDB_EXPORT capi_return_t tiledb_group_add_member(
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_group_add_member_by_type(
+    tiledb_ctx_t* ctx,
     tiledb_group_handle_t* group,
     const char* group_uri,
     const uint8_t relative,

--- a/tiledb/sm/enums/object_type.h
+++ b/tiledb/sm/enums/object_type.h
@@ -28,7 +28,7 @@
  * @section DESCRIPTION
  *
  * This file defines the tiledb ObjectType enum that maps to the
- * tiledb_object_type_t C-api enum
+ * tiledb_object_t C-api enum
  */
 
 #ifndef TILEDB_OBJECT_TYPE_H

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -643,7 +643,8 @@ void Group::delete_member(const shared_ptr<GroupMember> group_member) {
 void Group::mark_member_for_addition(
     const URI& group_member_uri,
     const bool& relative,
-    std::optional<std::string>& name) {
+    std::optional<std::string>& name,
+    std::optional<ObjectType> type) {
   std::lock_guard<std::mutex> lck(mtx_);
   // Check if group is open
   if (!is_open_) {
@@ -666,7 +667,7 @@ void Group::mark_member_for_addition(
         "mode");
   }
   group_details_->mark_member_for_addition(
-      resources_, group_member_uri, relative, name);
+      resources_, group_member_uri, relative, name, type);
 }
 
 void Group::mark_member_for_removal(const std::string& name) {

--- a/tiledb/sm/group/group.h
+++ b/tiledb/sm/group/group.h
@@ -299,11 +299,13 @@ class Group {
    * @param group_member_uri group member uri
    * @param relative is this URI relative
    * @param name optional name for member
+   * @param type optional type for member if known in advance
    */
   void mark_member_for_addition(
       const URI& group_member_uri,
       const bool& relative,
-      std::optional<std::string>& name);
+      std::optional<std::string>& name,
+      std::optional<ObjectType> type);
 
   /**
    * Remove a member from a group, this will be flushed to disk on close

--- a/tiledb/sm/group/group_details.h
+++ b/tiledb/sm/group/group_details.h
@@ -67,12 +67,14 @@ class GroupDetails {
    * @param group_member_uri group member uri
    * @param relative is this URI relative
    * @param name optional name for member
+   * @param type optional type for member if known in advance
    */
   void mark_member_for_addition(
       ContextResources& resources,
       const URI& group_member_uri,
       const bool& relative,
-      std::optional<std::string>& name);
+      std::optional<std::string>& name,
+      std::optional<ObjectType> type);
 
   /**
    * Remove a member from a group, this will be flushed to disk on close


### PR DESCRIPTION
Add a new `tiledb_group_add_member_by_type` API to avoid checking for the type of the asset before adding a member to a group for optimization purposes.

[sc-47918]

---
TYPE: C_API
DESC: Add API to get group member by type

TYPE: CPP_API
DESC: Add API to get group member by type