### PR TITLE
Remove deprecated call to fix CI docs builder

### DIFF
--- a/tiledb/doxygen/source/conf.py
+++ b/tiledb/doxygen/source/conf.py
@@ -133,7 +133,6 @@ if readthedocs:
 else:
     import sphinx_rtd_theme
     html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
Followed the error log advice: 
`sphinx.errors.SphinxWarning: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.`

Temporarily added a CPP API change and verified that now Docs build passes. Reverted that change.

---
TYPE: NO_HISTORY
DESC: Fix doc build
