### PR TITLE
Add Config::login API.

### DIFF
--- a/test/src/unit-curl.cc
+++ b/test/src/unit-curl.cc
@@ -129,12 +129,12 @@ TEST_CASE(
     "RestClient: Remove trailing slash from rest_server_", "[rest-client]") {
   std::string rest_server =
       GENERATE("http://localhost:8080/", "http://localhost:8080//");
+  SECTION("rest.server_address set in environment") {
+    setenv_local("TILEDB_REST_SERVER_ADDRESS", rest_server.c_str());
+  }
   tiledb::sm::Config cfg;
   SECTION("rest.server_address set in Config") {
     cfg.set("rest.server_address", rest_server).ok();
-  }
-  SECTION("rest.server_address set in environment") {
-    setenv_local("TILEDB_REST_SERVER_ADDRESS", rest_server.c_str());
   }
   SECTION("rest.server_address set by loaded config file") {
     std::string cfg_file = "tiledb_config.txt";

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -827,6 +827,16 @@ class Config {
 
   /** Returns the param -> value map. */
   const std::map<std::string, std::string>& param_values() const;
+
+  /**
+   * Internally sets the given config parameter.
+   *
+   * @note For internal use only; This API does not update the user-set params.
+   *
+   * @param param The config parameter to set.
+   * @param value The value of the parameter.
+   */
+  void set_internal(const std::string& param, const std::string& value);
 };
 
 /**

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -666,6 +666,9 @@ class Config {
   /* ********************************* */
   /*                API                */
   /* ********************************* */
+
+  /** Log in to TileDB Cloud, saving profile info to the config. */
+  void login();
 
   /** Loads the config parameters from a configuration (local) file. */
   Status load_from_file(const std::string& filename);

--- a/tiledb/sm/config/test/unit_config.cc
+++ b/tiledb/sm/config/test/unit_config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2022 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -110,17 +110,4 @@ TEST_CASE("Config::get<std::string> - found and matched", "[config]") {
   std::string expected_value = GENERATE("test", "true", "0", "1.5");
   CHECK(c.set(key, expected_value).ok());
   TestConfig<std::string>::check_expected(expected_value, c, key);
-}
-
-TEST_CASE("Config::login", "[config][login]") {
-  Config c{};
-
-  // Upon initial Config construction, no rest token is set
-  auto initial_token = c.get<std::string>("rest.token");
-  CHECK(!initial_token.has_value());
-
-  // After login, the rest token is set from the cloud.json file
-  c.login();
-  auto login_token = c.get<std::string>("rest.token");
-  CHECK(login_token.has_value());
 }

--- a/tiledb/sm/config/test/unit_config.cc
+++ b/tiledb/sm/config/test/unit_config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -110,4 +110,17 @@ TEST_CASE("Config::get<std::string> - found and matched", "[config]") {
   std::string expected_value = GENERATE("test", "true", "0", "1.5");
   CHECK(c.set(key, expected_value).ok());
   TestConfig<std::string>::check_expected(expected_value, c, key);
+}
+
+TEST_CASE("Config::login", "[config][login]") {
+  Config c{};
+
+  // Upon initial Config construction, no rest token is set
+  auto initial_token = c.get<std::string>("rest.token");
+  CHECK(!initial_token.has_value());
+
+  // After login, the rest token is set from the cloud.json file
+  c.login();
+  auto login_token = c.get<std::string>("rest.token");
+  CHECK(login_token.has_value());
 }


### PR DESCRIPTION
Add `Config::login` API, which logs into TileDB Cloud, saving the profile to the internal configuration. 

---
TYPE: FEATURE
DESC: Add `Config::login` API.
