### PR TITLE
Relax Profile parameter constraints for flexibility.

### DIFF
--- a/test/src/unit-cppapi-profile.cc
+++ b/test/src/unit-cppapi-profile.cc
@@ -62,24 +62,6 @@ struct ProfileCPPFx {
   }
 };
 
-struct expected_values_t {
-  std::string profile_name = sm::RestProfile::DEFAULT_PROFILE_NAME;
-  std::string password = sm::RestProfile::DEFAULT_PASSWORD;
-  std::string payer_namespace = sm::RestProfile::DEFAULT_PAYER_NAMESPACE;
-  std::string token = sm::RestProfile::DEFAULT_TOKEN;
-  std::string server_address = sm::RestProfile::DEFAULT_SERVER_ADDRESS;
-  std::string username = sm::RestProfile::DEFAULT_USERNAME;
-};
-
-bool is_expected(const Profile& p, const expected_values_t& e) {
-  return p.name() == e.profile_name &&
-         p.get_param("rest.username") == e.username &&
-         p.get_param("rest.password") == e.password &&
-         p.get_param("rest.payer_namespace") == e.payer_namespace &&
-         p.get_param("rest.server_address") == e.server_address &&
-         p.get_param("rest.token") == e.token;
-}
-
 TEST_CASE_METHOD(
     ProfileCPPFx,
     "C++ API: Profile get_name validation",
@@ -184,16 +166,6 @@ TEST_CASE_METHOD(
     REQUIRE(profile_exists(
         tempdir_.path() + tiledb::sm::constants::rest_profile_filename, name_));
   }
-  SECTION("rest.username set and rest.password not set") {
-    Profile p(name_, tempdir_.path());
-    p.set_param("rest.username", "test_user");
-    REQUIRE_THROWS(p.save());
-  }
-  SECTION("rest.username not set and rest.password set") {
-    Profile p(name_, tempdir_.path());
-    p.set_param("rest.password", "test_password");
-    REQUIRE_THROWS(p.save());
-  }
 }
 
 TEST_CASE_METHOD(
@@ -202,13 +174,11 @@ TEST_CASE_METHOD(
     "[cppapi][profile][load]") {
   SECTION("success") {
     Profile p(name_, tempdir_.path());
-    expected_values_t expected;
     // check that the profiles file was not there before
     REQUIRE(!std::filesystem::exists(
         tempdir_.path() + tiledb::sm::constants::rest_profile_filename));
     // save some parameters
-    p.set_param("rest.username", "test_user");
-    p.set_param("rest.password", "test_password");
+    p.set_param("rest.token", "test_token");
     // save the profile
     p.save();
     // check that the profiles file is created
@@ -218,9 +188,8 @@ TEST_CASE_METHOD(
     // load the profile again
     Profile p2 = Profile::load(name_, tempdir_.path());
     // check that the parameters are loaded correctly
-    expected.username = "test_user";
-    expected.password = "test_password";
-    is_expected(p2, expected);
+    REQUIRE(p2.name() == name_);
+    REQUIRE(p2.get_param("rest.token") == "test_token");
   }
   SECTION("profiles file is present") {
     // check that the profiles file is not there
@@ -312,19 +281,12 @@ TEST_CASE_METHOD(
     "[cppapi][profile][dump]") {
   SECTION("success") {
     Profile p(name_, tempdir_.path());
-    p.set_param("rest.username", "test_user");
-    p.set_param("rest.password", "test_password");
+    p.set_param("rest.token", "test_token");
     std::string dump_str = p.dump();
 
     // check that the dump string contains the expected values
-    REQUIRE(dump_str.find("rest.username") != std::string::npos);
-    REQUIRE(dump_str.find("test_user") != std::string::npos);
-    REQUIRE(dump_str.find("rest.password") != std::string::npos);
-    REQUIRE(dump_str.find("test_password") != std::string::npos);
-    REQUIRE(dump_str.find("rest.payer_namespace") != std::string::npos);
-    REQUIRE(dump_str.find("rest.server_address") != std::string::npos);
-    REQUIRE(dump_str.find("https://api.tiledb.com") != std::string::npos);
     REQUIRE(dump_str.find("rest.token") != std::string::npos);
+    REQUIRE(dump_str.find("test_token") != std::string::npos);
   }
 }
 
@@ -333,17 +295,15 @@ TEST_CASE_METHOD(
     "C++ API: Profile default constructor validation",
     "[cppapi][profile][default_constructor]") {
   SECTION("Default constructor") {
-    expected_values_t expected;
-
     Profile p1;
-    REQUIRE(p1.name() == expected.profile_name);
+    REQUIRE(p1.name() == sm::RestProfile::DEFAULT_PROFILE_NAME);
     REQUIRE(
         p1.dir() == tiledb::common::filesystem::ensure_trailing_slash(
                         tiledb::common::filesystem::home_directory() +
                         tiledb::sm::constants::rest_profile_foldername));
 
     Profile p2(std::nullopt, std::nullopt);
-    REQUIRE(p2.name() == expected.profile_name);
+    REQUIRE(p2.name() == sm::RestProfile::DEFAULT_PROFILE_NAME);
     REQUIRE(
         p2.dir() == tiledb::common::filesystem::ensure_trailing_slash(
                         tiledb::common::filesystem::home_directory() +

--- a/test/src/unit-cppapi-profile.cc
+++ b/test/src/unit-cppapi-profile.cc
@@ -166,6 +166,16 @@ TEST_CASE_METHOD(
     REQUIRE(profile_exists(
         tempdir_.path() + tiledb::sm::constants::rest_profile_filename, name_));
   }
+  SECTION("rest.username set and rest.password not set") {
+    Profile p(name_, tempdir_.path());
+    p.set_param("rest.username", "test_user");
+    REQUIRE_THROWS(p.save());
+  }
+  SECTION("rest.username not set and rest.password set") {
+    Profile p(name_, tempdir_.path());
+    p.set_param("rest.password", "test_password");
+    REQUIRE_THROWS(p.save());
+  }
 }
 
 TEST_CASE_METHOD(

--- a/tiledb/api/c_api/profile/test/unit_capi_profile.cc
+++ b/tiledb/api/c_api/profile/test/unit_capi_profile.cc
@@ -246,7 +246,7 @@ TEST_CASE_METHOD(
   rc = tiledb_profile_save(profile, &err);
   REQUIRE(tiledb_status(rc) == TILEDB_OK);
   tiledb_profile_t* loaded_profile;
-  // use the same name and directory
+  // Use the same name and directory
   tiledb_profile_alloc(name_, tempdir_.path().c_str(), &loaded_profile, &err);
   REQUIRE(loaded_profile != nullptr);
   SECTION("success") {

--- a/tiledb/api/c_api/profile/test/unit_capi_profile.cc
+++ b/tiledb/api/c_api/profile/test/unit_capi_profile.cc
@@ -39,11 +39,13 @@ using namespace tiledb::api::test_support;
 
 struct CAPINProfileFx {
   const char* name_;
-  tiledb::sm::TemporaryLocalDirectory tempdir_;
+  std::string dir_;
 
   CAPINProfileFx()
       : name_(tiledb::sm::RestProfile::DEFAULT_PROFILE_NAME.c_str())
-      , tempdir_("unit_capi_profile") {
+      , dir_(tiledb::sm::TemporaryLocalDirectory("unit_rest_profile").path()) {
+    // Fstream cannot create directories, only files, so create the dir.
+    std::filesystem::create_directories(dir_);
   }
 };
 
@@ -54,19 +56,18 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_error_t* err = nullptr;
   tiledb_profile_t* profile;
-  auto profile_dir_ = tempdir_.path().c_str();
   SECTION("success") {
-    rc = tiledb_profile_alloc(name_, profile_dir_, &profile, &err);
+    rc = tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
     REQUIRE_NOTHROW(tiledb_profile_free(&profile));
     CHECK(profile == nullptr);
   }
   SECTION("empty name") {
-    rc = tiledb_profile_alloc("", profile_dir_, &profile, &err);
+    rc = tiledb_profile_alloc("", dir_.c_str(), &profile, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
   }
   SECTION("null name") {
-    rc = tiledb_profile_alloc(nullptr, profile_dir_, &profile, &err);
+    rc = tiledb_profile_alloc(nullptr, dir_.c_str(), &profile, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
     REQUIRE_NOTHROW(tiledb_profile_free(&profile));
     CHECK(profile == nullptr);
@@ -83,7 +84,7 @@ TEST_CASE_METHOD(
     CHECK(profile == nullptr);
   }
   SECTION("null profile") {
-    rc = tiledb_profile_alloc(name_, profile_dir_, nullptr, &err);
+    rc = tiledb_profile_alloc(name_, dir_.c_str(), nullptr, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_ERR);
   }
 }
@@ -94,8 +95,7 @@ TEST_CASE_METHOD(
     "[capi][profile]") {
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  auto rc =
-      tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  auto rc = tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(tiledb_status(rc) == TILEDB_OK);
   SECTION("success") {
     REQUIRE_NOTHROW(tiledb_profile_free(&profile));
@@ -112,7 +112,7 @@ TEST_CASE_METHOD(
     "[capi][profile]") {
   capi_return_t rc;
   tiledb_error_t* err = nullptr;
-  ordinary_profile x{name_, tempdir_.path().c_str()};
+  ordinary_profile x{name_, dir_.c_str()};
   tiledb_string_t* name;
   SECTION("success") {
     rc = tiledb_profile_get_name(x.profile, &name, &err);
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(
     "[capi][profile]") {
   capi_return_t rc;
   tiledb_error_t* err = nullptr;
-  ordinary_profile x{name_, tempdir_.path().c_str()};
+  ordinary_profile x{name_, dir_.c_str()};
   tiledb_string_t* profile_dir;
   SECTION("success") {
     rc = tiledb_profile_get_dir(x.profile, &profile_dir, &err);
@@ -157,7 +157,7 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(profile != nullptr);
 
   SECTION("success") {
@@ -191,7 +191,7 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(profile != nullptr);
 
   tiledb_string_t* value;
@@ -220,7 +220,7 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(profile != nullptr);
   SECTION("success") {
     rc = tiledb_profile_save(profile, &err);
@@ -241,13 +241,13 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(profile != nullptr);
   rc = tiledb_profile_save(profile, &err);
   REQUIRE(tiledb_status(rc) == TILEDB_OK);
   tiledb_profile_t* loaded_profile;
   // Use the same name and directory
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &loaded_profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &loaded_profile, &err);
   REQUIRE(loaded_profile != nullptr);
   SECTION("success") {
     rc = tiledb_profile_load(loaded_profile, &err);
@@ -266,12 +266,12 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(profile != nullptr);
   SECTION("success") {
     rc = tiledb_profile_save(profile, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
-    rc = tiledb_profile_remove(name_, tempdir_.path().c_str(), &err);
+    rc = tiledb_profile_remove(name_, dir_.c_str(), &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
   }
   SECTION("null profile") {
@@ -288,7 +288,7 @@ TEST_CASE_METHOD(
   capi_return_t rc;
   tiledb_profile_t* profile;
   tiledb_error_t* err = nullptr;
-  tiledb_profile_alloc(name_, tempdir_.path().c_str(), &profile, &err);
+  tiledb_profile_alloc(name_, dir_.c_str(), &profile, &err);
   REQUIRE(profile != nullptr);
   tiledb_string_t* dump_ascii;
   SECTION("success") {

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -930,50 +930,49 @@ const char* Config::get_from_profile(
     return "";
   }
 
-  if (RestProfile::can_have_parameter(param)) {
-    // If there is no profile loaded yet and we have not attempted to load it,
-    // we try to load the configure specified profile.
-    if (!rest_profile_.has_value() && !rest_profile_load_attempted_) {
-      bool found_name = false;
-      const char* profile_name_cstr =
-          get_from_config_or_fallback("profile_name", &found_name);
-      std::optional<std::string> profile_name =
-          found_name ? std::make_optional(profile_name_cstr) : std::nullopt;
+  // If there is no profile loaded yet and we have not attempted to load it,
+  // we try to load the configure specified profile.
+  if (!rest_profile_.has_value() && !rest_profile_load_attempted_) {
+    bool found_name = false;
+    const char* profile_name_cstr =
+        get_from_config_or_fallback("profile_name", &found_name);
+    std::optional<std::string> profile_name =
+        found_name ? std::make_optional(profile_name_cstr) : std::nullopt;
 
-      bool found_dir = false;
-      const char* profile_dir_cstr =
-          get_from_config_or_fallback("profile_dir", &found_dir);
-      std::optional<std::string> profile_dir =
-          found_dir ? std::make_optional(profile_dir_cstr) : std::nullopt;
+    bool found_dir = false;
+    const char* profile_dir_cstr =
+        get_from_config_or_fallback("profile_dir", &found_dir);
+    std::optional<std::string> profile_dir =
+        found_dir ? std::make_optional(profile_dir_cstr) : std::nullopt;
 
-      try {
-        // Create a Profile object and load the profile
-        rest_profile_ = RestProfile(profile_name, profile_dir);
-        rest_profile_.value().load_from_file();
-      } catch (const std::exception&) {
-        // Throw an exception if the user has specified profile-related
-        // parameters but the profile could not be loaded.
-        if ((profile_name.has_value() && !profile_name.value().empty()) ||
-            (profile_dir.has_value() && !profile_dir.value().empty())) {
-          throw ConfigException(
-              "Failed to load the REST profile. "
-              "Please check the profile name and directory parameters.");
-        }
-        // Do not throw an exception for the default profile since this might
-        // not be intended by the user.
-        rest_profile_load_attempted_ = true;
-        rest_profile_.reset();
+    try {
+      // Create a Profile object and load the profile
+      rest_profile_ = RestProfile(profile_name, profile_dir);
+      rest_profile_.value().load_from_file();
+    } catch (const std::exception&) {
+      // Throw an exception if the user has specified profile-related
+      // parameters but the profile could not be loaded.
+      if ((profile_name.has_value() && !profile_name.value().empty()) ||
+          (profile_dir.has_value() && !profile_dir.value().empty())) {
+        throw ConfigException(
+            "Failed to load the REST profile. "
+            "Please check the profile name and directory parameters.");
       }
-    }
-    // If the profile was loaded successfully, try to get the parameter from it.
-    if (rest_profile_.has_value()) {
-      const std::string* value = rest_profile_.value().get_param(param);
-      if (value) {
-        *found = true;
-        return value->c_str();
-      }
+      // Do not throw an exception for the default profile since this might
+      // not be intended by the user.
+      rest_profile_load_attempted_ = true;
+      rest_profile_.reset();
     }
   }
+  // If the profile was loaded successfully, try to get the parameter from it.
+  if (rest_profile_.has_value()) {
+    const std::string* value = rest_profile_.value().get_param(param);
+    if (value) {
+      *found = true;
+      return value->c_str();
+    }
+  }
+
   *found = false;
   return "";
 }
@@ -1003,7 +1002,7 @@ const char* Config::get_from_config_or_fallback(
   if (*found)
     return value_env;
 
-  // [3. profiles] -- only for rest.* params
+  // [3. profiles]
   const char* value_profile = get_from_profile(param, found);
   if (*found)
     return value_profile;

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -167,6 +167,16 @@ const std::string* RestProfile::get_param(const std::string& param) const {
  * See issue [#727](https://github.com/nlohmann/json/issues/727) for details.
  */
 void RestProfile::save_to_file(const bool overwrite) {
+  // Validate that the profile is complete (if username is set, so is password)
+  if ((param_values_.contains("rest.username") &&
+       !param_values_.contains("rest.password")) ||
+      (!param_values_.contains("rest.username") &&
+       param_values_.contains("rest.password"))) {
+    throw RestProfileException(
+        "Failed to save profile: 'rest.username' and 'rest.password' must "
+        "either both be set or both remain unset. Mixing a default username "
+        "with a custom password (or vice versa) is not allowed.");
+  }
   // Fstream cannot create directories. If the directory does not exist,
   // create it.
   std::filesystem::create_directories(dir_);

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -100,17 +100,6 @@ static void write_file(json data, const std::string& filepath) {
 /* ****************************** */
 
 const std::string RestProfile::DEFAULT_PROFILE_NAME{"default"};
-const std::string RestProfile::DEFAULT_PASSWORD{""};
-const std::string RestProfile::DEFAULT_PAYER_NAMESPACE{""};
-const std::string RestProfile::DEFAULT_TOKEN{""};
-const std::string RestProfile::DEFAULT_SERVER_ADDRESS{"https://api.tiledb.com"};
-const std::string RestProfile::DEFAULT_USERNAME{""};
-const std::vector<std::string> RestProfile::REST_PARAMETERS = {
-    "rest.password",
-    "rest.payer_namespace",
-    "rest.token",
-    "rest.server_address",
-    "rest.username"};
 
 /* ****************************** */
 /*   CONSTRUCTORS & DESTRUCTORS   */
@@ -160,12 +149,6 @@ void RestProfile::set_param(
         "Failed to retrieve parameter; parameter name must not be empty.");
   }
 
-  // Validate incoming parameter name
-  auto it = param_values_.find(param);
-  if (it == param_values_.end()) {
-    throw RestProfileException(
-        "Failed to set parameter of invalid name '" + param + "'");
-  }
   param_values_[param] = value;
 }
 
@@ -184,17 +167,9 @@ const std::string* RestProfile::get_param(const std::string& param) const {
  * See issue [#727](https://github.com/nlohmann/json/issues/727) for details.
  */
 void RestProfile::save_to_file(const bool overwrite) {
-  // Validate that the profile is complete (if username is set, so is password)
-  if ((param_values_["rest.username"] == RestProfile::DEFAULT_USERNAME) !=
-      (param_values_["rest.password"] == RestProfile::DEFAULT_PASSWORD)) {
-    throw RestProfileException(
-        "Failed to save profile: 'rest.username' and 'rest.password' must "
-        "either both be set or both remain unset. Mixing a default username "
-        "with a custom password (or vice versa) is not allowed.");
-  }
-  // Fstream cannot create directories. If `profile_dir/.tiledb/` DNE, create
-  // it.
-  std::filesystem::create_directories(dir_ + ".tiledb");
+  // Fstream cannot create directories. If the directory does not exist,
+  // create it.
+  std::filesystem::create_directories(dir_);
 
   // If the file already exists, load it into a json object.
   json data;
@@ -342,13 +317,6 @@ void RestProfile::remove_profile_from_file(
         "Failed to remove profile; error writing file: " +
         std::string(e.what()));
   }
-}
-
-bool RestProfile::can_have_parameter(std::string_view param) {
-  return std::find(
-             RestProfile::REST_PARAMETERS.begin(),
-             RestProfile::REST_PARAMETERS.end(),
-             param) != RestProfile::REST_PARAMETERS.end();
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -281,13 +281,8 @@ void RestProfile::load_from_json_file(const std::string& filename) {
   }
   json profile = it.value();
 
-  if (!profile.is_null()) {
-    for (auto it = profile.begin(); it != profile.end(); ++it) {
-      param_values_[it.key()] = profile[it.key()];
-    }
-  } else {
-    throw RestProfileException(
-        "Failed to load profile; profile '" + name_ + "' does not exist.");
+  for (auto it = profile.begin(); it != profile.end(); ++it) {
+    param_values_[it.key()] = profile[it.key()];
   }
 }
 

--- a/tiledb/sm/rest/rest_profile.h
+++ b/tiledb/sm/rest/rest_profile.h
@@ -63,26 +63,8 @@ class RestProfile {
   /*       PARAMETER DEFAULTS       */
   /* ****************************** */
 
-  /** The default REST password of a RestProfile. */
-  static const std::string DEFAULT_PASSWORD;
-
-  /** The default namespace that should be charged for the request. */
-  static const std::string DEFAULT_PAYER_NAMESPACE;
-
   /** The default name of a RestProfile. */
   static const std::string DEFAULT_PROFILE_NAME;
-
-  /** The default REST token of a RestProfile. */
-  static const std::string DEFAULT_TOKEN;
-
-  /** The default REST server address of a RestProfile. */
-  static const std::string DEFAULT_SERVER_ADDRESS;
-
-  /** The default REST username of a RestProfile. */
-  static const std::string DEFAULT_USERNAME;
-
-  /** A vector of the REST parameters that can be set. */
-  static const std::vector<std::string> REST_PARAMETERS;
 
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -132,11 +114,6 @@ class RestProfile {
    * @param value The value to set on the given parameter.
    */
   void set_param(const std::string& param, const std::string& value);
-
-  /**
-   * Returns true if the given parameter can be handled by RestProfile.
-   */
-  static bool can_have_parameter(std::string_view param);
 
   /**
    * Retrieves a pointer to the value of the given parameter.
@@ -230,14 +207,7 @@ class RestProfile {
   std::string filepath_;
 
   /** Stores a map of <param, value> for the set-parameters. */
-  std::map<std::string, std::string> param_values_ = {
-      std::make_pair("rest.password", RestProfile::DEFAULT_PASSWORD),
-      std::make_pair(
-          "rest.payer_namespace", RestProfile::DEFAULT_PAYER_NAMESPACE),
-      std::make_pair("rest.token", RestProfile::DEFAULT_TOKEN),
-      std::make_pair(
-          "rest.server_address", RestProfile::DEFAULT_SERVER_ADDRESS),
-      std::make_pair("rest.username", RestProfile::DEFAULT_USERNAME)};
+  std::map<std::string, std::string> param_values_;
 };
 }  // namespace tiledb::sm
 


### PR DESCRIPTION
This change relaxes the constraints on Profile parameters to allow storage of arbitrary defined parameters. The need for this flexibility originates from higher-level APIs, which may require storing additional parameters in the future. By enabling this now, we avoid boxing ourselves into a rigid structure that could require deeper core changes later on.

Closes CORE-260

---
TYPE: IMPROVEMENT
DESC: Relax Profile parameter constraints for flexibility.