### PR TITLE
Install serialization C API headers regardless of build configuration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,13 +286,8 @@ list(APPEND TILEDB_C_API_FILENAME_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_version.h"
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_experimental.h"
     "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_dimension_label_experimental.h"
+    "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_serialization.h"
 )
-
-if (TILEDB_SERIALIZATION)
-    list(APPEND TILEDB_C_API_FILENAME_HEADERS
-        "${CMAKE_SOURCE_DIR}/tiledb/sm/c_api/tiledb_serialization.h"
-    )
-endif()
 
 list(APPEND TILEDB_C_API_RELATIVE_HEADERS
     "${CMAKE_SOURCE_DIR}/tiledb/api/c_api/api_external_common.h"


### PR DESCRIPTION
Currently, we install `tiledb_serialization.h` only if the Core is built with `TILEDB_SERIALIZATION` enabled. This is not ideal, as it forces downstream projects to include compile-time logic to conditionally include `tiledb_serialization.h`. Context: https://github.com/TileDB-Inc/TileDB-Py/pull/2199.

This PR updates the behavior to always install `tiledb_serialization.h`. The compiled binaries already always export the C APIs, which will simply fail at runtime if serialization is disabled.

Closes CORE-232

---
TYPE: IMPROVEMENT | C_API
DESC: Install serialization C API headers regardless of build configuration.