### PR TITLE
Fix query condition regression introduced by #5417

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,12 +169,13 @@ if (MSVC)
   add_compile_definitions("$<IF:$<CONFIG:Debug>,DEBUG,NDEBUG>")
   add_compile_options(
     # /Od: Disable optimizations
-    # /bigobj: Increase number of sections in .obj file
-    "$<$<CONFIG:Debug>:/Od;/bigobj>"
+    "$<$<CONFIG:Debug>:/Od>"
     # /Ox: Enable most speed optimizations
     "$<$<CONFIG:Release,RelWithDebInfo>:/Ox>"
     # /Zi: Generate debug info in a separate .pdb file
     "$<$<CONFIG:Debug,RelWithDebInfo>:/Zi>")
+  # /bigobj: increase number of sections in .obj file
+  add_compile_options("/bigobj")
 else()
   add_compile_options(-Wall -Wextra)
   if (TILEDB_WERROR)

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1561,7 +1561,8 @@ TEST_CASE_METHOD(
       auto condition =
           *rc::make_query_condition<FxRun1D<>::FragmentType>(std::make_tuple(
               templates::Domain<int>(1, 200),
-              templates::Domain<int>(0, num_fragments * fragment_size)));
+              templates::Domain<int>(
+                  0, static_cast<int>(num_fragments * fragment_size))));
       doit.operator()<tiledb::test::AsserterRapidcheck>(
           num_fragments,
           fragment_size,
@@ -1651,7 +1652,8 @@ TEST_CASE_METHOD(
       auto condition =
           *rc::make_query_condition<FxRun1D<>::FragmentType>(std::make_tuple(
               templates::Domain<int>(1, 200),
-              templates::Domain<int>(0, num_fragments * fragment_size)));
+              templates::Domain<int>(
+                  0, static_cast<int>(num_fragments * fragment_size))));
       doit.operator()<tiledb::test::AsserterRapidcheck>(
           num_fragments,
           fragment_size,
@@ -1823,7 +1825,8 @@ TEST_CASE_METHOD(
           *rc::make_query_condition<FxRun2D::FragmentType>(std::make_tuple(
               templates::Domain<int>(1, 200),
               templates::Domain<int>(1, 200),
-              templates::Domain<int>(0, (num_fragments + 1) * fragment_size)));
+              templates::Domain<int>(
+                  0, static_cast<int>((num_fragments + 1) * fragment_size))));
 
       doit.operator()<tiledb::test::AsserterRapidcheck>(
           tile_order,
@@ -1988,7 +1991,9 @@ TEST_CASE_METHOD(
               templates::Domain<int>(1, 200),
               templates::Domain<int>(1, 200),
               templates::Domain<int>(
-                  0, 2 * num_fragments * d1_extent * d2_extent)));
+                  0,
+                  static_cast<int>(
+                      2 * num_fragments * d1_extent * d2_extent))));
       doit.operator()<tiledb::test::AsserterRapidcheck>(
           tile_order,
           cell_order,

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -2027,7 +2027,7 @@ TEST_CASE_METHOD(
     CSparseGlobalOrderFx,
     "Sparse global order reader: fragment full copy 1d",
     "[sparse-global-order][rest][rapidcheck]") {
-  using FxRunType = FxRun1D<Datatype::INT64, Datatype::INT64, Datatype::UINT8>;
+  using FxRunType = FxRun1D<Datatype::INT64, Datatype::INT64, Datatype::UINT16>;
   auto doit = [this]<typename Asserter>(
                   size_t num_fragments,
                   templates::Dimension<Datatype::INT64> dimension,
@@ -2067,7 +2067,7 @@ TEST_CASE_METHOD(
       std::iota(
           std::get<1>(fragment.atts_).begin(),
           std::get<1>(fragment.atts_).end(),
-          f * fragment.dim_.size());
+          static_cast<uint16_t>(f * fragment.dim_.size()));
 
       instance.fragments.push_back(fragment);
     }
@@ -2103,10 +2103,10 @@ TEST_CASE_METHOD(
       const auto domains = std::make_tuple(
           dimension.domain,
           templates::Domain<int64_t>(0, dimension.domain.upper_bound),
-          templates::Domain<uint8_t>(
+          templates::Domain<uint16_t>(
               0,
-              static_cast<uint8_t>(std::min<int64_t>(
-                  std::numeric_limits<uint8_t>::max(),
+              static_cast<uint16_t>(std::min<int64_t>(
+                  std::numeric_limits<uint16_t>::max(),
                   dimension.domain.upper_bound * num_fragments))));
       auto condition =
           *rc::make_query_condition<FxRunType::FragmentType>(domains);

--- a/test/support/rapidcheck/array_templates.h
+++ b/test/support/rapidcheck/array_templates.h
@@ -128,7 +128,7 @@ struct Arbitrary<templates::Dimension<D>> {
         });
 
     return gen::map(tup, [](std::pair<Domain<CoordType>, CoordType> tup) {
-      return templates::Dimension<D>{.domain = tup.first, .extent = tup.second};
+      return templates::Dimension<D>(tup.first, tup.second);
     });
   }
 };

--- a/test/support/rapidcheck/array_templates.h
+++ b/test/support/rapidcheck/array_templates.h
@@ -49,10 +49,10 @@ struct Arbitrary<templates::Domain<D>> {
     // NB: `gen::inRange` is exclusive at the upper end but tiledb domain is
     // inclusive. So we have to use `int64_t` to avoid overflow.
     auto bounds = gen::mapcat(gen::arbitrary<D>(), [](D lb) {
-      if (std::is_same<D, int64_t>::value) {
+      if constexpr (std::is_same<D, int64_t>::value) {
         return gen::pair(
             gen::just(lb), gen::inRange(lb, std::numeric_limits<D>::max()));
-      } else if (std::is_same<D, uint64_t>::value) {
+      } else if constexpr (std::is_same<D, uint64_t>::value) {
         return gen::pair(
             gen::just(lb), gen::inRange(lb, std::numeric_limits<D>::max()));
       } else {

--- a/test/support/rapidcheck/query_condition.h
+++ b/test/support/rapidcheck/query_condition.h
@@ -1,0 +1,117 @@
+/**
+ * @file test/support/rapidcheck/query_condition.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines rapidcheck generators for query condition AST.
+ */
+
+#ifndef TILEDB_RAPIDCHECK_QUERY_CONDITION_H
+#define TILEDB_RAPIDCHECK_QUERY_CONDITION_H
+
+#include "tiledb/sm/query/ast/query_ast.h"
+
+#include <test/support/src/array_templates.h>
+#include <test/support/stdx/tuple.h>
+#include <test/support/tdb_rapidcheck.h>
+
+namespace rc {
+
+template <>
+struct Arbitrary<tiledb::sm::QueryConditionOp> {
+  static Gen<tiledb::sm::QueryConditionOp> arbitrary() {
+    // NOT IN and IN are not handled yet by the users of this
+    return gen::element(
+        tiledb::sm::QueryConditionOp::LT,
+        tiledb::sm::QueryConditionOp::LE,
+        tiledb::sm::QueryConditionOp::GT,
+        tiledb::sm::QueryConditionOp::GE,
+        tiledb::sm::QueryConditionOp::EQ,
+        tiledb::sm::QueryConditionOp::NE);
+  }
+};
+
+template <FragmentType Fragment>
+Gen<tdb_unique_ptr<tiledb::sm::ASTNode>> make_query_condition() {
+  using DimensionTuple =
+      stdx::decay_tuple<decltype(std::declval<Fragment>().dimensions())>;
+  using AttributeTuple =
+      stdx::decay_tuple<decltype(std::declval<Fragment>().attributes())>;
+  using FieldTuple = decltype(std::tuple_cat(
+      std::declval<DimensionTuple>(), std::declval<AttributeTuple>()));
+
+  auto field = gen::inRange<size_t>(0, std::tuple_size_v<FieldTuple>);
+  auto op = gen::arbitrary<tiledb::sm::QueryConditionOp>();
+
+  auto parts = gen::mapcat(gen::pair(field, op), [](auto arg) {
+    size_t field;
+    tiledb::sm::QueryConditionOp op;
+    std::tie(field, op) = arg;
+
+    const auto field_names = QueryConditionEvalSchema<Fragment>().field_names_;
+
+    using R = std::pair<std::string, Gen<std::string>>;
+    auto make_value_gen = [&](auto i) -> std::optional<R> {
+      if (field == i) {
+        using ValueType =
+            typename std::tuple_element<i, FieldTuple>::type::value_type;
+        // NB: `arbitrary` will provide mostly useless values
+        // This range likely suits the current test cases
+        auto value = gen::inRange<ValueType>(-128, 128);
+        auto p = std::make_pair(field_names[i], gen::map(value, [](auto value) {
+                                  return std::string(
+                                      reinterpret_cast<char*>(&value),
+                                      sizeof(value));
+                                }));
+        return std::optional<R>{p};
+      } else {
+        return std::optional<R>{};
+      }
+    };
+
+    auto fielddata = stdx::fold_optional<R>(
+        std::make_index_sequence<std::tuple_size_v<FieldTuple>>{},
+        make_value_gen);
+
+    return gen::tuple(
+        gen::just(fielddata.value().first),
+        gen::just(op),
+        fielddata.value().second);
+  });
+
+  return gen::map(parts, [](auto arg) {
+    return tdb_unique_ptr<tiledb::sm::ASTNode>(new tiledb::sm::ASTNodeVal(
+        std::get<0>(arg),
+        std::get<2>(arg).data(),
+        std::get<2>(arg).size(),
+        std::get<1>(arg)));
+  });
+}
+
+}  // namespace rc
+
+#endif

--- a/test/support/src/array_templates.h
+++ b/test/support/src/array_templates.h
@@ -184,6 +184,12 @@ template <tiledb::sm::Datatype DATATYPE>
 struct Dimension {
   using value_type = tiledb::type::datatype_traits<DATATYPE>::value_type;
 
+  Dimension() = default;
+  Dimension(Domain<value_type> domain, value_type extent)
+      : domain(domain)
+      , extent(extent) {
+  }
+
   Domain<value_type> domain;
   value_type extent;
 };
@@ -283,6 +289,8 @@ struct QueryConditionEvalSchema {
  */
 template <DimensionType D, AttributeType... Att>
 struct Fragment1D {
+  using DimensionType = D;
+
   std::vector<D> dim_;
   std::tuple<std::vector<Att>...> atts_;
 

--- a/test/support/src/array_templates.h
+++ b/test/support/src/array_templates.h
@@ -35,11 +35,15 @@
 #define TILEDB_ARRAY_TEMPLATES_H
 
 #include "tiledb.h"
+#include "tiledb/common/unreachable.h"
+#include "tiledb/sm/query/ast/query_ast.h"
 #include "tiledb/type/datatype_traits.h"
 #include "tiledb/type/range/range.h"
 
 #include <test/support/assert_helpers.h>
 #include <test/support/src/error_helpers.h>
+#include <test/support/stdx/fold.h>
+#include <test/support/stdx/tuple.h>
 
 #include <algorithm>
 #include <concepts>
@@ -182,6 +186,96 @@ struct Dimension {
 
   Domain<value_type> domain;
   value_type extent;
+};
+
+/**
+ * Schema of named fields for simple evaluation of a query condition
+ */
+template <FragmentType Fragment>
+struct QueryConditionEvalSchema {
+  std::vector<std::string> field_names_;
+
+  QueryConditionEvalSchema() {
+    stdx::decay_tuple<decltype(std::declval<Fragment>().dimensions())> dims;
+    stdx::decay_tuple<decltype(std::declval<Fragment>().attributes())> atts;
+
+    auto add_dimension = [&](auto) {
+      field_names_.push_back("d" + std::to_string(field_names_.size() + 1));
+    };
+    auto add_attribute = [&](auto) {
+      field_names_.push_back(
+          "a" +
+          std::to_string(
+              field_names_.size() + 1 - std::tuple_size<decltype(dims)>()));
+    };
+
+    std::apply([&](const auto... dim) { (add_dimension(dim), ...); }, dims);
+    std::apply([&](const auto... att) { (add_attribute(att), ...); }, atts);
+  }
+
+  /**
+   * @return true if a value passes a simple condition
+   */
+  template <AttributeType T>
+  static bool test(const T& value, const tiledb::sm::ASTNode& condition) {
+    switch (condition.get_op()) {
+      case tiledb::sm::QueryConditionOp::LT:
+        return value < *static_cast<const T*>(condition.get_value_ptr());
+      case tiledb::sm::QueryConditionOp::LE:
+        return value <= *static_cast<const T*>(condition.get_value_ptr());
+      case tiledb::sm::QueryConditionOp::GT:
+        return value > *static_cast<const T*>(condition.get_value_ptr());
+      case tiledb::sm::QueryConditionOp::GE:
+        return value >= *static_cast<const T*>(condition.get_value_ptr());
+      case tiledb::sm::QueryConditionOp::EQ:
+        return value == *static_cast<const T*>(condition.get_value_ptr());
+      case tiledb::sm::QueryConditionOp::NE:
+        return value != *static_cast<const T*>(condition.get_value_ptr());
+      case tiledb::sm::QueryConditionOp::IN:
+      case tiledb::sm::QueryConditionOp::NOT_IN:
+      case tiledb::sm::QueryConditionOp::ALWAYS_TRUE:
+      case tiledb::sm::QueryConditionOp::ALWAYS_FALSE:
+      default:
+        // not implemented here, lazy
+        stdx::unreachable();
+    }
+  }
+
+  /**
+   * @return true if `record` passes a simple (i.e. non-combination) query
+   * condition
+   */
+  bool test(
+      const Fragment& fragment,
+      int record,
+      const tiledb::sm::ASTNode& condition) const {
+    using DimensionTuple = stdx::decay_tuple<decltype(fragment.dimensions())>;
+    using AttributeTuple = stdx::decay_tuple<decltype(fragment.attributes())>;
+
+    const auto dim_eval = stdx::fold_sequence(
+        std::make_index_sequence<std::tuple_size_v<DimensionTuple>>{},
+        [&](auto i) {
+          if (condition.get_field_name() == field_names_[i]) {
+            return test(std::get<i>(fragment.dimensions())[record], condition);
+          } else {
+            return false;
+          }
+        });
+    if (dim_eval) {
+      return dim_eval;
+    }
+
+    return stdx::fold_sequence(
+        std::make_index_sequence<std::tuple_size_v<AttributeTuple>>{},
+        [&](auto i) {
+          if (condition.get_field_name() ==
+              field_names_[i + std::tuple_size_v<DimensionTuple>]) {
+            return test(std::get<i>(fragment.attributes())[record], condition);
+          } else {
+            return false;
+          }
+        });
+  }
 };
 
 /**

--- a/test/support/stdx/fold.h
+++ b/test/support/stdx/fold.h
@@ -1,0 +1,73 @@
+/**
+ * @file test/support/stdx/fold.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2025 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines functions which do things you would want a fold expression
+ * to do but can't figure out how to make them do it.
+ */
+
+#ifndef TILEDB_TEST_SUPPORT_FOLD_H
+#define TILEDB_TEST_SUPPORT_FOLD_H
+
+namespace stdx {
+
+template <typename T, T... S, typename F>
+constexpr bool fold_sequence(std::integer_sequence<T, S...>, F&& f) {
+  return (f(std::integral_constant<T, S>{}) || ...);
+}
+
+template <typename T, T First, T... Rest>
+struct fold_optional_t {
+  template <typename R, typename F>
+  static constexpr std::optional<R> fold(F&& f) {
+    const auto maybe = f(std::integral_constant<T, First>{});
+    if (maybe.has_value()) {
+      return maybe;
+    } else {
+      return fold_optional_t<T, Rest...>::template fold<R, F>(f);
+    }
+  }
+};
+
+template <typename T, T Only>
+struct fold_optional_t<T, Only> {
+  template <typename R, typename F>
+  static constexpr std::optional<R> fold(F&& f) {
+    return f(std::integral_constant<T, Only>{});
+  }
+};
+
+template <typename R, typename T, T... S, typename F>
+constexpr std::optional<R> fold_optional(
+    std::integer_sequence<T, S...>, F&& f) {
+  return fold_optional_t<T, S...>::template fold<R, F>(f);
+}
+
+}  // namespace stdx
+
+#endif

--- a/test/support/stdx/tuple.h
+++ b/test/support/stdx/tuple.h
@@ -131,4 +131,5 @@ std::tuple<std::vector<Ts>...> select(
 }
 
 }  // namespace stdx
+
 #endif

--- a/test/support/stdx/tuple.h
+++ b/test/support/stdx/tuple.h
@@ -76,6 +76,19 @@ std::tuple<const std::decay_t<Ts>&...> reference_tuple(
       tuple);
 }
 
+// Helper function used for `value_type_tuple_t`.
+// This is not intended to be evaluated.
+template <typename... Ts>
+constexpr std::tuple<typename Ts::value_type...> value_type_tuple_f(
+    std::tuple<Ts...> tuple);
+
+/**
+ * Maps a tuple type `(T1, T2, ...)`,
+ * to a type `(T1::value_type, T2::value_type, ...)`.
+ */
+template <typename Tuple>
+using value_type_tuple_t = decltype(value_type_tuple_f(std::declval<Tuple>()));
+
 /**
  * Given two tuples of vectors, extends each of the fields of `dst`
  * with the corresponding field of `src`.

--- a/test/support/tdb_rapidcheck.h
+++ b/test/support/tdb_rapidcheck.h
@@ -79,6 +79,8 @@ namespace rc {
  */
 template <typename T>
 struct NonShrinking {
+  using value_type = T;
+
   NonShrinking(T&& inner)
       : inner_(std::move(inner)) {
   }

--- a/test/support/tdb_rapidcheck.h
+++ b/test/support/tdb_rapidcheck.h
@@ -80,7 +80,7 @@ namespace rc {
 template <typename T>
 struct NonShrinking {
   NonShrinking(T&& inner)
-      : inner_(inner) {
+      : inner_(std::move(inner)) {
   }
 
   T inner_;

--- a/tiledb/sm/query/readers/result_coords.h
+++ b/tiledb/sm/query/readers/result_coords.h
@@ -227,7 +227,8 @@ struct GlobalOrderResultCoords
    *
    * @return Max slab length that can be merged for this tile.
    */
-  uint64_t max_slab_length() {
+  uint64_t max_slab_length(
+      uint64_t upper_bound = std::numeric_limits<uint64_t>::max()) const {
     uint64_t ret = 1;
     uint64_t cell_num = base::tile_->cell_num();
     uint64_t next_pos = base::pos_ + 1;
@@ -250,13 +251,14 @@ struct GlobalOrderResultCoords
 
       // With bitmap, find the longest contiguous set of bits in the bitmap
       // from the current position.
-      while (next_pos < cell_num && bitmap[next_pos] == 1) {
+      while (ret < upper_bound && next_pos < cell_num &&
+             bitmap[next_pos] == 1) {
         next_pos++;
         ret++;
       }
     } else {
       // No bitmap, add all cells from current position.
-      ret = cell_num - base::pos_;
+      ret = std::min(upper_bound, cell_num - base::pos_);
     }
 
     return ret;

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1855,9 +1855,12 @@ SparseGlobalOrderReader<BitmapType>::merge_result_cell_slabs(
           }
         } else {
           if (add_next_cell_result == AddNextCellResult::NeedMoreTiles) {
-            // e.g. because we were hitting duplicate coords and reached
-            // the end of a tile while de-duplicating
-            length = 1;
+            // This happens while de-duplicating, so this `NeedMoreTiles`
+            // came from a different fragment. Emit this coordinate
+            // (if it qualifies) but not anything past it, since they might
+            // need to be de-duplicated with coordinates from the next round
+            // of tiles.
+            length = to_process.max_slab_length(1);
           } else if (tile_queue.empty()) {
             length = to_process.max_slab_length();
           } else {


### PR DESCRIPTION
#5417 made several changes to `SparseGlobalOrderReader::merge_result_cell_slabs`. One of these changes erroneously caused coordinates which do not pass the query condition to be emitted.  This pull request restores the correct behavior.

The crux of the change is
```
            length = 1;
```
to
```
            length = to_process.max_slab_length(1);
```

The affected line of code occurs during coordinate de-duplication.  `merge_result_cell_slabs` puts coordinates from the leading tile of each fragment into a priority queue and pops them off.  If the coordinate at the head of the queue matches what we just pulled off, then we continue popping until there is no longer a match.

This de-duplication can cause a fragment to run out of loaded tiles, in which case it is necessary to end the loop to get more data so that we do not emit coordinates out of order.  That's how we get to this `length = 1` code, which signals that we should emit a result slab of length 1.  In contrast, `max_slab_length(1)` checks the query condition bitmap to see if the duplicated coordinate actually belongs in the query result.

This was found by a customer data set which has many fragments which are essentially copies of the whole coordinate domain.  This scenario de-duplicates many coordinates and is likely to hit the condition described.  The new test `Sparse global order reader: fragment full copy 1d` simulates this set-up.

A large fraction of the changes in this PR are the test scaffolding changes to support evaluating query conditions upon our `FxRun1D` and `FxRun2D` structures, so we can continue to check whether the expected and actual results match in the presence of a query condition.

---
TYPE: BUG
DESC: Fix query condition regression introduced by #5417 