### PR TITLE
Load enumerations for all array schemas in a single request.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,5 +18,4 @@ trigger_pipeline:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
   trigger:
     project: tiledb-inc/tiledb-internal
-    branch: yt/enable_v2_testing_for_back_comp
     strategy: depend    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,4 +18,5 @@ trigger_pipeline:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
   trigger:
     project: tiledb-inc/tiledb-internal
+    branch: yt/enable_v2_testing_for_back_comp
     strategy: depend    

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -326,7 +326,7 @@ TEST_CASE_METHOD(
     CPPEnumerationFx,
     "C API: Array load_all_enumerations - Check nullptr",
     "[enumeration][array-load-all-enumerations][rest]") {
-  auto rc = tiledb_array_load_all_enumerations(ctx_.ptr().get(), nullptr, 0);
+  auto rc = tiledb_array_load_all_enumerations(ctx_.ptr().get(), nullptr);
   REQUIRE(rc != TILEDB_OK);
 }
 
@@ -364,7 +364,7 @@ TEST_CASE_METHOD(
   ase.add_attribute(attr4);
   ase.array_evolve(uri_);
   array.reopen();
-  ArrayExperimental::load_all_enumerations(ctx_, array, true);
+  ArrayExperimental::load_enumerations_all_schemas(ctx_, array);
   auto all_schemas = array.ptr()->array()->array_schemas_all();
   schema = array.load_schema(ctx_, uri_);
   std::string schema_name_2 = schema.ptr()->array_schema()->name();
@@ -390,7 +390,7 @@ TEST_CASE_METHOD(
   CHECK_NOTHROW(ase2.array_evolve(uri_));
   // Apply evolution to the array and reopen.
   CHECK_NOTHROW(array.reopen());
-  CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array, true));
+  CHECK_NOTHROW(ArrayExperimental::load_enumerations_all_schemas(ctx_, array));
   all_schemas = array.ptr()->array()->array_schemas_all();
   schema = array.load_schema(ctx_, uri_);
   std::string schema_name_3 = schema.ptr()->array_schema()->name();
@@ -426,7 +426,7 @@ TEST_CASE_METHOD(
 
   // Apply evolution to the array and reopen.
   CHECK_NOTHROW(array.reopen());
-  CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array, true));
+  CHECK_NOTHROW(ArrayExperimental::load_enumerations_all_schemas(ctx_, array));
   all_schemas = array.ptr()->array()->array_schemas_all();
   schema = array.load_schema(ctx_, uri_);
   std::string schema_name_4 = schema.ptr()->array_schema()->name();

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -389,9 +389,8 @@ TEST_CASE_METHOD(
   ase2.drop_attribute("attr1");
   CHECK_NOTHROW(ase2.array_evolve(uri_));
   // Apply evolution to the array and reopen.
-  CHECK_NOTHROW(array.close());
-  CHECK_NOTHROW(array.open(TILEDB_READ));
-  ArrayExperimental::load_all_enumerations(ctx_, array, true);
+  CHECK_NOTHROW(array.reopen());
+  CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array, true));
   all_schemas = array.ptr()->array()->array_schemas_all();
   schema = array.load_schema(ctx_, uri_);
   std::string schema_name_3 = schema.ptr()->array_schema()->name();
