### PR TITLE
Expose `operator<<` overloads for the `CurrentDomain` and `NDRectangle` C and CPP APIs.

### DIFF
--- a/test/src/test-cppapi-current-domain.cc
+++ b/test/src/test-cppapi-current-domain.cc
@@ -741,3 +741,31 @@ TEST_CASE_METHOD(
     vfs.remove_dir(array_name);
   }
 }
+
+TEST_CASE(
+    "C++ API: CurrentDomain - Dump", "[cppapi][ArraySchema][currentDomain]") {
+  tiledb::Context ctx;
+  // Create domain
+  tiledb::Domain domain(ctx);
+  auto d1 = tiledb::Dimension::create<int32_t>(ctx, "x", {{0, 100}}, 10);
+  auto d2 = tiledb::Dimension::create<int32_t>(ctx, "y", {{0, 100}}, 10);
+  domain.add_dimension(d1);
+  domain.add_dimension(d2);
+  // Create an NDRectangle and set ranges
+  tiledb::NDRectangle ndrect(ctx, domain);
+  int range_one[] = {10, 20};
+  int range_two[] = {30, 40};
+  ndrect.set_range(0, range_one[0], range_one[1]);
+  ndrect.set_range(1, range_two[0], range_two[1]);
+  // Create a currentDomain and set the NDRectangle
+  tiledb::CurrentDomain cdn(ctx);
+  cdn.set_ndrectangle(ndrect);
+
+  // Check that operator<< works correctly
+  std::stringstream ss;
+  ss << cdn;
+  CHECK(ss.str().find("### Current domain ###") != std::string::npos);
+  CHECK(ss.str().find("Version:") != std::string::npos);
+  CHECK(ss.str().find("Empty: 0") != std::string::npos);
+  CHECK(ss.str().find("Type: NDRECTANGLE") != std::string::npos);
+}

--- a/test/src/test-cppapi-ndrectangle.cc
+++ b/test/src/test-cppapi-ndrectangle.cc
@@ -98,3 +98,29 @@ TEST_CASE("NDRectangle - Errors", "[cppapi][ArraySchema][NDRectangle]") {
   CHECK_THROWS(ndrect.set_range(0, 2, 1));
   CHECK_THROWS(ndrect.set_range("d2", "bbb", "aaa"));
 }
+
+TEST_CASE("NDRectangle - Dump", "[cppapi][ArraySchema][NDRectangle]") {
+  tiledb::Context ctx;
+
+  // Create a domain
+  tiledb::Domain domain(ctx);
+  auto d1 = tiledb::Dimension::create<int32_t>(ctx, "d1", {{1, 10}}, 5);
+  auto d2 = tiledb::Dimension::create(
+      ctx, "d2", TILEDB_STRING_ASCII, nullptr, nullptr);
+  domain.add_dimension(d1);
+  domain.add_dimension(d2);
+
+  // Create an NDRectangle
+  tiledb::NDRectangle ndrect(ctx, domain);
+
+  // Set ranges
+  ndrect.set_range(0, 1, 5);
+  ndrect.set_range("d2", "aaa", "zzz");
+
+  // Check that operator<< works correctly
+  std::stringstream ss;
+  ss << ndrect;
+  CHECK(ss.str().find("NDRectangle") != std::string::npos);
+  CHECK(ss.str().find("[1, 5]") != std::string::npos);
+  CHECK(ss.str().find("[aaa, zzz]") != std::string::npos);
+}

--- a/tiledb/api/c_api/current_domain/current_domain_api.cc
+++ b/tiledb/api/c_api/current_domain/current_domain_api.cc
@@ -30,6 +30,7 @@
  * This file defines the current domain C API of TileDB.
  **/
 
+#include "../string/string_api_internal.h"
 #include "current_domain_api_external_experimental.h"
 #include "current_domain_api_internal.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
@@ -104,6 +105,17 @@ capi_return_t tiledb_current_domain_get_type(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_current_domain_dump_str(
+    tiledb_current_domain_t* current_domain, tiledb_string_handle_t** out) {
+  ensure_handle_is_valid(current_domain);
+  ensure_output_pointer_is_valid(out);
+
+  std::stringstream ss;
+  ss << *(current_domain->current_domain());
+  *out = tiledb_string_handle_t::make_handle(ss.str());
+  return TILEDB_OK;
+}
+
 }  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
@@ -157,4 +169,13 @@ CAPI_INTERFACE(
     tiledb_current_domain_type_t* type) {
   return api_entry_context<tiledb::api::tiledb_current_domain_get_type>(
       ctx, current_domain, type);
+}
+
+CAPI_INTERFACE(
+    current_domain_dump_str,
+    tiledb_ctx_t* ctx,
+    tiledb_current_domain_t* current_domain,
+    tiledb_string_handle_t** out) {
+  return api_entry_context<tiledb::api::tiledb_current_domain_dump_str>(
+      ctx, current_domain, out);
 }

