### PR TITLE
Finalize Profile and add example.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -338,6 +338,10 @@ jobs:
           $TestAppDataDir = (Join-Path $env:BUILD_BUILDDIRECTORY "examples\cpp_api\test_app_data")
           Get-ChildItem (Join-Path $env:BUILD_BUILDDIRECTORY "examples\cpp_api\") -Filter *.exe |
           Foreach-Object {
+            if ($_.Name -ieq "profile_cpp.exe") {
+              Write-Host "Skipping $_.Name"
+              return
+            }
             try {
               Set-Location -path $TestAppDir
               Remove-Item -Path $TestAppDataDir -recurse -force -ErrorAction SilentlyContinue

--- a/examples/cpp_api/profile.cc
+++ b/examples/cpp_api/profile.cc
@@ -33,6 +33,8 @@
  * this profile. It will then print the parameters of the config object, which
  * should come from the profile. Finally, it will create an array using the
  * profile, and then remove the profile.
+ *
+ * @note This example is not running on CI since it requires serialization.
  */
 
 #include <iostream>

--- a/examples/cpp_api/profile.cc
+++ b/examples/cpp_api/profile.cc
@@ -1,0 +1,97 @@
+/**
+ * @file   profile.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2025 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * When run, this program will create a simple 2D sparse array, write some data
+ * to it, and read a slice of the data back.
+ */
+
+#include <iostream>
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
+using namespace tiledb;
+
+void create_and_save_profile(
+    std::optional<std::string> profile_name = std::nullopt) {
+  Profile profile = profile_name ? Profile(profile_name.value()) : Profile();
+  profile.set_param(
+      "rest.token", profile_name ? "named_custom_token" : "my_custom_token");
+  profile.set_param(
+      "rest.server_address",
+      profile_name ? "https://named.custom.server.address" :
+                     "https://my.custom.server.address");
+  profile.save();
+}
+
+void print_config(std::optional<std::string> profile_name = std::nullopt) {
+  // Create a config object. The default profile will be used automatically if
+  // it exists.
+  Config config;
+
+  if (profile_name.has_value()) {
+    config.set_profile(profile_name.value());
+  }
+
+  // Print the parameters of the config. They should come from the profile.
+  std::cout << "Config parameters coming from "
+            << (profile_name.has_value() ? profile_name.value() : "default")
+            << " profile" << std::endl;
+  std::cout << "rest.token: " << config.get("rest.token") << std::endl;
+  std::cout << "rest.server_address: " << config.get("rest.server_address")
+            << std::endl
+            << std::endl;
+}
+
+int main() {
+  // IMPORTANT NOTE: both the default and the named profiles  will not be
+  // overwritten in case they already exist. If you want to overwrite them, you
+  // need to remove them first.
+  try {
+    // Create, save, and print the config parameters for the default profile
+    create_and_save_profile();
+    print_config();
+    // Remove the default profile ONLY if it was created as part of this example
+    Profile::remove();
+  } catch (const ProfileException& e) {
+    std::cerr << "Error creating default profile: " << e.what() << std::endl;
+  }
+
+  try {
+    // Create, save, and print the config parameters for a named profile
+    const std::string profile_name = "profile_example_123";
+    create_and_save_profile(profile_name);
+    print_config(profile_name);
+    // Remove the named profile
+    Profile::remove(profile_name);
+  } catch (const ProfileException& e) {
+    std::cerr << "Error creating named profile: " << e.what() << std::endl;
+  }
+
+  return 0;
+}

--- a/examples/cpp_api/profile.cc
+++ b/examples/cpp_api/profile.cc
@@ -87,9 +87,9 @@ void create_array_with_profile(const std::string& profile_name) {
 }
 
 int main() {
-  // IMPORTANT NOTE: in case a profile of the same name already exists it will
-  // not be overwritten. If you want to overwrite it, you need to remove it
-  // first.
+  // IMPORTANT NOTE: Profiles are immutable. If you want to overwrite an
+  // existing Profile with a new one of the same name, you must first remove the
+  // old one.
   try {
     // Create, save, and print the config parameters for a named profile
     const std::string profile_name = "profile_example_123";

--- a/scripts/run-nix-examples.sh
+++ b/scripts/run-nix-examples.sh
@@ -37,6 +37,10 @@ do
   if [ "${example##*/}" == png_ingestion_webp.cc ]; then
     continue
   fi;
+  # Skip Profile example as it requires serialization
+  if [ "${example##*/}" == profile.cc ]; then
+    continue
+  fi;
 
   cd ${TestAppDir}
   rm -rf ${TestAppDataDir}

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/src/unit-cppapi-profile.cc
+++ b/test/src/unit-cppapi-profile.cc
@@ -109,7 +109,9 @@ TEST_CASE_METHOD(
   }
   SECTION("inherited from nullptr") {
     Profile p(name_, std::nullopt);
-    REQUIRE(p.dir() == tiledb::common::filesystem::home_directory());
+    REQUIRE(
+        p.dir() == tiledb::common::filesystem::home_directory() +
+                       tiledb::sm::constants::rest_profile_foldername + "/");
   }
 }
 
@@ -155,15 +157,15 @@ TEST_CASE_METHOD(
     Profile p(name_, tempdir_.path());
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save the profile
     p.save();
     // check that the profiles file is created
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // check that the profile is saved
     REQUIRE(profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath, name_));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename, name_));
   }
   SECTION("rest.username and rest.password set") {
     Profile p(name_, tempdir_.path());
@@ -171,15 +173,15 @@ TEST_CASE_METHOD(
     p.set_param("rest.password", "test_password");
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save the profile
     p.save();
     // check that the profiles file is created
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // check that the profile is saved
     REQUIRE(profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath, name_));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename, name_));
   }
   SECTION("rest.username set and rest.password not set") {
     Profile p(name_, tempdir_.path());
@@ -202,7 +204,7 @@ TEST_CASE_METHOD(
     expected_values_t expected;
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save some parameters
     p.set_param("rest.username", "test_user");
     p.set_param("rest.password", "test_password");
@@ -210,7 +212,7 @@ TEST_CASE_METHOD(
     p.save();
     // check that the profiles file is created
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
 
     // load the profile again
     Profile p2 = Profile::load(name_, tempdir_.path());
@@ -222,7 +224,7 @@ TEST_CASE_METHOD(
   SECTION("profiles file is present") {
     // check that the profiles file is not there
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // attempt to load the profile
     REQUIRE_THROWS(Profile::load(name_, tempdir_.path()));
   }
@@ -231,15 +233,15 @@ TEST_CASE_METHOD(
     Profile p2("another_profile", tempdir_.path());
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save the other profile
     p1.save();
     // check that the profiles file is created
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // check that the other profile is saved
     REQUIRE(profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath,
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename,
         p1.name()));
   }
 }
@@ -252,26 +254,26 @@ TEST_CASE_METHOD(
     Profile p(name_, tempdir_.path());
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save the profile
     p.save();
     // check that the profiles file is created
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // remove the profile
-    p.remove();
+    Profile::remove(name_, tempdir_.path());
     // check that the profiles file is still there
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // check that the profile is removed
     REQUIRE(!profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath, name_));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename, name_));
   }
   SECTION("profiles file is present") {
     Profile p(name_, tempdir_.path());
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // attempt to remove the profile
     REQUIRE_THROWS(p.remove());
   }
