### PR TITLE
Include r-tools build in release artifacts

### DIFF
--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -50,7 +50,7 @@ jobs:
           DESCRIPTION_MACOS_ARM64="MacOS ARM64 release artifact"
           DESCRIPTION_MACOS_X86_64="MacOS x86_64 release artifact"
           DESCRIPTION_WINDOWS_X86_64="Windows x86_64 release artifact"
-          DESCRIPTION_WINDOWS_X86_64-UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
+          DESCRIPTION_WINDOWS_X86_64_UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
           
           for FILE in $(ls release)
           do

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -44,13 +44,13 @@ jobs:
           cp cmake/inputs/DownloadPrebuiltTileDB.cmake $MODULE
           echo "platform,url,sha256,description" > $RELLIST
           
-          DESCRIPTION_LINUX-X86_64="Linux x86_64 release artifact"
-          DESCRIPTION_LINUX-X86_64-NOAVX2="Linux x86_64 release artifact without AVX2 instructions"
-          DESCRIPTION_LINUX-ARM64="Linux ARM64(aarch64) release artifact"
-          DESCRIPTION_MACOS-ARM64="MacOS ARM64 release artifact"
-          DESCRIPTION_MACOS-X86_64="MacOS x86_64 release artifact"
-          DESCRIPTION_WINDOWS-X86_64="Windows x86_64 release artifact"
-          DESCRIPTION_WINDOWS-X86_64-UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
+          DESCRIPTION_LINUX_X86_64="Linux x86_64 release artifact"
+          DESCRIPTION_LINUX_X86_64_NOAVX2="Linux x86_64 release artifact without AVX2 instructions"
+          DESCRIPTION_LINUX_ARM64="Linux ARM64(aarch64) release artifact"
+          DESCRIPTION_MACOS_ARM64="MacOS ARM64 release artifact"
+          DESCRIPTION_MACOS_X86_64="MacOS x86_64 release artifact"
+          DESCRIPTION_WINDOWS_X86_64="Windows x86_64 release artifact"
+          DESCRIPTION_WINDOWS_X86_64-UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
           
           for FILE in $(ls release)
           do
@@ -68,7 +68,8 @@ jobs:
                           URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$FILE"
                           HASH=$(cat release/$FILE.sha256 | cut -d \t -f 1)
           
