### PR TITLE
manylinux 2014 DIND build

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -106,17 +106,6 @@ jobs:
       timeout: 120
       bootstrap_args: '--enable-azure'
 
-  ci_manylinux:
-    uses: ./.github/workflows/ci-linux_mac.yml
-    with:
-      ci_backend: MANYLINUX
-      matrix_image: ubuntu-20.04
-      matrix_compiler_cflags: "-lrt"
-      matrix_compiler_cxxflags: "-lrt"
-      timeout: 120
-      bootstrap_args: '--enable-serialization'
-      manylinux: true
-
   ci_msvc:
     uses: ./.github/workflows/build-windows.yml
 
@@ -145,7 +134,6 @@ jobs:
         ci7,
         ci8,
         ci9,
-        ci_manylinux,
         ci_msvc,
         backward_compatibility,
         standalone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,6 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
-      # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.
-      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ matrix.manylinux && 'true' || 'false' }}
 
     steps:
       - name: Checkout TileDB
@@ -107,8 +104,10 @@ jobs:
             set -e pipefail
             yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
             python3.9 -m pip install ninja
-            export PATH="${PATH}:/opt/_internal/cpython-3.9.20/bin"
+            export PATH="${PATH}:/opt/_internal/cpython-3.9.20/lib/python-3.9/site-packages"
             export VCPKG_FORCE_SYSTEM_BINARIES=YES
+
+            ninja --version
 
             cmake -S /work -B /work/build \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: arm64-osx-release
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.manylinux || '' }}
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
         if: ${{ startsWith(matrix.platform, 'linux') == true }}
         with:
           image: ${{ matrix.manylinux }}
-          options: -v ${{ github.workspace }}:/work
+          options: -v ${{ github.workspace }}:/work -e TILEDB_PACKAGE_VERSION=${{ steps.get-values.outputs.release_version }}
           run: |
             set -e pipefail
             yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
             set -e pipefail
             yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
             python3.9 -m pip install ninja
-            export PATH="${PATH}:/opt/_internal/cpython-3.9.20/lib/python-3.9/site-packages"
+            export PATH="${PATH}:/opt/_internal/cpython-3.9.21/bin"
             export VCPKG_FORCE_SYSTEM_BINARIES=YES
 
             ninja --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
               -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
               ${{ matrix.cmake_args }}
 
-            cmake --build build -j4 --config Release --target package
+            cmake --build /work/build -j4 --config Release --target package
 
       - name: Configure TileDB
         if: ${{ startsWith(matrix.platform, 'linux') == false }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,10 @@ jobs:
           run: |
             set -e pipefail
             yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
-            echo "source /opt/rh/devtoolset-7/enable" >> ~/.bashrc
+            source /opt/rh/devtoolset-7/enable
             python3.9 -m pip install ninja
-            echo "/opt/_internal/cpython-3.9.20/bin" >> $GITHUB_PATH
-            echo "VCPKG_FORCE_SYSTEM_BINARIES=YES" >> $GITHUB_ENV
+            export PATH="${PATH}:/opt/_internal/cpython-3.9.20/bin"
+            export VCPKG_FORCE_SYSTEM_BINARIES=YES
 
             cmake -S /work -B /work/build \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
           run: |
             set -e pipefail
             yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
-            source /opt/rh/devtoolset-7/enable
             python3.9 -m pip install ninja
             export PATH="${PATH}:/opt/_internal/cpython-3.9.20/bin"
             export VCPKG_FORCE_SYSTEM_BINARIES=YES

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,16 +99,38 @@ jobs:
           ref=${{ github.head_ref || github.ref_name }}
           echo "release_version=${ref##*/}-$release_hash" >> $GITHUB_OUTPUT
         shell: bash
-      - name: Install manylinux prerequisites
+      - uses: addnab/docker-run-action@v3
         if: ${{ startsWith(matrix.platform, 'linux') == true }}
-        run: |
-          set -e pipefail
-          yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
-          echo "source /opt/rh/devtoolset-7/enable" >> ~/.bashrc
-          python3.9 -m pip install ninja
-          echo "/opt/_internal/cpython-3.9.20/bin" >> $GITHUB_PATH
-          echo "VCPKG_FORCE_SYSTEM_BINARIES=YES" >> $GITHUB_ENV
+        with:
+          image: ${{ matrix.manylinux }}
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            set -e pipefail
+            yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
+            echo "source /opt/rh/devtoolset-7/enable" >> ~/.bashrc
+            python3.9 -m pip install ninja
+            echo "/opt/_internal/cpython-3.9.20/bin" >> $GITHUB_PATH
+            echo "VCPKG_FORCE_SYSTEM_BINARIES=YES" >> $GITHUB_ENV
+
+            cmake -S /work -B /work/build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DBUILD_SHARED_LIBS=ON \
+              -DCMAKE_INSTALL_PREFIX=/work/dist \
+              -DTILEDB_INSTALL_LIBDIR=lib \
+              -DTILEDB_S3=ON \
+              -DTILEDB_AZURE=ON \
+              -DTILEDB_GCS=ON \
+              -DTILEDB_HDFS=${{ startsWith(matrix.platform, 'windows') && 'OFF' || 'ON' }} \
+              -DTILEDB_SERIALIZATION=ON \
+              -DTILEDB_WEBP=ON \
+              -DTILEDB_TESTS=OFF \
+              -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
+              ${{ matrix.cmake_args }}
+
+            cmake --build build -j4 --config Release --target package
+
       - name: Configure TileDB
+        if: ${{ startsWith(matrix.platform, 'linux') == false }}
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
@@ -126,6 +148,7 @@ jobs:
             ${{ matrix.cmake_args }}
         shell: bash
       - name: Build TileDB
+        if: ${{ startsWith(matrix.platform, 'linux') == false }}
         env:
           TILEDB_PACKAGE_VERSION: ${{ steps.get-values.outputs.release_version }}
         run: cmake --build build -j4 --config Release --target package


### PR DESCRIPTION
Change Release CI so that it only uses manylinux2014 image to build TileDB artifacts and do all the orchestration outside.

---
TYPE: NO_HISTORY
DESC: Fix manylinux2014 release ci
