### PR TITLE
Add configuration parameter to load enumerations on all schemas.

### DIFF
--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -233,6 +233,7 @@ void check_save_to_file() {
   ss << "rest.curl.verbose false\n";
   ss << "rest.http_compressor any\n";
   ss << "rest.load_enumerations_on_array_open false\n";
+  ss << "rest.load_enumerations_on_array_open_all_schemas false\n";
   ss << "rest.load_metadata_on_array_open true\n";
   ss << "rest.load_non_empty_domain_on_array_open true\n";
   ss << "rest.retry_count 25\n";
@@ -617,6 +618,8 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["rest.load_metadata_on_array_open"] = "false";
   all_param_values["rest.load_non_empty_domain_on_array_open"] = "false";
   all_param_values["rest.load_enumerations_on_array_open"] = "false";
+  all_param_values["rest.load_enumerations_on_array_open_all_schemas"] =
+      "false";
   all_param_values["rest.use_refactored_array_open"] = "false";
   all_param_values["rest.use_refactored_array_open_and_query_submit"] = "false";
   all_param_values["rest.payer_namespace"] = "";

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -431,7 +431,8 @@ TEST_CASE_METHOD(
     "CPP API: Load All Enumerations - All Schemas",
     "[enumeration][array][load-all-enumerations][all-schemas][rest]") {
   create_array();
-  // Test with `rest.load_enumerations_on_array_open` enabled and disabled.
+  // Test with `rest.load_enumerations_on_array_open_all_schemas` enabled and
+  // disabled.
   bool load_enmrs = GENERATE(true, false);
   auto config = ctx_.config();
   config["rest.load_enumerations_on_array_open_all_schemas"] =
@@ -636,7 +637,8 @@ TEST_CASE_METHOD(
     "[enumeration][array][schema-evolution][load-all-enumerations][all-schemas]"
     "[rest]") {
   create_array();
-  // Test with `rest.load_enumerations_on_array_open` enabled and disabled.
+  // Test with `rest.load_enumerations_on_array_open_all_schemas` enabled and
+  // disabled.
   bool load_enmrs = GENERATE(true, false);
   auto config = ctx_.config();
   config["rest.load_enumerations_on_array_open_all_schemas"] =
@@ -662,9 +664,9 @@ TEST_CASE_METHOD(
         array.schema().ptr()->array_schema()->is_enumeration_loaded(
             "an_enumeration") == true);
   }
-  // If `rest.load_enumerations_on_array_open=false` do not load enmrs
-  // explicitly. Leave enumerations unloaded initially, evolve the array without
-  // reopening, and then attempt to load all enumerations.
+  // If `rest.load_enumerations_on_array_open_all_schemas=false` do not load
+  // enmrs explicitly. Leave enumerations unloaded initially, evolve the array
+  // without reopening, and then attempt to load all enumerations.
 
   // Evolve once to add an enumeration.
   ArraySchemaEvolution ase(ctx_);
@@ -832,6 +834,337 @@ TEST_CASE_METHOD(
   CHECK(
       array.schema().ptr()->array_schema()->is_enumeration_loaded(
           "an_enumeration") == true);
+}
+
+TEST_CASE_METHOD(
+    CPPEnumerationFx,
+    "CPP API: Load Enumerations - Latest Schema",
+    "[enumeration][array][load-enumerations][schema][rest]") {
+  create_array();
+  // Test with `rest.load_enumerations_on_array_open` enabled and disabled.
+  bool load_enmrs = GENERATE(true, false);
+  auto config = ctx_.config();
+  config["rest.load_enumerations_on_array_open"] =
+      load_enmrs ? "true" : "false";
+  vfs_test_setup_.update_config(config.ptr().get());
+  ctx_ = vfs_test_setup_.ctx();
+
+  auto array = tiledb::Array(ctx_, uri_, TILEDB_READ);
+  bool array_open_v2 = array.ptr()->array()->use_refactored_array_open();
+
+  // Helper function to reopen and conditionally call load_all_enumerations.
+  auto reopen_and_load_enmrs = [&]() {
+    // We always reopen because we are evolving the schema which requires
+    // reopening the array after applying the schema evolution.
+    CHECK_NOTHROW(array.reopen());
+
+    // If we are not loading enmrs on array open we must load them explicitly
+    // with a separate request.
+    if (!load_enmrs) {
+      // Load enumerations for all schemas if using array open v2.
+      CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
+    }
+  };
+  reopen_and_load_enmrs();
+
+  REQUIRE(
+      array.schema().ptr()->array_schema()->has_enumeration("an_enumeration") ==
+      true);
+  REQUIRE(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "an_enumeration") == true);
+  std::string schema_name_1 = array.schema().ptr()->array_schema()->name();
+
+  // Evolve once to add an enumeration.
+  ArraySchemaEvolution ase(ctx_);
+  std::vector<std::string> var_values{"one", "two", "three"};
+  auto var_enmr = Enumeration::create(ctx_, "ase_var_enmr", var_values);
+  ase.add_enumeration(var_enmr);
+  auto attr4 = Attribute::create<uint16_t>(ctx_, "attr4");
+  AttributeExperimental::set_enumeration_name(ctx_, attr4, "ase_var_enmr");
+  ase.add_attribute(attr4);
+  // Apply evolution to the array and reopen.
+  ase.array_evolve(uri_);
+  reopen_and_load_enmrs();
+
+  std::string schema_name_2 = array.schema().ptr()->array_schema()->name();
+  if (array_open_v2) {
+    // Check all schemas if we are using array open v2.
+    auto all_schemas = array.ptr()->array()->array_schemas_all();
+    // Previous schemas
+    CHECK(
+        all_schemas[schema_name_1]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_1]->is_enumeration_loaded("an_enumeration") ==
+        false);
+
+    // Latest schema
+    CHECK(
+        all_schemas[schema_name_2]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("an_enumeration") ==
+        true);
+    CHECK(all_schemas[schema_name_2]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("ase_var_enmr") ==
+        true);
+  }
+  // We can always validate the latest schema.
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("an_enumeration") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "an_enumeration") == true);
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("ase_var_enmr") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "ase_var_enmr") == true);
+
+  // Evolve a second time to drop an enumeration.
+  ArraySchemaEvolution ase2(ctx_);
+  ase2.drop_enumeration("an_enumeration");
+  ase2.drop_attribute("attr1");
+  // Apply evolution to the array and reopen.
+  CHECK_NOTHROW(ase2.array_evolve(uri_));
+  reopen_and_load_enmrs();
+
+  std::string schema_name_3 = array.schema().ptr()->array_schema()->name();
+  if (array_open_v2) {
+    // Check all schemas if we are using array open v2.
+    auto all_schemas = array.ptr()->array()->array_schemas_all();
+    // Previous schemas
+    CHECK(
+        all_schemas[schema_name_1]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_1]->is_enumeration_loaded("an_enumeration") ==
+        false);
+    CHECK(
+        all_schemas[schema_name_2]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("an_enumeration") ==
+        false);
+    CHECK(all_schemas[schema_name_2]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("ase_var_enmr") ==
+        false);
+
+    // Latest schema
+    CHECK(
+        all_schemas[schema_name_3]->has_enumeration("an_enumeration") == false);
+    CHECK(all_schemas[schema_name_3]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_3]->is_enumeration_loaded("ase_var_enmr") ==
+        true);
+  }
+  // Always validate the latest schema.
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("an_enumeration") ==
+      false);
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("ase_var_enmr") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "ase_var_enmr") == true);
+
+  // Evolve a third time to add an enumeration with a name equal to a previously
+  // dropped enumeration.
+  ArraySchemaEvolution ase3(ctx_);
+  auto old_enmr = Enumeration::create(ctx_, "an_enumeration", var_values);
+  ase3.add_enumeration(old_enmr);
+  auto attr5 = Attribute::create<uint16_t>(ctx_, "attr5");
+  AttributeExperimental::set_enumeration_name(ctx_, attr5, "an_enumeration");
+  ase.add_attribute(attr5);
+  // Apply evolution to the array and reopen.
+  CHECK_NOTHROW(ase3.array_evolve(uri_));
+  reopen_and_load_enmrs();
+
+  // Check all schemas.
+  if (array_open_v2) {
+    auto all_schemas = array.ptr()->array()->array_schemas_all();
+    std::string schema_name_4 = array.schema().ptr()->array_schema()->name();
+    // Previous schemas.
+    CHECK(
+        all_schemas[schema_name_1]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_1]->is_enumeration_loaded("an_enumeration") ==
+        false);
+    CHECK(
+        all_schemas[schema_name_2]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("an_enumeration") ==
+        false);
+    CHECK(all_schemas[schema_name_2]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("ase_var_enmr") ==
+        false);
+    CHECK(
+        all_schemas[schema_name_3]->has_enumeration("an_enumeration") == false);
+    CHECK(all_schemas[schema_name_3]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_3]->is_enumeration_loaded("ase_var_enmr") ==
+        false);
+
+    // Latest schema.
+    CHECK(
+        all_schemas[schema_name_4]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_4]->is_enumeration_loaded("an_enumeration") ==
+        true);
+    CHECK(all_schemas[schema_name_4]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_4]->is_enumeration_loaded("ase_var_enmr") ==
+        true);
+  }
+  // Always validate the latest schema.
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("an_enumeration") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "an_enumeration") == true);
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("ase_var_enmr") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "ase_var_enmr") == true);
+}
+
+TEST_CASE_METHOD(
+    CPPEnumerationFx,
+    "CPP API: Load Enumerations - Latest schema post evolution",
+    "[enumeration][array][schema-evolution][load-enumerations][schema][rest]") {
+  create_array();
+  // Test with `rest.load_enumerations_on_array_open` enabled and disabled.
+  bool load_enmrs = GENERATE(true, false);
+  auto config = ctx_.config();
+  config["rest.load_enumerations_on_array_open"] =
+      load_enmrs ? "true" : "false";
+  vfs_test_setup_.update_config(config.ptr().get());
+  ctx_ = vfs_test_setup_.ctx();
+
+  // Open the array with no explicit timestamps set.
+  auto array = tiledb::Array(ctx_, uri_, TILEDB_READ);
+
+  // REST CI will test with both array open v1 and v2.
+  bool array_open_v2 = array.ptr()->array()->use_refactored_array_open();
+  REQUIRE(
+      array.schema().ptr()->array_schema()->has_enumeration("an_enumeration") ==
+      true);
+  if (load_enmrs) {
+    // Array open v1 does not support loading enumerations on array open so we
+    // must load them explicitly in this case.
+    if (!array_open_v2) {
+      ArrayExperimental::load_all_enumerations(ctx_, array);
+    }
+    REQUIRE(
+        array.schema().ptr()->array_schema()->is_enumeration_loaded(
+            "an_enumeration") == true);
+  }
+  // If `rest.load_enumerations_on_array_open=false` do not load enmrs
+  // explicitly. Leave enumerations unloaded initially, evolve the array without
+  // reopening, and then attempt to load all enumerations.
+
+  // Evolve once to add an enumeration.
+  ArraySchemaEvolution ase(ctx_);
+  std::vector<std::string> var_values{"one", "two", "three"};
+  auto var_enmr = Enumeration::create(ctx_, "ase_var_enmr", var_values);
+  ase.add_enumeration(var_enmr);
+  auto attr4 = Attribute::create<uint16_t>(ctx_, "attr4");
+  AttributeExperimental::set_enumeration_name(ctx_, attr4, "ase_var_enmr");
+  ase.add_attribute(attr4);
+  // Apply evolution to the array and intentionally skip reopening after
+  // evolution to test exceptions.
+  ase.array_evolve(uri_);
+
+  // Store the original array schema name so we can validate all_schemas later.
+  std::string schema_name_1 = array.schema().ptr()->array_schema()->name();
+  if (array_open_v2) {
+    if (load_enmrs) {
+      // If we load enmrs before reopen, we will not load the evolved schema
+      // that contains the enumeration added during evolution. Since we
+      // explicitly load only enumerations in the latest schema, we will not hit
+      // an exception when loading enumerations on an evolved schema prior to
+      // reopening.
+      CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
+      auto all_schemas = array.ptr()->array_schemas_all();
+      CHECK(all_schemas.size() == 1);
+      CHECK(
+          all_schemas[schema_name_1]->has_enumeration("an_enumeration") ==
+          true);
+      CHECK(
+          all_schemas[schema_name_1]->is_enumeration_loaded("an_enumeration") ==
+          true);
+      CHECK(
+          all_schemas[schema_name_1]->has_enumeration("ase_var_enmr") == false);
+    }
+
+    // Reopen and load the evolved enumerations.
+    array.reopen();
+    std::string schema_name_2 = array.schema().ptr()->array_schema()->name();
+    if (!load_enmrs) {
+      CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
+    }
+    // Validate all array schemas now contain the expected enumerations.
+    auto all_schemas = array.ptr()->array_schemas_all();
+    CHECK(
+        all_schemas[schema_name_1]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_1]->is_enumeration_loaded("an_enumeration") ==
+        false);
+
+    // Latest schema.
+    CHECK(
+        all_schemas[schema_name_2]->has_enumeration("an_enumeration") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("an_enumeration") ==
+        true);
+    CHECK(all_schemas[schema_name_2]->has_enumeration("ase_var_enmr") == true);
+    CHECK(
+        all_schemas[schema_name_2]->is_enumeration_loaded("ase_var_enmr") ==
+        true);
+  } else {
+    // If we load enmrs before reopen, we will not load the evolved schema that
+    // contains the enumeration added during evolution.
+    CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
+    CHECK(
+        array.schema().ptr()->array_schema()->has_enumeration(
+            "an_enumeration") == true);
+    CHECK(
+        array.schema().ptr()->array_schema()->is_enumeration_loaded(
+            "an_enumeration") == true);
+    CHECK(
+        array.schema().ptr()->array_schema()->has_enumeration("ase_var_enmr") ==
+        false);
+    CHECK_THROWS_WITH(
+        array.schema().ptr()->array_schema()->is_enumeration_loaded(
+            "ase_var_enmr"),
+        Catch::Matchers::ContainsSubstring("unknown enumeration"));
+
+    // Reopen to apply the schema evolution and reload enumerations.
+    array.reopen();
+    if (!load_enmrs) {
+      CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
+    }
+  }
+
+  // Check all original and evolved enumerations are in the latest schema.
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("an_enumeration") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "an_enumeration") == true);
+  CHECK(
+      array.schema().ptr()->array_schema()->has_enumeration("ase_var_enmr") ==
+      true);
+  CHECK(
+      array.schema().ptr()->array_schema()->is_enumeration_loaded(
+          "ase_var_enmr") == true);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -454,7 +454,7 @@ TEST_CASE_METHOD(
     if (array_open_v2) {
       // If we are not loading enmrs on array open we must load them explicitly
       // with a separate request.
-      if (!load_enmrs) {
+      if (!load_enmrs || !vfs_test_setup_.is_rest()) {
         // Load enumerations for all schemas if using array open v2.
         CHECK_NOTHROW(
             ArrayExperimental::load_enumerations_all_schemas(ctx_, array));
@@ -657,7 +657,7 @@ TEST_CASE_METHOD(
   if (load_enmrs) {
     // Array open v1 does not support loading enumerations on array open so we
     // must load them explicitly in this case.
-    if (!array_open_v2) {
+    if (!array_open_v2 || !vfs_test_setup_.is_rest()) {
       ArrayExperimental::load_all_enumerations(ctx_, array);
     }
     REQUIRE(
@@ -736,7 +736,7 @@ TEST_CASE_METHOD(
     // Reopen and load the evolved enumerations.
     array.reopen();
     std::string schema_name_2 = array.schema().ptr()->array_schema()->name();
-    if (!load_enmrs) {
+    if (!load_enmrs || !vfs_test_setup_.is_rest()) {
       CHECK_NOTHROW(
           ArrayExperimental::load_enumerations_all_schemas(ctx_, array));
     }
@@ -776,7 +776,7 @@ TEST_CASE_METHOD(
 
     // Reopen to apply the schema evolution and reload enumerations.
     array.reopen();
-    if (!load_enmrs) {
+    if (!load_enmrs || !vfs_test_setup_.is_rest()) {
       CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
     }
   }
@@ -860,7 +860,7 @@ TEST_CASE_METHOD(
 
     // If we are not loading enmrs on array open we must load them explicitly
     // with a separate request.
-    if (!load_enmrs) {
+    if (!load_enmrs || !vfs_test_setup_.is_rest()) {
       // Load enumerations for all schemas if using array open v2.
       CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
     }
@@ -1060,6 +1060,8 @@ TEST_CASE_METHOD(
     // must load them explicitly in this case.
     if (!array_open_v2) {
       ArrayExperimental::load_all_enumerations(ctx_, array);
+    } else if (!vfs_test_setup_.is_rest()) {
+      ArrayExperimental::load_enumerations_all_schemas(ctx_, array);
     }
     REQUIRE(
         array.schema().ptr()->array_schema()->is_enumeration_loaded(
@@ -1106,7 +1108,7 @@ TEST_CASE_METHOD(
     // Reopen and load the evolved enumerations.
     array.reopen();
     std::string schema_name_2 = array.schema().ptr()->array_schema()->name();
-    if (!load_enmrs) {
+    if (!load_enmrs || !vfs_test_setup_.is_rest()) {
       CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
     }
     // Validate all array schemas now contain the expected enumerations.
@@ -1147,7 +1149,7 @@ TEST_CASE_METHOD(
 
     // Reopen to apply the schema evolution and reload enumerations.
     array.reopen();
-    if (!load_enmrs) {
+    if (!load_enmrs || !vfs_test_setup_.is_rest()) {
       CHECK_NOTHROW(ArrayExperimental::load_all_enumerations(ctx_, array));
     }
   }

--- a/test/src/unit-cppapi-enumerations.cc
+++ b/test/src/unit-cppapi-enumerations.cc
@@ -434,7 +434,7 @@ TEST_CASE_METHOD(
   // Test with `rest.load_enumerations_on_array_open` enabled and disabled.
   bool load_enmrs = GENERATE(true, false);
   auto config = ctx_.config();
-  config["rest.load_enumerations_on_array_open"] =
+  config["rest.load_enumerations_on_array_open_all_schemas"] =
       load_enmrs ? "true" : "false";
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
@@ -639,7 +639,7 @@ TEST_CASE_METHOD(
   // Test with `rest.load_enumerations_on_array_open` enabled and disabled.
   bool load_enmrs = GENERATE(true, false);
   auto config = ctx_.config();
-  config["rest.load_enumerations_on_array_open"] =
+  config["rest.load_enumerations_on_array_open_all_schemas"] =
       load_enmrs ? "true" : "false";
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -2488,7 +2488,7 @@ TEST_CASE_METHOD(
   REQUIRE(a1->serialize_enumerations() == (do_load == "true"));
   REQUIRE(
       a1->array_schema_latest_ptr()->get_loaded_enumeration_names().size() ==
-      (do_load == "true" ? 2 : 0));
+      0);
 
   auto a2 = make_shared<Array>(HERE(), ctx.resources(), uri_);
 

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -595,20 +595,6 @@ Status Array::open(
     return LOG_STATUS(Status_ArrayError(e.what()));
   }
 
-  // Handle any array open config options for local arrays.
-  if (!remote_) {
-    // For fetching remote enumerations REST calls
-    // tiledb_handle_load_enumerations_request which loads enumerations. For
-    // local arrays we don't call this method.
-    if (serialize_enumerations() && use_refactored_array_open()) {
-      load_all_enumerations(config_.get<bool>(
-          "rest.load_enumerations_on_array_open_all_schemas",
-          Config::must_find));
-    } else if (serialize_enumerations()) {
-      load_all_enumerations(false);
-    }
-  }
-
   is_opening_or_closing_ = false;
   return Status::Ok();
 }
@@ -1143,13 +1129,6 @@ Status Array::reopen(uint64_t timestamp_start, uint64_t timestamp_end) {
   set_array_schema_latest(array_schema_latest);
   set_array_schemas_all(std::move(array_schemas_all));
   set_fragment_metadata(std::move(fragment_metadata));
-
-  if (serialize_enumerations() && use_refactored_array_open()) {
-    load_all_enumerations(config_.get<bool>(
-        "rest.load_enumerations_on_array_open_all_schemas", Config::must_find));
-  } else if (serialize_enumerations()) {
-    load_all_enumerations(false);
-  }
 
   return Status::Ok();
 }

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -601,9 +601,10 @@ Status Array::open(
     // For fetching remote enumerations REST calls
     // tiledb_handle_load_enumerations_request which loads enumerations. For
     // local arrays we don't call this method.
-    if (config_.get<bool>(
-            "rest.load_enumerations_on_array_open", Config::must_find)) {
-      load_all_enumerations(use_refactored_array_open());
+    if (serialize_enumerations()) {
+      load_all_enumerations(config_.get<bool>(
+          "rest.load_enumerations_on_array_open_all_schemas",
+          Config::must_find));
     }
   }
 
@@ -1615,13 +1616,11 @@ bool Array::serialize_non_empty_domain() const {
 }
 
 bool Array::serialize_enumerations() const {
-  auto serialize = config_.get<bool>("rest.load_enumerations_on_array_open");
-  if (!serialize.has_value()) {
-    throw std::runtime_error(
-        "Cannot get rest.load_enumerations_on_array_open configuration option "
-        "from config");
-  }
-  return serialize.value();
+  return config_.get<bool>(
+             "rest.load_enumerations_on_array_open", Config::must_find) ||
+         config_.get<bool>(
+             "rest.load_enumerations_on_array_open_all_schemas",
+             Config::must_find);
 }
 
 bool Array::serialize_metadata() const {

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -985,7 +985,11 @@ class Array {
   bool serialize_non_empty_domain() const;
 
   /**
-   * Checks the config to se if enumerations should be serialized on array open.
+   * Checks the config to see if enumerations should be serialized on array
+   * open.
+   *
+   * @return True if either `rest.load_enumerations_on_array_open` or
+   * `rest.load_enumerations_on_array_open_all_schemas` is set, else False.
    */
   bool serialize_enumerations() const;
 

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -142,6 +142,8 @@ class OpenedArray {
   inline void set_array_schema_latest(
       const shared_ptr<ArraySchema>& array_schema) {
     array_schema_latest_ = array_schema;
+    // Update the latest schema in the map of all array schemas.
+    array_schemas_all_[array_schema->name()] = array_schema;
   }
 
   /** Returns all array schemas. */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2155,7 +2155,7 @@ capi_return_t tiledb_handle_load_array_schema_request(
           static_cast<tiledb::sm::SerializationType>(serialization_type),
           request->buffer());
 
-  if (load_schema_req.include_enumerations()) {
+  if (load_schema_req.include_enumerations_latest_schema()) {
     array->load_all_enumerations();
   }
 

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -94,6 +94,8 @@ const std::string Config::REST_CURL_VERBOSE = "false";
 const std::string Config::REST_CURL_TCP_KEEPALIVE = "true";
 const std::string Config::REST_CURL_RETRY_ERRORS = "true";
 const std::string Config::REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN = "false";
+const std::string Config::REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN_ALL_SCHEMAS =
+    "false";
 const std::string Config::REST_LOAD_METADATA_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_LOAD_NON_EMPTY_DOMAIN_ON_ARRAY_OPEN = "true";
 const std::string Config::REST_USE_REFACTORED_ARRAY_OPEN = "true";
@@ -264,6 +266,9 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "rest.load_enumerations_on_array_open",
         Config::REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN),
+    std::make_pair(
+        "rest.load_enumerations_on_array_open_all_schemas",
+        Config::REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN_ALL_SCHEMAS),
     std::make_pair(
         "rest.load_metadata_on_array_open",
         Config::REST_LOAD_METADATA_ON_ARRAY_OPEN),

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -116,8 +116,17 @@ class Config {
   /** If we should retry Curl errors in requests to REST. */
   static const std::string REST_CURL_RETRY_ERRORS;
 
-  /** If the array enumerations should be loaded on array open */
+  /**
+   * If the array enumerations should be loaded on array open for the latest
+   * array schema only.
+   */
   static const std::string REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN;
+
+  /**
+   * If the array enumerations should be loaded on array open for all array
+   * schemas.
+   */
+  static const std::string REST_LOAD_ENUMERATIONS_ON_ARRAY_OPEN_ALL_SCHEMAS;
 
   /** If the array metadata should be loaded on array open */
   static const std::string REST_LOAD_METADATA_ON_ARRAY_OPEN;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -928,8 +928,12 @@ class Config {
    *    together with the open array <br>
    *    **Default**: true
    * - `rest.load_enumerations_on_array_open` <br>
-   *    If true, enumerations will be loaded and sent to server together with
-   *    the open array.
+   *    If true, enumerations will be loaded for the latest array schema on
+   *    array open.
+   *    **Default**: false
+   * - `rest.load_enumerations_on_array_open_all_schemas` <br>
+   *    If true, enumerations will be loaded for all array schemas on array
+   *    open.
    *    **Default**: false
    * - `rest.use_refactored_array_open` <br>
    *    If true, the new REST routes and APIs for opening an array will be used

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -148,7 +148,8 @@ Status array_to_capnp(
   array_builder->setQueryType(query_type_str(array->get_query_type()));
 
   if (array->use_refactored_array_open() && array->serialize_enumerations()) {
-    array->load_all_enumerations(true);
+    array->load_all_enumerations(array->config().get<bool>(
+        "rest.load_enumerations_on_array_open_all_schemas", Config::must_find));
   }
 
   const auto& array_schema_latest = array->array_schema_latest();

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -1638,7 +1638,7 @@ void load_array_schema_request_to_capnp(
   throw_if_not_ok(config_to_capnp(config, &config_builder));
   // This boolean is only serialized to support clients using TileDB < 2.26.
   // Future options should only be serialized within the Config object above.
-  builder.setIncludeEnumerations(req.include_enumerations());
+  builder.setIncludeEnumerations(req.include_enumerations_latest_schema());
 }
 
 void serialize_load_array_schema_request(

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -60,16 +60,23 @@ namespace serialization {
 class LoadArraySchemaRequest {
  public:
   explicit LoadArraySchemaRequest(const Config& config)
-      : include_enumerations_(config.get<bool>(
+      : include_enumerations_latest_schema_(config.get<bool>(
+            "rest.load_enumerations_on_array_open", Config::must_find))
+      , include_enumerations_all_schemas_(config.get<bool>(
             "rest.load_enumerations_on_array_open", Config::must_find)) {
   }
 
-  inline bool include_enumerations() const {
-    return include_enumerations_;
+  inline bool include_enumerations_latest_schema() const {
+    return include_enumerations_latest_schema_;
+  }
+
+  inline bool include_enumerations_all_schemas() const {
+    return include_enumerations_all_schemas_;
   }
 
  private:
-  bool include_enumerations_;
+  bool include_enumerations_latest_schema_;
+  bool include_enumerations_all_schemas_;
 };
 
 #ifdef TILEDB_SERIALIZATION


### PR DESCRIPTION
This adds a new config parameter `rest.load_enumerations_on_array_open_all_schemas` to control loading enumerations on all array schemas. The previously existing `rest.load_enumerations_on_array_open` config parameter is used to control loading enumerations on the latest schema only. 

---
TYPE: FEATURE
DESC: Add `rest.load_enumerations_on_array_open_all_schemas` config parameter.