### PR TITLE
perf: [sc-60446] Enumerations loaded from schema execute `generate_value_map` in a background task

### DIFF
--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1022,8 +1022,7 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Unable to extend an enumeration without a data buffer.");
-  REQUIRE_THROWS_WITH(
-      enmr->extend(ctx_.resources(), nullptr, 10, nullptr, 0), matcher);
+  REQUIRE_THROWS_WITH(enmr->extend(nullptr, 10, nullptr, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1035,8 +1034,7 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Unable to extend an enumeration with a zero sized data buffer.");
-  REQUIRE_THROWS_WITH(
-      enmr->extend(ctx_.resources(), data, 0, nullptr, 0), matcher);
+  REQUIRE_THROWS_WITH(enmr->extend(data, 0, nullptr, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1048,8 +1046,7 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "The offsets buffer is required for this enumeration extension.");
-  REQUIRE_THROWS_WITH(
-      enmr->extend(ctx_.resources(), data, 11, nullptr, 0), matcher);
+  REQUIRE_THROWS_WITH(enmr->extend(data, 11, nullptr, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1063,8 +1060,7 @@ TEST_CASE_METHOD(
   auto matcher = Catch::Matchers::ContainsSubstring(
       "The offsets buffer for "
       "this enumeration extension must have a non-zero size.");
-  REQUIRE_THROWS_WITH(
-      enmr->extend(ctx_.resources(), data, 11, offsets, 0), matcher);
+  REQUIRE_THROWS_WITH(enmr->extend(data, 11, offsets, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1077,8 +1073,7 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Invalid offsets size is not a multiple of sizeof(uint64_t)");
-  REQUIRE_THROWS_WITH(
-      enmr->extend(ctx_.resources(), data, 11, offsets, 17), matcher);
+  REQUIRE_THROWS_WITH(enmr->extend(data, 11, offsets, 17), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1091,8 +1086,7 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Offsets buffer provided when extending a fixed sized enumeration.");
-  REQUIRE_THROWS_WITH(
-      enmr->extend(ctx_.resources(), data, 11, offsets, 16), matcher);
+  REQUIRE_THROWS_WITH(enmr->extend(data, 11, offsets, 16), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1106,11 +1100,7 @@ TEST_CASE_METHOD(
       "Offsets size is non-zero when extending a fixed sized enumeration.");
   REQUIRE_THROWS_WITH(
       enmr->extend(
-          ctx_.resources(),
-          add_values.data(),
-          add_values.size() * sizeof(int),
-          nullptr,
-          16),
+          add_values.data(), add_values.size() * sizeof(int), nullptr, 16),
       matcher);
 }
 
@@ -1125,11 +1115,7 @@ TEST_CASE_METHOD(
       "Invalid duplicated value in enumeration");
   REQUIRE_THROWS_WITH(
       enmr->extend(
-          ctx_.resources(),
-          add_values.data(),
-          add_values.size() * sizeof(int),
-          nullptr,
-          0),
+          add_values.data(), add_values.size() * sizeof(int), nullptr, 0),
       matcher);
 }
 
@@ -2888,14 +2874,9 @@ shared_ptr<const Enumeration> EnumerationFx::extend_enumeration(
       raw_values[i] = values[i] ? 1 : 0;
     }
     return enmr->extend(
-        ctx_.resources(),
-        raw_values.data(),
-        raw_values.size() * sizeof(uint8_t),
-        nullptr,
-        0);
+        raw_values.data(), raw_values.size() * sizeof(uint8_t), nullptr, 0);
   } else if constexpr (std::is_pod_v<T>) {
-    return enmr->extend(
-        ctx_.resources(), values.data(), values.size() * sizeof(T), nullptr, 0);
+    return enmr->extend(values.data(), values.size() * sizeof(T), nullptr, 0);
   } else {
     uint64_t total_size = 0;
     for (auto v : values) {
@@ -2914,7 +2895,6 @@ shared_ptr<const Enumeration> EnumerationFx::extend_enumeration(
     }
 
     return enmr->extend(
-        ctx_.resources(),
         data.data(),
         total_size,
         offsets.data(),

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -172,6 +172,7 @@ TEST_CASE_METHOD(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_);
 }
 
@@ -189,6 +190,7 @@ TEST_CASE_METHOD(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_);
 }
 
@@ -271,6 +273,7 @@ TEST_CASE_METHOD(
       0,
       &offsets,
       sizeof(uint64_t),
+      false,
       memory_tracker_);
 
   std::vector<std::string> values = {""};
@@ -298,6 +301,7 @@ TEST_CASE_METHOD(
       0,
       &offsets,
       sizeof(uint64_t),
+      false,
       memory_tracker_);
 
   std::string value_str = "";
@@ -322,6 +326,7 @@ TEST_CASE_METHOD(
       0,
       &offsets,
       sizeof(uint64_t),
+      false,
       memory_tracker_);
 
   REQUIRE(enmr->data().data() == nullptr);
@@ -360,6 +365,7 @@ TEST_CASE_METHOD(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_);
 
   REQUIRE(enmr->data().data() == nullptr);
@@ -429,6 +435,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_);
   check_enumeration(enmr, default_enmr_name, values, Datatype::INT32, 2, false);
 }
@@ -450,6 +457,7 @@ TEST_CASE_METHOD(
           10,
           nullptr,
           0,
+          false,
           memory_tracker_),
       matcher);
 }
@@ -472,6 +480,7 @@ TEST_CASE_METHOD(
           0,
           nullptr,
           0,
+          false,
           memory_tracker_),
       matcher);
 }
@@ -494,6 +503,7 @@ TEST_CASE_METHOD(
           strlen(val),
           nullptr,
           8,
+          false,
           memory_tracker_),
       matcher);
 }
@@ -517,6 +527,7 @@ TEST_CASE_METHOD(
           strlen(val),
           &offset,
           0,
+          false,
           memory_tracker_),
       matcher);
 }
@@ -540,6 +551,7 @@ TEST_CASE_METHOD(
           5,
           &offsets,
           sizeof(uint64_t),
+          false,
           memory_tracker_),
       matcher);
 }
@@ -563,6 +575,7 @@ TEST_CASE_METHOD(
           5,
           &offsets,
           sizeof(uint64_t),
+          false,
           memory_tracker_),
       matcher);
 }
@@ -587,6 +600,7 @@ TEST_CASE_METHOD(
           2,
           &offsets,
           sizeof(uint64_t),
+          false,
           memory_tracker_),
       matcher);
 }
@@ -606,6 +620,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -624,6 +639,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -643,6 +659,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -661,6 +678,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -679,6 +697,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -697,6 +716,7 @@ TEST_CASE_METHOD(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -716,6 +736,7 @@ TEST_CASE_METHOD(
       strlen(data),
       nullptr,
       offsets.size() * sizeof(uint64_t),
+      false,
       memory_tracker_));
 }
 
@@ -735,6 +756,7 @@ TEST_CASE_METHOD(
       strlen(data),
       offsets.data(),
       0,
+      false,
       memory_tracker_));
 }
 
@@ -754,6 +776,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       offsets.data(),
       0,
+      false,
       memory_tracker_));
 }
 
@@ -772,6 +795,7 @@ TEST_CASE_METHOD(
       values.size() * sizeof(int),
       nullptr,
       100,
+      false,
       memory_tracker_));
 }
 
@@ -793,6 +817,7 @@ TEST_CASE_METHOD(
       strlen(data),
       offsets.data(),
       3,
+      false,
       memory_tracker_));
 }
 
@@ -813,6 +838,7 @@ TEST_CASE_METHOD(
       strlen(data),
       offsets.data(),
       offsets.size() * sizeof(uint64_t),
+      false,
       memory_tracker_));
 }
 
@@ -833,6 +859,7 @@ TEST_CASE_METHOD(
       3,
       nullptr,
       0,
+      false,
       memory_tracker_));
 }
 
@@ -905,6 +932,7 @@ TEST_CASE_METHOD(
       init_values.size() * sizeof(int),
       nullptr,
       0,
+      false,
       memory_tracker_);
   auto enmr2 = extend_enumeration(enmr1, extend_values);
   check_enumeration(
@@ -1571,6 +1599,7 @@ TEST_CASE_METHOD(
       data.size(),
       offsets.data(),
       offsets.size() * constants::cell_var_offset_size,
+      false,
       memory_tracker_);
 
   schema->add_enumeration(enmr);
@@ -1614,6 +1643,7 @@ TEST_CASE_METHOD(
         data.size(),
         offsets.data(),
         offsets.size() * constants::cell_var_offset_size,
+        false,
         memory_tracker_);
     schema->add_enumeration(enmr);
   }