-                          echo "${PLATFORM},${URL},${HASH},${DESCRIPTION_${PLATFORM}}" >> $RELLIST
+                          DESCRIPTION_VAR=${PLATFORM//-/_}
+                          echo "${PLATFORM},${URL},${HASH},${!DESCRIPTION_VAR}" >> $RELLIST
                   fi
           done
           

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Render template
         run: |
-          PATTERN="tiledb-([^-]+)-([^-]+)(-noavx2|-ucrt64)?-(.+)\.(tar\.gz|tar\.xz|zip)$"
+          PATTERN="tiledb-([^-]+)-([^-]+)(-noavx2|-mingw64_ucrt64)?-(.+)\.(tar\.gz|tar\.xz|zip)$"
           RELLIST="output/releases.csv"
           MODULE="output/DownloadPrebuiltTileDB.cmake"
           cp cmake/inputs/DownloadPrebuiltTileDB.cmake $MODULE

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -42,7 +42,15 @@ jobs:
           RELLIST="output/releases.csv"
           MODULE="output/DownloadPrebuiltTileDB.cmake"
           cp cmake/inputs/DownloadPrebuiltTileDB.cmake $MODULE
-          echo "platform,url,sha256" > $RELLIST
+          echo "platform,url,sha256,description" > $RELLIST
+          
+          DESCRIPTION_LINUX-X86_64="Linux x86_64 release artifact"
+          DESCRIPTION_LINUX-X86_64-NOAVX2="Linux x86_64 release artifact without AVX2 instructions"
+          DESCRIPTION_LINUX-ARM64="Linux ARM64(aarch64) release artifact"
+          DESCRIPTION_MACOS-ARM64="MacOS ARM64 release artifact"
+          DESCRIPTION_MACOS-X86_64="MacOS x86_64 release artifact"
+          DESCRIPTION_WINDOWS-X86_64="Windows x86_64 release artifact"
+          DESCRIPTION_WINDOWS-X86_64-UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
           
           for FILE in $(ls release)
           do
@@ -60,13 +68,13 @@ jobs:
                           URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$FILE"
                           HASH=$(cat release/$FILE.sha256 | cut -d \t -f 1)
           
-                          echo "${PLATFORM},${URL},${HASH}" >> $RELLIST
+                          echo "${PLATFORM},${URL},${HASH},${DESCRIPTION_${PLATFORM}}" >> $RELLIST
                   fi
           done
           
           SOURCE_FILE_NAME=$(ls release/tiledb-source-*.tar.gz)
           URL_TILEDB_SOURCE="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$(basename $SOURCE_FILE_NAME)"
-          HASH_TILEDB_SOURCE=$(cat $SOURCE_FILE_NAME.sha256 | cut -d \t -f 1)
+          HASH_TILEDB_SOURCE=$(cat $SOURCE_FILE_NAME.sha256 | cut -d \  -f 1)
           
           echo "source,${URL_TILEDB_SOURCE},${HASH_TILEDB_SOURCE}" >> $RELLIST
           

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -66,20 +66,22 @@ jobs:
                           fi
           
                           URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$FILE"
-                          HASH=$(cat release/$FILE.sha256 | cut -d \  -f 1)
+                          HASH=$(cat release/$FILE.sha256 | cut -d ' ' -f 1)
           
                           DESCRIPTION_VAR="DESCRIPTION_${PLATFORM//-/_}"
+                          echo ${DESCRIPTION_VAR}
+                          echo ${!DESCRIPTION_VAR}
                           echo "${PLATFORM},${URL},${HASH},${!DESCRIPTION_VAR}" >> $RELLIST
                   fi
           done
           
           SOURCE_FILE_NAME=$(ls release/tiledb-source-*.tar.gz)
           URL_TILEDB_SOURCE="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$(basename $SOURCE_FILE_NAME)"
-          HASH_TILEDB_SOURCE=$(cat $SOURCE_FILE_NAME.sha256 | cut -d \  -f 1)
+          HASH_TILEDB_SOURCE=$(cat $SOURCE_FILE_NAME.sha256 | cut -d ' ' -f 1)
           
           echo "source,${URL_TILEDB_SOURCE},${HASH_TILEDB_SOURCE},Source release artifact" >> $RELLIST
           
-          HASH=$(sha256sum $RELLIST | cut -d " " -f 1)
+          HASH=$(sha256sum $RELLIST | cut -d ' ' -f 1)
           echo $HASH > $RELLIST.sha256
           
           cat $RELLIST

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Render template
         run: |
-          PATTERN="tiledb-([^-]+)-([^-]+)(-noavx2)?-(.+)\.(tar\.gz|zip)$"
+          PATTERN="tiledb-([^-]+)-([^-]+)(-noavx2|-ucrt64)?-(.+)\.(tar\.gz|tar\.xz|zip)$"
           RELLIST="output/releases.csv"
           MODULE="output/DownloadPrebuiltTileDB.cmake"
           cp cmake/inputs/DownloadPrebuiltTileDB.cmake $MODULE
@@ -50,8 +50,8 @@ jobs:
                   then
                           OS=${BASH_REMATCH[1]^^}
                           ARCH=${BASH_REMATCH[2]^^}
-                          NOAVX2=${BASH_REMATCH[3]^^}
-                          PLATFORM=${OS}-${ARCH}${NOAVX2}
+                          OPTION=${BASH_REMATCH[3]^^}
+                          PLATFORM=${OS}-${ARCH}${OPTION}
           
                           if [[ $PLATFORM == *"SOURCE"* ]]; then
                             continue

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -66,9 +66,9 @@ jobs:
                           fi
           
                           URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$FILE"
-                          HASH=$(cat release/$FILE.sha256 | cut -d \t -f 1)
+                          HASH=$(cat release/$FILE.sha256 | cut -d \  -f 1)
           
-                          DESCRIPTION_VAR=${PLATFORM//-/_}
+                          DESCRIPTION_VAR="DESCRIPTION_${PLATFORM//-/_}"
                           echo "${PLATFORM},${URL},${HASH},${!DESCRIPTION_VAR}" >> $RELLIST
                   fi
           done

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           # repository: 'TileDB-Inc/TileDB'
           version: ${{ inputs.ref }}
-          asset-file: '*.zip,*.tar.gz'
+          asset-file: '*.zip,*.tar.gz,*.tar.xz'
           asset-output: './release/'
 
       - name: Render template

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -76,7 +76,7 @@ jobs:
           URL_TILEDB_SOURCE="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$(basename $SOURCE_FILE_NAME)"
           HASH_TILEDB_SOURCE=$(cat $SOURCE_FILE_NAME.sha256 | cut -d \  -f 1)
           
-          echo "source,${URL_TILEDB_SOURCE},${HASH_TILEDB_SOURCE}" >> $RELLIST
+          echo "source,${URL_TILEDB_SOURCE},${HASH_TILEDB_SOURCE},Source release artifact" >> $RELLIST
           
           HASH=$(sha256sum $RELLIST | cut -d " " -f 1)
           echo $HASH > $RELLIST.sha256

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -50,7 +50,7 @@ jobs:
           DESCRIPTION_MACOS_ARM64="MacOS ARM64 release artifact"
           DESCRIPTION_MACOS_X86_64="MacOS x86_64 release artifact"
           DESCRIPTION_WINDOWS_X86_64="Windows x86_64 release artifact"
-          DESCRIPTION_WINDOWS_X86_64_UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
+          DESCRIPTION_WINDOWS_X86_64_MINGW64_UCRT64="INTERNAL USE: Windows x86_64 release artifact produced in R toolchain"
           
           for FILE in $(ls release)
           do
@@ -69,8 +69,6 @@ jobs:
                           HASH=$(cat release/$FILE.sha256 | cut -d ' ' -f 1)
           
                           DESCRIPTION_VAR="DESCRIPTION_${PLATFORM//-/_}"
-                          echo ${DESCRIPTION_VAR}
-                          echo ${!DESCRIPTION_VAR}
                           echo "${PLATFORM},${URL},${HASH},${!DESCRIPTION_VAR}" >> $RELLIST
                   fi
           done

--- a/.github/workflows/append-release-cmake.yml
+++ b/.github/workflows/append-release-cmake.yml
@@ -53,6 +53,10 @@ jobs:
                           NOAVX2=${BASH_REMATCH[3]^^}
                           PLATFORM=${OS}-${ARCH}${NOAVX2}
           
+                          if [[ $PLATFORM == *"SOURCE"* ]]; then
+                            continue
+                          fi
+          
                           URL="${{ github.server_url }}/${{ github.repository }}/releases/download/${{ inputs.ref }}/$FILE"
                           HASH=$(cat release/$FILE.sha256 | cut -d \t -f 1)
           

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -65,12 +65,12 @@ jobs:
       - name: "Rename release artifact and create sha256 hash"
         run: |
           mkdir release
-          mv .github/workflows/mingw-w64-tiledb/*.pkg.tar.xz release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz
-          sha256sum release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz > release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz.sha256
+          mv .github/workflows/mingw-w64-tiledb/*.pkg.tar.xz release/tiledb-windows-x86_64-mingw64_ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz
+          sha256sum release/tiledb-windows-x86_64-mingw64_ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz > release/tiledb-windows-x86_64-mingw64_ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz.sha256
       - name: "Upload binaries"
         uses: actions/upload-artifact@v4
         with:
-          name: release-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
+          name: release-windows-x86_64-mingw64_ucrt64-${{ steps.get-values.outputs.release_version }}
           path: release/tiledb-*
       - name: "Print log files (failed build only)"
         shell: bash

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Upload binaries"
         uses: actions/upload-artifact@v4
         with:
-          name: tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
+          name: release-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
           path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*
       - name: "Print log files (failed build only)"
         shell: bash

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -62,11 +62,16 @@ jobs:
           release_hash=$( echo ${{ github.sha }} | cut -c-7 - )
           ref=${{ github.head_ref || github.ref_name }}
           echo "release_version=${ref##*/}-$release_hash" >> $GITHUB_OUTPUT
+      - name: "Rename release artifact and create sha256 hash"
+        run: |
+          mkdir release
+          mv .github/workflows/mingw-w64-tiledb/*.pkg.tar.xz release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
+          sha256sum release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }} > release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.sha256
       - name: "Upload binaries"
         uses: actions/upload-artifact@v4
         with:
           name: release-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
-          path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*
+          path: release/tiledb-*
       - name: "Print log files (failed build only)"
         shell: bash
         run: |

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -55,10 +55,17 @@ jobs:
           VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
+      - name: Set variables
+        shell: bash
+        id: get-values
+        run: |
+          release_hash=$( echo ${{ github.sha }} | cut -c-7 - )
+          ref=${{ github.head_ref || github.ref_name }}
+          echo "release_version=${ref##*/}-$release_hash" >> $GITHUB_OUTPUT
       - name: "Upload binaries"
         uses: actions/upload-artifact@v4
         with:
