### PR TITLE
Update ensure_filter_type_is_valid upper bound enum.

### DIFF
--- a/test/src/unit-capi-enum_values.cc
+++ b/test/src/unit-capi-enum_values.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -82,6 +82,7 @@ TEST_CASE("C API: Test enum values", "[capi][enums]") {
   REQUIRE(TILEDB_FILTER_DEPRECATED == 17);
   REQUIRE(TILEDB_FILTER_WEBP == 18);
   REQUIRE(TILEDB_FILTER_DELTA == 19);
+  REQUIRE(TILEDB_INTERNAL_FILTER_COUNT == 20);
 
   /** Filter option */
   REQUIRE(TILEDB_COMPRESSION_LEVEL == 0);
@@ -227,25 +228,53 @@ TEST_CASE("C API: Test enum string conversion", "[capi][enums]") {
            TILEDB_OK &&
        filter_type == TILEDB_FILTER_POSITIVE_DELTA));
   REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_CHECKSUM_MD5, &c_str) ==
+           TILEDB_OK &&
+       std::string(c_str) == "CHECKSUM_MD5"));
+  REQUIRE(
       (tiledb_filter_type_from_str("CHECKSUM_MD5", &filter_type) == TILEDB_OK &&
        filter_type == TILEDB_FILTER_CHECKSUM_MD5));
+  REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_CHECKSUM_SHA256, &c_str) ==
+           TILEDB_OK &&
+       std::string(c_str) == "CHECKSUM_SHA256"));
   REQUIRE(
       (tiledb_filter_type_from_str("CHECKSUM_SHA256", &filter_type) ==
            TILEDB_OK &&
        filter_type == TILEDB_FILTER_CHECKSUM_SHA256));
   REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_DICTIONARY, &c_str) ==
+           TILEDB_OK &&
+       std::string(c_str) == "DICTIONARY_ENCODING"));
+  REQUIRE(
       (tiledb_filter_type_from_str("DICTIONARY_ENCODING", &filter_type) ==
            TILEDB_OK &&
        filter_type == TILEDB_FILTER_DICTIONARY));
   REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_SCALE_FLOAT, &c_str) ==
+           TILEDB_OK &&
+       std::string(c_str) == "SCALE_FLOAT"));
+  REQUIRE(
       (tiledb_filter_type_from_str("SCALE_FLOAT", &filter_type) == TILEDB_OK &&
        filter_type == TILEDB_FILTER_SCALE_FLOAT));
+  REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_XOR, &c_str) == TILEDB_OK &&
+       std::string(c_str) == "XOR"));
   REQUIRE(
       (tiledb_filter_type_from_str("XOR", &filter_type) == TILEDB_OK &&
        filter_type == TILEDB_FILTER_XOR));
   REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_WEBP, &c_str) == TILEDB_OK &&
+       std::string(c_str) == "WEBP"));
+  REQUIRE(
       (tiledb_filter_type_from_str("WEBP", &filter_type) == TILEDB_OK &&
        filter_type == TILEDB_FILTER_WEBP));
