### PR TITLE
Support workspace and teamspace for REST requests.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,9 @@ trigger_pipeline:
 
   variables:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
+    TILEDB_SERVER_REF: phw/add-workspace-to-legacy-routes
+
   trigger:
     project: tiledb-inc/tiledb-internal
     strategy: depend
+    branch: smr/sc-64563/test-tiledb-server

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,9 +16,7 @@ trigger_pipeline:
 
   variables:
     TILEDB_REF: ${CI_COMMIT_REF_NAME}
-    TILEDB_SERVER_REF: phw/add-workspace-to-legacy-routes
 
   trigger:
     project: tiledb-inc/tiledb-internal
     strategy: depend
-    branch: smr/sc-64563/test-tiledb-server

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -202,6 +202,7 @@ if (TILEDB_SERIALIZATION)
     src/unit-capi-serialized_queries.cc
     src/unit-QueryCondition-serialization.cc
     src/unit-curl.cc
+    src/unit-rest-client-remote.cc
   )
 endif()
 

--- a/test/src/unit-capi-array.cc
+++ b/test/src/unit-capi-array.cc
@@ -884,7 +884,7 @@ TEST_CASE_METHOD(
   // TODO: refactor for each supported FS.
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_path = temp_dir + "array-open-at-reads";
-  std::string array_name = vfs_array_uri(fs_vec_[0], array_path);
+  std::string array_name = vfs_array_uri(fs_vec_[0], array_path, ctx_);
 
   SECTION("- without encryption") {
     encryption_type_ = TILEDB_NO_ENCRYPTION;
@@ -1510,7 +1510,7 @@ TEST_CASE_METHOD(
   // TODO: refactor for each supported FS.
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "array-open-at-writes");
+      vfs_array_uri(fs_vec_[0], temp_dir + "array-open-at-writes", ctx_);
 
   SECTION("- without encryption") {
     encryption_type_ = TILEDB_NO_ENCRYPTION;
@@ -1728,7 +1728,7 @@ TEST_CASE_METHOD(
     "[capi][array][array-write-coords-oob][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "array-write-coords-oob");
+      vfs_array_uri(fs_vec_[0], temp_dir + "array-write-coords-oob", ctx_);
   create_temp_dir(temp_dir);
 
   int dimension = 0;
@@ -1876,7 +1876,8 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     ArrayFx, "C API: Test empty array", "[capi][array][array-empty][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
-  std::string array_name = vfs_array_uri(fs_vec_[0], temp_dir + "array_empty");
+  std::string array_name =
+      vfs_array_uri(fs_vec_[0], temp_dir + "array_empty", ctx_);
 
   create_temp_dir(temp_dir);
 
@@ -1928,7 +1929,7 @@ TEST_CASE_METHOD(
     ArrayFx, "C API: Test deletion of array", "[capi][array][delete][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_path = temp_dir + "array_delete";
-  std::string array_name = vfs_array_uri(fs_vec_[0], array_path);
+  std::string array_name = vfs_array_uri(fs_vec_[0], array_path, ctx_);
 
   create_temp_dir(temp_dir);
 
@@ -2004,7 +2005,7 @@ TEST_CASE_METHOD(
     "[capi][subarray][error][sparse][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_sparse");
+      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_sparse", ctx_);
   create_temp_dir(temp_dir);
 
   create_sparse_vector(array_name);
@@ -2066,7 +2067,7 @@ TEST_CASE_METHOD(
     "[capi][query][error][dense][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_dense");
+      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_dense", ctx_);
   create_temp_dir(temp_dir);
 
   create_dense_array(array_name);
@@ -2146,7 +2147,7 @@ TEST_CASE_METHOD(
     "[capi][query][error][dense][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_dense");
+      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_dense", ctx_);
 
   create_temp_dir(temp_dir);
 
@@ -2184,7 +2185,7 @@ TEST_CASE_METHOD(
     "[capi][query][error][dense][rest]") {
   std::string temp_dir = fs_vec_[0]->temp_dir();
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_dense");
+      vfs_array_uri(fs_vec_[0], temp_dir + "query_error_dense", ctx_);
 
   create_temp_dir(temp_dir);
 

--- a/test/src/unit-capi-attributes.cc
+++ b/test/src/unit-capi-attributes.cc
@@ -162,7 +162,7 @@ TEST_CASE_METHOD(
     for (const auto& fs : fs_vec_) {
       std::string temp_dir = fs->temp_dir();
       std::string array_name = vfs_array_uri(
-          fs, temp_dir + "array-illegal-char" + std::to_string(num++));
+          fs, temp_dir + "array-illegal-char" + std::to_string(num++), ctx_);
 
       // Create new TileDB context with file lock config disabled, rest the
       // same.
@@ -277,7 +277,8 @@ TEST_CASE_METHOD(
 
   for (const auto& fs : fs_vec_) {
     std::string temp_dir = fs->temp_dir();
-    std::string array_name = vfs_array_uri(fs, temp_dir + "byte-attribute");
+    std::string array_name =
+        vfs_array_uri(fs, temp_dir + "byte-attribute", ctx_);
     std::string attr_name = "a";
 
     // Create new TileDB context with file lock config disabled, rest the
@@ -468,7 +469,8 @@ TEST_CASE_METHOD(
     "[capi][attributes][tiledb_bool][rest]") {
   for (const auto& fs : fs_vec_) {
     std::string temp_dir = fs->temp_dir();
-    std::string array_name = vfs_array_uri(fs, temp_dir + "bool-attribute");
+    std::string array_name =
+        vfs_array_uri(fs, temp_dir + "bool-attribute", ctx_);
 
     std::string attr_name = "attr";
 

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -252,7 +252,7 @@ DenseArrayFx::DenseArrayFx()
     : fs_vec_(vfs_test_get_fs_vec()) {
   // Initialize vfs test
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
-  prefix_ = vfs_array_uri(fs_vec_[0], fs_vec_[0]->temp_dir());
+  prefix_ = vfs_array_uri(fs_vec_[0], fs_vec_[0]->temp_dir(), ctx_);
   std::srand(0);
 }
 

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -249,10 +249,10 @@ struct DenseArrayFx {
 };
 
 DenseArrayFx::DenseArrayFx()
-    : fs_vec_(vfs_test_get_fs_vec())
-    , prefix_(vfs_array_uri(fs_vec_[0], fs_vec_[0]->temp_dir())) {
+    : fs_vec_(vfs_test_get_fs_vec()) {
   // Initialize vfs test
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
+  prefix_ = vfs_array_uri(fs_vec_[0], fs_vec_[0]->temp_dir());
   std::srand(0);
 }
 

--- a/test/src/unit-capi-dense_neg.cc
+++ b/test/src/unit-capi-dense_neg.cc
@@ -539,7 +539,7 @@ TEST_CASE_METHOD(
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
   std::string vector_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "dense_neg_vector");
+      vfs_array_uri(fs_vec_[0], temp_dir + "dense_neg_vector", ctx_);
 
   create_dense_vector(vector_name);
   write_dense_vector(vector_name);
@@ -555,7 +555,7 @@ TEST_CASE_METHOD(
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
   std::string array_name =
-      vfs_array_uri(fs_vec_[0], temp_dir + "dense_neg_array");
+      vfs_array_uri(fs_vec_[0], temp_dir + "dense_neg_array", ctx_);
 
   create_dense_array(array_name);
   write_dense_array_global(array_name);

--- a/test/src/unit-capi-group.cc
+++ b/test/src/unit-capi-group.cc
@@ -397,7 +397,7 @@ TEST_CASE_METHOD(
   // TODO: refactor for each supported FS.
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
-  std::string group1_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group1");
+  std::string group1_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group1", ctx_);
 
   REQUIRE(tiledb_group_create(ctx_, group1_uri.c_str()) == TILEDB_OK);
 
@@ -1550,10 +1550,10 @@ TEST_CASE_METHOD(
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
 
-  std::string group1_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group1");
+  std::string group1_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group1", ctx_);
   REQUIRE(tiledb_group_create(ctx_, group1_uri.c_str()) == TILEDB_OK);
 
-  std::string group2_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group2");
+  std::string group2_uri = vfs_array_uri(fs_vec_[0], temp_dir + "group2", ctx_);
   REQUIRE(tiledb_group_create(ctx_, group2_uri.c_str()) == TILEDB_OK);
 
   tiledb_group_t* group1;

--- a/test/src/unit-capi-nullable.cc
+++ b/test/src/unit-capi-nullable.cc
@@ -217,7 +217,8 @@ NullableArrayFx::~NullableArrayFx() {
 }
 
 const string NullableArrayFx::array_path(const string& array_name) {
-  return vfs_array_uri(vfs_test_get_fs_vec()[0], temp_dir_.path() + array_name);
+  return vfs_array_uri(
+      vfs_test_get_fs_vec()[0], temp_dir_.path() + array_name, ctx_);
 }
 
 void NullableArrayFx::create_array(

--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -220,7 +220,7 @@ SparseArrayFx::SparseArrayFx()
   for (const auto& fs : fs_vec_)
     create_temp_dir(fs->temp_dir());
 
-  prefix_ = vfs_array_uri(fs_vec_[0], fs_vec_[0]->temp_dir());
+  prefix_ = vfs_array_uri(fs_vec_[0], fs_vec_[0]->temp_dir(), ctx_);
 }
 
 SparseArrayFx::~SparseArrayFx() {

--- a/test/src/unit-capi-sparse_heter.cc
+++ b/test/src/unit-capi-sparse_heter.cc
@@ -148,7 +148,7 @@ SparseHeterFx::SparseHeterFx()
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
   auto temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
-  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir);
+  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir, ctx_);
 }
 
 SparseHeterFx::~SparseHeterFx() {

--- a/test/src/unit-capi-sparse_neg.cc
+++ b/test/src/unit-capi-sparse_neg.cc
@@ -77,7 +77,7 @@ SparseNegFx::SparseNegFx()
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
   auto temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
-  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir);
+  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir, ctx_);
 }
 
 SparseNegFx::~SparseNegFx() {

--- a/test/src/unit-capi-sparse_neg_2.cc
+++ b/test/src/unit-capi-sparse_neg_2.cc
@@ -76,7 +76,7 @@ SparseNegFx2::SparseNegFx2()
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
   auto temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
-  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir);
+  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir, ctx_);
 }
 
 SparseNegFx2::~SparseNegFx2() {

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -179,7 +179,7 @@ StringDimsFx::StringDimsFx()
   REQUIRE(vfs_test_init(fs_vec_, &ctx_, &vfs_).ok());
   auto temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);
-  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir);
+  prefix_ = vfs_array_uri(fs_vec_[0], temp_dir, ctx_);
 }
 
 StringDimsFx::~StringDimsFx() {

--- a/test/src/unit-rest-client-remote.cc
+++ b/test/src/unit-rest-client-remote.cc
@@ -1,0 +1,135 @@
+/**
+ * @file   unit-rest-client-remote.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2025 TileDB Inc.
+ * @copyright Copyright (c) 2016 MIT and Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for RestClientRemote class. This class and the tests in this file are
+ * only compiled when TILEDB_SERIALIZATION is enabled.
+ */
+
+#include <test/support/tdb_catch.h>
+#include "test/support/src/vfs_helpers.h"
+#include "tiledb/sm/rest/rest_client_remote.h"
+
+TEST_CASE("REST capabilities endpoint", "[rest][version]") {
+  tiledb::test::VFSTestSetup vfs_test_setup;
+  if (!vfs_test_setup.is_rest()) {
+    return;
+  }
+
+  tiledb::Config config;
+  std::string serialization_format = GENERATE("JSON", "CAPNP");
+  config["rest.server_serialization_format"] = serialization_format;
+
+  auto expected_version =
+      std::make_from_tuple<tiledb::sm::RestCapabilities::TileDBVersion>(
+          tiledb::version());
+  tiledb::common::ThreadPool tp(1);
+  DYNAMIC_SECTION(
+      "GET request to retrieve REST tiledb version - "
+      << serialization_format) {
+    auto rest_client = tiledb::sm::RestClientRemote(
+        tiledb::test::g_helper_stats,
+        config.ptr()->config(),
+        tp,
+        *tiledb::test::g_helper_logger(),
+        tiledb::test::get_test_memory_tracker());
+    tiledb::sm::RestCapabilities expected_capabilities(
+        expected_version, {2, 28, 0});
+    // Check on construction the capabilities are not initialized.
+    REQUIRE(!rest_client.rest_capabilities_detected());
+    auto actual_capabilities = rest_client.get_capabilities_from_rest();
+
+    // If we detected a legacy REST server the test was successful but there
+    // is no version response from legacy REST to validate.
+    if (!actual_capabilities.legacy_) {
+      REQUIRE(expected_capabilities == actual_capabilities);
+    }
+    // We should have detected REST capabilities, either legacy or 3.0.
+    REQUIRE(rest_client.rest_capabilities_detected());
+  }
+  DYNAMIC_SECTION(
+      "Initialization of rest_tiledb_version_ on first access - "
+      << serialization_format) {
+    // Construct enabled Stats for this test to verify http request count.
+    auto stats = tiledb::sm::stats::Stats("capabilities_stats");
+    auto rest_client = tiledb::sm::RestClientRemote(
+        stats,
+        config.ptr()->config(),
+        tp,
+        *tiledb::test::g_helper_logger(),
+        tiledb::test::get_test_memory_tracker());
+    // Here we don't call `get_capabilities_from_rest`, but instead attempt to
+    // first access RestCapabilities directly. The RestClient should submit
+    // the GET request and initialize RestCapabilities, returning the result.
+    REQUIRE(!rest_client.rest_capabilities_detected());
+
+    // Should submit capabilities request and return the TileDBVersion result.
+    auto tiledb_version = rest_client.rest_tiledb_version();
+    // After the access above, RestCapabilities has been initialized.
+    REQUIRE(rest_client.rest_capabilities_detected());
+    // Validate the TileDB version if it was provided in the response.
+    if (!rest_client.get_capabilities_from_rest().legacy_) {
+      // TODO: Should we use some default version for legacy?
+      //    This creates an edge case where rest_tiledb_version_ is not
+      //    initialized for legacy. That's fine until we start to add checks on
+      //    this version, expecting it to be relevant.
+      REQUIRE(tiledb_version == expected_version);
+    }
+
+    // Check there was only one request sent.
+    auto match_request_count = Catch::Matchers::ContainsSubstring(
+        "\"capabilities_stats.RestClient.rest_http_requests\": 1");
+    REQUIRE_THAT(stats.dump(0, 0), match_request_count);
+
+    // Further access attempts should not submit additional requests.
+    auto capabilities = rest_client.get_capabilities_from_rest();
+    if (!capabilities.legacy_) {
+      REQUIRE(rest_client.rest_tiledb_version() == expected_version);
+    }
+
+    // Subsequent access attempts should not submit any additional requests.
+    REQUIRE_THAT(stats.dump(0, 0), match_request_count);
+  }
+}
+
+TEST_CASE("Test getting REST URI components", "[uri]") {
+  // TODO: Add more URI combinations, relocate test alongside other URI tests.
+  std::string ns = GENERATE("workspace/teamspace", "ws_1234/ts_1234");
+  std::string arr = GENERATE(
+      "8f039466-6e90-42ea-af53-dc0ba47d00c2",
+      "array_name",
+      "s3://bucket/arrays/array_name");
+  tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
+
+  std::string array_namespace, array_uri;
+  REQUIRE(uri.get_rest_components(&array_namespace, &array_uri, false).ok());
+
+  REQUIRE(array_namespace == ns);
+  REQUIRE(array_uri == arr);
+}

--- a/test/src/unit-rest-client-remote.cc
+++ b/test/src/unit-rest-client-remote.cc
@@ -62,8 +62,7 @@ TEST_CASE("REST capabilities endpoint", "[rest][capabilities]") {
     auto actual_capabilities = rest_client.get_capabilities_from_rest();
 
     if (rest_client.get_capabilities_from_rest().legacy_) {
-      REQUIRE(
-          RestCapabilities({2, 28, 0}, {2, 0, 0}, true) == actual_capabilities);
+      REQUIRE(RestCapabilities(nullopt, nullopt, true) == actual_capabilities);
     } else {
       // We don't know what core version to expect on TileDB-Server.
       // TileDB-Server supports clients >= 2.28.0, we can check minimum version.
@@ -73,7 +72,7 @@ TEST_CASE("REST capabilities endpoint", "[rest][capabilities]") {
       REQUIRE(actual_capabilities.legacy_ == false);
       REQUIRE(actual_capabilities.detected_);
     }
-    // We should have detected REST capabilities, either legacy or 3.0.
+    // We should have detected REST capabilities either legacy or TileDB-Server.
     REQUIRE(rest_client.rest_capabilities_detected());
   }
   DYNAMIC_SECTION(
@@ -96,12 +95,11 @@ TEST_CASE("REST capabilities endpoint", "[rest][capabilities]") {
     // After the access above, RestCapabilities has been initialized.
     REQUIRE(rest_client.rest_capabilities_detected());
     // Check min version since we don't know what core version is on the server.
-    RestCapabilities::TileDBVersion expected_min_tiledb;
+    std::optional<RestCapabilities::TileDBVersion> expected_min_tiledb;
     if (rest_client.get_capabilities_from_rest().legacy_) {
-      // TODO: Minimum supported version for TileDB-Cloud-REST.
-      expected_min_tiledb = RestCapabilities::TileDBVersion(2, 0, 0);
+      expected_min_tiledb = nullopt;
     } else {
-      expected_min_tiledb = RestCapabilities::TileDBVersion(2, 28, 0);
+      expected_min_tiledb = {2, 28, 0};
     }
 
     REQUIRE(min_tiledb_version == expected_min_tiledb);

--- a/test/src/unit-rest-client-remote.cc
+++ b/test/src/unit-rest-client-remote.cc
@@ -36,7 +36,7 @@
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/sm/rest/rest_client_remote.h"
 
-TEST_CASE("REST capabilities endpoint", "[rest][version]") {
+TEST_CASE("REST capabilities endpoint", "[rest][capabilities]") {
   using tiledb::sm::RestCapabilities;
   tiledb::test::VFSTestSetup vfs_test_setup;
   if (!vfs_test_setup.is_rest()) {

--- a/test/src/unit-rest-client-remote.cc
+++ b/test/src/unit-rest-client-remote.cc
@@ -61,8 +61,6 @@ TEST_CASE("REST capabilities endpoint", "[rest][version]") {
     REQUIRE(!rest_client.rest_capabilities_detected());
     auto actual_capabilities = rest_client.get_capabilities_from_rest();
 
-    // If we detected a legacy REST server the test was successful but there
-    // is no version response from legacy REST to validate.
     if (rest_client.get_capabilities_from_rest().legacy_) {
       REQUIRE(
           RestCapabilities({2, 28, 0}, {2, 0, 0}, true) == actual_capabilities);

--- a/test/src/unit-rest-client-remote.cc
+++ b/test/src/unit-rest-client-remote.cc
@@ -121,32 +121,3 @@ TEST_CASE("REST capabilities endpoint", "[rest][version]") {
     REQUIRE_THAT(stats.dump(0, 0), match_request_count);
   }
 }
-
-TEST_CASE("Parse REST URI components", "[uri]") {
-  std::string arr = GENERATE(
-      "8f039466-6e90-42ea-af53-dc0ba47d00c2",
-      "a",
-      "array_name",
-      "s3://bucket/arrays/array_name",
-      "s3://b/d/a");
-
-  std::string array_namespace, array_uri;
-  SECTION("Legacy REST URI components") {
-    std::string ns = GENERATE("demo", "d");
-    tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
-    REQUIRE(uri.get_rest_components(&array_namespace, &array_uri, true).ok());
-    REQUIRE(array_namespace == ns);
-    REQUIRE(array_uri == arr);
-  }
-
-  SECTION("Carrara REST URI components") {
-    std::string ns = GENERATE(
-        "workspace/teamspace",
-        "ws_cvsj3li97ng28m60nhj0/ts_cvsj4ei97ng28m60nhkg",
-        "w/t");
-    tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
-    REQUIRE(uri.get_rest_components(&array_namespace, &array_uri, false).ok());
-    REQUIRE(array_namespace == ns);
-    REQUIRE(array_uri == arr);
-  }
-}

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -97,7 +97,9 @@ void vfs_test_create_temp_dir(
     tiledb_ctx_t* ctx, tiledb_vfs_t* vfs, const std::string& path);
 
 std::string vfs_array_uri(
-    const std::unique_ptr<SupportedFs>& fs, const std::string& array_name);
+    const std::unique_ptr<SupportedFs>& fs,
+    const std::string& array_name,
+    tiledb_ctx_t* ctx);
 
 /**
  * This class defines and manipulates
@@ -159,13 +161,6 @@ class SupportedFs {
    * @return true if REST, false if not
    */
   virtual bool is_rest() = 0;
-
-  /**
-   * Checks if we are using legacy or 3.0 REST.
-   *
-   * @return true if legacy REST, false if 3.0 REST.
-   */
-  virtual bool is_legacy_rest() = 0;
 
   /**
    * Checks if the filesystem is local or remote
@@ -236,15 +231,6 @@ class SupportedFsS3 : public SupportedFs {
    * @return true if REST, false if not
    */
   virtual bool is_rest();
-
-  /**
-   * Checks if we are using legacy or 3.0 REST.
-   *
-   * @return true if legacy REST, false if 3.0 REST.
-   */
-  inline bool is_legacy_rest() {
-    return legacy_rest_;
-  }
 
   /**
    * Checks if the filesystem is local or remote
@@ -339,15 +325,6 @@ class SupportedFsAzure : public SupportedFs {
   }
 
   /**
-   * Checks if we are using legacy or 3.0 REST.
-   *
-   * @return true if legacy REST, false if 3.0 REST.
-   */
-  inline bool is_legacy_rest() {
-    return false;
-  }
-
-  /**
    * Checks if the filesystem is local or remote
    *
    * @return true if local, false if not
@@ -429,15 +406,6 @@ class SupportedFsGCS : public SupportedFs {
    * @return true if REST, false if not
    */
   inline bool is_rest() {
-    return false;
-  }
-
-  /**
-   * Checks if we are using legacy or 3.0 REST.
-   *
-   * @return true if legacy REST, false if 3.0 REST.
-   */
-  inline bool is_legacy_rest() {
     return false;
   }
 
@@ -540,15 +508,6 @@ class SupportedFsLocal : public SupportedFs {
   }
 
   /**
-   * Checks if we are using legacy or 3.0 REST.
-   *
-   * @return true if legacy REST, false if 3.0 REST.
-   */
-  inline bool is_legacy_rest() {
-    return false;
-  }
-
-  /**
    * Checks if the filesystem is local or remote
    *
    * @return true if local, false if not
@@ -635,15 +594,6 @@ class SupportedFsMem : public SupportedFs {
    * @return true if REST, false if not
    */
   inline bool is_rest() {
-    return false;
-  }
-
-  /**
-   * Checks if we are using legacy or 3.0 REST.
-   *
-   * @return true if legacy REST, false if 3.0 REST.
-   */
-  inline bool is_legacy_rest() {
     return false;
   }
 
@@ -901,9 +851,7 @@ struct VFSTestSetup {
     return fs_vec[0]->is_rest();
   }
 
-  bool is_legacy_rest() {
-    return fs_vec[0]->is_legacy_rest();
-  }
+  bool is_legacy_rest();
 
   bool is_local() {
     return fs_vec[0]->is_local();

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -176,12 +176,11 @@ class SupportedFs {
  */
 class SupportedFsS3 : public SupportedFs {
  public:
-  SupportedFsS3(bool rest = false, bool legacy_rest = false)
+  SupportedFsS3(bool rest = false)
       : s3_prefix_("s3://")
       , s3_bucket_(s3_prefix_ + "tiledb-" + random_label() + "/")
       , temp_dir_(s3_bucket_ + "tiledb_test/")
-      , rest_(rest)
-      , legacy_rest_(legacy_rest) {
+      , rest_(rest) {
   }
 
   ~SupportedFsS3() = default;
@@ -257,9 +256,6 @@ class SupportedFsS3 : public SupportedFs {
 
   /** If the filesystem is accessed via REST. */
   bool rest_;
-
-  /** True if the REST server is legacy, false if using 3.0 REST */
-  bool legacy_rest_;
 };
 
 /**

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -161,7 +161,7 @@ class SupportedFs {
   virtual bool is_rest() = 0;
 
   /**
-   * Checks if the we are using legacy or 3.0 REST.
+   * Checks if we are using legacy or 3.0 REST.
    *
    * @return true if legacy REST, false if 3.0 REST.
    */
@@ -238,7 +238,7 @@ class SupportedFsS3 : public SupportedFs {
   virtual bool is_rest();
 
   /**
-   * Checks if the we are using legacy or 3.0 REST.
+   * Checks if we are using legacy or 3.0 REST.
    *
    * @return true if legacy REST, false if 3.0 REST.
    */
@@ -339,7 +339,7 @@ class SupportedFsAzure : public SupportedFs {
   }
 
   /**
-   * Checks if the we are using legacy or 3.0 REST.
+   * Checks if we are using legacy or 3.0 REST.
    *
    * @return true if legacy REST, false if 3.0 REST.
    */
@@ -433,7 +433,7 @@ class SupportedFsGCS : public SupportedFs {
   }
 
   /**
-   * Checks if the we are using legacy or 3.0 REST.
+   * Checks if we are using legacy or 3.0 REST.
    *
    * @return true if legacy REST, false if 3.0 REST.
    */
@@ -540,7 +540,7 @@ class SupportedFsLocal : public SupportedFs {
   }
 
   /**
-   * Checks if the we are using legacy or 3.0 REST.
+   * Checks if we are using legacy or 3.0 REST.
    *
    * @return true if legacy REST, false if 3.0 REST.
    */
@@ -639,7 +639,7 @@ class SupportedFsMem : public SupportedFs {
   }
 
   /**
-   * Checks if the we are using legacy or 3.0 REST.
+   * Checks if we are using legacy or 3.0 REST.
    *
    * @return true if legacy REST, false if 3.0 REST.
    */

--- a/tiledb/sm/filesystem/test/unit_uri.cc
+++ b/tiledb/sm/filesystem/test/unit_uri.cc
@@ -262,7 +262,7 @@ TEST_CASE("URI: Get REST components", "[uri]") {
     REQUIRE(array_uri == arr);
   }
 
-  SECTION("Carrara REST URI components") {
+  SECTION("TileDB-Server REST URI components") {
     std::string ns = GENERATE(
         "workspace/teamspace",
         "ws_cvsj3li97ng28m60nhj0/ts_cvsj4ei97ng28m60nhkg",

--- a/tiledb/sm/filesystem/test/unit_uri.cc
+++ b/tiledb/sm/filesystem/test/unit_uri.cc
@@ -185,7 +185,8 @@ TEST_CASE("URI: Test REST components, valid", "[uri]") {
       "array", "array/uri", "s3://bucket/dir", "azure://container/dir");
   const std::string uri{"tiledb://" + ns_component + "/" + array_component};
   std::string ns, array;
-  DYNAMIC_SECTION((legacy ? "legacy " : "3.0 ") << "\"" << uri << "\" valid") {
+  DYNAMIC_SECTION(
+      (legacy ? "legacy " : "TileDB-Server ") << "\"" << uri << "\" valid") {
     CHECK(URI(uri).get_rest_components(&ns, &array, legacy).ok());
     CHECK(ns == ns_component);
     CHECK(array == array_component);
@@ -216,7 +217,7 @@ TEST_CASE("URI: Test REST components, invalid", "[uri]") {
   for (size_t j = 0; j < N; ++j) {
     std::string x{invalid_rest_uri[j]};
     DYNAMIC_SECTION(
-        (legacy ? "legacy " : "3.0 ") << "\"" << x << "\" invalid") {
+        (legacy ? "legacy " : "TileDB-Server ") << "\"" << x << "\" invalid") {
       CHECK(!URI(x).get_rest_components(&ns, &array, legacy).ok());
     }
   }

--- a/tiledb/sm/filesystem/test/unit_uri.cc
+++ b/tiledb/sm/filesystem/test/unit_uri.cc
@@ -179,30 +179,16 @@ TEST_CASE("URI: Test schemes", "[uri]") {
 }
 
 TEST_CASE("URI: Test REST components, valid", "[uri]") {
+  bool legacy = GENERATE(true, false);
+  const std::string ns_component = legacy ? "namespace" : "workspace/teampsace";
+  const std::string array_component = GENERATE(
+      "array", "array/uri", "s3://bucket/dir", "azure://container/dir");
+  const std::string uri{"tiledb://" + ns_component + "/" + array_component};
   std::string ns, array;
-
-  struct test_vector {
-    std::string uri;
-    std::string ns;
-    std::string array;
-  };
-  const test_vector valid_rest_uri[] = {
-      {"tiledb://namespace/array", "namespace", "array"},
-      {"tiledb://namespace/array/uri", "namespace", "array/uri"},
-      {"tiledb://namespace/s3://bucket/dir", "namespace", "s3://bucket/dir"},
-      {"tiledb://namespace/azure://container/dir",
-       "namespace",
-       "azure://container/dir"}};
-  constexpr size_t N = sizeof(valid_rest_uri) / sizeof(test_vector);
-
-  for (size_t j = 0; j < N; ++j) {
-    auto x{valid_rest_uri[j]};
-    auto uri{x.uri};
-    DYNAMIC_SECTION("\"" << uri << "\" valid") {
-      CHECK(URI(uri).get_rest_components(&ns, &array).ok());
-      CHECK(ns == x.ns);
-      CHECK(array == x.array);
-    }
+  DYNAMIC_SECTION((legacy ? "legacy " : "3.0 ") << "\"" << uri << "\" valid") {
+    CHECK(URI(uri).get_rest_components(&ns, &array, legacy).ok());
+    CHECK(ns == ns_component);
+    CHECK(array == array_component);
   }
 }
 
@@ -226,10 +212,12 @@ TEST_CASE("URI: Test REST components, invalid", "[uri]") {
       "tiledb:///"};
   constexpr size_t N{sizeof(invalid_rest_uri) / sizeof(std::string)};
 
+  bool legacy = GENERATE(true, false);
   for (size_t j = 0; j < N; ++j) {
     std::string x{invalid_rest_uri[j]};
-    DYNAMIC_SECTION("\"" << x << "\" invalid") {
-      CHECK(!URI(x).get_rest_components(&ns, &array).ok());
+    DYNAMIC_SECTION(
+        (legacy ? "legacy " : "3.0 ") << "\"" << x << "\" invalid") {
+      CHECK(!URI(x).get_rest_components(&ns, &array, legacy).ok());
     }
   }
 }
@@ -254,6 +242,35 @@ TEST_CASE("URI: Test get_fragment_name", "[uri][get_fragment_name]") {
 
   for (auto& test : cases) {
     REQUIRE(test.first.get_fragment_name() == test.second);
+  }
+}
+
+TEST_CASE("URI: Get REST components", "[uri]") {
+  std::string arr = GENERATE(
+      "8f039466-6e90-42ea-af53-dc0ba47d00c2",
+      "a",
+      "array_name",
+      "s3://bucket/arrays/array_name",
+      "s3://b/d/a");
+
+  std::string array_namespace, array_uri;
+  SECTION("Legacy REST URI components") {
+    std::string ns = GENERATE("demo", "d");
+    tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
+    REQUIRE(uri.get_rest_components(&array_namespace, &array_uri, true).ok());
+    REQUIRE(array_namespace == ns);
+    REQUIRE(array_uri == arr);
+  }
+
+  SECTION("Carrara REST URI components") {
+    std::string ns = GENERATE(
+        "workspace/teamspace",
+        "ws_cvsj3li97ng28m60nhj0/ts_cvsj4ei97ng28m60nhkg",
+        "w/t");
+    tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
+    REQUIRE(uri.get_rest_components(&array_namespace, &array_uri, false).ok());
+    REQUIRE(array_namespace == ns);
+    REQUIRE(array_uri == arr);
   }
 }
 

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -225,7 +225,7 @@ Status URI::get_rest_components(
   }
 
   if (legacy) {
-    // Extract '<namespace>' if we are using a 3.0 REST server.
+    // Extract '<namespace>' if we are talking to legacy REST.
 
     // Find '/' between namespace and array uri.
     auto slash = uri_.find('/', prefix.size());
@@ -240,7 +240,7 @@ Status URI::get_rest_components(
     *array_namespace = uri_.substr(prefix.size(), namespace_len);
     *array_uri = uri_.substr(slash + 1, array_len);
   } else {
-    // Extract '<workspace>/<teamspace>' if we are using a 3.0 REST server.
+    // Extract '<workspace>/<teamspace>' if we are talking to TileDB-Server.
 
     // Find '/' between workspace and teamspace.
     auto ws_slash = uri_.find('/', prefix.size());

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -262,9 +262,8 @@ Status URI::get_rest_components(
 
     std::string ws = uri_.substr(prefix.size(), ws_len);
     std::string ts = uri_.substr(ws_slash + 1, ts_len);
-    std::string arr_uri = uri_.substr(ts_slash + 1, array_len);
     *array_namespace = ws + "/" + ts;
-    *array_uri = arr_uri;
+    *array_uri = uri_.substr(ts_slash + 1, array_len);
   }
 
   return Status::Ok();

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -255,6 +255,9 @@ Status URI::get_rest_components(
     auto ws_len = ws_slash - prefix.size();
     auto ts_len = ts_slash - (ws_len + 1) - prefix.size();
     auto array_len = uri_.size() - (ts_len + 1);
+    if (ws_len == 0 || ts_len == 0 || array_len == 0) {
+      return LOG_STATUS(error_st);
+    }
 
     std::string ws = uri_.substr(prefix.size(), ws_len);
     std::string ts = uri_.substr(ws_slash + 1, ts_len);

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -214,14 +214,10 @@ Status URI::get_rest_components(
     std::string* array_namespace, std::string* array_uri, bool legacy) const {
   const std::string prefix = "tiledb://";
   const std::string ns_component =
-      legacy ? "<namespace>" : "<workspace>/<teamspace>";
+      legacy ? "tiledb://<namespace>" : "tiledb://<workspace>/<teamspace>";
   const auto error_st = Status_RestError(
-      "Invalid array URI for REST service; expected format is "
-      "'tiledb://" +
-      ns_component +
-      "/<array-name>' or "
-      "'tiledb://" +
-      ns_component + "/<array-uri>'.");
+      "Invalid array URI for REST service; expected format is " + ns_component +
+      "/<array-name>' or " + ns_component + "/<array-uri>'.");
 
   if (!is_tiledb() || uri_.empty() || uri_.find(prefix) == std::string::npos ||
       uri_.size() <= prefix.size()) {

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -241,9 +241,7 @@ class URI {
    * @return Status
    */
   Status get_rest_components(
-      std::string* array_namespace,
-      std::string* array_uri,
-      bool legacy) const;
+      std::string* array_namespace, std::string* array_uri, bool legacy) const;
 
   /**
    * Return the fragment name from the URI if one can be found.

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -236,10 +236,14 @@ class URI {
    *
    * @param array_namespace Set to the namespace of the input URI
    * @param array_uri Set to the array URI of the input URI.
+   * @param legacy True if we are communicating with a legacy REST server.
+   *    If False, the namespace component will contain `workspace/teamspace`.
    * @return Status
    */
   Status get_rest_components(
-      std::string* array_namespace, std::string* array_uri) const;
+      std::string* array_namespace,
+      std::string* array_uri,
+      bool legacy = true) const;
 
   /**
    * Return the fragment name from the URI if one can be found.

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -243,7 +243,7 @@ class URI {
   Status get_rest_components(
       std::string* array_namespace,
       std::string* array_uri,
-      bool legacy = true) const;
+      bool legacy) const;
 
   /**
    * Return the fragment name from the URI if one can be found.

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -833,6 +833,51 @@ Status Curl::check_curl_errors(
   return Status::Ok();
 }
 
+void Curl::check_curl_errors_v2(
+    CURLcode curl_code,
+    const std::string& operation,
+    const Buffer* returned_data) const {
+  CURL* curl = curl_.get();
+  if (curl == nullptr) {
+    throw CurlException(
+        "Error checking curl error; curl instance is null.", curl_code);
+  }
+
+  if (curl_code != CURLE_OK) {
+    std::stringstream msg;
+    msg << "Error in libcurl " << operation
+        << " operation: libcurl error message '" << get_curl_errstr(curl_code)
+        << "; ";
+    throw CurlException(msg.str(), curl_code);
+  }
+
+  long http_code = 0;
+  if (curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code) != CURLE_OK) {
+    throw CurlException(
+        "Error checking curl error; could not get HTTP code.", curl_code);
+  }
+
+  if (http_code >= 400) {
+    // TODO: Should see if message has error data object
+    std::stringstream msg;
+    msg << "Error in libcurl " << operation
+        << " operation: libcurl error message '" << get_curl_errstr(curl_code)
+        << "'; HTTP code " << http_code << "; ";
+    if (returned_data) {
+      if (returned_data->size() > 0) {
+        msg << "server response data '"
+            << std::string(
+                   reinterpret_cast<const char*>(returned_data->data()),
+                   returned_data->size())
+            << "'.";
+      } else {
+        msg << "server response was empty.";
+      }
+    }
+    throw CurlException(msg.str(), curl_code, http_code);
+  }
+}
+
 std::string Curl::get_curl_errstr(CURLcode curl_code) const {
   if (curl_code == CURLE_OK)
     return "CURLE_OK";
@@ -936,37 +981,37 @@ Status Curl::post_data_common(
   return Status::Ok();
 }
 
-Status Curl::get_data(
+void Curl::get_data(
     stats::Stats* const stats,
     const std::string& url,
     SerializationType serialization_type,
     Buffer* returned_data,
     const std::string& res_ns_uri) {
   CURL* curl = curl_.get();
-  if (curl == nullptr)
-    return LOG_STATUS(
-        Status_RestError("Error getting data; curl instance is null."));
+  if (curl == nullptr) {
+    throw CurlException("Error getting data; curl instance is null.");
+  }
 
   // Set auth and content-type for request
   struct curl_slist* headers = nullptr;
-  RETURN_NOT_OK_ELSE(set_headers(&headers), curl_slist_free_all(headers));
-  RETURN_NOT_OK_ELSE(
-      set_content_type(serialization_type, &headers),
-      curl_slist_free_all(headers));
-
-  /* pass our list of custom made headers */
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-
   CURLcode ret;
-  headerData.uri = &res_ns_uri;
-  auto st = make_curl_request(stats, url.c_str(), &ret, nullptr, returned_data);
-  curl_slist_free_all(headers);
-  RETURN_NOT_OK(st);
+  try {
+    throw_if_not_ok(set_headers(&headers));
+    throw_if_not_ok(set_content_type(serialization_type, &headers));
 
-  // Check for errors
-  RETURN_NOT_OK(check_curl_errors(ret, "GET", returned_data));
+    // Pass our list of custom-made headers.
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
-  return Status::Ok();
+    headerData.uri = &res_ns_uri;
+    throw_if_not_ok(
+        make_curl_request(stats, url.c_str(), &ret, nullptr, returned_data));
+  } catch (...) {
+    curl_slist_free_all(headers);
+    throw;
+  }
+
+  // Throws CurlException containing the error, if any is found.
+  check_curl_errors_v2(ret, "GET", returned_data);
 }
 
 Status Curl::options(

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -71,7 +71,9 @@ namespace sm {
 class CurlException : public StatusException {
  public:
   explicit CurlException(
-      const std::string& message, int curl_code, int http_code = HTTP_NONE)
+      const std::string& message,
+      int curl_code = CURL_NONE,
+      int http_code = HTTP_NONE)
       : StatusException("Curl", message)
       , curl_code_(curl_code)
       , http_code_(http_code) {
@@ -85,7 +87,7 @@ class CurlException : public StatusException {
     return http_code_;
   }
 
-  static constexpr int HTTP_NONE = -1;
+  enum { CURL_NONE = -2, HTTP_NONE };
 
  private:
   int curl_code_;

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -71,9 +71,7 @@ namespace sm {
 class CurlException : public StatusException {
  public:
   explicit CurlException(
-      const std::string& message,
-      int curl_code = CURL_NONE,
-      int http_code = HTTP_NONE)
+      const std::string& message, int curl_code, int http_code = HTTP_NONE)
       : StatusException("Curl", message)
       , curl_code_(curl_code)
       , http_code_(http_code) {
@@ -87,8 +85,7 @@ class CurlException : public StatusException {
     return http_code_;
   }
 
-  // TODO: IIUC curl code will always be available.
-  enum StatusCode { CURL_NONE = -2, HTTP_NONE };
+  static constexpr int HTTP_NONE = -1;
 
  private:
   int curl_code_;

--- a/tiledb/sm/rest/rest_capabilities.h
+++ b/tiledb/sm/rest/rest_capabilities.h
@@ -61,8 +61,11 @@ struct RestCapabilities {
    * releases.
    */
   RestCapabilities(
-      TileDBVersion rest_version, TileDBVersion rest_minimum_version)
+      TileDBVersion rest_version,
+      TileDBVersion rest_minimum_version,
+      bool legacy = false)
       : detected_(true)
+      , legacy_(legacy)
       , rest_tiledb_version_(rest_version)
       , rest_minimum_supported_version_(rest_minimum_version) {
   }

--- a/tiledb/sm/rest/rest_capabilities.h
+++ b/tiledb/sm/rest/rest_capabilities.h
@@ -72,6 +72,9 @@ struct RestCapabilities {
   /// Whether or not the REST capabilities have been initialized.
   bool detected_ = false;
 
+  /// True if the configured REST server is legacy.
+  bool legacy_ = false;
+
   /// The currently deployed TileDB version available on the REST server.
   TileDBVersion rest_tiledb_version_{};
 

--- a/tiledb/sm/rest/rest_capabilities.h
+++ b/tiledb/sm/rest/rest_capabilities.h
@@ -61,8 +61,8 @@ struct RestCapabilities {
    * releases.
    */
   RestCapabilities(
-      TileDBVersion rest_version,
-      TileDBVersion rest_minimum_version,
+      std::optional<TileDBVersion> rest_version,
+      std::optional<TileDBVersion> rest_minimum_version,
       bool legacy = false)
       : detected_(true)
       , legacy_(legacy)
@@ -79,10 +79,10 @@ struct RestCapabilities {
   bool legacy_ = false;
 
   /// The currently deployed TileDB version available on the REST server.
-  TileDBVersion rest_tiledb_version_{};
+  std::optional<TileDBVersion> rest_tiledb_version_ = std::nullopt;
 
   /// The minimum TileDB version supported by the REST server.
-  TileDBVersion rest_minimum_supported_version_{};
+  std::optional<TileDBVersion> rest_minimum_supported_version_ = std::nullopt;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -313,6 +313,11 @@ class RestClient {
     throw RestClientDisabledException();
   }
 
+  /// Operation disabled in base class.
+  inline virtual bool rest_legacy() const {
+    throw RestClientDisabledException();
+  }
+
   //-------------------------------------------------------
   // Rest client operations
   //-------------------------------------------------------

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -298,13 +298,14 @@ class RestClient {
   }
 
   /// Operation disabled in base class.
-  inline virtual const TileDBVersion& rest_tiledb_version() const {
+  inline virtual const std::optional<TileDBVersion>& rest_tiledb_version()
+      const {
     throw RestClientDisabledException();
   }
 
   /// Operation disabled in base class.
-  inline virtual const TileDBVersion& rest_minimum_supported_tiledb_version()
-      const {
+  inline virtual const std::optional<TileDBVersion>&
+  rest_minimum_supported_tiledb_version() const {
     throw RestClientDisabledException();
   }
 

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -124,9 +124,7 @@ RestClientRemote::check_array_exists_from_rest(const URI& uri) {
   Curl curlc(logger_);
   std::string array_ns, array_uri;
   RETURN_NOT_OK_TUPLE(
-      uri.get_rest_components(
-          &array_ns, &array_uri, get_capabilities_from_rest().legacy_),
-      nullopt);
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()), nullopt);
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
@@ -164,9 +162,7 @@ RestClientRemote::check_group_exists_from_rest(const URI& uri) {
   Curl curlc(logger_);
   std::string group_ns, group_uri;
   RETURN_NOT_OK_TUPLE(
-      uri.get_rest_components(
-          &group_ns, &group_uri, get_capabilities_from_rest().legacy_),
-      nullopt);
+      uri.get_rest_components(&group_ns, &group_uri, rest_legacy()), nullopt);
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
@@ -204,9 +200,7 @@ RestClientRemote::get_array_schema_from_rest(const URI& uri) {
   Curl curlc(logger_);
   std::string array_ns, array_uri;
   RETURN_NOT_OK_TUPLE(
-      uri.get_rest_components(
-          &array_ns, &array_uri, get_capabilities_from_rest().legacy_),
-      nullopt);
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()), nullopt);
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
@@ -253,8 +247,8 @@ RestClientRemote::post_array_schema_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -299,8 +293,7 @@ Status RestClientRemote::post_array_schema_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   // We don't want to cache the URI used for array creation as it will
   // always be hardcoded to the default server. After creation the REST
@@ -335,8 +328,8 @@ void RestClientRemote::post_array_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -369,8 +362,8 @@ void RestClientRemote::delete_array_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -399,8 +392,8 @@ void RestClientRemote::post_delete_fragments_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -428,8 +421,8 @@ void RestClientRemote::post_delete_fragments_list_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -452,8 +445,7 @@ Status RestClientRemote::deregister_array_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -478,7 +470,7 @@ Status RestClientRemote::get_array_non_empty_domain(
   Curl curlc(logger_);
   std::string array_ns, array_uri;
   RETURN_NOT_OK(array->array_uri().get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+      &array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -515,8 +507,7 @@ Status RestClientRemote::get_array_metadata_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -558,8 +549,7 @@ Status RestClientRemote::post_array_metadata_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -596,8 +586,8 @@ RestClientRemote::post_enumerations_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -641,8 +631,8 @@ void RestClientRemote::post_query_plan_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -735,8 +725,7 @@ Status RestClientRemote::post_query_submit(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -979,8 +968,7 @@ Status RestClientRemote::finalize_query_to_rest(const URI& uri, Query* query) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1040,8 +1028,7 @@ Status RestClientRemote::submit_and_finalize_query_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1169,8 +1156,7 @@ Status RestClientRemote::get_query_est_result_sizes(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1221,8 +1207,7 @@ Status RestClientRemote::post_array_schema_evolution_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1253,8 +1238,7 @@ Status RestClientRemote::post_fragment_info_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1293,8 +1277,7 @@ Status RestClientRemote::post_group_metadata_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri, rest_legacy()));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1337,8 +1320,7 @@ Status RestClientRemote::put_group_metadata_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri, rest_legacy()));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1361,13 +1343,12 @@ Status RestClientRemote::post_group_create_to_rest(
   BufferList serialized{memory_tracker_};
   auto& buff = serialized.emplace_buffer();
   RETURN_NOT_OK(serialization::group_create_serialize(
-      group, serialization_type_, buff, get_capabilities_from_rest().legacy_));
+      group, serialization_type_, buff, rest_legacy()));
 
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri, rest_legacy()));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1393,8 +1374,7 @@ Status RestClientRemote::post_group_from_rest(const URI& uri, Group* group) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri, rest_legacy()));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1433,8 +1413,7 @@ Status RestClientRemote::patch_group_to_rest(const URI& uri, Group* group) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri, rest_legacy()));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1451,8 +1430,8 @@ void RestClientRemote::delete_group_from_rest(const URI& uri, bool recursive) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&group_ns, &group_uri, rest_legacy()));
   const std::string cache_key = group_ns + ":" + group_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1476,8 +1455,7 @@ Status RestClientRemote::post_consolidation_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1500,8 +1478,7 @@ Status RestClientRemote::post_vacuum_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1525,8 +1502,8 @@ RestClientRemote::post_consolidation_plan_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(
-      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
+  throw_if_not_ok(
+      uri.get_rest_components(&array_ns, &array_uri, rest_legacy()));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -123,7 +123,10 @@ RestClientRemote::check_array_exists_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK_TUPLE(uri.get_rest_components(&array_ns, &array_uri), nullopt);
+  RETURN_NOT_OK_TUPLE(
+      uri.get_rest_components(
+          &array_ns, &array_uri, get_capabilities_from_rest().legacy_),
+      nullopt);
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
@@ -160,7 +163,10 @@ RestClientRemote::check_group_exists_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK_TUPLE(uri.get_rest_components(&group_ns, &group_uri), nullopt);
+  RETURN_NOT_OK_TUPLE(
+      uri.get_rest_components(
+          &group_ns, &group_uri, get_capabilities_from_rest().legacy_),
+      nullopt);
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
@@ -197,7 +203,10 @@ RestClientRemote::get_array_schema_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK_TUPLE(uri.get_rest_components(&array_ns, &array_uri), nullopt);
+  RETURN_NOT_OK_TUPLE(
+      uri.get_rest_components(
+          &array_ns, &array_uri, get_capabilities_from_rest().legacy_),
+      nullopt);
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
@@ -244,7 +253,8 @@ RestClientRemote::post_array_schema_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -289,7 +299,8 @@ Status RestClientRemote::post_array_schema_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   // We don't want to cache the URI used for array creation as it will
   // always be hardcoded to the default server. After creation the REST
@@ -324,7 +335,8 @@ void RestClientRemote::post_array_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -357,7 +369,8 @@ void RestClientRemote::delete_array_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -386,7 +399,8 @@ void RestClientRemote::post_delete_fragments_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -414,7 +428,8 @@ void RestClientRemote::post_delete_fragments_list_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -437,7 +452,8 @@ Status RestClientRemote::deregister_array_from_rest(const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -461,7 +477,8 @@ Status RestClientRemote::get_array_non_empty_domain(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(array->array_uri().get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(array->array_uri().get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -498,7 +515,8 @@ Status RestClientRemote::get_array_metadata_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -540,7 +558,8 @@ Status RestClientRemote::post_array_metadata_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -577,7 +596,8 @@ RestClientRemote::post_enumerations_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -621,7 +641,8 @@ void RestClientRemote::post_query_plan_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -714,7 +735,8 @@ Status RestClientRemote::post_query_submit(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -957,7 +979,8 @@ Status RestClientRemote::finalize_query_to_rest(const URI& uri, Query* query) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1017,7 +1040,8 @@ Status RestClientRemote::submit_and_finalize_query_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1145,7 +1169,8 @@ Status RestClientRemote::get_query_est_result_sizes(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1196,7 +1221,8 @@ Status RestClientRemote::post_array_schema_evolution_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1227,7 +1253,8 @@ Status RestClientRemote::post_fragment_info_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1266,7 +1293,8 @@ Status RestClientRemote::post_group_metadata_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1309,7 +1337,8 @@ Status RestClientRemote::put_group_metadata_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1332,12 +1361,17 @@ Status RestClientRemote::post_group_create_to_rest(
   BufferList serialized{memory_tracker_};
   auto& buff = serialized.emplace_buffer();
   RETURN_NOT_OK(
-      serialization::group_create_serialize(group, serialization_type_, buff));
+      serialization::group_create_serialize(
+          group,
+          serialization_type_,
+          buff,
+          get_capabilities_from_rest().legacy_));
 
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1363,7 +1397,8 @@ Status RestClientRemote::post_group_from_rest(const URI& uri, Group* group) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1402,7 +1437,8 @@ Status RestClientRemote::patch_group_to_rest(const URI& uri, Group* group) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&group_ns, &group_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1419,7 +1455,8 @@ void RestClientRemote::delete_group_from_rest(const URI& uri, bool recursive) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string group_ns, group_uri;
-  throw_if_not_ok(uri.get_rest_components(&group_ns, &group_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &group_ns, &group_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = group_ns + ":" + group_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1443,7 +1480,8 @@ Status RestClientRemote::post_consolidation_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1466,7 +1504,8 @@ Status RestClientRemote::post_vacuum_to_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  RETURN_NOT_OK(uri.get_rest_components(&array_ns, &array_uri));
+  RETURN_NOT_OK(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1490,7 +1529,8 @@ RestClientRemote::post_consolidation_plan_from_rest(
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
-  throw_if_not_ok(uri.get_rest_components(&array_ns, &array_uri));
+  throw_if_not_ok(uri.get_rest_components(
+      &array_ns, &array_uri, get_capabilities_from_rest().legacy_));
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
@@ -1537,7 +1577,9 @@ const RestCapabilities& RestClientRemote::get_capabilities_from_rest() const {
     std::string msg = e.what();
     if (msg.find("HTTP code 404") != std::string::npos) {
       // Check if the message was a 404, indicating a legacy REST server.
-      rest_capabilities_.detected_ = rest_capabilities_.legacy_ = true;
+      // Legacy REST supports clients <= 2.28.0.
+      rest_capabilities_ = RestCapabilities({2, 28, 0}, {2, 0, 0});
+      rest_capabilities_.legacy_ = true;
     } else {
       // Failed to determine REST capabilities due to an unexpected error.
       throw RestClientException(e.what());

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -1360,12 +1360,8 @@ Status RestClientRemote::post_group_create_to_rest(
 
   BufferList serialized{memory_tracker_};
   auto& buff = serialized.emplace_buffer();
-  RETURN_NOT_OK(
-      serialization::group_create_serialize(
-          group,
-          serialization_type_,
-          buff,
-          get_capabilities_from_rest().legacy_));
+  RETURN_NOT_OK(serialization::group_create_serialize(
+      group, serialization_type_, buff, get_capabilities_from_rest().legacy_));
 
   // Init curl and form the URL
   Curl curlc(logger_);
@@ -1576,10 +1572,9 @@ const RestCapabilities& RestClientRemote::get_capabilities_from_rest() const {
   } catch (const std::exception& e) {
     std::string msg = e.what();
     if (msg.find("HTTP code 404") != std::string::npos) {
-      // Check if the message was a 404, indicating a legacy REST server.
+      // If the error was a 404, this indicates a legacy REST server.
       // Legacy REST supports clients <= 2.28.0.
-      rest_capabilities_ = RestCapabilities({2, 28, 0}, {2, 0, 0});
-      rest_capabilities_.legacy_ = true;
+      rest_capabilities_ = RestCapabilities({2, 28, 0}, {2, 0, 0}, true);
     } else {
       // Failed to determine REST capabilities due to an unexpected error.
       throw RestClientException(e.what());

--- a/tiledb/sm/rest/rest_client_remote.h
+++ b/tiledb/sm/rest/rest_client_remote.h
@@ -145,6 +145,15 @@ class RestClientRemote : public RestClient {
   }
 
   /**
+   * Check if we are using a legacy or 3.0 REST server.
+   *
+   * @return True if we're using legacy REST, False if we're using 3.0 REST.
+   */
+  inline bool rest_legacy() const override {
+    return get_capabilities_from_rest().legacy_;
+  }
+
+  /**
    * Check if an array exists by making a REST call. To start with this fetches
    * the schema but ignores the body returned if non-error
    *

--- a/tiledb/sm/rest/rest_client_remote.h
+++ b/tiledb/sm/rest/rest_client_remote.h
@@ -114,8 +114,7 @@ class RestClientRemote : public RestClient {
    * input config so that rest_client chooses the right URI
    *
    * @param config Config to check
-   *
-   * */
+   */
   static bool use_refactored_query(const Config& config);
 
   /**

--- a/tiledb/sm/rest/rest_client_remote.h
+++ b/tiledb/sm/rest/rest_client_remote.h
@@ -120,15 +120,16 @@ class RestClientRemote : public RestClient {
   /**
    * @return TileDB core version currently deployed to the REST server.
    */
-  inline const TileDBVersion& rest_tiledb_version() const override {
+  inline const std::optional<TileDBVersion>& rest_tiledb_version()
+      const override {
     return get_capabilities_from_rest().rest_tiledb_version_;
   }
 
   /**
    * @return Minimum TileDB core version currently supported by the REST server.
    */
-  inline const TileDBVersion& rest_minimum_supported_tiledb_version()
-      const override {
+  inline const std::optional<TileDBVersion>&
+  rest_minimum_supported_tiledb_version() const override {
     return get_capabilities_from_rest().rest_minimum_supported_version_;
   }
 
@@ -144,9 +145,9 @@ class RestClientRemote : public RestClient {
   }
 
   /**
-   * Check if we are using a legacy or 3.0 REST server.
+   * Check if we are using legacy REST or TileDB-Server.
    *
-   * @return True if we're using legacy REST, False if we're using 3.0 REST.
+   * @return True if we're using legacy REST, False if using TileDB-Server.
    */
   inline bool rest_legacy() const override {
     return get_capabilities_from_rest().legacy_;

--- a/tiledb/sm/serialization/group.h
+++ b/tiledb/sm/serialization/group.h
@@ -140,7 +140,8 @@ Status group_update_deserialize(
 Status group_create_serialize(
     const Group* group,
     SerializationType serialize_type,
-    SerializationBuffer& serialized_buffer);
+    SerializationBuffer& serialized_buffer,
+    bool legacy);
 
 /**
  * Serialize a group metadata for remote POSTING


### PR DESCRIPTION
Adds support for constructing REST requests using workspace and teamspace endpoint parameters instead of namespace.

[Successful REST CI run against TileDB-Server](https://gitlab.com/TileDB-Inc/TileDB-Internal/-/jobs/9732682469)

At the moment I've tested URI parsing changes when communicating with legacy and TileDB-Server. The legacy REST tests pass when ran locally, and those tests have been updated to create TileDB-Server URIs if we are not using legacy REST.

---
TYPE: NO_HISTORY
DESC: Add support for constructing REST requests using workspace and teamspace.