### PR TITLE
Fix linker errors in `unit_synchronized_optional`.

### DIFF
--- a/tiledb/stdx/synchronized_optional/test/CMakeLists.txt
+++ b/tiledb/stdx/synchronized_optional/test/CMakeLists.txt
@@ -30,4 +30,5 @@ commence(unit_test synchronized_optional)
       unit_synchronized_optional.cc
       unit_synchronized_optional_comparisons.cc
       unit_synchronized_optional_swap.cc)
+  this_target_link_libraries(Threads::Threads)
 conclude(unit_test)


### PR DESCRIPTION
[SC-64607](https://app.shortcut.com/tiledb-inc/story/64607/linker-errors-in-unit-synchronized-optional)

---
TYPE: BUG
DESC: Fixed linker errors when building tests.