### PR TITLE
fix: rest_profile.cc: add missing <filesystem>

### DIFF
--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -31,6 +31,7 @@
  */
 
 #include <iostream>
+#include <filesystem>
 
 #include "rest_profile.h"
 #include "tiledb/common/random/random_label.h"

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -30,8 +30,8 @@
  * This file implements class RestProfile.
  */
 
-#include <iostream>
 #include <filesystem>
+#include <iostream>
 
 #include "rest_profile.h"
 #include "tiledb/common/random/random_label.h"


### PR DESCRIPTION
Self-evident and trivial fix.

---
TYPE: NO_HISTORY
DESC: Add missing <filesystem> to rest_profile.cc