### PR TITLE
Change manylinux image to manylinux 2_28

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -114,7 +114,7 @@ jobs:
           python-version: '3.12'
 
       - name: Prevent vpckg from building debug variants
-        run: python ./scripts/ci/patch_vcpkg_triplets.py
+        run: python3 ./scripts/ci/patch_vcpkg_triplets.py
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.3

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -128,8 +128,7 @@ jobs:
         if: inputs.manylinux
         run: |
           set -e pipefail
-          yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
-          echo "source /opt/rh/devtoolset-7/enable" >> ~/.bashrc
+          yum install -y redhat-lsb-core perl-IPC-Cmd
 
       # This must happen after checkout, because checkout would remove the directory.
       - name: Install Ninja

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -128,7 +128,7 @@ jobs:
         if: inputs.manylinux
         run: |
           set -e pipefail
-          yum install -y redhat-lsb-core perl-IPC-Cmd
+          yum install -y redhat-lsb-core perl-IPC-Cmd curl zip unzip tar
 
       # This must happen after checkout, because checkout would remove the directory.
       - name: Install Ninja

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -80,9 +80,6 @@ env:
   bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'arm64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
-  # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.
-  # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ inputs.manylinux && 'true' || 'false' }}
 
 jobs:
   build:
@@ -91,7 +88,7 @@ jobs:
         os:
           - ${{ inputs.matrix_image }}
     runs-on: ${{matrix.os}}
-    container: ${{inputs.manylinux && 'quay.io/pypa/manylinux2014_x86_64' || ''}}
+    container: ${{inputs.manylinux && 'quay.io/pypa/manylinux_2_28_x86_64' || ''}}
 
     if: ${{ startsWith(github.ref , 'refs/tags') != true && startsWith(github.ref , 'build-') != true }}
     timeout-minutes: ${{ inputs.timeout || 90 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,9 +75,6 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
-      # Manylinux does not support Node 20 due to libc incompatibility. Temporarily opt out.
-      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ matrix.manylinux && 'true' || 'false' }}
 
     steps:
       - name: Checkout TileDB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,7 @@ jobs:
         if: ${{ startsWith(matrix.platform, 'linux') == true }}
         run: |
           set -e pipefail
-          yum install -y redhat-lsb-core centos-release-scl devtoolset-7 perl-IPC-Cmd
-          echo "source /opt/rh/devtoolset-7/enable" >> ~/.bashrc
-          python3.9 -m pip install ninja
-          echo "/opt/_internal/cpython-3.9.20/bin" >> $GITHUB_PATH
+          yum install -y ninja-build perl-IPC-Cmd
           echo "VCPKG_FORCE_SYSTEM_BINARIES=YES" >> $GITHUB_ENV
       - name: Configure TileDB
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ startsWith(matrix.platform, 'linux') == true }}
         run: |
           set -e pipefail
-          yum install -y ninja-build perl-IPC-Cmd
+          yum install -y ninja-build perl-IPC-Cmd curl zip unzip tar
           echo "VCPKG_FORCE_SYSTEM_BINARIES=YES" >> $GITHUB_ENV
       - name: Configure TileDB
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,17 +49,17 @@ jobs:
             triplet: x64-windows-release
           - platform: linux-x86_64
             os: ubuntu-20.04
-            manylinux: quay.io/pypa/manylinux2014_x86_64
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64
             triplet: x64-linux-release
           - platform: linux-x86_64-noavx2
             os: ubuntu-20.04
             cmake_args: -DCOMPILER_SUPPORTS_AVX2=OFF
             triplet: x64-linux-release
-            manylinux: quay.io/pypa/manylinux2014_x86_64
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64
           - platform: linux-aarch64
             os: linux-arm64-ubuntu24
             triplet: arm64-linux-release
-            manylinux: quay.io/pypa/manylinux2014_aarch64
+            manylinux: quay.io/pypa/manylinux_2_28_aarch64
           - platform: macos-x86_64
             os: macos-12
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64


### PR DESCRIPTION
This PR changes the manylinux images that we use for release to version 2_28

Testing Release CI: https://github.com/dudoslav/TileDB/actions/runs/12180726330

[sc-60195]

---
TYPE: IMPROVEMENT
DESC: manylinux_2_28 for linux release
