### PR TITLE
Remove CAPI test case that's failing in ASAN nightly.

### DIFF
--- a/tiledb/api/c_api/subarray/test/unit_capi_subarray.cc
+++ b/tiledb/api/c_api/subarray/test/unit_capi_subarray.cc
@@ -191,10 +191,11 @@ TEST_CASE(
         tiledb_subarray_add_point_ranges(x.ctx(), x.subarray, 0, ranges_inv, 2);
     REQUIRE(tiledb_status(rc) == TILEDB_ERR);
   }
-  SECTION("invalid count") {
-    rc = tiledb_subarray_add_point_ranges(x.ctx(), x.subarray, 0, ranges, 20);
-    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
-  }
+  /**
+   * No "invalid count" section here;
+   * There is no way to programmatically (in)validate the count. An invalid
+   * value will result in a segfault from an OOB memcpy.
+   */
 }
 
 TEST_CASE(


### PR DESCRIPTION
The design of `Subarray::add_point_ranges` does not allow for programmatic validation of parameter `count`. As such, there is a possibility of writing out of bounds on `std::memcpy`. This PR removes the CAPI test case which inherently tests this behavior and causes a segfault in the nightly builds.  

[sc-58520]

---
TYPE: BUG
DESC: Remove defective test case that's failing in nightly builds. 
