### PR TITLE
Use Config parameters instead of a Config setter to set a Profile on a Config object.

### DIFF
--- a/examples/cpp_api/profile.cc
+++ b/examples/cpp_api/profile.cc
@@ -34,7 +34,8 @@
  * should come from the profile. Finally, it will create an array using the
  * profile, and then remove the profile.
  *
- * @note This example is not running on CI since it requires serialization.
+ * @note This example is not running on CI since it requires access to a TileDB
+ * REST server.
  */
 
 #include <iostream>
@@ -53,7 +54,7 @@ void create_and_save_profile(const std::string& profile_name) {
 void print_config(const std::string& profile_name) {
   // Create a config object and set the profile to use.
   Config config;
-  config.set_profile(profile_name);
+  config["profile_name"] = profile_name;
 
   // Print the parameters of the config. They should come from the profile.
   std::cout << "Config parameters coming from profile " << profile_name << ":"
@@ -67,7 +68,7 @@ void print_config(const std::string& profile_name) {
 void create_array_with_profile(const std::string& profile_name) {
   // Create a config object and set the profile to use.
   Config config;
-  config.set_profile(profile_name);
+  config["profile_name"] = profile_name;
   // Create a context using the config
   Context ctx(config);
 

--- a/scripts/run-nix-examples.sh
+++ b/scripts/run-nix-examples.sh
@@ -37,7 +37,7 @@ do
   if [ "${example##*/}" == png_ingestion_webp.cc ]; then
     continue
   fi;
-  # Skip Profile example as it requires serialization
+  # Skip Profile example as it requires access to a TileDB REST server
   if [ "${example##*/}" == profile.cc ]; then
     continue
   fi;

--- a/tiledb/api/c_api/config/config_api.cc
+++ b/tiledb/api/c_api/config/config_api.cc
@@ -103,18 +103,6 @@ capi_return_t tiledb_config_save_to_file(
   return TILEDB_OK;
 }
 
-capi_return_t tiledb_config_set_profile(
-    tiledb_config_t* config, const char* name, const char* dir) {
-  ensure_config_is_valid(config);
-  std::optional<std::string> profile_name_opt =
-      (name == nullptr) ? std::nullopt : std::make_optional(std::string(name));
-  std::optional<std::string> profile_dir_opt =
-      (dir == nullptr) ? std::nullopt : std::make_optional(std::string(dir));
-  throw_if_not_ok(
-      config->config().set_profile(profile_name_opt, profile_dir_opt));
-  return TILEDB_OK;
-}
-
 capi_return_t tiledb_config_compare(
     tiledb_config_t* lhs, tiledb_config_t* rhs, uint8_t* equal) {
   ensure_config_is_valid(lhs);
@@ -244,16 +232,6 @@ CAPI_INTERFACE(
     tiledb_error_t** error) {
   return api_entry_error<tiledb::api::tiledb_config_save_to_file>(
       error, config, filename);
-}
-
-CAPI_INTERFACE(
-    config_set_profile,
-    tiledb_config_t* config,
-    const char* name,
-    const char* dir,
-    tiledb_error_t** error) {
-  return api_entry_error<tiledb::api::tiledb_config_set_profile>(
-      error, config, name, dir);
 }
 
 /*

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -697,6 +697,12 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  * - `config.logging_format` <br>
  *    The logging format configured (DEFAULT or JSON)
  *    **Default**: "DEFAULT"
+ * - `profile_name` <br>
+ *    The name of the Profile to be used for REST transactions. <br>
+ *    **Default**: ""
+ * - `profile_dir` <br>
+ *    The directory where the user profiles are stored. <br>
+ *    **Default**: ""
  * - `rest.server_address` <br>
  *    URL for REST server to use for remote arrays. <br>
  *    **Default**: "https://api.tiledb.com"

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -902,33 +902,6 @@ TILEDB_EXPORT capi_return_t tiledb_config_save_to_file(
     tiledb_error_t** error) TILEDB_NOEXCEPT;
 
 /**
- * Sets the profile to use for the current config object.
- * By default the config object uses the default profile stored in the
- * default location, if any. This API allows to set a named profile
- * instead or a profile stored in a different location that the home
- * directory.
- *
- * **Example:**
- *
- * @code{.c}
- * tiledb_error_t* error = NULL;
- * tiledb_config_set_profile(config, "my_profile", "/path/to/profile", &error);
- * @endcode
- *
- * @param config The config object.
- * @param name The name of the profile to set.
- * @param dir The directory of the profile to set.
- * @param error Error object returned upon error (`NULL` if there is
- *    no error).
- * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
- */
-TILEDB_EXPORT capi_return_t tiledb_config_set_profile(
-    tiledb_config_t* config,
-    const char* name,
-    const char* dir,
-    tiledb_error_t** error) TILEDB_NOEXCEPT;
-
-/**
  * Compares 2 configurations for equality
  *
  * **Example:**

--- a/tiledb/api/c_api/config/test/unit_capi_config.cc
+++ b/tiledb/api/c_api/config/test/unit_capi_config.cc
@@ -210,34 +210,6 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C API: tiledb_config_set_profile argument validation", "[capi][config]") {
-  ordinary_config x;
-  /*
-   * No "success" sections here; too much overhead to set up.
-   */
-  SECTION("both arguments set - but no such profile") {
-    auto rc{tiledb_config_set_profile(x.config, "foo", "bar", &x.error)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null profile name") {
-    auto rc{tiledb_config_set_profile(x.config, nullptr, "bar", &x.error)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null profile dir") {
-    auto rc{tiledb_config_set_profile(x.config, "foo", nullptr, &x.error)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null config") {
-    auto rc{tiledb_config_set_profile(nullptr, "foo", "bar", &x.error)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null error") {
-    auto rc{tiledb_config_set_profile(x.config, "foo", "bar", nullptr)};
-    CHECK(tiledb_status(rc) == TILEDB_INVALID_ERROR);
-  }
-}
-
-TEST_CASE(
     "C API: tiledb_config_compare argument validation", "[capi][config]") {
   ordinary_config x, y;  // Empty configurations are equal.
   uint8_t result;

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -636,6 +636,13 @@ Status Config::set(const std::string& param, const std::string& value) {
   param_values_[param] = value;
   set_params_.insert(param);
 
+  // We need to reset the profile load attempt flag in order to allow
+  // loading a new profile in case the user changes a profile-related parameter.
+  if (param.starts_with("profile")) {
+    rest_profile_load_attempted_ = false;
+    rest_profile_.reset();
+  }
+
   return Status::Ok();
 }
 
@@ -714,24 +721,6 @@ void Config::inherit(const Config& config) {
     passert(found);
     throw_if_not_ok(set(p, v));
   }
-}
-
-Status Config::set_profile(
-    const std::optional<std::string>& profile_name,
-    const std::optional<std::string>& profile_dir) {
-  try {
-    // Load the Profile
-    tiledb::sm::RestProfile loaded_profile =
-        RestProfile(profile_name, profile_dir);
-    loaded_profile.load_from_file();
-    // Set the profile
-    rest_profile_ = std::move(loaded_profile);
-  } catch (const RestProfileException& e) {
-    throw RestProfileException(
-        "Failed to load profile; " + std::string(e.what()));
-  }
-
-  return Status::Ok();
 }
 
 bool Config::operator==(const Config& rhs) const {
@@ -928,6 +917,53 @@ const char* Config::get_from_config(
   return *found ? it->second.c_str() : "";
 }
 
+const char* Config::get_from_profile(
+    const std::string& param, bool* found) const {
+  if (RestProfile::can_have_parameter(param)) {
+    // If there is no profile loaded yet and we have not attempted to load it,
+    // we try to load the configure specified profile.
+    if (!rest_profile_.has_value() && !rest_profile_load_attempted_) {
+      bool found_name = false;
+      const char* profile_name_cstr =
+          get_from_config_or_fallback("profile_name", &found_name);
+      std::optional<std::string> profile_name =
+          found_name ? std::make_optional(profile_name_cstr) : std::nullopt;
+      bool found_dir = false;
+      const char* profile_dir_cstr =
+          get_from_config_or_fallback("profile_dir", &found_dir);
+      std::optional<std::string> profile_dir =
+          found_dir ? std::make_optional(profile_dir_cstr) : std::nullopt;
+      try {
+        // Create a Profile object and load the profile
+        rest_profile_ = RestProfile(profile_name, profile_dir);
+        rest_profile_.value().load_from_file();
+      } catch (const std::exception&) {
+        // Throw an exception if the user has specified profile-related
+        // parameters but the profile could not be loaded.
+        if (profile_name.has_value() || profile_dir.has_value()) {
+          throw ConfigException(
+              "Failed to load the REST profile. "
+              "Please check the profile name and directory parameters.");
+        }
+        // Do not throw an exception for the default profile since this might
+        // not be intended by the user.
+        rest_profile_load_attempted_ = true;
+        rest_profile_.reset();
+      }
+    }
+    // If the profile was loaded successfully, try to get the parameter from it.
+    if (rest_profile_.has_value()) {
+      const std::string* value = rest_profile_.value().get_param(param);
+      if (value) {
+        *found = true;
+        return value->c_str();
+      }
+    }
+  }
+  *found = false;
+  return "";
+}
+
 const char* Config::get_from_config_or_fallback(
     const std::string& param, bool* found) const {
   // First check if the user has set the parameter
@@ -954,27 +990,10 @@ const char* Config::get_from_config_or_fallback(
     return value_env;
 
   // [3. profiles] -- only for rest.* params
-  if (RestProfile::can_have_parameter(param)) {
-    // If the there is no set profile and there was no previous attempt to
-    // load the default profile, attempt to load it.
-    if (!rest_profile_.has_value() && !default_rest_profile_not_found_) {
-      try {
-        // Create a Profile object and load the default profile
-        rest_profile_ = RestProfile();
-        rest_profile_.value().load_from_file();
-      } catch (const std::exception&) {
-        default_rest_profile_not_found_ = true;
-      }
-    }
-    // If the profile was loaded successfully, try to get the parameter from it.
-    if (rest_profile_.has_value()) {
-      const std::string* value = rest_profile_.value().get_param(param);
-      if (value) {
-        *found = true;
-        return value->c_str();
-      }
-    }
-  }
+  const char* value_profile = get_from_profile(param, found);
+  if (*found)
+    return value_profile;
+
   // [4. default config value]
   *found = found_config;
 

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -932,11 +932,13 @@ const char* Config::get_from_profile(
           get_from_config_or_fallback("profile_name", &found_name);
       std::optional<std::string> profile_name =
           found_name ? std::make_optional(profile_name_cstr) : std::nullopt;
+
       bool found_dir = false;
       const char* profile_dir_cstr =
           get_from_config_or_fallback("profile_dir", &found_dir);
       std::optional<std::string> profile_dir =
           found_dir ? std::make_optional(profile_dir_cstr) : std::nullopt;
+
       try {
         // Create a Profile object and load the profile
         rest_profile_ = RestProfile(profile_name, profile_dir);
@@ -944,7 +946,8 @@ const char* Config::get_from_profile(
       } catch (const std::exception&) {
         // Throw an exception if the user has specified profile-related
         // parameters but the profile could not be loaded.
-        if (profile_name.has_value() || profile_dir.has_value()) {
+        if ((profile_name.has_value() && !profile_name.value().empty()) ||
+            (profile_dir.has_value() && !profile_dir.value().empty())) {
           throw ConfigException(
               "Failed to load the REST profile. "
               "Please check the profile name and directory parameters.");

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -79,6 +79,8 @@ const std::string Config::CONFIG_LOGGING_LEVEL = "1";
 const std::string Config::CONFIG_LOGGING_LEVEL = "0";
 #endif
 const std::string Config::CONFIG_LOGGING_DEFAULT_FORMAT = "DEFAULT";
+const std::string Config::PROFILE_NAME = "";
+const std::string Config::PROFILE_DIR = "";
 const std::string Config::REST_SERVER_DEFAULT_ADDRESS =
     "https://api.tiledb.com";
 const std::string Config::REST_SERIALIZATION_DEFAULT_FORMAT = "CAPNP";
@@ -244,6 +246,8 @@ const std::string Config::VFS_S3_INSTALL_SIGPIPE_HANDLER = "true";
 const std::string Config::FILESTORE_BUFFER_SIZE = "104857600";
 
 const std::map<std::string, std::string> default_config_values = {
+    std::make_pair("profile_name", Config::PROFILE_NAME),
+    std::make_pair("profile_dir", Config::PROFILE_DIR),
     std::make_pair("rest.server_address", Config::REST_SERVER_DEFAULT_ADDRESS),
     std::make_pair(
         "rest.server_serialization_format",

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -746,18 +746,6 @@ class Config {
    */
   Status unset(const std::string& param);
 
-  /**
-   * Sets the profile to use for the config.
-   *
-   * @param profile_name The name of the profile to set.
-   * @param profile_dir The home directory of the profile to set.
-   *
-   * Throws ConfigException if the profile is not found.
-   */
-  Status set_profile(
-      const std::optional<std::string>& profile_name = std::nullopt,
-      const std::optional<std::string>& profile_dir = std::nullopt);
-
   /** Inherits the **set** parameters of the input `config`. */
   void inherit(const Config& config);
 
@@ -782,11 +770,11 @@ class Config {
   /** Stores the RestProfile loaded. */
   mutable std::optional<RestProfile> rest_profile_;
 
-  /** Stores whether the default REST profile was previously attempted
-   * to be fetched and failed. This is used to avoid repeatedly trying to
-   * fetch the default profile if it has failed once.
+  /**
+   * Indicates whether the REST profile, with the current configuration
+   * parameters, has previously been attempted to be fetched.
    */
-  mutable bool default_rest_profile_not_found_ = false;
+  mutable bool rest_profile_load_attempted_ = false;
 
   /* ********************************* */
   /*          PRIVATE CONSTANTS        */
@@ -834,12 +822,25 @@ class Config {
   const char* get_from_config(const std::string& param, bool* found) const;
 
   /**
+   * Get a parameter from Profile.
+   *
+   * @pre The profile to be parsed has been set using `profile_name` and
+   * `profile_dir` config parameters. Elsewise, the default profile is used if
+   * found.
+   *
+   * @param param parameter to fetch
+   * @param found pointer to bool to set if parameter was found or not
+   * @return parameter value if found or nullptr if not found
+   */
+  const char* get_from_profile(const std::string& param, bool* found) const;
+
+  /**
    * Get a configuration parameter from config object or a fallback
    * (environmental variables or profiles).
    *
    * @pre When using the third (profiles) fallback, the profile to be
-   * parsed has been set on the config using `set_profile`.
-   * Elsewise, the default profile is used if found.
+   * parsed has been set using `profile_name` and `profile_dir` config
+   * parameters. Elsewise, the default profile is used if found.
    *
    * The order we look for values are
    * 1. user-set config parameters

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -81,6 +81,12 @@ class Config {
   /*        CONFIG DEFAULTS         */
   /* ****************************** */
 
+  /** The default name for the profile. */
+  static const std::string PROFILE_NAME;
+
+  /** The default directory for profiles. */
+  static const std::string PROFILE_DIR;
+
   /** The default address for rest server. */
   static const std::string REST_SERVER_DEFAULT_ADDRESS;
 

--- a/tiledb/sm/config/test/unit_config.cc
+++ b/tiledb/sm/config/test/unit_config.cc
@@ -116,15 +116,15 @@ TEST_CASE("Config::get<std::string> - found and matched", "[config]") {
 }
 
 TEST_CASE("Config::set_profile - failures", "[config]") {
-  Config c{};
-  // Check that setting a profile without parameters throws an exception
-  CHECK_THROWS(c.set_profile());
-
   std::string profile_name = "test_profile";
-  tiledb::sm::TemporaryLocalDirectory tempdir_;
-  std::string profile_dir(tempdir_.path());
+  std::string profile_dir = "non_existent_directory";
+  Config c{};
+  CHECK(c.set("profile_name", profile_name).ok());
+  CHECK(c.set("profile_dir", profile_dir).ok());
+
   // Set a profile that does not exist. This will throw an exception.
-  CHECK_THROWS(c.set_profile(profile_name, profile_dir).ok());
+  bool found;
+  CHECK_THROWS(c.get("rest.server_address", &found));
 }
 
 TEST_CASE("Config::set_params - set and unset", "[config]") {
@@ -161,7 +161,8 @@ TEST_CASE("Config::set_profile - found", "[config]") {
   profile.save_to_file();
 
   // Set the profile in the config
-  CHECK(c.set_profile(profile_name, profile_dir).ok());
+  CHECK(c.set("profile_name", profile_name).ok());
+  CHECK(c.set("profile_dir", profile_dir).ok());
 
   // Check that the config has the profile's parameters
   bool found;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -237,28 +237,6 @@ class Config {
     impl::check_config_error(err);
   }
 
-  /**
-   * Sets the profile to use for the current config object.
-   *
-   * @param profile_name The name of the profile to use. If not provided,
-   *                     the default profile will be used.
-   * @param profile_dir The directory where the profile is located. If not
-   *                    provided, the home directory will be used.
-   */
-  void set_profile(
-      const std::optional<std::string>& profile_name = std::nullopt,
-      const std::optional<std::string>& profile_dir = std::nullopt) {
-    tiledb_error_t* err;
-
-    tiledb_config_set_profile(
-        config_.get(),
-        profile_name.has_value() ? profile_name->c_str() : nullptr,
-        profile_dir.has_value() ? profile_dir->c_str() : nullptr,
-        &err);
-
-    impl::check_config_error(err);
-  }
-
   /** Compares configs for equality. */
   bool operator==(const Config& rhs) const {
     uint8_t equal;

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -870,6 +870,12 @@ class Config {
    * - `config.logging_format` <br>
    *    The logging format configured (DEFAULT or JSON)
    *    **Default**: "DEFAULT"
+   * - `profile_name` <br>
+   *    The name of the Profile to be used for REST transactions. <br>
+   *    **Default**: ""
+   * - `profile_dir` <br>
+   *    The directory where the user profiles are stored. <br>
+   *    **Default**: ""
    * - `rest.server_address` <br>
    *    URL for REST server to use for remote arrays. <br>
    *    **Default**: "https://api.tiledb.com"


### PR DESCRIPTION
This PR removes the `Config::set_profile` method along with its corresponding C and C++ APIs, changing the logic so that users can specify a Profile directly on a Config object to retrieve its `rest.*` parameters. Instead of using the setter method, the new approach is to pass the Profile details as normal config parameters: `"profile_name"` and `"profile_dir"`.

The primary motivation for this change is to enable setting Profile details via environment variables as an alternative to configuring them through code. This approach leverages the existing behavior of `Config::get_from_config_or_fallback`, which reads environment variables and treats them as standard config parameters. As a result, users can now use the `TILEDB_PROFILE_NAME` and `TILEDB_PROFILE_DIR` environment variables, improving the overall user experience - especially for those who frequently switch/test across different internal clusters.

Closes CORE-235

---
TYPE: IMPROVEMENT | C_API | CPP_API
DESC: Use config parameters instead of a config setter to set a profile on a config object.
