### PR TITLE
chore: add callback registration to `passert_failure` to enable dumping rapidcheck test input

### DIFF
--- a/tiledb/common/assert.cc
+++ b/tiledb/common/assert.cc
@@ -68,6 +68,8 @@ static std::vector<std::function<void()>> passertFailureCallbacks;
   passert_failure_abort();
 }
 
+#ifdef TILEDB_ASSERTIONS
+
 PAssertFailureCallbackRegistration::PAssertFailureCallbackRegistration(
     std::function<void()>&& callback) {
   std::unique_lock<std::mutex> lk(passertFailureCallbackMutex);
@@ -79,5 +81,7 @@ PAssertFailureCallbackRegistration::~PAssertFailureCallbackRegistration() {
   std::unique_lock<std::mutex> lk(passertFailureCallbackMutex);
   passertFailureCallbacks.pop_back();
 }
+
+#endif
 
 }  // namespace tiledb::common

--- a/tiledb/common/assert.h
+++ b/tiledb/common/assert.h
@@ -88,6 +88,7 @@
 
 #include <fmt/format.h>
 #include <cstdlib>
+#include <functional>
 #include <iostream>
 
 #define __SOURCE__ (&__FILE__[__SOURCE_DIR_PATH_SIZE__])
@@ -169,6 +170,11 @@ template <typename... Args>
 }
 
 /**
+ * Aborts the process upon `passert` failure.
+ */
+[[noreturn]] void passert_failure_abort(void);
+
+/**
  * Assertion failure which results in a process panic.
  * SIGABRT is raised.
  *
@@ -203,8 +209,23 @@ template <typename... Args>
   std::cerr << "  " << file << ":" << line << std::endl;
   std::cerr << "  Details: "
             << fmt::format(fmt, std::forward<Args>(fmt_args)...) << std::endl;
-  std::abort();
+
+  passert_failure_abort();
 }
+
+/**
+ * Registers a callback to run upon `passert` failure.
+ * This can be used to print any diagnostic info prior to aborting the process.
+ */
+struct PAssertFailureCallbackRegistration {
+#ifdef TILEDB_ASSERTIONS
+  PAssertFailureCallbackRegistration(std::function<void()>&& callback);
+  ~PAssertFailureCallbackRegistration();
+#else
+  PAssertFailureCallbackRegistration(std::function<void()>&&) {
+  }
+#endif
+};
 
 }  // namespace tiledb::common
 


### PR DESCRIPTION
Resolves CORE-233.

A `passert` failure crashes the process without returning.  While `Catch2` has a `SIGABRT` handler to print some details around this, `rapidcheck` does not.  As such, if a randomized `rapidcheck` input fails a `passert`, no details about what the input was are printed.

Ostensibly we have some means of recovering that failed input using the seed which produced the test case, but this might not be helpful:
1) we don't know if it is platform-independent
2) if there is a non-deterministic or undefined behavior leading to failure, then the seed may not be enough to clue us in

This pull request adds a callback registration to `passert_failure` so that we can register a callback in our `rapidcheck` properties to print the last attempted input in the event of a `passert` failure.  This way we can recover a bad input with certainty.

Example:
```
FATAL TileDB core library internal error: false
  test/src/unit-sparse-global-order-reader.cc:1396
Last rapidcheck input: (2, 1, 1, [[1, 1]], d1 LT 0x01 0x00 0x00 0x00)
```

---
TYPE: NO_HISTORY
DESC: add callback registration to `passert_failure` to enable dumping rapidcheck test input