@@ -1746,6 +1776,7 @@ TEST_CASE_METHOD(
       enmr2->data().size(),
       enmr2->offsets().data(),
       enmr2->offsets().size(),
+      false,
       memory_tracker_);
 
   auto matcher = Catch::Matchers::ContainsSubstring(
@@ -2421,6 +2452,7 @@ TEST_CASE_METHOD(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_);
   auto enmr2 = Enumeration::create(
       ctx_.resources(),
@@ -2432,6 +2464,7 @@ TEST_CASE_METHOD(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_);
 
   schema1->add_enumeration(enmr1);
@@ -2746,6 +2779,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
         raw_values.size() * sizeof(uint8_t),
         nullptr,
         0,
+        false,
         memory_tracker_);
   } else if constexpr (std::is_pod_v<T>) {
     return Enumeration::create(
@@ -2758,6 +2792,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
         values.size() * sizeof(T),
         nullptr,
         0,
+        false,
         memory_tracker_);
   } else {
     uint64_t total_size = 0;
@@ -2786,6 +2821,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
         total_size,
         offsets.data(),
         offsets.size() * sizeof(uint64_t),
+        false,
         memory_tracker_);
   }
 }
@@ -2802,6 +2838,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_empty_enumeration(
       0,
       nullptr,
       0,
+      false,
       memory_tracker_);
 }
 

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -163,6 +163,7 @@ QueryCondition create_qc(
 TEST_CASE_METHOD(
     EnumerationFx, "Create Empty Enumeration", "[enumeration][empty]") {
   Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       1,
@@ -179,6 +180,7 @@ TEST_CASE_METHOD(
     "Create Empty Var Sized Enumeration",
     "[enumeration][empty]") {
   Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -260,6 +262,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][invalid-offsets-args]") {
   uint64_t offsets = 0;
   auto enmr = Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -286,6 +289,7 @@ TEST_CASE_METHOD(
     "[enumeration][index-of][var-size]") {
   uint64_t offsets = 0;
   auto enmr = Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -309,6 +313,7 @@ TEST_CASE_METHOD(
     "[enumeration][basic][buffer-address]") {
   uint64_t offsets = 0;
   auto enmr = Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -346,6 +351,7 @@ TEST_CASE_METHOD(
     "Basic Variable Size Empty Address Check",
     "[enumeration][basic][buffer-address]") {
   auto enmr = Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -414,6 +420,7 @@ TEST_CASE_METHOD(
     "[enumeration][basic][fixed][multi-cell-val-num]") {
   std::vector<int> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   auto enmr = Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       2,
@@ -434,6 +441,7 @@ TEST_CASE_METHOD(
       "Invalid data buffer must not be nullptr for fixed sized data.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::INT32,
           1,
@@ -455,6 +463,7 @@ TEST_CASE_METHOD(
       "Invalid data size; must be non-zero for fixed size data.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::INT32,
           1,
@@ -476,6 +485,7 @@ TEST_CASE_METHOD(
       "Var sized enumeration values require a non-null offsets pointer.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::STRING_ASCII,
           constants::var_num,
@@ -498,6 +508,7 @@ TEST_CASE_METHOD(
       "Var sized enumeration values require a non-zero offsets size.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::STRING_ASCII,
           constants::var_num,
@@ -520,6 +531,7 @@ TEST_CASE_METHOD(
       "is non-zero.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::STRING_ASCII,
           constants::var_num,
@@ -542,6 +554,7 @@ TEST_CASE_METHOD(
       "require data.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::STRING_ASCII,
           constants::var_num,
@@ -565,6 +578,7 @@ TEST_CASE_METHOD(
       "offset.");
   REQUIRE_THROWS_WITH(
       Enumeration::create(
+          ctx_.resources(),
           default_enmr_name,
           Datatype::STRING_ASCII,
           constants::var_num,
@@ -583,6 +597,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][invalid-name]") {
   std::vector<int> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       std::string(),
       Datatype::INT32,
       2,
@@ -600,6 +615,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][invalid-name]") {
   std::vector<int> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       "",
       Datatype::INT32,
       2,
@@ -617,6 +633,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][invalid-name]") {
   std::vector<int> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       "an/bad/path",
       Datatype::INT32,
@@ -635,6 +652,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][invalid-cell-val-num]") {
   std::vector<int> values = {1, 2, 3};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       0,
@@ -652,6 +670,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][data-nullptr]") {
   std::vector<int> values = {1, 2, 3};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       1,
@@ -669,6 +688,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][data-zero-size]") {
   std::vector<int> values = {1, 2, 3};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       1,
@@ -687,6 +707,7 @@ TEST_CASE_METHOD(
   auto data = "foobarbazbam";
   std::vector<uint64_t> offsets = {0, 3, 6, 9};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -705,6 +726,7 @@ TEST_CASE_METHOD(
   auto data = "foobarbazbam";
   std::vector<uint64_t> offsets = {0, 3, 6, 9};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -723,6 +745,7 @@ TEST_CASE_METHOD(
   std::vector<int> values = {0, 1, 2, 3, 4};
   std::vector<uint64_t> offsets = {0, 3, 6, 9};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       1,
@@ -740,6 +763,7 @@ TEST_CASE_METHOD(
     "[enumeration][error][offsets-not-required]") {
   std::vector<int> values = {0, 1, 2, 3, 4};
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       1,
@@ -760,6 +784,7 @@ TEST_CASE_METHOD(
   // Passing 3 for the offsets size is incorrect because the offsets size has
   // to be a multiple of `sizeof(uint64_t)`
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -779,6 +804,7 @@ TEST_CASE_METHOD(
   std::vector<uint64_t> offsets = {0, 3, 6, 100};
   // The last offset is larger than data_size
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -798,6 +824,7 @@ TEST_CASE_METHOD(
   // Passing 3 for the data size is invalid as its not a multiple of
   // sizeof(int)
   REQUIRE_THROWS(Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       1,
@@ -869,6 +896,7 @@ TEST_CASE_METHOD(
   std::vector<int> extend_values = {5, 6, 7, 8, 9, 10};
   std::vector<int> final_values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
   auto enmr1 = Enumeration::create(
+      ctx_.resources(),
       default_enmr_name,
       Datatype::INT32,
       2,
@@ -932,7 +960,8 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Unable to extend an enumeration without a data buffer.");
-  REQUIRE_THROWS_WITH(enmr->extend(nullptr, 10, nullptr, 0), matcher);
+  REQUIRE_THROWS_WITH(
+      enmr->extend(ctx_.resources(), nullptr, 10, nullptr, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -944,7 +973,8 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Unable to extend an enumeration with a zero sized data buffer.");
-  REQUIRE_THROWS_WITH(enmr->extend(data, 0, nullptr, 0), matcher);
+  REQUIRE_THROWS_WITH(
+      enmr->extend(ctx_.resources(), data, 0, nullptr, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -956,7 +986,8 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "The offsets buffer is required for this enumeration extension.");
-  REQUIRE_THROWS_WITH(enmr->extend(data, 11, nullptr, 0), matcher);
+  REQUIRE_THROWS_WITH(
+      enmr->extend(ctx_.resources(), data, 11, nullptr, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -970,7 +1001,8 @@ TEST_CASE_METHOD(
   auto matcher = Catch::Matchers::ContainsSubstring(
       "The offsets buffer for "
       "this enumeration extension must have a non-zero size.");
-  REQUIRE_THROWS_WITH(enmr->extend(data, 11, offsets, 0), matcher);
+  REQUIRE_THROWS_WITH(
+      enmr->extend(ctx_.resources(), data, 11, offsets, 0), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -983,7 +1015,8 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Invalid offsets size is not a multiple of sizeof(uint64_t)");
-  REQUIRE_THROWS_WITH(enmr->extend(data, 11, offsets, 17), matcher);
+  REQUIRE_THROWS_WITH(
+      enmr->extend(ctx_.resources(), data, 11, offsets, 17), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -996,7 +1029,8 @@ TEST_CASE_METHOD(
   auto enmr = create_enumeration(init_values);
   auto matcher = Catch::Matchers::ContainsSubstring(
       "Offsets buffer provided when extending a fixed sized enumeration.");
-  REQUIRE_THROWS_WITH(enmr->extend(data, 11, offsets, 16), matcher);
+  REQUIRE_THROWS_WITH(
+      enmr->extend(ctx_.resources(), data, 11, offsets, 16), matcher);
 }
 
 TEST_CASE_METHOD(
@@ -1010,7 +1044,11 @@ TEST_CASE_METHOD(
       "Offsets size is non-zero when extending a fixed sized enumeration.");
   REQUIRE_THROWS_WITH(
       enmr->extend(
-          add_values.data(), add_values.size() * sizeof(int), nullptr, 16),
+          ctx_.resources(),
+          add_values.data(),
+          add_values.size() * sizeof(int),
+          nullptr,
+          16),
       matcher);
 }
 
@@ -1025,7 +1063,11 @@ TEST_CASE_METHOD(
       "Invalid duplicated value in enumeration");
   REQUIRE_THROWS_WITH(
       enmr->extend(
-          add_values.data(), add_values.size() * sizeof(int), nullptr, 0),
+          ctx_.resources(),
+          add_values.data(),
+          add_values.size() * sizeof(int),
+          nullptr,
+          0),
       matcher);
 }
 
@@ -1074,7 +1116,8 @@ TEST_CASE_METHOD(
   memset(data, 1, 4);
 
   Deserializer deserializer(tile->data(), tile->size());
-  REQUIRE_THROWS(Enumeration::deserialize(deserializer, memory_tracker_));
+  REQUIRE_THROWS(Enumeration::deserialize(
+      ctx_.resources(), deserializer, memory_tracker_));
 }
 
 TEST_CASE_METHOD(
@@ -1519,6 +1562,7 @@ TEST_CASE_METHOD(
   std::vector<uint8_t> data(1024 * 1024 * 10 + 1);
   std::vector<uint64_t> offsets = {0};
   auto enmr = Enumeration::create(
+      ctx_.resources(),
       "enmr_name",
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -1561,6 +1605,7 @@ TEST_CASE_METHOD(
   // Create more than 50MiB of enumeration data
   for (size_t i = 0; i < 10; i++) {
     auto enmr = Enumeration::create(
+        ctx_.resources(),
         "enmr_name_" + std::to_string(i),
         Datatype::STRING_ASCII,
         constants::var_num,
@@ -1690,6 +1735,7 @@ TEST_CASE_METHOD(
 
   // We have to force this condition by hand
   auto enmr3 = tiledb::sm::Enumeration::create(
+      ctx_.resources(),
       enmr2->name(),
       // Notice we're reusing the existing path name from enmr1
       enmr1->path_name(),
@@ -2366,6 +2412,7 @@ TEST_CASE_METHOD(
   auto schema1 = create_schema();
 
   auto enmr1 = Enumeration::create(
+      ctx_.resources(),
       "empty_fixed",
       Datatype::INT32,
       1,
@@ -2376,6 +2423,7 @@ TEST_CASE_METHOD(
       0,
       memory_tracker_);
   auto enmr2 = Enumeration::create(
+      ctx_.resources(),
       "empty_var",
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -2689,6 +2737,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
       raw_values[i] = values[i] ? 1 : 0;
     }
     return Enumeration::create(
+        ctx_.resources(),
         name,
         tp.type_,
         tp.cell_val_num_,
@@ -2700,6 +2749,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
         memory_tracker_);
   } else if constexpr (std::is_pod_v<T>) {
     return Enumeration::create(
+        ctx_.resources(),
         name,
         tp.type_,
         tp.cell_val_num_,
@@ -2727,6 +2777,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
     }
 
     return Enumeration::create(
+        ctx_.resources(),
         name,
         tp.type_,
         tp.cell_val_num_,
@@ -2742,6 +2793,7 @@ shared_ptr<const Enumeration> EnumerationFx::create_enumeration(
 shared_ptr<const Enumeration> EnumerationFx::create_empty_enumeration(
     Datatype type, uint32_t cell_val_num, bool ordered, std::string name) {
   return Enumeration::create(
+      ctx_.resources(),
       name,
       type,
       cell_val_num,
@@ -2764,9 +2816,14 @@ shared_ptr<const Enumeration> EnumerationFx::extend_enumeration(
       raw_values[i] = values[i] ? 1 : 0;
     }
     return enmr->extend(
-        raw_values.data(), raw_values.size() * sizeof(uint8_t), nullptr, 0);
+        ctx_.resources(),
+        raw_values.data(),
+        raw_values.size() * sizeof(uint8_t),
+        nullptr,
+        0);
   } else if constexpr (std::is_pod_v<T>) {
-    return enmr->extend(values.data(), values.size() * sizeof(T), nullptr, 0);
+    return enmr->extend(
+        ctx_.resources(), values.data(), values.size() * sizeof(T), nullptr, 0);
   } else {
     uint64_t total_size = 0;
     for (auto v : values) {
@@ -2785,6 +2842,7 @@ shared_ptr<const Enumeration> EnumerationFx::extend_enumeration(
     }
 
     return enmr->extend(
+        ctx_.resources(),
         data.data(),
         total_size,
         offsets.data(),
@@ -2824,7 +2882,8 @@ void EnumerationFx::check_storage_deserialization(
   auto tile = serialize_to_tile(enmr);
 
   Deserializer deserializer(tile->data(), tile->size());
-  auto deserialized = Enumeration::deserialize(deserializer, memory_tracker_);
+  auto deserialized =
+      Enumeration::deserialize(ctx_.resources(), deserializer, memory_tracker_);
 
   REQUIRE(deserialized->name() == enmr->name());
   REQUIRE(deserialized->path_name().empty() == false);
@@ -3011,7 +3070,8 @@ shared_ptr<ArraySchema> EnumerationFx::ser_des_array_schema(
       MemoryType::SERIALIZATION_BUFFER)};
   throw_if_not_ok(serialization::array_schema_serialize(
       *(schema.get()), stype, buf, client_side));
-  return serialization::array_schema_deserialize(stype, buf, memory_tracker_);
+  return serialization::array_schema_deserialize(
+      ctx_.resources(), stype, buf, memory_tracker_);
 }
 
 shared_ptr<ArraySchemaEvolution> EnumerationFx::ser_des_array_schema_evolution(
@@ -3023,7 +3083,7 @@ shared_ptr<ArraySchemaEvolution> EnumerationFx::ser_des_array_schema_evolution(
 
   ArraySchemaEvolution* ret;
   throw_if_not_ok(serialization::array_schema_evolution_deserialize(
-      &ret, cfg_, stype, buf, memory_tracker_));
+      &ret, ctx_.resources(), cfg_, stype, buf, memory_tracker_));
 
   return shared_ptr<ArraySchemaEvolution>(ret);
 }

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -474,6 +474,7 @@ HandleLoadArraySchemaRequestFx::create_string_enumeration(
       total_size,
       offsets.data(),
       offsets.size() * sizeof(uint64_t),
+      true,
       tiledb::test::create_test_memory_tracker());
 }
 

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -465,6 +465,7 @@ HandleLoadArraySchemaRequestFx::create_string_enumeration(
   }
 
   return Enumeration::create(
+      ctx_.resources(),
       name,
       Datatype::STRING_ASCII,
       constants::var_num,
@@ -546,7 +547,7 @@ HandleLoadArraySchemaRequestFx::call_handler(
   REQUIRE(rval == TILEDB_OK);
 
   return serialization::deserialize_load_array_schema_response(
-      uri_, cfg_, stype, resp_buf->buffer(), memory_tracker_);
+      ctx_.resources(), uri_, cfg_, stype, resp_buf->buffer(), memory_tracker_);
 }
 
 shared_ptr<ArraySchema> HandleQueryPlanRequestFx::create_schema() {

--- a/tiledb/api/c_api/enumeration/enumeration_api.cc
+++ b/tiledb/api/c_api/enumeration/enumeration_api.cc
@@ -94,7 +94,6 @@ capi_return_t tiledb_enumeration_alloc(
 }
 
 capi_return_t tiledb_enumeration_extend(
-    tiledb_ctx_t* ctx,
     tiledb_enumeration_t* old_enumeration,
     const void* data,
     uint64_t data_size,
@@ -105,7 +104,7 @@ capi_return_t tiledb_enumeration_extend(
   ensure_output_pointer_is_valid(new_enumeration);
 
   auto new_enmr =
-      old_enumeration->extend(ctx, data, data_size, offsets, offsets_size);
+      old_enumeration->extend(data, data_size, offsets, offsets_size);
 
   try {
     *new_enumeration = tiledb_enumeration_handle_t::make_handle(new_enmr);
@@ -268,7 +267,7 @@ CAPI_INTERFACE(
     const void* offsets,
     uint64_t offsets_size,
     tiledb_enumeration_t** new_enumeration) {
-  return api_entry<tiledb::api::tiledb_enumeration_extend>(
+  return api_entry_context<tiledb::api::tiledb_enumeration_extend>(
       ctx,
       old_enumeration,
       data,

--- a/tiledb/api/c_api/enumeration/enumeration_api.cc
+++ b/tiledb/api/c_api/enumeration/enumeration_api.cc
@@ -71,6 +71,7 @@ capi_return_t tiledb_enumeration_alloc(
     memory_tracker->set_type(tiledb::sm::MemoryTrackerType::ENUMERATION_CREATE);
 
     *enumeration = tiledb_enumeration_handle_t::make_handle(
+        ctx->context().resources(),
         std::string(name),
         datatype,
         cell_val_num,
@@ -89,6 +90,7 @@ capi_return_t tiledb_enumeration_alloc(
 }
 
 capi_return_t tiledb_enumeration_extend(
+    tiledb_ctx_t* ctx,
     tiledb_enumeration_t* old_enumeration,
     const void* data,
     uint64_t data_size,
@@ -99,7 +101,7 @@ capi_return_t tiledb_enumeration_extend(
   ensure_output_pointer_is_valid(new_enumeration);
 
   auto new_enmr =
-      old_enumeration->extend(data, data_size, offsets, offsets_size);
+      old_enumeration->extend(ctx, data, data_size, offsets, offsets_size);
 
   try {
     *new_enumeration = tiledb_enumeration_handle_t::make_handle(new_enmr);
@@ -262,7 +264,7 @@ CAPI_INTERFACE(
     const void* offsets,
     uint64_t offsets_size,
     tiledb_enumeration_t** new_enumeration) {
-  return api_entry_context<tiledb::api::tiledb_enumeration_extend>(
+  return api_entry<tiledb::api::tiledb_enumeration_extend>(
       ctx,
       old_enumeration,
       data,

--- a/tiledb/api/c_api/enumeration/enumeration_api.cc
+++ b/tiledb/api/c_api/enumeration/enumeration_api.cc
@@ -80,7 +80,11 @@ capi_return_t tiledb_enumeration_alloc(
         data_size,
         offsets,
         offsets_size,
+        false,
         memory_tracker);
+
+    // wait for the value map to finish in case it throws
+    (*enumeration)->enumeration()->value_map();
   } catch (...) {
     *enumeration = nullptr;
     throw;

--- a/tiledb/api/c_api/enumeration/enumeration_api_internal.h
+++ b/tiledb/api/c_api/enumeration/enumeration_api_internal.h
@@ -34,6 +34,7 @@
 #define TILEDB_CAPI_ENUMERATION_INTERNAL_H
 
 #include "enumeration_api_experimental.h"
+#include "tiledb/api/c_api/context/context_api_internal.h"
 #include "tiledb/api/c_api_support/handle/handle.h"
 #include "tiledb/common/common.h"
 #include "tiledb/sm/array_schema/enumeration.h"
@@ -82,11 +83,13 @@ struct tiledb_enumeration_handle_t
    * Extend a given enumeration.
    */
   [[nodiscard]] shared_ptr<const tiledb::sm::Enumeration> extend(
+      tiledb_ctx_t* ctx,
       const void* data,
       uint64_t data_size,
       const void* offsets,
       uint64_t offsets_size) const {
-    return enumeration_->extend(data, data_size, offsets, offsets_size);
+    return enumeration_->extend(
+        ctx->context().resources(), data, data_size, offsets, offsets_size);
   }
 
   /**

--- a/tiledb/api/c_api/enumeration/enumeration_api_internal.h
+++ b/tiledb/api/c_api/enumeration/enumeration_api_internal.h
@@ -83,13 +83,11 @@ struct tiledb_enumeration_handle_t
    * Extend a given enumeration.
    */
   [[nodiscard]] shared_ptr<const tiledb::sm::Enumeration> extend(
-      tiledb_ctx_t* ctx,
       const void* data,
       uint64_t data_size,
       const void* offsets,
       uint64_t offsets_size) const {
-    return enumeration_->extend(
-        ctx->context().resources(), data, data_size, offsets, offsets_size);
+    return enumeration_->extend(data, data_size, offsets, offsets_size);
   }
 
   /**

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -336,7 +336,7 @@ Status Array::open_without_fragments(
         throw instead of return Status */
       if (!use_refactored_array_open()) {
         auto&& [st, array_schema_latest] =
-            rest_client->get_array_schema_from_rest(array_uri_);
+            rest_client->get_array_schema_from_rest(resources_, array_uri_);
         if (!st.ok()) {
           throw StatusException(st);
         }
@@ -499,7 +499,7 @@ Status Array::open(
       }
       if (!use_refactored_array_open()) {
         auto&& [st, array_schema_latest] =
-            rest_client->get_array_schema_from_rest(array_uri_);
+            rest_client->get_array_schema_from_rest(resources_, array_uri_);
         throw_if_not_ok(st);
         set_array_schema_latest(array_schema_latest.value());
         if (serialize_enumerations()) {
@@ -850,6 +850,7 @@ Array::get_enumerations_all_schemas() {
       // Pass an empty list of enumeration names. REST will use timestamps to
       // load all enumerations on all schemas for the array within that range.
       ret = rest_client->post_enumerations_from_rest(
+          resources_,
           array_uri_,
           array_dir_timestamp_start_,
           array_dir_timestamp_end_,
@@ -949,6 +950,7 @@ std::vector<shared_ptr<const Enumeration>> Array::get_enumerations(
       }
 
       loaded = rest_client->post_enumerations_from_rest(
+          resources_,
           array_uri_,
           array_dir_timestamp_start_,
           array_dir_timestamp_end_,
@@ -2137,6 +2139,7 @@ void load_enumeration_into_schema(
     }
 
     auto ret = rest_client->post_enumerations_from_rest(
+        ctx.resources(),
         array_schema.array_uri(),
         array_schema.timestamp_start(),
         array_schema.timestamp_end(),

--- a/tiledb/sm/array/array.h
+++ b/tiledb/sm/array/array.h
@@ -746,6 +746,10 @@ class Array {
     return config_;
   }
 
+  inline const ContextResources& resources() const {
+    return resources_;
+  }
+
   /** Directly set the array URI for serialized compatibility with pre
    * TileDB 2.5 clients */
   void set_uri_serialized(const std::string& uri) {

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -1344,7 +1344,7 @@ shared_ptr<const Enumeration> ArrayDirectory::load_enumeration(
   }
 
   Deserializer deserializer(tile->data(), tile->size());
-  return Enumeration::deserialize(deserializer, memory_tracker);
+  return Enumeration::deserialize(resources_, deserializer, memory_tracker);
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/array_schema/CMakeLists.txt
+++ b/tiledb/sm/array_schema/CMakeLists.txt
@@ -63,6 +63,9 @@ conclude(object_library)
 commence(object_library enumeration)
     this_target_sources(enumeration.cc)
     this_target_object_libraries(buffer constants seedable_global_PRNG)
+    if(TILEDB_STATS)
+        this_target_compile_definitions(-DTILEDB_STATS)
+    endif()
 conclude(object_library)
 
 #

--- a/tiledb/sm/array_schema/array_schema_operations.cc
+++ b/tiledb/sm/array_schema/array_schema_operations.cc
@@ -245,7 +245,7 @@ shared_ptr<ArraySchema> load_array_schema(
   if (uri.is_tiledb()) {
     auto& rest_client = ctx.rest_client();
     auto&& [st, array_schema_response] =
-        rest_client.get_array_schema_from_rest(uri);
+        rest_client.get_array_schema_from_rest(ctx.resources(), uri);
     throw_if_not_ok(st);
     auto array_schema = std::move(array_schema_response).value();
 
@@ -254,6 +254,7 @@ shared_ptr<ArraySchema> load_array_schema(
       // Pass an empty list of enumeration names. REST will use timestamps to
       // load all enumerations on all schemas for the array within that range.
       auto ret = rest_client.post_enumerations_from_rest(
+          ctx.resources(),
           uri,
           array_schema->timestamp_start(),
           array_schema->timestamp_end(),

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -62,7 +62,8 @@ Enumeration::Enumeration(
     uint64_t offsets_size,
     bool async,
     shared_ptr<MemoryTracker> memory_tracker)
-    : memory_tracker_(memory_tracker)
+    : resources_(resources)
+    , memory_tracker_(memory_tracker)
     , name_(name)
     , path_name_(path_name)
     , type_(type)
@@ -277,7 +278,6 @@ shared_ptr<const Enumeration> Enumeration::deserialize(
 }
 
 shared_ptr<const Enumeration> Enumeration::extend(
-    const ContextResources& resources,
     const void* data,
     uint64_t data_size,
     const void* offsets,
@@ -358,7 +358,7 @@ shared_ptr<const Enumeration> Enumeration::extend(
   }
 
   return create(
-      resources,
+      resources_,
       name_,
       "",
       type_,
@@ -474,6 +474,9 @@ static void add_value_to_map(
 }
 
 void Enumeration::generate_value_map() {
+  auto timer =
+      resources_.stats().start_timer("Enumeration::generate_value_map");
+
   auto char_data = data_.data_as<char>();
   if (var_size()) {
     auto offsets = offsets_.data_as<uint64_t>();

--- a/tiledb/sm/array_schema/enumeration.cc
+++ b/tiledb/sm/array_schema/enumeration.cc
@@ -49,6 +49,7 @@ class EnumerationException : public StatusException {
 };
 
 Enumeration::Enumeration(
+    const ContextResources& resources,
     const std::string& name,
     const std::string& path_name,
     Datatype type,
@@ -191,11 +192,13 @@ Enumeration::Enumeration(
     throw_if_not_ok(offsets_.write(offsets, 0, offsets_size));
   }
 
-  generate_value_map();
+  generate_value_map(resources);
 }
 
 shared_ptr<const Enumeration> Enumeration::deserialize(
-    Deserializer& deserializer, shared_ptr<MemoryTracker> memory_tracker) {
+    const ContextResources& resources,
+    Deserializer& deserializer,
+    shared_ptr<MemoryTracker> memory_tracker) {
   auto disk_version = deserializer.read<uint32_t>();
   if (disk_version > constants::enumerations_version) {
     throw EnumerationException(
@@ -233,6 +236,7 @@ shared_ptr<const Enumeration> Enumeration::deserialize(
   }
 
   return create(
+      resources,
       name,
       path_name,
       static_cast<Datatype>(type),
@@ -246,6 +250,7 @@ shared_ptr<const Enumeration> Enumeration::deserialize(
 }
 
 shared_ptr<const Enumeration> Enumeration::extend(
+    const ContextResources& resources,
     const void* data,
     uint64_t data_size,
     const void* offsets,
@@ -326,6 +331,7 @@ shared_ptr<const Enumeration> Enumeration::extend(
   }
 
   return create(
+      resources,
       name_,
       "",
       type_,
@@ -421,7 +427,7 @@ uint64_t Enumeration::index_of(const void* data, uint64_t size) const {
   return iter->second;
 }
 
-void Enumeration::generate_value_map() {
+void Enumeration::generate_value_map(const ContextResources&) {
   auto char_data = data_.data_as<char>();
   if (var_size()) {
     auto offsets = offsets_.data_as<uint64_t>();

--- a/tiledb/sm/array_schema/enumeration.h
+++ b/tiledb/sm/array_schema/enumeration.h
@@ -230,7 +230,6 @@ class Enumeration {
    * @return shared_ptr<Enumeration> The extended enumeration.
    */
   shared_ptr<const Enumeration> extend(
-      const ContextResources& resources,
       const void* data,
       uint64_t data_size,
       const void* offsets,
@@ -293,6 +292,10 @@ class Enumeration {
    */
   const tdb::pmr::unordered_map<std::string_view, uint64_t>& value_map() const {
     if (value_map_future_.valid()) {
+#ifdef TILEDB_STATS
+      stats::DurationInstrument<stats::Stats> timer =
+          resources_.stats().start_timer("Enumeration::await_value_map");
+#endif
       value_map_status_.emplace(value_map_future_.wait());
     }
     if (value_map_status_.value().ok()) {
@@ -426,6 +429,12 @@ class Enumeration {
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
   /* ********************************* */
+
+  /**
+   * Resources of the enclosing context.
+   * Used for timers.
+   */
+  const ContextResources& resources_;
 
   /**
    * The memory tracker of the Enumeration.

--- a/tiledb/sm/array_schema/enumeration.h
+++ b/tiledb/sm/array_schema/enumeration.h
@@ -40,6 +40,7 @@
 #include "tiledb/common/types/untyped_datum.h"
 #include "tiledb/sm/buffer/buffer.h"
 #include "tiledb/sm/enums/datatype.h"
+#include "tiledb/sm/storage_manager/context.h"
 #include "tiledb/storage_format/serialization/serializers.h"
 
 namespace tiledb::sm {
@@ -75,6 +76,7 @@ class Enumeration {
 
   /** Create a new Enumeration
    *
+   * @param resources Resources for computing the enumeration value map.
    * @param name The name of this Enumeration as referenced by attributes.
    * @param type The datatype of the enumeration values.
    * @param cell_val_num The cell_val_num of the enumeration.
@@ -91,6 +93,7 @@ class Enumeration {
    * @return shared_ptr<Enumeration> The created enumeration.
    */
   static shared_ptr<const Enumeration> create(
+      const ContextResources& resources,
       const std::string& name,
       Datatype type,
       uint32_t cell_val_num,
@@ -101,6 +104,7 @@ class Enumeration {
       uint64_t offsets_size,
       shared_ptr<MemoryTracker> memory_tracker) {
     return create(
+        resources,
         name,
         "",
         type,
@@ -115,6 +119,7 @@ class Enumeration {
 
   /** Create a new Enumeration
    *
+   * @param resources Resources for computing the enumeration value map.
    * @param name The name of this Enumeration as referenced by attributes.
    * @param path_name The last URI path component of the Enumeration.
    * @param type The datatype of the enumeration values.
@@ -132,6 +137,7 @@ class Enumeration {
    * @return shared_ptr<Enumeration> The created enumeration.
    */
   static shared_ptr<const Enumeration> create(
+      const ContextResources& resources,
       const std::string& name,
       const std::string& path_name,
       Datatype type,
@@ -144,6 +150,7 @@ class Enumeration {
       shared_ptr<MemoryTracker> memory_tracker) {
     struct EnableMakeShared : public Enumeration {
       EnableMakeShared(
+          const ContextResources& resources,
           const std::string& name,
           const std::string& path_name,
           Datatype type,
@@ -155,6 +162,7 @@ class Enumeration {
           uint64_t offsets_size,
           shared_ptr<MemoryTracker> memory_tracker)
           : Enumeration(
+                resources,
                 name,
                 path_name,
                 type,
@@ -169,6 +177,7 @@ class Enumeration {
     };
     return make_shared<EnableMakeShared>(
         HERE(),
+        resources,
         name,
         path_name,
         type,
@@ -189,7 +198,9 @@ class Enumeration {
    * @return A new Enumeration.
    */
   static shared_ptr<const Enumeration> deserialize(
-      Deserializer& deserializer, shared_ptr<MemoryTracker> memory_tracker);
+      const ContextResources& resources,
+      Deserializer& deserializer,
+      shared_ptr<MemoryTracker> memory_tracker);
 
   /**
    * Create a new enumeration by extending an existing enumeration's
@@ -207,6 +218,7 @@ class Enumeration {
    * @return shared_ptr<Enumeration> The extended enumeration.
    */
   shared_ptr<const Enumeration> extend(
+      const ContextResources& resources,
       const void* data,
       uint64_t data_size,
       const void* offsets,
@@ -361,6 +373,7 @@ class Enumeration {
 
   /** Constructor
    *
+   * @param resources Resources for building the enumeration value map.
    * @param name The name of this Enumeration as referenced by attributes.
    * @param path_name The last URI path component of the Enumeration.
    * @param type The datatype of the enumeration values.
@@ -377,6 +390,7 @@ class Enumeration {
    * @param memory_tracker The memory tracker.
    */
   Enumeration(
+      const ContextResources& resources,
       const std::string& name,
       const std::string& path_name,
       Datatype type,
@@ -426,7 +440,7 @@ class Enumeration {
   /* ********************************* */
 
   /** Populate the value_map_ */
-  void generate_value_map();
+  void generate_value_map(const ContextResources& resources);
 
   /**
    * Add a value to value_map_

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -1454,6 +1454,7 @@ int32_t tiledb_deserialize_array_schema(
   auto memory_tracker = ctx->resources().create_memory_tracker();
   memory_tracker->set_type(sm::MemoryTrackerType::ARRAY_LOAD);
   auto shared_schema = tiledb::sm::serialization::array_schema_deserialize(
+      ctx->context().resources(),
       (tiledb::sm::SerializationType)serialize_type,
       buffer->buffer(),
       memory_tracker);
@@ -1578,6 +1579,7 @@ int32_t tiledb_deserialize_array_schema_evolution(
           ctx,
           tiledb::sm::serialization::array_schema_evolution_deserialize(
               &((*array_schema_evolution)->array_schema_evolution_),
+              ctx->resources(),
               ctx->config(),
               (tiledb::sm::SerializationType)serialize_type,
               buffer->buffer(),
@@ -2136,6 +2138,7 @@ int32_t tiledb_deserialize_fragment_info(
   if (SAVE_ERROR_CATCH(
           ctx,
           tiledb::sm::serialization::fragment_info_deserialize(
+              ctx->context().resources(),
               fragment_info->fragment_info().get(),
               (tiledb::sm::SerializationType)serialize_type,
               uri,

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -818,7 +818,8 @@ Status FragmentInfo::load() {
     // as it's the case for local fragment info load requests.
     throw_if_not_ok(config_.set("sm.fragment_info.preload_mbrs", "true"));
 
-    return rest_client->post_fragment_info_from_rest(array_uri_, this);
+    return rest_client->post_fragment_info_from_rest(
+        *resources_, array_uri_, this);
   }
 
   // Create an ArrayDirectory object and load

--- a/tiledb/sm/rest/rest_client.h
+++ b/tiledb/sm/rest/rest_client.h
@@ -331,7 +331,7 @@ class RestClient {
 
   /// Operation disabled in base class.
   inline virtual tuple<Status, optional<shared_ptr<ArraySchema>>>
-  get_array_schema_from_rest(const URI&) {
+  get_array_schema_from_rest(const ContextResources&, const URI&) {
     throw RestClientDisabledException();
   }
 
@@ -340,7 +340,12 @@ class RestClient {
       shared_ptr<ArraySchema>,
       std::unordered_map<std::string, shared_ptr<ArraySchema>>>
   post_array_schema_from_rest(
-      const Config&, const URI&, uint64_t, uint64_t, bool) {
+      const ContextResources&,
+      const Config&,
+      const URI&,
+      uint64_t,
+      uint64_t,
+      bool) {
     throw RestClientDisabledException();
   }
 
@@ -399,6 +404,7 @@ class RestClient {
   inline virtual std::
       unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
       post_enumerations_from_rest(
+          const ContextResources&,
           const URI&,
           uint64_t,
           uint64_t,
@@ -443,7 +449,7 @@ class RestClient {
 
   /// Operation disabled in base class.
   inline virtual Status post_fragment_info_from_rest(
-      const URI&, FragmentInfo*) {
+      const ContextResources&, const URI&, FragmentInfo*) {
     throw RestClientDisabledException();
   }
 

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -193,7 +193,8 @@ RestClientRemote::check_group_exists_from_rest(const URI& uri) {
 }
 
 tuple<Status, optional<shared_ptr<ArraySchema>>>
-RestClientRemote::get_array_schema_from_rest(const URI& uri) {
+RestClientRemote::get_array_schema_from_rest(
+    const ContextResources& resources, const URI& uri) {
   // Init curl and form the URL
   Curl curlc(logger_);
   std::string array_ns, array_uri;
@@ -218,7 +219,7 @@ RestClientRemote::get_array_schema_from_rest(const URI& uri) {
         nullopt};
 
   auto array_schema = serialization::array_schema_deserialize(
-      serialization_type_, returned_data, memory_tracker_);
+      resources, serialization_type_, returned_data, memory_tracker_);
 
   array_schema->set_array_uri(uri);
 
@@ -229,6 +230,7 @@ std::tuple<
     shared_ptr<ArraySchema>,
     std::unordered_map<std::string, shared_ptr<ArraySchema>>>
 RestClientRemote::post_array_schema_from_rest(
+    const ContextResources& resources,
     const Config& config,
     const URI& uri,
     uint64_t timestamp_start,
@@ -268,7 +270,12 @@ RestClientRemote::post_array_schema_from_rest(
   }
 
   return serialization::deserialize_load_array_schema_response(
-      uri, config, serialization_type_, returned_data, memory_tracker_);
+      resources,
+      uri,
+      config,
+      serialization_type_,
+      returned_data,
+      memory_tracker_);
 }
 
 Status RestClientRemote::post_array_schema_to_rest(
@@ -558,6 +565,7 @@ Status RestClientRemote::post_array_metadata_to_rest(
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 RestClientRemote::post_enumerations_from_rest(
+    const ContextResources& resources,
     const URI& uri,
     uint64_t timestamp_start,
     uint64_t timestamp_end,
@@ -601,7 +609,12 @@ RestClientRemote::post_enumerations_from_rest(
   }
 
   return serialization::deserialize_load_enumerations_response(
-      array_schema, config, serialization_type_, returned_data, memory_tracker);
+      resources,
+      array_schema,
+      config,
+      serialization_type_,
+      returned_data,
+      memory_tracker);
 }
 
 void RestClientRemote::post_query_plan_from_rest(
@@ -1214,7 +1227,9 @@ Status RestClientRemote::post_array_schema_evolution_to_rest(
 }
 
 Status RestClientRemote::post_fragment_info_from_rest(
-    const URI& uri, FragmentInfo* fragment_info) {
+    const ContextResources& resources,
+    const URI& uri,
+    FragmentInfo* fragment_info) {
   if (fragment_info == nullptr)
     return LOG_STATUS(Status_RestError(
         "Error getting fragment info from REST; fragment info is null."));
@@ -1248,7 +1263,12 @@ Status RestClientRemote::post_fragment_info_from_rest(
         "Error getting fragment info from REST; server returned no data."));
 
   return serialization::fragment_info_deserialize(
-      fragment_info, serialization_type_, uri, returned_data, memory_tracker_);
+      resources,
+      fragment_info,
+      serialization_type_,
+      uri,
+      returned_data,
+      memory_tracker_);
 }
 
 Status RestClientRemote::post_group_metadata_from_rest(

--- a/tiledb/sm/rest/rest_client_remote.h
+++ b/tiledb/sm/rest/rest_client_remote.h
@@ -167,17 +167,19 @@ class RestClientRemote : public RestClient {
   /**
    * Get a data encoded array schema from rest server.
    *
+   * @param resources resources for building data structures
    * @param uri of array being loaded
    * @return Status and new ArraySchema shared pointer.
    */
   tuple<Status, optional<shared_ptr<ArraySchema>>> get_array_schema_from_rest(
-      const URI& uri) override;
+      const ContextResources& resources, const URI& uri) override;
 
   /**
    * Get an array schema from the rest server. This will eventually replace the
    * get_array_schema_from_rest after TileDB-Cloud-REST merges support for the
    * POST endpoint.
    *
+   * @param resources Resources for building data structures
    * @param config The TileDB config.
    * @param uri The Array URI to load the schema from.
    * @param timestamp_start The starting timestamp used to open the array.
@@ -189,6 +191,7 @@ class RestClientRemote : public RestClient {
       shared_ptr<ArraySchema>,
       std::unordered_map<std::string, shared_ptr<ArraySchema>>>
   post_array_schema_from_rest(
+      const ContextResources& resources,
       const Config& config,
       const URI& uri,
       uint64_t timestamp_start,
@@ -312,6 +315,7 @@ class RestClientRemote : public RestClient {
    */
   std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
   post_enumerations_from_rest(
+      const ContextResources& ctx,
       const URI& uri,
       uint64_t timestamp_start,
       uint64_t timestamp_end,
@@ -380,12 +384,15 @@ class RestClientRemote : public RestClient {
   /**
    * Get array's fragment info from rest server
    *
+   * @param resources Resources for building data structures
    * @param uri Array uri to query for
    * @param fragment_info Fragment info object to store the incoming info
    * @return Status Ok() on success Error() on failures
    */
   Status post_fragment_info_from_rest(
-      const URI& uri, FragmentInfo* fragment_info) override;
+      const ContextResources& resources,
+      const URI& uri,
+      FragmentInfo* fragment_info) override;
 
   /**
    * Gets the group's metadata from the REST server (and updates the in-memory

--- a/tiledb/sm/serialization/array.cc
+++ b/tiledb/sm/serialization/array.cc
@@ -275,7 +275,10 @@ void array_from_capnp(
       auto entries = array_reader.getArraySchemasAll().getEntries();
       for (auto array_schema_build : entries) {
         auto schema = array_schema_from_capnp(
-            array_schema_build.getValue(), array->array_uri(), memory_tracker);
+            resources,
+            array_schema_build.getValue(),
+            array->array_uri(),
+            memory_tracker);
         schema->set_array_uri(array->array_uri());
         all_schemas[array_schema_build.getKey()] = schema;
       }
@@ -286,7 +289,10 @@ void array_from_capnp(
   if (array_reader.hasArraySchemaLatest()) {
     auto array_schema_latest_reader = array_reader.getArraySchemaLatest();
     auto array_schema_latest{array_schema_from_capnp(
-        array_schema_latest_reader, array->array_uri(), memory_tracker)};
+        resources,
+        array_schema_latest_reader,
+        array->array_uri(),
+        memory_tracker)};
     array_schema_latest->set_array_uri(array->array_uri());
     array->set_array_schema_latest(array_schema_latest);
   }

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -800,6 +800,7 @@ void dimension_label_to_capnp(
 }
 
 shared_ptr<DimensionLabel> dimension_label_from_capnp(
+    const ContextResources& resources,
     const capnp::DimensionLabel::Reader& dim_label_reader,
     shared_ptr<MemoryTracker> memory_tracker) {
   // Get datatype
@@ -808,7 +809,8 @@ shared_ptr<DimensionLabel> dimension_label_from_capnp(
   shared_ptr<ArraySchema> schema{nullptr};
   if (dim_label_reader.hasSchema()) {
     auto schema_reader = dim_label_reader.getSchema();
-    schema = array_schema_from_capnp(schema_reader, URI(), memory_tracker);
+    schema = array_schema_from_capnp(
+        resources, schema_reader, URI(), memory_tracker);
   }
 
   auto is_relative = dim_label_reader.getRelative();
@@ -938,6 +940,7 @@ Status array_schema_to_capnp(
 
 // #TODO Add security validation on incoming URI
 shared_ptr<ArraySchema> array_schema_from_capnp(
+    const ContextResources& resources,
     const capnp::ArraySchema::Reader& schema_reader,
     const URI& uri,
     shared_ptr<MemoryTracker> memory_tracker) {
@@ -1093,8 +1096,8 @@ shared_ptr<ArraySchema> array_schema_from_capnp(
     dimension_labels.reserve(dim_labels_reader.size());
     try {
       for (auto dim_label_reader : dim_labels_reader) {
-        dimension_labels.emplace_back(
-            dimension_label_from_capnp(dim_label_reader, memory_tracker));
+        dimension_labels.emplace_back(dimension_label_from_capnp(
+            resources, dim_label_reader, memory_tracker));
       }
     } catch (const std::exception& e) {
       std::throw_with_nested(std::runtime_error(
@@ -1111,7 +1114,7 @@ shared_ptr<ArraySchema> array_schema_from_capnp(
     try {
       for (auto&& enmr_reader : enmr_readers) {
         enumerations.emplace_back(
-            enumeration_from_capnp(enmr_reader, memory_tracker));
+            enumeration_from_capnp(resources, enmr_reader, memory_tracker));
       }
     } catch (const std::exception& e) {
       std::throw_with_nested(std::runtime_error(
@@ -1229,6 +1232,7 @@ Status array_schema_serialize(
 }
 
 shared_ptr<ArraySchema> array_schema_deserialize(
+    const ContextResources& resources,
     SerializationType serialize_type,
     span<const char> serialized_buffer,
     shared_ptr<MemoryTracker> memory_tracker) {
@@ -1243,7 +1247,7 @@ shared_ptr<ArraySchema> array_schema_deserialize(
         utils::decode_json_message(serialized_buffer, array_schema_builder);
         array_schema_reader = array_schema_builder.asReader();
         return array_schema_from_capnp(
-            array_schema_reader, URI(), memory_tracker);
+            resources, array_schema_reader, URI(), memory_tracker);
       }
       case SerializationType::CAPNP: {
         const auto mBytes =
@@ -1253,7 +1257,7 @@ shared_ptr<ArraySchema> array_schema_deserialize(
             serialized_buffer.size() / sizeof(::capnp::word)));
         array_schema_reader = reader.getRoot<capnp::ArraySchema>();
         return array_schema_from_capnp(
-            array_schema_reader, URI(), memory_tracker);
+            resources, array_schema_reader, URI(), memory_tracker);
       }
       default: {
         throw StatusException(Status_SerializationError(
@@ -1782,11 +1786,13 @@ std::tuple<
     shared_ptr<ArraySchema>,
     std::unordered_map<std::string, shared_ptr<ArraySchema>>>
 load_array_schema_response_from_capnp(
+    const ContextResources& resources,
     const URI& uri,
     capnp::LoadArraySchemaResponse::Reader& reader,
     shared_ptr<MemoryTracker> memory_tracker) {
   auto schema_reader = reader.getSchema();
-  auto schema = array_schema_from_capnp(schema_reader, URI(), memory_tracker);
+  auto schema =
+      array_schema_from_capnp(resources, schema_reader, URI(), memory_tracker);
   schema->set_array_uri(uri);
 
   std::unordered_map<std::string, shared_ptr<ArraySchema>> all_schemas;
@@ -1797,7 +1803,10 @@ load_array_schema_response_from_capnp(
       auto entries = all_schemas_reader.getEntries();
       for (auto array_schema_build : entries) {
         auto schema_entry = array_schema_from_capnp(
-            array_schema_build.getValue(), schema->array_uri(), memory_tracker);
+            resources,
+            array_schema_build.getValue(),
+            schema->array_uri(),
+            memory_tracker);
         schema_entry->set_array_uri(schema->array_uri());
         all_schemas[array_schema_build.getKey()] = schema_entry;
       }
@@ -1810,6 +1819,7 @@ std::tuple<
     shared_ptr<ArraySchema>,
     std::unordered_map<std::string, shared_ptr<ArraySchema>>>
 deserialize_load_array_schema_response(
+    const ContextResources& resources,
     const URI& uri,
     const Config& config,
     SerializationType serialization_type,
@@ -1824,7 +1834,7 @@ deserialize_load_array_schema_response(
         utils::decode_json_message(data, builder);
         auto reader = builder.asReader();
         return load_array_schema_response_from_capnp(
-            uri, reader, memory_tracker);
+            resources, uri, reader, memory_tracker);
       }
       case SerializationType::CAPNP: {
         // Set traversal limit from config
@@ -1842,7 +1852,7 @@ deserialize_load_array_schema_response(
             readerOptions);
         auto reader = array_reader.getRoot<capnp::LoadArraySchemaResponse>();
         return load_array_schema_response_from_capnp(
-            uri, reader, memory_tracker);
+            resources, uri, reader, memory_tracker);
       }
       default: {
         throw ArraySchemaSerializationException(

--- a/tiledb/sm/serialization/array_schema.h
+++ b/tiledb/sm/serialization/array_schema.h
@@ -123,6 +123,7 @@ Status array_schema_to_capnp(
  * @return a new ArraySchema
  */
 shared_ptr<ArraySchema> array_schema_from_capnp(
+    const ContextResources& resources,
     const capnp::ArraySchema::Reader& schema_reader,
     const URI& uri,
     shared_ptr<MemoryTracker> memory_tracker);
@@ -142,11 +143,13 @@ void dimension_label_to_capnp(
 /**
  * Deserialize a dimension label from a cap'n proto object
  *
+ * @param resources Resources for building data structures
  * @param reader Cap'n proto reader object.
  * @param memory_tracker The memory tracker to use.
  * @return A new DimensionLabel.
  */
 shared_ptr<DimensionLabel> dimension_label_from_capnp(
+    const ContextResources& resources,
     const capnp::DimensionLabel::Reader& reader,
     shared_ptr<MemoryTracker> memory_tracker);
 
@@ -168,6 +171,7 @@ Status array_schema_serialize(
     const bool client_side);
 
 shared_ptr<ArraySchema> array_schema_deserialize(
+    const ContextResources& resources,
     SerializationType serialize_type,
     span<const char> serialized_buffer,
     shared_ptr<MemoryTracker> memory_tracker);
@@ -214,6 +218,7 @@ std::tuple<
     shared_ptr<ArraySchema>,
     std::unordered_map<std::string, shared_ptr<ArraySchema>>>
 deserialize_load_array_schema_response(
+    const ContextResources& resources,
     const URI& uri,
     const Config& config,
     SerializationType serialization_type,

--- a/tiledb/sm/serialization/array_schema_evolution.cc
+++ b/tiledb/sm/serialization/array_schema_evolution.cc
@@ -165,6 +165,7 @@ Status array_schema_evolution_to_capnp(
 }
 
 tdb_unique_ptr<ArraySchemaEvolution> array_schema_evolution_from_capnp(
+    const ContextResources& resources,
     const capnp::ArraySchemaEvolution::Reader& evolution_reader,
     shared_ptr<MemoryTracker> memory_tracker) {
   // Create attributes to add
@@ -187,7 +188,7 @@ tdb_unique_ptr<ArraySchemaEvolution> array_schema_evolution_from_capnp(
   std::unordered_map<std::string, shared_ptr<const Enumeration>> enmrs_to_add;
   auto enmrs_to_add_reader = evolution_reader.getEnumerationsToAdd();
   for (auto enmr_reader : enmrs_to_add_reader) {
-    auto enmr = enumeration_from_capnp(enmr_reader, memory_tracker);
+    auto enmr = enumeration_from_capnp(resources, enmr_reader, memory_tracker);
     enmrs_to_add[enmr->name()] = enmr;
   }
 
@@ -196,7 +197,7 @@ tdb_unique_ptr<ArraySchemaEvolution> array_schema_evolution_from_capnp(
       enmrs_to_extend;
   auto enmrs_to_extend_reader = evolution_reader.getEnumerationsToExtend();
   for (auto enmr_reader : enmrs_to_extend_reader) {
-    auto enmr = enumeration_from_capnp(enmr_reader, memory_tracker);
+    auto enmr = enumeration_from_capnp(resources, enmr_reader, memory_tracker);
     enmrs_to_extend[enmr->name()] = enmr;
   }
 
@@ -289,6 +290,7 @@ Status array_schema_evolution_serialize(
 
 Status array_schema_evolution_deserialize(
     ArraySchemaEvolution** array_schema_evolution,
+    const ContextResources& resources,
     const Config& config,
     SerializationType serialize_type,
     span<const char> serialized_buffer,
@@ -307,7 +309,7 @@ Status array_schema_evolution_deserialize(
         capnp::ArraySchemaEvolution::Reader array_schema_evolution_reader =
             array_schema_evolution_builder.asReader();
         decoded_array_schema_evolution = array_schema_evolution_from_capnp(
-            array_schema_evolution_reader, memory_tracker);
+            resources, array_schema_evolution_reader, memory_tracker);
         break;
       }
       case SerializationType::CAPNP: {
@@ -328,7 +330,7 @@ Status array_schema_evolution_deserialize(
         capnp::ArraySchemaEvolution::Reader array_schema_evolution_reader =
             reader.getRoot<capnp::ArraySchemaEvolution>();
         decoded_array_schema_evolution = array_schema_evolution_from_capnp(
-            array_schema_evolution_reader, memory_tracker);
+            resources, array_schema_evolution_reader, memory_tracker);
         break;
       }
       default: {

--- a/tiledb/sm/serialization/array_schema_evolution.h
+++ b/tiledb/sm/serialization/array_schema_evolution.h
@@ -70,6 +70,7 @@ Status array_schema_evolution_serialize(
 /**
  * Deserialize an array schema evolution via Cap'n Proto
  * @param array_schema_evolution pointer to store evolution object in
+ * @param resources resources for constructing
  * @param config associated config object
  * @param serialize_type format to serialize into Cap'n Proto or JSON
  * @param serialized_buffer buffer where serialized bytes are stored
@@ -78,6 +79,7 @@ Status array_schema_evolution_serialize(
  */
 Status array_schema_evolution_deserialize(
     ArraySchemaEvolution** array_schema_evolution,
+    const ContextResources& resources,
     const Config& config,
     SerializationType serialize_type,
     span<const char> serialized_buffer,

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -124,6 +124,7 @@ shared_ptr<const Enumeration> enumeration_from_capnp(
       data_size,
       offsets,
       offsets_size,
+      true,
       memory_tracker);
 }
 

--- a/tiledb/sm/serialization/enumeration.cc
+++ b/tiledb/sm/serialization/enumeration.cc
@@ -88,6 +88,7 @@ void enumeration_to_capnp(
 }
 
 shared_ptr<const Enumeration> enumeration_from_capnp(
+    const ContextResources& resources,
     const capnp::Enumeration::Reader& reader,
     shared_ptr<MemoryTracker> memory_tracker) {
   auto name = reader.getName();
@@ -113,6 +114,7 @@ shared_ptr<const Enumeration> enumeration_from_capnp(
   }
 
   return Enumeration::create(
+      resources,
       name,
       path_name,
       datatype,
@@ -190,6 +192,7 @@ void load_enumerations_response_to_capnp(
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 load_enumerations_response_from_capnp(
+    const ContextResources& resources,
     const capnp::LoadEnumerationsResponse::Reader& reader,
     const ArraySchema& array_schema,
     shared_ptr<MemoryTracker> memory_tracker) {
@@ -200,7 +203,7 @@ load_enumerations_response_from_capnp(
     auto enmr_readers = reader.getEnumerations();
     for (auto enmr_reader : enmr_readers) {
       loaded_enmrs.push_back(
-          enumeration_from_capnp(enmr_reader, memory_tracker));
+          enumeration_from_capnp(resources, enmr_reader, memory_tracker));
     }
     // The name of the latest array schema will not be serialized in the
     // response if we are only loading enumerations from the latest schema.
@@ -211,7 +214,7 @@ load_enumerations_response_from_capnp(
       std::vector<shared_ptr<const Enumeration>> loaded_enmrs;
       for (auto enmr_reader : enmr_entry_reader.getValue()) {
         loaded_enmrs.push_back(
-            enumeration_from_capnp(enmr_reader, memory_tracker));
+            enumeration_from_capnp(resources, enmr_reader, memory_tracker));
       }
 
       ret[enmr_entry_reader.getKey()] = loaded_enmrs;
@@ -344,6 +347,7 @@ void serialize_load_enumerations_response(
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
+    const ContextResources& resources,
     const ArraySchema& array_schema,
     const Config& config,
     SerializationType serialize_type,
@@ -358,7 +362,7 @@ deserialize_load_enumerations_response(
         utils::decode_json_message(response, builder);
         capnp::LoadEnumerationsResponse::Reader reader = builder.asReader();
         return load_enumerations_response_from_capnp(
-            reader, array_schema, memory_tracker);
+            resources, reader, array_schema, memory_tracker);
       }
       case SerializationType::CAPNP: {
         // Set traversal limit from config
@@ -377,7 +381,7 @@ deserialize_load_enumerations_response(
         capnp::LoadEnumerationsResponse::Reader reader =
             array_reader.getRoot<capnp::LoadEnumerationsResponse>();
         return load_enumerations_response_from_capnp(
-            reader, array_schema, memory_tracker);
+            resources, reader, array_schema, memory_tracker);
       }
       default: {
         throw EnumerationSerializationException(
@@ -421,6 +425,7 @@ void serialize_load_enumerations_response(
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
+    const Context&,
     const Array&,
     const Config&,
     SerializationType,

--- a/tiledb/sm/serialization/enumeration.h
+++ b/tiledb/sm/serialization/enumeration.h
@@ -63,12 +63,14 @@ void enumeration_to_capnp(
 /**
  * Deserialize an enumeration from a cap'n proto object
  *
+ * @param resources Resources for building the enumeration value map
  * @param reader Cap'n proto reader object
  * @param memory_tracker The memory tracker associated with the Enumeration
  * object.
  * @return A new Enumeration
  */
 shared_ptr<const Enumeration> enumeration_from_capnp(
+    const ContextResources& resources,
     const capnp::Enumeration::Reader& reader,
     shared_ptr<MemoryTracker> memory_tracker);
 
@@ -92,6 +94,7 @@ void serialize_load_enumerations_response(
 
 std::unordered_map<std::string, std::vector<shared_ptr<const Enumeration>>>
 deserialize_load_enumerations_response(
+    const ContextResources& ctx,
     const ArraySchema& array_schema,
     const Config& config,
     SerializationType serialization_type,

--- a/tiledb/sm/serialization/fragment_info.cc
+++ b/tiledb/sm/serialization/fragment_info.cc
@@ -266,6 +266,7 @@ Status single_fragment_info_to_capnp(
 }
 
 Status fragment_info_from_capnp(
+    const ContextResources& resources,
     const capnp::FragmentInfo::Reader& fragment_info_reader,
     const URI& array_uri,
     FragmentInfo* fragment_info,
@@ -275,7 +276,7 @@ Status fragment_info_from_capnp(
     auto array_schema_latest_reader =
         fragment_info_reader.getArraySchemaLatest();
     auto array_schema_latest{array_schema_from_capnp(
-        array_schema_latest_reader, array_uri, memory_tracker)};
+        resources, array_schema_latest_reader, array_uri, memory_tracker)};
     array_schema_latest->set_array_uri(array_uri);
     fragment_info->array_schema_latest() = array_schema_latest;
   }
@@ -288,7 +289,10 @@ Status fragment_info_from_capnp(
       auto entries = fragment_info_reader.getArraySchemasAll().getEntries();
       for (auto array_schema_build : entries) {
         auto schema{array_schema_from_capnp(
-            array_schema_build.getValue(), array_uri, memory_tracker)};
+            resources,
+            array_schema_build.getValue(),
+            array_uri,
+            memory_tracker)};
         schema->set_array_uri(array_uri);
         auto key = std::string_view{
             array_schema_build.getKey().cStr(),
@@ -430,6 +434,7 @@ Status fragment_info_serialize(
 }
 
 Status fragment_info_deserialize(
+    const ContextResources& resources,
     FragmentInfo* fragment_info,
     SerializationType serialize_type,
     const URI& uri,
@@ -450,7 +455,7 @@ Status fragment_info_deserialize(
 
         // Deserialize
         RETURN_NOT_OK(fragment_info_from_capnp(
-            reader, uri, fragment_info, memory_tracker));
+            resources, reader, uri, fragment_info, memory_tracker));
         break;
       }
       case SerializationType::CAPNP: {
@@ -473,7 +478,7 @@ Status fragment_info_deserialize(
 
         // Deserialize
         RETURN_NOT_OK(fragment_info_from_capnp(
-            reader, uri, fragment_info, memory_tracker));
+            resources, reader, uri, fragment_info, memory_tracker));
         break;
       }
       default: {

--- a/tiledb/sm/serialization/fragment_info.h
+++ b/tiledb/sm/serialization/fragment_info.h
@@ -56,6 +56,7 @@ namespace serialization {
 /**
  * Convert Cap'n Proto message to Fragment Info.
  *
+ * @param resources Resources for building structures
  * @param fragment_info_reader cap'n proto class.
  * @param uri array uri that the fragment belongs to
  * @param fragment_info fragment info object to deserialize into.
@@ -63,6 +64,7 @@ namespace serialization {
  * @return Status
  */
 Status fragment_info_from_capnp(
+    const ContextResources& resources,
     const capnp::FragmentInfo::Reader& fragment_info_reader,
     const URI& uri,
     FragmentInfo* fragment_info,
@@ -122,6 +124,7 @@ Status fragment_info_serialize(
 /**
  * Deserialize a Cap'n Proto message into a fragment info object.
  *
+ * @param resources Resources for building structures
  * @param fragment_info fragment info object to deserialize into.
  * @param serialize_type format the data is serialized in: Cap'n Proto of JSON.
  * @param uri array uri that the fragment belongs to
@@ -130,6 +133,7 @@ Status fragment_info_serialize(
  * @return Status
  */
 Status fragment_info_deserialize(
+    const ContextResources& resources,
     FragmentInfo* fragment_info,
     SerializationType serialize_type,
     const URI& uri,


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/60446

In the story we have observed that `generate_value_map` can take a non-trivial amount of time to execute. This function builds a map from enumeration variant to key, so that we can detect duplicates and do fast lookups.

However, `generate_value_map` is *always* called when we construct an Enumeration. However:
1) barring a data corruption, an Enumeration which is constructed as we load it from an ArraySchema was already validated when it was either created or extended!
2) lookup of the key for a variant is an uncommon operation, merged in #5482 which has not appeared in a release as of this writing.

Hence all users of Enumeration are paying the potentially expensive cost of an operation whose result is never used.

This pull request adds an option to migrate the execution of `generate_value_map` to a background task.  If the `bool async` flag is true then `generate_value_map` will be called from a thread pool task, and `Enumeration::value_map()` will wait for that computation to finish.  We construct Enumerations with `async = true` when loading them for an ArraySchema and `async = false` when they are created by the user (in which case we want the duplicate validation to happen immediately).

If an exception is thrown due to a corrupted Enumeration for some reason, then we will only see it upon calling `value_map()` in which case the exception thrown while executing the future will be thrown (TODO test this).

This requires threading a `ContextResources` through all of the call stacks which find their way to `Enumeration::create`. This represents most of the changes in this PR, which are largely encapsulated in the single commit 28f97ce, so I recommend reviewing commit by commit.

I have also added timers to measure time spent in `generate_value_map` and time spent waiting for the it to finish.

---
TYPE: IMPROVEMENT
DESC: async `Enumeration::generate_value_map`