### PR TITLE
Show errant values in current-domain out-of-bounds error message

### DIFF
--- a/test/src/test-cppapi-current-domain.cc
+++ b/test/src/test-cppapi-current-domain.cc
@@ -468,7 +468,7 @@ TEST_CASE_METHOD(
   CHECK_THROWS_WITH(
       query_read2.submit(),
       Catch::Matchers::ContainsSubstring(
-          "A range was set outside of the current domain."));
+          "was set outside of the current domain"));
 
   tiledb::Query query_read3(ctx_, array_read, TILEDB_READ);
   tiledb::Subarray subarray_read3(ctx_, array_read);
@@ -483,7 +483,7 @@ TEST_CASE_METHOD(
   CHECK_THROWS_WITH(
       query_read3.submit(),
       Catch::Matchers::ContainsSubstring(
-          "A range was set outside of the current domain."));
+          "was set outside of the current domain"));
 
   array_read.close();
 
@@ -588,7 +588,7 @@ TEST_CASE_METHOD(
       .set_data_buffer("a", a_with_cd2)
       .set_data_buffer("dim1", dim1_with_cd2);
   auto matcher = Catch::Matchers::ContainsSubstring(
-      "A range was set outside of the current domain.");
+      "was set outside of the current domain");
   REQUIRE_THROWS_WITH(query_for_cd2.submit(), matcher);
   array_with_cd2.close();
 

--- a/tiledb/sm/array_schema/current_domain.cc
+++ b/tiledb/sm/array_schema/current_domain.cc
@@ -414,7 +414,8 @@ std::string CurrentDomain::as_string() const {
   } else {
     // As of 2025-01-09 there is no other such type. When/if we do make such a
     // type, we'd need to configure it to return a description of itself.
-    return "CurrentDomain of non-NDRectangle type";
+    throw std::runtime_error(
+        "CurrentDomain::as_string of non-NDRectangle type is not implemented");
   }
 }
 

--- a/tiledb/sm/array_schema/current_domain.cc
+++ b/tiledb/sm/array_schema/current_domain.cc
@@ -408,6 +408,16 @@ void CurrentDomain::expand_to_tiles(
   }
 }
 
