### PR TITLE
Fix missing newline in schema-printer

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -53,7 +53,7 @@ To **install** to the configured prefix, run the following:
 $ make install
 ```
 
-Note that building against the installed shared library requires setting the library search path at build-time or run-time, as documented in [Usage](usage.md). System-wide installations requiring `sudo` permissions may avoid this step by running `sudo ldconfig` after installation.
+Note that building against the installed shared library requires setting the library search path at build-time or run-time, as documented in [Usage](USAGE.md). System-wide installations requiring `sudo` permissions may avoid this step by running `sudo ldconfig` after installation.
 
 Other helpful `Makefile` targets are as follows:
 

--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -919,7 +919,7 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
       "- Cell val num: " + CELL_VAL_NUM_STR + "\n" + "- Filters: 2\n" +
       "  > BZIP2: COMPRESSION_LEVEL=5\n" +
       "  > BitWidthReduction: BIT_WIDTH_MAX_WINDOW=1000\n" +
-      "- Fill value: " + FILL_VALUE_STR + "\n" + "### Current domain ###\n" +
+      "- Fill value: " + FILL_VALUE_STR + "\n\n" + "### Current domain ###\n" +
       "- Version: " +
       std::to_string(tiledb::sm::constants::current_domain_version) + "\n" +
       "- Empty: 1" + "\n";

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -1761,6 +1761,7 @@ std::ostream& operator<<(
     os << *label;
   }
 
+  os << std::endl;
   os << *schema.get_current_domain();
 
   return os;

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -1734,9 +1734,9 @@ std::ostream& operator<<(
      << "- Validity filters: " << schema.cell_validity_filters().size();
 
   os << schema.cell_validity_filters();
-  os << std::endl;
 
   if (schema.shared_domain() != nullptr) {
+    os << std::endl;
     os << *schema.shared_domain();
   }
 

--- a/tiledb/sm/array_schema/dimension_label.cc
+++ b/tiledb/sm/array_schema/dimension_label.cc
@@ -330,7 +330,6 @@ std::ostream& operator<<(
   (dl.label_cell_val_num() == tiledb::sm::constants::var_num) ?
       os << "- Label cell val num: var\n" :
       os << "- Label cell val num: " << dl.label_cell_val_num() << std::endl;
-  os << std::endl;
 
   return os;
 }


### PR DESCRIPTION
Reported here: https://github.com/TileDB-Inc/TileDB-R/issues/824#issuecomment-2916132071

Repro:

<details>

```
// Compile and link with:
// g++ -g -std=c++20 -Wno-deprecated-declarations "$@" -I/usr/local/include -L/usr/local/lib -ltiledb

#include <iostream>
#include <tiledb/tiledb>

using namespace tiledb;

int main(int argc, char* argv[]) {
  Context ctx;

  for (int argi = 1; argi < argc; argi++) {
    std::string uri(argv[argi]);
    ArraySchema schema(ctx, uri);
    std::cout << schema << "\n";
  }

  return 0;
}
```

```
$ ./a.out /path/to/my/array
```


</details>

Before and after;

```diff
$ diff -U20 -a before.txt after.txt
--- before.txt	2025-05-28 13:40:28
+++ after.txt	2025-05-28 13:40:23
@@ -58,25 +58,26 @@
 - Cell val num: 1
 - Filters: 1
   > ZSTD: COMPRESSION_LEVEL=-1
 - Fill value: nan
 - Fill value validity: 0

 ### Attribute ###
 - Name: louvain
 - Type: INT32
 - Nullable: true
 - Cell val num: 1
 - Filters: 1
   > ZSTD: COMPRESSION_LEVEL=-1
 - Fill value: -2147483648
 - Fill value validity: 0
 - Enumeration name: louvain_U

 ### Enumeration ###
 - Name: louvain_U
 - Loaded: false
+
 ### Current domain ###
 - Version: 0
 - Empty: 0
 - Type: NDRECTANGLE
```

---
TYPE: BUG
DESC: Fix a missing newline in array-schema printer.
