### PR TITLE
Revert selective Rtree serialization to allow release testing

### DIFF
--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -326,6 +326,9 @@ void array_from_capnp(
       // pass the right schema to deserialize fragment metadata
       throw_if_not_ok(
           fragment_metadata_from_capnp(schema, frag_meta_reader, meta));
+      if (client_side) {
+        meta->loaded_metadata()->set_rtree_loaded();
+      }
       fragment_metadata.emplace_back(meta);
     }
     array->set_fragment_metadata(std::move(fragment_metadata));

--- a/tiledb/sm/serialization/fragment_info.cc
+++ b/tiledb/sm/serialization/fragment_info.cc
@@ -242,6 +242,8 @@ single_fragment_info_from_capnp(
       meta->non_empty_domain(),
       expanded_non_empty_domain,
       meta};
+  // This is needed so that we don't try to load rtee from disk
+  single_frag_info.meta()->loaded_metadata()->set_rtree_loaded();
 
   return {Status::Ok(), single_frag_info};
 }
@@ -257,8 +259,6 @@ Status single_fragment_info_to_capnp(
   auto frag_meta_builder = single_frag_info_builder->initMeta();
   RETURN_NOT_OK(
       fragment_metadata_to_capnp(*single_frag_info.meta(), &frag_meta_builder));
-  rtree_to_capnp(
-      single_frag_info.meta()->loaded_metadata()->rtree(), &frag_meta_builder);
 
   // set fragment size
   single_frag_info_builder->setFragmentSize(single_frag_info.fragment_size());

--- a/tiledb/sm/serialization/fragment_metadata.cc
+++ b/tiledb/sm/serialization/fragment_metadata.cc
@@ -372,8 +372,6 @@ Status fragment_metadata_from_capnp(
   }
   frag_meta->last_tile_cell_num() = frag_meta_reader.getLastTileCellNum();
 
-  frag_meta->loaded_metadata()->set_loaded_metadata(loaded_metadata);
-
   if (frag_meta_reader.hasRtree()) {
     auto data = frag_meta_reader.getRtree();
     auto& domain = fragment_array_schema->domain();
@@ -390,8 +388,6 @@ Status fragment_metadata_from_capnp(
     // deserialize it as well in that way.
     frag_meta->loaded_metadata()->rtree().deserialize(
         deserializer, &domain, constants::format_version);
-
-    frag_meta->loaded_metadata()->set_rtree_loaded();
   }
 
   // It's important to do this here as init_domain depends on some fields
@@ -414,6 +410,8 @@ Status fragment_metadata_from_capnp(
     generic_tile_offsets_from_capnp(
         frag_meta_reader.getGtOffsets(), frag_meta->generic_tile_offsets());
   }
+
+  frag_meta->loaded_metadata()->set_loaded_metadata(loaded_metadata);
 
   return Status::Ok();
 }
@@ -536,25 +534,6 @@ void fragment_meta_sizes_offsets_to_capnp(
         builder[i].set(j, tile_validity_offsets[i][j]);
       }
     }
-  }
-
-  rtree_to_capnp(frag_meta.loaded_metadata()->rtree(), frag_meta_builder);
-}
-
-void rtree_to_capnp(
-    const RTree& rtree, capnp::FragmentMetadata::Builder* frag_meta_builder) {
-  // TODO: Can this be done better? Does this make a lot of copies?
-  SizeComputationSerializer size_computation_serializer;
-  rtree.serialize(size_computation_serializer);
-  if (size_computation_serializer.size() != 0) {
-    std::vector<uint8_t> buff(size_computation_serializer.size());
-    Serializer serializer(buff.data(), buff.size());
-    rtree.serialize(serializer);
-
-    auto vec = kj::Vector<uint8_t>();
-    vec.addAll(
-        kj::ArrayPtr<uint8_t>(static_cast<uint8_t*>(buff.data()), buff.size()));
-    frag_meta_builder->setRtree(vec.asPtr());
   }
 }
 
@@ -709,6 +688,19 @@ Status fragment_metadata_to_capnp(
       ned_builder,
       frag_meta.non_empty_domain(),
       frag_meta.array_schema()->dim_num()));
+
+  // TODO: Can this be done better? Does this make a lot of copies?
+  SizeComputationSerializer size_computation_serializer;
+  frag_meta.loaded_metadata()->rtree().serialize(size_computation_serializer);
+
+  std::vector<uint8_t> buff(size_computation_serializer.size());
+  Serializer serializer(buff.data(), buff.size());
+  frag_meta.loaded_metadata()->rtree().serialize(serializer);
+
+  auto vec = kj::Vector<uint8_t>();
+  vec.addAll(
+      kj::ArrayPtr<uint8_t>(static_cast<uint8_t*>(buff.data()), buff.size()));
+  frag_meta_builder->setRtree(vec.asPtr());
 
   auto gt_offsets_builder = frag_meta_builder->initGtOffsets();
   generic_tile_offsets_to_capnp(

--- a/tiledb/sm/serialization/fragment_metadata.h
+++ b/tiledb/sm/serialization/fragment_metadata.h
@@ -85,15 +85,6 @@ void fragment_meta_sizes_offsets_to_capnp(
     capnp::FragmentMetadata::Builder* frag_meta_builder);
 
 /**
- * Serializes FragmentMetadata's RTree to Cap'n Proto message
- *
- * @param rtree RTREE to serialize
- * @param frag_meta_builder cap'n proto class
- */
-void rtree_to_capnp(
-    const RTree& rtree, capnp::FragmentMetadata::Builder* frag_meta_builder);
-
-/**
  * Convert Fragment Metadata to Cap'n Proto message
  *
  * @param frag_meta fragment metadata to serialize


### PR DESCRIPTION
This reverts https://github.com/TileDB-Inc/TileDB/pull/5265 although it has introduced a good change: only serialize rtrees when absolutely needed. However, the problem is that the server will be in 2.26 and will expect to serialize rtrees that have not been deserialized before and will fail. This will not allow the release to get verified completely.

---
TYPE: IMPROVEMENT
DESC: Revert selective Rtree serialization to allow release testing
