### PR TITLE
chore: add memory tracker `passert_failure` callback to dump memory info to `stderr` if destructor assertion fails

### DIFF
--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1957,6 +1957,25 @@ TEST_CASE_METHOD(
         TILEDB_ROW_MAJOR, TILEDB_ROW_MAJOR, 4, 100, 32, 6, false);
   }
 
+  SECTION("Shrinking") {
+    Subarray2DType<int, int> subarray = {std::make_pair(
+        std::optional<templates::Domain<int>>{templates::Domain<int>(44, 49)},
+        std::optional<templates::Domain<int>>{templates::Domain<int>(9, 24)})};
+    int value = 58;
+    tdb_unique_ptr<tiledb::sm::ASTNode> qc(new tiledb::sm::ASTNodeVal(
+        "d1", &value, sizeof(int), tiledb::sm::QueryConditionOp::LT));
+    doit.operator()<tiledb::test::AsserterCatch>(
+        TILEDB_COL_MAJOR,
+        TILEDB_ROW_MAJOR,
+        3,
+        72,
+        120,
+        5,
+        true,
+        subarray,
+        std::move(qc));
+  }
+
   SECTION("Rapidcheck") {
     rc::prop("rapidcheck out-of-order MBRs", [doit](bool allow_dups) {
       const auto tile_order =

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -1320,8 +1320,9 @@ struct PAssertFailureCallbackShowRapidcheckInput {
   }
 
   void operator()() const {
-    std::cerr << "Last rapidcheck input: ";
+    std::cerr << "LAST RAPIDCHECK INPUT:" << std::endl;
     rc::show<decltype(inputs_)>(inputs_, std::cerr);
+    std::cerr << std::endl;
   }
 };
 


### PR DESCRIPTION
We are occasionally seeing the following failure in CI:
```
106: FATAL TileDB core library internal error: total_counter_.fetch_add(0) == 0 && "MemoryTracker destructed with outstanding allocations."
106:   tiledb/common/memory_tracker.cc:192
```
This assert failing indicates that we have some memory resource which is allocating memory but not freeing it.  However, we receive no guidance as to what entity might be responsible for that.

This pull request adds a `passert_failure` callback which dumps the memory tracker state to `stderr` if this assertion fails.  This way we will have a little more information the next time it fails.

Here's an example output from this assertion failing in a rapidcheck test:
```
FATAL TileDB core library internal error: total_counter_.fetch_add(0) == 0 && "MemoryTracker destructed with outstanding allocations."
  tiledb/common/memory_tracker.cc:192
LAST RAPIDCHECK INPUT:
(200, 8, 2, [], ???
)
MEMORY REPORT:
{"by_type":{"FilteredData":0,"FilteredDataBlock":0,"ParallelMergeControl":0,"QueryCondition":0,"ResultTileBitmap":0,"TileData":0,"TileHilbertValues":0},"total_memory":1,"tracker_id":"23","tracker_type":"QueryRead"}
```

---
TYPE: NO_HISTORY
DESC: Add callback to print memory tracker info if its destructor assert fails