### PR TITLE
Update temporary file extension to `.tiledb.tmp`.

### DIFF
--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -406,7 +406,7 @@ class GCS {
     std::string next_part_path() {
       const uint64_t part_id = next_part_id_++;
       const std::string part_path =
-          object_path_ + ".part" + std::to_string(part_id) + ".tmp";
+          object_path_ + ".part" + std::to_string(part_id) + ".tiledb.tmp";
       part_paths_.emplace_back(part_path);
       return part_path;
     }


### PR DESCRIPTION
[SC-59383](https://app.shortcut.com/tiledb-inc/story/59383/update-temporary-file-suffix-to-tiledb-tmp)

This PR updates the extension of temporary files from `.tmp` (first introduced in #5308) to `.tiledb.tmp`, enabling users to take action specifically to temporary files produced by TileDB.

---
TYPE: IMPROVEMENT
DESC: Temporary files (currently used by GCS only) now end with `.tiledb.tmp`, allowing you to set a lifecycle rule to automatically delete them after a set amount of time if they happen to be left over.