### PR TITLE
Disable x-gha binary cache for vcpkg

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 90
     name: Build Docs
     env:
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;'
     steps:
       - uses: actions/checkout@v3
       - name: 'Print env'
@@ -42,13 +42,6 @@ jobs:
           echo "uname -v: " $(uname -v)
           printenv
         shell: bash
-
-      - name: Set environment variables for vcpkg binary caching
-        uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,8 +28,6 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     name: Build Docs
-    env:
-      VCPKG_BINARY_SOURCES: 'clear;'
     steps:
       - uses: actions/checkout@v3
       - name: 'Print env'

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -45,7 +45,6 @@ jobs:
         env:
           TILEDB_HOME: ${{ github.workspace }}
           MINGW_ARCH: ${{ matrix.msystem }}
-          VCPKG_BINARY_SOURCES: 'clear;'
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
       - name: Set variables

--- a/.github/workflows/build-rtools40.yml
+++ b/.github/workflows/build-rtools40.yml
@@ -32,13 +32,6 @@ jobs:
           ref: ${{ steps.vcpkg_commit.outputs.ref }}
           # Vcpkg requires fetching all commits.
           fetch-depth: 0
-      # Configure required environment variables for vcpkg to use
-      # GitHub's Action Cache
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Install rtools40 if needed
         uses: r-windows/install-rtools@master
       - name: Building TileDB with Rtools40
@@ -52,7 +45,7 @@ jobs:
         env:
           TILEDB_HOME: ${{ github.workspace }}
           MINGW_ARCH: ${{ matrix.msystem }}
-          VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+          VCPKG_BINARY_SOURCES: 'clear;'
           VCPKG_ROOT: ${{ github.workspace }}/vcpkg
         shell: c:\rtools40\usr\bin\bash.exe --login {0}
       - name: Set variables

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,7 +55,7 @@ jobs:
       TILEDB_SERIALIZATION: ${{ matrix.TILEDB_SERIALIZATION }} #serialization }}
       TILEDB_WEBP: ${{ matrix.TILEDB_WEBP }}
       TILEDB_CMAKE_BUILD_TYPE: 'Release'
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;'
     steps:
       - name: 'tiledb env prep'
         run: |
@@ -71,14 +71,6 @@ jobs:
 
           write-host "BUILD_BUILDDIRECTORY=$env:BUILD_BUILDDIRECTORY" *>> $env:GITHUB_ENV
           write-host "BUILD_SOURCESDIRECTORY=$env:BUILD_SOURCESDIRECTORY" *>> $env:GITHUB_ENV
-
-      # Configure required environment variables for vcpkg to use
-      # GitHub's Action Cache
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: 'Print env'
         shell: cmd

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,7 +55,6 @@ jobs:
       TILEDB_SERIALIZATION: ${{ matrix.TILEDB_SERIALIZATION }} #serialization }}
       TILEDB_WEBP: ${{ matrix.TILEDB_WEBP }}
       TILEDB_CMAKE_BUILD_TYPE: 'Release'
-      VCPKG_BINARY_SOURCES: 'clear;'
     steps:
       - name: 'tiledb env prep'
         run: |

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -78,7 +78,6 @@ env:
   CFLAGS: ${{ inputs.matrix_compiler_cflags }}
   CXXFLAGS: ${{ inputs.matrix_compiler_cxxflags }}
   bootstrap_args: "--enable-assertions --enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'arm64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
-  VCPKG_BINARY_SOURCES: 'clear;'
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -78,7 +78,7 @@ env:
   CFLAGS: ${{ inputs.matrix_compiler_cflags }}
   CXXFLAGS: ${{ inputs.matrix_compiler_cxxflags }}
   bootstrap_args: "--enable-assertions --enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'arm64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;'
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
@@ -98,14 +98,6 @@ jobs:
         with:
             submodules: true
             fetch-depth: 0
-
-      # Configure required environment variables for vcpkg to use
-      # GitHub's Action Cache
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Install Python
         if: ${{ !inputs.manylinux }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
     container: ${{ matrix.manylinux || '' }}
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
-      VCPKG_BINARY_SOURCES: 'clear;'
 
     steps:
       - name: Checkout TileDB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     container: ${{ matrix.manylinux || '' }}
     env:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.MACOSX_DEPLOYMENT_TARGET }}
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;'
 
     steps:
       - name: Checkout TileDB
@@ -84,12 +84,6 @@ jobs:
       - name: 'Homebrew setup'
         run: brew install automake ninja
         if: ${{ startsWith(matrix.os, 'macos-') == true }}
-      - name: Export GitHub Actions cache variables
-        uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
       - name: Set variables
         id: get-values
         run: |

--- a/.github/workflows/test-cloud-e2e.yml
+++ b/.github/workflows/test-cloud-e2e.yml
@@ -13,7 +13,7 @@ on:
       - release-*
 
 env:
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;'
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
@@ -30,14 +30,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      # Configure required environment variables for vcpkg to use
-      # GitHub's Action Cache
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: Prevent vpckg from building debug variants
         run: python ./scripts/ci/patch_vcpkg_triplets.py

--- a/.github/workflows/test-cloud-e2e.yml
+++ b/.github/workflows/test-cloud-e2e.yml
@@ -13,7 +13,6 @@ on:
       - release-*
 
 env:
-  VCPKG_BINARY_SOURCES: 'clear;'
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -3,9 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  VCPKG_BINARY_SOURCES: 'clear;'
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+  VCPKG_BINARY_SOURCES: 'clear;'
 
 jobs:
   build:
@@ -47,14 +47,6 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows-') }}
         with:
           arch: x64
-
-      # Configure required environment variables for vcpkg to use
-      # GitHub's Action Cache
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - name: 'Print env'
         run: |


### PR DESCRIPTION
CI has been failing for the last couple of days with caching related failures. See for example : https://github.com/TileDB-Inc/TileDB/actions/runs/15327048347/job/43143363036?pr=5522

- Investigation showed that this is due to:
 "Recent [changes in GitHub Actions Cache's API](https://github.com/actions/cache/discussions/1510) have rendered the x-gha binary caching provider useless." 
From: https://github.com/microsoft/vcpkg-tool/pull/1662 . In this PR ways to replace this cache with alternatives (e.g. NuGet) are suggested.
- Microsoft put a warning in the vcpkg page: https://learn.microsoft.com/is-is/vcpkg/consume/binary-caching-github-actions-cache that x-gha cache is no longer supported.
- Github-actions have warned about messing up with `ACTIONS_` env variables here: https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

For now we'll disable x-gha. We can open a follow up ticket to investigate/implement alternatives if needed.

closes CORE-231

---
TYPE: NO_HISTORY
DESC: Disable x-gha binary cache for vcpkg