--- a/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h
+++ b/tiledb/api/c_api/current_domain/current_domain_api_external_experimental.h
@@ -34,6 +34,7 @@
 #ifndef TILEDB_CAPI_CURRENT_DOMAIN_API_EXTERNAL_EXPERIMENTAL_H
 #define TILEDB_CAPI_CURRENT_DOMAIN_API_EXTERNAL_EXPERIMENTAL_H
 
+#include "../string/string_api_external.h"
 #include "tiledb/api/c_api/api_external_common.h"
 #include "tiledb/api/c_api/context/context_api_external.h"
 #include "tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h"
@@ -185,6 +186,31 @@ TILEDB_EXPORT capi_return_t tiledb_current_domain_get_type(
     tiledb_ctx_t* ctx,
     tiledb_current_domain_t* current_domain,
     tiledb_current_domain_type_t* type) TILEDB_NOEXCEPT;
+
+/**
+ * Dumps the contents of a current domain in ASCII form to the selected string
+ * output.
+ *
+ * The output string handle must be freed by the user after use.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_string_t* tdb_string;
+ * tiledb_current_domain_dump_str(ctx, current_domain, &tdb_string);
+ * // Use the string
+ * tiledb_string_free(&tdb_string);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param current_domain The current domain.
+ * @param out The output string.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_current_domain_dump_str(
+    tiledb_ctx_t* ctx,
+    tiledb_current_domain_t* current_domain,
+    tiledb_string_t** out) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/tiledb/api/c_api/current_domain/test/unit_capi_current_domain.cc
+++ b/tiledb/api/c_api/current_domain/test/unit_capi_current_domain.cc
@@ -169,3 +169,27 @@ TEST_CASE_METHOD(
   tiledb_ndrectangle_free(&ndr);
   tiledb_current_domain_free(&crd);
 }
+
+TEST_CASE_METHOD(
+    CAPICurrentDomainFx,
+    "C API: current_domain: dump_str",
+    "[capi][current_domain][dump_str]") {
+  tiledb_current_domain_t* crd = nullptr;
+  REQUIRE(tiledb_current_domain_create(ctx, &crd) == TILEDB_OK);
+
+  tiledb_string_t* str = nullptr;
+  REQUIRE(tiledb_current_domain_dump_str(ctx, crd, &str) == TILEDB_OK);
+  REQUIRE(str != nullptr);
+
+  const char* c_str = nullptr;
+  size_t len = 0;
+  REQUIRE(tiledb_string_view(str, &c_str, &len) == TILEDB_OK);
+  REQUIRE(c_str != nullptr);
+  REQUIRE(len > 0);
+
+  std::string output(c_str, len);
+  CHECK(output.find("### Current domain ###") != std::string::npos);
+
+  tiledb_string_free(&str);
+  tiledb_current_domain_free(&crd);
+}

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api.cc
@@ -30,6 +30,7 @@
  * This file defines the NDRectangle C API of TileDB.
  **/
 
+#include "../string/string_api_internal.h"
 #include "ndrectangle_api_external_experimental.h"
 #include "ndrectangle_api_internal.h"
 #include "tiledb/api/c_api/context/context_api_internal.h"
@@ -202,6 +203,17 @@ capi_return_t tiledb_ndrectangle_get_dim_num(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_ndrectangle_dump_str(
+    tiledb_ndrectangle_t* ndr, tiledb_string_handle_t** out) {
+  ensure_handle_is_valid(ndr);
+  ensure_output_pointer_is_valid(out);
+
+  std::stringstream ss;
+  ss << *(ndr->ndrectangle());
+  *out = tiledb_string_handle_t::make_handle(ss.str());
+  return TILEDB_OK;
+}
+
 }  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
@@ -289,4 +301,13 @@ CAPI_INTERFACE(
     uint32_t* ndim) {
   return api_entry_with_context<tiledb::api::tiledb_ndrectangle_get_dim_num>(
       ctx, ndr, ndim);
+}
+
+CAPI_INTERFACE(
+    ndrectangle_dump_str,
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    tiledb_string_handle_t** out) {
+  return api_entry_context<tiledb::api::tiledb_ndrectangle_dump_str>(
+      ctx, ndr, out);
 }

--- a/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
+++ b/tiledb/api/c_api/ndrectangle/ndrectangle_api_external_experimental.h
@@ -34,6 +34,7 @@
 #ifndef TILEDB_CAPI_NDRECTANGLE_API_EXTERNAL_EXPERIMENTAL_H
 #define TILEDB_CAPI_NDRECTANGLE_API_EXTERNAL_EXPERIMENTAL_H
 
+#include "../string/string_api_external.h"
 #include "tiledb/api/c_api/api_external_common.h"
 #include "tiledb/api/c_api/context/context_api_external.h"
 #include "tiledb/api/c_api/domain/domain_api_external.h"
@@ -265,6 +266,31 @@ TILEDB_EXPORT capi_return_t tiledb_ndrectangle_get_dim_num(
     tiledb_ctx_t* ctx,
     tiledb_ndrectangle_t* ndr,
     uint32_t* ndim) TILEDB_NOEXCEPT;
