### PR TITLE
Fix windows runtime out of bounds assert for empty output tiles in sparse global order reader

### DIFF
--- a/tiledb/common/algorithm/parallel_merge.h
+++ b/tiledb/common/algorithm/parallel_merge.h
@@ -684,4 +684,36 @@ tdb::pmr::unique_ptr<ParallelMergeFuture> parallel_merge(
 
 }  // namespace tiledb::algorithm
 
+namespace stdx {
+
+/**
+ * Wrapper for `ParallelMergeOutputBuffer` types with a `size()` method
+ * whose index operator asserts that indices are in bounds.
+ */
+template <typename T>
+struct strict_index {
+  T value_;
+
+ public:
+  strict_index(T&& value)
+      : value_(std::move(value)) {
+  }
+
+  template <typename IndexType>
+  decltype(value_[std::declval<IndexType>()]) operator[](IndexType i) {
+    assert(i < value_.size());
+    return value_[i];
+  }
+
+  template <typename IndexType>
+  decltype(std::declval<
+           std::add_const<decltype(value_)>>()[std::declval<IndexType>()])
+  operator[](IndexType i) const {
+    assert(i < value_.size());
+    return value_[i];
+  }
+};
+
+}  // namespace stdx
+
 #endif

--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -816,7 +816,7 @@ void SparseGlobalOrderReader<BitmapType>::preprocess_compute_result_tile_order(
         future.merge_options_,
         future.fragment_result_tiles_,
         *static_cast<ResultTileCmp*>(future.cmp_.get()),
-        &preprocess_tile_order_.tiles_[0]);
+        stdx::strict_index(std::span(preprocess_tile_order_.tiles_)));
   };
 
   switch (array_schema_.cell_order()) {


### PR DESCRIPTION
This pull request corrects a `std::vector` buffer access which fails an assertion inside the windows C runtime.
```
    future.merge_ = algorithm::parallel_merge(
        resources_.compute_tp(),
        merge_resources,
        future.merge_options_,
        future.fragment_result_tiles_,
        *static_cast<ResultTileCmp*>(future.cmp_.get()),
        &preprocess_tile_order_.tiles_[0]);
```
The `&preprocess_tile_order_.tiles_[0]` access intends to get a pointer to a buffer for the parallel merge to write its output.  When the expected number of results is zero, however, this represents is an out-of-bounds access, even if we would never write to that memory location.

Our resolution to this issue draws inspiration from this safety feature.  We add `strict_span` which wraps `std::span` and uses our new assertion routines to check that writes to the parallel merge output buffer are within bounds.
---
TYPE: NO_HISTORY
DESC: Fix windows runtime out of bounds assert for empty output tiles in sparse global order reader
