### PR TITLE
Set increased traversal limit in enumeration deserialization

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -2940,7 +2940,7 @@ shared_ptr<ArraySchemaEvolution> EnumerationFx::ser_des_array_schema_evolution(
 
   ArraySchemaEvolution* ret;
   throw_if_not_ok(serialization::array_schema_evolution_deserialize(
-      &ret, stype, buf, memory_tracker_));
+      &ret, cfg_, stype, buf, memory_tracker_));
 
   return shared_ptr<ArraySchemaEvolution>(ret);
 }

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -546,7 +546,7 @@ HandleLoadArraySchemaRequestFx::call_handler(
   REQUIRE(rval == TILEDB_OK);
 
   return serialization::deserialize_load_array_schema_response(
-      uri_, stype, resp_buf->buffer(), memory_tracker_);
+      uri_, cfg_, stype, resp_buf->buffer(), memory_tracker_);
 }
 
 shared_ptr<ArraySchema> HandleQueryPlanRequestFx::create_schema() {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1572,6 +1572,7 @@ int32_t tiledb_deserialize_array_schema_evolution(
           ctx,
           tiledb::sm::serialization::array_schema_evolution_deserialize(
               &((*array_schema_evolution)->array_schema_evolution_),
+              ctx->config(),
               (tiledb::sm::SerializationType)serialize_type,
               buffer->buffer(),
               memory_tracker))) {

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -274,7 +274,7 @@ RestClientRemote::post_array_schema_from_rest(
   // Ensure data has a null delimiter for cap'n proto if using JSON
   throw_if_not_ok(ensure_json_null_delimited_string(&returned_data));
   return serialization::deserialize_load_array_schema_response(
-      uri, serialization_type_, returned_data, memory_tracker_);
+      uri, config, serialization_type_, returned_data, memory_tracker_);
 }
 
 Status RestClientRemote::post_array_schema_to_rest(
@@ -616,7 +616,7 @@ RestClientRemote::post_enumerations_from_rest(
   // Ensure data has a null delimiter for cap'n proto if using JSON
   throw_if_not_ok(ensure_json_null_delimited_string(&returned_data));
   return serialization::deserialize_load_enumerations_response(
-      array_schema, serialization_type_, returned_data, memory_tracker);
+      array_schema, config, serialization_type_, returned_data, memory_tracker);
 }
 
 void RestClientRemote::post_query_plan_from_rest(

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -208,6 +208,7 @@ std::tuple<
     std::unordered_map<std::string, shared_ptr<ArraySchema>>>
 deserialize_load_array_schema_response(
     const URI& uri,
+    const Config& config,
     SerializationType serialization_type,
     span<const char> data,
     shared_ptr<MemoryTracker> memory_tracker);

--- a/tiledb/sm/serialization/array_schema_evolution.h
+++ b/tiledb/sm/serialization/array_schema_evolution.h
@@ -70,6 +70,7 @@ Status array_schema_evolution_serialize(
 /**
  * Deserialize an array schema evolution via Cap'n Proto
  * @param array_schema_evolution pointer to store evolution object in
+ * @param config associated config object
  * @param serialize_type format to serialize into Cap'n Proto or JSON
  * @param serialized_buffer buffer where serialized bytes are stored
  * @param memory_tracker memory tracker associated with the evolution object
@@ -77,6 +78,7 @@ Status array_schema_evolution_serialize(
  */
 Status array_schema_evolution_deserialize(
     ArraySchemaEvolution** array_schema_evolution,
+    const Config& config,
     SerializationType serialize_type,
     span<const char> serialized_buffer,
     shared_ptr<MemoryTracker> memory_tracker);

--- a/tiledb/sm/serialization/enumeration.h
+++ b/tiledb/sm/serialization/enumeration.h
@@ -93,6 +93,7 @@ void serialize_load_enumerations_response(
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
     const ArraySchema& array_schema,
+    const Config& config,
     SerializationType serialization_type,
     span<const char> response,
     shared_ptr<MemoryTracker> memory_tracker);


### PR DESCRIPTION
So far we'd only apply an increased traversal limit to the deserialization of certain objects like Query, groups and metadata of all sorts. For the rest of them, like Array Schema evolution we use the default Capnp value that is actually [64MB](https://capnproto.org/encoding.html#:~:text=We%20call%20this%20limit%20the,a%20different%20limit%20if%20desired.). 

We had a real life scenario where evolving the array schema hit the traversal limit and failed. This is most probably due to the addition of a lot of enumerations in a new schema, and it seems that large enumerations are commonly used in certain scientific use cases. To cope with such cases, this PR sets an increased traversal limit to every deserialization that includes enumerations: schema evolution, array schema and load enumerations response.

TYPE: BUG
DESC: Set increased traversal limit in enumeration deserialization
