### PR TITLE
Revert improve readers by parallelizing I/O and compute operations.

### DIFF
--- a/test/src/unit-ReadCellSlabIter.cc
+++ b/test/src/unit-ReadCellSlabIter.cc
@@ -183,10 +183,7 @@ void set_result_tile_dim(
       std::nullopt,
       std::nullopt,
       std::nullopt);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -636,7 +636,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "50000");
+  cfg.set("sm.mem.total_budget", "30000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 
@@ -685,7 +685,7 @@ TEST_CASE_METHOD(
 
   // Will only allow to load two tiles out of 3.
   Config cfg;
-  cfg.set("sm.mem.total_budget", "50000");
+  cfg.set("sm.mem.total_budget", "30000");
   cfg.set("sm.mem.reader.sparse_global_order.ratio_coords", "0.15");
   ctx_ = Context(cfg);
 

--- a/test/src/unit-result-tile.cc
+++ b/test/src/unit-result-tile.cc
@@ -213,10 +213,7 @@ TEST_CASE_METHOD(
         0,
         std::nullopt,
         std::nullopt);
-    ResultTile::TileData tile_data{
-        {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()}};
+    ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -233,10 +230,7 @@ TEST_CASE_METHOD(
       0,
       std::nullopt,
       std::nullopt);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,
@@ -332,10 +326,7 @@ TEST_CASE_METHOD(
         0,
         std::nullopt,
         std::nullopt);
-    ResultTile::TileData tile_data{
-        {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()},
-        {nullptr, ThreadPool::SharedTask()}};
+    ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
     rt.init_coord_tile(
         constants::format_version,
         array_schema,
@@ -352,10 +343,7 @@ TEST_CASE_METHOD(
       0,
       std::nullopt,
       std::nullopt);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   rt.init_coord_tile(
       constants::format_version,
       array_schema,

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -2224,10 +2224,9 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tiles (2 * (2842 + 8)) = 5700 will be bigger than the per
-  // fragment budget (50000 * 0.11 / 2 fragments = 2750), so only one result
-  // tile will be loaded each time.
-  memory_.total_budget_ = "60000";
+  // Two result tile (2 * (~3000 + 8) will be bigger than the per fragment
+  // budget (1000).
+  memory_.total_budget_ = "35000";
   memory_.ratio_coords_ = "0.11";
   update_config();
 
@@ -2750,9 +2749,8 @@ TEST_CASE_METHOD(
   }
 
   // FIXME: there is no per fragment budget anymore
-  // Two result tiles (2 * (2842 + 8)) = 5700 will be bigger than the per
-  // fragment budget (40000 * 0.22 /2 frag = 4400), so only one will be loaded
-  // each time.
+  // Two result tile (2 * (~4000 + 8) will be bigger than the per fragment
+  // budget (1000).
   memory_.total_budget_ = "40000";
   memory_.ratio_coords_ = "0.22";
   update_config();

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -1064,12 +1064,9 @@ TEST_CASE_METHOD(
 
     if (one_frag) {
       CHECK(1 == loop_num->second);
+    } else {
+      CHECK(9 == loop_num->second);
     }
-    /**
-     * We can't do a similar check for multiple fragments as it is architecture
-     * dependent how many tiles fit in the memory budget. And thus also
-     * architecture dependent as to how many internal loops we have.
-     */
 
     // Try to read multiple frags without partial tile offset reading. Should
     // fail

--- a/tiledb/sm/filter/compression_filter.cc
+++ b/tiledb/sm/filter/compression_filter.cc
@@ -636,7 +636,7 @@ Status CompressionFilter::decompress_var_string_coords(
   auto output_view = span<std::byte>(
       reinterpret_cast<std::byte*>(output_buffer->data()), uncompressed_size);
   auto offsets_view = span<uint64_t>(
-      offsets_tile->data_as_unsafe<offsets_t>(), uncompressed_offsets_size);
+      offsets_tile->data_as<offsets_t>(), uncompressed_offsets_size);
 
   if (compressor_ == Compressor::RLE) {
     uint8_t rle_len_bytesize, string_len_bytesize;

--- a/tiledb/sm/filter/filter_pipeline.cc
+++ b/tiledb/sm/filter/filter_pipeline.cc
@@ -461,7 +461,7 @@ Status FilterPipeline::run_reverse(
     // If the pipeline is empty, just copy input to output.
     if (filters_.empty()) {
       void* output_chunk_buffer =
-          tile->data_as_unsafe<char>() + chunk_data.chunk_offsets_[i];
+          tile->data_as<char>() + chunk_data.chunk_offsets_[i];
       RETURN_NOT_OK(input_data.copy_to(output_chunk_buffer));
       continue;
     }
@@ -484,7 +484,7 @@ Status FilterPipeline::run_reverse(
       bool last_filter = filter_idx == 0;
       if (last_filter) {
         void* output_chunk_buffer =
-            tile->data_as_unsafe<char>() + chunk_data.chunk_offsets_[i];
+            tile->data_as<char>() + chunk_data.chunk_offsets_[i];
         RETURN_NOT_OK(output_data.set_fixed_allocation(
             output_chunk_buffer, chunk.unfiltered_data_size_));
         reader_stats->add_counter(

--- a/tiledb/sm/filter/test/filter_test_support.cc
+++ b/tiledb/sm/filter/test/filter_test_support.cc
@@ -203,8 +203,7 @@ Tile create_tile_for_unfiltering(
       tile->cell_size() * nelts,
       tile->filtered_buffer().data(),
       tile->filtered_buffer().size(),
-      tracker,
-      std::nullopt};
+      tracker};
 }
 
 void run_reverse(

--- a/tiledb/sm/filter/test/tile_data_generator.h
+++ b/tiledb/sm/filter/test/tile_data_generator.h
@@ -99,8 +99,7 @@ class TileDataGenerator {
         original_tile_size(),
         filtered_buffer.data(),
         filtered_buffer.size(),
-        memory_tracker,
-        std::nullopt);
+        memory_tracker);
   }
 
   /** Returns the size of the original unfiltered data. */

--- a/tiledb/sm/metadata/test/unit_metadata.cc
+++ b/tiledb/sm/metadata/test/unit_metadata.cc
@@ -123,8 +123,7 @@ TEST_CASE(
       tile1->size(),
       tile1->filtered_buffer().data(),
       tile1->filtered_buffer().size(),
-      tracker,
-      ThreadPool::SharedTask());
+      tracker);
   memcpy(metadata_tiles[0]->data(), tile1->data(), tile1->size());
 
   metadata_tiles[1] = tdb::make_shared<Tile>(
@@ -136,8 +135,7 @@ TEST_CASE(
       tile2->size(),
       tile2->filtered_buffer().data(),
       tile2->filtered_buffer().size(),
-      tracker,
-      ThreadPool::SharedTask());
+      tracker);
   memcpy(metadata_tiles[1]->data(), tile2->data(), tile2->size());
 
   metadata_tiles[2] = tdb::make_shared<Tile>(
@@ -149,8 +147,7 @@ TEST_CASE(
       tile3->size(),
       tile3->filtered_buffer().data(),
       tile3->filtered_buffer().size(),
-      tracker,
-      ThreadPool::SharedTask());
+      tracker);
   memcpy(metadata_tiles[2]->data(), tile3->data(), tile3->size());
 
   meta = Metadata::deserialize(metadata_tiles);

--- a/tiledb/sm/query/readers/dense_reader.cc
+++ b/tiledb/sm/query/readers/dense_reader.cc
@@ -453,9 +453,6 @@ Status DenseReader::dense_read() {
     // processing.
     if (qc_coords_mode_) {
       t_start = t_end;
-      if (compute_task.valid()) {
-        throw_if_not_ok(compute_task.wait());
-      }
       continue;
     }
 
@@ -772,8 +769,8 @@ DenseReader::compute_result_space_tiles(
   const auto fragment_num = (unsigned)frag_tile_domains.size();
   const auto& tile_coords = subarray.tile_coords();
 
-  // Keep track of the required memory to load the result space tiles. Split
-  // up filtered versus unfiltered. The memory budget is combined for all
+  // Keep track of the required memory to load the result space tiles. Split up
+  // filtered versus unfiltered. The memory budget is combined for all
   // query condition attributes.
   uint64_t required_memory_query_condition_unfiltered = 0;
   std::vector<uint64_t> required_memory_unfiltered(
@@ -789,28 +786,28 @@ DenseReader::compute_result_space_tiles(
     aggregate_only_field[n - condition_names.size()] = aggregate_only(name);
   }
 
-  // Here we estimate the size of the tile structures. First, we have to
-  // account the size of the space tile structure. We could go deeper in the
-  // class to account for other things but for now we keep it simpler. Second,
-  // we try to account for the tile subarray (DenseTileSubarray). This class
-  // will have a vector of ranges per dimensions, so 1 + dim_num *
-  // sizeof(vector). Here we choose 32 for the size of the vector to
-  // anticipate the conversion to a PMR vector. We also add dim_num * 2 *
-  // sizeof(DimType) to account for at least one range per dimension (this
-  // should be improved by accounting for the exact number of ranges). Finally
-  // for the original range index member, we have to add 1 + dim_num *
-  // sizeof(vector) as well and one uint64_t per dimension (this can also be
-  // improved by accounting for the exact number of ranges).
+  // Here we estimate the size of the tile structures. First, we have to account
+  // the size of the space tile structure. We could go deeper in the class to
+  // account for other things but for now we keep it simpler. Second, we try to
+  // account for the tile subarray (DenseTileSubarray). This class will have a
+  // vector of ranges per dimensions, so 1 + dim_num * sizeof(vector). Here we
+  // choose 32 for the size of the vector to anticipate the conversion to a PMR
+  // vector. We also add dim_num * 2 * sizeof(DimType) to account for at least
+  // one range per dimension (this should be improved by accounting for the
+  // exact number of ranges). Finally for the original range index member, we
+  // have to add 1 + dim_num * sizeof(vector) as well and one uint64_t per
+  // dimension (this can also be improved by accounting for the
+  // exact number of ranges).
   uint64_t est_tile_structs_size =
       sizeof(ResultSpaceTile<DimType>) + (1 + dim_num) * 2 * 32 +
       dim_num * (2 * sizeof(DimType) + sizeof(uint64_t));
 
   // Create the vector of result tiles to operate on. We stop once we reach
-  // the end or the memory budget. We either reach the tile upper memory
-  // limit, which is only for unfiltered data, or the limit of the available
-  // budget, which is for filtered data, unfiltered data and the tile structs.
-  // We try to process two tile batches at a time so the available memory is
-  // half of what we have available.
+  // the end or the memory budget. We either reach the tile upper memory limit,
+  // which is only for unfiltered data, or the limit of the available budget,
+  // which is for filtered data, unfiltered data and the tile structs. We try to
+  // process two tile batches at a time so the available memory is half of what
+  // we have available.
   uint64_t t_end = t_start;
   bool wait_compute_task_before_read = false;
   bool done = false;
@@ -898,8 +895,8 @@ DenseReader::compute_result_space_tiles(
       uint64_t tile_memory_filtered = 0;
       uint64_t r_idx = n - condition_names.size();
 
-      // We might not need to load this tile into memory at all for
-      // aggregation only.
+      // We might not need to load this tile into memory at all for aggregation
+      // only.
       if (aggregate_only_field[r_idx] &&
           can_aggregate_tile_with_frag_md(
               names[n], result_space_tile, tiles_cell_num[t_end])) {
@@ -956,14 +953,13 @@ DenseReader::compute_result_space_tiles(
                               required_memory_unfiltered[r_idx] +
                               est_tile_structs_size;
 
-      // Disable the multiple iterations if the tiles don't fit in the
-      // iteration budget.
+      // Disable the multiple iterations if the tiles don't fit in the iteration
+      // budget.
       if (total_memory > available_memory_iteration) {
         wait_compute_task_before_read = true;
       }
 
-      // If a single tile doesn't fit in the available memory, we can't
-      // proceed.
+      // If a single tile doesn't fit in the available memory, we can't proceed.
       if (total_memory > available_memory) {
         throw DenseReaderException(
             "Cannot process a single tile requiring " +
@@ -1007,8 +1003,7 @@ std::vector<ResultTile*> DenseReader::result_tiles_to_load(
   const auto& tile_coords = subarray.tile_coords();
   const bool agg_only = name.has_value() && aggregate_only(name.value());
 
-  // If the result is already loaded in query condition, return the empty
-  // list;
+  // If the result is already loaded in query condition, return the empty list;
   std::vector<ResultTile*> ret;
   if (name.has_value() && condition_names.count(name.value()) != 0) {
     return ret;
@@ -1038,8 +1033,8 @@ std::vector<ResultTile*> DenseReader::result_tiles_to_load(
 
 /**
  * Apply the query condition. The computation will be pushed on the compute
- * thread pool in `compute_task`. Callers should wait on this task before
- * using the results of the query condition.
+ * thread pool in `compute_task`. Callers should wait on this task before using
+ * the results of the query condition.
  */
 template <class DimType, class OffType>
 Status DenseReader::apply_query_condition(

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -121,14 +121,6 @@ class FilteredDataBlock {
            offset + size <= offset_ + size_;
   }
 
-  void set_io_task(ThreadPool::SharedTask task) {
-    io_task_ = std::move(task);
-  }
-
-  ThreadPool::SharedTask io_task() {
-    return io_task_;
-  }
-
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -147,9 +139,6 @@ class FilteredDataBlock {
 
   /** Data for the data block. */
   tdb::pmr::unique_ptr<std::byte> filtered_data_;
-
-  /** IO Task to block on for data access. */
-  ThreadPool::SharedTask io_task_;
 };
 
 /**
@@ -198,6 +187,7 @@ class FilteredData {
       const bool var_sized,
       const bool nullable,
       const bool validity_only,
+      std::vector<ThreadPool::Task>& read_tasks,
       shared_ptr<MemoryTracker> memory_tracker)
       : resources_(resources)
       , memory_tracker_(memory_tracker)
@@ -211,7 +201,7 @@ class FilteredData {
       , fragment_metadata_(fragment_metadata)
       , var_sized_(var_sized)
       , nullable_(nullable)
-      , stats_(reader.stats()->create_child("FilteredData")) {
+      , read_tasks_(read_tasks) {
     if (result_tiles.size() == 0) {
       return;
     }
@@ -329,64 +319,56 @@ class FilteredData {
   /* ********************************* */
 
   /**
-   * Get a pointer to the fixed filtered data for the result tile and a future
-   * which signals when the data is valid.
+   * Get the fixed filtered data for the result tile.
    *
    * @param fragment Fragment metadata for the tile.
    * @param rt Result tile.
    * @return Fixed filtered data pointer.
    */
-  inline std::pair<void*, ThreadPool::SharedTask> fixed_filtered_data(
+  inline void* fixed_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     auto offset{
         fragment->loaded_metadata()->file_offset(name_, rt->tile_idx())};
     ensure_data_block_current(TileType::FIXED, fragment, rt, offset);
-    return {
-        current_data_block(TileType::FIXED)->data_at(offset),
-        current_data_block(TileType::FIXED)->io_task()};
+    return current_data_block(TileType::FIXED)->data_at(offset);
   }
 
   /**
-   * Get a pointer to the var filtered data for the result tile and a future
-   * which signals when the data is valid.   *
+   * Get the var filtered data for the result tile.
+   *
    * @param fragment Fragment metadata for the tile.
    * @param rt Result tile.
    * @return Var filtered data pointer.
    */
-  inline std::pair<void*, ThreadPool::SharedTask> var_filtered_data(
+  inline void* var_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!var_sized_) {
-      return {nullptr, ThreadPool::SharedTask()};
+      return nullptr;
     }
 
     auto offset{
         fragment->loaded_metadata()->file_var_offset(name_, rt->tile_idx())};
     ensure_data_block_current(TileType::VAR, fragment, rt, offset);
-    return {
-        current_data_block(TileType::VAR)->data_at(offset),
-        current_data_block(TileType::VAR)->io_task()};
+    return current_data_block(TileType::VAR)->data_at(offset);
   }
 
   /**
-   * Get a pointer to the nullable filtered data for the result tile and a
-   * future which signals when the data is valid.
+   * Get the nullable filtered data for the result tile.
    *
    * @param fragment Fragment metadata for the tile.
    * @param rt Result tile.
    * @return Nullable filtered data pointer.
    */
-  inline std::pair<void*, ThreadPool::SharedTask> nullable_filtered_data(
+  inline void* nullable_filtered_data(
       const FragmentMetadata* fragment, const ResultTile* rt) {
     if (!nullable_) {
-      return {nullptr, ThreadPool::SharedTask()};
+      return nullptr;
     }
 
     auto offset{fragment->loaded_metadata()->file_validity_offset(
         name_, rt->tile_idx())};
     ensure_data_block_current(TileType::NULLABLE, fragment, rt, offset);
-    return {
-        current_data_block(TileType::NULLABLE)->data_at(offset),
-        current_data_block(TileType::NULLABLE)->io_task()};
+    return current_data_block(TileType::NULLABLE)->data_at(offset);
   }
 
  private:
@@ -412,13 +394,11 @@ class FilteredData {
     auto data{block.data()};
     auto size{block.size()};
     URI uri{file_uri(fragment_metadata_[block.frag_idx()].get(), type)};
-    ThreadPool::SharedTask task =
-        resources_.io_tp().execute([this, offset, data, size, uri]() {
-          auto timer_se = stats_->start_timer("read");
-          return resources_.vfs().read(uri, offset, data, size, false);
-        });
-    // This should be changed once we use taskgraphs for modeling the data flow
-    block.set_io_task(task);
+    auto task = resources_.io_tp().execute([this, offset, data, size, uri]() {
+      throw_if_not_ok(resources_.vfs().read(uri, offset, data, size, false));
+      return Status::Ok();
+    });
+    read_tasks_.push_back(std::move(task));
   }
 
   /** @return Data blocks corresponding to the tile type. */
@@ -655,8 +635,8 @@ class FilteredData {
   /** Is the attribute nullable? */
   const bool nullable_;
 
-  /** Stats to track loading. */
-  stats::Stats* stats_;
+  /** Read tasks. */
+  std::vector<ThreadPool::Task>& read_tasks_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -543,8 +543,7 @@ class ReaderBase : public StrategyBase {
 
   /**
    * Concurrently executes across each name in `names` and each result tile
-   * in 'result_tiles'. Attaches a future to each result_tile that is signaling
-   * when reading the corresponding data from disk is done.
+   * in 'result_tiles'.
    *
    * This must be the entry point for reading attribute tiles because it
    * generates stats for reading attributes.
@@ -560,8 +559,7 @@ class ReaderBase : public StrategyBase {
 
   /**
    * Concurrently executes across each name in `names` and each result tile
-   * in 'result_tiles'. Attaches a future to each result_tile that is signaling
-   * when reading the corresponding data from disk is done.
+   * in 'result_tiles'.
    *
    * This must be the entry point for reading coordinate tiles because it
    * generates stats for reading coordinates.
@@ -580,8 +578,7 @@ class ReaderBase : public StrategyBase {
    * in the appropriate result tile.
    *
    * Concurrently executes across each name in `names` and each result tile
-   * in 'result_tiles'. Attaches a future to each result_tile that is signaling
-   * when reading the corresponding data from disk is done.
+   * in 'result_tiles'.
    *
    * @param names The field names.
    * @param result_tiles The retrieved tiles will be stored inside the

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -91,20 +91,6 @@ ResultTile::ResultTile(
   coord_func_ = &ResultTile::zipped_coord;
 }
 
-ResultTile::~ResultTile() {
-  try {
-    // Wait for all attribute tasks to be done
-    wait_all_tiles(attr_tiles_);
-  } catch (...) {
-  }
-
-  try {
-    // Wait for all coordinates tasks to be done
-    wait_all_tiles(coord_tiles_);
-  } catch (...) {
-  }
-}
-
 /* ****************************** */
 /*               API              */
 /* ****************************** */
@@ -144,7 +130,7 @@ void ResultTile::erase_tile(const std::string& name) {
 
   // Handle attribute tile
   for (auto& at : attr_tiles_) {
-    if (at.second.has_value() && at.first == name) {
+    if (at.first == name) {
       at.second.reset();
       return;
     }
@@ -275,23 +261,6 @@ ResultTile::TileTuple* ResultTile::tile_tuple(const std::string& name) {
   return nullptr;
 }
 
-void ResultTile::wait_all_tiles(
-    const std::vector<std::pair<std::string, optional<TileTuple>>>& tiles)
-    const {
-  for (auto& at : tiles) {
-    const auto& tile_tuple = at.second;
-    if (tile_tuple.has_value()) {
-      tile_tuple.value().fixed_tile().data();
-      if (tile_tuple.value().var_tile_opt().has_value()) {
-        tile_tuple.value().var_tile_opt().value().data();
-      }
-      if (tile_tuple.value().validity_tile_opt().has_value()) {
-        tile_tuple.value().validity_tile_opt().value().data();
-      }
-    }
-  }
-}
-
 const void* ResultTile::unzipped_coord(uint64_t pos, unsigned dim_idx) const {
   const auto& coord_tile = coord_tiles_[dim_idx].second->fixed_tile();
   const uint64_t offset = pos * coord_tile.cell_size();
@@ -414,11 +383,7 @@ Status ResultTile::read(
   if ((!is_dim && name != constants::coords && !use_fragment_ts) ||
       (is_dim && !coord_tiles_[0].first.empty()) ||
       (name == constants::coords && coords_tile_.has_value())) {
-    auto tile_tuple = this->tile_tuple(name);
-    if (tile_tuple == nullptr) {
-      return Status::Ok();
-    }
-    const auto& tile = tile_tuple->fixed_tile();
+    const auto& tile = this->tile_tuple(name)->fixed_tile();
     auto cell_size = tile.cell_size();
     auto nbytes = len * cell_size;
     auto offset = pos * cell_size;

--- a/tiledb/sm/query/readers/result_tile.cc
+++ b/tiledb/sm/query/readers/result_tile.cc
@@ -281,15 +281,12 @@ void ResultTile::wait_all_tiles(
   for (auto& at : tiles) {
     const auto& tile_tuple = at.second;
     if (tile_tuple.has_value()) {
-      // Wait for the fixed tile i/o to be done
-      tile_tuple.value().fixed_tile().filtered_data();
+      tile_tuple.value().fixed_tile().data();
       if (tile_tuple.value().var_tile_opt().has_value()) {
-        // Wait for the var tile i/o to be done
-        tile_tuple.value().var_tile_opt().value().filtered_data();
+        tile_tuple.value().var_tile_opt().value().data();
       }
       if (tile_tuple.value().validity_tile_opt().has_value()) {
-        // Wait for the validity tile i/o to be done
-        tile_tuple.value().validity_tile_opt().value().filtered_data();
+        tile_tuple.value().validity_tile_opt().value().data();
       }
     }
   }

--- a/tiledb/sm/query/readers/result_tile.h
+++ b/tiledb/sm/query/readers/result_tile.h
@@ -225,38 +225,12 @@ class ResultTile {
     /*     CONSTRUCTORS & DESTRUCTORS    */
     /* ********************************* */
     TileData(
-        std::pair<void*, ThreadPool::SharedTask> fixed_filtered_data,
-        std::pair<void*, ThreadPool::SharedTask> var_filtered_data,
-        std::pair<void*, ThreadPool::SharedTask> validity_filtered_data)
-        : fixed_filtered_data_(fixed_filtered_data.first)
-        , var_filtered_data_(var_filtered_data.first)
-        , validity_filtered_data_(validity_filtered_data.first)
-        , fixed_filtered_data_task_(fixed_filtered_data.second)
-        , var_filtered_data_task_(var_filtered_data.second)
-        , validity_filtered_data_task_(validity_filtered_data.second) {
-    }
-
-    ~TileData() {
-      try {
-        if (fixed_filtered_data_task_.valid()) {
-          auto st = fixed_filtered_data_task_.wait();
-        }
-      } catch (...) {
-      }
-
-      try {
-        if (var_filtered_data_task_.valid()) {
-          auto st = var_filtered_data_task_.wait();
-        }
-      } catch (...) {
-      }
-
-      try {
-        if (validity_filtered_data_task_.valid()) {
-          auto st = validity_filtered_data_task_.wait();
-        }
-      } catch (...) {
-      }
+        void* fixed_filtered_data,
+        void* var_filtered_data,
+        void* validity_filtered_data)
+        : fixed_filtered_data_(fixed_filtered_data)
+        , var_filtered_data_(var_filtered_data)
+        , validity_filtered_data_(validity_filtered_data) {
     }
 
     /* ********************************* */
@@ -278,21 +252,6 @@ class ResultTile {
       return validity_filtered_data_;
     }
 
-    /** @return The fixed filtered data I/O task. */
-    inline ThreadPool::SharedTask fixed_filtered_data_task() const {
-      return fixed_filtered_data_task_;
-    }
-
-    /** @return The var filtered data I/O task. */
-    inline ThreadPool::SharedTask var_filtered_data_task() const {
-      return var_filtered_data_task_;
-    }
-
-    /** @return The validity filtered data I/O task. */
-    inline ThreadPool::SharedTask validity_filtered_data_task() const {
-      return validity_filtered_data_task_;
-    }
-
    private:
     /* ********************************* */
     /*        PRIVATE ATTRIBUTES         */
@@ -306,15 +265,6 @@ class ResultTile {
 
     /** Stores the validity filtered data pointer. */
     void* validity_filtered_data_;
-
-    /** Stores the fixed filtered data I/O task. */
-    ThreadPool::SharedTask fixed_filtered_data_task_;
-
-    /** Stores the var filtered data I/O task. */
-    ThreadPool::SharedTask var_filtered_data_task_;
-
-    /** Stores the validity filtered data I/O task. */
-    ThreadPool::SharedTask validity_filtered_data_task_;
   };
 
   /**
@@ -348,8 +298,7 @@ class ResultTile {
               tile_sizes.tile_size(),
               tile_data.fixed_filtered_data(),
               tile_sizes.tile_persisted_size(),
-              memory_tracker_,
-              tile_data.fixed_filtered_data_task()) {
+              memory_tracker_) {
       if (tile_sizes.has_var_tile()) {
         auto type = array_schema.type(name);
         var_tile_.emplace(
@@ -360,8 +309,7 @@ class ResultTile {
             tile_sizes.tile_var_size(),
             tile_data.var_filtered_data(),
             tile_sizes.tile_var_persisted_size(),
-            memory_tracker_,
-            tile_data.var_filtered_data_task());
+            memory_tracker_);
       }
 
       if (tile_sizes.has_validity_tile()) {
@@ -373,8 +321,7 @@ class ResultTile {
             tile_sizes.tile_validity_size(),
             tile_data.validity_filtered_data(),
             tile_sizes.tile_validity_persisted_size(),
-            memory_tracker_,
-            tile_data.validity_filtered_data_task());
+            memory_tracker_);
       }
     }
 
@@ -395,16 +342,6 @@ class ResultTile {
     /** @returns Validity tile. */
     Tile& validity_tile() {
       return validity_tile_.value();
-    }
-
-    /** @returns Var tile. */
-    const std::optional<Tile>& var_tile_opt() const {
-      return var_tile_;
-    }
-
-    /** @returns Validity tile. */
-    const std::optional<Tile>& validity_tile_opt() const {
-      return validity_tile_;
     }
 
     /** @returns Fixed tile. */
@@ -467,8 +404,8 @@ class ResultTile {
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTile);
   DISABLE_MOVE_AND_MOVE_ASSIGN(ResultTile);
 
-  /** Destructor needs to be virtual, this is a base class. */
-  virtual ~ResultTile();
+  /** Default destructor. */
+  ~ResultTile() = default;
 
   /* ********************************* */
   /*                API                */
@@ -754,11 +691,6 @@ class ResultTile {
       const uint64_t min_cell,
       const uint64_t max_cell) const;
 
-  /* Waits for all tiles results to be available */
-  void wait_all_tiles(
-      const std::vector<std::pair<std::string, optional<TileTuple>>>& tiles)
-      const;
-
  protected:
   /* ********************************* */
   /*        PROTECTED ATTRIBUTES       */
@@ -930,9 +862,6 @@ class ResultTileWithBitmap : public ResultTile {
 
   DISABLE_COPY_AND_COPY_ASSIGN(ResultTileWithBitmap);
   DISABLE_MOVE_AND_MOVE_ASSIGN(ResultTileWithBitmap);
-
-  /** Default destructor needs to be virtual, this is a base class. */
-  virtual ~ResultTileWithBitmap() = default;
 
  public:
   /* ********************************* */

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -1545,6 +1545,7 @@ AddNextCellResult SparseGlobalOrderReader<BitmapType>::add_next_cell_to_queue(
         }
       }
     }
+
     std::unique_lock<std::mutex> ul(tile_queue_mutex_);
 
     // Add all the cells in this tile with the same coordinates as this cell

--- a/tiledb/sm/query/test/unit_query_condition.cc
+++ b/tiledb/sm/query/test/unit_query_condition.cc
@@ -1628,10 +1628,7 @@ void test_apply<char*>(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(cells * constants::cell_validity_size) :
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1690,10 +1687,7 @@ void test_apply(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -1809,10 +1803,7 @@ TEST_CASE(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, *frag_md[0], memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2354,10 +2345,7 @@ void test_apply_dense<char*>(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2416,10 +2404,7 @@ void test_apply_dense(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -2534,10 +2519,7 @@ TEST_CASE(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3072,10 +3054,7 @@ void test_apply_sparse<char*>(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3134,10 +3113,7 @@ void test_apply_sparse(const Datatype type, bool var_size, bool nullable) {
       nullable ? std::optional(0) : std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -3916,10 +3892,7 @@ TEST_CASE(
       std::nullopt,
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4211,10 +4184,7 @@ TEST_CASE(
       std::nullopt,
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4632,10 +4602,7 @@ TEST_CASE(
       std::nullopt,
       std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -4900,10 +4867,7 @@ TEST_CASE(
       cells * constants::cell_validity_size,
       0);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,
@@ -5009,10 +4973,7 @@ TEST_CASE(
                  std::nullopt,
       nullable ? std::optional(0) : std::nullopt);
   ResultTile result_tile(0, 0, frag_md, memory_tracker);
-  ResultTile::TileData tile_data{
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()},
-      {nullptr, ThreadPool::SharedTask()}};
+  ResultTile::TileData tile_data{nullptr, nullptr, nullptr};
   result_tile.init_attr_tile(
       constants::format_version,
       *array_schema,

--- a/tiledb/sm/tile/CMakeLists.txt
+++ b/tiledb/sm/tile/CMakeLists.txt
@@ -32,7 +32,7 @@ include(object_library)
 #
 commence(object_library tile)
   this_target_sources(tile.cc)
-  this_target_object_libraries(baseline buffer constants thread_pool)
+  this_target_object_libraries(baseline buffer constants)
 conclude(object_library)
 
 #

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -120,8 +120,7 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       header.tile_size,
       filtered_data.data(),
       header.persisted_size,
-      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
-      std::nullopt);
+      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO));
 
   // Read the tile.
   throw_if_not_ok(resources_.vfs().read(

--- a/tiledb/sm/tile/test/unit_tile.cc
+++ b/tiledb/sm/tile/test/unit_tile.cc
@@ -57,8 +57,7 @@ TEST_CASE("Tile: Test basic IO", "[Tile][basic_io]") {
       tile_size,
       nullptr,
       0,
-      tracker,
-      std::nullopt);
+      tracker);
   CHECK(tile.size() == tile_size);
 
   // Create a buffer to write to the test Tile.

--- a/tiledb/sm/tile/tile.cc
+++ b/tiledb/sm/tile/tile.cc
@@ -31,7 +31,6 @@
  */
 
 #include "tiledb/sm/tile/tile.h"
-
 #include "tiledb/common/exception/exception.h"
 #include "tiledb/common/heap_memory.h"
 #include "tiledb/common/memory_tracker.h"
@@ -70,8 +69,7 @@ shared_ptr<Tile> Tile::from_generic(
       tile_size,
       nullptr,
       0,
-      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO),
-      std::nullopt);
+      memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO));
 }
 
 shared_ptr<WriterTile> WriterTile::from_generic(
@@ -134,8 +132,7 @@ Tile::Tile(
     const uint64_t size,
     void* filtered_data,
     uint64_t filtered_size,
-    shared_ptr<MemoryTracker> memory_tracker,
-    std::optional<ThreadPool::SharedTask> data_io_task)
+    shared_ptr<MemoryTracker> memory_tracker)
     : Tile(
           format_version,
           type,
@@ -144,8 +141,7 @@ Tile::Tile(
           size,
           filtered_data,
           filtered_size,
-          memory_tracker->get_resource(MemoryType::TILE_DATA),
-          std::move(data_io_task)) {
+          memory_tracker->get_resource(MemoryType::TILE_DATA)) {
 }
 
 Tile::Tile(
@@ -156,13 +152,11 @@ Tile::Tile(
     const uint64_t size,
     void* filtered_data,
     uint64_t filtered_size,
-    tdb::pmr::memory_resource* resource,
-    std::optional<ThreadPool::SharedTask> filtered_data_io_task)
+    tdb::pmr::memory_resource* resource)
     : TileBase(format_version, type, cell_size, size, resource)
     , zipped_coords_dim_num_(zipped_coords_dim_num)
     , filtered_data_(filtered_data)
-    , filtered_size_(filtered_size)
-    , filtered_data_io_task_(std::move(filtered_data_io_task)) {
+    , filtered_size_(filtered_size) {
 }
 
 WriterTile::WriterTile(
@@ -211,7 +205,7 @@ void TileBase::write(const void* data, uint64_t offset, uint64_t nbytes) {
   size_ = std::max(offset + nbytes, size_);
 }
 
-void Tile::zip_coordinates_unsafe() {
+void Tile::zip_coordinates() {
   assert(zipped_coords_dim_num_ > 0);
 
   // For easy reference
@@ -285,15 +279,6 @@ void WriterTile::write_var(const void* data, uint64_t offset, uint64_t nbytes) {
 uint64_t Tile::load_chunk_data(
     ChunkData& unfiltered_tile, uint64_t expected_original_size) {
   assert(filtered());
-
-  std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
-  if (filtered_data_io_task_.has_value()) {
-    if (filtered_data_io_task_.value().valid()) {
-      throw_if_not_ok(filtered_data_io_task_.value().wait());
-    } else {
-      throw std::future_error(std::future_errc::no_state);
-    }
-  }
 
   Deserializer deserializer(filtered_data(), filtered_size());
 

--- a/tiledb/sm/tile/tile.h
+++ b/tiledb/sm/tile/tile.h
@@ -280,7 +280,7 @@ class Tile : public TileBase {
   }
 
   /** Returns the buffer that contains the filtered, on-disk format. */
-  inline char* filtered_data() const {
+  inline char* filtered_data() {
     std::scoped_lock<std::recursive_mutex> lock{filtered_data_io_task_mtx_};
     if (filtered_data_io_task_.has_value()) {
       if (filtered_data_io_task_.value().valid()) {


### PR DESCRIPTION
This reverts #5401 for parallelizing I/O and compute operations (backported in #5451) and the follow-up PR #5446 (backported in  #5458).

---
TYPE: IMPROVEMENT
DESC: Revert improve readers by parallelizing I/O and compute operations
