### PR TITLE
Fix intermittently failing schema evolution UT

### DIFF
--- a/test/src/unit-cppapi-schema-evolution.cc
+++ b/test/src/unit-cppapi-schema-evolution.cc
@@ -1106,7 +1106,7 @@ void test_schema_evolution_drop_fixed_add_var(
 
   // Evolve schema to drop attribute "a"
   ArraySchemaEvolution schema_evolution = ArraySchemaEvolution(ctx);
-  uint64_t now = tiledb_timestamp_now_ms() + 1;
+  uint64_t now = fragment_write_ts + 1;
   schema_evolution.set_timestamp_range(std::make_pair(now, now));
   schema_evolution.drop_attribute("a");
   schema_evolution.array_evolve(array_uri);
@@ -1114,7 +1114,7 @@ void test_schema_evolution_drop_fixed_add_var(
 
   // Evolve schema to add back attribute "a" as a string
   auto a_new = Attribute::create<std::string>(ctx, "a");
-  now = tiledb_timestamp_now_ms() + 1;
+  now++;
   schema_evolution.set_timestamp_range(std::make_pair(now, now));
   schema_evolution.add_attribute(a_new);
   schema_evolution.array_evolve(array_uri);

--- a/tiledb/sm/subarray/tile_cell_slab_iter.cc
+++ b/tiledb/sm/subarray/tile_cell_slab_iter.cc
@@ -267,7 +267,6 @@ void TileCellSlabIter<T>::init_cell_slab_lengths() {
           ranges_[dim_num_ - 1][i].end_ - ranges_[dim_num_ - 1][i].start_ + 1;
     }
   } else {
-    assert(layout_ == Layout::COL_MAJOR);
     auto range_num = ranges_[0].size();
     cell_slab_lengths_.resize(range_num);
     for (size_t i = 0; i < range_num; ++i) {


### PR DESCRIPTION
Nightlies have been failing often on MacOS and ubuntu machines. I have reproduced locally on my laptop as well.
This is fixing the flaky behavior by making sure we remove and add an attribute to an array at the same timestamp, causing non deterministic schema evolution result.

This also removes a wrong assert that fails when building in debug mode.

---
TYPE: NO_HISTORY
DESC: Fix intermittently failing schema evolution UT
