### PR TITLE
Fix SparseGlobalOrderReader check for progression

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -266,12 +266,23 @@ jobs:
 
           # Actually run tests
 
-          $cmds = "$env:BUILD_BUILDDIRECTORY\test\tiledb_unit.exe -d=yes"
+          $cmds = "$env:BUILD_BUILDDIRECTORY\test\tiledb_unit.exe -d=yes ~[rapidcheck]"
           Write-Host "cmds: '$cmds'"
           Invoke-Expression $cmds
           if ($LastExitCode -ne 0) {
               Write-Host "Tests failed. tiledb_unit exit status: " $LastExitCocde
               $host.SetShouldExit($LastExitCode)
+          }
+
+          # Run rapidcheck tests as their own process so we can see the random seed for each
+          Invoke-Expression "$env:BUILD_BUILDDIRECTORY\test\tiledb_unit.exe --list-tests [rapidcheck] --verbosity quiet" | Foreach-Object {
+            $rapidcheck = "$env:BUILD_BUILDDIRECTORY\test\tiledb_unit.exe '$_'"
+            Write-Host "cmds: '$rapidcheck'"
+            Invoke-Expression $rapidcheck
+            if ($LastExitCode -ne 0) {
+              Write-Host "Rapidcheck test \"$_\" failed with exit status: " $LastExitCode
+              $host.SetShouldExit($LastExitCode)
+            }
           }
 
           $cmds = "$env:BUILD_BUILDDIRECTORY\tiledb\sm\filesystem\test\unit_vfs -d=yes"

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -200,8 +200,13 @@ jobs:
           # Bypass Catch2 Framework stdout interception with awk on test output
           ./test/regression/tiledb_regression -d yes
           ./test/ci/test_assert -d yes
-          ./test/tiledb_unit -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
+          ./test/tiledb_unit -d yes "~[rapidcheck]" | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
           ./tiledb/sm/filesystem/test/unit_vfs -d yes | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
