### PR TITLE
Restore visibility of `tiledb_ctx_alloc_with_error`.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -110,6 +110,12 @@ jobs:
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
+      - name: Install Python
+        if: ${{ !inputs.manylinux }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Prevent vpckg from building debug variants
         run: python ./scripts/ci/patch_vcpkg_triplets.py
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,7 @@ list(APPEND TILEDB_C_API_RELATIVE_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/buffer/buffer_api_external.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/buffer_list/buffer_list_api_external.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/config/config_api_external.h"
+    "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/context/context_api_experimental.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/context/context_api_external.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/current_domain/current_domain_api_enum.h"
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h"

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -61,6 +61,17 @@ capi_return_t tiledb_ctx_alloc(
   return TILEDB_OK;
 }
 
+/**
+ * Transparent forwarder to tiledb_ctx_alloc.
+ *
+ * Must be a separate function with its own name due to requirements of the
+ * CAPI_INTERFACE macro.
+ */
+capi_return_t tiledb_ctx_alloc_with_error(
+    tiledb_config_handle_t* config, tiledb_ctx_handle_t** ctx) {
+  return tiledb::api::tiledb_ctx_alloc(config, ctx);
+}
+
 void tiledb_ctx_free(tiledb_ctx_t** ctx) {
   ensure_output_pointer_is_valid(ctx);
   ensure_context_is_valid(*ctx);
@@ -150,11 +161,7 @@ CAPI_INTERFACE(
     tiledb_config_handle_t* config,
     tiledb_ctx_handle_t** ctx,
     tiledb_error_handle_t** error) {
-  /*
-   * Wrapped with the `api_entry_error` variation. Note that the same function
-   * is wrapped with `api_entry_plain` above.
-   */
-  return tiledb::api::api_entry_error<tiledb::api::tiledb_ctx_alloc>(
+  return tiledb::api::api_entry_error<tiledb::api::tiledb_ctx_alloc_with_error>(
       error, config, ctx);
 }
 

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -31,6 +31,7 @@
  */
 
 #include "../config/config_api_internal.h"
+#include "context_api_experimental.h"
 #include "context_api_external.h"
 #include "context_api_internal.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
@@ -144,22 +145,11 @@ CAPI_INTERFACE(
       config, ctx);
 }
 
-/*
- * We have a special case with tiledb_ctx_alloc_with_error. It's declared in
- * tiledb_experimental.h. Rather than all the apparatus needed to split up that
- * header (as tiledb.h is), we declare its linkage separately at the point of
- * definition.
- *
- * Not including the experimental header means that we're not using the compiler
- * to check the definition against the declaration. This won't scale
- * particularly well, but it doesn't need to for the time being.
- */
-extern "C" {
-
-capi_return_t tiledb_ctx_alloc_with_error(
+CAPI_INTERFACE(
+    ctx_alloc_with_error,
     tiledb_config_handle_t* config,
     tiledb_ctx_handle_t** ctx,
-    tiledb_error_handle_t** error) noexcept {
+    tiledb_error_handle_t** error) {
   /*
    * Wrapped with the `api_entry_error` variation. Note that the same function
    * is wrapped with `api_entry_plain` above.
@@ -167,8 +157,6 @@ capi_return_t tiledb_ctx_alloc_with_error(
   return tiledb::api::api_entry_error<tiledb::api::tiledb_ctx_alloc>(
       error, config, ctx);
 }
-
-}  // extern "C"
 
 /*
  * API Audit: void return

--- a/tiledb/api/c_api/context/context_api_experimental.h
+++ b/tiledb/api/c_api/context/context_api_experimental.h
@@ -1,0 +1,87 @@
+/**
+ * @file tiledb/api/c_api/context/context_api_experimentnal.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file declares the experimental C API for TileDB context.
+ */
+
+#ifndef TILEDB_CAPI_CONTEXT_EXPERIMENTAL_H
+#define TILEDB_CAPI_CONTEXT_EXPERIMENTAL_H
+
+#include "../api_external_common.h"
+#include "../error/error_api_external.h"
+#include "context_api_external.h"
+
+#include "../config/config_api_external.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Creates a TileDB context, which contains the TileDB storage manager
+ * that manages everything in the TileDB library. This is a provisional API
+ * which returns an error object when the context creation fails. This API will
+ * be replaced with a more proper "v2" of context alloc in the near future. The
+ * main goal is to use to this to capture potential failures to inform the v2
+ * alloc design.
+ *
+ * **Examples:**
+ *
+ * Without config (i.e., use default configuration):
+ *
+ * @code{.c}
+ * tiledb_ctx_t* ctx;
+ * tiledb_error_t* error;
+ * tiledb_ctx_alloc_with_error(NULL, &ctx, &error);
+ * @endcode
+ *
+ * With some config:
+ *
+ * @code{.c}
+ * tiledb_ctx_t* ctx;
+ * tiledb_error_t* error;
+ * tiledb_ctx_alloc_with_error(config, &ctx, &error);
+ * @endcode
+ *
+ * @param[in] config The configuration parameters (`NULL` means default).
+ * @param[out] ctx The TileDB context to be created.
+ * @param[out] error Error object returned upon error (`NULL` if there is
+ *     no error).
+ * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_ctx_alloc_with_error(
+    tiledb_config_t* config,
+    tiledb_ctx_t** ctx,
+    tiledb_error_t** error) TILEDB_NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TILEDB_CAPI_CONTEXT_EXPERIMENTAL_H

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -44,6 +44,7 @@
 #include "tiledb/api/c_api/array_schema/array_schema_api_experimental.h"
 #include "tiledb/api/c_api/array_schema_evolution/array_schema_evolution_api_experimental.h"
 #include "tiledb/api/c_api/attribute/attribute_api_external_experimental.h"
+#include "tiledb/api/c_api/context/context_api_experimental.h"
 #include "tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h"
 #include "tiledb/api/c_api/enumeration/enumeration_api_experimental.h"
 #include "tiledb/api/c_api/fragment_info/fragment_info_api_experimental.h"
@@ -498,43 +499,6 @@ TILEDB_EXPORT int32_t tiledb_query_get_status_details(
 /* ********************************* */
 /*              CONTEXT              */
 /* ********************************* */
-
-/**
- * Creates a TileDB context, which contains the TileDB storage manager
- * that manages everything in the TileDB library. This is a provisional API
- * which returns an error object when the context creation fails. This API will
- * be replaced with a more proper "v2" of context alloc in the near future. The
- * main goal is to use to this to capture potential failures to inform the v2
- * alloc design.
- *
- * **Examples:**
- *
- * Without config (i.e., use default configuration):
- *
- * @code{.c}
- * tiledb_ctx_t* ctx;
- * tiledb_error_t* error;
- * tiledb_ctx_alloc_with_error(NULL, &ctx, &error);
- * @endcode
- *
- * With some config:
- *
- * @code{.c}
- * tiledb_ctx_t* ctx;
- * tiledb_error_t* error;
- * tiledb_ctx_alloc_with_error(config, &ctx, &error);
- * @endcode
- *
- * @param[in] config The configuration parameters (`NULL` means default).
- * @param[out] ctx The TileDB context to be created.
- * @param[out] error Error object returned upon error (`NULL` if there is
- *     no error).
- * @return `TILEDB_OK` for success and `TILEDB_OOM` or `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT capi_return_t tiledb_ctx_alloc_with_error(
-    tiledb_config_t* config,
-    tiledb_ctx_t** ctx,
-    tiledb_error_t** error) TILEDB_NOEXCEPT;
 
 /* ********************************* */
 /*         ARRAY CONSOLIDATION       */


### PR DESCRIPTION
[SC-58150](https://app.shortcut.com/tiledb-inc/story/58150/tledb-ctx-alloc-with-error-is-not-exported)

Starting with #3524 due to an oversight, the `tiledb_ctx_alloc_with_error` function could not be used because the symbol was not publicly visible. This PR fixes this and conforms the implementation of the API to match the other APIs.

Validated by adding a usage of `tiledb_ctx_alloc_with_error` to an example (which links dynamically to libtiledb).

---
TYPE: BUG
DESC: Fixed the `tiledb_ctx_alloc_with_error` function not being exported from the library.