### PR TITLE
Re-enable `TILEDB_CCACHE` support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 if (TILEDB_CCACHE)
   include(FindCcache)
   set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
+  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE})
 endif()
 
 # Set -fvisibility=hidden (or equivalent) flags by default.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,11 @@ else()
   set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
+if (TILEDB_CCACHE)
+  include(FindCcache)
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE})
+endif()
+
 # Set -fvisibility=hidden (or equivalent) flags by default.
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/cmake/Modules/FindCcache.cmake
+++ b/cmake/Modules/FindCcache.cmake
@@ -7,5 +7,3 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" # GNU is GNU GCC
   # without this compiler messages in `make` backend would be uncolored
   set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fdiagnostics-color=auto")
 endif()
-set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE})
-set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE})

--- a/cmake/Modules/FindCcache.cmake
+++ b/cmake/Modules/FindCcache.cmake
@@ -1,16 +1,11 @@
 ## cf https://stackoverflow.com/questions/1815688/how-to-use-ccache-with-cmake
 ## leading to https://invent.kde.org/kde/konsole/merge_requests/26/diffs
-find_program(CCACHE_FOUND NAMES "sccache" "ccache")
-set(CCACHE_SUPPORT ON CACHE BOOL "Enable ccache support")
-if (CCACHE_FOUND AND CCACHE_SUPPORT)
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" # GNU is GNU GCC
-      OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    # without this compiler messages in `make` backend would be uncolored
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fdiagnostics-color=auto")
-  endif()
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_FOUND})
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
-  message(STATUS "Found ccache: ${CCACHE_FOUND}")
-else()
-  message(FATAL_ERROR "Unable to find ccache")
+find_program(CCACHE REQUIRED NAMES "sccache" "ccache")
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" # GNU is GNU GCC
+    OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  # without this compiler messages in `make` backend would be uncolored
+  set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -fdiagnostics-color=auto")
 endif()
+set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE})
+set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE})


### PR DESCRIPTION
[SC-57386](https://app.shortcut.com/tiledb-inc/story/57386/tiledb-ccache-was-accidentally-removed-along-with-the-superbuild)

Fixes #5341 and simplifies `FindCcache.cmake`. Validated locally.

![image](https://github.com/user-attachments/assets/0db0e033-0e2f-416b-9291-57824a5e1a86)

---
TYPE: BUILD
DESC: The `TILEDB_CCACHE` option was fixed to have effect, after being accidentally disabled in version 2.26.0.