### PR TITLE
Update to use new routes for group creation.

### DIFF
--- a/tiledb/sm/filesystem/test/unit_uri.cc
+++ b/tiledb/sm/filesystem/test/unit_uri.cc
@@ -194,7 +194,7 @@ TEST_CASE(
     tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(true, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == arr);
+    REQUIRE(rest_components.asset_storage == arr);
   }
 }
 
@@ -212,7 +212,6 @@ TEST_CASE(
     tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == arr);
     REQUIRE(rest_components.asset_storage == "");
     REQUIRE(rest_components.server_path == arr);
 
@@ -220,7 +219,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == arr);
     REQUIRE(rest_components.asset_storage == "");
     REQUIRE(rest_components.server_path == arr);
 
@@ -228,7 +226,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == arr);
     REQUIRE(rest_components.asset_storage == "");
     REQUIRE(rest_components.server_path == arr);
 
@@ -236,7 +233,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "array_name");
     REQUIRE(rest_components.asset_storage == "");
     REQUIRE(rest_components.server_path == "fld01/array_name");
 
@@ -244,7 +240,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "array_name");
     REQUIRE(rest_components.asset_storage == "");
     REQUIRE(rest_components.server_path == "fld01/fld02/array_name");
 
@@ -252,7 +247,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "array name");
     REQUIRE(rest_components.asset_storage == "");
     REQUIRE(rest_components.server_path == "fld-01/fld 02/array name");
   }
@@ -262,7 +256,6 @@ TEST_CASE(
     tiledb::sm::URI uri("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "array_name");
     REQUIRE(rest_components.asset_storage == "s3://bucket/arrays/array_name");
     REQUIRE(rest_components.server_path == "array_name");
 
@@ -270,7 +263,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "a");
     REQUIRE(rest_components.asset_storage == "s3://b/a");
     REQUIRE(rest_components.server_path == "a");
 
@@ -278,7 +270,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "array_name");
     REQUIRE(rest_components.asset_storage == "s3://bucket/arrays/array_name");
     REQUIRE(rest_components.server_path == "fld01/fld02/array_name");
 
@@ -286,7 +277,6 @@ TEST_CASE(
     uri = tiledb::sm::URI("tiledb://" + ns + "/" + arr);
     REQUIRE(uri.get_rest_components(false, &rest_components).ok());
     REQUIRE(rest_components.server_namespace == ns);
-    REQUIRE(rest_components.asset_name == "array_name");
     REQUIRE(rest_components.asset_storage == "gs://bucket/array_name");
     REQUIRE(rest_components.server_path == "fld01/array_name");
   }

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -274,8 +274,8 @@ Status URI::get_rest_components(
     }
     rest_components->server_namespace =
         uri_.substr(prefix.size(), namespace_len);
-    rest_components->asset_name = uri_.substr(slash + 1, array_len);
-    rest_components->server_path = rest_components->asset_name;
+    rest_components->asset_storage = uri_.substr(slash + 1, array_len);
+    rest_components->server_path = rest_components->asset_storage;
   } else {
     // Extract '<workspace>/<teamspace>' if we are talking to TileDB-Server.
 
@@ -299,7 +299,7 @@ Status URI::get_rest_components(
     std::string ws = uri_.substr(prefix.size(), ws_len);
     std::string ts = uri_.substr(ws_slash + 1, ts_len);
     rest_components->server_namespace = ws + "/" + ts;
-    rest_components->asset_name = last_path_part();
+    auto asset_name = last_path_part();
 
     auto storage_component_index = get_storage_component_index(ts_slash + 1);
     if (!storage_component_index.has_value()) {
@@ -315,7 +315,7 @@ Status URI::get_rest_components(
       rest_components->server_path =
           uri_.substr(
               ts_slash + 1, storage_component_index.value() - ts_slash - 1) +
-          rest_components->asset_name;
+          asset_name;
     }
   }
 

--- a/tiledb/sm/filesystem/uri.h
+++ b/tiledb/sm/filesystem/uri.h
@@ -61,9 +61,7 @@ class URI {
   struct RESTURIComponents {
     /* The namespace of the input URI */
     std::string server_namespace;
-    /* The name of the asset */
-    std::string asset_name;
-    /* The hierarchical path in TileDB Server of the asset */
+    /* The path in TileDB Server of the asset */
     std::string server_path;
     /* The storage path backing this asset */
     std::string asset_storage;

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -285,9 +285,8 @@ RestClientRemote::post_array_schema_from_rest(
 }
 
 Status RestClientRemote::post_array_schema_to_rest(
-    // This method called on Array create
-    const URI& uri,
-    const ArraySchema& array_schema) {
+    const URI& uri, const ArraySchema& array_schema) {
+  // This method is called on Array create
   BufferList serialized{memory_tracker_};
   auto& buff = serialized.emplace_buffer();
   RETURN_NOT_OK(serialization::array_schema_serialize(

--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -337,12 +337,7 @@ Status group_create_details_to_capnp(
   if (group_uri.is_tiledb()) {
     URI::RESTURIComponents rest_uri;
     RETURN_NOT_OK(group->group_uri().get_rest_components(legacy, &rest_uri));
-    if (legacy) {
-      group_create_details_builder->setUri(rest_uri.asset_name);
-    } else {
-      group_create_details_builder->setUri(rest_uri.asset_storage);
-    }
-
+    group_create_details_builder->setUri(rest_uri.asset_storage);
   } else {
     group_create_details_builder->setUri(group_uri.to_string());
   }


### PR DESCRIPTION
Recently the route for group creation was updated from `{workspace}/{teamspace} POST` to `{workspace}/{teamspace}/{group} POST`. This updates `post_group_create_to_rest` to call the new endpoint if we are not communicating with a legacy REST server.

It also updates two group routes that were moved under `/contents` for the new server.

---
TYPE: BUG
DESC: Update to use new route for group creation.