### PR TITLE
[Backport release-2.27] Fix typo in Release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
-          name: release-*
+          pattern: release-*
           merge-multiple: true
           path: dist
       - name: Publish release artifacts


### PR DESCRIPTION
Backport #5467 to release-2.27

---
TYPE: NO_HISTORY