### PR TITLE
Improve efficiency of `Enumeration::generate_value_map`

### DIFF
--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -455,7 +455,7 @@ void Enumeration::generate_value_map() {
 }
 
 void Enumeration::add_value_to_map(std::string_view& sv, uint64_t index) {
-  const auto res = value_map_.insert(std::make_pair(sv, index));
+  const auto res = value_map_.emplace(sv, index);
   if (!res.second) {
     throw EnumerationException(
         "Invalid duplicated value in enumeration '" + std::string(sv) + "'");

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -427,6 +427,8 @@ void Enumeration::generate_value_map() {
     auto offsets = offsets_.data_as<uint64_t>();
     uint64_t num_offsets = offsets_.size() / sizeof(uint64_t);
 
+    value_map_.reserve(num_offsets);
+
     for (uint64_t i = 0; i < num_offsets; i++) {
       uint64_t length = 0;
       if (i < num_offsets - 1) {
@@ -441,6 +443,9 @@ void Enumeration::generate_value_map() {
   } else {
     uint64_t i = 0;
     auto stride = cell_size();
+
+    value_map_.reserve(data_.size() / stride);
+
     while (i * stride < data_.size()) {
       auto sv = std::string_view(char_data + i * stride, stride);
       add_value_to_map(sv, i);

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -450,11 +450,11 @@ void Enumeration::generate_value_map() {
 }
 
 void Enumeration::add_value_to_map(std::string_view& sv, uint64_t index) {
-  if (value_map_.find(sv) != value_map_.end()) {
+  const auto res = value_map_.insert(std::make_pair(sv, index));
+  if (!res.second) {
     throw EnumerationException(
         "Invalid duplicated value in enumeration '" + std::string(sv) + "'");
   }
-  value_map_[sv] = index;
 }
 
 }  // namespace tiledb::sm


### PR DESCRIPTION
`Enumeration::generate_value_map` builds a map from enumeration value to key so that we can identify duplicates and do look-ups for insertion.  This method reads through the enumeration data and offset buffers and populates this map.

This pull request implements some low-hanging fruit to improve the performance of this method.  The first commit consolidates the duplicate check with the insert, and the second commit reserves an initial size of the `std::unordered_map` (hash table) using the variant buffer sizes.

A not-especially scientific benchmark indicates a better than 33% performance improvement in reading a variable-length enumeration with 4062980 variants.  The measurements below in seconds are the end-to-end latency of running the `tiledb-tables` query `select count(cell_val_num) FROM tiledb_enumerations('/local-fs-path/sc-60446-large-enumerations') where name = 'sample'`.  This query was chosen because it materializes the enumeration variants but does a minimal amount of further processing.
```
main = [2.880, 2.778, 2.876]
bc70 = [2.619, 2.696, 2.675]
bee8 = [1.852, 1.916, 1.922]
```

We see a small but noticeable improvement from the first commit and then a larger improvement from the second resulting in a roughly 33% improvement overall.

---
TYPE: IMPROVEMENT
DESC: Improve efficiency of `Enumeration::generate_value_map`
