### PR TITLE
Prevent undefined behavior in Enumeration constructor 

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -256,7 +256,7 @@ TEST_CASE_METHOD(
 
 TEST_CASE_METHOD(
     EnumerationFx,
-    "Basic Variable Size With Single Empty Value Using nullptr",
+    "Basic Variable Size With Single Empty Value Using nullptr ",
     "[enumeration][error][invalid-offsets-args]") {
   uint64_t offsets = 0;
   auto enmr = Enumeration::create(
@@ -278,6 +278,89 @@ TEST_CASE_METHOD(
       Datatype::STRING_ASCII,
       constants::var_num,
       false);
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
+    "Basic Variable Size With Single Empty Value Using nullptr Index Retrieval",
+    "[enumeration][basic][index_of]") {
+  uint64_t offsets = 0;
+  auto enmr = Enumeration::create(
+      default_enmr_name,
+      Datatype::STRING_ASCII,
+      constants::var_num,
+      false,
+      nullptr,
+      0,
+      &offsets,
+      sizeof(uint64_t),
+      memory_tracker_);
+
+  std::string value_str = "";
+  const char* value_ptr = "";
+
+  REQUIRE(enmr->index_of(value_str.data(), value_str.size()) == 0);
+  REQUIRE(enmr->index_of(value_ptr, 0) == 0);
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
+    "Basic Variable Size With Single Empty Value Using nullptr Address Check",
+    "[enumeration][basic][buffer-address]") {
+  uint64_t offsets = 0;
+  auto enmr = Enumeration::create(
+      default_enmr_name,
+      Datatype::STRING_ASCII,
+      constants::var_num,
+      false,
+      nullptr,
+      0,
+      &offsets,
+      sizeof(uint64_t),
+      memory_tracker_);
+
+  REQUIRE(enmr->data().data() != nullptr);
+  REQUIRE(enmr->data().size() == 0);
+  REQUIRE(enmr->offsets().data() != nullptr);
+  REQUIRE(enmr->offsets().size() == sizeof(uint64_t));
+  REQUIRE(enmr->elem_count() == 1);
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
+    "Basic Variable Size With Single Empty Value Enumeration Creation Address "
+    "Check",
+    "[enumeration][basic][buffer-address]") {
+  std::vector<std::string> values = {""};
+  auto enmr = create_enumeration(values);
+
+  REQUIRE(enmr->data().data() != nullptr);
+  REQUIRE(enmr->data().size() == 0);
+  REQUIRE(enmr->offsets().data() != nullptr);
+  REQUIRE(enmr->offsets().size() == sizeof(uint64_t));
+  REQUIRE(enmr->elem_count() == 1);
+}
+
+TEST_CASE_METHOD(
+    EnumerationFx,
+    "Basic Variable Size Empty Address Check",
+    "[enumeration][basic][buffer-address]") {
+  auto enmr = Enumeration::create(
+      default_enmr_name,
+      Datatype::STRING_ASCII,
+      constants::var_num,
+      false,
+      nullptr,
+      0,
+      nullptr,
+      0,
+      memory_tracker_);
+
+  REQUIRE(enmr->data().data() == nullptr);
+  REQUIRE(enmr->data().size() == 0);
+  REQUIRE(enmr->offsets().data() == nullptr);
+  REQUIRE(enmr->offsets().size() == 0);
+  REQUIRE(enmr->elem_count() == 0);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -283,7 +283,7 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     EnumerationFx,
     "Basic Variable Size With Single Empty Value Using nullptr Index Retrieval",
-    "[enumeration][basic][index_of]") {
+    "[enumeration][index-of][var-size]") {
   uint64_t offsets = 0;
   auto enmr = Enumeration::create(
       default_enmr_name,
@@ -319,7 +319,7 @@ TEST_CASE_METHOD(
       sizeof(uint64_t),
       memory_tracker_);
 
-  REQUIRE(enmr->data().data() != nullptr);
+  REQUIRE(enmr->data().data() == nullptr);
   REQUIRE(enmr->data().size() == 0);
   REQUIRE(enmr->offsets().data() != nullptr);
   REQUIRE(enmr->offsets().size() == sizeof(uint64_t));
@@ -334,7 +334,7 @@ TEST_CASE_METHOD(
   std::vector<std::string> values = {""};
   auto enmr = create_enumeration(values);
 
-  REQUIRE(enmr->data().data() != nullptr);
+  REQUIRE(enmr->data().data() == nullptr);
   REQUIRE(enmr->data().size() == 0);
   REQUIRE(enmr->offsets().data() != nullptr);
   REQUIRE(enmr->offsets().size() == sizeof(uint64_t));

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -187,7 +187,7 @@ Enumeration::Enumeration(
     // For the empty string edge case allocate 1 byte to obtain a valid memory
     // address even though unused
     if (data_size == 0) {
-      data_.realloc(1);
+      throw_if_not_ok(data_.realloc(1));
     }
 
     throw_if_not_ok(data_.write(data, 0, data_size));

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -182,14 +182,14 @@ Enumeration::Enumeration(
     }
   }
 
+  // For the empty string edge case allocate 1 byte to obtain a valid memory
+  // address even though unused
+  if (data_size == 0) {
+    throw_if_not_ok(data_.realloc(1));
+  }
+
   // std::memcpy with nullptr in either src or dest can lead to UB
   if (data != nullptr) {
-    // For the empty string edge case allocate 1 byte to obtain a valid memory
-    // address even though unused
-    if (data_size == 0) {
-      throw_if_not_ok(data_.realloc(1));
-    }
-
     throw_if_not_ok(data_.write(data, 0, data_size));
   }
   if (offsets != nullptr) {

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -182,14 +182,9 @@ Enumeration::Enumeration(
     }
   }
 
-  // For the empty string edge case allocate 1 byte to obtain a valid memory
-  // address even though unused
-  if (data_size == 0) {
-    throw_if_not_ok(data_.realloc(1));
-  }
-
   // std::memcpy with nullptr in either src or dest can lead to UB
-  if (data != nullptr) {
+  // data_size != 0 guarantees internal data buffer address to be not null
+  if (data != nullptr && data_size != 0) {
     throw_if_not_ok(data_.write(data, 0, data_size));
   }
   if (offsets != nullptr) {

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -182,8 +182,20 @@ Enumeration::Enumeration(
     }
   }
 
-  throw_if_not_ok(data_.write(data, 0, data_size));
-  throw_if_not_ok(offsets_.write(offsets, 0, offsets_size));
+  // std::memcpy with nullptr in either src or dest can lead to UB
+  if (data != nullptr) {
+    // For the empty string edge case allocate 1 byte to obtain a valid memory
+    // address even though unused
+    if (data_size == 0) {
+      data_.realloc(1);
+    }
+
+    throw_if_not_ok(data_.write(data, 0, data_size));
+  }
+  if (offsets != nullptr) {
+    throw_if_not_ok(offsets_.write(offsets, 0, offsets_size));
+  }
+
   generate_value_map();
 }
 
@@ -415,11 +427,6 @@ uint64_t Enumeration::index_of(const void* data, uint64_t size) const {
 }
 
 void Enumeration::generate_value_map() {
-  // If we've got no data, there are no values to generate.
-  if (data_.size() == 0) {
-    return;
-  }
-
   auto char_data = data_.data_as<char>();
   if (var_size()) {
     auto offsets = offsets_.data_as<uint64_t>();


### PR DESCRIPTION
Constructing a string enumeration with only an empty string as a value can result in UB inside the enumeration constructor. There 
is an acceptable parameter configuration (`data == nullptr` and `data_size == 0`) where both the internal `Buffer`'s pointer and the data pointer are null. Writing to the buffer results in `std::memcpy(nullptr, nullptr, 0)` which is UB according to the spec.

The same holds true for the offsets buffer in fixed sized enumerations.

The data size check in `generate_value_map` is now redundant because the data buffer when the enumeration in not empty will have a valid memory address thus the `string_view` construction will not exhibit UB when constructed using an empty string. IN case the enumeration is empty the loop limits will guard from dereferencing the null buffers

---
TYPE: BUG
DESC: Fix undefined behavior in Enumeration constructor
