### PR TITLE
Result tile wait_all should block on the async i/o result

### DIFF
--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -281,12 +281,15 @@ void ResultTile::wait_all_tiles(
   for (auto& at : tiles) {
     const auto& tile_tuple = at.second;
     if (tile_tuple.has_value()) {
-      tile_tuple.value().fixed_tile().data();
+      // Wait for the fixed tile i/o to be done
+      tile_tuple.value().fixed_tile().filtered_data();
       if (tile_tuple.value().var_tile_opt().has_value()) {
-        tile_tuple.value().var_tile_opt().value().data();
+        // Wait for the var tile i/o to be done
+        tile_tuple.value().var_tile_opt().value().filtered_data();
       }
       if (tile_tuple.value().validity_tile_opt().has_value()) {
-        tile_tuple.value().validity_tile_opt().value().data();
+        // Wait for the validity tile i/o to be done
+        tile_tuple.value().validity_tile_opt().value().filtered_data();
       }
     }
   }

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -280,7 +280,7 @@ class Tile : public TileBase {
   }
 
   /** Returns the buffer that contains the filtered, on-disk format. */
-  inline char* filtered_data() {
+  inline char* filtered_data() const {
     std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
     if (filtered_data_io_task_.has_value()) {
       if (filtered_data_io_task_.value().valid()) {


### PR DESCRIPTION
As @ihnorton has noticed while auditing the code in https://github.com/TileDB-Inc/TileDB/pull/5401 , in result tile destructor we were waiting on `data()` instead of `filtered_data()` for the async task to have finished. This was a leftover from the previous version of the code (before the split between part 1 and 2), where we were also unfiltering in an async fashion, so `data()` was also blocking waiting for the unfiltering shared future to be done.

This PR fixes this by waiting just for the I/O task to be done.

---
TYPE: IMPROVEMENT
DESC: Result tile wait_all should block on the async I/O result
