### PR TITLE
Schema evolution test intermittent failure fix.

### DIFF
--- a/tiledb/sm/subarray/tile_cell_slab_iter.cc
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.cc
@@ -267,7 +267,6 @@ void TileCellSlabIter<T>::init_cell_slab_lengths() {
           ranges_[dim_num_ - 1][i].end_ - ranges_[dim_num_ - 1][i].start_ + 1;
     }
   } else {
-    assert(layout_ == Layout::COL_MAJOR);
     auto range_num = ranges_[0].size();
     cell_slab_lengths_.resize(range_num);
     for (size_t i = 0; i < range_num; ++i) {


### PR DESCRIPTION
There has been an intermittent failure in the test `C++ API: SchemaEvolution, drop fixed attribute and add back as var-sized`. It's been reproduced on M2 and M3 Macs in both `Release` and `Debug` modes, and is most prevalent in the nightlies under a series of `cmake` parameters. 

This fix was caught on my M2 Mac in `Debug` mode, and seems to be a copypasta oversight. 

After making the change, I was unable to reproduce the original failure again. I tried under 4 _different_ builds, each of which saw the failure in a nightly job. Each test was run **5000** times. 
* `RelWithDebugInfo` with `asan`;  `experimental-features, serialization`
* `Release` with `asan`
  * `experimental-features`,  `serialization`
  * `verbose`,  `ccache`,  `experimental-features`,  `serialization`
  * `verbose`,  `ccache`,  `serialization`

---
Fixes CORE-49

---
TYPE: BUG
DESC: Bug fix: C++ `SchemaEvolution` test intermittent failure.