+std::string CurrentDomain::as_string() const {
+  if (type_ == CurrentDomainType::NDRECTANGLE) {
+    return ndrectangle_->as_string();
+  } else {
+    // As of 2025-01-09 there is no other such type. When/if we do make such a
+    // type, we'd need to configure it to return a description of itself.
+    return "CurrentDomain of non-NDRectangle type";
+  }
+}
+
 }  // namespace tiledb::sm
 
 std::ostream& operator<<(

--- a/tiledb/sm/array_schema/current_domain.h
+++ b/tiledb/sm/array_schema/current_domain.h
@@ -219,6 +219,14 @@ class CurrentDomain {
    */
   void expand_to_tiles(const Domain& domain, NDRange& query_ndrange) const;
 
+  /**
+   * Returns a human-readable display of the current domain. Nominal use is
+   * to improve readability / actionability of out-of-bounds error messages.
+   *
+   * @return A string.
+   */
+  std::string as_string() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/array_schema/ndrectangle.cc
+++ b/tiledb/sm/array_schema/ndrectangle.cc
@@ -181,6 +181,20 @@ Datatype NDRectangle::range_dtype_for_name(const std::string& name) const {
   return range_dtype(idx);
 }
 
+std::string NDRectangle::as_string() const {
+  std::stringstream ss;
+  ss << "[";
+  for (uint32_t i = 0; i < get_ndranges().size(); ++i) {
+    if (i > 0) {
+      ss << ",";
+    }
+    auto dtype = domain()->dimension_ptr(i)->type();
+    ss << range_str(get_range(i), dtype);
+  }
+  ss << "]";
+  return ss.str();
+}
+
 }  // namespace tiledb::sm
 
 std::ostream& operator<<(std::ostream& os, const tiledb::sm::NDRectangle& ndr) {

--- a/tiledb/sm/array_schema/ndrectangle.h
+++ b/tiledb/sm/array_schema/ndrectangle.h
@@ -198,6 +198,14 @@ class NDRectangle {
    */
   Datatype range_dtype_for_name(const std::string& name) const;
 
+  /**
+   * Returns a human-readable display of the NDRectangle. Nominal use is
+   * to improve readability / actionability of out-of-bounds error messages.
+   *
+   * @return A string.
+   */
+  std::string as_string() const;
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -860,7 +860,10 @@ Status Query::process() {
           for (auto& range : subarray_.ranges_for_dim(d)) {
             if (!cd->includes(d, range)) {
               throw QueryException(
-                  "A range was set outside of the current domain.");
+                std::format("A range {} on dimension '{}' was set outside of the current domain {}.",
+                  range_str(range, array_schema_->domain().dimension_ptr(d)->type()),
+                  array_schema_->domain().dimension_ptr(d)->name(),
+                  cd->as_string()));
             }
           }
         } else if (!all_ned_contained_in_current_domain) {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -59,7 +59,6 @@
 #include "tiledb/sm/tile/writer_tile_tuple.h"
 
 #include <cassert>
-#include <format>
 #include <iostream>
 #include <sstream>
 
@@ -860,13 +859,18 @@ Status Query::process() {
           // Make sure all ranges are contained in the current domain.
           for (auto& range : subarray_.ranges_for_dim(d)) {
             if (!cd->includes(d, range)) {
-              throw QueryException(std::format(
-                  "A range {} on dimension '{}' was set outside of the current "
-                  "domain {}.",
-                  range_str(
-                      range, array_schema_->domain().dimension_ptr(d)->type()),
-                  array_schema_->domain().dimension_ptr(d)->name(),
-                  cd->as_string()));
+              // No std::format:
+              // https://github.com/TileDB-Inc/TileDB/pull/5421#discussion_r1909405876
+              std::stringstream ss;
+              ss << "A range ";
+              ss << range_str(
+                  range, array_schema_->domain().dimension_ptr(d)->type());
+              ss << " on dimension '";
+              ss << array_schema_->domain().dimension_ptr(d)->name();
+              ss << "' was set outside of the current domain ";
+              ss << cd->as_string();
+              ss << ".";
+              throw QueryException(ss.str());
             }
           }
         } else if (!all_ned_contained_in_current_domain) {

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -859,9 +859,11 @@ Status Query::process() {
           // Make sure all ranges are contained in the current domain.
           for (auto& range : subarray_.ranges_for_dim(d)) {
             if (!cd->includes(d, range)) {
-              throw QueryException(
-                std::format("A range {} on dimension '{}' was set outside of the current domain {}.",
-                  range_str(range, array_schema_->domain().dimension_ptr(d)->type()),
+              throw QueryException(std::format(
+                  "A range {} on dimension '{}' was set outside of the current "
+                  "domain {}.",
+                  range_str(
+                      range, array_schema_->domain().dimension_ptr(d)->type()),
                   array_schema_->domain().dimension_ptr(d)->name(),
                   cd->as_string()));
             }

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -59,6 +59,7 @@
 #include "tiledb/sm/tile/writer_tile_tuple.h"
 
 #include <cassert>
+#include <format>
 #include <iostream>
 #include <sstream>
 


### PR DESCRIPTION
<long description>

[[sc-61579]](https://app.shortcut.com/tiledb-inc/story/61579/print-actual-coordinate-values-for-out-of-bounds-errors)

Before:

```
tiledbsoma._exception.SOMAError: [ManagedQuery] [unnamed] Query FAILED: Query: A range was set outside the current domain.
```

After:

```
tiledbsoma._exception.SOMAError: [ManagedQuery] [unnamed] Query FAILED: Query: A range [99999, 99999] on dimension 'soma_joinid' was set outside of the current domain [[0, 2637]].
```

---
TYPE: IMPROVEMENT
DESC: Show errant values in current-domain out-of-bounds error message