-          name: mingw-w64-${{ matrix.msystem }}-tiledb
+          name: tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
           path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*
       - name: "Print log files (failed build only)"
         shell: bash

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -65,8 +65,8 @@ jobs:
       - name: "Rename release artifact and create sha256 hash"
         run: |
           mkdir release
-          mv .github/workflows/mingw-w64-tiledb/*.pkg.tar.xz release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}
-          sha256sum release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }} > release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.sha256
+          mv .github/workflows/mingw-w64-tiledb/*.pkg.tar.xz release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz
+          sha256sum release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz > release/tiledb-windows-x86_64-ucrt64-${{ steps.get-values.outputs.release_version }}.tar.xz.sha256
       - name: "Upload binaries"
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           name: release-source
           path: |
-            build/tiledb-*.tar.gz*
+            build/tiledb-*
 
   Package-Binary-Release:
     name: Package Binary Release - ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release
+          name: release-source
           path: |
             build/tiledb-*.tar.gz*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,9 @@ jobs:
           source $GITHUB_WORKSPACE/scripts/ci/print_logs.sh
         if: failure() # only run this job if the build step failed
 
+  Build-R-Binaries:
+    uses: ./.github/workflows/build-rtools40.yml
+
   Test-Release-Artifacts:
     needs:
       - Package-Binary-Release
@@ -144,7 +147,7 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: release-*
+          pattern: "*"
           merge-multiple: true
           path: dist
       - name: Test names of release artifacts
@@ -158,15 +161,19 @@ jobs:
     needs:
       - Test-Release-Artifacts
       - Package-Source-Release
+      - Build-R-Binaries
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-*
+          name: "*"
           merge-multiple: true
           path: dist
+      - name: DEBUG
+        run: |
+          ls -R dist/
       - name: Publish release artifacts
         uses: actions/github-script@v6
         with:
@@ -179,8 +186,9 @@ jobs:
               repo: repo.repo,
               tag: "${{ github.ref_name }}"
             });
-            const globber = await glob.create('dist/*');
+            const globber = await glob.create('dist/**/*');
             for await (const file of globber.globGenerator()) {
+              console.log(`Uploading file: ${file}`);
               await github.rest.repos.uploadReleaseAsset({
                 owner: repo.owner,
                 repo: repo.repo,


### PR DESCRIPTION
This PR adds rtools binaries into release artifacts. In order to upload/download artifacts and merge them into a single folder we had to upgrade upload/download-artifact to version 4.

The CI/CD for release looks like this: https://github.com/dudoslav/TileDB/releases/tag/t45

---
TYPE: NO_HISTORY
DESC: RTools release binaries
