### PR TITLE
Add missing build type to macos ASAN nightly

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -20,6 +20,7 @@ jobs:
           - os: macos-latest # ASAN build
             sanitizer: "address"
             assertions: ON
+            build_type: "Release"
             base_triplet: "arm64-osx"
           - os: macos-latest # Arbitrary job to run EXPERIMENTAL=ON
             build_type: Debug


### PR DESCRIPTION
This PR adds a missing build_type to our nightly MacOS ASAN job that was leading to [failure](https://github.com/TileDB-Inc/TileDB/actions/runs/15575190893/job/43858631376) in configuring the build.

---
TYPE: NO_HISTORY
DESC: Add missing build type to macos ASAN nightly