### PR TITLE
Avoid throwing on missing Profile parameters in getter APIs.

### DIFF
--- a/test/src/unit-cppapi-profile.cc
+++ b/test/src/unit-cppapi-profile.cc
@@ -126,9 +126,13 @@ TEST_CASE_METHOD(
     p.set_param("rest.username", "test_user");
     REQUIRE(p.get_param("rest.username") == "test_user");
   }
+  SECTION("invalid key") {
+    Profile p(name_, tempdir_.path());
+    REQUIRE(p.get_param("does.not.exist") == std::nullopt);
+  }
   SECTION("invalid empty key") {
     Profile p(name_, tempdir_.path());
-    REQUIRE_THROWS(p.get_param(""));
+    REQUIRE(p.get_param("") == std::nullopt);
   }
 }
 

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -830,7 +830,7 @@ TILEDB_EXPORT capi_return_t tiledb_config_set(
  * @endcode
  *
  * @param config The config object.
- * @param param The parameter to be set.
+ * @param param The parameter to be retrieved.
  * @param value A pointer to the value of the parameter to be retrieved
  *    (`NULL` if it does not exist).
  * @param error Error object returned upon error (`NULL` if there is

--- a/tiledb/api/c_api/profile/profile_api.cc
+++ b/tiledb/api/c_api/profile/profile_api.cc
@@ -95,13 +95,10 @@ capi_return_t tiledb_profile_get_param(
 
   const std::string* param_value = profile->profile()->get_param(param);
 
-  if (!param_value) {
-    throw CAPIException(
-        "[tiledb_profile_get_param] Parameter '" + std::string(param) +
-        "' does not exist in the profile.");
-  }
+  *value = param_value != nullptr ?
+               tiledb_string_handle_t::make_handle(*param_value) :
+               nullptr;
 
-  *value = tiledb_string_handle_t::make_handle(*param_value);
   return TILEDB_OK;
 }
 

--- a/tiledb/api/c_api/profile/profile_api_experimental.h
+++ b/tiledb/api/c_api/profile/profile_api_experimental.h
@@ -167,7 +167,8 @@ TILEDB_EXPORT capi_return_t tiledb_profile_set_param(
  *
  * @param[in] profile The profile.
  * @param[in] param The parameter name.
- * @param[out] value The parameter value.
+ * @param[out] value A pointer to the value of the parameter to be retrieved
+ *    (`NULL` if it does not exist).
  * @param[out] error Error object returned upon error (`NULL` if there is no
  * error).
  * @return TILEDB_EXPORT

--- a/tiledb/api/c_api/profile/test/unit_capi_profile.cc
+++ b/tiledb/api/c_api/profile/test/unit_capi_profile.cc
@@ -279,10 +279,6 @@ TEST_CASE_METHOD(
     rc = tiledb_profile_remove(name_, dir_.c_str(), &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
   }
-  SECTION("null profile") {
-    rc = tiledb_profile_remove(nullptr, nullptr, &err);
-    REQUIRE(tiledb_status(rc) == TILEDB_ERR);
-  }
   tiledb_profile_free(&profile);
 }
 

--- a/tiledb/api/c_api/profile/test/unit_capi_profile.cc
+++ b/tiledb/api/c_api/profile/test/unit_capi_profile.cc
@@ -201,6 +201,11 @@ TEST_CASE_METHOD(
     rc = tiledb_profile_get_param(profile, "rest.username", &value, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_OK);
   }
+  SECTION("param not found") {
+    rc = tiledb_profile_get_param(profile, "does.not.exist", &value, &err);
+    REQUIRE(tiledb_status(rc) == TILEDB_OK);
+    REQUIRE(value == nullptr);
+  }
   SECTION("null param") {
     rc = tiledb_profile_get_param(profile, nullptr, &value, &err);
     REQUIRE(tiledb_status(rc) == TILEDB_ERR);

--- a/tiledb/sm/cpp_api/profile_experimental.h
+++ b/tiledb/sm/cpp_api/profile_experimental.h
@@ -199,9 +199,9 @@ class Profile {
   }
 
   /** Retrieves a parameter value from the profile. */
-  std::string get_param(const std::string& param) const {
+  std::optional<std::string> get_param(const std::string& param) const {
     tiledb_error_t* capi_error = nullptr;
-    tiledb_string_t* value;
+    tiledb_string_t* value = nullptr;
     int rc = tiledb_profile_get_param(
         profile_.get(), param.c_str(), &value, &capi_error);
     if (rc != TILEDB_OK) {
@@ -210,6 +210,11 @@ class Profile {
       std::string msg = msg_cstr;
       tiledb_error_free(&capi_error);
       throw ProfileException(msg);
+    }
+
+    if (value == nullptr) {
+      // If the value is not set, return std::nullopt
+      return std::nullopt;
     }
 
     // Convert string handle to a std::string


### PR DESCRIPTION
This PR updates the Profile getter C and CPP APIs to avoid throwing exceptions when a requested parameter is not found in the internal `std::map`. Instead, the getters now return a `nullptr` (C API) or `std::nullopt` (CPP API) to signal that the key is missing.

This behavior aligns with the rest of our APIs, where "not found" cases are generally handled without exceptions. Throwing is now reserved for actual errors.

Closes CORE-271

---
TYPE: IMPROVEMENT
DESC: Avoid throwing on missing Profile parameters in getter APIs.