@@ -280,25 +282,25 @@ TEST_CASE_METHOD(
     Profile p2("another_profile", tempdir_.path());
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save the other profile
     p2.save();
     // check that the profiles file is created
     REQUIRE(std::filesystem::exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath));
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // check that the other profile is saved
     REQUIRE(profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath,
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename,
         p2.name()));
     // attempt remove the tested profile
     REQUIRE_THROWS(p1.remove());
     // check that the other profile still exists
     REQUIRE(profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath,
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename,
         p2.name()));
     // check that the tested profile still does not exist
     REQUIRE(!profile_exists(
-        tempdir_.path() + tiledb::sm::constants::rest_profile_filepath,
+        tempdir_.path() + tiledb::sm::constants::rest_profile_filename,
         p1.name()));
   }
 }
@@ -334,10 +336,14 @@ TEST_CASE_METHOD(
 
     Profile p1;
     REQUIRE(p1.name() == expected.profile_name);
-    REQUIRE(p1.dir() == tiledb::common::filesystem::home_directory());
+    REQUIRE(
+        p1.dir() == tiledb::common::filesystem::home_directory() +
+                        tiledb::sm::constants::rest_profile_foldername + "/");
 
     Profile p2(std::nullopt, std::nullopt);
     REQUIRE(p2.name() == expected.profile_name);
-    REQUIRE(p2.dir() == tiledb::common::filesystem::home_directory());
+    REQUIRE(
+        p2.dir() == tiledb::common::filesystem::home_directory() +
+                        tiledb::sm::constants::rest_profile_foldername + "/");
   }
 }

