### PR TITLE
Bug fix: schema evolution fix-to-var reads followup.

### DIFF
--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -1136,7 +1136,7 @@ uint64_t ReaderBase::offsets_bytesize() const {
 uint64_t ReaderBase::get_attribute_tile_size(
     const std::string& name, unsigned f, uint64_t t) const {
   uint64_t tile_size = 0;
-  if (!fragment_metadata_[f]->array_schema()->is_field(name)) {
+  if (skip_field(f, name)) {
     return tile_size;
   }
 
@@ -1148,8 +1148,7 @@ uint64_t ReaderBase::get_attribute_tile_size(
    * contains fixed tiles. The tile_var_size should be calculated iff
    * both the current _and_ loaded attributes are var-sized.
    */
-  if (array_schema_.var_size(name) &&
-      fragment_metadata_[f]->array_schema()->var_size(name)) {
+  if (array_schema_.var_size(name)) {
     tile_size +=
         fragment_metadata_[f]->loaded_metadata()->tile_var_size(name, t);
   }
@@ -1165,12 +1164,9 @@ uint64_t ReaderBase::get_attribute_tile_size(
 uint64_t ReaderBase::get_attribute_persisted_tile_size(
     const std::string& name, unsigned f, uint64_t t) const {
   uint64_t tile_size = 0;
-  if (!fragment_metadata_[f]->array_schema()->is_field(name)) {
+  if (skip_field(f, name)) {
     return tile_size;
   }
-
-  tile_size +=
-      fragment_metadata_[f]->loaded_metadata()->persisted_tile_size(name, t);
 
   if (array_schema_.var_size(name)) {
     tile_size +=


### PR DESCRIPTION
Schema evolution bug fix: Reads no longer fail after dropping a fixed attribute and adding it back as var-sized.

Followup to #5321 to address a previously-missed case caught by [TileDB-Inc/TileDB-Py/#2083](https://github.com/TileDB-Inc/TileDB-Py/pull/2083)

[sc-55085]

---
TYPE: BUG
DESC: Schema evolution bug fix: Reads no longer fail after dropping a fixed attribute and adding it back as var-sized, part 2.
