### PR TITLE
Update GCS emulator.

### DIFF
--- a/scripts/install-gcs-emu.sh
+++ b/scripts/install-gcs-emu.sh
@@ -31,7 +31,7 @@ die() {
 }
 
 install_gcs(){
-    git clone --branch v0.45.0 --depth 1 https://github.com/googleapis/storage-testbench.git /tmp/storage-testbench
+    git clone --branch v0.49.0 --depth 1 https://github.com/googleapis/storage-testbench.git /tmp/storage-testbench
     # Create a virtual environment and keep it active
     python3 -m venv /tmp/storage-testbench-venv
     source /tmp/storage-testbench-venv/bin/activate

--- a/scripts/install-run-gcs-emu.ps1
+++ b/scripts/install-run-gcs-emu.ps1
@@ -23,7 +23,7 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
-$version = "v0.45.0"
+$version = "v0.49.0"
 $testbenchPath = "$env:TEMP\storage-testbench-$version"
 $venvPath = "$env:TEMP\storage-testbench-venv"
 


### PR DESCRIPTION
[SC-58132](https://app.shortcut.com/tiledb-inc/story/58132/gcs-ci-fails-on-macos-after-image-bump)

Should fix `macos-latest - GCS` CI job (which has Python 3.13 for which the old version does not provide wheels for grpcio).

---
TYPE: NO_HISTORY