### PR TITLE
Update macOS GitHub Actions images to `macos-latest`.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -77,7 +77,7 @@ env:
   CC: ${{ inputs.matrix_compiler_cc }}
   CFLAGS: ${{ inputs.matrix_compiler_cflags }}
   CXXFLAGS: ${{ inputs.matrix_compiler_cxxflags }}
-  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'x64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
+  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'arm64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
   # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: S3
-      matrix_image: macos-12
+      matrix_image: macos-latest
       cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: GCS
-      matrix_image: macos-12
+      matrix_image: macos-latest
       cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
@@ -101,7 +101,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: AZURE
-      matrix_image: macos-12
+      matrix_image: macos-latest
       cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       timeout: 120
       bootstrap_args: '--enable-azure'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
             triplet: arm64-linux-release
           - platform: macos-x86_64
             os: macos-latest
+            cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release
           - platform: macos-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,11 @@ jobs:
             cmake_args: -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$PWD/cmake/arm64_linux_toolchain.cmake
             triplet: arm64-linux-release
           - platform: macos-x86_64
-            os: macos-12
+            os: macos-latest
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release
           - platform: macos-arm64
-            os: macos-12
+            os: macos-latest
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=arm64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: arm64-osx-release


### PR DESCRIPTION
[SC-57897](https://app.shortcut.com/tiledb-inc/story/57897/use-macos-latest-for-core-ci)

This is done in anticipation of the removal of the `macos-12` image. The minimum supported OS version for the release binaries will not be affected.

---
TYPE: NO_HISTORY