### PR TITLE
fix: `assert` object library uses `spdlog::spdlog` instead of `fmt::fmt`

### DIFF
--- a/tiledb/common/CMakeLists.txt
+++ b/tiledb/common/CMakeLists.txt
@@ -60,8 +60,8 @@ set(TILEDB_COMMON_SOURCES ${COMMON_SOURCES} PARENT_SCOPE)
 commence(object_library assert)
     this_target_sources(assert.cc)
     # can be removed when c++20 `<format>` is consistently supported
-    find_package(fmt REQUIRED)
-    target_link_libraries(assert PUBLIC fmt::fmt)
+    find_package(spdlog REQUIRED)
+    target_link_libraries(assert PUBLIC spdlog::spdlog)
 conclude(object_library)
 
 #

--- a/tiledb/common/assert.h
+++ b/tiledb/common/assert.h
@@ -86,7 +86,7 @@
 #ifndef TILEDB_ASSERT_H
 #define TILEDB_ASSERT_H
 
-#include <fmt/format.h>
+#include <spdlog/fmt/fmt.h>
 #include <cstdlib>
 #include <functional>
 #include <iostream>


### PR DESCRIPTION
Resolves #5534 which points out that use of `fmt::fmt` brings in an additional dependency which may conflict with `spdlog::spdlog`.

---
TYPE: NO_HISTORY
DESC: `assert` object library uses `spdlog::spdlog` instead of `fmt::fmt`