--- a/test/src/unit-cppapi-profile.cc
+++ b/test/src/unit-cppapi-profile.cc
@@ -110,8 +110,9 @@ TEST_CASE_METHOD(
   SECTION("inherited from nullptr") {
     Profile p(name_, std::nullopt);
     REQUIRE(
-        p.dir() == tiledb::common::filesystem::home_directory() +
-                       tiledb::sm::constants::rest_profile_foldername + "/");
+        p.dir() == tiledb::common::filesystem::ensure_trailing_slash(
+                       tiledb::common::filesystem::home_directory() +
+                       tiledb::sm::constants::rest_profile_foldername));
   }
 }
 
@@ -337,13 +338,15 @@ TEST_CASE_METHOD(
     Profile p1;
     REQUIRE(p1.name() == expected.profile_name);
     REQUIRE(
-        p1.dir() == tiledb::common::filesystem::home_directory() +
-                        tiledb::sm::constants::rest_profile_foldername + "/");
+        p1.dir() == tiledb::common::filesystem::ensure_trailing_slash(
+                        tiledb::common::filesystem::home_directory() +
+                        tiledb::sm::constants::rest_profile_foldername));
 
     Profile p2(std::nullopt, std::nullopt);
     REQUIRE(p2.name() == expected.profile_name);
     REQUIRE(
-        p2.dir() == tiledb::common::filesystem::home_directory() +
-                        tiledb::sm::constants::rest_profile_foldername + "/");
+        p2.dir() == tiledb::common::filesystem::ensure_trailing_slash(
+                        tiledb::common::filesystem::home_directory() +
+                        tiledb::sm::constants::rest_profile_foldername));
   }
 }

--- a/tiledb/api/c_api/config/test/unit_capi_config.cc
+++ b/tiledb/api/c_api/config/test/unit_capi_config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/api/c_api/profile/profile_api.cc
+++ b/tiledb/api/c_api/profile/profile_api.cc
@@ -117,9 +117,12 @@ capi_return_t tiledb_profile_load(tiledb_profile_t* profile) {
   return TILEDB_OK;
 }
 
