### PR TITLE
Fix a CI error-reporting glitch for MacOS

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -236,7 +236,13 @@ jobs:
         run: ./scripts/ci/posix/dump-core-stacks.sh
 
       - name: List files in build directory on failure
-        run: du --exclude _deps -h $GITHUB_WORKSPACE/build
+        run: |
+          if [ $(uname) = "Darwin" ] ; then
+            # MacOS du lacks --exclude
+            du -h $GITHUB_WORKSPACE/build
+          else
+            du --exclude _deps -h $GITHUB_WORKSPACE/build
+          fi
         if: ${{ failure() }}
 
       - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go


### PR DESCRIPTION
In failed CI runs such as
https://github.com/TileDB-Inc/TileDB/actions/runs/12699737048/job/35400999272
when we try to list files in the build directory on failure, we fail trying to do _that_ on MacOS, since MacOS `du` does not support `--exclude`:

![Screenshot 2025-01-10 at 10 50 14 AM](https://github.com/user-attachments/assets/95b33bb8-c6ce-457c-85ad-428810953538)

---
TYPE: NO_HISTORY
DESC: Avoid `--exclude` for MacOS `du` in failure-logging
