### PR TITLE
chore: [sc-63841] [core] adding multiple attributes with schema evolution does not add them in a predictable order

### DIFF
--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -32,7 +32,10 @@
 
 #include <test/support/src/vfs_helpers.h>
 #include <test/support/tdb_catch.h>
+#include "test/support/src/array_helpers.h"
+#include "test/support/src/array_schema_helpers.h"
 #include "test/support/src/mem_helpers.h"
+
 #include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/array_schema/array_schema_evolution.h"
 #include "tiledb/sm/array_schema/attribute.h"
@@ -949,4 +952,76 @@ TEST_CASE(
   throw_if_not_ok(schema->set_domain(dom));
 
   CHECK_NOTHROW(ase->evolve_schema(schema));
+}
+
+TEST_CASE(
+    "C++ API: SchemaEvolution add multiple attributes",
+    "[cppapi][schema][evolution][add]") {
+  test::VFSTestSetup vfs_test_setup;
+  Context ctx{vfs_test_setup.ctx()};
+  auto array_uri{vfs_test_setup.array_uri(
+      "test_schema_evolution_add_multiple_attributes")};
+
+  // create initial array
+  Domain domain(ctx);
+  auto d1 = Dimension::create<int>(ctx, "d1", {{-100, 100}}, 10);
+  domain.add_dimension(d1);
+
+  auto a1 = Attribute::create<int>(ctx, "a1");
+
+  ArraySchema schema(ctx, TILEDB_DENSE);
+  schema.set_domain(domain);
+  schema.add_attribute(a1);
+
+  auto add_attributes = std::vector<Attribute>{
+      Attribute::create<int>(ctx, "a2"),
+      Attribute::create<int>(ctx, "a3"),
+      Attribute::create<int>(ctx, "a4")};
+
+  auto permutation = GENERATE(
+      std::vector<int>{0, 1, 2},
+      std::vector<int>{0, 2, 1},
+      std::vector<int>{1, 0, 2},
+      std::vector<int>{1, 2, 0},
+      std::vector<int>{2, 0, 1},
+      std::vector<int>{2, 1, 0});
+
+  DYNAMIC_SECTION(
+      "Add a1/a2/a3 in permutation: " + std::to_string(permutation[0]) + "/" +
+      std::to_string(permutation[1]) + std::to_string(permutation[2])) {
+    // create array
+    Array::create(array_uri, schema);
+    test::DeleteArrayGuard guard(ctx.ptr().get(), array_uri.c_str());
+
+    // evolve it
+    auto evolution = ArraySchemaEvolution(ctx);
+    for (auto idx : permutation) {
+      evolution.add_attribute(add_attributes[idx]);
+    }
+    evolution.array_evolve(array_uri);
+
+    // check attribute order
+    auto schema = Array::load_schema(ctx, array_uri);
+    std::vector<Attribute> attributes;
+    for (unsigned a = 0; a < schema.attribute_num(); a++) {
+      attributes.push_back(schema.attribute(a));
+    }
+
+    CHECK(attributes.size() == 4);
+    if (attributes.size() >= 1) {
+      CHECK(test::is_equivalent_attribute(attributes[0], a1));
+    }
+    if (attributes.size() >= 2) {
+      CHECK(test::is_equivalent_attribute(
+          attributes[1], add_attributes[permutation[0]]));
+    }
+    if (attributes.size() >= 3) {
+      CHECK(test::is_equivalent_attribute(
+          attributes[2], add_attributes[permutation[1]]));
+    }
+    if (attributes.size() >= 4) {
+      CHECK(test::is_equivalent_attribute(
+          attributes[3], add_attributes[permutation[2]]));
+    }
+  }
 }

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1639,7 +1639,7 @@ TEST_CASE_METHOD(
 
   auto orig_schema = array->array_schema_latest_ptr();
   auto ase = make_shared<ArraySchemaEvolution>(HERE(), memory_tracker_);
-  auto attr3 = make_shared<Attribute>(HERE(), "attr3", Datatype::UINT32);
+  auto attr3 = make_shared<Attribute>(HERE(), "attr4", Datatype::UINT32);
   ase->add_attribute(attr3);
   CHECK_NOTHROW(ase->evolve_schema(orig_schema));
 }
@@ -1656,7 +1656,7 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(values);
   ase->add_enumeration(enmr);
 
-  auto attr3 = make_shared<Attribute>(HERE(), "attr3", Datatype::UINT32);
+  auto attr3 = make_shared<Attribute>(HERE(), "attr4", Datatype::UINT32);
   attr3->set_enumeration_name(default_enmr_name);
   ase->add_attribute(attr3);
 

--- a/test/support/src/array_schema_helpers.cc
+++ b/test/support/src/array_schema_helpers.cc
@@ -31,6 +31,7 @@
  */
 
 #include "test/support/src/array_schema_helpers.h"
+#include "tiledb/api/c_api/enumeration/enumeration_api_internal.h"
 
 using namespace tiledb;
 
@@ -89,6 +90,12 @@ bool is_equivalent_enumeration(
              left.data().end(),
              right.data().begin(),
              right.data().end());
+}
+
+bool is_equivalent_enumeration(
+    const Enumeration& left, const Enumeration& right) {
+  return is_equivalent_enumeration(
+      *left.ptr()->enumeration().get(), *right.ptr()->enumeration().get());
 }
 
 }  // namespace tiledb::test

--- a/test/support/src/array_schema_helpers.h
+++ b/test/support/src/array_schema_helpers.h
@@ -33,9 +33,31 @@
 #ifndef TILEDB_TEST_ARRAY_SCHEMA_HELPERS_H
 #define TILEDB_TEST_ARRAY_SCHEMA_HELPERS_H
 
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/array_schema/attribute.h"
 #include "tiledb/sm/array_schema/enumeration.h"
