### PR TITLE
[Draft: checking CI] Don't load again enums on client side when serializing array

### DIFF
--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -147,7 +147,8 @@ Status array_to_capnp(
 
   array_builder->setQueryType(query_type_str(array->get_query_type()));
 
-  if (array->use_refactored_array_open() && array->serialize_enumerations()) {
+  if (array->use_refactored_array_open() && array->serialize_enumerations() &&
+      !client_side) {
     array->load_all_enumerations(true);
   }
 


### PR DESCRIPTION
<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
