### PR TITLE
Fix double installation of `tiledb_serialization.h`.

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -69,12 +69,6 @@ set(TILEDB_CORE_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 # List of API headers (to be installed)
 set(TILEDB_PUBLIC_HEADERS ${TILEDB_C_API_FILENAME_HEADERS})
 
-if (TILEDB_SERIALIZATION)
-  list(APPEND TILEDB_PUBLIC_HEADERS
-    ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/c_api/tiledb_serialization.h
-  )
-endif()
-
 if (TILEDB_CPP_API)
   list(APPEND TILEDB_PUBLIC_HEADERS
     ${TILEDB_CORE_INCLUDE_DIR}/tiledb/sm/cpp_api/tiledb


### PR DESCRIPTION
This PR fixes `tiledb_serialization.h` being specified for installation twice. We already include the header in `TILEDB_C_API_FILENAME_HEADERS` [here](https://github.com/TileDB-Inc/TileDB/blob/2ff07a56c4a81eec1a986989336c941a9c35690b/CMakeLists.txt#L287-L291), which gets included just above the deleted lines.

---
TYPE: BUILD
DESC: Fixed double installation of a header when serialization is enabled.