### PR TITLE
Fix windows hang in nightlies CI

### DIFF
--- a/test/ci/try_assert.cc
+++ b/test/ci/try_assert.cc
@@ -3,6 +3,10 @@
 
 #include "tiledb/common/assert.h"
 
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#endif
+
 int main(int, char**) {
 #if defined(_MSC_VER)
   // We disable the following events on abort:
@@ -11,6 +15,9 @@ int main(int, char**) {
   // The second parameter specifies which flags to change, and the first
   // the value of these flags.
   _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+  // Configures assert() failures to write message to stderr and fail-fast.
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
   passert(false);
 

--- a/test/ci/try_libc_assert.cc
+++ b/test/ci/try_libc_assert.cc
@@ -1,6 +1,10 @@
 #include <iostream>
 #include <vector>
 
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#endif
+
 int main(int, char**) {
 #if defined(_MSC_VER)
   // We disable the following events on abort:
@@ -9,6 +13,9 @@ int main(int, char**) {
   // The second parameter specifies which flags to change, and the first
   // the value of these flags.
   _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+  // Configures assert() failures to write message to stderr and fail-fast.
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
   std::vector<int> values;
 


### PR DESCRIPTION
After https://github.com/TileDB-Inc/TileDB/pull/5531 went in I see hangs again in nightlies CI for Windows that look like the asserts we used to have before https://github.com/TileDB-Inc/TileDB/pull/5516/files .  I am following the example to extend that fix to a couple of places more in case that fixes the issue and allows the actual assert to get logged.

---
TYPE: NO_HISTORY
DESC: Fix windows hang in nightlies CI
