### PR TITLE
Add disk free step for ubuntu to avoid out of space CI errors

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -87,6 +87,21 @@ jobs:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v4
 
+      - name: Free disk space
+        if: ${{ startsWith(matrix.os, 'ubuntu-') == true }}
+        run: |
+          set -e pipefail
+          df -h
+          sudo apt clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
+          df -h
+        shell: bash
+
       - name: Setup MSVC toolset
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: runner.os == 'Windows'


### PR DESCRIPTION
See #5553 

While we are not currently encountering disk space issues on main nightly test, #5546 did encounter them.  Might as well copy over this logic from PR CI

---
TYPE: NO_HISTORY
DESC: attempt to free some disk space in ubuntu nightly CI
