### PR TITLE
Remove docker image from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,7 @@ $ conda install -c conda-forge tiledb
 
 (see links below for Python, R, and other API installation instructions)
 
-Alternatively, you can use the Docker image we provide:
-
-```bash
-$ docker pull tiledb/tiledb
-$ docker run -it tiledb/tiledb
-```
+Alternatively, you can use the [Dockerfile we provide.](examples/Dockerfile/Dockerfile)
 
 We include several [examples](https://github.com/TileDB-Inc/TileDB/tree/main/examples). You can start with the following:
 


### PR DESCRIPTION
Updates README to remove docker image, pointing to [Dockerfile that we test in CI instead](https://github.com/TileDB-Inc/TileDB/blob/main/.github/workflows/build-dockerfile.yml).

---
TYPE: NO_HISTORY
DESC: Remove docker image from README.
