### PR TITLE
Only keep deserialization changes for rtrees

### DIFF
--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -326,6 +326,9 @@ void array_from_capnp(
       // pass the right schema to deserialize fragment metadata
       throw_if_not_ok(
           fragment_metadata_from_capnp(schema, frag_meta_reader, meta));
+      if (client_side) {
+        meta->loaded_metadata()->set_rtree_loaded();
+      }
       fragment_metadata.emplace_back(meta);
     }
     array->set_fragment_metadata(std::move(fragment_metadata));

--- a/tiledb/sm/serialization/fragment_info.cc
+++ b/tiledb/sm/serialization/fragment_info.cc
@@ -257,8 +257,6 @@ Status single_fragment_info_to_capnp(
   auto frag_meta_builder = single_frag_info_builder->initMeta();
   RETURN_NOT_OK(
       fragment_metadata_to_capnp(*single_frag_info.meta(), &frag_meta_builder));
-  rtree_to_capnp(
-      single_frag_info.meta()->loaded_metadata()->rtree(), &frag_meta_builder);
 
   // set fragment size
   single_frag_info_builder->setFragmentSize(single_frag_info.fragment_size());

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -390,8 +390,6 @@ Status fragment_metadata_from_capnp(
     // deserialize it as well in that way.
     frag_meta->loaded_metadata()->rtree().deserialize(
         deserializer, &domain, constants::format_version);
-
-    frag_meta->loaded_metadata()->set_rtree_loaded();
   }
 
   // It's important to do this here as init_domain depends on some fields

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -537,8 +537,6 @@ void fragment_meta_sizes_offsets_to_capnp(
       }
     }
   }
-
-  rtree_to_capnp(frag_meta.loaded_metadata()->rtree(), frag_meta_builder);
 }
 
 void rtree_to_capnp(
@@ -709,6 +707,10 @@ Status fragment_metadata_to_capnp(
       ned_builder,
       frag_meta.non_empty_domain(),
       frag_meta.array_schema()->dim_num()));
+
+  if (frag_meta.loaded_metadata()) {
+    rtree_to_capnp(frag_meta.loaded_metadata()->rtree(), frag_meta_builder);
+  }
 
   auto gt_offsets_builder = frag_meta_builder->initGtOffsets();
   generic_tile_offsets_to_capnp(


### PR DESCRIPTION
[sc-54668]

https://github.com/TileDB-Inc/TileDB/pull/5265 has introduced a good change: only serialize rtrees when absolutely needed. However, this has to be rolled out in 2 phases so that release 2.27 testing can happen smoothly. 

The problem is that the server will be in 2.26 and will expect to serialize rtrees that have not been deserialized before and hit a segfault which will not allow release testing to be performed. 

This PR reverts a part of the changes to avoid the issue. In this first part we still serialize the rtrees in all the cases, but we introduce all the deserialization changes. After this has been released and picked up server side we'll introduce as phase 2 the actual change of only serializing the rtrees when needed.

---
TYPE: NO_HISTORY
DESC: Only keep deserialization changes for rtrees