+#include "tiledb/sm/cpp_api/tiledb"
 
 namespace tiledb::test {
+
+/**
+ * @return if two filters `left` and `right` represent the same transformations
+ */
+bool is_equivalent_filter(
+    const tiledb::Filter& left, const tiledb::Filter& right);
+
+/**
+ * @return if two filter lists `left` and `right` have the same filters in the
+ * same order
+ */
+bool is_equivalent_filter_list(
+    const tiledb::FilterList& left, const tiledb::FilterList& right);
+
+/**
+ * @return if two attributes `left` and `right` are equivalent
+ */
+bool is_equivalent_attribute(
+    const tiledb::Attribute& left, const tiledb::Attribute& right);
 
 /**
  * @return if two enumerations `left` and `right` are equivalent,

--- a/test/support/src/array_schema_helpers.h
+++ b/test/support/src/array_schema_helpers.h
@@ -38,6 +38,9 @@
 #include "tiledb/sm/array_schema/enumeration.h"
 #include "tiledb/sm/cpp_api/tiledb"
 
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/cpp_api/tiledb_experimental"
+
 namespace tiledb::test {
 
 /**
@@ -65,6 +68,13 @@ bool is_equivalent_attribute(
  */
 bool is_equivalent_enumeration(
     const sm::Enumeration& left, const sm::Enumeration& right);
+
+/**
+ * @return if two enumerations `left` and `right` are equivalent,
+ *         i.e. have the same name, datatype, variants, etc
+ */
+bool is_equivalent_enumeration(
+    const Enumeration& left, const Enumeration& right);
 
 }  // namespace tiledb::test
 

--- a/tiledb/sm/array_schema/array_schema_evolution.cc
+++ b/tiledb/sm/array_schema/array_schema_evolution.cc
@@ -181,6 +181,8 @@ shared_ptr<ArraySchema> ArraySchemaEvolution::evolve_schema(
     schema->expand_current_domain(current_domain_to_expand_);
   }
 
+  schema->check_without_config();
+
   return schema;
 }
 

--- a/tiledb/sm/array_schema/array_schema_evolution.h
+++ b/tiledb/sm/array_schema/array_schema_evolution.h
@@ -84,7 +84,7 @@ class ArraySchemaEvolution {
    * @param memory_tracker Memory tracker to use for the new schema.
    */
   ArraySchemaEvolution(
-      std::unordered_map<std::string, shared_ptr<Attribute>> attrs_to_add,
+      std::vector<shared_ptr<Attribute>> attrs_to_add,
       std::unordered_set<std::string> attrs_to_drop,
       std::unordered_map<std::string, shared_ptr<const Enumeration>>
           enmrs_to_add,
@@ -215,8 +215,7 @@ class ArraySchemaEvolution {
 
   /** The array attributes to be added. */
   /** It maps each attribute name to the corresponding attribute object. */
-  tdb::pmr::unordered_map<std::string, shared_ptr<Attribute>>
-      attributes_to_add_map_;
+  tdb::pmr::vector<shared_ptr<Attribute>> attributes_to_add_;
 
   /** The names of array attributes to be dropped. */
   std::unordered_set<std::string> attributes_to_drop_;

--- a/tiledb/sm/cpp_api/attribute.h
+++ b/tiledb/sm/cpp_api/attribute.h
@@ -303,7 +303,7 @@ class Attribute {
    * @param value A pointer to the fill value to get.
    * @param size The size of the fill value to get.
    */
-  void get_fill_value(const void** value, uint64_t* size) {
+  void get_fill_value(const void** value, uint64_t* size) const {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_attribute_get_fill_value(
         ctx.ptr().get(), attr_.get(), value, size));
@@ -392,7 +392,8 @@ class Attribute {
    * @param size The size of the fill value to get.
    * @param valid The fill value validity to get.
    */
-  void get_fill_value(const void** value, uint64_t* size, uint8_t* valid) {
+  void get_fill_value(
+      const void** value, uint64_t* size, uint8_t* valid) const {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_attribute_get_fill_value_nullable(
         ctx.ptr().get(), attr_.get(), value, size, valid));

--- a/tiledb/sm/serialization/array_schema_evolution.cc
+++ b/tiledb/sm/serialization/array_schema_evolution.cc
@@ -168,11 +168,11 @@ tdb_unique_ptr<ArraySchemaEvolution> array_schema_evolution_from_capnp(
     const capnp::ArraySchemaEvolution::Reader& evolution_reader,
     shared_ptr<MemoryTracker> memory_tracker) {
   // Create attributes to add
-  std::unordered_map<std::string, shared_ptr<Attribute>> attrs_to_add;
+  std::vector<shared_ptr<Attribute>> attrs_to_add;
   auto attrs_to_add_reader = evolution_reader.getAttributesToAdd();
   for (auto attr_reader : attrs_to_add_reader) {
     auto attr = attribute_from_capnp(attr_reader);
-    attrs_to_add[attr->name()] = attr;
+    attrs_to_add.push_back(attr);
   }
 
   // Create attributes to drop


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/63841

Previously attributes were stored in the `SchemaEvolution` via `std::unordered_map` which resulted in an arbitrary order that the attributes would be appended to the target schema.

This pull request uses `std::vector` instead to preserve the order of added attributes.  Lookups by attribute name now require a linear scan of the added attributes.  This will probably be faster than the `unordered_map` lookup was for small numbers of attributes; when there are many attributes it may not be, but it should be a rare use case where that would be noticeable.

I also noticed that it is possible to evolve into an invalid schema which cannot be loaded. This pull request adds an integrity check before returning a successful schema evolution to fix this.

---
TYPE: IMPROVEMENT
DESC: Schema evolution consistent attribute order