### PR TITLE
Add missing headers.

### DIFF
--- a/tiledb/common/heap_profiler.cc
+++ b/tiledb/common/heap_profiler.cc
@@ -30,13 +30,13 @@
  * This file contains the implementation of the HeapProfiler class.
  */
 
+#include <chrono>
 #include <fstream>
 #include <iostream>
 
 #include "tiledb/common/heap_profiler.h"
 
-namespace tiledb {
-namespace common {
+namespace tiledb::common {
 
 HeapProfiler heap_profiler;
 
@@ -332,5 +332,4 @@ void HeapProfiler::dump_internal() {
     file_stream.close();
 }
 
-}  // namespace common
-}  // namespace tiledb
+}  // namespace tiledb::common

--- a/tiledb/sm/stats/duration_instrument.h
+++ b/tiledb/sm/stats/duration_instrument.h
@@ -33,13 +33,13 @@
 #ifndef TILEDB_DURATION_INSTRUMENT_H
 #define TILEDB_DURATION_INSTRUMENT_H
 
+#include <chrono>
+
 #include "tiledb/common/common.h"
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
-namespace stats {
+namespace tiledb::sm::stats {
 
 class Stats;
 
@@ -81,8 +81,6 @@ class DurationInstrument {
   std::chrono::high_resolution_clock::time_point start_time_;
 };
 
-}  // namespace stats
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm::stats
 
 #endif  // TILEDB_DURATION_INSTRUMENT_H


### PR DESCRIPTION
Fixes compile errors with the newly released Visual Studio 17.13.

---
TYPE: BUG
DESC: Fix compile errors with Visual Studio 2022 17.13.