### PR TITLE
Add disk free step for ubuntu to avoid out of space CI errors

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -119,9 +119,24 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: 'Ubuntu Prelim'
-        if: ${{ startsWith(matrix.os, 'ubuntu-') == true }}
+      - name: 'Ubuntu and Macos Prelim'
+        if: ${{ (startsWith(matrix.os, 'ubuntu-') == true) || (startsWith(matrix.os, 'macos-') == true) }}
         run: ./scripts/ci/posix/prelim.sh
+        shell: bash
+
+      - name: Free disk space
+        if: ${{ !inputs.manylinux && startsWith(matrix.os, 'ubuntu-') == true }}
+        run: |
+          set -e pipefail
+          df -h
+          sudo apt clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+          df -h
         shell: bash
 
       - name: Install manylinux prerequisites


### PR DESCRIPTION
Currently our AZURE ubuntu jobs fail 24 minutes into the Testing step with an [out of storage error](https://github.com/TileDB-Inc/TileDB/actions/runs/15777696447/job/44482087103?pr=5551). This PR adds a step to free disk space for ubuntu runners, similar to what we already do for backwards compatibility runners, so that we get rid of packages we don't need to use. 

It also adds a fix for missing core dumps on MacOS (probably, I didn't test), where we had a too strict check and where excluding the core dump step from running on macos runners.

---
TYPE: NO_HISTORY
DESC: Add disk free step for ubuntu to avoid out of space CI errors