### PR TITLE
Improve readers by parallelizing I/O and compute operations

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -186,8 +186,7 @@ void set_result_tile_dim(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -184,7 +184,9 @@ void set_result_tile_dim(
       std::nullopt,
       std::nullopt);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -186,7 +186,8 @@ void set_result_tile_dim(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -183,7 +183,8 @@ void set_result_tile_dim(
       std::nullopt,
       std::nullopt,
       std::nullopt);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -636,7 +636,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "65000");
+  cfg.set("sm.mem.total_budget", "50000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -636,7 +636,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "30000");
+  cfg.set("sm.mem.total_budget", "65000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 
@@ -685,7 +685,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "30000");
+  cfg.set("sm.mem.total_budget", "60000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -685,7 +685,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "60000");
+  cfg.set("sm.mem.total_budget", "50000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -214,7 +214,9 @@ TEST_CASE_METHOD(
         std::nullopt,
         std::nullopt);
     ResultTile::TileData tile_data{
-        {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+        {nullptr, ThreadPool::SharedTask()},
+        {nullptr, ThreadPool::SharedTask()},
+        {nullptr, ThreadPool::SharedTask()}};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -232,7 +234,9 @@ TEST_CASE_METHOD(
       std::nullopt,
       std::nullopt);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,
@@ -329,7 +333,9 @@ TEST_CASE_METHOD(
         std::nullopt,
         std::nullopt);
     ResultTile::TileData tile_data{
-        {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+        {nullptr, ThreadPool::SharedTask()},
+        {nullptr, ThreadPool::SharedTask()},
+        {nullptr, ThreadPool::SharedTask()}};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -347,7 +353,9 @@ TEST_CASE_METHOD(
       std::nullopt,
       std::nullopt);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -216,8 +216,7 @@ TEST_CASE_METHOD(
     ResultTile::TileData tile_data{
         {nullptr, ThreadPool::SharedTask()},
         {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()},
-        nullptr};
+        {nullptr, ThreadPool::SharedTask()}};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -237,8 +236,7 @@ TEST_CASE_METHOD(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,
@@ -337,8 +335,7 @@ TEST_CASE_METHOD(
     ResultTile::TileData tile_data{
         {nullptr, ThreadPool::SharedTask()},
         {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()},
-        nullptr};
+        {nullptr, ThreadPool::SharedTask()}};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -358,8 +355,7 @@ TEST_CASE_METHOD(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -213,7 +213,8 @@ TEST_CASE_METHOD(
         0,
         std::nullopt,
         std::nullopt);
-    ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+    ResultTile::TileData tile_data{
+        {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -230,7 +231,8 @@ TEST_CASE_METHOD(
       0,
       std::nullopt,
       std::nullopt);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,
@@ -326,7 +328,8 @@ TEST_CASE_METHOD(
         0,
         std::nullopt,
         std::nullopt);
-    ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+    ResultTile::TileData tile_data{
+        {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -343,7 +346,8 @@ TEST_CASE_METHOD(
       0,
       std::nullopt,
       std::nullopt);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -216,7 +216,8 @@ TEST_CASE_METHOD(
     ResultTile::TileData tile_data{
         {nullptr, ThreadPool::SharedTask()},
         {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()}};
+        {nullptr, ThreadPool::SharedTask()},
+        nullptr};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -236,7 +237,8 @@ TEST_CASE_METHOD(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,
@@ -335,7 +337,8 @@ TEST_CASE_METHOD(
     ResultTile::TileData tile_data{
         {nullptr, ThreadPool::SharedTask()},
         {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()}};
+        {nullptr, ThreadPool::SharedTask()},
+        nullptr};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -355,7 +358,8 @@ TEST_CASE_METHOD(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1993,9 +1993,10 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tiles (2 * (~3500 + 8) will be bigger than the per fragment
-  // budget (1000).
-  memory_.total_budget_ = "60000";
+  // Two result tiles (2 * (2736 + 8)) = 5488 will be bigger than the per
+  // fragment budget (50000 * 0.11 / 2 fragments = 2750), so only one result
+  // tile will be loaded each time.
+  memory_.total_budget_ = "50000";
   memory_.ratio_coords_ = "0.11";
   update_config();
 
@@ -2518,8 +2519,9 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tile (2 * (~4500 + 8) will be bigger than the per fragment
-  // budget (1000).
+  // Two result tiles (2 * (2736 + 8)) = 5488 will be bigger than the per
+  // fragment budget (40000 * 0.22 /2 frag = 4400), so only one will be loaded
+  // each time.
   memory_.total_budget_ = "40000";
   memory_.ratio_coords_ = "0.22";
   update_config();

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1993,10 +1993,10 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tiles (2 * (2736 + 8)) = 5488 will be bigger than the per
+  // Two result tiles (2 * (2842 + 8)) = 5700 will be bigger than the per
   // fragment budget (50000 * 0.11 / 2 fragments = 2750), so only one result
   // tile will be loaded each time.
-  memory_.total_budget_ = "50000";
+  memory_.total_budget_ = "60000";
   memory_.ratio_coords_ = "0.11";
   update_config();
 
@@ -2519,7 +2519,7 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tiles (2 * (2736 + 8)) = 5488 will be bigger than the per
+  // Two result tiles (2 * (2842 + 8)) = 5700 will be bigger than the per
   // fragment budget (40000 * 0.22 /2 frag = 4400), so only one will be loaded
   // each time.
   memory_.total_budget_ = "40000";

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1995,7 +1995,7 @@ TEST_CASE_METHOD(
   // FIXME: there is no per fragment budget anymore
   // Two result tiles (2 * (~3500 + 8) will be bigger than the per fragment
   // budget (1000).
-  memory_.total_budget_ = "70000";
+  memory_.total_budget_ = "82000";
   memory_.ratio_coords_ = "0.11";
   update_config();
 
@@ -2518,9 +2518,9 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tile (2 * (~4000 + 8) will be bigger than the per fragment
+  // Two result tile (2 * (~4500 + 8) will be bigger than the per fragment
   // budget (1000).
-  memory_.total_budget_ = "40000";
+  memory_.total_budget_ = "45000";
   memory_.ratio_coords_ = "0.22";
   update_config();
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1104,7 +1104,7 @@ TEST_CASE_METHOD(
 
   // Specific relationship for failure not known, but these values
   // will result in failure with data being written.
-  memory_.total_budget_ = "30000";
+  memory_.total_budget_ = "10000";
   // Failure here occurs with the value of 0.1 for ratio_tile_ranges_.
   update_config();
 
@@ -1193,7 +1193,7 @@ TEST_CASE_METHOD(
 
   // specific relationship for failure not known, but these values
   // will result in failure with data being written.
-  memory_.total_budget_ = "40000";
+  memory_.total_budget_ = "15000";
   // Failure here occurs with the value of 0.1 for ratio_tile_ranges_.
   update_config();
 
@@ -1995,7 +1995,7 @@ TEST_CASE_METHOD(
   // FIXME: there is no per fragment budget anymore
   // Two result tiles (2 * (~3500 + 8) will be bigger than the per fragment
   // budget (1000).
-  memory_.total_budget_ = "82000";
+  memory_.total_budget_ = "60000";
   memory_.ratio_coords_ = "0.11";
   update_config();
 
@@ -2520,7 +2520,7 @@ TEST_CASE_METHOD(
   // FIXME: there is no per fragment budget anymore
   // Two result tile (2 * (~4500 + 8) will be bigger than the per fragment
   // budget (1000).
-  memory_.total_budget_ = "45000";
+  memory_.total_budget_ = "40000";
   memory_.ratio_coords_ = "0.22";
   update_config();
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1104,7 +1104,7 @@ TEST_CASE_METHOD(
 
   // Specific relationship for failure not known, but these values
   // will result in failure with data being written.
-  memory_.total_budget_ = "10000";
+  memory_.total_budget_ = "30000";
   // Failure here occurs with the value of 0.1 for ratio_tile_ranges_.
   update_config();
 
@@ -1193,7 +1193,7 @@ TEST_CASE_METHOD(
 
   // specific relationship for failure not known, but these values
   // will result in failure with data being written.
-  memory_.total_budget_ = "15000";
+  memory_.total_budget_ = "40000";
   // Failure here occurs with the value of 0.1 for ratio_tile_ranges_.
   update_config();
 
@@ -1993,9 +1993,9 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
+  // Two result tiles (2 * (~3500 + 8) will be bigger than the per fragment
   // budget (1000).
-  memory_.total_budget_ = "35000";
+  memory_.total_budget_ = "70000";
   memory_.ratio_coords_ = "0.11";
   update_config();
 

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1065,7 +1065,7 @@ TEST_CASE_METHOD(
     if (one_frag) {
       CHECK(1 == loop_num->second);
     } else {
-      CHECK(16 == loop_num->second);
+      CHECK(20 == loop_num->second);
     }
 
     // Try to read multiple frags without partial tile offset reading. Should

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1065,7 +1065,7 @@ TEST_CASE_METHOD(
     if (one_frag) {
       CHECK(1 == loop_num->second);
     } else {
-      CHECK(9 == loop_num->second);
+      CHECK(18 == loop_num->second);
     }
 
     // Try to read multiple frags without partial tile offset reading. Should

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1065,11 +1065,12 @@ TEST_CASE_METHOD(
     if (one_frag) {
       CHECK(1 == loop_num->second);
     }
-
-    // FIXME: This check has become unpredictable, see why the loop number is
-    // not consistent } else {
-    //   CHECK(20 == loop_num->second);
-    // }
+    /**
+     * FIXME: The loop_num appears to be different on different
+     * architectures/build modes. SC-61065 to investigate why. } else { CHECK(20
+     * == loop_num->second);
+     * }
+     */
 
     // Try to read multiple frags without partial tile offset reading. Should
     // fail

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1066,10 +1066,9 @@ TEST_CASE_METHOD(
       CHECK(1 == loop_num->second);
     }
     /**
-     * FIXME: The loop_num appears to be different on different
-     * architectures/build modes. SC-61065 to investigate why. } else { CHECK(20
-     * == loop_num->second);
-     * }
+     * We can't do a similar check for multiple fragments as it is architecture
+     * dependent how many tiles fit in the memory budget. And thus also
+     * architecture dependent as to how many internal loops we have.
      */
 
     // Try to read multiple frags without partial tile offset reading. Should

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1064,9 +1064,12 @@ TEST_CASE_METHOD(
 
     if (one_frag) {
       CHECK(1 == loop_num->second);
-    } else {
-      CHECK(20 == loop_num->second);
     }
+
+    // FIXME: This check has become unpredictable, see why the loop number is
+    // not consistent } else {
+    //   CHECK(20 == loop_num->second);
+    // }
 
     // Try to read multiple frags without partial tile offset reading. Should
     // fail

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1065,7 +1065,7 @@ TEST_CASE_METHOD(
     if (one_frag) {
       CHECK(1 == loop_num->second);
     } else {
-      CHECK(18 == loop_num->second);
+      CHECK(16 == loop_num->second);
     }
 
     // Try to read multiple frags without partial tile offset reading. Should

--- a/tiledb/sm/filter/CMakeLists.txt
+++ b/tiledb/sm/filter/CMakeLists.txt
@@ -32,7 +32,7 @@ include(object_library)
 #
 commence(object_library filter)
     this_target_sources(filter.cc filter_buffer.cc filter_storage.cc)
-    this_target_object_libraries(baseline buffer tiledb_crypto)
+    this_target_object_libraries(baseline buffer tiledb_crypto thread_pool)
 conclude(object_library)
 
 #

--- a/tiledb/sm/filter/CMakeLists.txt
+++ b/tiledb/sm/filter/CMakeLists.txt
@@ -32,7 +32,7 @@ include(object_library)
 #
 commence(object_library filter)
     this_target_sources(filter.cc filter_buffer.cc filter_storage.cc)
-    this_target_object_libraries(baseline buffer tiledb_crypto thread_pool)
+    this_target_object_libraries(baseline buffer tiledb_crypto)
 conclude(object_library)
 
 #

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -636,7 +636,7 @@ Status CompressionFilter::decompress_var_string_coords(
   auto output_view = span<std::byte>(
       reinterpret_cast<std::byte*>(output_buffer->data()), uncompressed_size);
   auto offsets_view = span<uint64_t>(
-      offsets_tile->data_as<offsets_t>(), uncompressed_offsets_size);
+      offsets_tile->data_as_unsafe<offsets_t>(), uncompressed_offsets_size);
 
   if (compressor_ == Compressor::RLE) {
     uint8_t rle_len_bytesize, string_len_bytesize;

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -461,7 +461,7 @@ Status FilterPipeline::run_reverse(
     // If the pipeline is empty, just copy input to output.
     if (filters_.empty()) {
       void* output_chunk_buffer =
-          tile->data_as<char>() + chunk_data.chunk_offsets_[i];
+          tile->data_as_unsafe<char>() + chunk_data.chunk_offsets_[i];
       RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
       continue;
     }
@@ -484,7 +484,7 @@ Status FilterPipeline::run_reverse(
       bool last_filter = filter_idx == 0;
       if (last_filter) {
         void* output_chunk_buffer =
-            tile->data_as<char>() + chunk_data.chunk_offsets_[i];
+            tile->data_as_unsafe<char>() + chunk_data.chunk_offsets_[i];
         RETURN_NOT_OK(output_data.set_fixed_allocation(
             output_chunk_buffer, chunk.unfiltered_data_size_));
         reader_stats->add_counter(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -159,7 +159,8 @@ shared_ptr<WriterTile> make_increasing_tile(
       Datatype::UINT64,
       cell_size,
       tile_size,
-      tracker);
+      tracker,
+      true);
   for (uint64_t i = 0; i < nelts; i++) {
     CHECK_NOTHROW(tile->write(&i, i * sizeof(uint64_t), sizeof(uint64_t)));
   }
@@ -178,7 +179,8 @@ shared_ptr<WriterTile> make_offsets_tile(
       Datatype::UINT64,
       constants::cell_var_offset_size,
       offsets_tile_size,
-      tracker);
+      tracker,
+      true);
 
   // Set up test data
   for (uint64_t i = 0; i < offsets.size(); i++) {
@@ -204,7 +206,8 @@ Tile create_tile_for_unfiltering(
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask()};
+      ThreadPool::SharedTask(),
+      true};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -204,7 +204,7 @@ Tile create_tile_for_unfiltering(
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
       tracker,
-      nullptr};
+      ThreadPool::SharedTask()};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -159,8 +159,7 @@ shared_ptr<WriterTile> make_increasing_tile(
       Datatype::UINT64,
       cell_size,
       tile_size,
-      tracker,
-      true);
+      tracker);
   for (uint64_t i = 0; i < nelts; i++) {
     CHECK_NOTHROW(tile->write(&i, i * sizeof(uint64_t), sizeof(uint64_t)));
   }
@@ -179,8 +178,7 @@ shared_ptr<WriterTile> make_offsets_tile(
       Datatype::UINT64,
       constants::cell_var_offset_size,
       offsets_tile_size,
-      tracker,
-      true);
+      tracker);
 
   // Set up test data
   for (uint64_t i = 0; i < offsets.size(); i++) {
@@ -206,8 +204,7 @@ Tile create_tile_for_unfiltering(
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask(),
-      true};
+      std::nullopt};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -204,8 +204,7 @@ Tile create_tile_for_unfiltering(
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask(),
-      nullptr};
+      ThreadPool::SharedTask()};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -204,7 +204,8 @@ Tile create_tile_for_unfiltering(
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask()};
+      ThreadPool::SharedTask(),
+      nullptr};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -203,7 +203,8 @@ Tile create_tile_for_unfiltering(
       tile->cell_size() * nelts,
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
-      tracker};
+      tracker,
+      nullptr};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -68,7 +68,8 @@ class TileDataGenerator {
         datatype(),
         cell_size(),
         original_tile_size(),
-        memory_tracker);
+        memory_tracker,
+        true);
   }
 
   /**
@@ -100,7 +101,8 @@ class TileDataGenerator {
         filtered_buffer.data(),
         filtered_buffer.size(),
         memory_tracker,
-        ThreadPool::SharedTask());
+        ThreadPool::SharedTask(),
+        true);
   }
 
   /** Returns the size of the original unfiltered data. */
@@ -188,7 +190,8 @@ class IncrementTileDataGenerator : public TileDataGenerator {
         Datatype::UINT64,
         constants::cell_var_offset_size,
         offsets.size() * constants::cell_var_offset_size,
-        memory_tracker);
+        memory_tracker,
+        true);
     for (uint64_t index = 0; index < offsets.size(); ++index) {
       CHECK_NOTHROW(offsets_tile->write(
           &offsets[index],

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -100,7 +100,8 @@ class TileDataGenerator {
         filtered_buffer.data(),
         filtered_buffer.size(),
         memory_tracker,
-        ThreadPool::SharedTask());
+        ThreadPool::SharedTask(),
+        nullptr);
   }
 
   /** Returns the size of the original unfiltered data. */

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -100,8 +100,7 @@ class TileDataGenerator {
         filtered_buffer.data(),
         filtered_buffer.size(),
         memory_tracker,
-        ThreadPool::SharedTask(),
-        nullptr);
+        ThreadPool::SharedTask());
   }
 
   /** Returns the size of the original unfiltered data. */

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -99,7 +99,8 @@ class TileDataGenerator {
         original_tile_size(),
         filtered_buffer.data(),
         filtered_buffer.size(),
-        memory_tracker);
+        memory_tracker,
+        nullptr);
   }
 
   /** Returns the size of the original unfiltered data. */

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -100,7 +100,7 @@ class TileDataGenerator {
         filtered_buffer.data(),
         filtered_buffer.size(),
         memory_tracker,
-        nullptr);
+        ThreadPool::SharedTask());
   }
 
   /** Returns the size of the original unfiltered data. */

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -68,8 +68,7 @@ class TileDataGenerator {
         datatype(),
         cell_size(),
         original_tile_size(),
-        memory_tracker,
-        true);
+        memory_tracker);
   }
 
   /**
@@ -101,8 +100,7 @@ class TileDataGenerator {
         filtered_buffer.data(),
         filtered_buffer.size(),
         memory_tracker,
-        ThreadPool::SharedTask(),
-        true);
+        std::nullopt);
   }
 
   /** Returns the size of the original unfiltered data. */
@@ -190,8 +188,7 @@ class IncrementTileDataGenerator : public TileDataGenerator {
         Datatype::UINT64,
         constants::cell_var_offset_size,
         offsets.size() * constants::cell_var_offset_size,
-        memory_tracker,
-        true);
+        memory_tracker);
     for (uint64_t index = 0; index < offsets.size(); ++index) {
       CHECK_NOTHROW(offsets_tile->write(
           &offsets[index],

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -123,7 +123,8 @@ TEST_CASE(
       tile1->size(),
       tile1->filtered_buffer().data(),
       tile1->filtered_buffer().size(),
-      tracker);
+      tracker,
+      nullptr);
   memcpy(metadata_tiles[0]->data(), tile1->data(), tile1->size());
 
   metadata_tiles[1] = tdb::make_shared<Tile>(
@@ -135,7 +136,8 @@ TEST_CASE(
       tile2->size(),
       tile2->filtered_buffer().data(),
       tile2->filtered_buffer().size(),
-      tracker);
+      tracker,
+      nullptr);
   memcpy(metadata_tiles[1]->data(), tile2->data(), tile2->size());
 
   metadata_tiles[2] = tdb::make_shared<Tile>(
@@ -147,7 +149,8 @@ TEST_CASE(
       tile3->size(),
       tile3->filtered_buffer().data(),
       tile3->filtered_buffer().size(),
-      tracker);
+      tracker,
+      nullptr);
   memcpy(metadata_tiles[2]->data(), tile3->data(), tile3->size());
 
   meta = Metadata::deserialize(metadata_tiles);

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -124,8 +124,7 @@ TEST_CASE(
       tile1->filtered_buffer().data(),
       tile1->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask(),
-      nullptr);
+      ThreadPool::SharedTask());
   memcpy(metadata_tiles[0]->data(), tile1->data(), tile1->size());
 
   metadata_tiles[1] = tdb::make_shared<Tile>(
@@ -138,8 +137,7 @@ TEST_CASE(
       tile2->filtered_buffer().data(),
       tile2->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask(),
-      nullptr);
+      ThreadPool::SharedTask());
   memcpy(metadata_tiles[1]->data(), tile2->data(), tile2->size());
 
   metadata_tiles[2] = tdb::make_shared<Tile>(
@@ -152,8 +150,7 @@ TEST_CASE(
       tile3->filtered_buffer().data(),
       tile3->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask(),
-      nullptr);
+      ThreadPool::SharedTask());
   memcpy(metadata_tiles[2]->data(), tile3->data(), tile3->size());
 
   meta = Metadata::deserialize(metadata_tiles);

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -124,7 +124,7 @@ TEST_CASE(
       tile1->filtered_buffer().data(),
       tile1->filtered_buffer().size(),
       tracker,
-      nullptr);
+      ThreadPool::SharedTask());
   memcpy(metadata_tiles[0]->data(), tile1->data(), tile1->size());
 
   metadata_tiles[1] = tdb::make_shared<Tile>(
@@ -137,7 +137,7 @@ TEST_CASE(
       tile2->filtered_buffer().data(),
       tile2->filtered_buffer().size(),
       tracker,
-      nullptr);
+      ThreadPool::SharedTask());
   memcpy(metadata_tiles[1]->data(), tile2->data(), tile2->size());
 
   metadata_tiles[2] = tdb::make_shared<Tile>(
@@ -150,7 +150,7 @@ TEST_CASE(
       tile3->filtered_buffer().data(),
       tile3->filtered_buffer().size(),
       tracker,
-      nullptr);
+      ThreadPool::SharedTask());
   memcpy(metadata_tiles[2]->data(), tile3->data(), tile3->size());
 
   meta = Metadata::deserialize(metadata_tiles);

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -124,7 +124,8 @@ TEST_CASE(
       tile1->filtered_buffer().data(),
       tile1->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask());
+      ThreadPool::SharedTask(),
+      nullptr);
   memcpy(metadata_tiles[0]->data(), tile1->data(), tile1->size());
 
   metadata_tiles[1] = tdb::make_shared<Tile>(
@@ -137,7 +138,8 @@ TEST_CASE(
       tile2->filtered_buffer().data(),
       tile2->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask());
+      ThreadPool::SharedTask(),
+      nullptr);
   memcpy(metadata_tiles[1]->data(), tile2->data(), tile2->size());
 
   metadata_tiles[2] = tdb::make_shared<Tile>(
@@ -150,7 +152,8 @@ TEST_CASE(
       tile3->filtered_buffer().data(),
       tile3->filtered_buffer().size(),
       tracker,
-      ThreadPool::SharedTask());
+      ThreadPool::SharedTask(),
+      nullptr);
   memcpy(metadata_tiles[2]->data(), tile3->data(), tile3->size());
 
   meta = Metadata::deserialize(metadata_tiles);

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -452,6 +452,9 @@ Status DenseReader::dense_read() {
     // processing.
     if (qc_coords_mode_) {
       t_start = t_end;
+      if (compute_task.valid()) {
+        throw_if_not_ok(compute_task.wait());
+      }
       continue;
     }
 
@@ -568,10 +571,10 @@ Status DenseReader::dense_read() {
 
     t_start = t_end;
     subarray_start_cell = subarray_end_cell;
-  }
 
-  if (compute_task.valid()) {
-    throw_if_not_ok(compute_task.wait());
+    if (compute_task.valid()) {
+      throw_if_not_ok(compute_task.wait());
+    }
   }
 
   // For `qc_coords_mode` just fill in the coordinates and skip attribute

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -571,10 +571,10 @@ Status DenseReader::dense_read() {
 
     t_start = t_end;
     subarray_start_cell = subarray_end_cell;
+  }
 
-    if (compute_task.valid()) {
-      throw_if_not_ok(compute_task.wait());
-    }
+  if (compute_task.valid()) {
+    throw_if_not_ok(compute_task.wait());
   }
 
   // For `qc_coords_mode` just fill in the coordinates and skip attribute
@@ -765,8 +765,8 @@ DenseReader::compute_result_space_tiles(
   const auto fragment_num = (unsigned)frag_tile_domains.size();
   const auto& tile_coords = subarray.tile_coords();
 
-  // Keep track of the required memory to load the result space tiles. Split up
-  // filtered versus unfiltered. The memory budget is combined for all
+  // Keep track of the required memory to load the result space tiles. Split
+  // up filtered versus unfiltered. The memory budget is combined for all
   // query condition attributes.
   uint64_t required_memory_query_condition_unfiltered = 0;
   std::vector<uint64_t> required_memory_unfiltered(
@@ -782,28 +782,28 @@ DenseReader::compute_result_space_tiles(
     aggregate_only_field[n - condition_names.size()] = aggregate_only(name);
   }
 
-  // Here we estimate the size of the tile structures. First, we have to account
-  // the size of the space tile structure. We could go deeper in the class to
-  // account for other things but for now we keep it simpler. Second, we try to
-  // account for the tile subarray (DenseTileSubarray). This class will have a
-  // vector of ranges per dimensions, so 1 + dim_num * sizeof(vector). Here we
-  // choose 32 for the size of the vector to anticipate the conversion to a PMR
-  // vector. We also add dim_num * 2 * sizeof(DimType) to account for at least
-  // one range per dimension (this should be improved by accounting for the
-  // exact number of ranges). Finally for the original range index member, we
-  // have to add 1 + dim_num * sizeof(vector) as well and one uint64_t per
-  // dimension (this can also be improved by accounting for the
-  // exact number of ranges).
+  // Here we estimate the size of the tile structures. First, we have to
+  // account the size of the space tile structure. We could go deeper in the
+  // class to account for other things but for now we keep it simpler. Second,
+  // we try to account for the tile subarray (DenseTileSubarray). This class
+  // will have a vector of ranges per dimensions, so 1 + dim_num *
+  // sizeof(vector). Here we choose 32 for the size of the vector to
+  // anticipate the conversion to a PMR vector. We also add dim_num * 2 *
+  // sizeof(DimType) to account for at least one range per dimension (this
+  // should be improved by accounting for the exact number of ranges). Finally
+  // for the original range index member, we have to add 1 + dim_num *
+  // sizeof(vector) as well and one uint64_t per dimension (this can also be
+  // improved by accounting for the exact number of ranges).
   uint64_t est_tile_structs_size =
       sizeof(ResultSpaceTile<DimType>) + (1 + dim_num) * 2 * 32 +
       dim_num * (2 * sizeof(DimType) + sizeof(uint64_t));
 
   // Create the vector of result tiles to operate on. We stop once we reach
-  // the end or the memory budget. We either reach the tile upper memory limit,
-  // which is only for unfiltered data, or the limit of the available budget,
-  // which is for filtered data, unfiltered data and the tile structs. We try to
-  // process two tile batches at a time so the available memory is half of what
-  // we have available.
+  // the end or the memory budget. We either reach the tile upper memory
+  // limit, which is only for unfiltered data, or the limit of the available
+  // budget, which is for filtered data, unfiltered data and the tile structs.
+  // We try to process two tile batches at a time so the available memory is
+  // half of what we have available.
   uint64_t t_end = t_start;
   bool wait_compute_task_before_read = false;
   bool done = false;
@@ -891,8 +891,8 @@ DenseReader::compute_result_space_tiles(
       uint64_t tile_memory_filtered = 0;
       uint64_t r_idx = n - condition_names.size();
 
-      // We might not need to load this tile into memory at all for aggregation
-      // only.
+      // We might not need to load this tile into memory at all for
+      // aggregation only.
       if (aggregate_only_field[r_idx] &&
           can_aggregate_tile_with_frag_md(
               names[n], result_space_tile, tiles_cell_num[t_end])) {
@@ -949,13 +949,14 @@ DenseReader::compute_result_space_tiles(
                               required_memory_unfiltered[r_idx] +
                               est_tile_structs_size;
 
-      // Disable the multiple iterations if the tiles don't fit in the iteration
-      // budget.
+      // Disable the multiple iterations if the tiles don't fit in the
+      // iteration budget.
       if (total_memory > available_memory_iteration) {
         wait_compute_task_before_read = true;
       }
 
-      // If a single tile doesn't fit in the available memory, we can't proceed.
+      // If a single tile doesn't fit in the available memory, we can't
+      // proceed.
       if (total_memory > available_memory) {
         throw DenseReaderException(
             "Cannot process a single tile requiring " +
@@ -999,7 +1000,8 @@ std::vector<ResultTile*> DenseReader::result_tiles_to_load(
   const auto& tile_coords = subarray.tile_coords();
   const bool agg_only = name.has_value() && aggregate_only(name.value());
 
-  // If the result is already loaded in query condition, return the empty list;
+  // If the result is already loaded in query condition, return the empty
+  // list;
   std::vector<ResultTile*> ret;
   if (name.has_value() && condition_names.count(name.value()) != 0) {
     return ret;
@@ -1029,8 +1031,8 @@ std::vector<ResultTile*> DenseReader::result_tiles_to_load(
 
 /**
  * Apply the query condition. The computation will be pushed on the compute
- * thread pool in `compute_task`. Callers should wait on this task before using
- * the results of the query condition.
+ * thread pool in `compute_task`. Callers should wait on this task before
+ * using the results of the query condition.
  */
 template <class DimType, class OffType>
 Status DenseReader::apply_query_condition(

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -40,7 +40,6 @@
 #include "tiledb/sm/misc/parallel_functions.h"
 #include "tiledb/sm/query/legacy/cell_slab_iter.h"
 #include "tiledb/sm/query/query_macros.h"
-#include "tiledb/sm/query/readers/filtered_data.h"
 #include "tiledb/sm/query/readers/result_tile.h"
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/subarray/subarray.h"
@@ -460,7 +459,6 @@ Status DenseReader::dense_read() {
     // clear the memory. Also, a name in names might not be in the user buffers
     // so we might skip the copy but still clear the memory.
     for (auto& name : names) {
-      shared_ptr<std::list<FilteredData>> filtered_data;
       std::vector<ResultTile*> result_tiles;
       bool validity_only = null_count_aggregate_only(name);
       bool dense_dim = name == constants::coords || array_schema_.is_dim(name);
@@ -484,8 +482,7 @@ Status DenseReader::dense_read() {
         // Read and unfilter tiles.
         std::vector<ReaderBase::NameToLoad> to_load;
         to_load.emplace_back(name, validity_only);
-        filtered_data = make_shared<std::list<FilteredData>>(
-            read_attribute_tiles(to_load, result_tiles));
+        read_attribute_tiles(to_load, result_tiles);
       }
 
       if (compute_task.valid()) {
@@ -497,7 +494,6 @@ Status DenseReader::dense_read() {
 
       compute_task = resources_.compute_tp().execute([&,
                                                       iteration_tile_data,
-                                                      filtered_data,
                                                       dense_dim,
                                                       name,
                                                       validity_only,
@@ -508,9 +504,6 @@ Status DenseReader::dense_read() {
         if (!dense_dim) {
           // Unfilter tiles.
           RETURN_NOT_OK(unfilter_tiles(name, validity_only, result_tiles));
-
-          // The filtered data is no longer required, release it.
-          filtered_data.reset();
 
           // Only copy names that are present in the user buffers.
           if (buffers_.count(name) != 0) {
@@ -1070,16 +1063,13 @@ Status DenseReader::apply_query_condition(
         tiles_cell_num);
 
     // Read and unfilter query condition attributes.
-    shared_ptr<std::list<FilteredData>> filtered_data =
-        make_shared<std::list<FilteredData>>(read_attribute_tiles(
-            NameToLoad::from_string_vec(qc_names), result_tiles));
+    read_attribute_tiles(NameToLoad::from_string_vec(qc_names), result_tiles);
 
     if (compute_task.valid()) {
       throw_if_not_ok(compute_task.wait());
     }
 
     compute_task = resources_.compute_tp().execute([&,
-                                                    filtered_data,
                                                     iteration_tile_data,
                                                     qc_names,
                                                     num_range_threads,
@@ -1095,9 +1085,6 @@ Status DenseReader::apply_query_condition(
       for (auto& name : qc_names) {
         RETURN_NOT_OK(unfilter_tiles(name, false, result_tiles));
       }
-
-      // The filtered data is no longer required, release it.
-      filtered_data.reset();
 
       if (stride == UINT64_MAX) {
         stride = 1;

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -415,7 +415,7 @@ class FilteredData {
           auto timer_se = stats_->start_timer("read");
           return resources_.vfs().read(uri, offset, data, size, false);
         });
-    // This should be changes once we use taskgraphs for modeling the data flow
+    // This should be changed once we use taskgraphs for modeling the data flow
     block.set_io_task(task);
   }
 

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -329,13 +329,14 @@ class FilteredData {
   /* ********************************* */
 
   /**
-   * Get the fixed filtered data for the result tile.
+   * Get a pointer to the fixed filtered data for the result tile and a future
+   * which signals when the data is valid.
    *
    * @param fragment Fragment metadata for the tile.
    * @param rt Result tile.
    * @return Fixed filtered data pointer.
    */
-  inline std::tuple<void*, ThreadPool::SharedTask> fixed_filtered_data(
+  inline std::pair<void*, ThreadPool::SharedTask> fixed_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     auto offset{
         fragment->loaded_metadata()->file_offset(name_, rt->tile_idx())};
@@ -346,13 +347,13 @@ class FilteredData {
   }
 
   /**
-   * Get the var filtered data for the result tile.
-   *
+   * Get a pointer to the var filtered data for the result tile and a future
+   * which signals when the data is valid.   *
    * @param fragment Fragment metadata for the tile.
    * @param rt Result tile.
    * @return Var filtered data pointer.
    */
-  inline std::tuple<void*, ThreadPool::SharedTask> var_filtered_data(
+  inline std::pair<void*, ThreadPool::SharedTask> var_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!var_sized_) {
       return {nullptr, ThreadPool::SharedTask()};
@@ -367,13 +368,14 @@ class FilteredData {
   }
 
   /**
-   * Get the nullable filtered data for the result tile.
+   * Get a pointer to the nullable filtered data for the result tile and a
+   * future which signals when the data is valid.
    *
    * @param fragment Fragment metadata for the tile.
    * @param rt Result tile.
    * @return Nullable filtered data pointer.
    */
-  inline std::tuple<void*, ThreadPool::SharedTask> nullable_filtered_data(
+  inline std::pair<void*, ThreadPool::SharedTask> nullable_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!nullable_) {
       return {nullptr, ThreadPool::SharedTask()};

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -121,11 +121,11 @@ class FilteredDataBlock {
            offset + size <= offset_ + size_;
   }
 
-  void set_io_task(std::shared_ptr<ThreadPool::Task> task) {
+  void set_io_task(std::shared_ptr<ThreadPool::SharedTask> task) {
     io_task_ = std::move(task);
   }
 
-  shared_ptr<ThreadPool::Task> io_task() {
+  shared_ptr<ThreadPool::SharedTask> io_task() {
     return io_task_;
   }
 
@@ -149,7 +149,7 @@ class FilteredDataBlock {
   tdb::pmr::unique_ptr<std::byte> filtered_data_;
 
   /** IO Task to block on for data access. */
-  shared_ptr<ThreadPool::Task> io_task_;
+  shared_ptr<ThreadPool::SharedTask> io_task_;
 };
 
 /**
@@ -334,8 +334,8 @@ class FilteredData {
    * @param rt Result tile.
    * @return Fixed filtered data pointer.
    */
-  inline std::tuple<void*, shared_ptr<ThreadPool::Task>> fixed_filtered_data(
-      const FragmentMetadata* fragment, const ResultTile* rt) {
+  inline std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
+  fixed_filtered_data(const FragmentMetadata* fragment, const ResultTile* rt) {
     auto offset{
         fragment->loaded_metadata()->file_offset(name_, rt->tile_idx())};
     ensure_data_block_current(TileType::FIXED, fragment, rt, offset);
@@ -351,8 +351,8 @@ class FilteredData {
    * @param rt Result tile.
    * @return Var filtered data pointer.
    */
-  inline std::tuple<void*, std::shared_ptr<ThreadPool::Task>> var_filtered_data(
-      const FragmentMetadata* fragment, const ResultTile* rt) {
+  inline std::tuple<void*, std::shared_ptr<ThreadPool::SharedTask>>
+  var_filtered_data(const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!var_sized_) {
       return {nullptr, nullptr};
     }
@@ -372,7 +372,7 @@ class FilteredData {
    * @param rt Result tile.
    * @return Nullable filtered data pointer.
    */
-  inline std::tuple<void*, std::shared_ptr<ThreadPool::Task>>
+  inline std::tuple<void*, std::shared_ptr<ThreadPool::SharedTask>>
   nullable_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!nullable_) {
@@ -416,8 +416,8 @@ class FilteredData {
     });
     // Store as a shared_ptr so we can move lifetimes around
     // This should be changes once we use taskgraphs for modeling the data flow
-    shared_ptr<ThreadPool::Task> task_ptr =
-        make_shared<ThreadPool::Task>(std::move(task));
+    shared_ptr<ThreadPool::SharedTask> task_ptr =
+        make_shared<ThreadPool::SharedTask>(std::move(task));
     block.set_io_task(task_ptr);
   }
 

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -121,7 +121,7 @@ class FilteredDataBlock {
            offset + size <= offset_ + size_;
   }
 
-  void set_io_task(std::shared_ptr<ThreadPool::SharedTask> task) {
+  void set_io_task(shared_ptr<ThreadPool::SharedTask> task) {
     io_task_ = std::move(task);
   }
 
@@ -351,7 +351,7 @@ class FilteredData {
    * @param rt Result tile.
    * @return Var filtered data pointer.
    */
-  inline std::tuple<void*, std::shared_ptr<ThreadPool::SharedTask>>
+  inline std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
   var_filtered_data(const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!var_sized_) {
       return {nullptr, nullptr};
@@ -372,7 +372,7 @@ class FilteredData {
    * @param rt Result tile.
    * @return Nullable filtered data pointer.
    */
-  inline std::tuple<void*, std::shared_ptr<ThreadPool::SharedTask>>
+  inline std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
   nullable_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!nullable_) {

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -410,7 +410,7 @@ class FilteredData {
     auto data{block.data()};
     auto size{block.size()};
     URI uri{file_uri(fragment_metadata_[block.frag_idx()].get(), type)};
-    std::shared_future<Status> task =
+    ThreadPool::SharedTask task =
         resources_.io_tp().execute([this, offset, data, size, uri]() {
           auto timer_se = stats_->start_timer("read");
           return resources_.vfs().read(uri, offset, data, size, false);

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -210,7 +210,8 @@ class FilteredData {
       , name_(name)
       , fragment_metadata_(fragment_metadata)
       , var_sized_(var_sized)
-      , nullable_(nullable) {
+      , nullable_(nullable)
+      , stats_(reader.stats()->create_child("FilteredData")) {
     if (result_tiles.size() == 0) {
       return;
     }
@@ -411,6 +412,7 @@ class FilteredData {
     URI uri{file_uri(fragment_metadata_[block.frag_idx()].get(), type)};
     std::shared_future<Status> task =
         resources_.io_tp().execute([this, offset, data, size, uri]() {
+          auto timer_se = stats_->start_timer("read");
           return resources_.vfs().read(uri, offset, data, size, false);
         });
     // This should be changes once we use taskgraphs for modeling the data flow
@@ -650,6 +652,9 @@ class FilteredData {
 
   /** Is the attribute nullable? */
   const bool nullable_;
+
+  /** Stats to track loading. */
+  stats::Stats* stats_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -411,9 +411,7 @@ class FilteredData {
     URI uri{file_uri(fragment_metadata_[block.frag_idx()].get(), type)};
     std::shared_future<Status> task =
         resources_.io_tp().execute([this, offset, data, size, uri]() {
-          throw_if_not_ok(
-              resources_.vfs().read(uri, offset, data, size, false));
-          return Status::Ok();
+          return resources_.vfs().read(uri, offset, data, size, false);
         });
     // This should be changes once we use taskgraphs for modeling the data flow
     block.set_io_task(task);

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -747,7 +747,8 @@ std::list<FilteredData> ReaderBase::read_tiles(
       // 'TileData' objects should be returned by this function and passed into
       // 'unfilter_tiles' so that the filter pipeline can stop using the
       // 'ResultTile' object to get access to the filtered data.
-      std::tuple<void*, shared_ptr<ThreadPool::Task>> n = {nullptr, nullptr};
+      std::tuple<void*, shared_ptr<ThreadPool::SharedTask>> n = {
+          nullptr, nullptr};
       ResultTile::TileData tile_data{
           val_only ?
               n :

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -846,7 +846,7 @@ Status ReaderBase::zip_tile_coordinates(
         array_schema_.filters(name).get_filter<CompressionFilter>() != nullptr;
     auto version = tile->format_version();
     if (version > 1 || using_compression) {
-      tile->zip_coordinates();
+      tile->zip_coordinates_unsafe();
     }
   }
   return Status::Ok();
@@ -881,7 +881,7 @@ Status ReaderBase::post_process_unfiltered_tile(
     auto& t_var = tile_tuple->var_tile();
     t_var.clear_filtered_buffer();
     throw_if_not_ok(zip_tile_coordinates(name, &t_var));
-    t.add_extra_offset(t_var);
+    t.add_extra_offset_unsafe(t_var);
   }
 
   if (nullable) {

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -697,7 +697,6 @@ std::list<FilteredData> ReaderBase::read_tiles(
   }
 
   uint64_t num_tiles_read{0};
-  std::vector<ThreadPool::Task> read_tasks;
 
   // Run all attributes independently.
   for (auto n : names) {
@@ -721,7 +720,6 @@ std::list<FilteredData> ReaderBase::read_tiles(
         var_sized,
         nullable,
         val_only,
-        read_tasks,
         memory_tracker_);
 
     // Go through each tiles and create the attribute tiles.
@@ -749,12 +747,13 @@ std::list<FilteredData> ReaderBase::read_tiles(
       // 'TileData' objects should be returned by this function and passed into
       // 'unfilter_tiles' so that the filter pipeline can stop using the
       // 'ResultTile' object to get access to the filtered data.
+      std::tuple<void*, shared_ptr<ThreadPool::Task>> n = {nullptr, nullptr};
       ResultTile::TileData tile_data{
           val_only ?
-              nullptr :
+              n :
               filtered_data.back().fixed_filtered_data(fragment.get(), tile),
           val_only ?
-              nullptr :
+              n :
               filtered_data.back().var_filtered_data(fragment.get(), tile),
           filtered_data.back().nullable_filtered_data(fragment.get(), tile)};
 
@@ -778,12 +777,6 @@ std::list<FilteredData> ReaderBase::read_tiles(
   }
 
   stats_->add_counter("num_tiles_read", num_tiles_read);
-
-  // Wait for the read tasks to finish.
-  auto statuses{resources_.io_tp().wait_all_status(read_tasks)};
-  for (const auto& st : statuses) {
-    throw_if_not_ok(st);
-  }
 
   return filtered_data;
 }

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -897,8 +897,9 @@ Status ReaderBase::unfilter_tiles(
     const std::string& name,
     const bool validity_only,
     const std::vector<ResultTile*>& result_tiles) {
-  const auto stat_type = (array_schema_.is_attr(name)) ? "unfilter_attr_tiles" :
-                                                         "unfilter_coord_tiles";
+  const auto stat_type = (array_schema_.is_attr(name)) ?
+                             "unfilter_attr_tiles_builder" :
+                             "unfilter_coord_tiles_builder";
 
   const auto timer_se = stats_->start_timer(stat_type);
   auto var_size = array_schema_.var_size(name);
@@ -937,6 +938,12 @@ Status ReaderBase::unfilter_tiles(
                                          num_range_threads,
                                          result_tile,
                                          this]() {
+          const auto stat_type =
+              (array_schema_.is_attr(name)) ?
+                  "unfilter_attr_tiles_builder.unfilter_attr_tiles" :
+                  "unfilter_coord_tiles_builder.unfilter_coord_tiles";
+
+          const auto timer_se = stats_->start_timer(stat_type);
           // Chunks for unfiltering
           ChunkData tiles_chunk_data;
           ChunkData tiles_chunk_var_data;

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -649,7 +649,7 @@ Status ReaderBase::read_and_unfilter_attribute_tiles(
   // eventually get rid of it altogether so that we can clarify the data flow.
   // At the end of this function call, all memory inside of 'filtered_data' has
   // been used and the tiles are unfiltered so the data can be deleted.
-  read_attribute_tiles(names, result_tiles);
+  auto filtered_data{read_attribute_tiles(names, result_tiles)};
   for (auto& name : names) {
     RETURN_NOT_OK(
         unfilter_tiles(name.name(), name.validity_only(), result_tiles));
@@ -663,7 +663,7 @@ Status ReaderBase::read_and_unfilter_coordinate_tiles(
     const std::vector<ResultTile*>& result_tiles) {
   // See the comment in 'read_and_unfilter_attribute_tiles' to get more
   // information about the lifetime of this object.
-  read_coordinate_tiles(names, result_tiles);
+  auto filtered_data{read_coordinate_tiles(names, result_tiles)};
   for (auto& name : names) {
     RETURN_NOT_OK(unfilter_tiles(name, false, result_tiles));
   }
@@ -671,28 +671,29 @@ Status ReaderBase::read_and_unfilter_coordinate_tiles(
   return Status::Ok();
 }
 
-void ReaderBase::read_attribute_tiles(
+std::list<FilteredData> ReaderBase::read_attribute_tiles(
     const std::vector<NameToLoad>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_attribute_tiles");
   return read_tiles(names, result_tiles);
 }
 
-void ReaderBase::read_coordinate_tiles(
+std::list<FilteredData> ReaderBase::read_coordinate_tiles(
     const std::vector<std::string>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_coordinate_tiles");
   return read_tiles(NameToLoad::from_string_vec(names), result_tiles);
 }
 
-void ReaderBase::read_tiles(
+std::list<FilteredData> ReaderBase::read_tiles(
     const std::vector<NameToLoad>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_tiles");
+  std::list<FilteredData> filtered_data;
 
   // Shortcut for empty tile vec.
   if (result_tiles.empty() || names.empty()) {
-    return;
+    return filtered_data;
   }
 
   uint64_t num_tiles_read{0};
@@ -707,8 +708,7 @@ void ReaderBase::read_tiles(
     // read and memory allocations.
     const bool var_sized{array_schema_.var_size(name)};
     const bool nullable{array_schema_.is_nullable(name)};
-    shared_ptr<FilteredData> filtered_data = make_shared<FilteredData>(
-        HERE(),
+    filtered_data.emplace_back(
         resources_,
         *this,
         min_batch_size_,
@@ -747,14 +747,16 @@ void ReaderBase::read_tiles(
       // 'TileData' objects should be returned by this function and passed into
       // 'unfilter_tiles' so that the filter pipeline can stop using the
       // 'ResultTile' object to get access to the filtered data.
-      std::tuple<void*, ThreadPool::SharedTask> n = {
+      std::pair<void*, ThreadPool::SharedTask> t = {
           nullptr, ThreadPool::SharedTask()};
       ResultTile::TileData tile_data{
-          val_only ? n :
-                     filtered_data->fixed_filtered_data(fragment.get(), tile),
-          val_only ? n : filtered_data->var_filtered_data(fragment.get(), tile),
-          filtered_data->nullable_filtered_data(fragment.get(), tile),
-          filtered_data};
+          val_only ?
+              t :
+              filtered_data.back().fixed_filtered_data(fragment.get(), tile),
+          val_only ?
+              t :
+              filtered_data.back().var_filtered_data(fragment.get(), tile),
+          filtered_data.back().nullable_filtered_data(fragment.get(), tile)};
 
       // Initialize the tile(s)
       const format_version_t format_version{fragment->format_version()};
@@ -777,7 +779,7 @@ void ReaderBase::read_tiles(
 
   stats_->add_counter("num_tiles_read", num_tiles_read);
 
-  return;
+  return filtered_data;
 }
 
 tuple<Status, optional<uint64_t>, optional<uint64_t>, optional<uint64_t>>
@@ -927,93 +929,59 @@ Status ReaderBase::unfilter_tiles(
     num_range_threads = 1 + ((num_threads - 1) / num_tiles);
   }
 
-  for (size_t i = 0; i < num_tiles; i++) {
-    auto result_tile = result_tiles[i];
-    // if (skip_field(result_tile->frag_idx(), name)) {
-    //   continue;
-    // }
-    ThreadPool::SharedTask task =
-        resources_.compute_tp().execute([name,
-                                         validity_only,
-                                         var_size,
-                                         nullable,
-                                         num_range_threads,
-                                         result_tile,
-                                         this]() {
-          const auto stat_type =
-              (array_schema_.is_attr(name)) ?
-                  "unfilter_attr_tiles_builder.unfilter_attr_tiles" :
-                  "unfilter_coord_tiles_builder.unfilter_coord_tiles";
+  // Vectors with all the necessary chunk data for unfiltering
+  std::vector<ChunkData> tiles_chunk_data(num_tiles);
+  std::vector<ChunkData> tiles_chunk_var_data(num_tiles);
+  std::vector<ChunkData> tiles_chunk_validity_data(num_tiles);
 
-          const auto timer_se = stats_->start_timer(stat_type);
-          // Chunks for unfiltering
-          ChunkData tiles_chunk_data;
-          ChunkData tiles_chunk_var_data;
-          ChunkData tiles_chunk_validity_data;
-          auto&& [st, tile_size, tile_var_size, tile_validity_size] =
-              load_tile_chunk_data(
-                  name,
-                  validity_only,
-                  result_tile,
-                  var_size,
-                  nullable,
-                  tiles_chunk_data,
-                  tiles_chunk_var_data,
-                  tiles_chunk_validity_data);
-          if (!st.ok()) {
-            return st;
-          }
-
-          if (tile_size.value_or(0) == 0 && tile_var_size.value_or(0) == 0 &&
-              tile_validity_size.value_or(0) == 0) {
-            return Status::Ok();
-          }
-
-          // The current threadpool design does not allow for unfiltering to
-          // happen in chunks using a parallel for within this async task as the
-          // wait_all in the end of the parallel for can deadlock.
-          for (uint64_t range_thread_idx = 0;
-               range_thread_idx < num_range_threads;
-               range_thread_idx++) {
-            st = unfilter_tile(
+  // Pre-compute chunk offsets.
+  auto status = parallel_for(
+      &resources_.compute_tp(), 0, num_tiles, [&, this](uint64_t i) {
+        auto&& [st, tile_size, tile_var_size, tile_validity_size] =
+            load_tile_chunk_data(
                 name,
                 validity_only,
-                result_tile,
+                result_tiles[i],
                 var_size,
                 nullable,
-                range_thread_idx,
-                num_range_threads,
-                tiles_chunk_data,
-                tiles_chunk_var_data,
-                tiles_chunk_validity_data);
-            if (!st.ok()) {
-              return st;
-            }
-          }
+                tiles_chunk_data[i],
+                tiles_chunk_var_data[i],
+                tiles_chunk_validity_data[i]);
+        throw_if_not_ok(st);
+        return Status::Ok();
+      });
+  RETURN_NOT_OK_ELSE(status, throw_if_not_ok(logger_->status(status)));
 
-          // Perform required post-processing of unfiltered tiles
-          return post_process_unfiltered_tile(
-              name, validity_only, result_tile, var_size, nullable);
-        });
+  if (tiles_chunk_data.empty())
+    return Status::Ok();
 
-    if (skip_field(result_tile->frag_idx(), name)) {
-      RETURN_NOT_OK(task.wait());
-      continue;
-    }
+  // Unfilter all tiles/chunks in parallel using the precomputed offsets.
+  status = parallel_for_2d(
+      &resources_.compute_tp(),
+      0,
+      num_tiles,
+      0,
+      num_range_threads,
+      [&](uint64_t i, uint64_t range_thread_idx) {
+        throw_if_not_ok(unfilter_tile(
+            name,
+            validity_only,
+            result_tiles[i],
+            var_size,
+            nullable,
+            range_thread_idx,
+            num_range_threads,
+            tiles_chunk_data[i],
+            tiles_chunk_var_data[i],
+            tiles_chunk_validity_data[i]));
+        return Status::Ok();
+      });
+  RETURN_CANCEL_OR_ERROR(status);
 
-    // Unfiltering tasks have been launched, set the tasks to wait for in the
-    // corresponding tiles. When those tasks(futures) will be ready the tile
-    // processing that depends on the unfiltered tile will get unblocked.
-    auto tile_tuple = result_tile->tile_tuple(name);
-    tile_tuple->fixed_tile().set_unfilter_data_compute_task(task);
-
-    if (var_size && !validity_only) {
-      tile_tuple->var_tile().set_unfilter_data_compute_task(task);
-    }
-
-    if (nullable) {
-      tile_tuple->validity_tile().set_unfilter_data_compute_task(task);
-    }
+  // Perform required post-processing of unfiltered tiles
+  for (size_t i = 0; i < num_tiles; i++) {
+    RETURN_NOT_OK(post_process_unfiltered_tile(
+        name, validity_only, result_tiles[i], var_size, nullable));
   }
 
   return Status::Ok();

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -964,7 +964,8 @@ Status ReaderBase::unfilter_tiles(
             return st;
           }
 
-          if (tile_size.value() == 0 && tile_validity_size == 0) {
+          if (tile_size.value_or(0) == 0 && tile_var_size.value_or(0) == 0 &&
+              tile_validity_size.value_or(0) == 0) {
             return Status::Ok();
           }
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -994,7 +994,7 @@ Status ReaderBase::unfilter_tiles(
         });
 
     if (skip_field(result_tile->frag_idx(), name)) {
-      task.wait();
+      RETURN_NOT_OK(task.wait());
       continue;
     }
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -872,16 +872,18 @@ Status ReaderBase::post_process_unfiltered_tile(
     return Status::Ok();
   }
 
-  auto& t = tile_tuple->fixed_tile();
-  t.clear_filtered_buffer();
+  if (!validity_only) {
+    auto& t = tile_tuple->fixed_tile();
+    t.clear_filtered_buffer();
 
-  throw_if_not_ok(zip_tile_coordinates(name, &t));
+    throw_if_not_ok(zip_tile_coordinates(name, &t));
 
-  if (var_size && !validity_only) {
-    auto& t_var = tile_tuple->var_tile();
-    t_var.clear_filtered_buffer();
-    throw_if_not_ok(zip_tile_coordinates(name, &t_var));
-    t.add_extra_offset_unsafe(t_var);
+    if (var_size) {
+      auto& t_var = tile_tuple->var_tile();
+      t_var.clear_filtered_buffer();
+      throw_if_not_ok(zip_tile_coordinates(name, &t_var));
+      t.add_extra_offset_unsafe(t_var);
+    }
   }
 
   if (nullable) {
@@ -927,9 +929,9 @@ Status ReaderBase::unfilter_tiles(
 
   for (size_t i = 0; i < num_tiles; i++) {
     auto result_tile = result_tiles[i];
-    if (skip_field(result_tile->frag_idx(), name)) {
-      continue;
-    }
+    // if (skip_field(result_tile->frag_idx(), name)) {
+    //   continue;
+    // }
     ThreadPool::SharedTask task =
         resources_.compute_tp().execute([name,
                                          validity_only,
@@ -958,11 +960,13 @@ Status ReaderBase::unfilter_tiles(
                   tiles_chunk_data,
                   tiles_chunk_var_data,
                   tiles_chunk_validity_data);
-          if (!st.ok())
+          if (!st.ok()) {
             return st;
+          }
 
-          if (tile_size.value() == 0)
+          if (tile_size.value() == 0 && tile_validity_size == 0) {
             return Status::Ok();
+          }
 
           for (uint64_t range_thread_idx = 0;
                range_thread_idx < num_range_threads;
@@ -992,12 +996,11 @@ Status ReaderBase::unfilter_tiles(
       task.wait();
       continue;
     }
-    // Store as a shared_ptr so we can move lifetimes around
-    // This should be changes once we use taskgraphs for modeling the data flow
+
     auto tile_tuple = result_tile->tile_tuple(name);
     tile_tuple->fixed_tile().set_unfilter_data_compute_task(task);
 
-    if (var_size) {
+    if (var_size && !validity_only) {
       tile_tuple->var_tile().set_unfilter_data_compute_task(task);
     }
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -649,7 +649,7 @@ Status ReaderBase::read_and_unfilter_attribute_tiles(
   // eventually get rid of it altogether so that we can clarify the data flow.
   // At the end of this function call, all memory inside of 'filtered_data' has
   // been used and the tiles are unfiltered so the data can be deleted.
-  auto filtered_data{read_attribute_tiles(names, result_tiles)};
+  read_attribute_tiles(names, result_tiles);
   for (auto& name : names) {
     RETURN_NOT_OK(
         unfilter_tiles(name.name(), name.validity_only(), result_tiles));
@@ -663,7 +663,7 @@ Status ReaderBase::read_and_unfilter_coordinate_tiles(
     const std::vector<ResultTile*>& result_tiles) {
   // See the comment in 'read_and_unfilter_attribute_tiles' to get more
   // information about the lifetime of this object.
-  auto filtered_data{read_coordinate_tiles(names, result_tiles)};
+  read_coordinate_tiles(names, result_tiles);
   for (auto& name : names) {
     RETURN_NOT_OK(unfilter_tiles(name, false, result_tiles));
   }
@@ -671,29 +671,29 @@ Status ReaderBase::read_and_unfilter_coordinate_tiles(
   return Status::Ok();
 }
 
-std::list<FilteredData> ReaderBase::read_attribute_tiles(
+void ReaderBase::read_attribute_tiles(
     const std::vector<NameToLoad>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_attribute_tiles");
   return read_tiles(names, result_tiles);
 }
 
-std::list<FilteredData> ReaderBase::read_coordinate_tiles(
+void ReaderBase::read_coordinate_tiles(
     const std::vector<std::string>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_coordinate_tiles");
   return read_tiles(NameToLoad::from_string_vec(names), result_tiles);
 }
 
-std::list<FilteredData> ReaderBase::read_tiles(
+void ReaderBase::read_tiles(
     const std::vector<NameToLoad>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_tiles");
-  std::list<FilteredData> filtered_data;
+  //  std::list<FilteredData> filtered_data;
 
   // Shortcut for empty tile vec.
   if (result_tiles.empty() || names.empty()) {
-    return filtered_data;
+    return;
   }
 
   uint64_t num_tiles_read{0};
@@ -708,7 +708,8 @@ std::list<FilteredData> ReaderBase::read_tiles(
     // read and memory allocations.
     const bool var_sized{array_schema_.var_size(name)};
     const bool nullable{array_schema_.is_nullable(name)};
-    filtered_data.emplace_back(
+    shared_ptr<FilteredData> filtered_data = make_shared<FilteredData>(
+        HERE(),
         resources_,
         *this,
         min_batch_size_,
@@ -750,13 +751,11 @@ std::list<FilteredData> ReaderBase::read_tiles(
       std::tuple<void*, ThreadPool::SharedTask> n = {
           nullptr, ThreadPool::SharedTask()};
       ResultTile::TileData tile_data{
-          val_only ?
-              n :
-              filtered_data.back().fixed_filtered_data(fragment.get(), tile),
-          val_only ?
-              n :
-              filtered_data.back().var_filtered_data(fragment.get(), tile),
-          filtered_data.back().nullable_filtered_data(fragment.get(), tile)};
+          val_only ? n :
+                     filtered_data->fixed_filtered_data(fragment.get(), tile),
+          val_only ? n : filtered_data->var_filtered_data(fragment.get(), tile),
+          filtered_data->nullable_filtered_data(fragment.get(), tile),
+          filtered_data};
 
       // Initialize the tile(s)
       const format_version_t format_version{fragment->format_version()};
@@ -779,7 +778,7 @@ std::list<FilteredData> ReaderBase::read_tiles(
 
   stats_->add_counter("num_tiles_read", num_tiles_read);
 
-  return filtered_data;
+  return;
 }
 
 tuple<Status, optional<uint64_t>, optional<uint64_t>, optional<uint64_t>>

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -689,7 +689,6 @@ void ReaderBase::read_tiles(
     const std::vector<NameToLoad>& names,
     const std::vector<ResultTile*>& result_tiles) const {
   auto timer_se = stats_->start_timer("read_tiles");
-  //  std::list<FilteredData> filtered_data;
 
   // Shortcut for empty tile vec.
   if (result_tiles.empty() || names.empty()) {
@@ -925,62 +924,70 @@ Status ReaderBase::unfilter_tiles(
     num_range_threads = 1 + ((num_threads - 1) / num_tiles);
   }
 
-  // Vectors with all the necessary chunk data for unfiltering
-  std::vector<ChunkData> tiles_chunk_data(num_tiles);
-  std::vector<ChunkData> tiles_chunk_var_data(num_tiles);
-  std::vector<ChunkData> tiles_chunk_validity_data(num_tiles);
-  // Vectors with the sizes of all unfiltered tile buffers
-  std::vector<uint64_t> unfiltered_tile_size(num_tiles);
-  std::vector<uint64_t> unfiltered_tile_var_size(num_tiles);
-  std::vector<uint64_t> unfiltered_tile_validity_size(num_tiles);
-
   for (size_t i = 0; i < num_tiles; i++) {
-    ThreadPool::SharedTask task = resources_.compute_tp().execute([&, this]() {
-      auto&& [st, tile_size, tile_var_size, tile_validity_size] =
-          load_tile_chunk_data(
-              name,
-              validity_only,
-              result_tiles[i],
-              var_size,
-              nullable,
-              tiles_chunk_data[i],
-              tiles_chunk_var_data[i],
-              tiles_chunk_validity_data[i]);
-      throw_if_not_ok(st);
-      unfiltered_tile_size[i] = tile_size.value();
-      unfiltered_tile_var_size[i] = tile_var_size.value();
-      unfiltered_tile_validity_size[i] = tile_validity_size.value();
+    auto result_tile = result_tiles[i];
+    if (skip_field(result_tile->frag_idx(), name)) {
+      continue;
+    }
+    ThreadPool::SharedTask task =
+        resources_.compute_tp().execute([name,
+                                         validity_only,
+                                         var_size,
+                                         nullable,
+                                         num_range_threads,
+                                         result_tile,
+                                         this]() {
+          // Chunks for unfiltering
+          ChunkData tiles_chunk_data;
+          ChunkData tiles_chunk_var_data;
+          ChunkData tiles_chunk_validity_data;
+          auto&& [st, tile_size, tile_var_size, tile_validity_size] =
+              load_tile_chunk_data(
+                  name,
+                  validity_only,
+                  result_tile,
+                  var_size,
+                  nullable,
+                  tiles_chunk_data,
+                  tiles_chunk_var_data,
+                  tiles_chunk_validity_data);
+          if (!st.ok())
+            return st;
 
-      if (tile_size.value() == 0)
-        return Status::Ok();
+          if (tile_size.value() == 0)
+            return Status::Ok();
 
-      for (uint64_t range_thread_idx = 0; range_thread_idx < num_threads;
-           range_thread_idx++) {
-        throw_if_not_ok(unfilter_tile(
-            name,
-            validity_only,
-            result_tiles[i],
-            var_size,
-            nullable,
-            range_thread_idx,
-            num_range_threads,
-            tiles_chunk_data[i],
-            tiles_chunk_var_data[i],
-            tiles_chunk_validity_data[i]));
-      }
+          for (uint64_t range_thread_idx = 0;
+               range_thread_idx < num_range_threads;
+               range_thread_idx++) {
+            st = unfilter_tile(
+                name,
+                validity_only,
+                result_tile,
+                var_size,
+                nullable,
+                range_thread_idx,
+                num_range_threads,
+                tiles_chunk_data,
+                tiles_chunk_var_data,
+                tiles_chunk_validity_data);
+            if (!st.ok()) {
+              return st;
+            }
+          }
 
-      // Perform required post-processing of unfiltered tiles
-      throw_if_not_ok(post_process_unfiltered_tile(
-          name, validity_only, result_tiles[i], var_size, nullable));
-      return Status ::Ok();
-    });
-    if (skip_field(result_tiles[i]->frag_idx(), name)) {
+          // Perform required post-processing of unfiltered tiles
+          return post_process_unfiltered_tile(
+              name, validity_only, result_tile, var_size, nullable);
+        });
+
+    if (skip_field(result_tile->frag_idx(), name)) {
       task.wait();
       continue;
     }
     // Store as a shared_ptr so we can move lifetimes around
     // This should be changes once we use taskgraphs for modeling the data flow
-    auto tile_tuple = result_tiles[i]->tile_tuple(name);
+    auto tile_tuple = result_tile->tile_tuple(name);
     tile_tuple->fixed_tile().set_unfilter_data_compute_task(task);
 
     if (var_size) {

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -553,7 +553,7 @@ class ReaderBase : public StrategyBase {
    *     `ResultTile` instances in this vector.
    * @return Filtered data blocks.
    */
-  std::list<FilteredData> read_attribute_tiles(
+  void read_attribute_tiles(
       const std::vector<NameToLoad>& names,
       const std::vector<ResultTile*>& result_tiles) const;
 
@@ -569,7 +569,7 @@ class ReaderBase : public StrategyBase {
    *     `ResultTile` instances in this vector.
    * @return Filtered data blocks.
    */
-  std::list<FilteredData> read_coordinate_tiles(
+  void read_coordinate_tiles(
       const std::vector<std::string>& names,
       const std::vector<ResultTile*>& result_tiles) const;
 
@@ -586,7 +586,7 @@ class ReaderBase : public StrategyBase {
    * @param validity_only Is the field read for validity only.
    * @return Filtered data blocks.
    */
-  std::list<FilteredData> read_tiles(
+  void read_tiles(
       const std::vector<NameToLoad>& names,
       const std::vector<ResultTile*>& result_tiles) const;
 

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -543,7 +543,8 @@ class ReaderBase : public StrategyBase {
 
   /**
    * Concurrently executes across each name in `names` and each result tile
-   * in 'result_tiles'.
+   * in 'result_tiles'. Attaches a future to each result_tile that is signaling
+   * when reading the corresponding data from disk is done.
    *
    * This must be the entry point for reading attribute tiles because it
    * generates stats for reading attributes.
@@ -553,13 +554,14 @@ class ReaderBase : public StrategyBase {
    *     `ResultTile` instances in this vector.
    * @return Filtered data blocks.
    */
-  void read_attribute_tiles(
+  std::list<FilteredData> read_attribute_tiles(
       const std::vector<NameToLoad>& names,
       const std::vector<ResultTile*>& result_tiles) const;
 
   /**
    * Concurrently executes across each name in `names` and each result tile
-   * in 'result_tiles'.
+   * in 'result_tiles'. Attaches a future to each result_tile that is signaling
+   * when reading the corresponding data from disk is done.
    *
    * This must be the entry point for reading coordinate tiles because it
    * generates stats for reading coordinates.
@@ -569,7 +571,7 @@ class ReaderBase : public StrategyBase {
    *     `ResultTile` instances in this vector.
    * @return Filtered data blocks.
    */
-  void read_coordinate_tiles(
+  std::list<FilteredData> read_coordinate_tiles(
       const std::vector<std::string>& names,
       const std::vector<ResultTile*>& result_tiles) const;
 
@@ -578,7 +580,8 @@ class ReaderBase : public StrategyBase {
    * in the appropriate result tile.
    *
    * Concurrently executes across each name in `names` and each result tile
-   * in 'result_tiles'.
+   * in 'result_tiles'. Attaches a future to each result_tile that is signaling
+   * when reading the corresponding data from disk is done.
    *
    * @param names The field names.
    * @param result_tiles The retrieved tiles will be stored inside the
@@ -586,7 +589,7 @@ class ReaderBase : public StrategyBase {
    * @param validity_only Is the field read for validity only.
    * @return Filtered data blocks.
    */
-  void read_tiles(
+  std::list<FilteredData> read_tiles(
       const std::vector<NameToLoad>& names,
       const std::vector<ResultTile*>& result_tiles) const;
 

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -93,14 +93,14 @@ ResultTile::ResultTile(
 
 ResultTile::~ResultTile() {
   try {
-    // Wait for all tasks to be done
-    wait_all_attrs();
+    // Wait for all attribute tasks to be done
+    wait_all_tiles(attr_tiles_);
   } catch (...) {
   }
 
   try {
-    // Wait for all tasks to be done
-    wait_all_coords();
+    // Wait for all coordinates tasks to be done
+    wait_all_tiles(coord_tiles_);
   } catch (...) {
   }
 }
@@ -275,23 +275,10 @@ ResultTile::TileTuple* ResultTile::tile_tuple(const std::string& name) {
   return nullptr;
 }
 
-void ResultTile::wait_all_coords() const {
-  for (auto& at : coord_tiles_) {
-    auto& tile_tuple = at.second;
-    if (tile_tuple.has_value()) {
-      tile_tuple.value().fixed_tile().data();
-      if (tile_tuple.value().var_tile_opt().has_value()) {
-        tile_tuple.value().var_tile_opt().value().data();
-      }
-      if (tile_tuple.value().validity_tile_opt().has_value()) {
-        tile_tuple.value().validity_tile_opt().value().data();
-      }
-    }
-  }
-}
-
-void ResultTile::wait_all_attrs() const {
-  for (auto& at : attr_tiles_) {
+void ResultTile::wait_all_tiles(
+    const std::vector<std::pair<std::string, optional<TileTuple>>>& tiles)
+    const {
+  for (auto& at : tiles) {
     const auto& tile_tuple = at.second;
     if (tile_tuple.has_value()) {
       tile_tuple.value().fixed_tile().data();

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -261,6 +261,12 @@ ResultTile::TileTuple* ResultTile::tile_tuple(const std::string& name) {
   return nullptr;
 }
 
+void ResultTile::wait_all_coords() const {
+  for (auto& coord_tile : coord_tiles_) {
+    coord_tile.second->fixed_tile().data_as<char>();
+  }
+}
+
 const void* ResultTile::unzipped_coord(uint64_t pos, unsigned dim_idx) const {
   const auto& coord_tile = coord_tiles_[dim_idx].second->fixed_tile();
   const uint64_t offset = pos * coord_tile.cell_size();

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -84,11 +84,6 @@ ResultTile::ResultTile(
     auto attribute = array_schema->attribute(i);
     attr_tiles_[i] = std::make_pair(attribute->name(), nullopt);
   }
-  for (uint64_t i = 0; i < array_schema->dim_num(); i++) {
-    auto dimension = array_schema->dimension_ptr(i);
-    coord_tiles_[i] = std::make_pair(dimension->name(), nullopt);
-  }
-
   set_compute_results_func();
 
   // Default `coord_func_` to fetch from `coord_tile_` until at least

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -84,6 +84,11 @@ ResultTile::ResultTile(
     auto attribute = array_schema->attribute(i);
     attr_tiles_[i] = std::make_pair(attribute->name(), nullopt);
   }
+  for (uint64_t i = 0; i < array_schema->dim_num(); i++) {
+    auto dimension = array_schema->dimension_ptr(i);
+    coord_tiles_[i] = std::make_pair(dimension->name(), nullopt);
+  }
+
   set_compute_results_func();
 
   // Default `coord_func_` to fetch from `coord_tile_` until at least

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -394,7 +394,11 @@ Status ResultTile::read(
   if ((!is_dim && name != constants::coords && !use_fragment_ts) ||
       (is_dim && !coord_tiles_[0].first.empty()) ||
       (name == constants::coords && coords_tile_.has_value())) {
-    const auto& tile = this->tile_tuple(name)->fixed_tile();
+    auto tile_tuple = this->tile_tuple(name);
+    if (tile_tuple == nullptr) {
+      return Status::Ok();
+    }
+    const auto& tile = tile_tuple->fixed_tile();
     auto cell_size = tile.cell_size();
     auto nbytes = len * cell_size;
     auto offset = pos * cell_size;

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -95,9 +95,13 @@ ResultTile::~ResultTile() {
   try {
     // Wait for all tasks to be done
     wait_all_attrs();
+  } catch (...) {
+  }
+
+  try {
+    // Wait for all tasks to be done
     wait_all_coords();
   } catch (...) {
-    return;
   }
 }
 

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -754,11 +754,10 @@ class ResultTile {
       const uint64_t min_cell,
       const uint64_t max_cell) const;
 
-  /* Waits for all coord tiles results to be available */
-  void wait_all_coords() const;
-
-  /* Waits for all attr tiles results to be available */
-  void wait_all_attrs() const;
+  /* Waits for all tiles results to be available */
+  void wait_all_tiles(
+      const std::vector<std::pair<std::string, optional<TileTuple>>>& tiles)
+      const;
 
  protected:
   /* ********************************* */

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -408,6 +408,16 @@ class ResultTile {
       return validity_tile_.value();
     }
 
+    /** @returns Var tile. */
+    const std::optional<Tile>& var_tile_opt() const {
+      return var_tile_;
+    }
+
+    /** @returns Validity tile. */
+    const std::optional<Tile>& validity_tile_opt() const {
+      return validity_tile_;
+    }
+
     /** @returns Fixed tile. */
     const Tile& fixed_tile() const {
       return fixed_tile_;
@@ -469,7 +479,7 @@ class ResultTile {
   DISABLE_MOVE_AND_MOVE_ASSIGN(ResultTile);
 
   /** Default destructor. */
-  ~ResultTile() = default;
+  virtual ~ResultTile();
 
   /* ********************************* */
   /*                API                */
@@ -757,6 +767,9 @@ class ResultTile {
 
   /* Waits for all coord tiles results to be available */
   void wait_all_coords() const;
+
+  /* Waits for all attr tiles results to be available */
+  void wait_all_attrs() const;
 
  protected:
   /* ********************************* */

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -225,9 +225,11 @@ class ResultTile {
     /*     CONSTRUCTORS & DESTRUCTORS    */
     /* ********************************* */
     TileData(
-        std::tuple<void*, shared_ptr<ThreadPool::Task>> fixed_filtered_data,
-        std::tuple<void*, shared_ptr<ThreadPool::Task>> var_filtered_data,
-        std::tuple<void*, shared_ptr<ThreadPool::Task>> validity_filtered_data)
+        std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
+            fixed_filtered_data,
+        std::tuple<void*, shared_ptr<ThreadPool::SharedTask>> var_filtered_data,
+        std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
+            validity_filtered_data)
         : fixed_filtered_data_(std::get<0>(fixed_filtered_data))
         , var_filtered_data_(std::get<0>(var_filtered_data))
         , validity_filtered_data_(std::get<0>(validity_filtered_data))
@@ -256,17 +258,18 @@ class ResultTile {
     }
 
     /** @return The fixed filtered data I/O task. */
-    inline shared_ptr<ThreadPool::Task> fixed_filtered_data_task() const {
+    inline shared_ptr<ThreadPool::SharedTask> fixed_filtered_data_task() const {
       return fixed_filtered_data_task_;
     }
 
     /** @return The var filtered data I/O task. */
-    inline shared_ptr<ThreadPool::Task> var_filtered_data_task() const {
+    inline shared_ptr<ThreadPool::SharedTask> var_filtered_data_task() const {
       return var_filtered_data_task_;
     }
 
     /** @return The validity filtered data I/O task. */
-    inline shared_ptr<ThreadPool::Task> validity_filtered_data_task() const {
+    inline shared_ptr<ThreadPool::SharedTask> validity_filtered_data_task()
+        const {
       return validity_filtered_data_task_;
     }
 
@@ -285,13 +288,13 @@ class ResultTile {
     void* validity_filtered_data_;
 
     /** Stores the fixed filtered data I/O task. */
-    shared_ptr<ThreadPool::Task> fixed_filtered_data_task_;
+    shared_ptr<ThreadPool::SharedTask> fixed_filtered_data_task_;
 
     /** Stores the var filtered data I/O task. */
-    shared_ptr<ThreadPool::Task> var_filtered_data_task_;
+    shared_ptr<ThreadPool::SharedTask> var_filtered_data_task_;
 
     /** Stores the validity filtered data I/O task. */
-    shared_ptr<ThreadPool::Task> validity_filtered_data_task_;
+    shared_ptr<ThreadPool::SharedTask> validity_filtered_data_task_;
   };
 
   /**

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -755,6 +755,9 @@ class ResultTile {
       const uint64_t min_cell,
       const uint64_t max_cell) const;
 
+  /* Waits for all coord tiles results to be available */
+  void wait_all_coords() const;
+
  protected:
   /* ********************************* */
   /*        PROTECTED ATTRIBUTES       */

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -478,7 +478,7 @@ class ResultTile {
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTile);
   DISABLE_MOVE_AND_MOVE_ASSIGN(ResultTile);
 
-  /** Default destructor. */
+  /** Destructor needs to be virtual, this is a base class. */
   virtual ~ResultTile();
 
   /* ********************************* */
@@ -942,6 +942,9 @@ class ResultTileWithBitmap : public ResultTile {
 
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTileWithBitmap);
   DISABLE_MOVE_AND_MOVE_ASSIGN(ResultTileWithBitmap);
+
+  /** Default destructor needs to be virtual, this is a base class. */
+  virtual ~ResultTileWithBitmap() = default;
 
  public:
   /* ********************************* */

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -239,6 +239,21 @@ class ResultTile {
         , filtered_data_(std::move(filtered_data)) {
     }
 
+    ~TileData() {
+      // TODO: destructor should not throw, catch any exceptions
+      if (fixed_filtered_data_task_.valid()) {
+        fixed_filtered_data_task_.get();
+      }
+
+      if (var_filtered_data_task_.valid()) {
+        var_filtered_data_task_.get();
+      }
+
+      if (validity_filtered_data_task_.valid()) {
+        validity_filtered_data_task_.get();
+      }
+    }
+
     /* ********************************* */
     /*                API                */
     /* ********************************* */

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -64,6 +64,7 @@ class Domain;
 class FragmentMetadata;
 class QueryCondition;
 class Subarray;
+class FilteredData;
 
 /**
  * Utilitary function to sort result tiles by fragment first then tile index.
@@ -227,13 +228,15 @@ class ResultTile {
     TileData(
         std::tuple<void*, ThreadPool::SharedTask> fixed_filtered_data,
         std::tuple<void*, ThreadPool::SharedTask> var_filtered_data,
-        std::tuple<void*, ThreadPool::SharedTask> validity_filtered_data)
+        std::tuple<void*, ThreadPool::SharedTask> validity_filtered_data,
+        shared_ptr<FilteredData> filtered_data)
         : fixed_filtered_data_(std::get<0>(fixed_filtered_data))
         , var_filtered_data_(std::get<0>(var_filtered_data))
         , validity_filtered_data_(std::get<0>(validity_filtered_data))
         , fixed_filtered_data_task_(std::get<1>(fixed_filtered_data))
         , var_filtered_data_task_(std::get<1>(var_filtered_data))
-        , validity_filtered_data_task_(std::get<1>(validity_filtered_data)) {
+        , validity_filtered_data_task_(std::get<1>(validity_filtered_data))
+        , filtered_data_(std::move(filtered_data)) {
     }
 
     /* ********************************* */
@@ -270,6 +273,16 @@ class ResultTile {
       return validity_filtered_data_task_;
     }
 
+    /** @return shared_ptr to FilteredData block used by this Tile. */
+    inline shared_ptr<FilteredData> filtered_data() const {
+      return filtered_data_;
+    }
+
+    /** Clear the held filtered data. */
+    inline void clear_filtered_data() {
+      filtered_data_ = nullptr;
+    }
+
    private:
     /* ********************************* */
     /*        PRIVATE ATTRIBUTES         */
@@ -292,6 +305,9 @@ class ResultTile {
 
     /** Stores the validity filtered data I/O task. */
     ThreadPool::SharedTask validity_filtered_data_task_;
+
+    /** Pointer to hold the filtered data block as long as needed. */
+    shared_ptr<FilteredData> filtered_data_;
   };
 
   /**
@@ -326,7 +342,8 @@ class ResultTile {
               tile_data.fixed_filtered_data(),
               tile_sizes.tile_persisted_size(),
               memory_tracker_,
-              tile_data.fixed_filtered_data_task()) {
+              tile_data.fixed_filtered_data_task(),
+              tile_data.filtered_data()) {
       if (tile_sizes.has_var_tile()) {
         auto type = array_schema.type(name);
         var_tile_.emplace(
@@ -338,7 +355,8 @@ class ResultTile {
             tile_data.var_filtered_data(),
             tile_sizes.tile_var_persisted_size(),
             memory_tracker_,
-            tile_data.var_filtered_data_task());
+            tile_data.var_filtered_data_task(),
+            tile_data.filtered_data());
       }
 
       if (tile_sizes.has_validity_tile()) {
@@ -351,7 +369,8 @@ class ResultTile {
             tile_data.validity_filtered_data(),
             tile_sizes.tile_validity_persisted_size(),
             memory_tracker_,
-            tile_data.validity_filtered_data_task());
+            tile_data.validity_filtered_data_task(),
+            tile_data.filtered_data());
       }
     }
 

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -225,11 +225,9 @@ class ResultTile {
     /*     CONSTRUCTORS & DESTRUCTORS    */
     /* ********************************* */
     TileData(
-        std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
-            fixed_filtered_data,
-        std::tuple<void*, shared_ptr<ThreadPool::SharedTask>> var_filtered_data,
-        std::tuple<void*, shared_ptr<ThreadPool::SharedTask>>
-            validity_filtered_data)
+        std::tuple<void*, ThreadPool::SharedTask> fixed_filtered_data,
+        std::tuple<void*, ThreadPool::SharedTask> var_filtered_data,
+        std::tuple<void*, ThreadPool::SharedTask> validity_filtered_data)
         : fixed_filtered_data_(std::get<0>(fixed_filtered_data))
         , var_filtered_data_(std::get<0>(var_filtered_data))
         , validity_filtered_data_(std::get<0>(validity_filtered_data))
@@ -258,18 +256,17 @@ class ResultTile {
     }
 
     /** @return The fixed filtered data I/O task. */
-    inline shared_ptr<ThreadPool::SharedTask> fixed_filtered_data_task() const {
+    inline ThreadPool::SharedTask fixed_filtered_data_task() const {
       return fixed_filtered_data_task_;
     }
 
     /** @return The var filtered data I/O task. */
-    inline shared_ptr<ThreadPool::SharedTask> var_filtered_data_task() const {
+    inline ThreadPool::SharedTask var_filtered_data_task() const {
       return var_filtered_data_task_;
     }
 
     /** @return The validity filtered data I/O task. */
-    inline shared_ptr<ThreadPool::SharedTask> validity_filtered_data_task()
-        const {
+    inline ThreadPool::SharedTask validity_filtered_data_task() const {
       return validity_filtered_data_task_;
     }
 
@@ -288,13 +285,13 @@ class ResultTile {
     void* validity_filtered_data_;
 
     /** Stores the fixed filtered data I/O task. */
-    shared_ptr<ThreadPool::SharedTask> fixed_filtered_data_task_;
+    ThreadPool::SharedTask fixed_filtered_data_task_;
 
     /** Stores the var filtered data I/O task. */
-    shared_ptr<ThreadPool::SharedTask> var_filtered_data_task_;
+    ThreadPool::SharedTask var_filtered_data_task_;
 
     /** Stores the validity filtered data I/O task. */
-    shared_ptr<ThreadPool::SharedTask> validity_filtered_data_task_;
+    ThreadPool::SharedTask validity_filtered_data_task_;
   };
 
   /**

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -240,17 +240,20 @@ class ResultTile {
     }
 
     ~TileData() {
-      // TODO: destructor should not throw, catch any exceptions
-      if (fixed_filtered_data_task_.valid()) {
-        auto st = fixed_filtered_data_task_.wait();
-      }
+      try {
+        if (fixed_filtered_data_task_.valid()) {
+          auto st = fixed_filtered_data_task_.wait();
+        }
 
-      if (var_filtered_data_task_.valid()) {
-        auto st = var_filtered_data_task_.wait();
-      }
+        if (var_filtered_data_task_.valid()) {
+          auto st = var_filtered_data_task_.wait();
+        }
 
-      if (validity_filtered_data_task_.valid()) {
-        auto st = validity_filtered_data_task_.wait();
+        if (validity_filtered_data_task_.valid()) {
+          auto st = validity_filtered_data_task_.wait();
+        }
+      } catch (...) {
+        return;
       }
     }
 

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -225,12 +225,15 @@ class ResultTile {
     /*     CONSTRUCTORS & DESTRUCTORS    */
     /* ********************************* */
     TileData(
-        void* fixed_filtered_data,
-        void* var_filtered_data,
-        void* validity_filtered_data)
-        : fixed_filtered_data_(fixed_filtered_data)
-        , var_filtered_data_(var_filtered_data)
-        , validity_filtered_data_(validity_filtered_data) {
+        std::tuple<void*, shared_ptr<ThreadPool::Task>> fixed_filtered_data,
+        std::tuple<void*, shared_ptr<ThreadPool::Task>> var_filtered_data,
+        std::tuple<void*, shared_ptr<ThreadPool::Task>> validity_filtered_data)
+        : fixed_filtered_data_(std::get<0>(fixed_filtered_data))
+        , var_filtered_data_(std::get<0>(var_filtered_data))
+        , validity_filtered_data_(std::get<0>(validity_filtered_data))
+        , fixed_filtered_data_task_(std::get<1>(fixed_filtered_data))
+        , var_filtered_data_task_(std::get<1>(var_filtered_data))
+        , validity_filtered_data_task_(std::get<1>(validity_filtered_data)) {
     }
 
     /* ********************************* */
@@ -252,6 +255,21 @@ class ResultTile {
       return validity_filtered_data_;
     }
 
+    /** @return The fixed filtered data I/O task. */
+    inline shared_ptr<ThreadPool::Task> fixed_filtered_data_task() const {
+      return fixed_filtered_data_task_;
+    }
+
+    /** @return The var filtered data I/O task. */
+    inline shared_ptr<ThreadPool::Task> var_filtered_data_task() const {
+      return var_filtered_data_task_;
+    }
+
+    /** @return The validity filtered data I/O task. */
+    inline shared_ptr<ThreadPool::Task> validity_filtered_data_task() const {
+      return validity_filtered_data_task_;
+    }
+
    private:
     /* ********************************* */
     /*        PRIVATE ATTRIBUTES         */
@@ -265,6 +283,15 @@ class ResultTile {
 
     /** Stores the validity filtered data pointer. */
     void* validity_filtered_data_;
+
+    /** Stores the fixed filtered data I/O task. */
+    shared_ptr<ThreadPool::Task> fixed_filtered_data_task_;
+
+    /** Stores the var filtered data I/O task. */
+    shared_ptr<ThreadPool::Task> var_filtered_data_task_;
+
+    /** Stores the validity filtered data I/O task. */
+    shared_ptr<ThreadPool::Task> validity_filtered_data_task_;
   };
 
   /**
@@ -298,7 +325,8 @@ class ResultTile {
               tile_sizes.tile_size(),
               tile_data.fixed_filtered_data(),
               tile_sizes.tile_persisted_size(),
-              memory_tracker_) {
+              memory_tracker_,
+              tile_data.fixed_filtered_data_task()) {
       if (tile_sizes.has_var_tile()) {
         auto type = array_schema.type(name);
         var_tile_.emplace(
@@ -309,7 +337,8 @@ class ResultTile {
             tile_sizes.tile_var_size(),
             tile_data.var_filtered_data(),
             tile_sizes.tile_var_persisted_size(),
-            memory_tracker_);
+            memory_tracker_,
+            tile_data.var_filtered_data_task());
       }
 
       if (tile_sizes.has_validity_tile()) {
@@ -321,7 +350,8 @@ class ResultTile {
             tile_sizes.tile_validity_size(),
             tile_data.validity_filtered_data(),
             tile_sizes.tile_validity_persisted_size(),
-            memory_tracker_);
+            memory_tracker_,
+            tile_data.validity_filtered_data_task());
       }
     }
 

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -242,15 +242,15 @@ class ResultTile {
     ~TileData() {
       // TODO: destructor should not throw, catch any exceptions
       if (fixed_filtered_data_task_.valid()) {
-        fixed_filtered_data_task_.get();
+        auto st = fixed_filtered_data_task_.wait();
       }
 
       if (var_filtered_data_task_.valid()) {
-        var_filtered_data_task_.get();
+        auto st = var_filtered_data_task_.wait();
       }
 
       if (validity_filtered_data_task_.valid()) {
-        validity_filtered_data_task_.get();
+        auto st = validity_filtered_data_task_.wait();
       }
     }
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1545,6 +1545,12 @@ AddNextCellResult SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
         }
       }
     }
+    
+    // This enforces all the coords unfiltering results to be available before
+    // taking the lock on tile_queue_mutex_. This is to avoid a deadlock where a
+    // lock is held forever while waiting for a result to be available, while
+    // the next scheduled task is deadlocking on that lock
+    rc.tile_->wait_all_coords();
 
     std::unique_lock<std::mutex> ul(tile_queue_mutex_);
 

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1545,7 +1545,6 @@ AddNextCellResult SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
         }
       }
     }
-    
     std::unique_lock<std::mutex> ul(tile_queue_mutex_);
 
     // Add all the cells in this tile with the same coordinates as this cell

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1546,12 +1546,6 @@ AddNextCellResult SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
       }
     }
     
-    // This enforces all the coords unfiltering results to be available before
-    // taking the lock on tile_queue_mutex_. This is to avoid a deadlock where a
-    // lock is held forever while waiting for a result to be available, while
-    // the next scheduled task is deadlocking on that lock
-    rc.tile_->wait_all_coords();
-
     std::unique_lock<std::mutex> ul(tile_queue_mutex_);
 
     // Add all the cells in this tile with the same coordinates as this cell

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1628,7 +1628,8 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1687,7 +1688,8 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1803,7 +1805,8 @@ TEST_CASE(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, *frag_md[0], memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2345,7 +2348,8 @@ void test_apply_dense<char*>(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2404,7 +2408,8 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2519,7 +2524,8 @@ TEST_CASE(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3054,7 +3060,8 @@ void test_apply_sparse<char*>(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3113,7 +3120,8 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3892,7 +3900,8 @@ TEST_CASE(
       std::nullopt,
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4184,7 +4193,8 @@ TEST_CASE(
       std::nullopt,
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4602,7 +4612,8 @@ TEST_CASE(
       std::nullopt,
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4867,7 +4878,8 @@ TEST_CASE(
       cells * constants::cell_validity_size,
       0);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4973,7 +4985,8 @@ TEST_CASE(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
+  ResultTile::TileData tile_data{
+      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1629,7 +1629,9 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1689,7 +1691,9 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1806,7 +1810,9 @@ TEST_CASE(
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, *frag_md[0], memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2349,7 +2355,9 @@ void test_apply_dense<char*>(
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2409,7 +2417,9 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2525,7 +2535,9 @@ TEST_CASE(
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3061,7 +3073,9 @@ void test_apply_sparse<char*>(
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3121,7 +3135,9 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3901,7 +3917,9 @@ TEST_CASE(
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4194,7 +4212,9 @@ TEST_CASE(
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4613,7 +4633,9 @@ TEST_CASE(
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4879,7 +4901,9 @@ TEST_CASE(
       0);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4986,7 +5010,9 @@ TEST_CASE(
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
   ResultTile::TileData tile_data{
-      {nullptr, nullptr}, {nullptr, nullptr}, {nullptr, nullptr}};
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()},
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1631,8 +1631,7 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1694,8 +1693,7 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1814,8 +1812,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2360,8 +2357,7 @@ void test_apply_dense<char*>(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2423,8 +2419,7 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2542,8 +2537,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3081,8 +3075,7 @@ void test_apply_sparse<char*>(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3144,8 +3137,7 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3927,8 +3919,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4223,8 +4214,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4645,8 +4635,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4914,8 +4903,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -5024,8 +5012,7 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      nullptr};
+      {nullptr, ThreadPool::SharedTask()}};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1631,7 +1631,8 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1693,7 +1694,8 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1812,7 +1814,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2357,7 +2360,8 @@ void test_apply_dense<char*>(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2419,7 +2423,8 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2537,7 +2542,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3075,7 +3081,8 @@ void test_apply_sparse<char*>(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3137,7 +3144,8 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3919,7 +3927,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4214,7 +4223,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4635,7 +4645,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4903,7 +4914,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -5012,7 +5024,8 @@ TEST_CASE(
   ResultTile::TileData tile_data{
       {nullptr, ThreadPool::SharedTask()},
       {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+      {nullptr, ThreadPool::SharedTask()},
+      nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,

--- a/tiledb/sm/tile/CMakeLists.txt
+++ b/tiledb/sm/tile/CMakeLists.txt
@@ -32,7 +32,7 @@ include(object_library)
 #
 commence(object_library tile)
   this_target_sources(tile.cc)
-  this_target_object_libraries(baseline buffer constants)
+  this_target_object_libraries(baseline buffer constants thread_pool)
 conclude(object_library)
 
 #

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -120,7 +120,8 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       header.tile_size,
       filtered_data.data(),
       header.persisted_size,
-      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO));
+      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
+      nullptr);
 
   // Read the tile.
   throw_if_not_ok(resources_.vfs().read(

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -121,7 +121,8 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       filtered_data.data(),
       header.persisted_size,
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
-      ThreadPool::SharedTask());
+      ThreadPool::SharedTask(),
+      nullptr);
 
   // Read the tile.
   throw_if_not_ok(resources_.vfs().read(

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -122,7 +122,7 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       header.persisted_size,
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
       ThreadPool::SharedTask(),
-      nullptr);
+      true);
 
   // Read the tile.
   throw_if_not_ok(resources_.vfs().read(

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -121,7 +121,7 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       filtered_data.data(),
       header.persisted_size,
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
-      nullptr);
+      ThreadPool::SharedTask());
 
   // Read the tile.
   throw_if_not_ok(resources_.vfs().read(

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -121,8 +121,7 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       filtered_data.data(),
       header.persisted_size,
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
-      ThreadPool::SharedTask(),
-      true);
+      std::nullopt);
 
   // Read the tile.
   throw_if_not_ok(resources_.vfs().read(

--- a/tiledb/sm/tile/test/CMakeLists.txt
+++ b/tiledb/sm/tile/test/CMakeLists.txt
@@ -31,5 +31,5 @@ commence(unit_test tile)
         main.cc
         unit_tile.cc
     )
-    this_target_object_libraries(tile mem_helpers thread_pool)
+    this_target_object_libraries(tile mem_helpers)
 conclude(unit_test)

--- a/tiledb/sm/tile/test/CMakeLists.txt
+++ b/tiledb/sm/tile/test/CMakeLists.txt
@@ -31,5 +31,5 @@ commence(unit_test tile)
         main.cc
         unit_tile.cc
     )
-    this_target_object_libraries(tile mem_helpers)
+    this_target_object_libraries(tile mem_helpers thread_pool)
 conclude(unit_test)

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -58,7 +58,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       nullptr,
       0,
       tracker,
-      nullptr);
+      ThreadPool::SharedTask());
   CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -58,7 +58,8 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       nullptr,
       0,
       tracker,
-      ThreadPool::SharedTask());
+      ThreadPool::SharedTask(),
+      nullptr);
   CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -57,7 +57,8 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       tile_size,
       nullptr,
       0,
-      tracker);
+      tracker,
+      nullptr);
   CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -58,8 +58,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       nullptr,
       0,
       tracker,
-      ThreadPool::SharedTask(),
-      nullptr);
+      ThreadPool::SharedTask());
   CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -58,7 +58,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       nullptr,
       0,
       tracker,
-      ThreadPool::SharedTask());
+      std::nullopt);
   CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -206,6 +206,7 @@ void TileBase::read(
   if (unfilter_data_compute_task_.valid()) {
     unfilter_data_compute_task_.wait();
     throw_if_not_ok(unfilter_data_compute_task_.get());
+    unfilter_data_compute_task_ = ThreadPool::SharedTask();
   }
 
   if (nbytes > size_ - offset) {
@@ -230,6 +231,7 @@ void Tile::zip_coordinates() {
   if (unfilter_data_compute_task_.valid()) {
     unfilter_data_compute_task_.wait();
     throw_if_not_ok(unfilter_data_compute_task_.get());
+    unfilter_data_compute_task_ = ThreadPool::SharedTask();
   }
 
   // For easy reference
@@ -313,6 +315,7 @@ uint64_t Tile::load_chunk_data(
   if (filtered_data_io_task_.valid()) {
     filtered_data_io_task_.wait();
     throw_if_not_ok(filtered_data_io_task_.get());
+    filtered_data_io_task_ = ThreadPool::SharedTask();
   }
 
   Deserializer deserializer(filtered_data(), filtered_size());

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -136,7 +136,7 @@ Tile::Tile(
     void* filtered_data,
     uint64_t filtered_size,
     shared_ptr<MemoryTracker> memory_tracker,
-    shared_ptr<ThreadPool::Task> data_io_task)
+    shared_ptr<ThreadPool::SharedTask> data_io_task)
     : Tile(
           format_version,
           type,
@@ -158,7 +158,7 @@ Tile::Tile(
     void* filtered_data,
     uint64_t filtered_size,
     tdb::pmr::memory_resource* resource,
-    shared_ptr<ThreadPool::Task> filtered_data_io_task)
+    shared_ptr<ThreadPool::SharedTask> filtered_data_io_task)
     : TileBase(format_version, type, cell_size, size, resource)
     , zipped_coords_dim_num_(zipped_coords_dim_num)
     , filtered_data_(filtered_data)
@@ -290,6 +290,7 @@ uint64_t Tile::load_chunk_data(
   if (filtered_data_io_task_ != nullptr && filtered_data_io_task_->valid()) {
     filtered_data_io_task_->wait();
     throw_if_not_ok(filtered_data_io_task_->get());
+    filtered_data_io_task_ = nullptr;
   }
 
   Deserializer deserializer(filtered_data(), filtered_size());

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -212,8 +212,6 @@ WriterTile::WriterTile(
 void TileBase::read(
     void* const buffer, const uint64_t offset, const uint64_t nbytes) const {
   if (!ignore_tasks_) {
-    std::scoped_lock<std::recursive_mutex> lock{
-        unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
       throw_if_not_ok(unfilter_data_compute_task_.wait());
     } else {
@@ -284,8 +282,6 @@ void WriterTile::clear_data() {
 
 void Tile::set_unfilter_data_compute_task(
     ThreadPool::SharedTask unfilter_data_compute_task) {
-  // std::scoped_lock<std::recursive_mutex>
-  // lock{unfilter_data_compute_task_mtx_};
   unfilter_data_compute_task_ = std::move(unfilter_data_compute_task);
 }
 

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -72,7 +72,8 @@ shared_ptr<Tile> Tile::from_generic(
       nullptr,
       0,
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
-      ThreadPool::SharedTask());
+      ThreadPool::SharedTask(),
+      nullptr);
 }
 
 shared_ptr<WriterTile> WriterTile::from_generic(
@@ -136,7 +137,8 @@ Tile::Tile(
     void* filtered_data,
     uint64_t filtered_size,
     shared_ptr<MemoryTracker> memory_tracker,
-    ThreadPool::SharedTask data_io_task)
+    ThreadPool::SharedTask data_io_task,
+    shared_ptr<FilteredData> filtered_data_block)
     : Tile(
           format_version,
           type,
@@ -146,7 +148,8 @@ Tile::Tile(
           filtered_data,
           filtered_size,
           memory_tracker->get_resource(MemoryType::TILE_DATA),
-          std::move(data_io_task)) {
+          std::move(data_io_task),
+          std::move(filtered_data_block)) {
 }
 
 Tile::Tile(
@@ -158,12 +161,14 @@ Tile::Tile(
     void* filtered_data,
     uint64_t filtered_size,
     tdb::pmr::memory_resource* resource,
-    ThreadPool::SharedTask filtered_data_io_task)
+    ThreadPool::SharedTask filtered_data_io_task,
+    shared_ptr<FilteredData> filtered_data_block)
     : TileBase(format_version, type, cell_size, size, resource)
     , zipped_coords_dim_num_(zipped_coords_dim_num)
     , filtered_data_(filtered_data)
     , filtered_size_(filtered_size)
-    , filtered_data_io_task_(std::move(filtered_data_io_task)) {
+    , filtered_data_io_task_(std::move(filtered_data_io_task))
+    , filtered_data_block_(std::move(filtered_data_block)) {
 }
 
 WriterTile::WriterTile(

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -32,7 +32,6 @@
 
 #include "tiledb/sm/tile/tile.h"
 
-#include <utility>
 #include "tiledb/common/exception/exception.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/memory_tracker.h"

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -224,15 +224,8 @@ void TileBase::write(const void* data, uint64_t offset, uint64_t nbytes) {
   size_ = std::max(offset + nbytes, size_);
 }
 
-void Tile::zip_coordinates() {
-  std::scoped_lock<std::recursive_mutex> lock{unfilter_data_compute_task_mtx_};
+void Tile::zip_coordinates_unsafe() {
   assert(zipped_coords_dim_num_ > 0);
-
-  if (unfilter_data_compute_task_.valid()) {
-    unfilter_data_compute_task_.wait();
-    throw_if_not_ok(unfilter_data_compute_task_.get());
-    unfilter_data_compute_task_ = ThreadPool::SharedTask();
-  }
 
   // For easy reference
   const uint64_t tile_size = size_;

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -197,6 +197,7 @@ WriterTile::WriterTile(
 
 void TileBase::read(
     void* const buffer, const uint64_t offset, const uint64_t nbytes) const {
+  std::scoped_lock<std::recursive_mutex> lock{unfilter_data_compute_task_mtx_};
   if (unfilter_data_compute_task_.valid()) {
     unfilter_data_compute_task_.wait();
     throw_if_not_ok(unfilter_data_compute_task_.get());
@@ -218,6 +219,7 @@ void TileBase::write(const void* data, uint64_t offset, uint64_t nbytes) {
 }
 
 void Tile::zip_coordinates() {
+  std::scoped_lock<std::recursive_mutex> lock{unfilter_data_compute_task_mtx_};
   assert(zipped_coords_dim_num_ > 0);
 
   if (unfilter_data_compute_task_.valid()) {
@@ -300,6 +302,7 @@ void WriterTile::write_var(const void* data, uint64_t offset, uint64_t nbytes) {
 
 uint64_t Tile::load_chunk_data(
     ChunkData& unfiltered_tile, uint64_t expected_original_size) {
+  std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
   assert(filtered());
 
   if (filtered_data_io_task_.valid()) {

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -215,7 +215,7 @@ void TileBase::read(
     if (unfilter_data_compute_task_.valid()) {
       throw_if_not_ok(unfilter_data_compute_task_.wait());
     } else {
-      throw std::future_error(std::make_error_code(std::future_errc::no_state));
+      throw std::future_error(std::future_errc::no_state);
     }
   }
 

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -215,7 +215,7 @@ void TileBase::read(
     std::scoped_lock<std::recursive_mutex> lock{
         unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
-      throw_if_not_ok(unfilter_data_compute_task_.get());
+      throw_if_not_ok(unfilter_data_compute_task_.wait());
     } else {
       throw std::future_error(std::make_error_code(std::future_errc::no_state));
     }

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -31,6 +31,8 @@
  */
 
 #include "tiledb/sm/tile/tile.h"
+
+#include <utility>
 #include "tiledb/common/exception/exception.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/memory_tracker.h"
@@ -69,7 +71,8 @@ shared_ptr<Tile> Tile::from_generic(
       tile_size,
       nullptr,
       0,
-      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO));
+      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
+      nullptr);
 }
 
 shared_ptr<WriterTile> WriterTile::from_generic(
@@ -132,7 +135,8 @@ Tile::Tile(
     const uint64_t size,
     void* filtered_data,
     uint64_t filtered_size,
-    shared_ptr<MemoryTracker> memory_tracker)
+    shared_ptr<MemoryTracker> memory_tracker,
+    shared_ptr<ThreadPool::Task> data_io_task)
     : Tile(
           format_version,
           type,
@@ -141,7 +145,8 @@ Tile::Tile(
           size,
           filtered_data,
           filtered_size,
-          memory_tracker->get_resource(MemoryType::TILE_DATA)) {
+          memory_tracker->get_resource(MemoryType::TILE_DATA),
+          std::move(data_io_task)) {
 }
 
 Tile::Tile(
@@ -152,11 +157,13 @@ Tile::Tile(
     const uint64_t size,
     void* filtered_data,
     uint64_t filtered_size,
-    tdb::pmr::memory_resource* resource)
+    tdb::pmr::memory_resource* resource,
+    shared_ptr<ThreadPool::Task> filtered_data_io_task)
     : TileBase(format_version, type, cell_size, size, resource)
     , zipped_coords_dim_num_(zipped_coords_dim_num)
     , filtered_data_(filtered_data)
-    , filtered_size_(filtered_size) {
+    , filtered_size_(filtered_size)
+    , filtered_data_io_task_(std::move(filtered_data_io_task)) {
 }
 
 WriterTile::WriterTile(
@@ -279,6 +286,11 @@ void WriterTile::write_var(const void* data, uint64_t offset, uint64_t nbytes) {
 uint64_t Tile::load_chunk_data(
     ChunkData& unfiltered_tile, uint64_t expected_original_size) {
   assert(filtered());
+
+  if (filtered_data_io_task_ != nullptr && filtered_data_io_task_->valid()) {
+    filtered_data_io_task_->wait();
+    throw_if_not_ok(filtered_data_io_task_->get());
+  }
 
   Deserializer deserializer(filtered_data(), filtered_size());
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -74,6 +74,15 @@ class TileBase {
   DISABLE_COPY_AND_COPY_ASSIGN(TileBase);
   DISABLE_MOVE_AND_MOVE_ASSIGN(TileBase);
 
+  ~TileBase() {
+    // TODO: destructor should not throw, catch any exceptions
+    std::scoped_lock<std::recursive_mutex> lock{
+        unfilter_data_compute_task_mtx_};
+    if (unfilter_data_compute_task_.valid()) {
+      unfilter_data_compute_task_.get();
+    }
+  }
+
   /* ********************************* */
   /*                API                */
   /* ********************************* */
@@ -282,6 +291,15 @@ class Tile : public TileBase {
   DISABLE_MOVE_AND_MOVE_ASSIGN(Tile);
   DISABLE_COPY_AND_COPY_ASSIGN(Tile);
 
+  ~Tile() {
+    // TODO: destructor should not throw, catch any exceptions
+    std::scoped_lock<std::recursive_mutex> lock{
+        unfilter_data_compute_task_mtx_};
+    if (unfilter_data_compute_task_.valid()) {
+      unfilter_data_compute_task_.get();
+    }
+  }
+
   /* ********************************* */
   /*                API                */
   /* ********************************* */
@@ -332,7 +350,6 @@ class Tile : public TileBase {
   void clear_filtered_buffer() {
     filtered_data_ = nullptr;
     filtered_size_ = 0;
-    filtered_data_block_ = nullptr;
   }
 
   /**

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -96,6 +96,7 @@ class TileBase {
     if (unfilter_data_compute_task_.valid()) {
       unfilter_data_compute_task_.wait();
       throw_if_not_ok(unfilter_data_compute_task_.get());
+      unfilter_data_compute_task_ = ThreadPool::SharedTask();
     }
 
     return static_cast<T*>(data());
@@ -114,6 +115,7 @@ class TileBase {
     if (unfilter_data_compute_task_.valid()) {
       unfilter_data_compute_task_.wait();
       throw_if_not_ok(unfilter_data_compute_task_.get());
+      unfilter_data_compute_task_ = ThreadPool::SharedTask();
     }
 
     return data_.get();
@@ -295,6 +297,7 @@ class Tile : public TileBase {
     if (filtered_data_io_task_.valid()) {
       filtered_data_io_task_.wait();
       throw_if_not_ok(filtered_data_io_task_.get());
+      filtered_data_io_task_ = ThreadPool::SharedTask();
     }
     return static_cast<char*>(filtered_data_);
   }
@@ -306,6 +309,7 @@ class Tile : public TileBase {
     if (filtered_data_io_task_.valid()) {
       filtered_data_io_task_.wait();
       throw_if_not_ok(filtered_data_io_task_.get());
+      filtered_data_io_task_ = ThreadPool::SharedTask();
     }
     return static_cast<T*>(filtered_data_);
   }
@@ -314,6 +318,7 @@ class Tile : public TileBase {
   void clear_filtered_buffer() {
     filtered_data_ = nullptr;
     filtered_size_ = 0;
+    filtered_data_block_ = nullptr;
   }
 
   /**

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -102,6 +102,14 @@ class TileBase {
     return static_cast<T*>(data());
   }
 
+  /** Converts the data pointer to a specific type with no check on compute
+   * task. This is used for getting thte data from inside the compute thread
+   * itself for unfiltering. */
+  template <class T>
+  inline T* data_as_unsafe() const {
+    return static_cast<T*>(data_unsafe());
+  }
+
   /** Gets the size, considering the data as a specific type. */
   template <class T>
   inline size_t size_as() const {
@@ -118,6 +126,12 @@ class TileBase {
       unfilter_data_compute_task_ = ThreadPool::SharedTask();
     }
 
+    return data_.get();
+  }
+
+  /** Returns the internal buffer. This is used for getting thte data from
+   * inside the compute thread itself for unfiltering. */
+  inline void* data_unsafe() const {
     return data_.get();
   }
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -107,9 +107,11 @@ class TileBase {
     return static_cast<T*>(data());
   }
 
-  /** Converts the data pointer to a specific type with no check on compute
+  /**
+   * Converts the data pointer to a specific type with no check on compute
    * task. This is used for getting thte data from inside the compute thread
-   * itself for unfiltering. */
+   * itself for unfiltering.
+   */
   template <class T>
   inline T* data_as_unsafe() const {
     return static_cast<T*>(data_unsafe());
@@ -134,8 +136,10 @@ class TileBase {
     return data_.get();
   }
 
-  /** Returns the internal buffer. This is used for getting thte data from
-   * inside the compute thread itself for unfiltering. */
+  /**
+   * Returns the internal buffer. This is used for getting thte data from
+   * inside the compute thread itself for unfiltering.
+   */
   inline void* data_unsafe() const {
     return data_.get();
   }
@@ -198,7 +202,8 @@ class TileBase {
   /** The tile data type. */
   Datatype type_;
 
-  /** Whether to block waiting for io data to be ready before accessing data()
+  /**
+   * Whether to block waiting for io data to be ready before accessing data()
    */
   const bool skip_waiting_on_io_task_;
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -80,7 +80,7 @@ class TileBase {
     std::scoped_lock<std::recursive_mutex> lock{
         unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
-      unfilter_data_compute_task_.get();
+      auto st = unfilter_data_compute_task_.wait();
     }
   }
 
@@ -124,7 +124,7 @@ class TileBase {
       std::scoped_lock<std::recursive_mutex> lock{
           unfilter_data_compute_task_mtx_};
       if (unfilter_data_compute_task_.valid()) {
-        throw_if_not_ok(unfilter_data_compute_task_.get());
+        throw_if_not_ok(unfilter_data_compute_task_.wait());
       } else {
         throw std::future_error(
             std::make_error_code(std::future_errc::no_state));
@@ -294,7 +294,7 @@ class Tile : public TileBase {
     std::scoped_lock<std::recursive_mutex> lock{
         unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
-      unfilter_data_compute_task_.get();
+      auto st = unfilter_data_compute_task_.wait();
     }
   }
 
@@ -327,7 +327,7 @@ class Tile : public TileBase {
     if (filtered_data_block_ != nullptr) {
       std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
       if (filtered_data_io_task_.valid()) {
-        throw_if_not_ok(filtered_data_io_task_.get());
+        throw_if_not_ok(filtered_data_io_task_.wait());
       } else {
         throw std::future_error(
             std::make_error_code(std::future_errc::no_state));
@@ -344,7 +344,7 @@ class Tile : public TileBase {
     if (filtered_data_block_ != nullptr) {
       std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
       if (filtered_data_io_task_.valid()) {
-        throw_if_not_ok(filtered_data_io_task_.get());
+        throw_if_not_ok(filtered_data_io_task_.wait());
       } else {
         throw std::future_error(
             std::make_error_code(std::future_errc::no_state));
@@ -359,7 +359,7 @@ class Tile : public TileBase {
     if (filtered_data_block_ != nullptr) {
       std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
       if (filtered_data_io_task_.valid()) {
-        throw_if_not_ok(filtered_data_io_task_.get());
+        throw_if_not_ok(filtered_data_io_task_.wait());
       } else {
         throw std::future_error(
             std::make_error_code(std::future_errc::no_state));

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -166,8 +166,8 @@ class TileBase {
    *
    * @param var_tile Var tile.
    */
-  void add_extra_offset(TileBase& var_tile) {
-    data_as<uint64_t>()[size_ / cell_size_ - 1] = var_tile.size();
+  void add_extra_offset_unsafe(TileBase& var_tile) {
+    data_as_unsafe<uint64_t>()[size_ / cell_size_ - 1] = var_tile.size();
   }
 
  protected:
@@ -345,8 +345,12 @@ class Tile : public TileBase {
   /**
    * Zips the coordinate values such that a cell's coordinates across
    * all dimensions appear contiguously in the buffer.
+   *
+   * This is marked unsafe because we don't check for unfiltering to be
+   * completed since this function is used by the unfiltering task itself as
+   * part of post processing.
    */
-  void zip_coordinates();
+  void zip_coordinates_unsafe();
 
   /**
    * Reads the chunk data of a tile buffer and populates a chunk data structure.

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -366,7 +366,6 @@ class Tile : public TileBase {
       }
     }
 
-    // filtered_data_io_task_ = ThreadPool::SharedTask;
     filtered_data_ = nullptr;
     filtered_size_ = 0;
     filtered_data_block_ = nullptr;

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -77,8 +77,6 @@ class TileBase {
 
   ~TileBase() {
     // TODO: destructor should not throw, catch any exceptions
-    std::scoped_lock<std::recursive_mutex> lock{
-        unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
       auto st = unfilter_data_compute_task_.wait();
     }
@@ -121,8 +119,6 @@ class TileBase {
   /** Returns the internal buffer. */
   inline void* data() const {
     if (!ignore_tasks_) {
-      std::scoped_lock<std::recursive_mutex> lock{
-          unfilter_data_compute_task_mtx_};
       if (unfilter_data_compute_task_.valid()) {
         throw_if_not_ok(unfilter_data_compute_task_.wait());
       } else {
@@ -291,8 +287,6 @@ class Tile : public TileBase {
 
   ~Tile() {
     // TODO: destructor should not throw, catch any exceptions
-    std::scoped_lock<std::recursive_mutex> lock{
-        unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
       auto st = unfilter_data_compute_task_.wait();
     }

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -68,7 +68,8 @@ class TileBase {
       const Datatype type,
       const uint64_t cell_size,
       const uint64_t size,
-      tdb::pmr::memory_resource* resource);
+      tdb::pmr::memory_resource* resource,
+      const bool skip_waiting_on_io_task);
 
   DISABLE_COPY_AND_COPY_ASSIGN(TileBase);
   DISABLE_MOVE_AND_MOVE_ASSIGN(TileBase);
@@ -181,6 +182,11 @@ class TileBase {
 
   /** The tile data type. */
   Datatype type_;
+
+  /**
+   * Whether to block waiting for io data to be ready before accessing data()
+   */
+  const bool skip_waiting_on_io_task_;
 };
 
 /**
@@ -428,11 +434,6 @@ class Tile : public TileBase {
    * need a mutex since the tile will be accessed by multiple threads.
    */
   mutable std::recursive_mutex filtered_data_io_task_mtx_;
-
-  /**
-   * Whether to block waiting for io data to be ready before accessing data()
-   */
-  const bool skip_waiting_on_io_task_;
 };
 
 /**
@@ -483,7 +484,8 @@ class WriterTile : public TileBase {
       const Datatype type,
       const uint64_t cell_size,
       const uint64_t size,
-      shared_ptr<MemoryTracker> memory_tracker);
+      shared_ptr<MemoryTracker> memory_tracker,
+      const bool skip_waiting_on_io_task = false);
 
   /**
    * Constructor.
@@ -499,7 +501,8 @@ class WriterTile : public TileBase {
       const Datatype type,
       const uint64_t cell_size,
       const uint64_t size,
-      tdb::pmr::memory_resource* resource);
+      tdb::pmr::memory_resource* resource,
+      const bool skip_waiting_on_io_task = false);
 
   DISABLE_COPY_AND_COPY_ASSIGN(WriterTile);
   DISABLE_MOVE_AND_MOVE_ASSIGN(WriterTile);

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -122,8 +122,7 @@ class TileBase {
       if (unfilter_data_compute_task_.valid()) {
         throw_if_not_ok(unfilter_data_compute_task_.wait());
       } else {
-        throw std::future_error(
-            std::make_error_code(std::future_errc::no_state));
+        throw std::future_error(std::future_errc::no_state);
       }
     }
 
@@ -323,8 +322,7 @@ class Tile : public TileBase {
       if (filtered_data_io_task_.valid()) {
         throw_if_not_ok(filtered_data_io_task_.wait());
       } else {
-        throw std::future_error(
-            std::make_error_code(std::future_errc::no_state));
+        throw std::future_error(std::future_errc::no_state);
       }
     }
 
@@ -340,8 +338,7 @@ class Tile : public TileBase {
       if (filtered_data_io_task_.valid()) {
         throw_if_not_ok(filtered_data_io_task_.wait());
       } else {
-        throw std::future_error(
-            std::make_error_code(std::future_errc::no_state));
+        throw std::future_error(std::future_errc::no_state);
       }
     }
 
@@ -355,8 +352,7 @@ class Tile : public TileBase {
       if (filtered_data_io_task_.valid()) {
         throw_if_not_ok(filtered_data_io_task_.wait());
       } else {
-        throw std::future_error(
-            std::make_error_code(std::future_errc::no_state));
+        throw std::future_error(std::future_errc::no_state);
       }
     }
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -103,7 +103,6 @@ class TileBase {
     std::scoped_lock<std::recursive_mutex> lock{
         unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
-      unfilter_data_compute_task_.wait();
       throw_if_not_ok(unfilter_data_compute_task_.get());
       unfilter_data_compute_task_ = ThreadPool::SharedTask();
     }
@@ -130,7 +129,6 @@ class TileBase {
     std::scoped_lock<std::recursive_mutex> lock{
         unfilter_data_compute_task_mtx_};
     if (unfilter_data_compute_task_.valid()) {
-      unfilter_data_compute_task_.wait();
       throw_if_not_ok(unfilter_data_compute_task_.get());
       unfilter_data_compute_task_ = ThreadPool::SharedTask();
     }
@@ -327,7 +325,6 @@ class Tile : public TileBase {
   inline char* filtered_data() {
     std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
     if (filtered_data_io_task_.valid()) {
-      filtered_data_io_task_.wait();
       throw_if_not_ok(filtered_data_io_task_.get());
       filtered_data_io_task_ = ThreadPool::SharedTask();
     }
@@ -339,7 +336,6 @@ class Tile : public TileBase {
   inline T* filtered_data_as() {
     std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
     if (filtered_data_io_task_.valid()) {
-      filtered_data_io_task_.wait();
       throw_if_not_ok(filtered_data_io_task_.get());
       filtered_data_io_task_ = ThreadPool::SharedTask();
     }
@@ -348,6 +344,10 @@ class Tile : public TileBase {
 
   /** Clears the filtered buffer. */
   void clear_filtered_buffer() {
+    std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
+    if (filtered_data_io_task_.valid()) {
+      throw_if_not_ok(filtered_data_io_task_.get());
+    }
     filtered_data_ = nullptr;
     filtered_size_ = 0;
   }

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -46,6 +46,7 @@ using namespace tiledb::common;
 namespace tiledb {
 namespace sm {
 
+class FilteredData;
 class MemoryTracker;
 
 /**
@@ -219,6 +220,8 @@ class Tile : public TileBase {
    * @param filtered_size The filtered size to allocate.
    * @param memory_tracker The memory resource to use.
    * @param filtered_data_io_task The I/O task to wait on for data to be valid.
+   * @param filtered_data_block The FilteredData block class which backs the
+   * memory for this filtered tile.
    */
   Tile(
       const format_version_t format_version,
@@ -229,7 +232,8 @@ class Tile : public TileBase {
       void* filtered_data,
       uint64_t filtered_size,
       shared_ptr<MemoryTracker> memory_tracker,
-      ThreadPool::SharedTask filtered_data_io_task);
+      ThreadPool::SharedTask filtered_data_io_task,
+      shared_ptr<FilteredData> filtered_data_block);
 
   /**
    * Constructor.
@@ -244,6 +248,8 @@ class Tile : public TileBase {
    * @param filtered_size The filtered size to allocate.
    * @param resource The memory resource to use.
    * @param filtered_data_io_task The I/O task to wait on for data to be valid.
+   * @param filtered_data_block The FilteredData block class which backs the
+   * memory for this filtered tile.
    */
   Tile(
       const format_version_t format_version,
@@ -254,7 +260,8 @@ class Tile : public TileBase {
       void* filtered_data,
       uint64_t filtered_size,
       tdb::pmr::memory_resource* resource,
-      ThreadPool::SharedTask filtered_data_io_task);
+      ThreadPool::SharedTask filtered_data_io_task,
+      shared_ptr<FilteredData> filtered_data_block);
 
   DISABLE_MOVE_AND_MOVE_ASSIGN(Tile);
   DISABLE_COPY_AND_COPY_ASSIGN(Tile);
@@ -413,6 +420,12 @@ class Tile : public TileBase {
    * need a mutex since the tile will be accessed by multiple threads.
    */
   mutable std::recursive_mutex filtered_data_io_task_mtx_;
+
+  /**
+   * shared_ptr to the FilteredData class that backs this tile. We keep a shared
+   * pointer to maintain the lifetime.
+   */
+  shared_ptr<FilteredData> filtered_data_block_;
 };
 
 /**

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -90,11 +90,9 @@ class TileBase {
   /** Converts the data pointer to a specific type. */
   template <class T>
   inline T* data_as() const {
-    if (unfilter_data_compute_task_ != nullptr &&
-        unfilter_data_compute_task_->valid()) {
-      unfilter_data_compute_task_->wait();
-      throw_if_not_ok(unfilter_data_compute_task_->get());
-      unfilter_data_compute_task_ = nullptr;
+    if (unfilter_data_compute_task_.valid()) {
+      unfilter_data_compute_task_.wait();
+      throw_if_not_ok(unfilter_data_compute_task_.get());
     }
 
     return static_cast<T*>(data());
@@ -108,11 +106,9 @@ class TileBase {
 
   /** Returns the internal buffer. */
   inline void* data() const {
-    if (unfilter_data_compute_task_ != nullptr &&
-        unfilter_data_compute_task_->valid()) {
-      unfilter_data_compute_task_->wait();
-      throw_if_not_ok(unfilter_data_compute_task_->get());
-      unfilter_data_compute_task_ = nullptr;
+    if (unfilter_data_compute_task_.valid()) {
+      unfilter_data_compute_task_.wait();
+      throw_if_not_ok(unfilter_data_compute_task_.get());
     }
 
     return data_.get();
@@ -177,7 +173,7 @@ class TileBase {
   Datatype type_;
 
   /** Compute task to check and block on if unfiltered data is ready. */
-  mutable shared_ptr<ThreadPool::SharedTask> unfilter_data_compute_task_;
+  mutable ThreadPool::SharedTask unfilter_data_compute_task_;
 };
 
 /**
@@ -221,7 +217,7 @@ class Tile : public TileBase {
       void* filtered_data,
       uint64_t filtered_size,
       shared_ptr<MemoryTracker> memory_tracker,
-      shared_ptr<ThreadPool::SharedTask> filtered_data_io_task);
+      ThreadPool::SharedTask filtered_data_io_task);
 
   /**
    * Constructor.
@@ -246,7 +242,7 @@ class Tile : public TileBase {
       void* filtered_data,
       uint64_t filtered_size,
       tdb::pmr::memory_resource* resource,
-      shared_ptr<ThreadPool::SharedTask> filtered_data_io_task);
+      ThreadPool::SharedTask filtered_data_io_task);
 
   DISABLE_MOVE_AND_MOVE_ASSIGN(Tile);
   DISABLE_COPY_AND_COPY_ASSIGN(Tile);
@@ -276,10 +272,9 @@ class Tile : public TileBase {
 
   /** Returns the buffer that contains the filtered, on-disk format. */
   inline char* filtered_data() {
-    if (filtered_data_io_task_ != nullptr && filtered_data_io_task_->valid()) {
-      filtered_data_io_task_->wait();
-      throw_if_not_ok(filtered_data_io_task_->get());
-      filtered_data_io_task_ = nullptr;
+    if (filtered_data_io_task_.valid()) {
+      filtered_data_io_task_.wait();
+      throw_if_not_ok(filtered_data_io_task_.get());
     }
     return static_cast<char*>(filtered_data_);
   }
@@ -287,10 +282,9 @@ class Tile : public TileBase {
   /** Returns the data casted as a type. */
   template <class T>
   inline T* filtered_data_as() {
-    if (filtered_data_io_task_ != nullptr && filtered_data_io_task_->valid()) {
-      filtered_data_io_task_->wait();
-      throw_if_not_ok(filtered_data_io_task_->get());
-      filtered_data_io_task_ = nullptr;
+    if (filtered_data_io_task_.valid()) {
+      filtered_data_io_task_.wait();
+      throw_if_not_ok(filtered_data_io_task_.get());
     }
     return static_cast<T*>(filtered_data_);
   }
@@ -299,7 +293,6 @@ class Tile : public TileBase {
   void clear_filtered_buffer() {
     filtered_data_ = nullptr;
     filtered_size_ = 0;
-    filtered_data_io_task_ = nullptr;
   }
 
   /**
@@ -338,7 +331,7 @@ class Tile : public TileBase {
    * @param unfilter_data_compute_task task for unfiltering
    */
   void set_unfilter_data_compute_task(
-      shared_ptr<ThreadPool::SharedTask> unfilter_data_compute_task);
+      ThreadPool::SharedTask unfilter_data_compute_task);
 
  private:
   /* ********************************* */
@@ -397,7 +390,7 @@ class Tile : public TileBase {
   uint64_t filtered_size_;
 
   /** I/O task to check and block on if filtered data is ready. */
-  mutable shared_ptr<ThreadPool::SharedTask> filtered_data_io_task_;
+  mutable ThreadPool::SharedTask filtered_data_io_task_;
 };
 
 /**


### PR DESCRIPTION
Today when a reader issues the I/O request to VFS, we block waiting for all I/O to finish before moving to unfiltering. We then block again waiting for unfiltering to be done for all tiles and then continue to processing the results.

This PR is part1 of the effort to minimize wait all points in reader code : it removes the need to wait for all I/O to be done, and uses async tasks to signal when a tile is done reading so that it can proceed to unfiltering.

Part2 will come in a future PR for using async tasks for unfiltering as well in order to remove then need to wait for a tile is done unfiltering so that it can proceed to result processing before copying to the user buffers.

[sc-59605]

---
TYPE: IMPROVEMENT
DESC: Improve readers by parallelizing I/O and compute operations