-capi_return_t tiledb_profile_remove(tiledb_profile_t* profile) {
-  ensure_profile_is_valid(profile);
-  profile->profile()->remove_from_file();
+capi_return_t tiledb_profile_remove(const char* name, const char* dir) {
+  std::optional<std::string> name_opt =
+      (name == nullptr) ? std::nullopt : std::make_optional(std::string(name));
+  std::optional<std::string> dir_opt =
+      (dir == nullptr) ? std::nullopt : std::make_optional(std::string(dir));
+  tiledb::sm::RestProfile::remove_profile(name_opt, dir_opt);
   return TILEDB_OK;
 }
 
@@ -199,8 +202,8 @@ CAPI_INTERFACE(
 }
 
 CAPI_INTERFACE(
-    profile_remove, tiledb_profile_t* profile, tiledb_error_t** error) {
-  return api_entry_error<tiledb::api::tiledb_profile_remove>(error, profile);
+    profile_remove, const char* name, const char* dir, tiledb_error_t** error) {
+  return api_entry_error<tiledb::api::tiledb_profile_remove>(error, name, dir);
 }
 
 CAPI_INTERFACE(

--- a/tiledb/api/c_api/profile/profile_api_experimental.h
+++ b/tiledb/api/c_api/profile/profile_api_experimental.h
@@ -215,15 +215,17 @@ TILEDB_EXPORT capi_return_t tiledb_profile_load(
     tiledb_profile_t* profile, tiledb_error_t** error) TILEDB_NOEXCEPT;
 
 /**
- * Removes the given profile from the local file.
+ * Removes a profile from a given directory.
  *
- * @param[in] profile The profile.
+ * @param[in] name The profile name if you want to override the default.
+ * @param[in] dir The directory path that contains the profiles file. If `NULL`,
+ * the default directory is used.
  * @param[out] error Error object returned upon error (`NULL` if there is no
- * error).
- * @return TILEDB_EXPORT
+ *     error).
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
 TILEDB_EXPORT capi_return_t tiledb_profile_remove(
-    tiledb_profile_t* profile, tiledb_error_t** error) TILEDB_NOEXCEPT;
+    const char* name, const char* dir, tiledb_error_t** error) TILEDB_NOEXCEPT;
 
 /**
  * Dumps a string representation of the given profile.

--- a/tiledb/api/c_api/profile/profile_api_experimental.h
+++ b/tiledb/api/c_api/profile/profile_api_experimental.h
@@ -64,7 +64,7 @@ typedef struct tiledb_profile_handle_t tiledb_profile_t;
  * @endcode
  *
  * @param[in] name The profile name, or `nullptr` for default.
- * @param[in] dir The directory path that the profile will be stored, or
+ * @param[in] dir The directory path on which the profile will be stored, or
  * `nullptr` for home directory.
  * @param[out] profile The profile object to be created.
  * @param[out] error Error object returned upon error (`NULL` if there is

--- a/tiledb/api/c_api/profile/profile_api_experimental.h
+++ b/tiledb/api/c_api/profile/profile_api_experimental.h
@@ -47,8 +47,6 @@ typedef struct tiledb_profile_handle_t tiledb_profile_t;
 /**
  * Allocates a TileDB profile object.
  *
- * @note Users may specify the path, or use `nullptr` for the default.
- *
  * **Example:**
  *
  * @code{.c}
@@ -66,7 +64,8 @@ typedef struct tiledb_profile_handle_t tiledb_profile_t;
  * @endcode
  *
  * @param[in] name The profile name, or `nullptr` for default.
- * @param[in] dir The profile directory, or `nullptr` for default.
+ * @param[in] dir The directory path that the profile will be stored, or
+ * `nullptr` for home directory.
  * @param[out] profile The profile object to be created.
  * @param[out] error Error object returned upon error (`NULL` if there is
  *     no error).
@@ -215,11 +214,12 @@ TILEDB_EXPORT capi_return_t tiledb_profile_load(
     tiledb_profile_t* profile, tiledb_error_t** error) TILEDB_NOEXCEPT;
 
 /**
- * Removes a profile from a given directory.
+ * Removes a profile from the profiles file in the given directory.
  *
- * @param[in] name The profile name if you want to override the default.
+ * @param[in] name The name of the profile to be removed. If `NULL`, the
+ * default name is used.
  * @param[in] dir The directory path that contains the profiles file. If `NULL`,
- * the default directory is used.
+ * the home directory is used.
  * @param[out] error Error object returned upon error (`NULL` if there is no
  *     error).
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.

--- a/tiledb/api/c_api/profile/test/unit_capi_profile.cc
+++ b/tiledb/api/c_api/profile/test/unit_capi_profile.cc
@@ -271,11 +271,11 @@ TEST_CASE_METHOD(
   SECTION("success") {
     rc = tiledb_profile_save(profile, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
-    rc = tiledb_profile_remove(profile, &err);
+    rc = tiledb_profile_remove(name_, tempdir_.path().c_str(), &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
   }
   SECTION("null profile") {
-    rc = tiledb_profile_remove(nullptr, &err);
+    rc = tiledb_profile_remove(nullptr, nullptr, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_ERR);
   }
   tiledb_profile_free(&profile);

--- a/tiledb/common/filesystem/home_directory.cc
+++ b/tiledb/common/filesystem/home_directory.cc
@@ -45,6 +45,20 @@
 
 namespace tiledb::common::filesystem {
 
+// Ensures the given path has a trailing slash appropriate for the platform.
+std::string ensure_trailing_slash(const std::string& path) {
+#ifdef _WIN32
+  if (!path.empty() && path.back() != '\\') {
+    return path + '\\';
+  }
+#else
+  if (!path.empty() && path.back() != '/') {
+    return path + '/';
+  }
+#endif
+  return path;
+}
+
 std::string home_directory() {
   std::string path = "";
 #ifdef _WIN32
@@ -56,20 +70,13 @@ std::string home_directory() {
   if (SHGetKnownFolderPath(FOLDERID_Profile, 0, NULL, &home) == S_OK) {
     path = std::wstring_convert<std::codecvt_utf8<wchar_t>>{}.to_bytes(home);
   }
-  // Ensure path has trailing slash.
-  if (path.back() != '\\') {
-    path.push_back('\\');
-  }
 #else
   const char* home = std::getenv("HOME");
   if (home != nullptr) {
     path = home;
   }
-  // Ensure path has trailing slash.
-  if (path.back() != '/') {
-    path.push_back('/');
-  }
 #endif
+  path = ensure_trailing_slash(path);
   return path;
 }
 

--- a/tiledb/common/filesystem/home_directory.h
+++ b/tiledb/common/filesystem/home_directory.h
@@ -38,6 +38,11 @@
 namespace tiledb::common::filesystem {
 
 /**
+ * Ensures the given path has a trailing slash appropriate for the platform.
+ */
+std::string ensure_trailing_slash(const std::string& path);
+
+/**
  * Standalone function which returns the path to user's home directory.
  *
  * @invariant `sudo` does not always preserve the path to `$HOME`. Rather than

--- a/tiledb/sm/config/test/unit_config.cc
+++ b/tiledb/sm/config/test/unit_config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/sm/cpp_api/profile_experimental.h
+++ b/tiledb/sm/cpp_api/profile_experimental.h
@@ -236,10 +236,19 @@ class Profile {
     }
   }
 
-  /** Removes the profile from the local file. */
-  void remove() {
+  /**
+   * Removes a profile from a profiles file in a given directory.
+   *
+   * @param name The name of the profile to remove.
+   * @param dir The directory path where the profiles file is located.
+   */
+  static void remove(
+      std::optional<std::string> name = std::nullopt,
+      std::optional<std::string> dir = std::nullopt) {
+    const char* n = name.has_value() ? name->c_str() : nullptr;
+    const char* h = dir.has_value() ? dir->c_str() : nullptr;
     tiledb_error_t* capi_error = nullptr;
-    int rc = tiledb_profile_remove(profile_.get(), &capi_error);
+    int rc = tiledb_profile_remove(n, h, &capi_error);
     if (rc != TILEDB_OK) {
       const char* msg_cstr;
       tiledb_error_message(capi_error, &msg_cstr);

--- a/tiledb/sm/cpp_api/profile_experimental.h
+++ b/tiledb/sm/cpp_api/profile_experimental.h
@@ -64,8 +64,9 @@ class Profile {
    * preserve local files from in-test changes. Users may pass their own
    * `profile_dir`, but are encouraged to use `nullptr`, the default case.
    *
-   * @param name The profile name if you want to override the default.
-   * @param dir The directory path for the profile, or `nullptr` for the default
+   * @param name The profile name. If std::nullopt, the default name is used.
+   * @param dir The directory path that the profile will be stored. If
+   * `std::nullopt`, the home directory is used.
    * @throws ProfileException if the profile cannot be allocated.
    */
   explicit Profile(
@@ -105,7 +106,7 @@ class Profile {
    * Factory function to load a profile from the local file.
    *
    * @param name The profile name if you want to override the default.
-   * @param dir The local directory path that contains the profiles file.
+   * @param dir The directory path that contains the profiles file.
    * @return A Profile object loaded from the file.
    */
   static Profile load(

--- a/tiledb/sm/cpp_api/profile_experimental.h
+++ b/tiledb/sm/cpp_api/profile_experimental.h
@@ -65,7 +65,7 @@ class Profile {
    * `profile_dir`, but are encouraged to use `nullptr`, the default case.
    *
    * @param name The profile name. If std::nullopt, the default name is used.
-   * @param dir The directory path that the profile will be stored. If
+   * @param dir The directory path on which the profile will be stored. If
    * `std::nullopt`, the home directory is used.
    * @throws ProfileException if the profile cannot be allocated.
    */

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -778,8 +778,14 @@ const std::string rest_header_prefix = "rest.custom_headers.";
 /** The current RestProfile API version. */
 const format_version_t rest_profile_version = 1;
 
-/** Filepath for the special local RestProfile files used in TileDB. */
-const std::string rest_profile_filepath = ".tiledb/profiles.json";
+/**
+ * Foldername that the REST profiles are stored
+ * in when using the home directory.
+ */
+const std::string rest_profile_foldername = ".tiledb";
+
+/** The filename of the REST profiles file. */
+const std::string rest_profile_filename = "profiles.json";
 
 /** String describing MIME_AUTODETECT. */
 const std::string mime_autodetect_str = "AUTODETECT";

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -766,8 +766,14 @@ extern const std::string rest_header_prefix;
 /** The current RestProfile API version. */
 extern const format_version_t rest_profile_version;
 
-/** Filepath for the special local RestProfile files used in TileDB. */
-extern const std::string rest_profile_filepath;
+/**
+ * Foldername that the REST profiles are stored
+ * in when using the home directory.
+ */
+extern const std::string rest_profile_foldername;
+
+/** The filename of the REST profiles file. */
+extern const std::string rest_profile_filename;
 
 /** Delimiter for lists passed as config parameter */
 extern const std::string config_delimiter;

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -135,19 +135,16 @@ RestProfile::RestProfile(
               name.value() :
               RestProfile::DEFAULT_PROFILE_NAME) {
   if (dir.has_value() && !dir.value().empty()) {
-    dir_ = dir.value();
-    // Check if the provided directory ends with a slash, and add one if not.
-    if (dir_.back() != '/') {
-      dir_ += '/';
-    }
+    dir_ = ensure_trailing_slash(dir.value());
   } else {
     // We don't want to directly itneract with the home directory of the user,
     // so we create a folder in the user's home directory.
-    dir_ = home_directory() + constants::rest_profile_foldername + "/";
-    if (dir_.empty()) {
+    std::string home = home_directory();
+    if (home.empty()) {
       throw RestProfileException(
           "Failed to create RestProfile; $HOME is not set.");
     }
+    dir_ = ensure_trailing_slash(home + constants::rest_profile_foldername);
   }
   filepath_ = dir_ + constants::rest_profile_filename;
 };
@@ -260,9 +257,7 @@ void RestProfile::remove_profile(
     throw RestProfileException("Failed to remove profile; $HOME is not set.");
   }
 
-  if (profile_dir.back() != '/') {
-    profile_dir += '/';
-  }
+  profile_dir = ensure_trailing_slash(profile_dir);
 
   std::string filepath = profile_dir + constants::rest_profile_filename;
 

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -137,14 +137,14 @@ RestProfile::RestProfile(
   if (dir.has_value() && !dir.value().empty()) {
     dir_ = ensure_trailing_slash(dir.value());
   } else {
-    // We don't want to directly itneract with the home directory of the user,
+    // We don't want to directly interact with the home directory of the user,
     // so we create a folder in the user's home directory.
-    std::string home = home_directory();
-    if (home.empty()) {
+    std::string homedir = home_directory();
+    if (homedir.empty()) {
       throw RestProfileException(
           "Failed to create RestProfile; $HOME is not set.");
     }
-    dir_ = ensure_trailing_slash(home + constants::rest_profile_foldername);
+    dir_ = ensure_trailing_slash(homedir + constants::rest_profile_foldername);
   }
   filepath_ = dir_ + constants::rest_profile_filename;
 };
@@ -250,14 +250,19 @@ void RestProfile::remove_profile(
     const std::optional<std::string>& name,
     const std::optional<std::string>& dir) {
   std::string profile_name = name.value_or(RestProfile::DEFAULT_PROFILE_NAME);
-  std::string profile_dir =
-      dir.value_or(home_directory() + constants::rest_profile_foldername + "/");
+  std::string profile_dir;
 
-  if (profile_dir.empty()) {
-    throw RestProfileException("Failed to remove profile; $HOME is not set.");
+  if (dir.has_value() && !dir.value().empty()) {
+    profile_dir = ensure_trailing_slash(dir.value());
+  } else {
+    std::string homedir = home_directory();
+    if (homedir.empty()) {
+      throw RestProfileException(
+          "Failed to create RestProfile; $HOME is not set.");
+    }
+    profile_dir =
+        ensure_trailing_slash(homedir + constants::rest_profile_foldername);
   }
-
-  profile_dir = ensure_trailing_slash(profile_dir);
 
   std::string filepath = profile_dir + constants::rest_profile_filename;
 

--- a/tiledb/sm/rest/rest_profile.h
+++ b/tiledb/sm/rest/rest_profile.h
@@ -91,21 +91,14 @@ class RestProfile {
   /**
    * Constructor.
    *
-   * @param name The name of the RestProfile. Defaulted to "default".
-   */
-  RestProfile(const std::string& name = RestProfile::DEFAULT_PROFILE_NAME);
-
-  /**
-   * Constructor.
-   *
    * @param name The name of the RestProfile. If `std::nullopt`, the default
    * name is used.
    * @param dir The path to the local file that stores all profiles. If
    * `std::nullopt`, the home directory is used.
    */
   RestProfile(
-      const std::optional<std::string>& name,
-      const std::optional<std::string>& dir);
+      const std::optional<std::string>& name = std::nullopt,
+      const std::optional<std::string>& dir = std::nullopt);
 
   /** Destructor. */
   ~RestProfile() = default;

--- a/tiledb/sm/rest/rest_profile.h
+++ b/tiledb/sm/rest/rest_profile.h
@@ -165,8 +165,16 @@ class RestProfile {
    */
   void load_from_file();
 
-  /** Removes this profile from the local file. */
-  void remove_from_file();
+  /**
+   * Removes the profile with the given name from profiles file of the given
+   * directory.
+   *
+   * @param name The name of the profile to remove.
+   * @param dir The path that store the profiles file.
+   */
+  static void remove_profile(
+      const std::optional<std::string>& name = std::nullopt,
+      const std::optional<std::string>& dir = std::nullopt);
 
   /**
    * Exports this profile's parameters and their values to a json object.
@@ -193,6 +201,15 @@ class RestProfile {
    * @param filepath The path of the file to load.
    */
   void load_from_json_file(const std::string& filepath);
+
+  /**
+   * Helper function to remove a profile from the profiles file.
+   *
+   * @param name The name of the profile to remove.
+   * @param filepath The path to the local file that stores all profiles.
+   */
+  static void remove_profile_from_file(
+      const std::string& name, const std::string& filepath);
 
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */

--- a/tiledb/sm/rest/rest_profile.h
+++ b/tiledb/sm/rest/rest_profile.h
@@ -63,22 +63,22 @@ class RestProfile {
   /*       PARAMETER DEFAULTS       */
   /* ****************************** */
 
-  /** The user's REST password. */
+  /** The default REST password of a RestProfile. */
   static const std::string DEFAULT_PASSWORD;
 
-  /** The namespace that should be charged for the request. */
+  /** The default namespace that should be charged for the request. */
   static const std::string DEFAULT_PAYER_NAMESPACE;
 
   /** The default name of a RestProfile. */
   static const std::string DEFAULT_PROFILE_NAME;
 
-  /** The user's REST token. */
+  /** The default REST token of a RestProfile. */
   static const std::string DEFAULT_TOKEN;
 
-  /** The default address for REST server. */
+  /** The default REST server address of a RestProfile. */
   static const std::string DEFAULT_SERVER_ADDRESS;
 
-  /** The user's REST username. */
+  /** The default REST username of a RestProfile. */
   static const std::string DEFAULT_USERNAME;
 
   /** A vector of the REST parameters that can be set. */
@@ -93,7 +93,7 @@ class RestProfile {
    *
    * @param name The name of the RestProfile. If `std::nullopt`, the default
    * name is used.
-   * @param dir The path to the local file that stores all profiles. If
+   * @param dir The directory path that the profile will be stored. If
    * `std::nullopt`, the home directory is used.
    */
   RestProfile(
@@ -117,9 +117,9 @@ class RestProfile {
   }
 
   /**
-   * Returns the path to the local file that stores all profiles.
+   * Returns the directory path that stores the profiles file.
    *
-   * @return std::string The path to the local file that stores all profiles.
+   * @return std::string The directory path that stores the profiles file.
    */
   inline const std::string& dir() const {
     return dir_;
@@ -169,8 +169,10 @@ class RestProfile {
    * Removes the profile with the given name from profiles file of the given
    * directory.
    *
-   * @param name The name of the profile to remove.
-   * @param dir The path that store the profiles file.
+   * @param name The name of the profile to remove. If `std::nullopt`, the
+   * default name is used.
+   * @param dir The directory path that contains the profiles file. If
+   * `std::nullopt`, the home directory is used.
    */
   static void remove_profile(
       const std::optional<std::string>& name = std::nullopt,
@@ -206,7 +208,7 @@ class RestProfile {
    * Helper function to remove a profile from the profiles file.
    *
    * @param name The name of the profile to remove.
-   * @param filepath The path to the local file that stores all profiles.
+   * @param filepath The directory path that contains the profiles file.
    */
   static void remove_profile_from_file(
       const std::string& name, const std::string& filepath);
@@ -221,10 +223,10 @@ class RestProfile {
   /** The name of this RestProfile. */
   std::string name_;
 
-  /** The path that contains the local file with all profiles. */
+  /** The directory path that stores the profiles file. */
   std::string dir_;
 
-  /** The path to the local file which stores all profiles. */
+  /** The path to the file that stores the profiles. */
   std::string filepath_;
 
   /** Stores a map of <param, value> for the set-parameters. */

--- a/tiledb/sm/rest/rest_profile.h
+++ b/tiledb/sm/rest/rest_profile.h
@@ -93,7 +93,7 @@ class RestProfile {
    *
    * @param name The name of the RestProfile. If `std::nullopt`, the default
    * name is used.
-   * @param dir The directory path that the profile will be stored. If
+   * @param dir The directory path on which the profile will be stored. If
    * `std::nullopt`, the home directory is used.
    */
   RestProfile(

--- a/tiledb/sm/rest/test/unit_rest_profile.cc
+++ b/tiledb/sm/rest/test/unit_rest_profile.cc
@@ -58,9 +58,9 @@ struct RestProfileFx {
 
   RestProfileFx()
       : dir_(TemporaryLocalDirectory("unit_rest_profile").path())
-      , cloudpath_(dir_ + ".tiledb/cloud.json") {
-    // Fstream cannot create directories, only files, so create the .tiledb dir.
-    std::filesystem::create_directories(dir_ + ".tiledb");
+      , cloudpath_(dir_ + "cloud.json") {
+    // Fstream cannot create directories, only files, so create the dir.
+    std::filesystem::create_directories(dir_);
 
     // Write to the cloud path.
     json j = {
@@ -134,8 +134,8 @@ TEST_CASE_METHOD(
     RestProfileFx,
     "REST Profile: Default profile, empty directory",
     "[rest_profile][default][empty_directory]") {
-  // Remove the .tiledb directory to ensure the cloud.json file isn't inherited.
-  std::filesystem::remove_all(dir_ + ".tiledb");
+  // Remove the dir_ to ensure the cloud.json file isn't inherited.
+  std::filesystem::remove_all(dir_);
 
   // Create and validate a default RestProfile.
   RestProfile profile(create_profile());
@@ -160,7 +160,7 @@ TEST_CASE_METHOD(
     "[rest_profile][save][remove]") {
   // Create a default RestProfile.
   RestProfile p(create_profile());
-  std::string filepath = dir_ + ".tiledb/profiles.json";
+  std::string filepath = dir_ + "profiles.json";
   CHECK(profile_from_file_to_json(filepath, std::string(p.name())).empty());
 
   // Validate.
@@ -171,7 +171,7 @@ TEST_CASE_METHOD(
   CHECK(!profile_from_file_to_json(filepath, std::string(p.name())).empty());
 
   // Remove the profile and validate that the local json object is removed.
-  p.remove_from_file();
+  RestProfile::remove_profile(std::nullopt, dir_);
   CHECK(profile_from_file_to_json(filepath, std::string(p.name())).empty());
 }
 
@@ -289,7 +289,7 @@ TEST_CASE_METHOD(
       Catch::Matchers::Equals("RestProfile: Failed to save 'default'; This "
                               "profile has already been saved and must be "
                               "explicitly removed in order to be replaced."));
-  p.remove_from_file();
+  RestProfile::remove_profile(std::nullopt, dir_);
   p2.save_to_file();
   e.token = token;
   CHECK(is_expected(p2, e));


### PR DESCRIPTION
This PR is intended to be the final Profile-related update before the first release that includes the Profile feature. It includes the following changes:
- Addresses the comment in https://github.com/TileDB-Inc/TileDB/pull/5498#discussion_r2116503423 regarding the use of the `.tiledb` path extension: it is now only appended to the default path (homedir). If the user provides a custom path, nothing is appended.
- Removes the constructor of the `RestProfile` class that accepts only the profile name, by assigning default values to the parameters of the other constructor. This simplifies the overall logic.
- Makes the internal profile removal function, as well as the C++ API, static. This better aligns with the intended use cases of the feature, as Profiles are rarely created, and it is not logical to require users to create a Profile object just to remove a profile from disk.
- Adds a C++ example demonstrating the expected usage of Profiles.

Closes CORE-235

---
TYPE: IMPROVEMENT
DESC: Finalize Profile feature and add example.