+  REQUIRE(
+      (tiledb_filter_type_to_str(TILEDB_FILTER_DELTA, &c_str) == TILEDB_OK &&
+       std::string(c_str) == "DELTA"));
+  REQUIRE(
+      (tiledb_filter_type_from_str("DELTA", &filter_type) == TILEDB_OK &&
+       filter_type == TILEDB_FILTER_DELTA));
 
   tiledb_filter_option_t filter_option;
   REQUIRE(

--- a/test/src/unit-enum-helpers.cc
+++ b/test/src/unit-enum-helpers.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023-2024 TileDB Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 
 #include "test/support/tdb_catch.h"
 #include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/enums/filter_type.h"
 
 using namespace tiledb::sm;
 
@@ -70,4 +71,28 @@ TEST_CASE("Test datatype_is_byte", "[enums][datatype][datatype_is_byte]") {
 
   CHECK(datatype_is_byte(datatype));
   CHECK(!datatype_is_byte(Datatype::BOOL));
+}
+
+TEST_CASE(
+    "Test ensure_filtertype_is_valid",
+    "[enums][filter_type][ensure_filtertype_is_valid]") {
+  auto filter_deprecated = ::stdx::to_underlying(FilterType::FILTER_DEPRECATED);
+  auto filter_internal =
+      ::stdx::to_underlying(FilterType::INTERNAL_FILTER_AES_256_GCM);
+  auto filter_max = ::stdx::to_underlying(FilterType::INTERNAL_FILTER_COUNT);
+
+  for (auto filter_type = 0; filter_type <= filter_max; filter_type++) {
+    if (filter_type_str(FilterType(filter_type)) == constants::empty_str) {
+      if (filter_type == filter_deprecated || filter_type == filter_internal) {
+        // filter_[deprecated, internal] have valid enums but empty strings.
+        CHECK_NOTHROW(ensure_filtertype_is_valid(filter_type));
+      } else {
+        // invalid enums (>= filter_max) will throw.
+        CHECK_THROWS(ensure_filtertype_is_valid(filter_type));
+      }
+    } else {
+      // all other filter types have valid enums and strings.
+      CHECK_NOTHROW(ensure_filtertype_is_valid(filter_type));
+    }
+  }
 }

--- a/tiledb/api/c_api/filter/filter_api_enum.h
+++ b/tiledb/api/c_api/filter/filter_api_enum.h
@@ -65,6 +65,8 @@ TILEDB_FILTER_TYPE_ENUM(FILTER_NONE) = 0,
     TILEDB_FILTER_TYPE_ENUM(FILTER_WEBP) = 18,
     /** Delta filter. */
     TILEDB_FILTER_TYPE_ENUM(FILTER_DELTA) = 19,
+    /** The number of filter type enums. Must always be the last enum value. */
+    TILEDB_FILTER_TYPE_ENUM(INTERNAL_FILTER_COUNT) = 20,
 #endif
 
 #ifdef TILEDB_FILTER_OPTION_ENUM

--- a/tiledb/sm/cpp_api/filter.h
+++ b/tiledb/sm/cpp_api/filter.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -336,6 +336,8 @@ class Filter {
         return "WEBP";
       case TILEDB_FILTER_DELTA:
         return "DELTA";
+      case TILEDB_INTERNAL_FILTER_COUNT:
+        break;
     }
     return "";
   }

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -147,7 +147,7 @@ inline Status filter_type_enum(
 
 /** Throws error if the input Filtertype enum is not between 0 and 19. */
 inline void ensure_filtertype_is_valid(uint8_t type) {
-  if (type > 19) {
+  if (type > 19 || filter_type_str(FilterType(type)) == constants::empty_str) {
     throw std::runtime_error(
         "Invalid FilterType (" + std::to_string(type) + ")");
   }

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,8 +41,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /**
  * A filter type.
@@ -146,20 +145,19 @@ inline Status filter_type_enum(
   return Status::Ok();
 }
 
-/** Throws error if the input Filtertype enum is not between 0 and 16. */
+/** Throws error if the input Filtertype enum is not between 0 and 19. */
 inline void ensure_filtertype_is_valid(uint8_t type) {
-  if (type > 18) {
+  if (type > 19) {
     throw std::runtime_error(
         "Invalid FilterType (" + std::to_string(type) + ")");
   }
 }
 
-/** Throws error if the input Filtertype's enum is not between 0 and 16. */
+/** Throws error if the input Filtertype's enum is not between 0 and 19. */
 inline void ensure_filtertype_is_valid(FilterType type) {
   ensure_filtertype_is_valid(::stdx::to_underlying(type));
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_FILTER_TYPE_H

--- a/tiledb/sm/enums/filter_type.h
+++ b/tiledb/sm/enums/filter_type.h
@@ -145,17 +145,18 @@ inline Status filter_type_enum(
   return Status::Ok();
 }
 
-/** Throws error if the input Filtertype enum is not between 0 and 19. */
-inline void ensure_filtertype_is_valid(uint8_t type) {
-  if (type > 19 || filter_type_str(FilterType(type)) == constants::empty_str) {
+/** Throws error if the input FilterType is not a valid filter type. */
+inline void ensure_filtertype_is_valid(FilterType type) {
+  if (type >= FilterType::INTERNAL_FILTER_COUNT) {
     throw std::runtime_error(
-        "Invalid FilterType (" + std::to_string(type) + ")");
+        "Invalid FilterType (" + std::to_string(::stdx::to_underlying(type)) +
+        ")");
   }
 }
 
-/** Throws error if the input Filtertype's enum is not between 0 and 19. */
-inline void ensure_filtertype_is_valid(FilterType type) {
-  ensure_filtertype_is_valid(::stdx::to_underlying(type));
+/** Throws error if the input FilterType enum is not a valid filter type. */
+inline void ensure_filtertype_is_valid(uint8_t type) {
+  ensure_filtertype_is_valid(FilterType(type));
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -179,6 +179,7 @@ Status filter_to_capnp(
     case FilterType::INTERNAL_FILTER_AES_256_GCM:
     case FilterType::FILTER_XOR:
     case FilterType::FILTER_DEPRECATED:
+    case FilterType::INTERNAL_FILTER_COUNT:
       break;
   }
 


### PR DESCRIPTION
Update the upper bound in `ensure_filter_type_is_valid` to reflect the highest-possible `filter_type` enum.

---
[sc-65265]
Completes CORE-39

---
TYPE: NO_HISTORY
DESC: Update `ensure_filter_type_is_valid` upper bound enum.
