### PR TITLE
URL encode workspace and teamspace for REST URIs.

### DIFF
--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -154,7 +154,8 @@ std::string vfs_array_uri(
   if (fs->is_rest() && legacy) {
     return "tiledb://unit/" + array_name;
   } else if (fs->is_rest() && !legacy) {
-    return "tiledb://workspace/unit/" + array_name;
+    // Include a space in the URI to test URL encoding.
+    return "tiledb://unit workspace/unit teamspace/" + array_name;
   } else {
     return array_name;
   }

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -864,7 +864,8 @@ struct VFSTestSetup {
     if (is_legacy_rest()) {
       return "tiledb://unit/" + temp_dir + array_name;
     } else {
-      return "tiledb://workspace/unit/" + temp_dir + array_name;
+      // Include a space in the URI to test URL encoding.
+      return "tiledb://unit workspace/unit teamspace/" + temp_dir + array_name;
     }
   }
 

--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -331,6 +331,26 @@ std::string Curl::url_escape(const std::string& url) const {
   return escaped;
 }
 
+std::string Curl::url_escape_namespace(const std::string& ns) const {
+  if (curl_.get() == nullptr) {
+    return "";
+  }
+
+  // If the namespace contains a path seperator we are talking to 3.0 REST.
+  auto separator = ns.find('/');
+  if (separator != std::string::npos) {
+    // Encode workspace and teamspace, preserving the path separator.
+    std::string workspace, teamspace;
+    workspace = ns.substr(0, separator);
+    teamspace = ns.substr(separator + 1, ns.size() - 1);
+    return url_escape(workspace) + "/" + url_escape(teamspace);
+  } else {
+    // Legacy namespaces can only contain letters, numbers, and `-`. Encoding
+    // this would be a noop so we can return as-is.
+    return ns;
+  }
+}
+
 Status Curl::set_headers(struct curl_slist** headers) const {
   CURL* curl = curl_.get();
   if (curl == nullptr)

--- a/tiledb/sm/rest/curl.h
+++ b/tiledb/sm/rest/curl.h
@@ -193,6 +193,18 @@ class Curl {
   std::string url_escape(const std::string& url) const;
 
   /**
+   * Escapes the given namespace REST component.
+   * For REST 3.0 we escape the workspace and teamspace components, preserving
+   * the path seperator between them.
+   * Legacy REST namespace will be returned as-is, since naming requirements
+   * disallows using characters that require URL encoding.
+   *
+   * @param ns The namespace or workspace/teamspace to escape.
+   * @return Escaped namespace component.
+   */
+  std::string url_escape_namespace(const std::string& ns) const;
+
+  /**
    * Wrapper for sending patch request to server and returning
    * the unbuffered response body.
    *

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -129,8 +129,9 @@ RestClientRemote::check_array_exists_from_rest(const URI& uri) {
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
       nullopt);
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri);
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri);
 
   // Make the request, the return data is ignored
   Buffer returned_data;
@@ -168,8 +169,9 @@ RestClientRemote::check_group_exists_from_rest(const URI& uri) {
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
       nullopt);
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
-                          "/" + curlc.url_escape(group_uri);
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns) + "/" +
+                          curlc.url_escape(group_uri);
 
   // Make the request, the returned data is ignored for now.
   Buffer returned_data;
@@ -206,8 +208,9 @@ RestClientRemote::get_array_schema_from_rest(const URI& uri) {
   RETURN_NOT_OK_TUPLE(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_),
       nullopt);
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri);
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri);
 
   // Get the data
   Buffer returned_data;
@@ -250,8 +253,9 @@ RestClientRemote::post_array_schema_from_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/schema?" +
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/schema?" +
                           "start_timestamp=" + std::to_string(timestamp_start) +
                           "&end_timestamp=" + std::to_string(timestamp_end);
 
@@ -299,7 +303,8 @@ Status RestClientRemote::post_array_schema_to_rest(
   // side caching should start from then on.
   RETURN_NOT_OK(curlc.init(
       config_, extra_headers_, &redirect_meta_, &redirect_mtx_, false));
-  auto deduced_url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns + "/" +
+  auto deduced_url = redirect_uri(cache_key) + "/v1/arrays/" +
+                     curlc.url_escape_namespace(array_ns) + "/" +
                      curlc.url_escape(array_uri);
   Buffer returned_data;
   const Status sc = curlc.post_data(
@@ -331,7 +336,8 @@ void RestClientRemote::post_array_from_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  std::string url = redirect_uri(cache_key) + "/v2/arrays/" + array_ns + "/" +
+  std::string url = redirect_uri(cache_key) + "/v2/arrays/" +
+                    curlc.url_escape_namespace(array_ns) + "/" +
                     curlc.url_escape(array_uri) + "/?";
 
   // Remote array operations should provide start and end timestamps
@@ -365,8 +371,9 @@ void RestClientRemote::delete_array_from_rest(const URI& uri) {
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri);
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri);
 
   Buffer returned_data;
   throw_if_not_ok(curlc.delete_data(
@@ -395,9 +402,9 @@ void RestClientRemote::post_delete_fragments_to_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) +
-                          "/delete_fragments";
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/delete_fragments";
 
   Buffer returned_data;
   throw_if_not_ok(curlc.post_data(
@@ -424,8 +431,9 @@ void RestClientRemote::post_delete_fragments_list_to_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) +
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) +
                           "/delete_fragments_list";
 
   // Post query to rest
@@ -447,8 +455,9 @@ Status RestClientRemote::deregister_array_from_rest(const URI& uri) {
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/deregister";
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/deregister";
 
   Buffer returned_data;
   return curlc.delete_data(
@@ -472,9 +481,9 @@ Status RestClientRemote::get_array_non_empty_domain(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v2/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) +
-                          "/non_empty_domain?" +
+  const std::string url = redirect_uri(cache_key) + "/v2/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/non_empty_domain?" +
                           "start_timestamp=" + std::to_string(timestamp_start) +
                           "&end_timestamp=" + std::to_string(timestamp_end);
 
@@ -507,9 +516,9 @@ Status RestClientRemote::get_array_metadata_from_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) +
-                          "/array_metadata?" +
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/array_metadata?" +
                           "start_timestamp=" + std::to_string(timestamp_start) +
                           "&end_timestamp=" + std::to_string(timestamp_end);
 
@@ -548,9 +557,9 @@ Status RestClientRemote::post_array_metadata_to_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) +
-                          "/array_metadata?" +
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/array_metadata?" +
                           "start_timestamp=" + std::to_string(timestamp_start) +
                           "&end_timestamp=" + std::to_string(timestamp_end);
 
@@ -586,8 +595,9 @@ RestClientRemote::post_enumerations_from_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/enumerations?" +
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/enumerations?" +
                           "start_timestamp=" + std::to_string(timestamp_start) +
                           "&end_timestamp=" + std::to_string(timestamp_end);
 
@@ -633,11 +643,13 @@ void RestClientRemote::post_query_plan_from_rest(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   std::string url;
   if (use_refactored_query(query.config())) {
-    url = redirect_uri(cache_key) + "/v3/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v3/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/plan?type=" + query_type_str(query.type());
   } else {
-    url = redirect_uri(cache_key) + "/v2/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v2/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/plan?type=" + query_type_str(query.type());
   }
@@ -726,12 +738,14 @@ Status RestClientRemote::post_query_submit(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   std::string url;
   if (use_refactored_query(query->config())) {
-    url = redirect_uri(cache_key) + "/v3/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v3/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/submit?type=" + query_type_str(query->type()) +
           "&read_all=" + (resubmit_incomplete_ ? "true" : "false");
   } else {
-    url = redirect_uri(cache_key) + "/v2/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v2/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/submit?type=" + query_type_str(query->type()) +
           "&read_all=" + (resubmit_incomplete_ ? "true" : "false");
@@ -969,11 +983,13 @@ Status RestClientRemote::finalize_query_to_rest(const URI& uri, Query* query) {
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   std::string url;
   if (use_refactored_query(query->config())) {
-    url = redirect_uri(cache_key) + "/v3/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v3/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/finalize?type=" + query_type_str(query->type());
   } else {
-    url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v1/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/finalize?type=" + query_type_str(query->type());
   }
@@ -1029,11 +1045,13 @@ Status RestClientRemote::submit_and_finalize_query_to_rest(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   std::string url;
   if (use_refactored_query(query->config())) {
-    url = redirect_uri(cache_key) + "/v3/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v3/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/submit_and_finalize?type=" + query_type_str(query->type());
   } else {
-    url = redirect_uri(cache_key) + "/v2/arrays/" + array_ns + "/" +
+    url = redirect_uri(cache_key) + "/v2/arrays/" +
+          curlc.url_escape_namespace(array_ns) + "/" +
           curlc.url_escape(array_uri) +
           "/query/submit_and_finalize?type=" + query_type_str(query->type());
   }
@@ -1156,8 +1174,8 @@ Status RestClientRemote::get_query_est_result_sizes(
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   std::string url =
-      redirect_uri(cache_key) + "/v1/arrays/" + array_ns + "/" +
-      curlc.url_escape(array_uri) +
+      redirect_uri(cache_key) + "/v1/arrays/" +
+      curlc.url_escape_namespace(array_ns) + "/" + curlc.url_escape(array_uri) +
       "/query/est_result_sizes?type=" + query_type_str(query->type());
 
   // Remote array reads always supply the timestamp.
@@ -1206,7 +1224,8 @@ Status RestClientRemote::post_array_schema_evolution_to_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  auto deduced_url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns + "/" +
+  auto deduced_url = redirect_uri(cache_key) + "/v1/arrays/" +
+                     curlc.url_escape_namespace(array_ns) + "/" +
                      curlc.url_escape(array_uri) + "/evolve";
   Buffer returned_data;
   const Status sc = curlc.post_data(
@@ -1237,8 +1256,9 @@ Status RestClientRemote::post_fragment_info_from_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/fragment_info";
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/fragment_info";
 
   // Get the data
   Buffer returned_data;
@@ -1276,8 +1296,9 @@ Status RestClientRemote::post_group_metadata_from_rest(
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
-                          "/" + curlc.url_escape(group_uri) + "/metadata";
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns) + "/" +
+                          curlc.url_escape(group_uri) + "/metadata";
 
   // Get the data
   Buffer returned_data;
@@ -1319,8 +1340,9 @@ Status RestClientRemote::put_group_metadata_to_rest(
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
-                          "/" + curlc.url_escape(group_uri) + "/metadata";
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns) + "/" +
+                          curlc.url_escape(group_uri) + "/metadata";
 
   // Put the data
   Buffer returned_data;
@@ -1347,7 +1369,8 @@ Status RestClientRemote::post_group_create_to_rest(
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns;
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns);
 
   // Create the group and check for error
   Buffer returned_data;
@@ -1373,8 +1396,9 @@ Status RestClientRemote::post_group_from_rest(const URI& uri, Group* group) {
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
-                          "/" + curlc.url_escape(group_uri);
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns) + "/" +
+                          curlc.url_escape(group_uri);
 
   // Get the data
   Buffer returned_data;
@@ -1412,8 +1436,9 @@ Status RestClientRemote::patch_group_to_rest(const URI& uri, Group* group) {
   const std::string cache_key = group_ns + ":" + group_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
-                          "/" + curlc.url_escape(group_uri);
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns) + "/" +
+                          curlc.url_escape(group_uri);
 
   // Put the data
   Buffer returned_data;
@@ -1431,8 +1456,9 @@ void RestClientRemote::delete_group_from_rest(const URI& uri, bool recursive) {
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
   const std::string recursive_str = recursive ? "true" : "false";
-  const std::string url = redirect_uri(cache_key) + "/v2/groups/" + group_ns +
-                          "/" + curlc.url_escape(group_uri) +
+  const std::string url = redirect_uri(cache_key) + "/v2/groups/" +
+                          curlc.url_escape_namespace(group_ns) + "/" +
+                          curlc.url_escape(group_uri) +
                           "/delete?recursive=" + recursive_str;
 
   Buffer returned_data;
@@ -1454,8 +1480,9 @@ Status RestClientRemote::post_consolidation_to_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/consolidate";
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/consolidate";
 
   // Get the data
   Buffer returned_data;
@@ -1477,8 +1504,9 @@ Status RestClientRemote::post_vacuum_to_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   RETURN_NOT_OK(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) + "/vacuum";
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/vacuum";
 
   // Get the data
   Buffer returned_data;
@@ -1502,9 +1530,9 @@ RestClientRemote::post_consolidation_plan_from_rest(
   const std::string cache_key = array_ns + ":" + array_uri;
   throw_if_not_ok(
       curlc.init(config_, extra_headers_, &redirect_meta_, &redirect_mtx_));
-  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" + array_ns +
-                          "/" + curlc.url_escape(array_uri) +
-                          "/consolidate/plan";
+  const std::string url = redirect_uri(cache_key) + "/v1/arrays/" +
+                          curlc.url_escape_namespace(array_ns) + "/" +
+                          curlc.url_escape(array_uri) + "/consolidate/plan";
 
   // Get the data
   Buffer returned_data;


### PR DESCRIPTION
Follow up for #5499 to add URL encoding for the workspace and teamspace components for REST URIs if we are talking to a 3.0 REST server. If we are using legacy REST the namespace component is returned as-is since it is not allowed to contain characters that require encoding.

---
TYPE: BUG
DESC: URL encode workspace and teamspace for REST URIs.
