### PR TITLE
Fix 'tests' target build on macOS 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,9 @@ else()
     endif()
   endif()
 
+  if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "16")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fexperimental-library>)
+  endif()
 endif()
 
 # Definitions for all targets


### PR DESCRIPTION
On macOS 15, `make tests` is broken on current dev with errors like this:

```
pydev ❯ nj tests
[184/468] Building CXX object tiledb/stdx/test/CMakeFiles/unit_stdx.dir/compat.cc.o
FAILED: tiledb/stdx/test/CMakeFiles/unit_stdx.dir/compat.cc.o
/usr/bin/g++ -DNDEBUG -D_FILE_OFFSET_BITS=64 -I/Users/inorton/work/git/TileDB -isystem /Users/inorton/work/bld/TileDB-rel/vcpkg_installed/arm64-osx/include -O3 -DNDEBUG -std=c++20 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk -mmacosx-version-min=15.0 -fPIE -fvisibility=hidden -Wall -Wextra -Werror -O3 -Wno-unqualified-std-cast-call -MD -MT tiledb/stdx/test/CMakeFiles/unit_stdx.dir/compat.cc.o -MF tiledb/stdx/test/CMakeFiles/unit_stdx.dir/compat.cc.o.d -o tiledb/stdx/test/CMakeFiles/unit_stdx.dir/compat.cc.o -c /Users/inorton/work/git/TileDB/tiledb/stdx/test/compat.cc
In file included from /Users/inorton/work/git/TileDB/tiledb/stdx/test/compat.cc:34:
In file included from /Users/inorton/work/git/TileDB/tiledb/stdx/stop_token:41:
/Users/inorton/work/git/TileDB/tiledb/stdx/bits/stop_token.h:150:7: error: reference to '__stop_callback_base' is ambiguous
  150 |       __stop_callback_base* __cb,
      |       ^
```

gist: https://gist.github.com/ihnorton/2f616091f92be4b493f7fec6fdd40dee

It looks like AppleClang has added incomplete support for `stop_token` and `std::jthread`, but `__cpp_lib_jthread` guard doesn't exist, which breaks our existing feature guards in `tiledb/stdx/{stop_token,thread}`.

Fix is to add `-fexperimental-library` to AppleClang>16 cxx flags.

---
TYPE: NO_HISTORY
DESC: Fix 'tests' target build on AppleClang 16 (stop_token,jthread)