### PR TITLE
Add tiledb_field_get_nullable API

### DIFF
--- a/tiledb/api/c_api/query_field/query_field_api_external_experimental.h
+++ b/tiledb/api/c_api/query_field/query_field_api_external_experimental.h
@@ -138,6 +138,27 @@ TILEDB_EXPORT capi_return_t tiledb_field_cell_val_num(
     uint32_t* cell_val_num) TILEDB_NOEXCEPT;
 
 /**
+ * Retrieves the nullability of a field.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * uint8_t nullable;
+ * tiledb_field_get_nullable(ctx, attr, &nullable);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param field The query field handle
+ * @param nullable Output argument, non-zero for nullable and zero
+ *    for non-nullable.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_field_get_nullable(
+    tiledb_ctx_t* ctx,
+    tiledb_query_field_t* field,
+    uint8_t* nullable) TILEDB_NOEXCEPT;
+
+/**
  * Get the origin type of the passed field
  * **Example:**
  *

--- a/tiledb/api/c_api/query_field/query_field_api_external_experimental.h
+++ b/tiledb/api/c_api/query_field/query_field_api_external_experimental.h
@@ -147,10 +147,9 @@ TILEDB_EXPORT capi_return_t tiledb_field_cell_val_num(
  * tiledb_field_get_nullable(ctx, attr, &nullable);
  * @endcode
  *
- * @param ctx The TileDB context.
- * @param field The query field handle
- * @param nullable Output argument, non-zero for nullable and zero
- *    for non-nullable.
+ * @param[in] ctx The TileDB context.
+ * @param[in] field The query field handle
+ * @param[out] nullable Non-zero if `field` is nullable, and zero otherwise
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_field_get_nullable(

--- a/tiledb/api/c_api/query_field/query_field_api_internal.h
+++ b/tiledb/api/c_api/query_field/query_field_api_internal.h
@@ -73,6 +73,7 @@ struct tiledb_query_field_handle_t
   std::shared_ptr<FieldOrigin> field_origin_;
   tiledb::sm::Datatype type_;
   uint32_t cell_val_num_;
+  bool is_nullable_;
   std::shared_ptr<tiledb::sm::QueryChannel> channel_;
 
  public:
@@ -95,6 +96,9 @@ struct tiledb_query_field_handle_t
   }
   uint32_t cell_val_num() {
     return cell_val_num_;
+  }
+  bool is_nullable() const {
+    return is_nullable_;
   }
   tiledb_query_channel_handle_t* channel() {
     return tiledb_query_channel_handle_t::make_handle(channel_);


### PR DESCRIPTION
The set of "query field" APIs offers a means to ask about the datatype and cell val num of a query result field without understanding whether the queried field is a dimension, attribute, or aggregate.

For aggregates in particular `tiledb_field_datatype` and `tiledb_field_cell_val_num` allow a user to ask about the result type of their aggregate function operation, without having to read docs, source code, etc.

To date, however, there has not been a way to ask if a query field can be null.  This pull request adds that, via a C API `tiledb_field_get_nullable`.

---
TYPE: C_API
DESC: Add `tiledb_field_get_nullable` API
