### PR TITLE
chore: test_assert expects correct return code from libc assertion failure test

### DIFF
--- a/BUILDING_FROM_SOURCE.md
+++ b/BUILDING_FROM_SOURCE.md
@@ -30,7 +30,7 @@ The flags for the bootstrap script and the CMake equivalents are as follows:
 | `--enable-debug`         | Enable debug build                                                   | `CMAKE_BUILD_TYPE=Debug`        |
 | `--enable-coverage`      | Enable build with code coverage support                              | `CMAKE_BUILD_TYPE=Coverage`     |
 | `--enable-verbose`       | Enable verbose status messages                                       | `TILEDB_VERBOSE=ON`             |
-| `--enable-assertions     | Enable build with assertions enabled. Always on for debug builds.    | `TILEDB_ASSERTIONS=ON`          |
+| `--enable-assertions`    | Enable build with assertions enabled. Always on for debug builds.    | `TILEDB_ASSERTIONS=ON`          |
 | `--enable-hdfs`          | Enables building with HDFS storage backend support                   | `TILEDB_HDFS=ON`                |
 | `--enable-s3`            | Enables building with S3 storage backend support                     | `TILEDB_S3=ON`                  |
 | `--enable-azure`         | Enables building with Azure Blob Storage backend support             | `TILEDB_AZURE=ON`               |

--- a/test/ci/test_assert.cc
+++ b/test/ci/test_assert.cc
@@ -79,12 +79,14 @@ TEST_CASE("CI: Test libc assertions configuration", "[ci][assertions]") {
   // 2) on windows/max the standard library assertions are toggled
   //    by a macro, indepdently of the build configuration
 #if defined(_WIN32)
+  const std::vector<int> expectExitCodes = {static_cast<int>(0xc0000409)};
 #ifndef NDEBUG
   const bool expectAssertFailed = true;
 #else
   const bool expectAssertFailed = false;
 #endif
 #else
+  const std::vector<int> expectExitCodes = assert_exit_codes;
 #ifdef _GLIBCXX_ASSERTIONS
   const bool expectAssertFailed = true;
 #else
@@ -94,8 +96,8 @@ TEST_CASE("CI: Test libc assertions configuration", "[ci][assertions]") {
 
   if (expectAssertFailed) {
     REQUIRE(
-        std::find(assert_exit_codes.begin(), assert_exit_codes.end(), retval) !=
-        assert_exit_codes.end());
+        std::find(expectExitCodes.begin(), expectExitCodes.end(), retval) !=
+        expectExitCodes.end());
   } else {
     REQUIRE(retval == 0);
   }


### PR DESCRIPTION
<long description>

After #5548 we continue to observe failures in Windows nightlies, but now because of the following:
```
  106: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.43.34808\include\vector(1916) : Assertion failed: vector subscript out of range
  106: retval is c0000409 (0xc0000409) from C:/build/test/ci/Debug/try_libc_assert.exe
```
The `test_assert` binary is not expecting this exit code, which does not match the typical assert exit codes.

This exit code means `STATUS_STACK_BUFFER_OVERRUN` which does seem appropriate (if perhaps a little imprecise) given that this is an out-of-bounds access to a `std::vector`.

This pull request updates the `test_assert` logic to allow this exit code for windows.

---
TYPE: NO_HISTORY
DESC: allow `STATUS_STACK_BUFFER_OVERRUN` return code in `test_assert`
