### PR TITLE
Use macos-12 runner for x86_64 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             triplet: arm64-linux-release
             manylinux: quay.io/pypa/manylinux2014_aarch64
           - platform: macos-x86_64
-            os: macos-latest
+            os: macos-12
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release


### PR DESCRIPTION

Use macos-12 runner for x86_64 builds in order to generate correct release names. The most recent `macos-latest` image is ARM64 only and the release logic produces `-arm64-` artifacts only.

---
TYPE: BUG
DESC: Fix macos x86_64 release
