### PR TITLE
[cppapi] Use the right API to free stats strings.

### DIFF
--- a/tiledb/sm/cpp_api/context.h
+++ b/tiledb/sm/cpp_api/context.h
@@ -236,7 +236,7 @@ class Context {
 
     // Copy `c_str` into `str`.
     std::string str(c_str);
-    ::free(c_str);
+    tiledb_stats_free_str(&c_str);
 
     return str;
   }

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -991,7 +991,7 @@ class Query {
 
     // Copy `c_str` into `str`.
     std::string str(c_str);
-    free(c_str);
+    tiledb_stats_free_str(&c_str);
 
     return str;
   }


### PR DESCRIPTION
[SC-59016](https://app.shortcut.com/tiledb-inc/story/59016/cppapi-getting-context-and-query-stats-should-not-use-free)

This PR updates to use `tiledb_stats_free_str` instead of `free` to free stats strings in the C++ API. Will fix failures for cases when the application's and the Core's `free` functions are different (such as when using debug-mode CRT on Windows with the prebuilt `tiledb.dll`).

---
TYPE: BUG
DESC: Fix heap corruption when getting context and query stats from C++ under certain circumstances.