### PR TITLE
Show reasons a POSIX file cannot be read

### DIFF
--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -31,7 +31,6 @@
  */
 
 #include <algorithm>
-#include <format>
 #include <mutex>
 #include <sstream>
 #include <unordered_set>
@@ -184,7 +183,7 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     assert(buffer);
 
     if (offset + nbytes > size_)
-      return LOG_STATUS(Status_MemFSError(std::format(
+      return LOG_STATUS(Status_MemFSError(fmt::format(
           "Cannot read from file; Read exceeds file size: offset {} nbytes {} "
           "size_ {}",
           offset,

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -31,6 +31,7 @@
  */
 
 #include <algorithm>
+#include <format>
 #include <mutex>
 #include <sstream>
 #include <unordered_set>
@@ -183,8 +184,12 @@ class MemFilesystem::File : public MemFilesystem::FSNode {
     assert(buffer);
 
     if (offset + nbytes > size_)
-      return LOG_STATUS(
-          Status_MemFSError("Cannot read from file; Read exceeds file size"));
+      return LOG_STATUS(Status_MemFSError(std::format(
+          "Cannot read from file; Read exceeds file size: offset {} nbytes {} "
+          "size_ {}",
+          offset,
+          nbytes,
+          size_)));
 
     memcpy(buffer, (char*)data_ + offset, nbytes);
     return Status::Ok();

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -47,7 +47,6 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <format>
 #include <fstream>
 #include <future>
 #include <iostream>
@@ -275,7 +274,7 @@ void Posix::read(
   uint64_t file_size;
   this->file_size(URI(path), &file_size);
   if (offset + nbytes > file_size) {
-    throw IOError(std::format(
+    throw IOError(fmt::format(
         "Cannot read from file; Read exceeds file size: offset {}, nbytes {}, "
         "file_size {}, URI {}",
         offset,

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -32,10 +32,10 @@
 
 #ifndef _WIN32
 
-#include "tiledb/sm/filesystem/posix.h"
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/common/stdx_string.h"
+#include "tiledb/sm/filesystem/posix.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "uri.h"
@@ -47,6 +47,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <format>
 #include <fstream>
 #include <future>
 #include <iostream>
@@ -273,8 +274,15 @@ void Posix::read(
   auto path = uri.to_path();
   uint64_t file_size;
   this->file_size(URI(path), &file_size);
-  if (offset + nbytes > file_size)
-    throw IOError("Cannot read from file; Read exceeds file size");
+  if (offset + nbytes > file_size) {
+    throw IOError(std::format(
+        "Cannot read from file; Read exceeds file size: offset {}, nbytes {}, "
+        "file_size {}, URI {}",
+        offset,
+        nbytes,
+        file_size,
+        uri.to_path()));
+  }
 
   // Open file
   int fd = open(path.c_str(), O_RDONLY);

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -32,10 +32,10 @@
 
 #ifndef _WIN32
 
+#include "tiledb/sm/filesystem/posix.h"
 #include "tiledb/common/filesystem/directory_entry.h"
 #include "tiledb/common/logger.h"
 #include "tiledb/common/stdx_string.h"
-#include "tiledb/sm/filesystem/posix.h"
 #include "tiledb/sm/misc/constants.h"
 #include "tiledb/sm/misc/tdb_math.h"
 #include "uri.h"

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -462,11 +462,19 @@ Status Win::read(
         0) {
       auto gle = GetLastError();
       CloseHandle(file_h);
+
+      std::string err_msg;
+      if (gle != 0) {
+        err_msg = get_last_error_msg(gle, "ReadFile");
+      } else {
+        err_msg = "num_bytes_read " + std::to_string(num_bytes_read) +
+                  " != nbytes " + std::to_string(nbytes)
+      }
+
       return LOG_STATUS(Status_IOError(
-          "Cannot read from file '" + path + "'; File read error " +
-          (gle != 0 ? get_last_error_msg(gle, "ReadFile") :
-                      "num_bytes_read " + std::to_string(num_bytes_read) +
-                          " != nbyes " + std::to_string(nbytes))));
+          "Cannot read from file '" + path + "'; File read error '" + err_msg +
+          "' offset " + std::string(offset) + " nbytes " +
+          std::string(nbytes)));
     }
     byte_buffer += num_bytes_read;
     offset += num_bytes_read;
@@ -548,8 +556,9 @@ Status Win::write(
   uint64_t file_offset = file_size_lg_int.QuadPart;
   if (!write_at(file_h, file_offset, buffer, buffer_size).ok()) {
     CloseHandle(file_h);
-    return LOG_STATUS(
-        Status_IOError(std::string("Cannot write to file '") + path));
+    return LOG_STATUS(Status_IOError(
+        std::string("Cannot write to file '") + path + "'" + " file_offset " +
+        std::string(file_offset) + " buffer_size " + std::string(buffer_size)));
   }
   // Always close the handle.
   if (CloseHandle(file_h) == 0) {
@@ -588,9 +597,11 @@ Status Win::write_at(
             bytes_to_write,
             &bytes_written,
             &ov) == 0) {
+      // There's no guarantee that the bytes_written outarg was updated, when
+      // the write failed -- so let's not log it.
       return LOG_STATUS(Status_IOError(std::string(
-          "Cannot write to file; File writing error: " +
-          get_last_error_msg("WriteFile"))));
+          get_last_error_msg("WriteFile") + " bytes_to_write " +
+          std::string(bytes_to_write))));
     }
     remaining_bytes_to_write -= bytes_written;
     byte_idx += bytes_written;


### PR DESCRIPTION
Twice in the last few weeks, doing operational work, I've seen the error message

```
tiledb.cc.TileDBError: [TileDB::Array] Error: ArrayDirectory: IO Error:
Cannot read from file; Read exceeds file size
```

This error happens (rightly) when `offset + nbytes > file_size`. In order to be helpful, the message should say what those numbers are. If `offset` is 10 and `nbytes` is 5 but `file_size` is 0, that's a data problem to debug; if `nbytes` is in the billions, that's more likely a software problem to debug.

In any case, the error message should be helpful. As-is, not only does the message hide useful information, it doesn't even show the URI in question. This forces whoever's doing debug work to rebuild core in debug mode, re-run the repro in the debugger, and print things out in the debugger. It's a more effective use of time for the message to show that debug information.

See also [[sc-62426]](https://app.shortcut.com/tiledb-inc/story/62426) for Windows CI issue (@teo-tsirpanis)

---
TYPE: IMPROVEMENT
DESC: Show file size, offset, nbytes, and URI in file-read error message
