### PR TITLE
Fix example CMake project in usage

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -114,4 +114,4 @@ find_package(TileDB REQUIRED)
 target_link_libraries(MyExe PRIVATE TileDB::tiledb_static)
 ```
 
-You can see the [example CMake project](../examples/cmake_project) to see an example project structure that links against TileDB.
+You can see the [example CMake project](examples/cmake_project) to see an example project structure that links against TileDB.


### PR DESCRIPTION
This small PR fixes the `examples/cmake_project` reference in `USAGE.md`.

---
TYPE: NO_HISTORY
DESC: Fix example CMake project in usage
