### PR TITLE
Do not use read-ahead cache in array/group directory.

### DIFF
--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -726,7 +726,7 @@ ArrayDirectory::load_consolidated_commit_uris(
       std::string names;
       names.resize(size);
       RETURN_NOT_OK_TUPLE(
-          resources_.get().vfs().read(uri, 0, &names[0], size),
+          resources_.get().vfs().read(uri, 0, &names[0], size, false),
           nullopt,
           nullopt);
       std::stringstream ss(names);
@@ -752,7 +752,7 @@ ArrayDirectory::load_consolidated_commit_uris(
       auto& names = meta_files.back().second;
       names.resize(size);
       RETURN_NOT_OK_TUPLE(
-          resources_.get().vfs().read(uri, 0, &names[0], size),
+          resources_.get().vfs().read(uri, 0, &names[0], size, false),
           nullopt,
           nullopt);
       std::stringstream ss(names);
@@ -1082,7 +1082,7 @@ ArrayDirectory::compute_uris_to_vacuum(
     throw_if_not_ok(vfs.file_size(vac_files[i], &size));
     std::string names;
     names.resize(size);
-    throw_if_not_ok(vfs.read(vac_files[i], 0, &names[0], size));
+    throw_if_not_ok(vfs.read(vac_files[i], 0, &names[0], size, false));
     std::stringstream ss(names);
     bool vacuum_vac_file = true;
     for (std::string uri_str; std::getline(ss, uri_str);) {

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -273,7 +273,7 @@ GroupDirectory::compute_uris_to_vacuum(const std::vector<URI>& uris) const {
     throw_if_not_ok(vfs_.file_size(vac_files[i], &size));
     std::string names;
     names.resize(size);
-    throw_if_not_ok(vfs_.read(vac_files[i], 0, &names[0], size));
+    throw_if_not_ok(vfs_.read(vac_files[i], 0, &names[0], size, false));
     std::stringstream ss(names);
     bool vacuum_vac_file = true;
     for (std::string uri_str; std::getline(ss, uri_str);) {


### PR DESCRIPTION
[SC-62900](https://app.shortcut.com/tiledb-inc/story/62900)

In all cases where we read files from the VFS there, we get the file's size beforehand and read the entirety of it. This makes the read-ahead cache not actually required. Fixes failures when reading empty `.vac` files (in S3 we do a `GetObject` with a range of `0-102399`, which fails with a range not satisfiable error).

---
TYPE: BUG
DESC: Fix failures when opening an array or group with an empty `.vac` file.