### PR TITLE
C.41 compliance: Azure factory constructor.

### DIFF
--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -786,9 +786,8 @@ TEST_CASE("VFS: Construct Azure Blob Storage endpoint URIs", "[azure][uri]") {
     // perform any requests) to prevent Entra ID from being chosen.
     require_tiledb_ok(config.set("vfs.azure.storage_account_key", "foobar"));
   }
-  tiledb::sm::Azure azure;
   ThreadPool thread_pool(1);
-  require_tiledb_ok(azure.init(config, &thread_pool));
+  tiledb::sm::Azure azure(&thread_pool, config);
   REQUIRE(azure.client().GetUrl() == expected_endpoint);
 }
 #endif

--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -310,10 +310,6 @@ inline Status Status_UtilsError(const std::string& msg) {
 inline Status Status_S3Error(const std::string& msg) {
   return {"[TileDB::S3] Error", msg};
 }
-/** Return a FS_AZURE error class Status with a given message **/
-inline Status Status_AzureError(const std::string& msg) {
-  return {"[TileDB::Azure] Error", msg};
-}
 /** Return a FS_GCS error class Status with a given message **/
 inline Status Status_GCSError(const std::string& msg) {
   return {"[TileDB::GCS] Error", msg};

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -105,12 +105,6 @@ AzureParameters::AzureParameters(const Config& config)
           !get_config_with_env_fallback(
                config, "vfs.azure.storage_sas_token", "AZURE_STORAGE_SAS_TOKEN")
                .empty()) {
-  if (blob_endpoint_.empty()) {
-    throw AzureException(
-        "Azure VFS is not configured. Please set the "
-        "'vfs.azure.storage_account_name' and/or "
-        "'vfs.azure.blob_endpoint' configuration options.");
-  }
 }
 
 Azure::Azure(ThreadPool* const thread_pool, const Config& config)

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -126,12 +126,6 @@ struct AzureParameters {
 
   /** Whether the config specifies a SAS token. */
   bool has_sas_token_;
-
- private:
-  AzureParameters(
-      const Config& config,
-      const std::string& account_name,
-      const std::string& blob_endpoint);
 };
 
 class Azure;
@@ -278,7 +272,7 @@ class Azure {
    * @param thread_pool The parent VFS thread pool.
    * @param config Configuration parameters.
    */
-  Azure(ThreadPool* thread_pool, const AzureParameters& config);
+  Azure(ThreadPool* thread_pool, const Config& config);
 
   /**
    * Destructor.
@@ -297,38 +291,34 @@ class Azure {
    * Creates a container.
    *
    * @param container The name of the container to be created.
-   * @return Status
    */
-  Status create_container(const URI& container) const;
+  void create_container(const URI& container) const;
 
   /** Removes the contents of an Azure container. */
-  Status empty_container(const URI& container) const;
+  void empty_container(const URI& container) const;
 
   /**
    * Flushes an blob to Azure, finalizing the upload.
    *
    * @param uri The URI of the blob to be flushed.
-   * @return Status
    */
-  Status flush_blob(const URI& uri);
+  void flush_blob(const URI& uri);
 
   /**
    * Check if a container is empty.
    *
    * @param container The name of the container.
-   * @param is_empty Mutates to `true` if the container is empty.
-   * @return Status
+   * @return `true` if the container is empty, `false` otherwise.
    */
-  Status is_empty_container(const URI& uri, bool* is_empty) const;
+  bool is_empty_container(const URI& uri) const;
 
   /**
    * Check if a container exists.
    *
    * @param container The name of the container.
-   * @param is_container Mutates to `true` if `uri` is a container.
-   * @return Status
+   * @return `true` if `uri` is a container, `false` otherwise.
    */
-  Status is_container(const URI& uri, bool* is_container) const;
+  bool is_container(const URI& uri) const;
 
   /**
    * Checks if there is an object with prefix `uri/`. For instance, suppose
@@ -345,19 +335,17 @@ class Azure {
    * prefix `azure://some_container/foo2/` (in this case there is not).
    *
    * @param uri The URI to check.
-   * @param exists Sets it to `true` if the above mentioned condition holds.
-   * @return Status
+   * @return `true` if the above mentioned condition holds, `false` otherwise.
    */
-  Status is_dir(const URI& uri, bool* exists) const;
+  bool is_dir(const URI& uri) const;
 
   /**
    * Checks if the given URI is an existing Azure blob.
    *
    * @param uri The URI of the object to be checked.
-   * @param is_blob Mutates to `true` if `uri` is an existing blob, and `false`
-   * otherwise.
+   * @return `true` if `uri` is an existing blob, `false` otherwise.
    */
-  Status is_blob(const URI& uri, bool* is_blob) const;
+  bool is_blob(const URI& uri) const;
 
   /**
    * Lists the objects that start with `uri`. Full URI paths are
@@ -376,15 +364,13 @@ class Azure {
    * - `foo/bar`
    *
    * @param uri The prefix URI.
-   * @param paths Pointer of a vector of URIs to store the retrieved paths.
    * @param delimiter The delimiter that will
    * @param max_paths The maximum number of paths to be retrieved. The default
    *     `-1` indicates that no upper bound is specified.
-   * @return Status
+   * @return The retrieved paths.
    */
-  Status ls(
+  std::vector<std::string> ls(
       const URI& uri,
-      std::vector<std::string>* paths,
       const std::string& delimiter = "/",
       int max_paths = -1) const;
 
@@ -456,9 +442,8 @@ class Azure {
    *
    * @param old_uri The URI of the old path.
    * @param new_uri The URI of the new path.
-   * @return Status
    */
-  Status move_object(const URI& old_uri, const URI& new_uri);
+  void move_object(const URI& old_uri, const URI& new_uri);
 
   /**
    * Renames a directory. Note that this is an expensive operation.
@@ -468,18 +453,16 @@ class Azure {
    *
    * @param old_uri The URI of the old path.
    * @param new_uri The URI of the new path.
-   * @return Status
    */
-  Status move_dir(const URI& old_uri, const URI& new_uri);
+  void move_dir(const URI& old_uri, const URI& new_uri);
 
   /**
    * Returns the size of the input blob with a given URI in bytes.
    *
    * @param uri The URI of the blob.
-   * @param nbytes Pointer to `uint64_t` bytes to return.
-   * @return Status
+   * @return The size of the input blob, in bytes
    */
-  Status blob_size(const URI& uri, uint64_t* nbytes) const;
+  uint64_t blob_size(const URI& uri) const;
 
   /**
    * Reads data from an object into a buffer.
@@ -504,17 +487,15 @@ class Azure {
    * Deletes a container.
    *
    * @param uri The URI of the container to be deleted.
-   * @return Status
    */
-  Status remove_container(const URI& uri) const;
+  void remove_container(const URI& uri) const;
 
   /**
    * Deletes an blob with a given URI.
    *
    * @param uri The URI of the blob to be deleted.
-   * @return Status
    */
-  Status remove_blob(const URI& uri) const;
+  void remove_blob(const URI& uri) const;
 
   /**
    * Deletes all objects with prefix `uri/` (if the ending `/` does not
@@ -539,17 +520,15 @@ class Azure {
    * this example.
    *
    * @param uri The prefix uri of the objects to be deleted.
-   * @return Status
    */
-  Status remove_dir(const URI& uri) const;
+  void remove_dir(const URI& uri) const;
 
   /**
    * Creates an empty blob.
    *
    * @param uri The URI of the blob to be created.
-   * @return Status
    */
-  Status touch(const URI& uri) const;
+  void touch(const URI& uri) const;
 
   /**
    * Writes the input buffer to an Azure object. Note that this is essentially
@@ -558,9 +537,8 @@ class Azure {
    * @param uri The URI of the object to be written to.
    * @param buffer The input buffer.
    * @param length The size of the input buffer.
-   * @return Status
    */
-  Status write(const URI& uri, const void* buffer, uint64_t length);
+  void write(const URI& uri, const void* buffer, uint64_t length);
 
   /**
    * Initializes the Azure blob service client and returns a reference to it.
@@ -691,9 +669,8 @@ class Azure {
    * @param buffer The source binary buffer to fill the data from.
    * @param length The length of `buffer`.
    * @param nbytes_filled The number of bytes filled into `write_cache_buffer`.
-   * @return Status
    */
-  Status fill_write_cache(
+  void fill_write_cache(
       Buffer* write_cache_buffer,
       const void* buffer,
       const uint64_t length,
@@ -708,9 +685,8 @@ class Azure {
    * @param write_cache_buffer The input buffer to flush.
    * @param last_block Should be true only when the flush corresponds to the
    * last block(s) of a block list upload.
-   * @return Status
    */
-  Status flush_write_cache(
+  void flush_write_cache(
       const URI& uri, Buffer* write_cache_buffer, bool last_block);
 
   /**
@@ -721,9 +697,8 @@ class Azure {
    * @param buffer The input buffer.
    * @param length The size of the input buffer.
    * @param last_part Should be true only when this is the last block of a blob.
-   * @return Status
    */
-  Status write_blocks(
+  void write_blocks(
       const URI& uri, const void* buffer, uint64_t length, bool last_block);
 
   /**
@@ -752,7 +727,7 @@ class Azure {
    * Uploads the write cache buffer associated with 'uri' as an entire
    * blob.
    */
-  Status flush_blob_direct(const URI& uri);
+  void flush_blob_direct(const URI& uri);
 
   /**
    * Performs an Azure ListBlobs operation.
@@ -788,44 +763,17 @@ class Azure {
    * `*container_name == "my-container"` and `*blob_path == "dir1/file1"`.
    *
    * @param uri The URI to parse.
-   * @param container_name Mutates to the container name.
-   * @param blob_path Mutates to the blob path.
-   * @return Status
+   * @return A tuple of the container name and blob path.
    */
-  static Status parse_azure_uri(
-      const URI& uri, std::string* container_name, std::string* blob_path);
+  static std::tuple<std::string, std::string> parse_azure_uri(const URI& uri);
 
   /**
    * Copies the blob at 'old_uri' to `new_uri`.
    *
    * @param old_uri The blob's current URI.
    * @param new_uri The blob's URI to move to.
-   * @return Status
    */
-  Status copy_blob(const URI& old_uri, const URI& new_uri);
-
-  /**
-   * Check if 'container_name' is a container on Azure.
-   *
-   * @param container_name The container's name.
-   * @param is_container Mutates to the output.
-   * @return Status
-   */
-  Status is_container(
-      const std::string& container_name, bool* const is_container) const;
-
-  /**
-   * Check if 'is_blob' is a blob on Azure.
-   *
-   * @param container_name The blob's container name.
-   * @param blob_path The blob's path.
-   * @param is_blob Mutates to the output.
-   * @return Status
-   */
-  Status is_blob(
-      const std::string& container_name,
-      const std::string& blob_path,
-      bool* const is_blob) const;
+  void copy_blob(const URI& old_uri, const URI& new_uri);
 
   /**
    * Removes a leading slash from 'path' if it exists.
@@ -865,8 +813,8 @@ AzureScanner<F, D>::AzureScanner(
     throw AzureException("URI is not an Azure URI: " + prefix.to_string());
   }
 
-  throw_if_not_ok(Azure::parse_azure_uri(
-      prefix.add_trailing_slash(), &container_name_, &blob_path_));
+  auto [container_name, blob_path] =
+      Azure::parse_azure_uri(prefix.add_trailing_slash());
   fetch_results();
   next(begin_);
 }

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -547,6 +547,12 @@ class Azure {
    * use of the BlobServiceClient.
    */
   const ::Azure::Storage::Blobs::BlobServiceClient& client() const {
+    if (azure_params_.blob_endpoint_.empty()) {
+      throw AzureException(
+          "Azure VFS is not configured. Please set the "
+          "'vfs.azure.storage_account_name' and/or "
+          "'vfs.azure.blob_endpoint' configuration options.");
+    }
     return client_singleton_.get(azure_params_);
   }
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -821,6 +821,8 @@ AzureScanner<F, D>::AzureScanner(
 
   auto [container_name, blob_path] =
       Azure::parse_azure_uri(prefix.add_trailing_slash());
+  container_name_ = container_name;
+  blob_path_ = blob_path;
   fetch_results();
   next(begin_);
 }

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -574,7 +574,11 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    *size = azure().blob_size(uri);
+    try {
+      *size = azure().blob_size(uri);
+    } catch (std::exception& e) {
+      return Status_Error(e.what());
+    }
     return Status::Ok();
 #else
     throw BuiltWithout("Azure");

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -261,7 +261,8 @@ Status VFS::touch(const URI& uri) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().touch(uri);
+    azure().touch(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -296,7 +297,8 @@ Status VFS::create_bucket(const URI& uri) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().create_container(uri);
+    azure().create_container(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -322,7 +324,8 @@ Status VFS::remove_bucket(const URI& uri) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().remove_container(uri);
+    azure().remove_container(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -349,7 +352,8 @@ Status VFS::empty_bucket(const URI& uri) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().empty_container(uri);
+    azure().empty_container(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -377,7 +381,8 @@ Status VFS::is_empty_bucket(
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().is_empty_container(uri, is_empty);
+    *is_empty = azure().is_empty_container(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -414,7 +419,7 @@ Status VFS::remove_dir(const URI& uri) const {
 #endif
   } else if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().remove_dir(uri);
+    azure().remove_dir(uri);
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -481,7 +486,8 @@ Status VFS::remove_file(const URI& uri) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().remove_blob(uri);
+    azure().remove_blob(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -568,7 +574,8 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().blob_size(uri, size);
+    *size = azure().blob_size(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -614,7 +621,8 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().is_dir(uri, is_dir);
+    *is_dir = azure().is_dir(uri);
+    return Status::Ok();
 #else
     *is_dir = false;
     throw BuiltWithout("Azure");
@@ -665,7 +673,8 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().is_blob(uri, is_file);
+    *is_file = azure().is_blob(uri);
+    return Status::Ok();
 #else
     *is_file = false;
     throw BuiltWithout("Azure");
@@ -699,7 +708,7 @@ Status VFS::is_bucket(const URI& uri, bool* is_bucket) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    RETURN_NOT_OK(azure().is_container(uri, is_bucket));
+    *is_bucket = azure().is_container(uri);
     return Status::Ok();
 #else
     *is_bucket = false;
@@ -839,7 +848,8 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_azure()) {
     if (new_uri.is_azure())
 #ifdef HAVE_AZURE
-      return azure().move_object(old_uri, new_uri);
+      azure().move_object(old_uri, new_uri);
+    return Status::Ok();
 #else
       throw BuiltWithout("Azure");
 #endif
@@ -912,7 +922,8 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
   if (old_uri.is_azure()) {
     if (new_uri.is_azure())
 #ifdef HAVE_AZURE
-      return azure().move_dir(old_uri, new_uri);
+      azure().move_dir(old_uri, new_uri);
+    return Status::Ok();
 #else
       throw BuiltWithout("Azure");
 #endif
@@ -1431,7 +1442,8 @@ Status VFS::close_file(const URI& uri) {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().flush_blob(uri);
+    azure().flush_blob(uri);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif
@@ -1495,7 +1507,8 @@ Status VFS::write(
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    return azure().write(uri, buffer, buffer_size);
+    azure().write(uri, buffer, buffer_size);
+    return Status::Ok();
 #else
     throw BuiltWithout("Azure");
 #endif


### PR DESCRIPTION
Remove `Azure::init` in favor of a C.41-compliant factory constructor. The `Azure::azure_params_` member variable is no longer optional and is fully-initialized at construction time. 

[sc-60071]

---
TYPE: IMPROVEMENT
DESC: C.41 constructor: `Azure`. 
