### PR TITLE
Revert "Support cross-compiling in the libmagic vcpkg port overlay. (#5333)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,16 @@
 name: Release
 
 on:
+  pull_request:
+    branches:
+      - dev
+      - 'release-*'
+      - '*'
   push:
     branches:
       - dev
       - 'release-*'
+      - '*'
     tags:
       - '*'
 
@@ -14,6 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
+    if: false
     steps:
       - name: Checkout TileDB
         uses: actions/checkout@v3
@@ -41,11 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-arm64, macos-x86_64, linux-x86_64, linux-x86_64-noavx2, windows-x86_64]
         include:
-          - platform: windows-x86_64
-            os: windows-2019
-            triplet: x64-windows-release
           - platform: linux-x86_64
             os: ubuntu-20.04
             manylinux: true
@@ -55,19 +58,9 @@ jobs:
             cmake_args: -DCOMPILER_SUPPORTS_AVX2=OFF
             triplet: x64-linux-release
             manylinux: true
-          - platform: macos-x86_64
-            os: macos-12
-            MACOSX_DEPLOYMENT_TARGET: 11
-            triplet: x64-osx-release
-          - platform: macos-arm64
-            os: macos-12
-            cmake_args: -DCMAKE_OSX_ARCHITECTURES=arm64
-            MACOSX_DEPLOYMENT_TARGET: 11
-            triplet: arm64-osx-release
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.manylinux && 'quay.io/pypa/manylinux2014_x86_64' || '' }}
     env:
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.
       # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
@@ -199,7 +192,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     needs: Publish-Release
-    if: (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
+    if: false && (failure() || cancelled()) && github.event_name != 'workflow_dispatch'
     steps:
       # The open-issue action requires to clone the repository.
       - name: Checkout TileDB

--- a/ports/libmagic/CMakeLists.txt
+++ b/ports/libmagic/CMakeLists.txt
@@ -7,7 +7,6 @@ unset(CONFIGURE_AC_CONTENT)
 project(file VERSION ${CMAKE_MATCH_1})
 
 option(FILE_TESTS "Enable file tests" OFF)
-set(FILE_COMMAND "file" CACHE PATH "Path to the file command to generate magic.mgc. Should be set for cross-compiling scenarios.")
 
 # Get library directory for multiarch linux distros
 include(GNUInstallDirs)
@@ -134,7 +133,7 @@ foreach(MAGIC_FRAGMENT ${MAGIC_FRAGMENTS})
 endforeach()
 
 add_custom_command(OUTPUT magic.mgc
-  COMMAND ${FILE_COMMAND} -C -m magic
+  COMMAND file -C -m magic
   COMMENT "Compiling magic file"
 )
 

--- a/ports/libmagic/portfile.cmake
+++ b/ports/libmagic/portfile.cmake
@@ -31,19 +31,11 @@ file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-libmagic-config.cmake.in" DESTIN
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/magic.def" DESTINATION "${SOURCE_PATH}/src")
 file(COPY "${CMAKE_CURRENT_LIST_DIR}/config.h" DESTINATION "${SOURCE_PATH}/src")
 
-if(VCPKG_CROSSCOMPILING)
-    set(FILE_COMMAND_OPT "-DFILE_COMMAND=${CURRENT_HOST_INSTALLED_DIR}/tools/libmagic/file${VCPKG_HOST_EXECUTABLE_SUFFIX}")
-elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
-    set(EXTRA_ARGS "ADD_BIN_TO_PATH")
-endif()
-
 vcpkg_cmake_configure(
     SOURCE_PATH ${SOURCE_PATH}
-    OPTIONS
-        ${FILE_COMMAND_OPT}
 )
 
-vcpkg_cmake_install(${EXTRA_ARGS})
+vcpkg_cmake_install()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 vcpkg_copy_tools(TOOL_NAMES file AUTO_CLEAN)
@@ -54,6 +46,12 @@ vcpkg_cmake_config_fixup(
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/${PORT}/man5")
+
+if(VCPKG_CROSSCOMPILING)
+    vcpkg_add_to_path(PREPEND "${CURRENT_HOST_INSTALLED_DIR}/tools/libmagic/bin")
+elseif(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+    set(EXTRA_ARGS "ADD_BIN_TO_PATH")
+endif()
 
 if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
     file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")

--- a/ports/libmagic/vcpkg.json
+++ b/ports/libmagic/vcpkg.json
@@ -6,10 +6,6 @@
   "homepage": "https://github.com/file/file",
   "dependencies": [
     {
-      "name": "libmagic",
-      "host": true
-    },
-    {
       "name": "vcpkg-cmake",
       "host": true
     },


### PR DESCRIPTION
Since #5333 the Release workflow has been failing. Let's revert the PR until we fix the failures (work is underway in #5338), in order to reduce the noise from the failed runs.

Fixes #5335

---
TYPE: NO_HISTORY