### PR TITLE
[C API] Add bulk point-range setter `tiledb_subarray_add_point_ranges_var`

### DIFF
--- a/tiledb/api/c_api/subarray/subarray_api.cc
+++ b/tiledb/api/c_api/subarray/subarray_api.cc
@@ -97,6 +97,19 @@ capi_return_t tiledb_subarray_add_point_ranges(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_subarray_add_point_ranges_var(
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const void* buffer_val,
+    uint64_t buffer_val_size,
+    const uint64_t* buffer_off,
+    uint64_t buffer_off_size) {
+  ensure_subarray_is_valid(subarray);
+  subarray->add_point_ranges_var(
+      dim_idx, buffer_val, buffer_val_size, buffer_off, buffer_off_size);
+  return TILEDB_OK;
+}
+
 capi_return_t tiledb_subarray_add_range(
     tiledb_subarray_t* subarray,
     uint32_t dim_idx,
@@ -305,6 +318,25 @@ CAPI_INTERFACE(
     uint64_t count) {
   return api_entry_context<tiledb::api::tiledb_subarray_add_point_ranges>(
       ctx, subarray, dim_idx, start, count);
+}
+
+CAPI_INTERFACE(
+    subarray_add_point_ranges_var,
+    tiledb_ctx_t* ctx,
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const void* buffer_val,
+    uint64_t buffer_val_size,
+    const uint64_t* buffer_off,
+    uint64_t buffer_off_size) {
+  return api_entry_context<tiledb::api::tiledb_subarray_add_point_ranges_var>(
+      ctx,
+      subarray,
+      dim_idx,
+      buffer_val,
+      buffer_val_size,
+      buffer_off,
+      buffer_off_size);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/api/c_api/subarray/subarray_api_experimental.h
+++ b/tiledb/api/c_api/subarray/subarray_api_experimental.h
@@ -66,6 +66,40 @@ TILEDB_EXPORT capi_return_t tiledb_subarray_add_point_ranges(
     const void* start,
     uint64_t count) TILEDB_NOEXCEPT;
 
+/**
+ * Adds variable-sized point ranges to the given dimension index of the
+ * subarray. Effectively `add_range(x_i, x_i)` for all points in the
+ * target array, but set in bulk to amortize expensive steps.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const char* buffer_val = "TileDBtest";
+ * uint64_t buffer_val_size = 10;
+ * uint64_t buffer_off[] = {0, 2, 3, 6, 8};
+ * uint64_t buffer_off_size = 5;
+ * tiledb_subarray_add_point_ranges_var(ctx, subarray, 0, buffer_val,
+ * buffer_val_size, buffer_off, buffer_off_size);
+ * @endcode
+ *
+ * @param[in] ctx The TileDB context.
+ * @param[in] subarray The subarray.
+ * @param[in] dim_idx The index of the dimension to add the range to.
+ * @param[in] buffer_val Pointer to start of the array.
+ * @param[in] buffer_val_size Size of the buffer in bytes.
+ * @param[in] buffer_off Pointer to the start of the offsets array.
+ * @param[in] buffer_off_size Number of offsets in the offsets array.
+ *
+ */
+TILEDB_EXPORT capi_return_t tiledb_subarray_add_point_ranges_var(
+    tiledb_ctx_t* ctx,
+    tiledb_subarray_t* subarray,
+    uint32_t dim_idx,
+    const void* buffer_val,
+    uint64_t buffer_val_size,
+    const uint64_t* buffer_off,
+    uint64_t buffer_off_size) TILEDB_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/tiledb/api/c_api/subarray/subarray_api_internal.h
+++ b/tiledb/api/c_api/subarray/subarray_api_internal.h
@@ -93,6 +93,16 @@ struct tiledb_subarray_handle_t
     subarray_->add_point_ranges(dim_idx, start, count, check);
   }
 
+  void add_point_ranges_var(
+      unsigned dim_idx,
+      const void* buffer_val,
+      uint64_t buffer_val_size,
+      const uint64_t* buffer_off,
+      uint64_t buffer_off_size) {
+    subarray_->add_point_ranges_var(
+        dim_idx, buffer_val, buffer_val_size, buffer_off, buffer_off_size);
+  }
+
   void add_range(unsigned dim_idx, const void* start, const void* end) {
     subarray_->add_range(dim_idx, start, end);
   }

--- a/tiledb/api/c_api/subarray/test/unit_capi_subarray.cc
+++ b/tiledb/api/c_api/subarray/test/unit_capi_subarray.cc
@@ -172,6 +172,30 @@ TEST_CASE(
   SECTION("success") {
     rc = tiledb_subarray_add_point_ranges(x.ctx(), x.subarray, 0, ranges, 2);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
+
+    // validate range_num
+    uint64_t range_num;
+    rc = tiledb_subarray_get_range_num(x.ctx(), x.subarray, 0, &range_num);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    REQUIRE(range_num == 2);
+
+    // validate range
+    const void* start;
+    const void* end;
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 0, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(*static_cast<const int*>(start) == 1);
+    CHECK(*static_cast<const int*>(end) == 1);
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 1, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(*static_cast<const int*>(start) == 4);
+    CHECK(*static_cast<const int*>(end) == 4);
+    // there are only two ranges
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 2, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null context") {
     rc = tiledb_subarray_add_point_ranges(nullptr, x.subarray, 0, ranges, 2);
@@ -252,6 +276,10 @@ TEST_CASE(
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
     CHECK(std::string(static_cast<const char*>(start), 2) == "st");
     CHECK(std::string(static_cast<const char*>(end), 2) == "st");
+    // there are only five ranges
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 5, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
   }
   SECTION("null context") {
     rc = tiledb_subarray_add_point_ranges_var(

--- a/tiledb/api/c_api/subarray/test/unit_capi_subarray.cc
+++ b/tiledb/api/c_api/subarray/test/unit_capi_subarray.cc
@@ -199,6 +199,124 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "C API: tiledb_subarray_add_point_ranges_var argument validation",
+    "[capi][subarray]") {
+  capi_return_t rc;
+  ordinary_subarray_var x{};
+  const char* buffer_val = "TileDBtest";
+  uint64_t buffer_val_size = 10;
+  uint64_t buffer_off[] = {0, 2, 3, 6, 8};
+  uint64_t buffer_off_size = 5;
+  SECTION("success") {
+    rc = tiledb_subarray_add_point_ranges_var(
+        x.ctx(),
+        x.subarray,
+        0,
+        buffer_val,
+        buffer_val_size,
+        buffer_off,
+        buffer_off_size);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+
+    // validate range_num
+    uint64_t range_num;
+    rc = tiledb_subarray_get_range_num(x.ctx(), x.subarray, 0, &range_num);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    REQUIRE(range_num == 5);
+
+    // validate range
+    const void* start;
+    const void* end;
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 0, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(std::string(static_cast<const char*>(start), 2) == "Ti");
+    CHECK(std::string(static_cast<const char*>(end), 2) == "Ti");
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 1, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(std::string(static_cast<const char*>(start), 1) == "l");
+    CHECK(std::string(static_cast<const char*>(end), 1) == "l");
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 2, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(std::string(static_cast<const char*>(start), 3) == "eDB");
+    CHECK(std::string(static_cast<const char*>(end), 3) == "eDB");
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 3, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(std::string(static_cast<const char*>(start), 2) == "te");
+    CHECK(std::string(static_cast<const char*>(end), 2) == "te");
+    rc = tiledb_subarray_get_range(
+        x.ctx(), x.subarray, 0, 4, &start, &end, nullptr);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    CHECK(std::string(static_cast<const char*>(start), 2) == "st");
+    CHECK(std::string(static_cast<const char*>(end), 2) == "st");
+  }
+  SECTION("null context") {
+    rc = tiledb_subarray_add_point_ranges_var(
+        nullptr,
+        x.subarray,
+        0,
+        buffer_val,
+        buffer_val_size,
+        buffer_off,
+        buffer_off_size);
+    REQUIRE(tiledb_status(rc) == TILEDB_INVALID_CONTEXT);
+  }
+  SECTION("null subarray") {
+    rc = tiledb_subarray_add_point_ranges_var(
+        x.ctx(),
+        nullptr,
+        0,
+        buffer_val,
+        buffer_val_size,
+        buffer_off,
+        buffer_off_size);
+    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("invalid dim_idx") {
+    rc = tiledb_subarray_add_point_ranges_var(
+        x.ctx(),
+        x.subarray,
+        3,
+        buffer_val,
+        buffer_val_size,
+        buffer_off,
+        buffer_off_size);
+    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("null buffer_val") {
+    rc = tiledb_subarray_add_point_ranges_var(
+        x.ctx(),
+        x.subarray,
+        0,
+        nullptr,
+        buffer_val_size,
+        buffer_off,
+        buffer_off_size);
+    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
+  }
+  SECTION("null buffer_off") {
+    rc = tiledb_subarray_add_point_ranges_var(
+        x.ctx(),
+        x.subarray,
+        0,
+        buffer_val,
+        buffer_val_size,
+        nullptr,
+        buffer_off_size);
+    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
+  }
+
+  /**
+   * No "invalid buffer_val_size" and "invalid buffer_off_size" sections here;
+   * There is no way to programmatically (in)validate the size. An invalid
+   * value will result in a segfault from an OOB memcpy.
+   */
+}
+
+TEST_CASE(
     "C API: tiledb_subarray_add_range argument validation",
     "[capi][subarray]") {
   capi_return_t rc;

--- a/tiledb/sm/subarray/subarray.cc
+++ b/tiledb/sm/subarray/subarray.cc
@@ -420,7 +420,10 @@ void Subarray::add_point_ranges(
           .domain()
           .dimension_ptr(dim_idx)
           ->var_size()) {
-    throw SubarrayException("Cannot add range; Range must be fixed-sized");
+    throw SubarrayException(
+        "Cannot add range; Range must be fixed-sized. If you "
+        "want to add a variable-sized range, use the "
+        "add_range_var() instead");
   }
 
   // Prepare a temp range
@@ -438,6 +441,67 @@ void Subarray::add_point_ranges(
     // Add range
     this->add_range(
         dim_idx, Range(&range[0], 2 * coord_size), err_on_range_oob_);
+  }
+}
+
+void Subarray::add_point_ranges_var(
+    unsigned dim_idx,
+    const void* buffer_val,
+    uint64_t buffer_val_size,
+    const uint64_t* buffer_off,
+    uint64_t buffer_off_size,
+    bool check_for_label) {
+  if (dim_idx >= this->array_->array_schema_latest().dim_num()) {
+    throw SubarrayException("Cannot add range; Invalid dimension index");
+  }
+  if (check_for_label && label_range_subset_[dim_idx].has_value()) {
+    throw SubarrayException(
+        "Cannot add range to to dimension; A range is already set on a "
+        "dimension label for this dimension");
+  }
+  if (buffer_off == nullptr || buffer_val == nullptr) {
+    throw SubarrayException("Cannot add ranges; Invalid start pointer");
+  }
+  if (!this->array_->array_schema_latest()
+           .domain()
+           .dimension_ptr(dim_idx)
+           ->var_size()) {
+    throw SubarrayException(
+        "Cannot add range; Range must be variable-sized"
+        "If you want to add a fixed-sized range, use the "
+        "add_range() instead");
+  }
+
+  // Prepare a temp range
+  std::vector<uint8_t> range;
+
+  for (size_t i = 0; i < buffer_off_size; i++) {
+    uint64_t start_offset = ((uint64_t*)buffer_off)[i];
+    uint64_t end_offset;
+    if (i == buffer_off_size - 1) {
+      end_offset = buffer_val_size;
+    } else {
+      end_offset = ((uint64_t*)buffer_off)[i + 1];
+    }
+    if (start_offset > buffer_val_size || end_offset > buffer_val_size) {
+      throw SubarrayException("Cannot add ranges; Invalid range");
+    }
+
+    range.resize(2 * (end_offset - start_offset));
+    // point ranges
+    std::memcpy(
+        &range[0],
+        (uint8_t*)buffer_val + start_offset,
+        end_offset - start_offset);
+    std::memcpy(
+        &range[end_offset - start_offset],
+        (uint8_t*)buffer_val + start_offset,
+        end_offset - start_offset);
+    // Add range
+    this->add_range(
+        dim_idx,
+        Range(&range[0], 2 * (end_offset - start_offset)),
+        err_on_range_oob_);
   }
 }
 

--- a/tiledb/sm/subarray/subarray.h
+++ b/tiledb/sm/subarray/subarray.h
@@ -561,7 +561,7 @@ class Subarray {
   void add_range(unsigned dim_idx, const void* start, const void* end);
 
   /**
-   * @brief Set point ranges from an array
+   * @brief Set point ranges from a fixed-sized array
    *
    * @param dim_idx Dimension index.
    * @param start Pointer to start of the array.
@@ -574,6 +574,26 @@ class Subarray {
       unsigned dim_idx,
       const void* start,
       uint64_t count,
+      bool check_for_label = true);
+
+  /**
+   * @brief Set point ranges from a variable-sized array
+   *
+   * @param dim_idx Dimension index.
+   * @param buffer_val Pointer to start of the array.
+   * @param buffer_val_size Size of the buffer in bytes.
+   * @param buffer_off Pointer to the start of the offsets array.
+   * @param buffer_off_size Number of offsets in the offsets array.
+   * @param check_for_label If ``true``, verify no label ranges set on this
+   *   dimension. This should check for labels unless being called by
+   *   ``add_index_ranges_from_label`` to update label ranges with index values.
+   */
+  void add_point_ranges_var(
+      unsigned dim_idx,
+      const void* buffer_val,
+      uint64_t buffer_val_size,
+      const uint64_t* buffer_off,
+      uint64_t buffer_off_size,
       bool check_for_label = true);
 
   /**


### PR DESCRIPTION
SC-65001

This API allows bulk insertion of point-ranges (start==end) amortizing some expensive parts of the initial path, to reduce overhead with large range counts.

---
TYPE: C_API
DESC: Add bulk point-range setter `tiledb_subarray_add_point_ranges_var`