+
+          # Run rapidcheck tests as their own process so we can see the random seed for each
+          ./test/tiledb_unit --list-tests "[rapidcheck]" --verbosity quiet | while IFS= read -r testname; do
+            ./test/tiledb_unit "$testname"
+          done
 
           ctest -R tiledb_timing_unit | awk '/1: ::set-output/{sub(/.*1: /, ""); print; next} 1'
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -3384,7 +3384,8 @@ void CSparseGlobalOrderFx::run_execute(Instance& instance) {
       }
       if constexpr (std::is_same_v<Asserter, AsserterRapidcheck>) {
         if (err.find(
-                "Cannot allocate space for preprocess result tile ID list")) {
+                "Cannot allocate space for preprocess result tile ID list") !=
+            std::string::npos) {
           // not enough memory to determine tile order
           // we can probably make some assertions about what this should have
           // looked like but for now we'll let it go

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -3347,8 +3347,7 @@ void CSparseGlobalOrderFx::run_execute(Instance& instance) {
 
     auto icmp = [&](uint64_t ia, uint64_t ib) -> bool {
       return std::apply(
-          [&globalcmp, &expect_fragment, ia, ib]<typename... Ts>(
-              const std::vector<Ts>&... dims) {
+          [&globalcmp, ia, ib]<typename... Ts>(const std::vector<Ts>&... dims) {
             const auto l = std::make_tuple(dims[ia]...);
             const auto r = std::make_tuple(dims[ib]...);
             return globalcmp(

--- a/test/support/CMakeLists.txt
+++ b/test/support/CMakeLists.txt
@@ -36,6 +36,7 @@ list(APPEND TILEDB_CORE_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api")
 
 # Gather the test source files
 set(TILEDB_TEST_SUPPORT_SOURCES
+  rapidcheck/show.cc
   src/array_helpers.cc
   src/array_schema_helpers.cc
   src/ast_helpers.h

--- a/test/support/rapidcheck/query_condition.h
+++ b/test/support/rapidcheck/query_condition.h
@@ -119,7 +119,7 @@ Gen<tdb_unique_ptr<tiledb::sm::ASTNode>> make_query_condition(
     using R = std::pair<std::string, Gen<std::string>>;
     auto make_value_gen = [&](auto i) -> std::optional<R> {
       if (field == i) {
-        auto value = make_range(std::get<i>(field_domains));
+        auto value = make_coordinate(std::get<i>(field_domains));
         auto p = std::make_pair(field_names[i], gen::map(value, [](auto value) {
                                   return std::string(
                                       reinterpret_cast<char*>(&value),

--- a/test/support/rapidcheck/show.cc
+++ b/test/support/rapidcheck/show.cc
@@ -1,0 +1,79 @@
+/**
+ * @file test/support/rapidcheck/show.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file provides forward declarations of `rc::detail::showValue`
+ * overloads, which seemingly must be included prior to the rapidcheck
+ * header files.
+ */
+
+#include <test/support/rapidcheck/show.h>
+
+#include "tiledb/sm/enums/query_condition_op.h"
+#include "tiledb/sm/query/ast/query_ast.h"
+
+namespace rc::detail {
+
+void showValue(const tiledb::sm::ASTNode& node, std::ostream& os) {
+  const tiledb::sm::ASTNodeVal* valnode =
+      static_cast<const tiledb::sm::ASTNodeVal*>(&node);
+  const tiledb::sm::ASTNodeExpr* exprnode =
+      dynamic_cast<const tiledb::sm::ASTNodeExpr*>(&node);
+
+  if (valnode) {
+    const auto fname = valnode->get_field_name();
+    const auto op = valnode->get_op();
+    const auto bytes = valnode->get_data();
+
+    std::stringstream value;
+    for (size_t b = 0; b < bytes.size(); b++) {
+      if (b != 0) {
+        value << " ";
+      }
+      value << "0x" << std::hex << std::setw(2) << std::setfill('0')
+            << static_cast<int>(bytes.data()[b]);
+    }
+
+    os << fname << " " << query_condition_op_str(op) << " " << value.str();
+  } else if (exprnode) {
+    const auto op = exprnode->get_combination_op();
+    const auto& children = exprnode->get_children();
+    for (unsigned i = 0; i < children.size(); i++) {
+      if (i != 0) {
+        os << " " << query_condition_combination_op_str(op) << " ";
+      }
+      os << "(";
+      showValue(*children[i].get(), os);
+      os << ")";
+    }
+  } else {
+    os << "???" << std::endl;
+  }
+}
+
+}  // namespace rc::detail

--- a/test/support/rapidcheck/show.h
+++ b/test/support/rapidcheck/show.h
@@ -41,7 +41,7 @@
 
 namespace tiledb {
 namespace sm {
-struct ASTNode;
+class ASTNode;
 }
 }  // namespace tiledb
 

--- a/test/support/rapidcheck/show.h
+++ b/test/support/rapidcheck/show.h
@@ -1,11 +1,11 @@
 /**
- * @file test/support/stdx/optional.h
+ * @file test/support/rapidcheck/show.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2025 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,41 @@
  *
  * @section DESCRIPTION
  *
- * This file defines functions for manipulating `std::optional`.
+ * This file provides forward declarations of `rc::detail::showValue`
+ * overloads, which seemingly must be included prior to the rapidcheck
+ * header files.
  */
 
-#ifndef TILEDB_TEST_SUPPORT_OPTIONAL_H
-#define TILEDB_TEST_SUPPORT_OPTIONAL_H
+#ifndef TILEDB_RAPIDCHECK_SHOW_H_
+#define TILEDB_RAPIDCHECK_SHOW_H_
 
-#include <optional>
+#include <test/support/stdx/optional.h>
 
-namespace stdx {
+#include <ostream>
 
-template <typename T>
-struct is_optional {
-  static constexpr bool value = false;
-};
+namespace tiledb {
+namespace sm {
+struct ASTNode;
+}
+}  // namespace tiledb
 
-template <typename T>
-struct is_optional<std::optional<T>> {
-  static constexpr bool value = true;
-};
+// forward declarations of `showValue` overloads
+// (these must be declared prior to including `rapidcheck/Show.hpp` for some
+// reason)
+namespace rc::detail {
 
-template <typename T>
-concept is_optional_v = is_optional<T>::value;
-}  // namespace stdx
+/**
+ * Specializes `show` for `std::optional<T>` to print the final test case after
+ * shrinking
+ */
+template <stdx::is_optional_v T>
+void showValue(const T& value, std::ostream& os);
+
+/**
+ * Specializes `show` for query ASTNode
+ */
+void showValue(const tiledb::sm::ASTNode& value, std::ostream& os);
+
+}  // namespace rc::detail
 
 #endif

--- a/test/support/rapidcheck/show_templates.h
+++ b/test/support/rapidcheck/show_templates.h
@@ -1,11 +1,11 @@
 /**
- * @file test/support/stdx/optional.h
+ * @file test/support/rapidcheck/show.h
  *
  * @section LICENSE
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2025 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,28 +27,29 @@
  *
  * @section DESCRIPTION
  *
- * This file defines functions for manipulating `std::optional`.
+ * This file provides definitions of generic `rc::detail::showValue`
+ * templates from `test/support/rapidcheck/show_templates.h`.
  */
 
-#ifndef TILEDB_TEST_SUPPORT_OPTIONAL_H
-#define TILEDB_TEST_SUPPORT_OPTIONAL_H
+#ifndef TILEDB_RAPIDCHECK_SHOW_TEMPLATES_H_
+#define TILEDB_RAPIDCHECK_SHOW_TEMPLATES_H_
 
-#include <optional>
+#include <rapidcheck.h>
+#include <test/support/stdx/optional.h>
 
-namespace stdx {
+namespace rc::detail {
 
-template <typename T>
-struct is_optional {
-  static constexpr bool value = false;
-};
+template <stdx::is_optional_v T>
+void showValue(const T& value, std::ostream& os) {
+  if (value.has_value()) {
+    os << "Some(";
+    show<typename T::value_type>(value.value(), os);
+    os << ")";
+  } else {
+    os << "None";
+  }
+}
 
-template <typename T>
-struct is_optional<std::optional<T>> {
-  static constexpr bool value = true;
-};
-
-template <typename T>
-concept is_optional_v = is_optional<T>::value;
-}  // namespace stdx
+}  // namespace rc::detail
 
 #endif

--- a/test/support/src/array_templates.h
+++ b/test/support/src/array_templates.h
@@ -410,7 +410,7 @@ struct query_applicator {
               static_cast<const void*>(&field.data()[cell_offset]));
           auto rc = tiledb_query_set_data_buffer(
               ctx, query, name.c_str(), ptr, &field_size);
-          ASSERTER("" == error_if_any(ctx, rc));
+          ASSERTER(std::optional<std::string>() == error_if_any(ctx, rc));
         };
 
     unsigned d = 0;

--- a/test/support/src/error_helpers.h
+++ b/test/support/src/error_helpers.h
@@ -54,10 +54,11 @@
 /**
  * Asserts that a C API call does not return error.
  */
-#define TRY(ctx, thing)                                  \
-  do {                                                   \
-    auto rc = (thing);                                   \
-    ASSERTER("" == tiledb::test::error_if_any(ctx, rc)); \
+#define TRY(ctx, thing)                                   \
+  do {                                                    \
+    auto rc = (thing);                                    \
+    auto maybe_err = tiledb::test::error_if_any(ctx, rc); \
+    ASSERTER(std::optional<std::string>() == maybe_err);  \
   } while (0)
 
 namespace tiledb::test {
@@ -69,12 +70,12 @@ namespace tiledb::test {
  * Usage:
  * ```
  * auto rc = c_api_invocation();
- * REQUIRE("" == error_if_any(rc));
+ * REQUIRE(std::optional<std::string>() == error_if_any(rc));
  * ```
  */
-std::string error_if_any(tiledb_ctx_t* ctx, auto apirc) {
+std::optional<std::string> error_if_any(tiledb_ctx_t* ctx, auto apirc) {
   if (apirc == TILEDB_OK) {
-    return "";
+    return std::nullopt;
   }
 
   tiledb_error_t* error = NULL;

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -175,8 +175,8 @@ void require_tiledb_ok(tiledb_ctx_t* ctx, int rc) {
 
 void throw_if_error(tiledb_ctx_t* ctx, capi_return_t thing) {
   auto err = error_if_any(ctx, thing);
-  if (err != "") {
-    throw std::runtime_error(err);
+  if (err.has_value()) {
+    throw std::runtime_error(err.value());
   }
 }
 

--- a/test/support/tdb_rapidcheck.h
+++ b/test/support/tdb_rapidcheck.h
@@ -41,27 +41,23 @@
  * `CATCH_TEST_MACROS_HPP_INCLUDED`
  * which is the bridge between v2 and v3 compatibility for <rapidcheck/catch.h>
  */
-#include <test/support/stdx/optional.h>
 #include <test/support/tdb_catch.h>
 
-// forward declarations of `showValue` overloads
-// (these must be declared prior to including `rapidcheck/Show.hpp` for some
-// reason)
-namespace rc {
-namespace detail {
-
-/**
- * Specializes `show` for `std::optional<T>` to print the final test case after
- * shrinking
+/*
+ * `show.h` must be included next (well, before rapidcheck.h anyway)
+ * because seemingly the declarations of `showValue` overloads must
+ * be declared prior
  */
-template <stdx::is_optional_v T>
-void showValue(const T& value, std::ostream& os);
-
-}  // namespace detail
-}  // namespace rc
+#include <test/support/rapidcheck/show.h>
 
 #include <rapidcheck.h>
 #include <rapidcheck/catch.h>
+
+/*
+ * `show_templates.h` provides definitions of generic `showValue` templates
+ * and must be included after `show.h` and after `rapidcheck.h`
+ */
+#include <test/support/rapidcheck/show_templates.h>
 
 #include <type_traits>
 
@@ -104,21 +100,6 @@ struct Arbitrary<NonShrinking<T>> {
         [](T inner) { return NonShrinking<T>(std::move(inner)); }, inner);
   }
 };
-
-namespace detail {
-
-template <stdx::is_optional_v T>
-void showValue(const T& value, std::ostream& os) {
-  if (value.has_value()) {
-    os << "Some(";
-    show<typename T::value_type>(value.value(), os);
-    os << ")";
-  } else {
-    os << "None";
-  }
-}
-
-}  // namespace detail
 
 }  // namespace rc
 

--- a/tiledb/sm/query/readers/reader_base.cc
+++ b/tiledb/sm/query/readers/reader_base.cc
@@ -1134,13 +1134,14 @@ uint64_t ReaderBase::offsets_bytesize() const {
 }
 
 uint64_t ReaderBase::get_attribute_tile_size(
-    const std::string& name, unsigned f, uint64_t t) const {
+    const ArraySchema& array_schema,
+    const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
+    const std::string& name,
+    unsigned f,
+    uint64_t t) {
   uint64_t tile_size = 0;
-  if (skip_field(f, name)) {
-    return tile_size;
-  }
 
-  tile_size += fragment_metadata_[f]->tile_size(name, t);
+  tile_size += fragment_metadata[f]->tile_size(name, t);
 
   /**
    * Note: There is a distinct case in which a schema may evolve from
@@ -1148,17 +1149,27 @@ uint64_t ReaderBase::get_attribute_tile_size(
    * contains fixed tiles. The tile_var_size should be calculated iff
    * both the current _and_ loaded attributes are var-sized.
    */
-  if (array_schema_.var_size(name)) {
+  if (array_schema.var_size(name)) {
     tile_size +=
-        fragment_metadata_[f]->loaded_metadata()->tile_var_size(name, t);
+        fragment_metadata[f]->loaded_metadata()->tile_var_size(name, t);
   }
 
-  if (array_schema_.is_nullable(name)) {
+  if (array_schema.is_nullable(name)) {
     tile_size +=
-        fragment_metadata_[f]->cell_num(t) * constants::cell_validity_size;
+        fragment_metadata[f]->cell_num(t) * constants::cell_validity_size;
   }
 
   return tile_size;
+}
+
+uint64_t ReaderBase::get_attribute_tile_size(
+    const std::string& name, unsigned f, uint64_t t) const {
+  if (skip_field(f, name)) {
+    return 0;
+  } else {
+    return get_attribute_tile_size(
+        array_schema_, fragment_metadata_, name, f, t);
+  }
 }
 
 uint64_t ReaderBase::get_attribute_persisted_tile_size(

--- a/tiledb/sm/query/readers/reader_base.h
+++ b/tiledb/sm/query/readers/reader_base.h
@@ -221,6 +221,22 @@ class ReaderBase : public StrategyBase {
    */
   bool skip_field(const unsigned frag_idx, const std::string& name) const;
 
+  /**
+   * Get the size of an attribute tile.
+   *
+   * @param fragment_metadata The fragment metadata.
+   * @param name The attribute name.
+   * @param f The fragment idx.
+   * @param t The tile idx.
+   * @return Tile size.
+   */
+  static uint64_t get_attribute_tile_size(
+      const ArraySchema& array_schema,
+      const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
+      const std::string& name,
+      unsigned f,
+      uint64_t);
+
  protected:
   /* ********************************* */
   /*       PROTECTED ATTRIBUTES        */


### PR DESCRIPTION
Resolves [SC-64765](https://app.shortcut.com/tiledb-inc/story/64765/400-s-in-rapidcheck-rest-ci-tests).

The linked story observed many 400 errors occurring during the REST server rapidcheck CI job. This prompted two questions: why were these errors happening? And why did they not cause the tests to fail?

The errors were happening because the rapidcheck query condition generator had a mistake in it, causing it two insert two values rather than one into its AST nodes; and then a bug in the rapidcheck property was erroneously swallowing the errors, causing them not to be reported to the test handler.

These two issues masked an error in the sparse global order reader where it would throw an exception of inability to progress if all of the loaded tiles did not pass a query condition.

This pull request fixes all of the above issues and also makes some improvements to related test support code.

Each commit is a self-contained item so it might be helpful to review this one commit at a time.

---
TYPE: BUG
DESC: Fix sparse global order reader progress check