@@ -426,9 +425,8 @@ TEST_CASE_METHOD(
   CHECK_NOTHROW(ase3.array_evolve(uri_));
 
   // Apply evolution to the array and reopen.
-  CHECK_NOTHROW(array.close());
-  CHECK_NOTHROW(array.open(TILEDB_READ));
-  ArrayExperimental::load_all_enumerations(ctx_, array, true);
+  CHECK_NOTHROW(array.reopen());
+  CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array, true));
   all_schemas = array.ptr()->array()->array_schemas_all();
   schema = array.load_schema(ctx_, uri_);
   std::string schema_name_4 = schema.ptr()->array_schema()->name();

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -334,17 +334,12 @@ TEST_CASE_METHOD(
     CPPEnumerationFx,
     "CPP API: Load All Enumerations - All Schemas",
     "[enumeration][array][load-all-enumerations][all-schemas][rest]") {
-  auto cfg = ctx_.config();
-  cfg["rest.use_refactored_array_open"] = "false";
-  cfg["rest.use_refactored_array_open_and_query_submit"] = "false";
-  vfs_test_setup_.update_config(cfg.ptr().get());
-  ctx_ = vfs_test_setup_.ctx();
   create_array();
 
   // Loading the array with array open v1 will only initialize the latest schema
   // For the first test this is fine, we only need to load enumerations for the
   // latest schema. In subsequent tests we will need to call
-  // ArrayExperimental::load_all_enumerations.
+  // ArrayExperimental::load_enumerations_all_schemas.
   auto array = tiledb::Array(ctx_, uri_, TILEDB_READ);
   auto schema = array.load_schema(ctx_, uri_);
   REQUIRE(

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -349,6 +349,16 @@ TEST_CASE_METHOD(
       false);
   std::string schema_name_1 = schema.ptr()->array_schema()->name();
 
+  // If not using array open v3 just test that the correct exception is thrown
+  if (!array.ptr()->array()->use_refactored_array_open()) {
+    CHECK_THROWS_WITH(
+        ArrayExperimental::load_enumerations_all_schemas(ctx_, array),
+        Catch::Matchers::ContainsSubstring(
+            "The array must be opened using "
+            "`rest.use_refactored_array_open=true`"));
+    return;
+  }
+
   // Evolve once to add an enumeration.
   ArraySchemaEvolution ase(ctx_);
   std::vector<std::string> var_values{"one", "two", "three"};
@@ -359,7 +369,7 @@ TEST_CASE_METHOD(
   ase.add_attribute(attr4);
   ase.array_evolve(uri_);
   array.reopen();
-  ArrayExperimental::load_enumerations_all_schemas(ctx_, array);
+  CHECK_NOTHROW(ArrayExperimental::load_enumerations_all_schemas(ctx_, array));
   auto all_schemas = array.ptr()->array()->array_schemas_all();
   schema = array.load_schema(ctx_, uri_);
   std::string schema_name_2 = schema.ptr()->array_schema()->name();

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1128,6 +1128,16 @@ TEST_CASE_METHOD(
   REQUIRE(schema->is_enumeration_loaded("test_enmr") == false);
   std::string schema_name_1 = schema->name();
 
+  // If not using array open v3 just test that the correct exception is thrown
+  if (!array->use_refactored_array_open()) {
+    CHECK_THROWS_WITH(
+        array->load_all_enumerations(true),
+        Catch::Matchers::ContainsSubstring(
+            "The array must be opened using "
+            "`rest.use_refactored_array_open=true`"));
+    return;
+  }
+
   // Evolve once to add an enumeration.
   auto ase = make_shared<ArraySchemaEvolution>(HERE(), memory_tracker_);
   std::vector<std::string> var_values{"one", "two", "three"};

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1141,7 +1141,7 @@ TEST_CASE_METHOD(
   CHECK_NOTHROW(Array::evolve_array_schema(
       ctx_.resources(), uri_, ase.get(), array->get_encryption_key()));
   CHECK(array->reopen().ok());
-  CHECK_NOTHROW(array->load_all_enumerations());
+  CHECK_NOTHROW(array->load_all_enumerations(true));
   auto all_schemas = array->array_schemas_all();
   schema = array->array_schema_latest_ptr();
   std::string schema_name_2 = schema->name();
@@ -1162,7 +1162,7 @@ TEST_CASE_METHOD(
   CHECK_NOTHROW(Array::evolve_array_schema(
       ctx_.resources(), uri_, ase.get(), array->get_encryption_key()));
   CHECK(array->reopen().ok());
-  CHECK_NOTHROW(array->load_all_enumerations());
+  CHECK_NOTHROW(array->load_all_enumerations(true));
   all_schemas = array->array_schemas_all();
   schema = array->array_schema_latest_ptr();
   std::string schema_name_3 = schema->name();

--- a/tiledb/api/c_api/array/array_api.cc
+++ b/tiledb/api/c_api/array/array_api.cc
@@ -666,6 +666,14 @@ capi_return_t tiledb_array_load_all_enumerations(const tiledb_array_t* array) {
 capi_return_t tiledb_array_load_enumerations_all_schemas(
     const tiledb_array_t* array) {
   ensure_array_is_valid(array);
+  // Array::array_schemas_all_ is only initialized using array open V3, so we
+  // won't have schemas to store the loaded enumerations unless array open V3 is
+  // used.
+  if (!array->array()->use_refactored_array_open()) {
+    throw CAPIException(
+        "Unable to load enumerations for all array schemas; The array must be "
+        "opened using `rest.use_refactored_array_open=true`");
+  }
   array->load_all_enumerations(true);
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/array/array_api.cc
+++ b/tiledb/api/c_api/array/array_api.cc
@@ -657,10 +657,16 @@ capi_return_t tiledb_array_get_enumeration(
   return TILEDB_OK;
 }
 
-capi_return_t tiledb_array_load_all_enumerations(
-    const tiledb_array_t* array, uint8_t all_schemas) {
+capi_return_t tiledb_array_load_all_enumerations(const tiledb_array_t* array) {
   ensure_array_is_valid(array);
-  array->load_all_enumerations(all_schemas > 0);
+  array->load_all_enumerations();
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_array_load_enumerations_all_schemas(
+    const tiledb_array_t* array) {
+  ensure_array_is_valid(array);
+  array->load_all_enumerations(true);
   return TILEDB_OK;
 }
 
@@ -1051,8 +1057,15 @@ CAPI_INTERFACE(
 CAPI_INTERFACE(
     array_load_all_enumerations,
     tiledb_ctx_t* ctx,
-    const tiledb_array_t* array,
-    uint8_t all_schemas) {
+    const tiledb_array_t* array) {
   return api_entry_context<tiledb::api::tiledb_array_load_all_enumerations>(
-      ctx, array, all_schemas);
+      ctx, array);
+}
+
+CAPI_INTERFACE(
+    array_load_enumerations_all_schemas,
+    tiledb_ctx_t* ctx,
+    const tiledb_array_t* array) {
+  return api_entry_context<
+      tiledb::api::tiledb_array_load_enumerations_all_schemas>(ctx, array);
 }

--- a/tiledb/api/c_api/array/array_api.cc
+++ b/tiledb/api/c_api/array/array_api.cc
@@ -657,9 +657,10 @@ capi_return_t tiledb_array_get_enumeration(
   return TILEDB_OK;
 }
 
-capi_return_t tiledb_array_load_all_enumerations(const tiledb_array_t* array) {
+capi_return_t tiledb_array_load_all_enumerations(
+    const tiledb_array_t* array, uint8_t all_schemas) {
   ensure_array_is_valid(array);
-  array->load_all_enumerations();
+  array->load_all_enumerations(all_schemas > 0);
   return TILEDB_OK;
 }
 
@@ -1050,7 +1051,8 @@ CAPI_INTERFACE(
 CAPI_INTERFACE(
     array_load_all_enumerations,
     tiledb_ctx_t* ctx,
-    const tiledb_array_t* array) {
+    const tiledb_array_t* array,
+    uint8_t all_schemas) {
   return api_entry_context<tiledb::api::tiledb_array_load_all_enumerations>(
-      ctx, array);
+      ctx, array, all_schemas);
 }

--- a/tiledb/api/c_api/array/array_api_experimental.h
+++ b/tiledb/api/c_api/array/array_api_experimental.h
@@ -105,7 +105,9 @@ TILEDB_EXPORT capi_return_t tiledb_array_get_enumeration(
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_array_load_all_enumerations(
-    tiledb_ctx_t* ctx, const tiledb_array_t* array) TILEDB_NOEXCEPT;
+    tiledb_ctx_t* ctx,
+    const tiledb_array_t* array,
+    uint8_t all_schemas) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/tiledb/api/c_api/array/array_api_experimental.h
+++ b/tiledb/api/c_api/array/array_api_experimental.h
@@ -90,7 +90,7 @@ TILEDB_EXPORT capi_return_t tiledb_array_get_enumeration(
     tiledb_enumeration_t** enumeration) TILEDB_NOEXCEPT;
 
 /**
- * Load all enumerations for the array.
+ * Load all enumerations for the array's latest array schema.
  *
  * **Example:**
  *
@@ -100,14 +100,26 @@ TILEDB_EXPORT capi_return_t tiledb_array_get_enumeration(
  *
  * @param[in] ctx The TileDB context.
  * @param[in] array The TileDB array.
- * @param[in] latest_only If non-zero, only load enumerations for the latest
- * schema.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_array_load_all_enumerations(
-    tiledb_ctx_t* ctx,
-    const tiledb_array_t* array,
-    uint8_t all_schemas) TILEDB_NOEXCEPT;
+    tiledb_ctx_t* ctx, const tiledb_array_t* array) TILEDB_NOEXCEPT;
+
+/**
+ * Load all enumerations for all schemas in the array.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_array_load_enumerations_all_schemas(ctx, array);
+ * @endcode
+ *
+ * @param[in] ctx The TileDB context.
+ * @param[in] array The TileDB array.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_array_load_enumerations_all_schemas(
+    tiledb_ctx_t* ctx, const tiledb_array_t* array) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/tiledb/api/c_api/array/array_api_experimental.h
+++ b/tiledb/api/c_api/array/array_api_experimental.h
@@ -108,6 +108,9 @@ TILEDB_EXPORT capi_return_t tiledb_array_load_all_enumerations(
 /**
  * Load all enumerations for all schemas in the array.
  *
+ * This method requires the array to be opened with the config option
+ * `rest.use_refactored_array_open=true`.
+ *
  * **Example:**
  *
  * @code{.c}

--- a/tiledb/api/c_api/array/array_api_experimental.h
+++ b/tiledb/api/c_api/array/array_api_experimental.h
@@ -109,7 +109,7 @@ TILEDB_EXPORT capi_return_t tiledb_array_load_all_enumerations(
  * Load all enumerations for all schemas in the array.
  *
  * This method requires the array to be opened with the config option
- * `rest.use_refactored_array_open=true`.
+ * `rest.use_refactored_array_open=true` (default).
  *
  * **Example:**
  *

--- a/tiledb/api/c_api/array/array_api_internal.h
+++ b/tiledb/api/c_api/array/array_api_internal.h
@@ -147,10 +147,16 @@ struct tiledb_array_handle_t
     return array_->get_enumeration(enumeration_name);
   }
 
+  std::unordered_map<
+      std::string,
+      std::vector<shared_ptr<const tiledb::sm::Enumeration>>>
+  get_all_enumerations() {
+    return array_->get_all_enumerations();
+  }
+
   std::vector<shared_ptr<const tiledb::sm::Enumeration>> get_enumerations(
-      const std::vector<std::string>& enumeration_names,
-      shared_ptr<tiledb::sm::ArraySchema> schema) {
-    return array_->get_enumerations(enumeration_names, schema);
+      const std::vector<std::string>& enumeration_names) {
+    return array_->get_enumerations(enumeration_names);
   }
 
   void get_metadata(
@@ -179,8 +185,8 @@ struct tiledb_array_handle_t
     return array_->is_open();
   }
 
-  void load_all_enumerations() const {
-    array_->load_all_enumerations();
+  void load_all_enumerations(bool all_schemas = false) const {
+    array_->load_all_enumerations(all_schemas);
   }
 
   tiledb::sm::NDRange& loaded_non_empty_domain() {

--- a/tiledb/api/c_api/array/array_api_internal.h
+++ b/tiledb/api/c_api/array/array_api_internal.h
@@ -150,8 +150,8 @@ struct tiledb_array_handle_t
   std::unordered_map<
       std::string,
       std::vector<shared_ptr<const tiledb::sm::Enumeration>>>
-  get_all_enumerations() {
-    return array_->get_all_enumerations();
+  get_enumerations_all_schemas() {
+    return array_->get_enumerations_all_schemas();
   }
 
   std::vector<shared_ptr<const tiledb::sm::Enumeration>> get_enumerations(

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -959,11 +959,11 @@ void Array::load_all_enumerations(bool all_schemas) {
   }
   // Load all enumerations, discarding the returned list of loaded enumerations.
   if (all_schemas) {
-    // TODO: The enumerations are all here in a single request, they just need
-    // to be stored in a schema. Since array open v1 does not initialize
-    // array_schemas_all, we need to either serialize the full schemas with
-    // LoadEnumerationsResponse, or reopen the array using array open v2 (only
-    // if the config is set to use v1).
+    // Since array open v1 does not initialize array_schemas_all, we need to
+    // either serialize the full schemas with LoadEnumerationsResponse, or
+    // reopen the array using array open v2 (only if the config is set to use
+    // v1) so that we can store the enumerations from the response in the
+    // correct schemas using the schema names.
 
     // For now, reopen the array if it's found to be using array open v1.
     // Once we update to use post_array_schema_from_rest we will always have

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -919,16 +919,13 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
         names_to_load.push_back(enmr_name);
       }
 
-      loaded = rest_client
-                   ->post_enumerations_from_rest(
-                       array_uri_,
-                       array_dir_timestamp_start_,
-                       array_dir_timestamp_end_,
-                       this,
-                       names_to_load,
-                       memory_tracker_)
-                   .begin()
-                   ->second;
+      loaded = rest_client->post_enumerations_from_rest(
+          array_uri_,
+          array_dir_timestamp_start_,
+          array_dir_timestamp_end_,
+          this,
+          names_to_load,
+          memory_tracker_)[array_schema_latest().name()];
     } else {
       // Create a vector of paths to be loaded.
       std::vector<std::string> paths_to_load;

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -805,19 +805,6 @@ void Array::encryption_type(
 
 shared_ptr<const Enumeration> Array::get_enumeration(
     const std::string& enumeration_name) {
-  if (!is_open_) {
-    throw ArrayException("Unable to load enumerations; Array is not open.");
-  }
-
-  auto schema = opened_array_->array_schema_latest_ptr();
-  if (!schema->has_enumeration(enumeration_name)) {
-    throw ArrayException(
-        "Unable to get enumeration; Enumeration '" + enumeration_name +
-        "' does not exist.");
-  } else if (schema->is_enumeration_loaded(enumeration_name)) {
-    return schema->get_enumeration(enumeration_name);
-  }
-
   return get_enumerations({enumeration_name})[0];
 }
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -822,7 +822,7 @@ shared_ptr<const Enumeration> Array::get_enumeration(
 }
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
-Array::get_all_enumerations() {
+Array::get_enumerations_all_schemas() {
   if (!is_open_) {
     throw ArrayException("Unable to load enumerations; Array is not open.");
   }
@@ -977,7 +977,7 @@ void Array::load_all_enumerations(bool all_schemas) {
       throw_if_not_ok(config_.set("rest.use_refactored_array_open", "false"));
     }
 
-    get_all_enumerations();
+    get_enumerations_all_schemas();
   } else {
     get_enumerations(array_schema_latest().get_enumeration_names());
   }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -946,19 +946,13 @@ void Array::load_all_enumerations(bool all_schemas) {
   }
   // Load all enumerations, discarding the returned list of loaded enumerations.
   if (all_schemas) {
-    // Since array open v1 does not initialize array_schemas_all, we need to
-    // either serialize the full schemas with LoadEnumerationsResponse, or
-    // reopen the array using array open v2 (only if the config is set to use
-    // v1) so that we can store the enumerations from the response in the
-    // correct schemas using the schema names.
-
-    // For now, reopen the array if it's found to be using array open v1.
-    // Once we update to use post_array_schema_from_rest we will always have
-    // array_schemas_all initialized and this could go away.
+    // Unless we are using array open V3, Array::array_schemas_all_ will not be
+    // initialized. We throw an exception since this is required to store the
+    // loaded enumerations.
     if (!use_refactored_array_open()) {
-      throw_if_not_ok(config_.set("rest.use_refactored_array_open", "true"));
-      throw_if_not_ok(reopen());
-      throw_if_not_ok(config_.set("rest.use_refactored_array_open", "false"));
+      throw ArrayException(
+          "Unable to load enumerations for all array schemas; The array must "
+          "be opened using `rest.use_refactored_array_open=true`");
     }
 
     get_enumerations_all_schemas();

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -573,7 +573,7 @@ class Array {
    *
    * This function retrieves the enumeration for the given name. If the
    * corresponding enumeration has not been loaded from storage it is
-   * loaded before this function returns.
+   * loaded and stored in the latest schema before this function returns.
    *
    * @param enumeration_name The name of the enumeration.
    * @return shared_ptr<const Enumeration> or nullptr on failure.
@@ -583,6 +583,9 @@ class Array {
 
   /**
    * Load enumerations on all schemas for the array's opened timestamp range.
+   * This function will store all loaded enumerations into their corresponding
+   * schemas. The returned enumerations are provided as a convenience to the
+   * caller and can be discarded if loading the enumerations is sufficient.
    *
    * @return Map of schema names and a list of all loaded enumerations.
    */

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -582,6 +582,14 @@ class Array {
       const std::string& enumeration_name);
 
   /**
+   * Load enumerations on all schemas for the array's opened timestamp range.
+   *
+   * @return Map of schema names and a list of all loaded enumerations.
+   */
+  std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
+  get_all_enumerations();
+
+  /**
    * Get the enumerations with the given names.
    *
    * This function retrieves the enumerations with the given names. If the
@@ -589,15 +597,19 @@ class Array {
    * loaded before this function returns.
    *
    * @param enumeration_names The names of the enumerations.
-   * @param schema The ArraySchema to store loaded enumerations in.
    * @return std::vector<shared_ptr<const Enumeration>> The loaded enumerations.
    */
   std::vector<shared_ptr<const Enumeration>> get_enumerations(
-      const std::vector<std::string>& enumeration_names,
-      shared_ptr<ArraySchema> schema);
+      const std::vector<std::string>& enumeration_names);
 
-  /** Load all enumerations for the array. */
-  void load_all_enumerations();
+  /**
+   * Load all enumerations for the array.
+   *
+   * @param all_schemas If true, enumerations will be loaded on all schemas
+   *    within the current opened timestamps on the array. If false, only load
+   *    enumerations on the latest array schema.
+   */
+  void load_all_enumerations(bool all_schemas = false);
 
   /**
    * Returns `true` if the array is empty at the time it is opened.

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -569,7 +569,7 @@ class Array {
       EncryptionType* encryption_type);
 
   /**
-   * Get the enumeration for the given name.
+   * Get the enumeration for the given name from the latest array schema.
    *
    * This function retrieves the enumeration for the given name. If the
    * corresponding enumeration has not been loaded from storage it is
@@ -587,10 +587,10 @@ class Array {
    * @return Map of schema names and a list of all loaded enumerations.
    */
   std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
-  get_all_enumerations();
+  get_enumerations_all_schemas();
 
   /**
-   * Get the enumerations with the given names.
+   * Get the enumerations with the given names from the latest array schema.
    *
    * This function retrieves the enumerations with the given names. If the
    * corresponding enumerations have not been loaded from storage they are

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2202,7 +2202,7 @@ capi_return_t tiledb_handle_load_enumerations_request(
       std::vector<shared_ptr<const tiledb::sm::Enumeration>>>
       enumerations;
   if (enumeration_names.empty()) {
-    enumerations = array->get_all_enumerations();
+    enumerations = array->get_enumerations_all_schemas();
   } else {
     enumerations[array->array_schema_latest().name()] =
         array->get_enumerations(enumeration_names);

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2197,8 +2197,16 @@ capi_return_t tiledb_handle_load_enumerations_request(
       tiledb::sm::serialization::deserialize_load_enumerations_request(
           static_cast<tiledb::sm::SerializationType>(serialization_type),
           request->buffer());
-  auto enumerations = array->get_enumerations(
-      enumeration_names, array->opened_array()->array_schema_latest_ptr());
+  std::unordered_map<
+      std::string,
+      std::vector<shared_ptr<const tiledb::sm::Enumeration>>>
+      enumerations;
+  if (enumeration_names.empty()) {
+    enumerations = array->get_all_enumerations();
+  } else {
+    enumerations[array->array_schema_latest().name()] =
+        array->get_enumerations(enumeration_names);
+  }
 
   tiledb::sm::serialization::serialize_load_enumerations_response(
       enumerations,

--- a/tiledb/sm/cpp_api/array_experimental.h
+++ b/tiledb/sm/cpp_api/array_experimental.h
@@ -59,14 +59,16 @@ class ArrayExperimental {
   }
 
   /**
-   * Load all enumerations for the array
+   * Load all enumerations for the array.
    *
    * @param ctx The context to use.
    * @param array The array to load enumerations for.
+   * @param all_schemas Whether or not to load enumerations on all schemas.
    */
-  static void load_all_enumerations(const Context& ctx, const Array& array) {
-    ctx.handle_error(
-        tiledb_array_load_all_enumerations(ctx.ptr().get(), array.ptr().get()));
+  static void load_all_enumerations(
+      const Context& ctx, const Array& array, bool all_schemas = false) {
+    ctx.handle_error(tiledb_array_load_all_enumerations(
+        ctx.ptr().get(), array.ptr().get(), all_schemas ? 1 : 0));
   }
 };
 

--- a/tiledb/sm/cpp_api/array_experimental.h
+++ b/tiledb/sm/cpp_api/array_experimental.h
@@ -59,16 +59,26 @@ class ArrayExperimental {
   }
 
   /**
-   * Load all enumerations for the array.
+   * Load all enumerations for the array's latest array schema.
    *
    * @param ctx The context to use.
    * @param array The array to load enumerations for.
-   * @param all_schemas Whether or not to load enumerations on all schemas.
    */
-  static void load_all_enumerations(
-      const Context& ctx, const Array& array, bool all_schemas = false) {
-    ctx.handle_error(tiledb_array_load_all_enumerations(
-        ctx.ptr().get(), array.ptr().get(), all_schemas ? 1 : 0));
+  static void load_all_enumerations(const Context& ctx, const Array& array) {
+    ctx.handle_error(
+        tiledb_array_load_all_enumerations(ctx.ptr().get(), array.ptr().get()));
+  }
+
+  /**
+   * Load all enumerations for all schemas in the array.
+   *
+   * @param ctx The context to use.
+   * @param array The array to load enumerations for.
+   */
+  static void load_enumerations_all_schemas(
+      const Context& ctx, const Array& array) {
+    ctx.handle_error(tiledb_array_load_enumerations_all_schemas(
+        ctx.ptr().get(), array.ptr().get()));
   }
 };
 

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -386,14 +386,15 @@ class RestClient {
   }
 
   /// Operation disabled in base class.
-  inline virtual std::vector<shared_ptr<const Enumeration>>
-  post_enumerations_from_rest(
-      const URI&,
-      uint64_t,
-      uint64_t,
-      Array*,
-      const std::vector<std::string>&,
-      shared_ptr<MemoryTracker>) {
+  inline virtual std::
+      unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
+      post_enumerations_from_rest(
+          const URI&,
+          uint64_t,
+          uint64_t,
+          Array*,
+          const std::vector<std::string>&,
+          shared_ptr<MemoryTracker>) {
     throw RestClientDisabledException();
   }
 

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -607,7 +607,7 @@ Status RestClientRemote::post_array_metadata_to_rest(
       stats_, url, serialization_type_, &serialized, &returned_data, cache_key);
 }
 
-std::vector<shared_ptr<const Enumeration>>
+std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 RestClientRemote::post_enumerations_from_rest(
     const URI& uri,
     uint64_t timestamp_start,
@@ -622,13 +622,6 @@ RestClientRemote::post_enumerations_from_rest(
 
   if (!memory_tracker) {
     memory_tracker = memory_tracker_;
-  }
-
-  // This should never be called with an empty list of enumeration names, but
-  // there's no reason to not check an early return case here given that code
-  // changes.
-  if (enumeration_names.size() == 0) {
-    return {};
   }
 
   BufferList serialized{memory_tracker_};

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -658,7 +658,7 @@ RestClientRemote::post_enumerations_from_rest(
   // Ensure data has a null delimiter for cap'n proto if using JSON
   throw_if_not_ok(ensure_json_null_delimited_string(&returned_data));
   return serialization::deserialize_load_enumerations_response(
-      serialization_type_, returned_data, memory_tracker);
+      *array, serialization_type_, returned_data, memory_tracker);
 }
 
 void RestClientRemote::post_query_plan_from_rest(

--- a/tiledb/sm/rest/rest_client_remote.h
+++ b/tiledb/sm/rest/rest_client_remote.h
@@ -298,7 +298,8 @@ class RestClientRemote : public RestClient {
    * @param array Array to fetch metadata for.
    * @param enumeration_names The names of the enumerations to get.
    */
-  std::vector<shared_ptr<const Enumeration>> post_enumerations_from_rest(
+  std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
+  post_enumerations_from_rest(
       const URI& uri,
       uint64_t timestamp_start,
       uint64_t timestamp_end,

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -148,7 +148,7 @@ Status array_to_capnp(
   array_builder->setQueryType(query_type_str(array->get_query_type()));
 
   if (array->use_refactored_array_open() && array->serialize_enumerations()) {
-    array->load_all_enumerations();
+    array->load_all_enumerations(true);
   }
 
   const auto& array_schema_latest = array->array_schema_latest();

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -40,6 +40,7 @@
 // clang-format on
 
 #include "tiledb/sm/array_schema/enumeration.h"
+#include "tiledb/sm/array/array.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/enums/serialization_type.h"
 #include "tiledb/sm/serialization/enumeration.h"

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -201,8 +201,8 @@ load_enumerations_response_from_capnp(
       loaded_enmrs.push_back(
           enumeration_from_capnp(enmr_reader, memory_tracker));
     }
-    // The name of the array schema will not be used if we only loaded
-    // enumerations on the latest array schema.
+    // The name of the latest array schema will not be serialized in the
+    // response if we are only loading enumerations from the latest schema.
     return {{array.array_schema_latest().name(), loaded_enmrs}};
   } else if (reader.hasAllEnumerations()) {
     auto all_enmrs_reader = reader.getAllEnumerations();

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -154,28 +154,68 @@ std::vector<std::string> load_enumerations_request_from_capnp(
 
 void load_enumerations_response_to_capnp(
     capnp::LoadEnumerationsResponse::Builder& builder,
-    const std::vector<shared_ptr<const Enumeration>>& enumerations) {
-  auto num_enmrs = enumerations.size();
-  if (num_enmrs > 0) {
-    auto enmr_builders = builder.initEnumerations(num_enmrs);
-    for (size_t i = 0; i < num_enmrs; i++) {
+    const std::unordered_map<
+        std::string,
+        std::vector<shared_ptr<const Enumeration>>>& enumerations) {
+  auto num_schemas = enumerations.size();
+  // If there is only one schema, it is always the latest so we don't need to
+  // serialize the extra data.
+  if (num_schemas == 1) {
+    auto num_enmr = enumerations.begin()->second.size();
+    auto enmr_builders = builder.initEnumerations(num_enmr);
+    for (size_t i = 0; i < num_enmr; i++) {
       auto enmr_builder = enmr_builders[i];
-      enumeration_to_capnp(enumerations[i], enmr_builder);
+      enumeration_to_capnp(enumerations.begin()->second[i], enmr_builder);
+    }
+  } else if (num_schemas > 1) {
+    // If there were enumerations loaded on multiple schemas, serialize the full
+    // map of schema_names and their enumerations.
+    auto enmr_map_builder = builder.initAllEnumerations();
+    auto map_entry_builder = enmr_map_builder.initEntries(num_schemas);
+    for (size_t i = 0; const auto& entry : enumerations) {
+      auto num_enmr = entry.second.size();
+      // Set the map key to the schema name
+      map_entry_builder[i].setKey(entry.first);
+
+      // Build the list of enumerations that map to this schema name.
+      auto enmr_builders = map_entry_builder[i++].initValue(num_enmr);
+      for (size_t j = 0; j < num_enmr; j++) {
+        auto enmr_builder = enmr_builders[j];
+        enumeration_to_capnp(entry.second[j], enmr_builder);
+      }
     }
   }
 }
 
-std::vector<shared_ptr<const Enumeration>>
+std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 load_enumerations_response_from_capnp(
     const capnp::LoadEnumerationsResponse::Reader& reader,
     shared_ptr<MemoryTracker> memory_tracker) {
-  std::vector<shared_ptr<const Enumeration>> ret;
+  std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
+      ret;
   if (reader.hasEnumerations()) {
+    std::vector<shared_ptr<const Enumeration>> loaded_enmrs;
     auto enmr_readers = reader.getEnumerations();
     for (auto enmr_reader : enmr_readers) {
-      ret.push_back(enumeration_from_capnp(enmr_reader, memory_tracker));
+      loaded_enmrs.push_back(
+          enumeration_from_capnp(enmr_reader, memory_tracker));
+    }
+    // The name of the array schema will not be used if we only loaded
+    // enumerations on the latest array schema.
+    return {{"", loaded_enmrs}};
+  } else if (reader.hasAllEnumerations()) {
+    auto all_enmrs_reader = reader.getAllEnumerations();
+    for (auto enmr_entry_reader : all_enmrs_reader.getEntries()) {
+      std::vector<shared_ptr<const Enumeration>> loaded_enmrs;
+      for (auto enmr_reader : enmr_entry_reader.getValue()) {
+        loaded_enmrs.push_back(
+            enumeration_from_capnp(enmr_reader, memory_tracker));
+      }
+
+      ret[enmr_entry_reader.getKey()] = loaded_enmrs;
     }
   }
+
   return ret;
 }
 
@@ -260,7 +300,9 @@ std::vector<std::string> deserialize_load_enumerations_request(
 }
 
 void serialize_load_enumerations_response(
-    const std::vector<shared_ptr<const Enumeration>>& enumerations,
+    const std::unordered_map<
+        std::string,
+        std::vector<shared_ptr<const Enumeration>>>& enumerations,
     SerializationType serialize_type,
     SerializationBuffer& response) {
   try {
@@ -299,7 +341,7 @@ void serialize_load_enumerations_response(
   }
 }
 
-std::vector<shared_ptr<const Enumeration>>
+std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
     SerializationType serialize_type,
     span<const char> response,
@@ -357,13 +399,14 @@ std::vector<std::string> deserialize_load_enumerations_request(
 }
 
 void serialize_load_enumerations_response(
-    const std::vector<shared_ptr<const Enumeration>>&,
+    const std::
+        unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>&,
     SerializationType,
     SerializationBuffer&) {
   throw EnumerationSerializationDisabledException();
 }
 
-std::vector<shared_ptr<const Enumeration>>
+std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
     SerializationType, span<const char>, shared_ptr<MemoryTracker>) {
   throw EnumerationSerializationDisabledException();

--- a/tiledb/sm/serialization/enumeration.h
+++ b/tiledb/sm/serialization/enumeration.h
@@ -84,11 +84,13 @@ std::vector<std::string> deserialize_load_enumerations_request(
     SerializationType serialization_type, span<const char> request);
 
 void serialize_load_enumerations_response(
-    const std::vector<shared_ptr<const Enumeration>>& enumerations,
+    const std::unordered_map<
+        std::string,
+        std::vector<shared_ptr<const Enumeration>>>& enumerations,
     SerializationType serialization_type,
     SerializationBuffer& response);
 
-std::vector<shared_ptr<const Enumeration>>
+std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
     SerializationType serialization_type,
     span<const char> response,

--- a/tiledb/sm/serialization/enumeration.h
+++ b/tiledb/sm/serialization/enumeration.h
@@ -92,6 +92,7 @@ void serialize_load_enumerations_response(
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
+    const Array& array,
     SerializationType serialization_type,
     span<const char> response,
     shared_ptr<MemoryTracker> memory_tracker);

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -1266,10 +1266,12 @@ struct LoadEnumerationsRequest {
 
 struct LoadEnumerationsResponse {
   enumerations @0 :List(Enumeration);
-  # The loaded enumerations
+  # The loaded enumerations for the latest array schema
+  # This field is only used if enumerations are requested for the latest schema
 
   allEnumerations @1 :MapEnumeration;
   # The loaded enumerations for all array schemas
+  # This field is only used if enumerations are requested for all schemas
 }
 
 struct LoadArraySchemaRequest {

--- a/tiledb/sm/serialization/tiledb-rest.capnp
+++ b/tiledb/sm/serialization/tiledb-rest.capnp
@@ -379,6 +379,14 @@ struct Map(Key, Value) {
   }
 }
 
+struct MapEnumeration {
+  entries @0 :List(Entry);
+  struct Entry {
+    key @0 :Text;
+    value @1 :List(Enumeration);
+  }
+}
+
 struct MapUInt32 {
   entries @0 :List(Entry);
   struct Entry {
@@ -1259,6 +1267,9 @@ struct LoadEnumerationsRequest {
 struct LoadEnumerationsResponse {
   enumerations @0 :List(Enumeration);
   # The loaded enumerations
+
+  allEnumerations @1 :MapEnumeration;
+  # The loaded enumerations for all array schemas
 }
 
 struct LoadArraySchemaRequest {

--- a/tiledb/sm/serialization/tiledb-rest.capnp.c++
+++ b/tiledb/sm/serialization/tiledb-rest.capnp.c++
@@ -2932,6 +2932,128 @@ const ::capnp::_::RawSchema s_db5514c8aaf6faea = {
   0, 2, i_db5514c8aaf6faea, nullptr, nullptr, { &s_db5514c8aaf6faea, nullptr, nullptr, 0, 0, nullptr }, true
 };
 #endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<41> b_a9d01efb4b5d8599 = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    153, 133,  93,  75, 251,  30, 208, 169,
+     18,   0,   0,   0,   1,   0,   0,   0,
+    127, 216, 135, 181,  36, 146, 125, 181,
+      1,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  10,   1,   0,   0,
+     37,   0,   0,   0,  23,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  63,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  77,  97, 112,  69, 110, 117,
+    109, 101, 114,  97, 116, 105, 111, 110,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      4,   0,   0,   0,   1,   0,   1,   0,
+    106,  32,  72,  67,  25,  90, 145, 255,
+      1,   0,   0,   0,  50,   0,   0,   0,
+     69, 110, 116, 114, 121,   0,   0,   0,
+      4,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     13,   0,   0,   0,  66,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      8,   0,   0,   0,   3,   0,   1,   0,
+     36,   0,   0,   0,   2,   0,   1,   0,
+    101, 110, 116, 114, 105, 101, 115,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    106,  32,  72,  67,  25,  90, 145, 255,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_a9d01efb4b5d8599 = b_a9d01efb4b5d8599.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_a9d01efb4b5d8599[] = {
+  &s_ff915a194348206a,
+};
+static const uint16_t m_a9d01efb4b5d8599[] = {0};
+static const uint16_t i_a9d01efb4b5d8599[] = {0};
+const ::capnp::_::RawSchema s_a9d01efb4b5d8599 = {
+  0xa9d01efb4b5d8599, b_a9d01efb4b5d8599.words, 41, d_a9d01efb4b5d8599, m_a9d01efb4b5d8599,
+  1, 1, i_a9d01efb4b5d8599, nullptr, nullptr, { &s_a9d01efb4b5d8599, nullptr, nullptr, 0, 0, nullptr }, false
+};
+#endif  // !CAPNP_LITE
+static const ::capnp::_::AlignedData<53> b_ff915a194348206a = {
+  {   0,   0,   0,   0,   5,   0,   6,   0,
+    106,  32,  72,  67,  25,  90, 145, 255,
+     33,   0,   0,   0,   1,   0,   0,   0,
+    153, 133,  93,  75, 251,  30, 208, 169,
+      2,   0,   7,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     21,   0,   0,   0,  58,   1,   0,   0,
+     37,   0,   0,   0,   7,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     33,   0,   0,   0, 119,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    116, 105, 108, 101, 100,  98,  45, 114,
+    101, 115, 116,  46,  99,  97, 112, 110,
+    112,  58,  77,  97, 112,  69, 110, 117,
+    109, 101, 114,  97, 116, 105, 111, 110,
+     46,  69, 110, 116, 114, 121,   0,   0,
+      0,   0,   0,   0,   1,   0,   1,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   1,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     41,   0,   0,   0,  34,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     36,   0,   0,   0,   3,   0,   1,   0,
+     48,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     45,   0,   0,   0,  50,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+     68,   0,   0,   0,   2,   0,   1,   0,
+    107, 101, 121,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     12,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+    118,  97, 108, 117, 101,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   3,   0,   1,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    180, 185,  33, 204,  25,  47,  11, 208,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     14,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0, }
+};
+::capnp::word const* const bp_ff915a194348206a = b_ff915a194348206a.words;
+#if !CAPNP_LITE
+static const ::capnp::_::RawSchema* const d_ff915a194348206a[] = {
+  &s_d00b2f19cc21b9b4,
+};
+static const uint16_t m_ff915a194348206a[] = {0, 1};
+static const uint16_t i_ff915a194348206a[] = {0, 1};
+const ::capnp::_::RawSchema s_ff915a194348206a = {
+  0xff915a194348206a, b_ff915a194348206a.words, 53, d_ff915a194348206a, m_ff915a194348206a,
+  1, 2, i_ff915a194348206a, nullptr, nullptr, { &s_ff915a194348206a, nullptr, nullptr, 0, 0, nullptr }, false
+};
+#endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<40> b_c6b5bb09d4611252 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
      82,  18,  97, 212,   9, 187, 181, 198,
@@ -9677,17 +9799,17 @@ const ::capnp::_::RawSchema s_891a70a671f15cf6 = {
   1, 2, i_891a70a671f15cf6, nullptr, nullptr, { &s_891a70a671f15cf6, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
-static const ::capnp::_::AlignedData<40> b_805c080c10c1e959 = {
+static const ::capnp::_::AlignedData<56> b_805c080c10c1e959 = {
   {   0,   0,   0,   0,   5,   0,   6,   0,
      89, 233, 193,  16,  12,   8,  92, 128,
      18,   0,   0,   0,   1,   0,   0,   0,
     127, 216, 135, 181,  36, 146, 125, 181,
-      1,   0,   7,   0,   0,   0,   0,   0,
+      2,   0,   7,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
      21,   0,   0,   0,  90,   1,   0,   0,
      41,   0,   0,   0,   7,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     37,   0,   0,   0,  63,   0,   0,   0,
+     37,   0,   0,   0, 119,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
     116, 105, 108, 101, 100,  98,  45, 114,
@@ -9697,14 +9819,21 @@ static const ::capnp::_::AlignedData<40> b_805c080c10c1e959 = {
     110, 115,  82, 101, 115, 112, 111, 110,
     115, 101,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   1,   0,   1,   0,
-      4,   0,   0,   0,   3,   0,   4,   0,
+      8,   0,   0,   0,   3,   0,   4,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   1,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     13,   0,   0,   0, 106,   0,   0,   0,
+     41,   0,   0,   0, 106,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
-     12,   0,   0,   0,   3,   0,   1,   0,
-     40,   0,   0,   0,   2,   0,   1,   0,
+     40,   0,   0,   0,   3,   0,   1,   0,
+     68,   0,   0,   0,   2,   0,   1,   0,
+      1,   0,   0,   0,   1,   0,   0,   0,
+      0,   0,   1,   0,   1,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     65,   0,   0,   0, 130,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     64,   0,   0,   0,   3,   0,   1,   0,
+     76,   0,   0,   0,   2,   0,   1,   0,
     101, 110, 117, 109, 101, 114,  97, 116,
     105, 111, 110, 115,   0,   0,   0,   0,
      14,   0,   0,   0,   0,   0,   0,   0,
@@ -9717,18 +9846,28 @@ static const ::capnp::_::AlignedData<40> b_805c080c10c1e959 = {
       0,   0,   0,   0,   0,   0,   0,   0,
      14,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     97, 108, 108,  69, 110, 117, 109, 101,
+    114,  97, 116, 105, 111, 110, 115,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+    153, 133,  93,  75, 251,  30, 208, 169,
+      0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
+     16,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0, }
 };
 ::capnp::word const* const bp_805c080c10c1e959 = b_805c080c10c1e959.words;
 #if !CAPNP_LITE
 static const ::capnp::_::RawSchema* const d_805c080c10c1e959[] = {
+  &s_a9d01efb4b5d8599,
   &s_d00b2f19cc21b9b4,
 };
-static const uint16_t m_805c080c10c1e959[] = {0};
-static const uint16_t i_805c080c10c1e959[] = {0};
+static const uint16_t m_805c080c10c1e959[] = {1, 0};
+static const uint16_t i_805c080c10c1e959[] = {0, 1};
 const ::capnp::_::RawSchema s_805c080c10c1e959 = {
-  0x805c080c10c1e959, b_805c080c10c1e959.words, 40, d_805c080c10c1e959, m_805c080c10c1e959,
-  1, 1, i_805c080c10c1e959, nullptr, nullptr, { &s_805c080c10c1e959, nullptr, nullptr, 0, 0, nullptr }, false
+  0x805c080c10c1e959, b_805c080c10c1e959.words, 56, d_805c080c10c1e959, m_805c080c10c1e959,
+  2, 2, i_805c080c10c1e959, nullptr, nullptr, { &s_805c080c10c1e959, nullptr, nullptr, 0, 0, nullptr }, false
 };
 #endif  // !CAPNP_LITE
 static const ::capnp::_::AlignedData<52> b_83f094010132ff21 = {
@@ -10810,6 +10949,30 @@ constexpr uint16_t FilterPipeline::_capnpPrivate::pointerCount;
 #if CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
 constexpr ::capnp::Kind FilterPipeline::_capnpPrivate::kind;
 constexpr ::capnp::_::RawSchema const* FilterPipeline::_capnpPrivate::schema;
+#endif  // !CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+#endif  // !CAPNP_LITE
+
+// MapEnumeration
+#if CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+constexpr uint16_t MapEnumeration::_capnpPrivate::dataWordSize;
+constexpr uint16_t MapEnumeration::_capnpPrivate::pointerCount;
+#endif  // !CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+#if !CAPNP_LITE
+#if CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+constexpr ::capnp::Kind MapEnumeration::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* MapEnumeration::_capnpPrivate::schema;
+#endif  // !CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+#endif  // !CAPNP_LITE
+
+// MapEnumeration::Entry
+#if CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+constexpr uint16_t MapEnumeration::Entry::_capnpPrivate::dataWordSize;
+constexpr uint16_t MapEnumeration::Entry::_capnpPrivate::pointerCount;
+#endif  // !CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+#if !CAPNP_LITE
+#if CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
+constexpr ::capnp::Kind MapEnumeration::Entry::_capnpPrivate::kind;
+constexpr ::capnp::_::RawSchema const* MapEnumeration::Entry::_capnpPrivate::schema;
 #endif  // !CAPNP_NEED_REDUNDANT_CONSTEXPR_DECL
 #endif  // !CAPNP_LITE
 

--- a/tiledb/sm/serialization/tiledb-rest.capnp.h
+++ b/tiledb/sm/serialization/tiledb-rest.capnp.h
@@ -41,6 +41,8 @@ CAPNP_DECLARE_SCHEMA(9ceaf832b3ab897f);
 CAPNP_DECLARE_SCHEMA(bc4583f733eac4f5);
 CAPNP_DECLARE_SCHEMA(f179c194ae71718c);
 CAPNP_DECLARE_SCHEMA(db5514c8aaf6faea);
+CAPNP_DECLARE_SCHEMA(a9d01efb4b5d8599);
+CAPNP_DECLARE_SCHEMA(ff915a194348206a);
 CAPNP_DECLARE_SCHEMA(c6b5bb09d4611252);
 CAPNP_DECLARE_SCHEMA(884e0a5f2521a5c6);
 CAPNP_DECLARE_SCHEMA(a83707d3ba24dd32);
@@ -541,6 +543,41 @@ struct Map<Key, Value>::Entry {
     static const ::capnp::_::RawBrandedSchema specificBrand;
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return ::capnp::_::ChooseBrand<_capnpPrivate, Key, Value>::brand();
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct MapEnumeration {
+  MapEnumeration() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+  struct Entry;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(a9d01efb4b5d8599, 0, 1)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
+    }
+#endif  // !CAPNP_LITE
+  };
+};
+
+struct MapEnumeration::Entry {
+  Entry() = delete;
+
+  class Reader;
+  class Builder;
+  class Pipeline;
+
+  struct _capnpPrivate {
+    CAPNP_DECLARE_STRUCT_HEADER(ff915a194348206a, 0, 2)
+#if !CAPNP_LITE
+    static constexpr ::capnp::_::RawBrandedSchema const* brand() {
+      return &schema->defaultBrand;
     }
 #endif  // !CAPNP_LITE
   };
@@ -1657,7 +1694,7 @@ struct LoadEnumerationsResponse {
   class Pipeline;
 
   struct _capnpPrivate {
-    CAPNP_DECLARE_STRUCT_HEADER(805c080c10c1e959, 0, 1)
+    CAPNP_DECLARE_STRUCT_HEADER(805c080c10c1e959, 0, 2)
 #if !CAPNP_LITE
     static constexpr ::capnp::_::RawBrandedSchema const* brand() {
       return &schema->defaultBrand;
@@ -5416,6 +5453,244 @@ class Map<Key, Value>::Entry::Pipeline {
 
   inline ::capnp::PipelineFor<Key> getKey();
   inline ::capnp::PipelineFor<Value> getValue();
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class MapEnumeration::Reader {
+ public:
+  typedef MapEnumeration Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEntries() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>::Reader
+  getEntries() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class MapEnumeration::Builder {
+ public:
+  typedef MapEnumeration Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasEntries();
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>::Builder
+  getEntries();
+  inline void setEntries(
+      ::capnp::List<
+          ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+          ::capnp::Kind::STRUCT>::Reader value);
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>::Builder
+  initEntries(unsigned int size);
+  inline void adoptEntries(
+      ::capnp::Orphan<::capnp::List<
+          ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+          ::capnp::Kind::STRUCT>>&& value);
+  inline ::capnp::Orphan<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>
+  disownEntries();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class MapEnumeration::Pipeline {
+ public:
+  typedef MapEnumeration Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
+
+ private:
+  ::capnp::AnyPointer::Pipeline _typeless;
+  friend class ::capnp::PipelineHook;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+};
+#endif  // !CAPNP_LITE
+
+class MapEnumeration::Entry::Reader {
+ public:
+  typedef Entry Reads;
+
+  Reader() = default;
+  inline explicit Reader(::capnp::_::StructReader base)
+      : _reader(base) {
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return _reader.totalSize().asPublic();
+  }
+
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return ::capnp::_::structString(_reader, *_capnpPrivate::brand());
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasKey() const;
+  inline ::capnp::Text::Reader getKey() const;
+
+  inline bool hasValue() const;
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Reader
+  getValue() const;
+
+ private:
+  ::capnp::_::StructReader _reader;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::List;
+  friend class ::capnp::MessageBuilder;
+  friend class ::capnp::Orphanage;
+};
+
+class MapEnumeration::Entry::Builder {
+ public:
+  typedef Entry Builds;
+
+  Builder() = delete;  // Deleted to discourage incorrect usage.
+                       // You can explicitly initialize to nullptr instead.
+  inline Builder(decltype(nullptr)) {
+  }
+  inline explicit Builder(::capnp::_::StructBuilder base)
+      : _builder(base) {
+  }
+  inline operator Reader() const {
+    return Reader(_builder.asReader());
+  }
+  inline Reader asReader() const {
+    return *this;
+  }
+
+  inline ::capnp::MessageSize totalSize() const {
+    return asReader().totalSize();
+  }
+#if !CAPNP_LITE
+  inline ::kj::StringTree toString() const {
+    return asReader().toString();
+  }
+#endif  // !CAPNP_LITE
+
+  inline bool hasKey();
+  inline ::capnp::Text::Builder getKey();
+  inline void setKey(::capnp::Text::Reader value);
+  inline ::capnp::Text::Builder initKey(unsigned int size);
+  inline void adoptKey(::capnp::Orphan<::capnp::Text>&& value);
+  inline ::capnp::Orphan<::capnp::Text> disownKey();
+
+  inline bool hasValue();
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Builder
+  getValue();
+  inline void setValue(::capnp::List<
+                       ::tiledb::sm::serialization::capnp::Enumeration,
+                       ::capnp::Kind::STRUCT>::Reader value);
+  inline ::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>::Builder
+  initValue(unsigned int size);
+  inline void adoptValue(::capnp::Orphan<::capnp::List<
+                             ::tiledb::sm::serialization::capnp::Enumeration,
+                             ::capnp::Kind::STRUCT>>&& value);
+  inline ::capnp::Orphan<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>
+  disownValue();
+
+ private:
+  ::capnp::_::StructBuilder _builder;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::ToDynamic_;
+  friend class ::capnp::Orphanage;
+  template <typename, ::capnp::Kind>
+  friend struct ::capnp::_::PointerHelpers;
+};
+
+#if !CAPNP_LITE
+class MapEnumeration::Entry::Pipeline {
+ public:
+  typedef Entry Pipelines;
+
+  inline Pipeline(decltype(nullptr))
+      : _typeless(nullptr) {
+  }
+  inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
+      : _typeless(kj::mv(typeless)) {
+  }
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -14840,6 +15115,10 @@ class LoadEnumerationsResponse::Reader {
       ::capnp::Kind::STRUCT>::Reader
   getEnumerations() const;
 
+  inline bool hasAllEnumerations() const;
+  inline ::tiledb::sm::serialization::capnp::MapEnumeration::Reader
+  getAllEnumerations() const;
+
  private:
   ::capnp::_::StructReader _reader;
   template <typename, ::capnp::Kind>
@@ -14900,6 +15179,19 @@ class LoadEnumerationsResponse::Builder {
       ::capnp::Kind::STRUCT>>
   disownEnumerations();
 
+  inline bool hasAllEnumerations();
+  inline ::tiledb::sm::serialization::capnp::MapEnumeration::Builder
+  getAllEnumerations();
+  inline void setAllEnumerations(
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Reader value);
+  inline ::tiledb::sm::serialization::capnp::MapEnumeration::Builder
+  initAllEnumerations();
+  inline void adoptAllEnumerations(
+      ::capnp::Orphan<::tiledb::sm::serialization::capnp::MapEnumeration>&&
+          value);
+  inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::MapEnumeration>
+  disownAllEnumerations();
+
  private:
   ::capnp::_::StructBuilder _builder;
   template <typename, ::capnp::Kind>
@@ -14920,6 +15212,9 @@ class LoadEnumerationsResponse::Pipeline {
   inline explicit Pipeline(::capnp::AnyPointer::Pipeline&& typeless)
       : _typeless(kj::mv(typeless)) {
   }
+
+  inline ::tiledb::sm::serialization::capnp::MapEnumeration::Pipeline
+  getAllEnumerations();
 
  private:
   ::capnp::AnyPointer::Pipeline _typeless;
@@ -21605,6 +21900,194 @@ const ::capnp::_::RawBrandedSchema
         1,
         nullptr};
 #endif  // !CAPNP_LITE
+
+inline bool MapEnumeration::Reader::hasEntries() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool MapEnumeration::Builder::hasEntries() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+    ::capnp::Kind::STRUCT>::Reader
+MapEnumeration::Reader::getEntries() const {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>::get(_reader
+                                       .getPointerField(
+                                           ::capnp::bounded<0>() *
+                                           ::capnp::POINTERS));
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+    ::capnp::Kind::STRUCT>::Builder
+MapEnumeration::Builder::getEntries() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>::get(_builder
+                                       .getPointerField(
+                                           ::capnp::bounded<0>() *
+                                           ::capnp::POINTERS));
+}
+inline void MapEnumeration::Builder::setEntries(
+    ::capnp::List<
+        ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+        ::capnp::Kind::STRUCT>::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>::
+      set(_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+    ::capnp::Kind::STRUCT>::Builder
+MapEnumeration::Builder::initEntries(unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>::
+      init(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          size);
+}
+inline void MapEnumeration::Builder::adoptEntries(
+    ::capnp::Orphan<::capnp::List<
+        ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+        ::capnp::Kind::STRUCT>>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<
+    ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+    ::capnp::Kind::STRUCT>>
+MapEnumeration::Builder::disownEntries() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::MapEnumeration::Entry,
+      ::capnp::Kind::STRUCT>>::disown(_builder
+                                          .getPointerField(
+                                              ::capnp::bounded<0>() *
+                                              ::capnp::POINTERS));
+}
+
+inline bool MapEnumeration::Entry::Reader::hasKey() const {
+  return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool MapEnumeration::Entry::Builder::hasKey() {
+  return !_builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::Text::Reader MapEnumeration::Entry::Reader::getKey() const {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline ::capnp::Text::Builder MapEnumeration::Entry::Builder::getKey() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::get(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+inline void MapEnumeration::Entry::Builder::setKey(
+    ::capnp::Text::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::set(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      value);
+}
+inline ::capnp::Text::Builder MapEnumeration::Entry::Builder::initKey(
+    unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::init(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      size);
+}
+inline void MapEnumeration::Entry::Builder::adoptKey(
+    ::capnp::Orphan<::capnp::Text>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::Text>::adopt(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS),
+      kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::Text>
+MapEnumeration::Entry::Builder::disownKey() {
+  return ::capnp::_::PointerHelpers<::capnp::Text>::disown(
+      _builder.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS));
+}
+
+inline bool MapEnumeration::Entry::Reader::hasValue() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool MapEnumeration::Entry::Builder::hasValue() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Reader
+MapEnumeration::Entry::Reader::getValue() const {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::get(_reader
+                                       .getPointerField(
+                                           ::capnp::bounded<1>() *
+                                           ::capnp::POINTERS));
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Builder
+MapEnumeration::Entry::Builder::getValue() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::get(_builder
+                                       .getPointerField(
+                                           ::capnp::bounded<1>() *
+                                           ::capnp::POINTERS));
+}
+inline void MapEnumeration::Entry::Builder::setValue(
+    ::capnp::List<
+        ::tiledb::sm::serialization::capnp::Enumeration,
+        ::capnp::Kind::STRUCT>::Reader value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      set(_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>::Builder
+MapEnumeration::Entry::Builder::initValue(unsigned int size) {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      init(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          size);
+}
+inline void MapEnumeration::Entry::Builder::adoptValue(
+    ::capnp::Orphan<::capnp::List<
+        ::tiledb::sm::serialization::capnp::Enumeration,
+        ::capnp::Kind::STRUCT>>&& value) {
+  ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::
+      adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::capnp::List<
+    ::tiledb::sm::serialization::capnp::Enumeration,
+    ::capnp::Kind::STRUCT>>
+MapEnumeration::Entry::Builder::disownValue() {
+  return ::capnp::_::PointerHelpers<::capnp::List<
+      ::tiledb::sm::serialization::capnp::Enumeration,
+      ::capnp::Kind::STRUCT>>::disown(_builder
+                                          .getPointerField(
+                                              ::capnp::bounded<1>() *
+                                              ::capnp::POINTERS));
+}
 
 inline bool MapUInt32::Reader::hasEntries() const {
   return !_reader.getPointerField(::capnp::bounded<0>() * ::capnp::POINTERS)
@@ -33218,6 +33701,62 @@ LoadEnumerationsResponse::Builder::disownEnumerations() {
                                           .getPointerField(
                                               ::capnp::bounded<0>() *
                                               ::capnp::POINTERS));
+}
+
+inline bool LoadEnumerationsResponse::Reader::hasAllEnumerations() const {
+  return !_reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline bool LoadEnumerationsResponse::Builder::hasAllEnumerations() {
+  return !_builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS)
+              .isNull();
+}
+inline ::tiledb::sm::serialization::capnp::MapEnumeration::Reader
+LoadEnumerationsResponse::Reader::getAllEnumerations() const {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::MapEnumeration>::get(
+          _reader.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline ::tiledb::sm::serialization::capnp::MapEnumeration::Builder
+LoadEnumerationsResponse::Builder::getAllEnumerations() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::MapEnumeration>::get(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+#if !CAPNP_LITE
+inline ::tiledb::sm::serialization::capnp::MapEnumeration::Pipeline
+LoadEnumerationsResponse::Pipeline::getAllEnumerations() {
+  return ::tiledb::sm::serialization::capnp::MapEnumeration::Pipeline(
+      _typeless.getPointerField(1));
+}
+#endif  // !CAPNP_LITE
+inline void LoadEnumerationsResponse::Builder::setAllEnumerations(
+    ::tiledb::sm::serialization::capnp::MapEnumeration::Reader value) {
+  ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::MapEnumeration>::set(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          value);
+}
+inline ::tiledb::sm::serialization::capnp::MapEnumeration::Builder
+LoadEnumerationsResponse::Builder::initAllEnumerations() {
+  return ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::MapEnumeration>::init(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
+}
+inline void LoadEnumerationsResponse::Builder::adoptAllEnumerations(
+    ::capnp::Orphan<::tiledb::sm::serialization::capnp::MapEnumeration>&&
+        value) {
+  ::capnp::_::
+      PointerHelpers<::tiledb::sm::serialization::capnp::MapEnumeration>::adopt(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS),
+          kj::mv(value));
+}
+inline ::capnp::Orphan<::tiledb::sm::serialization::capnp::MapEnumeration>
+LoadEnumerationsResponse::Builder::disownAllEnumerations() {
+  return ::capnp::_::PointerHelpers<
+      ::tiledb::sm::serialization::capnp::MapEnumeration>::
+      disown(
+          _builder.getPointerField(::capnp::bounded<1>() * ::capnp::POINTERS));
 }
 
 inline bool LoadArraySchemaRequest::Reader::hasConfig() const {


### PR DESCRIPTION
This fixes a performance regression added in https://github.com/TileDB-Inc/TileDB/pull/5291 while loading enumerations for all array schemas. The regression impacts arrays with multiple evolved schemas. Previously #5291 introduced a loop over REST requests for-each schema, this PR loads all enumerations for all schemas in a single request.

---
TYPE: C_API
DESC: Introduce tiledb_array_load_enumerations_all_schemas

TYPE: CPP_API
DESC: Introduce ArrayExperimental::load_enumerations_all_schemas