### PR TITLE
Release using macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             triplet: arm64-linux-release
             manylinux: quay.io/pypa/manylinux_2_28_aarch64
           - platform: macos-x86_64
-            os: macos-12
+            os: macos-13
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release


### PR DESCRIPTION
Use `macos-13` for x86_64 macos release job, since `macos-12` is deprecated

---
TYPE: NO_HISTORY
DESC: Use `macos-13` for macos x86_64 release
