### PR TITLE
Remove windows 2019 CI / update to windows 2022

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
         #considering https://stackoverflow.com/questions/65035256/how-to-access-matrix-variables-in-github-actions
         environ: [azure, s3, gcs, serialization]
         include:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -20,7 +20,6 @@ jobs:
           - os: macos-latest
             experimental: ON
           - os: windows-latest
-          - os: windows-2019
           - os: windows-latest
             config: "Debug"
             # Insufficient space on default D:/ for debug build
@@ -83,7 +82,7 @@ jobs:
         include:
           - os: ubuntu-latest
             triplet: x64-linux
-          - os: windows-2019
+          - os: windows-2022
             triplet: x64-windows
           - os: macos-13
             triplet: x64-osx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include:
           - platform: windows-x86_64
-            os: windows-2019
+            os: windows-2022
             triplet: x64-windows-release
           - platform: linux-x86_64
             os: ubuntu-20.04


### PR DESCRIPTION
The conda feedstock is on VS2022, so we have no need to keep the 2019 CI.

This also reduces the need for developers to have to support older compilers.

---
TYPE:  DEPRECATION
DESC: advance windows CI from 2019 to 2022
