### PR TITLE
Fix nightly test build

### DIFF
--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -2949,10 +2949,10 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     DenseArrayFx,
     "C API: Test dense array, simultaneous writes",
-    "[capi][dense][dense-simultaneous-writes][rest][!mayfail]") {
+    "[capi][dense][dense-simultaneous-writes][rest][.]") {
   /* Catch2's assertion macros are not thread safe. In this test we are
-   * asserting using REQUIRE and CHECK macros, which are not thread safe so it
-   * might fail.
+   * asserting inside threads using REQUIRE macros, which are not thread safe so
+   * it might fail. Opened SC-66006 to adapt this test to avoid the issue.
    * https://github.com/catchorg/Catch2/blob/devel/docs/limitations.md#thread-safe-assertions
    * for more. */
 

--- a/test/src/unit-capi-dense_array.cc
+++ b/test/src/unit-capi-dense_array.cc
@@ -2949,7 +2949,13 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     DenseArrayFx,
     "C API: Test dense array, simultaneous writes",
-    "[capi][dense][dense-simultaneous-writes][rest]") {
+    "[capi][dense][dense-simultaneous-writes][rest][!mayfail]") {
+  /* Catch2's assertion macros are not thread safe. In this test we are
+   * asserting using REQUIRE and CHECK macros, which are not thread safe so it
+   * might fail.
+   * https://github.com/catchorg/Catch2/blob/devel/docs/limitations.md#thread-safe-assertions
+   * for more. */
+
   // TODO: refactor for each supported FS.
   std::string temp_dir = fs_vec_[0]->temp_dir();
   create_temp_dir(temp_dir);

--- a/test/src/unit-capi-rest-dense_array.cc
+++ b/test/src/unit-capi-rest-dense_array.cc
@@ -1210,7 +1210,13 @@ TEST_CASE_METHOD(
 TEST_CASE_METHOD(
     DenseArrayRESTFx,
     "C API: REST Test dense array, simultaneous writes",
-    "[capi][non-rest][dense][dense-simultaneous-writes]") {
+    "[capi][non-rest][dense][dense-simultaneous-writes][.]") {
+  /* Catch2's assertion macros are not thread safe. In this test we are
+   * asserting inside threads using REQUIRE macros, which are not thread safe so
+   * it might fail. Opened SC-66006 to adapt this test to avoid the issue.
+   * https://github.com/catchorg/Catch2/blob/devel/docs/limitations.md#thread-safe-assertions
+   * for more. */
+
   // Parallel array open requests on the same array fail on
   // remote arrays, as locking cannot work on Cloud REST
   // server to synchronize them, so we exclude this test

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -749,11 +749,10 @@ TEST_CASE(
 TEST_CASE(
     "C API: CallbackWrapperCAPI operator() validation",
     "[ls-recursive][callback][wrapper]") {
-  tiledb::sm::LsObjects data;
-  auto cb = [](const char* path,
-               size_t path_len,
-               uint64_t object_size,
-               void* data) -> int32_t {
+  tiledb::sm::LsCallback cb = [](const char* path,
+                                 size_t path_len,
+                                 uint64_t object_size,
+                                 void* data) -> int32_t {
     if (object_size > 100) {
       // Throw if object size is greater than 100 bytes.
       throw std::runtime_error("Throwing callback");
@@ -765,7 +764,9 @@ TEST_CASE(
     ls_data->push_back({{path, path_len}, object_size});
     return 1;
   };
-  tiledb::sm::CallbackWrapperCAPI wrapper(cb, &data);
+
+  tiledb::sm::LsObjects data{};
+  tiledb::sm::CallbackWrapperCAPI wrapper(cb, static_cast<void*>(&data));
 
   SECTION("Callback return 1 signals to continue traversal") {
     CHECK(wrapper("file.txt", 10) == 1);

--- a/tiledb/common/util/test/unit_sort_zip.cc
+++ b/tiledb/common/util/test/unit_sort_zip.cc
@@ -337,7 +337,7 @@ TEST_CASE("sort_zip: sort zip view", "[zip_view]") {
 /*
  * Disable test temporarily as they have compilations issues on the nightly
 builders
- * SC- to fix them.
+ * Opened SC-66005 to fix them.
 
 TEST_CASE(
     "sort_zip: sort zip view containing alt_var_length_view", "[zip_view]") {

--- a/tiledb/common/util/test/unit_sort_zip.cc
+++ b/tiledb/common/util/test/unit_sort_zip.cc
@@ -334,6 +334,11 @@ TEST_CASE("sort_zip: sort zip view", "[zip_view]") {
   }
 }
 
+/*
+ * Disable test temporarily as they have compilations issues on the nightly
+builders
+ * SC- to fix them.
+
 TEST_CASE(
     "sort_zip: sort zip view containing alt_var_length_view", "[zip_view]") {
   std::vector<double> r = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
@@ -366,3 +371,4 @@ TEST_CASE("sort_zip: sort zip view using alt_var_length_view", "[zip_view]") {
   CHECK(std::ranges::equal(v[1], std::vector<double>{4.0, 5.0, 6.0}));
   CHECK(std::ranges::equal(v[2], std::vector<double>{1.0, 2.0, 3.0}));
 }
+ */

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -296,7 +296,7 @@ class CallbackWrapperCAPI {
 
   /** Constructor */
   CallbackWrapperCAPI(LsCallback cb, void* data)
-      : cb_(cb)
+      : cb_(std::move(cb))
       , data_(data) {
     if (cb_ == nullptr) {
       throw LsScanException("ls_recursive callback function cannot be null");
@@ -314,7 +314,7 @@ class CallbackWrapperCAPI {
    * @param size The size of the object in bytes.
    * @return True if the object should be included, False otherwise.
    */
-  bool operator()(std::string_view path, const uint64_t& size) const {
+  bool operator()(std::string_view path, const uint64_t size) const {
     int ret = cb_(path.data(), path.size(), size, data_);
     if (ret == 0) {
       // Throw an exception to stop traversal, which will be caught by the C++


### PR DESCRIPTION
Core Arrays nightly builds have been failing for a while now. This PR is restoring the nightly builds by:
- Fixing warning as errors on ubuntu for some VFS tests.
- Disabling a couple of dense unit tests that were performing simultaneous writes but were running Catch2 assertions inside threads, which is unsupported. Opened sc-66006 to fix and re-enable those tests later.
- Disabling a couple of unit tests for which compilation was failing due to warnings as errors in external sort code that is unused right now, because it has no impact on the release and it was non-trivial to fix. Opened sc-66005 to fix and re-enable those tests later.

After those changes the nightly builds should succeed in the dry-run : https://github.com/TileDB-Inc/TileDB/actions/runs/14521108156

[sc-65112]

---
TYPE: NO_HISTORY
DESC: Fix nightly test build
