### PR TITLE
Use preinstalled `pkg-config` Homebrew recipe.

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'macos-') == true }}
         run: |
           set -e pipefail
-          brew install automake pkg-config
+          brew install automake
 
       - name: 'Configure libtiledb'
         id: configure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         # v4 uses node 20 which is incompatible with the libc version of the manylinux image
         uses: actions/checkout@v3
       - name: 'Homebrew setup'
-        run: brew install automake pkg-config ninja
+        run: brew install automake ninja
         if: ${{ startsWith(matrix.os, 'macos-') == true }}
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v6

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: 'Homebrew setup'
-        run: brew install automake pkg-config
+        run: brew install automake
         if: ${{ startsWith(matrix.os, 'macos-') }}
 
       - name: Install Ninja


### PR DESCRIPTION
[SC-59678](https://app.shortcut.com/tiledb-inc/story/59678/core-arrays-fix-ci-on-dev-branch)

GitHub Actions now [bundles](https://github.com/actions/runner-images/pull/10971) `pkg-config` in macOS images. This PR stops installing it with `brew`, which causes conflicts related to the recipe's deprecation and replacement with `pkgconf`.

---
TYPE: NO_HISTORY