### PR TITLE
Debugging CI failures [not for review]

### DIFF
--- a/test/src/unit-capi-array_schema.cc
+++ b/test/src/unit-capi-array_schema.cc
@@ -919,7 +919,7 @@ void ArraySchemaFx::load_and_check_array_schema(const std::string& path) {
       "- Cell val num: " + CELL_VAL_NUM_STR + "\n" + "- Filters: 2\n" +
       "  > BZIP2: COMPRESSION_LEVEL=5\n" +
       "  > BitWidthReduction: BIT_WIDTH_MAX_WINDOW=1000\n" +
-      "- Fill value: " + FILL_VALUE_STR + "\n" + "### Current domain ###\n" +
+      "- Fill value: " + FILL_VALUE_STR + "\n\n" + "### Current domain ###\n" +
       "- Version: " +
       std::to_string(tiledb::sm::constants::current_domain_version) + "\n" +
       "- Empty: 1" + "\n";

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -1738,9 +1738,9 @@ std::ostream& operator<<(
      << "- Validity filters: " << schema.cell_validity_filters().size();
 
   os << schema.cell_validity_filters();
-  os << std::endl;
 
   if (schema.shared_domain() != nullptr) {
+    os << std::endl;
     os << *schema.shared_domain();
   }
 
@@ -1765,6 +1765,7 @@ std::ostream& operator<<(
     os << *label;
   }
 
+  os << std::endl;
   os << *schema.get_current_domain();
 
   return os;

--- a/tiledb/sm/array_schema/dimension_label.cc
+++ b/tiledb/sm/array_schema/dimension_label.cc
@@ -330,7 +330,6 @@ std::ostream& operator<<(
   (dl.label_cell_val_num() == tiledb::sm::constants::var_num) ?
       os << "- Label cell val num: var\n" :
       os << "- Label cell val num: " << dl.label_cell_val_num() << std::endl;
-  os << std::endl;
 
   return os;
 }


### PR DESCRIPTION
This is not for review. It's an experiment.

This has the mods from https://github.com/TileDB-Inc/TileDB/pull/5522 but off Git hash `cca9c042f42d14d58fa55d6c325a815ede75c74b` from

```
commit cca9c042f42d14d58fa55d6c325a815ede75c74b
Author: Beka Davis <31743465+bekadavis9@users.noreply.github.com>
Date:   Mon May 19 15:14:18 2025 -0400

    Update ensure_filter_type_is_valid upper bound enum. (#5488)
```

which is from ten days ago which seems like a reasonable place to start bisecting to see if may a source change has a role to place in the curl timeouts we've been seeing recently. Note that PR https://github.com/TileDB-Inc/TileDB/pull/5488 had its CI complete green in just over an hour: https://github.com/TileDB-Inc/TileDB/actions/runs/15121284929. So if this PR also passes CI without cache-timeout issues, while #5522 doesn't, that'll suggest the cache-timeout issues we've been seeing recently are source-related.

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
