### PR TITLE
[release-2.27] Run CI tests on windows-2022

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
         #considering https://stackoverflow.com/questions/65035256/how-to-access-matrix-variables-in-github-actions
         environ: [azure, s3, gcs, serialization]
         include:

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -83,7 +83,7 @@ jobs:
         include:
           - os: ubuntu-latest
             triplet: x64-linux
-          - os: windows-2019
+          - os: windows-2022
             triplet: x64-windows
           - os: macos-13
             triplet: x64-osx


### PR DESCRIPTION
Partial backport of #5419 to release-2.27, due to compile errors in the tests of #5443.

Because the release workflow was not updated, this is not a breaking change. 

TYPE: NO_HISTORY