### PR TITLE
C.41 compliance: HDFS factory constructor.

### DIFF
--- a/tiledb/common/exception/status.h
+++ b/tiledb/common/exception/status.h
@@ -318,10 +318,6 @@ inline Status Status_AzureError(const std::string& msg) {
 inline Status Status_GCSError(const std::string& msg) {
   return {"[TileDB::GCS] Error", msg};
 }
-/** Return a FS_HDFS error class Status with a given message **/
-inline Status Status_HDFSError(const std::string& msg) {
-  return {"[TileDB::HDFS] Error", msg};
-}
 /** Return a FS_MEM error class Status with a given message **/
 inline Status Status_MemFSError(const std::string& msg) {
   return {"[TileDB::MemFS] Error", msg};


### PR DESCRIPTION
Remove`HDFS::init` in favor of a C.41-compliant factory constructor. Use struct `HDFSParameters` to store HDFS-specific configuration parameters. Remove `Status_HDFSError`, and replace call sites with throws of `HDFSException`.

[sc-60073]

---
TYPE: IMPROVEMENT
DESC: C.41 constructor: `HDFS`.
