### PR TITLE
Update artifacts actions to v4.

### DIFF
--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -56,7 +56,7 @@ jobs:
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
       - name: "Upload binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mingw-w64-${{ matrix.msystem }}-tiledb
           path: .github/workflows/mingw-w64-tiledb/*.pkg.tar.*

--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Save the tiledb_unit binary for use in the next step
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tiledb_unit
           path: ${{ github.workspace }}/build/test/tiledb_unit
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download a single artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tiledb_unit
           path: ${{ github.workspace }}/build/test/

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -406,7 +406,7 @@ jobs:
 
       - name: 'upload dumpfile artifacts' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ always() == true && startsWith(matrix.os, 'windows-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{matrix.environ}}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: 'Upload failure artifacts (Linux)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ startsWith(matrix.os, 'ubuntu-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "coredumps.${{ github.job }}.${{ matrix.os }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"
@@ -257,7 +257,7 @@ jobs:
 
       - name: 'Upload failure artifacts (macOS)' # https://github.com/actions/upload-artifact#where-does-the-upload-go
         if: ${{ failure() == true && startsWith(matrix.os, 'macos-') == true }} # only run this job if the build step failed
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 10
           name: "${{ matrix.os }}.coredumps.${{ github.job }}.${{ github.run_number }}.${{github.run_id}}.${{github.run_attempt}}"

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -146,4 +146,4 @@ jobs:
         with:
           name: nightly GitHub Actions build
           label: nightly
-          assignee: KiterLuc,teo-tsirpanis,davisp
+          assignee: davisp,dudoslav,ihnorton,teo-tsirpanis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,4 +216,4 @@ jobs:
         with:
           name: Release failed
           label: release
-          assignee: teo-tsirpanis,davisp
+          assignee: davisp,dudoslav,ihnorton,teo-tsirpanis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           TILEDB_PACKAGE_VERSION: ${{ steps.get-values.outputs.release_version }}
         run: cd build && cpack --config CPackSourceConfig.cmake
       - name: Upload Release Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: |
@@ -124,9 +124,9 @@ jobs:
           TILEDB_PACKAGE_VERSION: ${{ steps.get-values.outputs.release_version }}
         run: cmake --build build -j4 --config Release --target package
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: release
+          name: release-${{ matrix.platform }}
           path: |
             build/tiledb-*.tar.gz*
             build/tiledb-*.zip*
@@ -142,9 +142,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: release
+          pattern: release-*
+          merge-multiple: true
           path: dist
       - name: Test names of release artifacts
         run: |
@@ -161,9 +162,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: release
+          name: release-*
+          merge-multiple: true
           path: dist
       - name: Publish release artifacts
         uses: actions/github-script@v6
@@ -214,4 +216,4 @@ jobs:
         with:
           name: Release failed
           label: release
-          assignee: KiterLuc,teo-tsirpanis,davisp
+          assignee: teo-tsirpanis,davisp


### PR DESCRIPTION
CI is completely broken because the v3 actions are no longer supported ([example](https://github.com/TileDB-Inc/TileDB/actions/runs/12931712959/job/36066244432?pr=5430)).

---
TYPE: NO_HISTORY