+
+/**
+ * Dumps the contents of an ndrectangle in ASCII form to the selected string
+ * output.
+ *
+ * The output string handle must be freed by the user after use.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * tiledb_string_t* tdb_string;
+ * tiledb_ndrectangle_dump_str(ctx, ndr, &tdb_string);
+ * // Use the string
+ * tiledb_string_free(&tdb_string);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param ndr The ndrectangle.
+ * @param out The output string.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
+TILEDB_EXPORT capi_return_t tiledb_ndrectangle_dump_str(
+    tiledb_ctx_t* ctx,
+    tiledb_ndrectangle_t* ndr,
+    tiledb_string_t** out) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/tiledb/api/c_api/ndrectangle/test/unit_capi_ndrectangle.cc
+++ b/tiledb/api/c_api/ndrectangle/test/unit_capi_ndrectangle.cc
@@ -227,3 +227,27 @@ TEST_CASE_METHOD(
 
   REQUIRE(tiledb_ndrectangle_free(&ndr) == TILEDB_OK);
 }
+
+TEST_CASE_METHOD(
+    CAPINDRectangleFx,
+    "C API: ndrectangle: dump_str",
+    "[capi][ndrectangle][dump_str]") {
+  tiledb_ndrectangle_t* ndr = nullptr;
+  REQUIRE(tiledb_ndrectangle_alloc(ctx, domain_, &ndr) == TILEDB_OK);
+
+  tiledb_string_t* str = nullptr;
+  REQUIRE(tiledb_ndrectangle_dump_str(ctx, ndr, &str) == TILEDB_OK);
+  REQUIRE(str != nullptr);
+
+  const char* c_str = nullptr;
+  size_t len = 0;
+  REQUIRE(tiledb_string_view(str, &c_str, &len) == TILEDB_OK);
+  REQUIRE(c_str != nullptr);
+  REQUIRE(len > 0);
+
+  std::string output(c_str, len);
+  CHECK(output.find("NDRectangle ###") != std::string::npos);
+
+  tiledb_string_free(&str);
+  tiledb_ndrectangle_free(&ndr);
+}

--- a/tiledb/sm/cpp_api/current_domain.h
+++ b/tiledb/sm/cpp_api/current_domain.h
@@ -158,6 +158,11 @@ class CurrentDomain {
     return static_cast<bool>(ret);
   }
 
+  /** Returns the context that the current domain belongs to. */
+  const Context& context() const {
+    return ctx_;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -172,6 +177,20 @@ class CurrentDomain {
   /** An auxiliary deleter. */
   impl::Deleter deleter_;
 };
+
+/* ********************************* */
+/*               MISC                */
+/* ********************************* */
+
+/** Get a string representation of the current domain for an output stream. */
+inline std::ostream& operator<<(std::ostream& os, const CurrentDomain& cd) {
+  auto& ctx = cd.context();
+  tiledb_string_t* tdb_string;
+  ctx.handle_error(tiledb_current_domain_dump_str(
+      ctx.ptr().get(), cd.ptr().get(), &tdb_string));
+  os << impl::convert_to_string(&tdb_string).value();
+  return os;
+}
 
 }  // namespace tiledb
 

--- a/tiledb/sm/cpp_api/domain.h
+++ b/tiledb/sm/cpp_api/domain.h
@@ -112,7 +112,7 @@ class Domain {
   /*                API                */
   /* ********************************* */
 
-  /** Returns the context that the attribute belongs to. */
+  /** Returns the context that the domain belongs to. */
   const Context& context() const {
     return ctx_;
   }

--- a/tiledb/sm/cpp_api/ndrectangle.h
+++ b/tiledb/sm/cpp_api/ndrectangle.h
@@ -316,6 +316,11 @@ class NDRectangle {
     return ndim;
   }
 
+  /** Returns the context that the ndrectangle belongs to. */
+  const Context& context() const {
+    return ctx_;
+  }
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -373,6 +378,20 @@ inline std::array<std::string, 2> NDRectangle::range(unsigned dim_idx) {
   std::string end_str(static_cast<const char*>(range.max), range.max_size);
 
   return {std::move(start_str), std::move(end_str)};
+}
+
+/* ********************************* */
+/*               MISC                */
+/* ********************************* */
+
+/** Get a string representation of the ndrectangle for an output stream. */
+inline std::ostream& operator<<(std::ostream& os, const NDRectangle& ndr) {
+  auto& ctx = ndr.context();
+  tiledb_string_t* tdb_string;
+  ctx.handle_error(tiledb_ndrectangle_dump_str(
+      ctx.ptr().get(), ndr.ptr().get(), &tdb_string));
+  os << impl::convert_to_string(&tdb_string).value();
+  return os;
 }
 
 }  // namespace tiledb


### PR DESCRIPTION
This PR exposes the `operator<<` overloads for the `CurrentDomain` and `NDRectangle` C and C++ APIs. This change will simplify and unify the implementation of corresponding dump functions in the high-level APIs, as everything is now consolidated in the Core.

---
TYPE: C_API
DESC: Introduce `tiledb_current_domain_dump_str` and `tiledb_ndrectangle_dump_str`.

TYPE: CPP_API
DESC: Introduce `operator<<` overloads for the `CurrentDomain` and `NDRectangle`.