### PR TITLE
Remove OpenSSL dependency on Windows introduced by vcpkg baseline bump.

### DIFF
--- a/ports/README.md
+++ b/ports/README.md
@@ -30,13 +30,14 @@ For ease of review when patching existing ports, you are recommended to make one
 
 ## List of port overlays
 
-| Port          | Reason                                                         |
-|---------------|----------------------------------------------------------------|
-| `aws-sdk-cpp` | Patching to fix MinGW build failures.                          |
-| `capnproto`   | Patching to fix compatibility with CMake 4.0 (PR 2272)         |
-| `crc32c`      | Patching to fix compatibility with CMake 4.0 (PR 68)           |
-| `fmt`         | Patching to update to version 1.11.4 (vcpkg PR 44774)          |
-| `libmagic`    | Using a custom CMake-based port that is not accepted upstream. |
-| `libfaketime` | Port does not yet exist upstream                               |
-| `s2n`         | Patching to fix compatibility with CMake 4.0 (PR 4933)         |
-| `spdlog`      | Patching to compile with `-fvisibility=hidden`                 |
+| Port          | Reason                                                                   |
+|---------------|--------------------------------------------------------------------------|
+| `aws-c-cal`   | Patching to remove unused OpenSSL dependency on Windows (vcpkg PR 44996) |
+| `aws-sdk-cpp` | Patching to fix MinGW build failures.                                    |
+| `capnproto`   | Patching to fix compatibility with CMake 4.0 (PR 2272)                   |
+| `crc32c`      | Patching to fix compatibility with CMake 4.0 (PR 68)                     |
+| `fmt`         | Patching to update to version 1.11.4 (vcpkg PR 44774)                    |
+| `libmagic`    | Using a custom CMake-based port that is not accepted upstream.           |
+| `libfaketime` | Port does not yet exist upstream                                         |
+| `s2n`         | Patching to fix compatibility with CMake 4.0 (PR 4933)                   |
+| `spdlog`      | Patching to compile with `-fvisibility=hidden`                           |

--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -7,12 +7,16 @@ vcpkg_from_github(
     PATCHES remove-libcrypto-messages.patch
 )
 
+if (NOT (VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX))
+    set(USE_OPENSSL ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
         -DBUILD_TESTING=FALSE
-        -DUSE_OPENSSL=ON
+        -DUSE_OPENSSL=${USE_OPENSSL}
 )
 
 vcpkg_cmake_install()

--- a/ports/aws-c-cal/portfile.cmake
+++ b/ports/aws-c-cal/portfile.cmake
@@ -1,0 +1,34 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO awslabs/aws-c-cal
+    REF "v${VERSION}"
+    SHA512 c601a00f5e21bf42bd8e44787182be3805b90ab9c8a23025bed5acac602718548e6236106891b336c4ea81f68a26c3f0a5d33e090246b670efe53229df1fca90
+    HEAD_REF master
+    PATCHES remove-libcrypto-messages.patch
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DCMAKE_MODULE_PATH=${CURRENT_INSTALLED_DIR}/share/aws-c-common" # use extra cmake files
+        -DBUILD_TESTING=FALSE
+        -DUSE_OPENSSL=ON
+)
+
+vcpkg_cmake_install()
+
+string(REPLACE "dynamic" "shared" subdir "${VCPKG_LIBRARY_LINKAGE}")
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/${PORT}/cmake/${subdir}" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/${PORT}/cmake")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/${PORT}-config.cmake" [[/${type}/]] "/")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/${PORT}"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/lib/${PORT}"
+)
+
+vcpkg_copy_pdbs()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/aws-c-cal/remove-libcrypto-messages.patch
+++ b/ports/aws-c-cal/remove-libcrypto-messages.patch
@@ -1,0 +1,14 @@
+diff --git a/cmake/modules/Findcrypto.cmake b/cmake/modules/Findcrypto.cmake
+index fed83bb..9c1ae28 100644
+--- a/cmake/modules/Findcrypto.cmake
++++ b/cmake/modules/Findcrypto.cmake
+@@ -105,9 +105,6 @@ else()
+         set(CRYPTO_FOUND true)
+         set(crypto_FOUND true)
+ 
+-        message(STATUS "LibCrypto Include Dir: ${crypto_INCLUDE_DIR}")
+-        message(STATUS "LibCrypto Shared Lib:  ${crypto_SHARED_LIBRARY}")
+-        message(STATUS "LibCrypto Static Lib:  ${crypto_STATIC_LIBRARY}")
+         if (NOT TARGET AWS::crypto AND
+             (EXISTS "${crypto_LIBRARY}")
+             )

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -1,0 +1,20 @@
+{
+  "name": "aws-c-cal",
+  "version": "0.8.1",
+  "port-version": 1,
+  "description": "C99 wrapper for cryptography primitives.",
+  "homepage": "https://github.com/awslabs/aws-c-cal",
+  "license": "Apache-2.0",
+  "dependencies": [
+    "aws-c-common",
+    "openssl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/ports/aws-c-cal/vcpkg.json
+++ b/ports/aws-c-cal/vcpkg.json
@@ -7,7 +7,10 @@
   "license": "Apache-2.0",
   "dependencies": [
     "aws-c-common",
-    "openssl",
+    {
+      "name": "openssl",
+      "platform": "!windows & !osx"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION
[SC-65794](https://app.shortcut.com/tiledb-inc/story/65794/vcpkg-baseline-bump-reintroduced-openssl-dependency-on-windows)

This PR adds a port overlay of `aws-c-cal` that removes an unnecessary dependency to OpenSSL on Windows (and macOS, but we still depend on OpenSSL there in other ways). The same change has been submitted as microsoft/vcpkg#44996.

---
TYPE: NO_HISTORY