### PR TITLE
Do not create empty .vac files in metadata consolidation

### DIFF
--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -1083,6 +1083,19 @@ TEST_CASE_METHOD(
   tiledb::sm::URI group_uri(temp_dir + "group");
   REQUIRE(tiledb_group_create(ctx_, group_uri.c_str()) == TILEDB_OK);
 
+  // Consolidate empty metadata
+  tiledb_config_t* cfg;
+  tiledb_error_t* err = nullptr;
+  REQUIRE(tiledb_config_alloc(&cfg, &err) == TILEDB_OK);
+  int rc = tiledb_group_consolidate_metadata(ctx_, group_uri.c_str(), cfg);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Check no .vac file is created
+  std::vector<std::string> group_empty_meta_vac_files;
+  get_meta_vac_files(group_uri, group_empty_meta_vac_files);
+  CHECK(group_empty_meta_vac_files.size() == 0);
+  tiledb_config_free(&cfg);
+
   write_group_metadata(group_uri.c_str());
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   auto start = tiledb::sm::utils::time::timestamp_now_ms();
@@ -1100,7 +1113,7 @@ TEST_CASE_METHOD(
   CHECK(group_meta_files.size() == 4);
 
   uint64_t file_size = 0;
-  int rc = tiledb_vfs_file_size(
+  rc = tiledb_vfs_file_size(
       ctx_, vfs_, group_meta_vac_files[0].c_str(), &file_size);
   REQUIRE(rc == TILEDB_OK);
 

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -80,6 +80,12 @@ Status ArrayMetaConsolidator::consolidate(
       encryption_key,
       key_length));
 
+  // Check if there's actually more than 1 file to consolidate
+  auto& metadata_r = array_for_reads.metadata();
+  if (metadata_r.loaded_metadata_uris().size() <= 1) {
+    return Status::Ok();
+  }
+
   // Open array for writing
   Array array_for_writes(resources_, array_uri);
   RETURN_NOT_OK_ELSE(
@@ -88,7 +94,6 @@ Status ArrayMetaConsolidator::consolidate(
       throw_if_not_ok(array_for_reads.close()));
 
   // Copy-assign the read metadata into the metadata of the array for writes
-  auto& metadata_r = array_for_reads.metadata();
   array_for_writes.opened_array()->metadata() = metadata_r;
   URI new_uri = metadata_r.get_uri(array_uri);
   const auto& to_vacuum = metadata_r.loaded_metadata_uris();

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -83,8 +83,13 @@ Status GroupMetaConsolidator::consolidate(
     group_for_reads.close();
   }
 
-  // Copy-assign the read metadata into the metadata of the group for writes
+  // Check if there's actually more than 1 file to consolidate
   auto metadata_r = group_for_reads.metadata();
+  if (metadata_r->loaded_metadata_uris().size() <= 1) {
+    return Status::Ok();
+  }
+
+  // Copy-assign the read metadata into the metadata of the group for writes
   *(group_for_writes.metadata()) = *metadata_r;
   URI new_uri = metadata_r->get_uri(group_uri);
   const auto& to_vacuum = metadata_r->loaded_metadata_uris();


### PR DESCRIPTION
When we are trying to consolidate array or group metadata but there are no array or group metadata present, we are creating an empty `.vac` file on local filesystems. In object stores, notably on S3 that I have tested, our `write` method currently doesn't create a file when size is `0` (this is most probably another issue to fix), so we don't observe the same behavior.

This PR unifies the behavior by enforcing that we don't create a `.vac` file if no consolidation is possible, aka if there are 0 or 1 array/group metadata present. We already do such a check for fragment metadata, fragments and commit consolidation.
Both tests in this PR were failing without the fix and are now passing.

---
TYPE: BUG
DESC: Do not create empty .vac files in metadata consolidation
