### PR TITLE
Fix segfault in query condition after evolution.

### DIFF
--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -686,7 +686,211 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C++ API: SchemaEvolution, add and drop attributes",
+    "C++ API: SchemaEvolution, drop and add attribute",
+    "[cppapi][schema][evolution][drop][add][query-condition][rest]") {
+  test::VFSTestSetup vfs_test_setup;
+  Context ctx{vfs_test_setup.ctx()};
+  auto layout = GENERATE(
+      TILEDB_ROW_MAJOR,
+      TILEDB_COL_MAJOR,
+      TILEDB_UNORDERED,
+      TILEDB_GLOBAL_ORDER);
+  bool duplicates = GENERATE(true, false);
+  auto array_type = GENERATE(TILEDB_SPARSE, TILEDB_DENSE);
+  bool sparse = array_type == TILEDB_SPARSE;
+
+  const char* layout_str = nullptr;
+  tiledb_layout_to_str(layout, &layout_str);
+  const char* type_str = nullptr;
+  tiledb_array_type_to_str(array_type, &type_str);
+  auto array_uri{
+      vfs_test_setup.array_uri("test_schema_evolution_query_condition_v2")};
+
+  DYNAMIC_SECTION(
+      type_str << " " << layout_str << " array"
+               << (duplicates ? " with duplicates enabled" : "")) {
+    {
+      ArraySchema schema(ctx, array_type);
+      // Duplicates are not supported for dense arrays.
+      if (sparse) {
+        schema.set_allows_dups(duplicates);
+        CHECK(duplicates == schema.allows_dups());
+      }
+      schema.set_cell_order(TILEDB_ROW_MAJOR);
+      schema.set_tile_order(TILEDB_COL_MAJOR);
+
+      Domain domain(ctx);
+      auto id1 = Dimension::create<int>(ctx, "d1", {{1, 4}}, 2);
+      auto id2 = Dimension::create<int>(ctx, "d2", {{1, 4}}, 2);
+      domain.add_dimension(id1).add_dimension(id2);
+      schema.set_domain(domain);
+
+      std::vector<std::string> enum_values = {"A", "B", "C", "D"};
+      auto e = Enumeration::create(ctx, "a_label", enum_values, false);
+      ArraySchemaExperimental::add_enumeration(ctx, schema, e);
+
+      auto a = Attribute::create<int>(ctx, "a");
+      AttributeExperimental::set_enumeration_name(ctx, a, "a_label");
+      schema.add_attribute(a);
+
+      auto b = Attribute::create<float>(ctx, "b");
+      float b_fill = -1.0f;
+      uint64_t size = sizeof(b_fill);
+      b.set_fill_value(&b_fill, size);
+      schema.add_attribute(b);
+
+      Array::create(array_uri, schema);
+    }
+
+    // Write data
+    {
+      Array array(ctx, array_uri, TILEDB_WRITE);
+      Query query(ctx, array, TILEDB_WRITE);
+      std::vector<int> d1_data = {1, 1, 2, 2};
+      std::vector<int> d2_data = {1, 2, 1, 2};
+      std::vector<int> a_data = {1, 2, 3, 4};
+      std::vector<float> b_data = {1.1, 2.2, 3.3, 4.4};
+
+      // Set coordinates.
+      if (sparse) {
+        query.set_data_buffer("d1", d1_data).set_data_buffer("d2", d2_data);
+      } else {
+        Subarray subarray(ctx, array);
+        subarray.add_range<int>(0, 1, 2).add_range<int>(1, 1, 2);
+        query.set_subarray(subarray);
+      }
+
+      // Set data buffers.
+      query.set_data_buffer("a", a_data).set_data_buffer("b", b_data);
+
+      // Perform the write and close the array.
+      CHECK(query.submit() == Query::Status::COMPLETE);
+      array.close();
+    }
+
+    // Evolve
+    {
+      // Drop attribute 'a'.
+      uint64_t now = tiledb_timestamp_now_ms() + 1;
+      ArraySchemaEvolution schemaEvolution = ArraySchemaEvolution(ctx);
+      schemaEvolution.set_timestamp_range(std::make_pair(now, now));
+      schemaEvolution.drop_attribute("a").array_evolve(array_uri);
+
+      // Add attribute 'a' without an enumeration label.
+      // Also modify it's datatype from fixed int to var-size string.
+      schemaEvolution = ArraySchemaEvolution(ctx);
+      now += 1;  // Ensure schema timestamps are unique.
+      schemaEvolution.set_timestamp_range({now, now});
+      Attribute a = Attribute::create<std::string>(ctx, "a");
+      a.set_nullable(true);
+      schemaEvolution.add_attribute(a);
+      schemaEvolution.array_evolve(array_uri);
+    }
+
+    // Write again
+    {
+      Array array(ctx, array_uri, TILEDB_WRITE);
+      Query query(ctx, array, TILEDB_WRITE);
+
+      std::vector<int> d1_data = {1, 1, 2, 2};
+      std::vector<int> d2_data = {1, 2, 1, 2};
+      std::string a_data = "ABCD";
+      std::vector<uint64_t> a_offsets = {0, 1, 2, 3};
+      std::vector<uint8_t> a_validity = {1, 1, 1, 1};
+      std::vector<float> b_data = {5.5, 6.6, 7.7, 8.8};
+
+      // Set coordinates.
+      if (sparse) {
+        query.set_data_buffer("d1", d1_data).set_data_buffer("d2", d2_data);
+      } else {
+        Subarray subarray(ctx, array);
+        subarray.add_range<int>(0, 1, 2).add_range<int>(1, 1, 2);
+        query.set_subarray(subarray);
+      }
+
+      query.set_data_buffer("a", a_data)
+          .set_offsets_buffer("a", a_offsets)
+          .set_validity_buffer("a", a_validity)
+          .set_data_buffer("b", b_data);
+
+      CHECK(query.submit() == Query::Status::COMPLETE);
+      array.close();
+    }
+
+    // Read with Query Condition
+    {
+      Array array(ctx, array_uri, TILEDB_READ);
+
+      std::vector<int> d1_data(4);
+      std::vector<int> d2_data(4);
+      std::string a_data(4, 'Z');
+      std::vector<uint64_t> a_offsets(4);
+      std::vector<uint8_t> a_validity(4);
+      std::vector<float> b_data(4);
+
+      // Sparse array with column major layout returns INCOMPLETE with 4
+      // elements.
+      if (sparse && layout == TILEDB_COL_MAJOR) {
+        d1_data.resize(8);
+        d2_data.resize(8);
+        a_offsets.resize(5);
+        a_validity.resize(5);
+        b_data.resize(8);
+      }
+
+      char value = 'C';
+      QueryCondition query_condition(ctx);
+      query_condition.init("a", &value, sizeof(value), TILEDB_EQ);
+
+      Query query(ctx, array, TILEDB_READ);
+      query.set_condition(query_condition)
+          .set_data_buffer("a", a_data)
+          .set_offsets_buffer("a", a_offsets)
+          .set_validity_buffer("a", a_validity)
+          .set_data_buffer("b", b_data);
+
+      Subarray subarray(ctx, array);
+      subarray.add_range<int>(0, 1, 2).add_range<int>(1, 1, 2);
+      query.set_subarray(subarray);
+
+      if (sparse) {
+        query.set_data_buffer("d1", d1_data).set_data_buffer("d2", d2_data);
+        query.set_layout(layout);
+      }
+
+      CHECK(query.submit() == Query::Status::COMPLETE);
+      array.close();
+
+      size_t result_num = query.result_buffer_elements()["a"].second;
+      CHECK(result_num == (sparse ? 1 : 4));
+      // Resize data buffers to prune the unused elements with no result.
+      d1_data.resize(result_num);
+      d2_data.resize(result_num);
+      a_data.resize(result_num);
+      a_validity.resize(result_num);
+      b_data.resize(result_num);
+
+      if (sparse) {
+        CHECK(d1_data == std::vector<int>{2});
+        CHECK(d2_data == std::vector<int>{1});
+        CHECK(a_data == "C");
+        CHECK(a_validity == std::vector<uint8_t>{1});
+        CHECK(b_data == std::vector<float>{7.7});
+      } else {
+        // Coordinates are not read for dense arrays.
+        CHECK(d1_data == std::vector<int>{0, 0, 0, 0});
+        CHECK(d2_data == std::vector<int>{0, 0, 0, 0});
+        // Dense reads return fill values for cells that do not satisfy the QC.
+        CHECK(a_data[2] == 'C');
+        CHECK(a_validity == std::vector<uint8_t>{0, 0, 1, 0});
+        CHECK(b_data == std::vector<float>{-1.0, -1.0, 7.7, -1.0});
+      }
+    }
+  }
+}
+
+TEST_CASE(
+    "C++ API: SchemaEvolution, add attributes",
     "[cppapi][schema][evolution][add][query-condition][rest]") {
   test::VFSTestSetup vfs_test_setup;
   Context ctx{vfs_test_setup.ctx()};

--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -760,7 +760,7 @@ TEST_CASE(
       std::vector<int> d2_data = {1, 2, 1, 2};
       std::vector<int> a_data = {1, 2, 3, 4};
       std::vector<uint8_t> a_validity = {1, 1, 1, 1};
-      std::vector<float> b_data = {1.1, 2.2, 3.3, 4.4};
+      std::vector<float> b_data = {1.1f, 2.2f, 3.3f, 4.4f};
 
       // Set coordinates.
       if (sparse) {
@@ -816,7 +816,7 @@ TEST_CASE(
       std::string a_data = "ABCD";
       std::vector<uint64_t> a_offsets = {0, 1, 2, 3};
       std::vector<uint8_t> a_validity = {1, 1, 1, 1};
-      std::vector<float> b_data = {5.5, 6.6, 7.7, 8.8};
+      std::vector<float> b_data = {5.5f, 6.6f, 7.7f, 8.8f};
 
       // Set coordinates.
       if (sparse) {
@@ -902,9 +902,8 @@ TEST_CASE(
         if (nullable) {
           CHECK(a_validity == std::vector<uint8_t>{1});
         }
-        CHECK(b_data == std::vector<float>{7.7});
+        CHECK(b_data == std::vector<float>{7.7f});
       } else {
-        // Coordinates are not read for dense arrays.
         CHECK(d1_data == std::vector<int>{1, 1, 2, 2});
         CHECK(d2_data == std::vector<int>{1, 2, 1, 2});
         // Dense reads return fill values for cells that do not satisfy the QC.
@@ -912,7 +911,7 @@ TEST_CASE(
         if (nullable) {
           CHECK(a_validity == std::vector<uint8_t>{0, 0, 1, 0});
         }
-        CHECK(b_data == std::vector<float>{-1.0, -1.0, 7.7, -1.0});
+        CHECK(b_data == std::vector<float>{-1.0f, -1.0f, 7.7f, -1.0f});
       }
     }
   }

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -664,8 +664,9 @@ void QueryCondition::apply_ast_node(
       const auto tile_tuple = result_tile->tile_tuple(field_name);
       // Special attributes handle null tile_tuples specifically.
       // We can skip null tile_tuples only if they are not a special attribute.
-      bool skip_tile_tuple = !ArraySchema::is_special_attribute(field_name) &&
-                             tile_tuple == nullptr;
+      const bool skip_tile_tuple =
+          !ArraySchema::is_special_attribute(field_name) &&
+          tile_tuple == nullptr;
 
       // For delete timestamps conditions, if there's no delete metadata or
       // delete condition was already processed, GT condition is always true.
@@ -2662,8 +2663,9 @@ void QueryCondition::apply_ast_node_sparse(
   const auto tile_tuple = result_tile.tile_tuple(node_field_name);
   // Special attributes handle null tile_tuples specifically.
   // We can skip null tile_tuples only if they are not a special attribute.
-  bool skip_tile_tuple = !ArraySchema::is_special_attribute(node_field_name) &&
-                         tile_tuple == nullptr;
+  const bool skip_tile_tuple =
+      !ArraySchema::is_special_attribute(node_field_name) &&
+      tile_tuple == nullptr;
   if (!array_schema.is_field(node_field_name) || skip_tile_tuple) {
     std::fill(result_bitmap.begin(), result_bitmap.end(), 0);
     return;

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -71,7 +71,13 @@ class QueryCondition {
 
     Params() = delete;
 
-    /** Constructor setting all parameters. */
+    /**
+     * Constructor setting all parameters.
+     *
+     * @param memory_tracker The MemoryTracker to use for this class.
+     * @param array_schema The array schema associated with the
+     *      `result_cell_slabs` being processed by the QueryCondition.
+     */
     Params(
         shared_ptr<MemoryTracker> memory_tracker,
         const ArraySchema& array_schema)


### PR DESCRIPTION
This fixes a segmentation fault applying query conditions after evolving to drop an attribute and later adding it back with a different datatype under the same name. The initial segfault was found while investigating coredumps in [SC-62810](https://app.shortcut.com/tiledb-inc/story/62810/segfault-accessing-validity-tile-for-nullable-attribute).

For additional context it looks like this was similar to #3732, but for this case the QC did not skip the null TileTuple because of the identical attribute name used for [this check](https://github.com/TileDB-Inc/TileDB/pull/3732/files#diff-c6cfb75728f4b4036cb597f671843179d2197986ba326b4681e71462cf69e76fR421). Instead of checking based on attribute name, we can skip a null TileTuple only if it does not belong to a special attribute, since special attributes handle null tile tuples specifically but other fields would result in a segfault accessing tile data.

---
TYPE: BUG
DESC: Fix segfault in query condition after evolution.
