### PR TITLE
Add -fexperimental-library flag on Clang 16 to fix compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ else()
     endif()
   endif()
 
-  if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "16")
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "16")
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fexperimental-library>)
   endif()
 endif()


### PR DESCRIPTION
Fix compilation errors on newer Clang (upstream) versions which do not fully support jthread and stop_token. Already used for AppleClang variant.

x-ref
  - https://github.com/TileDB-Inc/TileDB/pull/5364
  - closes https://github.com/TileDB-Inc/TileDB/issues/5411

---
TYPE: NO_HISTORY
DESC: Add -fexperimental-library flag on Clang 16 to fix compile errors