### PR TITLE
feat: add `tiledb_query_add_predicate` API to parse a SQL expression string into a `QueryCondition`

### DIFF
--- a/examples/c_api/query_add_predicate.c
+++ b/examples/c_api/query_add_predicate.c
@@ -49,7 +49,7 @@
 #include <tiledb/tiledb.h>
 
 // Name of array.
-const char* array_name = "query_condition_sparse_array";
+const char* array_name = "query_add_predicate";
 
 #define TRY(ctx, action)                 \
   do {                                   \
@@ -387,8 +387,9 @@ int main() {
 
   // BEGIN EXAMPLES WITH NO EQUIVALENT
 
-  printf("WHERE a + d < index\n");
-  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "a + d < index"));
+  printf("WHERE coalesce(a, 2) + c < index\n");
+  RETURN_IF_NOT_OK(
+      read_array_with_predicate(ctx, "coalesce(a, 2) + c < index"));
   printf("\n");
 
   printf("WHERE a > 6 OR a IS NULL\n");

--- a/examples/c_api/query_add_predicate.c
+++ b/examples/c_api/query_add_predicate.c
@@ -49,7 +49,7 @@
 #include <tiledb/tiledb.h>
 
 // Name of array.
-const char* array_name = "query_add_predicate";
+const char* array_name = "array_query_add_predicate";
 
 #define TRY(ctx, action)                 \
   do {                                   \

--- a/examples/c_api/query_add_predicate.c
+++ b/examples/c_api/query_add_predicate.c
@@ -47,6 +47,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tiledb/tiledb.h>
+#include <tiledb/tiledb_experimental.h>
 
 // Name of array.
 const char* array_name = "array_query_add_predicate";
@@ -68,6 +69,19 @@ const char* array_name = "array_query_add_predicate";
   } while (0)
 
 /**
+ * Enumeration variants
+ */
+static const char* const states[] = {
+    "alabama",
+    "alaska",
+    "arizona",
+    "arkansas",
+    "california",
+    "colorado",
+    "connecticut",
+    "etc"};
+
+/**
  * @brief Function to print the values of all the attributes for one
  * index of this array.
  *
@@ -76,12 +90,23 @@ const char* array_name = "array_query_add_predicate";
  * @param c Attribute c's value.
  * @param d Attribute d's value.
  */
-void print_elem(int* a, char* b_start, int b_len, int32_t c, float d) {
+void print_elem(
+    int* a, char* b_start, int b_len, int32_t c, float d, uint8_t* e) {
+  char print_a[8], print_e[16];
   if (a == NULL) {
-    printf("{null, %.*s, %d, %.1f}\n", b_len, b_start, c, d);
+    strcpy(&print_a[0], "null");
   } else {
-    printf("{%d, %.*s, %d, %.1f}\n", *a, b_len, b_start, c, d);
+    sprintf(&print_a[0], "%d", *a);
   }
+  if (e == NULL) {
+    strcpy(&print_e[0], "null");
+  } else if (*e < sizeof(states) / sizeof(const char*)) {
+    strcpy(&print_e[0], states[*e]);
+  } else {
+    sprintf(&print_e[0], "(invalid key %hhu)", *e);
+  }
+
+  printf("{%s, %.*s, %d, %.1f, %s}\n", print_a, b_len, b_start, c, d, print_e);
 }
 
 /**
@@ -143,6 +168,43 @@ int32_t create_array(tiledb_ctx_t* ctx) {
   TRY(ctx, tiledb_array_schema_set_domain(ctx, schema, domain));
   TRY(ctx, tiledb_array_schema_set_cell_order(ctx, schema, TILEDB_ROW_MAJOR));
 
+  // Create enumeration
+  size_t states_size = 0;
+  for (uint64_t i = 0; i < sizeof(states) / sizeof(const char*); i++) {
+    states_size += strlen(states[i]);
+  }
+  const uint64_t states_offsets_size =
+      (sizeof(states) / sizeof(const char*)) * sizeof(uint64_t);
+
+  char* states_values = (char*)(malloc(states_size));
+  uint64_t* states_offsets = (uint64_t*)(malloc(states_offsets_size));
+
+  states_size = 0;
+  for (uint64_t i = 0; i < sizeof(states) / sizeof(const char*); i++) {
+    const uint64_t slen = strlen(states[i]);
+    memcpy(&states_values[states_size], &states[i][0], slen);
+    states_offsets[i] = states_size;
+    states_size += slen;
+  }
+  tiledb_enumeration_t* enumeration_states;
+  TRY(ctx,
+      tiledb_enumeration_alloc(
+          ctx,
+          "us_states",
+          TILEDB_STRING_ASCII,
+          UINT32_MAX,
+          false,
+          states_values,
+          states_size,
+          states_offsets,
+          states_offsets_size,
+          &enumeration_states));
+  free(states_offsets);
+  free(states_values);
+
+  TRY(ctx,
+      tiledb_array_schema_add_enumeration(ctx, schema, enumeration_states));
+
   // Adding the attributes of the array to the array schema.
   tiledb_attribute_t* a;
   TRY(ctx, tiledb_attribute_alloc(ctx, "a", TILEDB_INT32, &a));
@@ -158,15 +220,22 @@ int32_t create_array(tiledb_ctx_t* ctx) {
   tiledb_attribute_t* d;
   TRY(ctx, tiledb_attribute_alloc(ctx, "d", TILEDB_FLOAT32, &d));
 
+  tiledb_attribute_t* e;
+  TRY(ctx, tiledb_attribute_alloc(ctx, "e", TILEDB_UINT8, &e));
+  TRY(ctx, tiledb_attribute_set_nullable(ctx, e, true));
+  TRY(ctx, tiledb_attribute_set_enumeration_name(ctx, e, "us_states"));
+
   TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, a));
   TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, b));
   TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, c));
   TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, d));
+  TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, e));
 
   // Create the (empty) array.
   TRY(ctx, tiledb_array_create(ctx, array_name, schema));
 
   // Cleanup.
+  tiledb_attribute_free(&e);
   tiledb_attribute_free(&d);
   tiledb_attribute_free(&c);
   tiledb_attribute_free(&b);
@@ -183,18 +252,18 @@ int32_t create_array(tiledb_ctx_t* ctx) {
  * which then stores the following data in the array. The table
  * is organized by dimension/attribute.
  *
- * index |  a   |   b   | c |  d
- * -------------------------------
- *   0   | null | alice | 0 | 4.1
- *   1   | 2    | bob   | 0 | 3.4
- *   2   | null | craig | 0 | 5.6
- *   3   | 4    | dave  | 0 | 3.7
- *   4   | null | erin  | 0 | 2.3
- *   5   | 6    | frank | 0 | 1.7
- *   6   | null | grace | 1 | 3.8
- *   7   | 8    | heidi | 2 | 4.9
- *   8   | null | ivan  | 3 | 3.2
- *   9   | 10   | judy  | 4 | 3.1
+ * index |  a   |   b   | c |  d  |     e
+ * ------+------+-------+---+-----+------------
+ *   0   | null | alice | 0 | 4.1 | arizona
+ *   1   | 2    | bob   | 0 | 3.4 | etc
+ *   2   | null | craig | 0 | 5.6 | connecticut
+ *   3   | 4    | dave  | 0 | 3.7 | colorado
+ *   4   | null | erin  | 0 | 2.3 | null
+ *   5   | 6    | frank | 0 | 1.7 | arkansas
+ *   6   | null | grace | 1 | 3.8 | etc
+ *   7   | 8    | heidi | 2 | 4.9 | etc
+ *   8   | null | ivan  | 3 | 3.2 | colorado
+ *   9   | 10   | judy  | 4 | 3.1 | california
  *
  * @param ctx The context.
  */
@@ -214,6 +283,10 @@ int32_t write_array(tiledb_ctx_t* ctx) {
   uint64_t c_size = sizeof(c_data);
   float d_data[] = {4.1, 3.4, 5.6, 3.7, 2.3, 1.7, 3.8, 4.9, 3.2, 3.1};
   uint64_t d_size = sizeof(d_data);
+  uint8_t e_data[] = {2, 7, 5, 6, 100, 3, 7, 7, 5, 4};
+  uint64_t e_size = sizeof(e_data);
+  uint8_t e_validity[] = {1, 1, 1, 1, 0, 1, 1, 1, 1, 1};
+  uint64_t e_validity_size = sizeof(e_validity);
 
   tiledb_array_t* array_w;
   TRY(ctx, tiledb_array_alloc(ctx, array_name, &array_w));
@@ -235,6 +308,10 @@ int32_t write_array(tiledb_ctx_t* ctx) {
           ctx, query_w, "b", b_data_offsets, &b_offsets_size));
   TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "c", c_data, &c_size));
   TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "d", d_data, &d_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "e", e_data, &e_size));
+  TRY(ctx,
+      tiledb_query_set_validity_buffer(
+          ctx, query_w, "e", e_validity, &e_validity_size));
   TRY(ctx, tiledb_query_submit(ctx, query_w));
   TRY(ctx, tiledb_query_finalize(ctx, query_w));
   TRY(ctx, tiledb_array_close(ctx, array_w));
@@ -271,6 +348,11 @@ int32_t read_array_with_predicates(tiledb_ctx_t* ctx, int num_predicates, ...) {
   float d_data[10];
   uint64_t d_size = sizeof(d_data);
 
+  uint8_t e_data[10];
+  uint64_t e_size = sizeof(e_data);
+  uint8_t e_validity[10];
+  uint64_t e_validity_size = sizeof(e_validity);
+
   tiledb_array_t* array;
   TRY(ctx, tiledb_array_alloc(ctx, array_name, &array));
   TRY(ctx, tiledb_array_open(ctx, array, TILEDB_READ));
@@ -289,6 +371,10 @@ int32_t read_array_with_predicates(tiledb_ctx_t* ctx, int num_predicates, ...) {
           ctx, query, "b", b_data_offsets, &b_offsets_size));
   TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "c", c_data, &c_size));
   TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "d", d_data, &d_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "e", e_data, &e_size));
+  TRY(ctx,
+      tiledb_query_set_validity_buffer(
+          ctx, query, "e", e_validity, &e_validity_size));
 
   va_list predicates;
   va_start(predicates, num_predicates);
@@ -319,7 +405,8 @@ int32_t read_array_with_predicates(tiledb_ctx_t* ctx, int num_predicates, ...) {
         b_data + element_start,
         element_length,
         c_data[i],
-        d_data[i]);
+        d_data[i],
+        e_validity[i] ? &e_data[i] : NULL);
   }
 
   TRY(ctx, tiledb_query_finalize(ctx, query));
@@ -385,13 +472,26 @@ int main() {
       ctx, 3, "d BETWEEN 3.0 AND 4.0", "a IS NOT NULL", "b < 'eve'"));
   printf("\n");
 
+  // BEGIN EXAMPLES WITH ENUMERATIONS
+  printf("WHERE e = 'california'\n");
+  {
+    // error is expected since the enumeration is not loaded
+    const int32_t ret = read_array_with_predicate(ctx, "e = 'california'");
+    if (ret != TILEDB_ERR) {
+      return TILEDB_ERR;
+    }
+  }
+  printf("\n");
+
   // BEGIN EXAMPLES WITH NO EQUIVALENT
 
+  // query condition does not have functions, here we use coalesce
   printf("WHERE coalesce(a, 2) + c < index\n");
   RETURN_IF_NOT_OK(
       read_array_with_predicate(ctx, "coalesce(a, 2) + c < index"));
   printf("\n");
 
+  // FIXME: this is query-condition-able, use arithmetic
   printf("WHERE a > 6 OR a IS NULL\n");
   RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "a > 6 OR a IS NULL"));
   printf("\n");

--- a/examples/c_api/query_add_predicate.c
+++ b/examples/c_api/query_add_predicate.c
@@ -1,0 +1,401 @@
+/**
+ * @file   query_condition_sparse.c
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This example demonstrates using the `tiledb_query_add_predicate` API
+ * to add one or more text predicates to a query. This API parses a SQL
+ * predicate and uses it to filter results inside of the storage engine
+ * before returning them to the user.
+ *
+ * The array used in this example is identical to that of the
+ * `query_condition_sparse` example. The first group of predicates which
+ * run are text equivalents of the predicates in that example, and produce
+ * the same results.
+ *
+ * This example also has additional queries which use predicates which
+ * combine dimensions and attributes.
+ */
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tiledb/tiledb.h>
+
+// Name of array.
+const char* array_name = "query_condition_sparse_array";
+
+#define TRY(ctx, action)                 \
+  do {                                   \
+    const capi_return_t r = (action);    \
+    if (r != TILEDB_OK) {                \
+      return print_last_error((ctx), r); \
+    }                                    \
+  } while (0)
+
+#define RETURN_IF_NOT_OK(r)     \
+  do {                          \
+    const int32_t status = (r); \
+    if (status != TILEDB_OK) {  \
+      return status;            \
+    }                           \
+  } while (0)
+
+/**
+ * @brief Function to print the values of all the attributes for one
+ * index of this array.
+ *
+ * @param a Attribute a's value.
+ * @param b Attribute b's value.
+ * @param c Attribute c's value.
+ * @param d Attribute d's value.
+ */
+void print_elem(int* a, char* b_start, int b_len, int32_t c, float d) {
+  if (a == NULL) {
+    printf("{null, %.*s, %d, %.1f}\n", b_len, b_start, c, d);
+  } else {
+    printf("{%d, %.*s, %d, %.1f}\n", *a, b_len, b_start, c, d);
+  }
+}
+
+/**
+ * Retrieve and print the last error.
+ *
+ * @param ctx The context object to get the error from.
+ */
+int32_t print_last_error(tiledb_ctx_t* ctx, int32_t rc) {
+  tiledb_error_t* err = NULL;
+  tiledb_ctx_get_last_error(ctx, &err);
+  if (err == NULL) {
+    fprintf(stderr, "TileDB Error: Error code returned but no error found.");
+    return rc;
+  }
+  const char* msg = NULL;
+  tiledb_error_message(err, &msg);
+  if (msg == NULL) {
+    fprintf(stderr, "TileDB Error");
+  } else {
+    fprintf(stderr, "%s\n", msg);
+  }
+  return rc;
+}
+
+/**
+ * @brief Function to create the TileDB array used in this example.
+ * The array will be 1D with size 1 with dimension "index".
+ * The bounds on the index will be 0 through 9, inclusive.
+ *
+ * The array has two attributes. The two attributes are
+ *  - "a" (type int)
+ *  - "b" (type ASCII string)
+ *  - "c" (type int32_t)
+ *  - "d" (type float)
+ *
+ * @param ctx The context.
+ */
+int32_t create_array(tiledb_ctx_t* ctx) {
+  // Creating the dimension and the domain.
+  tiledb_dimension_t* dimension;
+  int dim_domain[] = {0, 9};
+  int tile_extents[] = {1};
+  TRY(ctx,
+      tiledb_dimension_alloc(
+          ctx,
+          "index",
+          TILEDB_INT32,
+          &dim_domain[0],
+          &tile_extents[0],
+          &dimension));
+
+  tiledb_domain_t* domain;
+  TRY(ctx, tiledb_domain_alloc(ctx, &domain));
+  TRY(ctx, tiledb_domain_add_dimension(ctx, domain, dimension));
+
+  // The array will be sparse.
+  tiledb_array_schema_t* schema;
+  TRY(ctx, tiledb_array_schema_alloc(ctx, TILEDB_SPARSE, &schema));
+  TRY(ctx, tiledb_array_schema_set_domain(ctx, schema, domain));
+  TRY(ctx, tiledb_array_schema_set_cell_order(ctx, schema, TILEDB_ROW_MAJOR));
+
+  // Adding the attributes of the array to the array schema.
+  tiledb_attribute_t* a;
+  TRY(ctx, tiledb_attribute_alloc(ctx, "a", TILEDB_INT32, &a));
+  TRY(ctx, tiledb_attribute_set_nullable(ctx, a, true));
+
+  tiledb_attribute_t* b;
+  TRY(ctx, tiledb_attribute_alloc(ctx, "b", TILEDB_STRING_ASCII, &b));
+  TRY(ctx, tiledb_attribute_set_cell_val_num(ctx, b, TILEDB_VAR_NUM));
+
+  tiledb_attribute_t* c;
+  TRY(ctx, tiledb_attribute_alloc(ctx, "c", TILEDB_INT32, &c));
+
+  tiledb_attribute_t* d;
+  TRY(ctx, tiledb_attribute_alloc(ctx, "d", TILEDB_FLOAT32, &d));
+
+  TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, a));
+  TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, b));
+  TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, c));
+  TRY(ctx, tiledb_array_schema_add_attribute(ctx, schema, d));
+
+  // Create the (empty) array.
+  TRY(ctx, tiledb_array_create(ctx, array_name, schema));
+
+  // Cleanup.
+  tiledb_attribute_free(&d);
+  tiledb_attribute_free(&c);
+  tiledb_attribute_free(&b);
+  tiledb_attribute_free(&a);
+  tiledb_array_schema_free(&schema);
+  tiledb_domain_free(&domain);
+  tiledb_dimension_free(&dimension);
+
+  return TILEDB_OK;
+}
+
+/**
+ * @brief Execute a write on array query_condition_sparse array
+ * which then stores the following data in the array. The table
+ * is organized by dimension/attribute.
+ *
+ * index |  a   |   b   | c |  d
+ * -------------------------------
+ *   0   | null | alice | 0 | 4.1
+ *   1   | 2    | bob   | 0 | 3.4
+ *   2   | null | craig | 0 | 5.6
+ *   3   | 4    | dave  | 0 | 3.7
+ *   4   | null | erin  | 0 | 2.3
+ *   5   | 6    | frank | 0 | 1.7
+ *   6   | null | grace | 1 | 3.8
+ *   7   | 8    | heidi | 2 | 4.9
+ *   8   | null | ivan  | 3 | 3.2
+ *   9   | 10   | judy  | 4 | 3.1
+ *
+ * @param ctx The context.
+ */
+int32_t write_array(tiledb_ctx_t* ctx) {
+  // Create data buffers that store the values to be written in.
+  int dim_data[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  uint64_t dim_size = sizeof(dim_data);
+  int32_t a_data[] = {0, 2, 0, 4, 0, 6, 0, 8, 0, 10};
+  uint64_t a_size = sizeof(a_data);
+  uint8_t a_data_validity[] = {0, 1, 0, 1, 0, 1, 0, 1, 0, 1};
+  uint64_t a_validity_size = sizeof(a_data_validity);
+  char* b_data = "alicebobcraigdaveerinfrankgraceheidiivanjudy";
+  uint64_t b_size = strlen(b_data);
+  uint64_t b_data_offsets[] = {0, 5, 8, 13, 17, 21, 26, 31, 36, 40};
+  uint64_t b_offsets_size = sizeof(b_data_offsets);
+  int32_t c_data[] = {0, 0, 0, 0, 0, 0, 1, 2, 3, 4};
+  uint64_t c_size = sizeof(c_data);
+  float d_data[] = {4.1, 3.4, 5.6, 3.7, 2.3, 1.7, 3.8, 4.9, 3.2, 3.1};
+  uint64_t d_size = sizeof(d_data);
+
+  tiledb_array_t* array_w;
+  TRY(ctx, tiledb_array_alloc(ctx, array_name, &array_w));
+  TRY(ctx, tiledb_array_open(ctx, array_w, TILEDB_WRITE));
+
+  // Execute the write query.
+  tiledb_query_t* query_w;
+  TRY(ctx, tiledb_query_alloc(ctx, array_w, TILEDB_WRITE, &query_w));
+  TRY(ctx, tiledb_query_set_layout(ctx, query_w, TILEDB_UNORDERED));
+  TRY(ctx,
+      tiledb_query_set_data_buffer(ctx, query_w, "index", dim_data, &dim_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "a", a_data, &a_size));
+  TRY(ctx,
+      tiledb_query_set_validity_buffer(
+          ctx, query_w, "a", a_data_validity, &a_validity_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "b", b_data, &b_size));
+  TRY(ctx,
+      tiledb_query_set_offsets_buffer(
+          ctx, query_w, "b", b_data_offsets, &b_offsets_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "c", c_data, &c_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query_w, "d", d_data, &d_size));
+  TRY(ctx, tiledb_query_submit(ctx, query_w));
+  TRY(ctx, tiledb_query_finalize(ctx, query_w));
+  TRY(ctx, tiledb_array_close(ctx, array_w));
+
+  tiledb_query_free(&query_w);
+  tiledb_array_free(&array_w);
+
+  return TILEDB_OK;
+}
+
+/**
+ * @brief Executes the read query for the array created in write_array.
+ *
+ * @param ctx The context.
+ * @param qc The query condition to execute the query with.
+ */
+int32_t read_array_with_predicates(tiledb_ctx_t* ctx, int num_predicates, ...) {
+  // Create data buffers to read the values into.
+  int a_data[10];
+  uint64_t a_size = sizeof(a_data);
+  uint8_t a_data_validity[10];
+  uint64_t a_validity_size = sizeof(a_data_validity);
+
+  // We initialize the string b_data to contain 45 characters because
+  // that is the combined size of all strings in attribute b.
+  char b_data[256];
+  memset(b_data, 0, 256);
+  uint64_t b_size = sizeof(b_data);
+  uint64_t b_data_offsets[10];
+  uint64_t b_offsets_size = sizeof(b_data_offsets);
+
+  int32_t c_data[10];
+  uint64_t c_size = sizeof(c_data);
+  float d_data[10];
+  uint64_t d_size = sizeof(d_data);
+
+  tiledb_array_t* array;
+  TRY(ctx, tiledb_array_alloc(ctx, array_name, &array));
+  TRY(ctx, tiledb_array_open(ctx, array, TILEDB_READ));
+
+  // Execute the read query.
+  tiledb_query_t* query;
+  TRY(ctx, tiledb_query_alloc(ctx, array, TILEDB_READ, &query));
+  TRY(ctx, tiledb_query_set_layout(ctx, query, TILEDB_GLOBAL_ORDER));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "a", a_data, &a_size));
+  TRY(ctx,
+      tiledb_query_set_validity_buffer(
+          ctx, query, "a", a_data_validity, &a_validity_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "b", b_data, &b_size));
+  TRY(ctx,
+      tiledb_query_set_offsets_buffer(
+          ctx, query, "b", b_data_offsets, &b_offsets_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "c", c_data, &c_size));
+  TRY(ctx, tiledb_query_set_data_buffer(ctx, query, "d", d_data, &d_size));
+
+  va_list predicates;
+  va_start(predicates, num_predicates);
+  for (int i = 0; i < num_predicates; i++) {
+    const char* predicate = va_arg(predicates, const char*);
+    TRY(ctx, tiledb_query_add_predicate(ctx, query, predicate));
+  }
+  va_end(predicates);
+
+  TRY(ctx, tiledb_query_submit(ctx, query));
+
+  // Collect the results of the read query. The number of elements
+  // the filtered array contains is calculated by determining the
+  // number of valid elements in c_data, since the array is
+  // sparse. The length of the filtered substring of all the
+  // data is in b_data, and all the offsets for filtered
+  // individual elements are in b_data_offsets.
+
+  // Here we print all the elements that are returned by the query.
+  uint64_t result_num = c_size / sizeof(int);
+  for (uint64_t i = 0; i < result_num; ++i) {
+    uint64_t element_start = b_data_offsets[i];
+    uint64_t element_length = (i == result_num - 1) ?
+                                  (b_size / sizeof(char)) - element_start :
+                                  b_data_offsets[i + 1] - element_start;
+    print_elem(
+        a_data_validity[i] ? &a_data[i] : NULL,
+        b_data + element_start,
+        element_length,
+        c_data[i],
+        d_data[i]);
+  }
+
+  TRY(ctx, tiledb_query_finalize(ctx, query));
+  TRY(ctx, tiledb_array_close(ctx, array));
+
+  tiledb_query_free(&query);
+  tiledb_array_free(&array);
+
+  return TILEDB_OK;
+}
+
+int32_t read_array_with_predicate(tiledb_ctx_t* ctx, const char* predicate) {
+  return read_array_with_predicates(ctx, 1, predicate);
+}
+
+int main() {
+  // Create the context.
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(NULL, &ctx);
+
+  tiledb_vfs_t* vfs;
+  tiledb_vfs_alloc(ctx, NULL, &vfs);
+
+  int32_t is_dir = 0;
+  tiledb_vfs_is_dir(ctx, vfs, array_name, &is_dir);
+  if (!is_dir) {
+    // Create and write data to the array.
+    RETURN_IF_NOT_OK(create_array(ctx));
+    RETURN_IF_NOT_OK(write_array(ctx));
+  }
+
+  // EXAMPLES FROM query_condition_sparse.c EXAMPLE
+
+  // Printing the entire array.
+  printf("WHERE TRUE\n");
+  RETURN_IF_NOT_OK(read_array_with_predicates(ctx, 0));
+  printf("\n");
+
+  // Execute a read query with query condition `a = null`.
+  printf("WHERE a IS NULL\n");
+  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "a IS NULL"));
+  printf("\n");
+
+  // Execute a read query with query condition `b < "eve"`.
+  printf("SELECT * WHERE b < 'eve'\n");
+  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "b < 'eve'"));
+  printf("\n");
+
+  // Execute a read query with query condition `c >= 1`.
+  printf("SELECT * WHERE c >= 1\n");
+  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "c >= 1"));
+  printf("\n");
+
+  // Execute a read query with query condition `3.0f <= d AND d <= 4.0f`.
+  printf("WHERE d BETWEEN 3.0 AND 4.0\n");
+  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "d BETWEEN 3.0 AND 4.0"));
+  printf("\n");
+
+  // Execute a read query with query condition `3.0f <= d AND d <= 4.0f AND a !=
+  // null AND b < \"eve\"`.
+  printf("WHERE (d BETWEEN 3.0 AND 4.0) AND a IS NOT NULL AND b < 'eve'\n");
+  RETURN_IF_NOT_OK(read_array_with_predicates(
+      ctx, 3, "d BETWEEN 3.0 AND 4.0", "a IS NOT NULL", "b < 'eve'"));
+  printf("\n");
+
+  // BEGIN EXAMPLES WITH NO EQUIVALENT
+
+  printf("WHERE a + d < index\n");
+  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "a + d < index"));
+  printf("\n");
+
+  printf("WHERE a > 6 OR a IS NULL\n");
+  RETURN_IF_NOT_OK(read_array_with_predicate(ctx, "a > 6 OR a IS NULL"));
+  printf("\n");
+
+  tiledb_ctx_free(&ctx);
+
+  return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(TILEDB_UNIT_TEST_SOURCES
   src/unit-ordered-dim-label-reader.cc
   src/unit-tile-metadata.cc
   src/unit-tile-metadata-generator.cc
+  src/unit-query-add-predicate.cc
   src/unit-query-plan.cc
   src/unit-ReadCellSlabIter.cc
   src/unit-Reader.cc

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -1244,7 +1244,7 @@ TEST_CASE_METHOD(
   auto enmr_name = schema->attribute("attr1")->get_enumeration_name();
   REQUIRE(enmr_name.has_value());
 
-  auto enmr_path = schema->get_enumeration_path_name(enmr_name.value());
+  auto enmr_path = schema->get_enumeration_path_name(enmr_name.value().get());
 
   auto loaded =
       ad->load_enumerations_from_paths({enmr_path}, enc_key_, memory_tracker_);
@@ -1292,7 +1292,7 @@ TEST_CASE_METHOD(
   auto ad = get_array_directory();
 
   auto enmr_name = schema->attribute("attr1")->get_enumeration_name();
-  auto enmr_path = schema->get_enumeration_path_name(enmr_name.value());
+  auto enmr_path = schema->get_enumeration_path_name(enmr_name.value().get());
 
   memory_tracker_->set_budget(memory_tracker_->get_memory_usage() + 1);
 

--- a/test/src/unit-query-add-predicate.cc
+++ b/test/src/unit-query-add-predicate.cc
@@ -1,0 +1,270 @@
+/**
+ * @file unit-capi-query-add-predicate.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2025 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * Tests for the C API tiledb_query_add_predicate.
+ */
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+#include <test/support/assert_helpers.h>
+#include <test/support/tdb_catch.h>
+
+#include "test/support/src/error_helpers.h"
+#include "test/support/src/helpers.h"
+#include "test/support/src/vfs_helpers.h"
+#include "tiledb/sm/cpp_api/tiledb"
+#include "tiledb/sm/cpp_api/tiledb_experimental"
+
+using namespace tiledb;
+using namespace tiledb::test;
+
+// no rapidcheck
+using Asserter = AsserterCatch;
+
+struct QueryAddPredicateFx {
+  VFSTestSetup vfs_test_setup_;
+
+  Context context() const {
+    return vfs_test_setup_.ctx();
+  }
+
+  /**
+   * Creates and writes a two-dimension array with attributes:
+   * - 'a INT32'
+   * - 'v VARCHAR NOT NULL'
+   * - 'e UINT8:VARCHAR'
+   */
+  void create_array(const std::string& path, tiledb_array_type_t atype);
+
+  /**
+   * Writes cells to saturate the ranges [[1, 4], [1, 4]] for an array
+   * of the schema given above
+   */
+  void write_array(const std::string& path, tiledb_array_type_t atype);
+};
+
+void QueryAddPredicateFx::create_array(
+    const std::string& path, tiledb_array_type_t atype) {
+  auto ctx = context();
+
+  Domain domain(ctx);
+  domain.add_dimension(Dimension::create<uint64_t>(ctx, "row", {{1, 4}}, 4));
+  domain.add_dimension(Dimension::create<uint64_t>(ctx, "col", {{1, 4}}, 4));
+
+  ArraySchema schema(ctx, atype);
+  schema.set_tile_order(TILEDB_ROW_MAJOR);
+  schema.set_cell_order(TILEDB_ROW_MAJOR);
+  schema.set_domain(domain);
+
+  schema.add_attribute(Attribute::create<int32_t>(ctx, "a").set_nullable(true));
+  schema.add_attribute(Attribute::create<std::string>(ctx, "v"));
+
+  // enumerated attribute
+  std::vector<std::string> us_states = {
+      "alabama",
+      "alaska",
+      "arizona",
+      "arkansas",
+      "california",
+      "colorado",
+      "connecticut",
+      "etc"};
+  ArraySchemaExperimental::add_enumeration(
+      ctx,
+      schema,
+      Enumeration::create(ctx, std::string("us_states"), us_states));
+  {
+    auto e = Attribute::create<int32_t>(ctx, "e").set_nullable(true);
+    AttributeExperimental::set_enumeration_name(ctx, e, "us_states");
+    schema.add_attribute(e);
+  }
+
+  Array::create(path, schema);
+}
+
+void QueryAddPredicateFx::write_array(
+    const std::string& path, tiledb_array_type_t atype) {
+  auto ctx = context();
+  Array array(ctx, path, TILEDB_WRITE);
+  Query query(ctx, array);
+
+  std::vector<uint64_t> rows = {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4};
+  std::vector<uint64_t> cols = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4};
+
+  if (atype == TILEDB_SPARSE) {
+    query.set_data_buffer("row", rows).set_data_buffer("col", cols);
+  } else {
+    Subarray s(ctx, array);
+    s.add_range(0, 1, 4);
+    s.add_range(1, 1, 4);
+    query.set_layout(TILEDB_ROW_MAJOR).set_subarray(s);
+  }
+
+  std::vector<int32_t> a_values = {
+      15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+  std::vector<uint8_t> a_validity(a_values.size(), 1);
+  a_validity[1] = a_validity[2] = a_validity[3] = a_validity[5] =
+      a_validity[8] = a_validity[13] = 0;
+
+  std::vector<std::string> v_strings = {
+      "one",
+      "two",
+      "three",
+      "four",
+      "five",
+      "six",
+      "seven",
+      "eight",
+      "nine",
+      "ten",
+      "eleven",
+      "twelve",
+      "thirteen",
+      "fourteen",
+      "fifteen",
+      "sixteen"};
+  std::vector<char> v_values;
+  std::vector<uint64_t> v_offsets;
+  for (const auto& s : v_strings) {
+    v_offsets.push_back(v_values.size());
+    v_values.insert(v_values.end(), s.begin(), s.end());
+  }
+
+  std::vector<int32_t> e_keys = {
+      4, 4, 7, 4, 7, 7, 7, 0, 1, 2, 3, 4, 5, 6, 7, 6};
+  std::vector<uint8_t> e_validity(e_keys.size(), 1);
+  e_validity[3] = e_validity[6] = e_validity[9] = e_validity[12] =
+      e_validity[15] = 0;
+
+  query.set_data_buffer("a", a_values)
+      .set_validity_buffer("a", a_validity)
+      .set_data_buffer("v", v_values)
+      .set_offsets_buffer("v", v_offsets)
+      .set_data_buffer("e", e_keys)
+      .set_validity_buffer("e", e_validity);
+
+  query.submit();
+}
+
+TEST_CASE_METHOD(
+    QueryAddPredicateFx,
+    "C API: Test query add predicate errors",
+    "[capi][query][add_predicate]") {
+  const std::string array_name =
+      vfs_test_setup_.array_uri("test_qeury_add_predicate_errors");
+
+  create_array(array_name, TILEDB_SPARSE);
+  write_array(array_name, TILEDB_SPARSE);
+
+  auto ctx = context();
+
+  SECTION("Non-read query errors") {
+    Array array(ctx, array_name, TILEDB_WRITE);
+    Query query(ctx, array);
+
+    REQUIRE_THROWS_WITH(
+        QueryExperimental::add_predicate(ctx, query, "row BETWEEN 4 AND 7"),
+        Catch::Matchers::ContainsSubstring(
+            "Cannot add query predicate; Operation only applicable to read "
+            "queries"));
+  }
+
+  SECTION("Read query errors") {
+    Array array(ctx, array_name, TILEDB_READ);
+    Query query(ctx, array);
+
+    SECTION("Null") {
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(ctx, query, nullptr),
+          Catch::Matchers::ContainsSubstring(
+              "Argument \"predicate\" may not be NULL"));
+    }
+
+    SECTION("Syntax error") {
+      // FIXME: this smells like a bug in datafusion.
+      // If you dbg! the returned expr it prints `Expr::Column(Column { name:
+      // "row" })`
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(ctx, query, "row col"),
+          Catch::Matchers::ContainsSubstring(
+              "Error: Expression does not return a boolean value"));
+    }
+
+    SECTION("Non-expression") {
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(
+              ctx, query, "CREATE TABLE foo (id INT)"),
+          Catch::Matchers::ContainsSubstring(
+              "Error adding predicate: Parse error: SQL error: "
+              "ParserError(\"Unsupported command in expression\")"));
+    }
+
+    SECTION("Not a predicate") {
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(ctx, query, "row"),
+          Catch::Matchers::ContainsSubstring(
+              "Expression does not return a boolean value"));
+    }
+
+    SECTION("Schema error") {
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(ctx, query, "depth = 3"),
+          Catch::Matchers::ContainsSubstring(
+              "Error adding predicate: Parse error: Schema error: No field "
+              "named depth. Valid fields are row, col, a, v, e."));
+    }
+
+    SECTION("Type coercion failure") {
+      // FIXME: from the tables CLI this gives a very different error which is
+      // more user-friendly, there must be some optimization pass which we are
+      // not doing
+      const std::string dferror =
+          "Error adding predicate: Type coercion error: Internal error: Expect "
+          "TypeSignatureClass::Native(LogicalType(Native(String), String)) but "
+          "received NativeType::UInt64, DataType: UInt64.\nThis was likely "
+          "caused by a bug in DataFusion's code and we would welcome that you "
+          "file an bug report in our issue tracker";
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(ctx, query, "starts_with(row, '1')"),
+          Catch::Matchers::ContainsSubstring(dferror));
+    }
+
+    SECTION("Aggregate") {
+      REQUIRE_THROWS_WITH(
+          QueryExperimental::add_predicate(ctx, query, "sum(row) >= 10"),
+          Catch::Matchers::ContainsSubstring(
+              "Aggregate functions in predicate is not supported"));
+    }
+  }
+}

--- a/test/src/unit-query-add-predicate.cc
+++ b/test/src/unit-query-add-predicate.cc
@@ -40,9 +40,11 @@
 #include <test/support/assert_helpers.h>
 #include <test/support/tdb_catch.h>
 
+#include "test/support/src/array_templates.h"
 #include "test/support/src/error_helpers.h"
 #include "test/support/src/helpers.h"
 #include "test/support/src/vfs_helpers.h"
+#include "tiledb/api/c_api/array/array_api_internal.h"
 #include "tiledb/sm/cpp_api/tiledb"
 #include "tiledb/sm/cpp_api/tiledb_experimental"
 
@@ -51,6 +53,14 @@ using namespace tiledb::test;
 
 // no rapidcheck
 using Asserter = AsserterCatch;
+
+// query result type for the array schema used in these tests
+using Cells = templates::Fragment2D<
+    uint64_t,
+    uint64_t,
+    std::optional<int32_t>,
+    std::vector<char>,
+    std::optional<int32_t>>;
 
 struct QueryAddPredicateFx {
   VFSTestSetup vfs_test_setup_;
@@ -72,7 +82,79 @@ struct QueryAddPredicateFx {
    * of the schema given above
    */
   void write_array(const std::string& path, tiledb_array_type_t atype);
+
+  Cells query_array(
+      const std::string& path,
+      tiledb_layout_t layout,
+      std::vector<const char*> predicates);
+
+  Cells query_array(
+      const std::string& path, tiledb_layout_t layout, const char* predicate) {
+    return query_array(path, layout, std::vector<const char*>{predicate});
+  }
+
+  static const Cells INPUT;
 };
+
+const Cells QueryAddPredicateFx::INPUT = Cells{
+    .d1_ = templates::query_buffers<uint64_t>(
+        {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4}),
+    .d2_ = templates::query_buffers<uint64_t>(
+        {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}),
+    .atts_ = std::make_tuple(
+        templates::query_buffers<std::optional<int32_t>>(
+            std::vector<std::optional<int32_t>>{
+                15,
+                std::nullopt,
+                std::nullopt,
+                12,
+                std::nullopt,
+                10,
+                9,
+                std::nullopt,
+                7,
+                6,
+                5,
+                4,
+                std::nullopt,
+                2,
+                1,
+                0}),
+        templates::query_buffers<std::string>(std::vector<std::string>{
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+            "thirteen",
+            "fourteen",
+            "fifteen",
+            "sixteen"}),
+        templates::query_buffers<std::optional<int32_t>>(
+            std::vector<std::optional<int32_t>>{
+                4,
+                4,
+                7,
+                std::nullopt,
+                7,
+                7,
+                std::nullopt,
+                0,
+                1,
+                std::nullopt,
+                3,
+                4,
+                std::nullopt,
+                6,
+                7,
+                std::nullopt}))};
 
 void QueryAddPredicateFx::create_array(
     const std::string& path, tiledb_array_type_t atype) {
@@ -119,62 +201,81 @@ void QueryAddPredicateFx::write_array(
   Array array(ctx, path, TILEDB_WRITE);
   Query query(ctx, array);
 
-  std::vector<uint64_t> rows = {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4};
-  std::vector<uint64_t> cols = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4};
-
-  if (atype == TILEDB_SPARSE) {
-    query.set_data_buffer("row", rows).set_data_buffer("col", cols);
-  } else {
+  if (atype == TILEDB_DENSE) {
     Subarray s(ctx, array);
-    s.add_range(0, 1, 4);
-    s.add_range(1, 1, 4);
+    s.add_range<uint64_t>(0, 1, 4);
+    s.add_range<uint64_t>(1, 1, 4);
     query.set_layout(TILEDB_ROW_MAJOR).set_subarray(s);
+
+    templates::Fragment<
+        std::optional<int32_t>,
+        std::vector<char>,
+        std::optional<int32_t>>
+        cells = {.atts_ = INPUT.atts_};
+
+    auto field_sizes = templates::query::make_field_sizes<Asserter>(cells);
+    templates::query::set_fields<Asserter>(
+        ctx.ptr().get(),
+        query.ptr().get(),
+        field_sizes,
+        cells,
+        array.ptr().get()->array_schema_latest());
+
+    query.submit();
+  } else {
+    auto field_sizes =
+        templates::query::make_field_sizes<Asserter>(const_cast<Cells&>(INPUT));
+    templates::query::set_fields<Asserter>(
+        ctx.ptr().get(),
+        query.ptr().get(),
+        field_sizes,
+        const_cast<Cells&>(INPUT),
+        array.ptr().get()->array_schema_latest());
+    query.submit();
+  }
+}
+
+Cells QueryAddPredicateFx::query_array(
+    const std::string& path,
+    tiledb_layout_t layout,
+    std::vector<const char*> predicates) {
+  auto ctx = context();
+
+  Array array(ctx, path, TILEDB_READ);
+  Query query(ctx, array);
+
+  query.set_layout(layout);
+
+  Cells out;
+  out.resize(32);
+
+  auto field_sizes =
+      templates::query::make_field_sizes<Asserter>(out, out.size());
+
+  templates::query::set_fields<Asserter>(
+      ctx.ptr().get(),
+      query.ptr().get(),
+      field_sizes,
+      out,
+      array.ptr().get()->array_schema_latest());
+
+  for (const char* pred : predicates) {
+    QueryExperimental::add_predicate(ctx, query, pred);
   }
 
-  std::vector<int32_t> a_values = {
-      15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
-  std::vector<uint8_t> a_validity(a_values.size(), 1);
-  a_validity[1] = a_validity[2] = a_validity[3] = a_validity[5] =
-      a_validity[8] = a_validity[13] = 0;
-
-  std::vector<std::string> v_strings = {
-      "one",
-      "two",
-      "three",
-      "four",
-      "five",
-      "six",
-      "seven",
-      "eight",
-      "nine",
-      "ten",
-      "eleven",
-      "twelve",
-      "thirteen",
-      "fourteen",
-      "fifteen",
-      "sixteen"};
-  std::vector<char> v_values;
-  std::vector<uint64_t> v_offsets;
-  for (const auto& s : v_strings) {
-    v_offsets.push_back(v_values.size());
-    v_values.insert(v_values.end(), s.begin(), s.end());
+  if (array.schema().array_type() == TILEDB_DENSE) {
+    Subarray s(ctx, array);
+    s.add_range<uint64_t>(0, 1, 4);
+    s.add_range<uint64_t>(1, 1, 4);
+    query.set_subarray(s);
   }
 
-  std::vector<int32_t> e_keys = {
-      4, 4, 7, 4, 7, 7, 7, 0, 1, 2, 3, 4, 5, 6, 7, 6};
-  std::vector<uint8_t> e_validity(e_keys.size(), 1);
-  e_validity[3] = e_validity[6] = e_validity[9] = e_validity[12] =
-      e_validity[15] = 0;
+  const auto st = query.submit();
+  REQUIRE(st == Query::Status::COMPLETE);
 
-  query.set_data_buffer("a", a_values)
-      .set_validity_buffer("a", a_validity)
-      .set_data_buffer("v", v_values)
-      .set_offsets_buffer("v", v_offsets)
-      .set_data_buffer("e", e_keys)
-      .set_validity_buffer("e", e_validity);
+  templates::query::resize_fields<Asserter>(out, field_sizes);
 
-  query.submit();
+  return out;
 }
 
 TEST_CASE_METHOD(
@@ -266,5 +367,76 @@ TEST_CASE_METHOD(
           Catch::Matchers::ContainsSubstring(
               "Aggregate functions in predicate is not supported"));
     }
+  }
+}
+
+TEST_CASE_METHOD(
+    QueryAddPredicateFx,
+    "C API: Test query add predicate dense",
+    "[capi][query][add_predicate]") {
+  const std::string array_name =
+      vfs_test_setup_.array_uri("test_qeury_add_predicate_dense");
+
+  create_array(array_name, TILEDB_DENSE);
+  write_array(array_name, TILEDB_DENSE);
+
+  // FIXME: error messages
+  REQUIRE_THROWS(query_array(array_name, TILEDB_UNORDERED, "row >= 3"));
+  REQUIRE_THROWS(query_array(array_name, TILEDB_ROW_MAJOR, "row >= 3"));
+  REQUIRE_THROWS(query_array(array_name, TILEDB_COL_MAJOR, "row >= 3"));
+  REQUIRE_THROWS(query_array(array_name, TILEDB_GLOBAL_ORDER, "row >= 3"));
+  REQUIRE_THROWS(query_array(array_name, TILEDB_HILBERT, "row >= 3"));
+}
+
+TEST_CASE_METHOD(
+    QueryAddPredicateFx,
+    "C API: Test query add predicate legacy",
+    "[capi][query][add_predicate]") {
+  const std::string array_name =
+      vfs_test_setup_.array_uri("test_qeury_add_predicate_legacy");
+  // TODO
+}
+
+TEST_CASE_METHOD(
+    QueryAddPredicateFx,
+    "C API: Test query add predicate sparse unsupported query order",
+    "[capi][query][add_predicate]") {
+  const std::string array_name =
+      vfs_test_setup_.array_uri("test_qeury_add_predicate_sparse_unsupported");
+
+  create_array(array_name, TILEDB_SPARSE);
+  write_array(array_name, TILEDB_SPARSE);
+  // TODO
+}
+
+TEST_CASE_METHOD(
+    QueryAddPredicateFx,
+    "C API: Test query add predicate sparse global order",
+    "[capi][query][add_predicate]") {
+  const std::string array_name =
+      vfs_test_setup_.array_uri("test_qeury_add_predicate_sparse_global_order");
+
+  create_array(array_name, TILEDB_SPARSE);
+  write_array(array_name, TILEDB_SPARSE);
+
+  SECTION("WHERE TRUE") {
+    const auto result = query_array(array_name, TILEDB_GLOBAL_ORDER, "TRUE");
+    CHECK(result == INPUT);
+  }
+
+  SECTION("WHERE a IS NULL") {
+    // TODO
+  }
+
+  SECTION("WHERE b < 'fourteen'") {
+    // TODO
+  }
+
+  SECTION("WHERE row + col <= 4") {
+    // TODO
+  }
+
+  SECTION("WHERE coalesce(a, row) > a") {
+    // TODO
   }
 }

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -509,7 +509,8 @@ struct CSparseGlobalOrderFx {
   template <typename Asserter, InstanceType Instance>
   DeleteArrayGuard run_create(Instance& instance);
   template <typename Asserter, InstanceType Instance>
-  void run_execute(Instance& instance);
+  std::optional<typename Instance::FragmentType> run_execute(
+      Instance& instance);
 
   /**
    * Runs an input against a fresh array.
@@ -517,7 +518,7 @@ struct CSparseGlobalOrderFx {
    * and checks that what we read out matches what we put in.
    */
   template <typename Asserter, InstanceType Instance>
-  void run(Instance& instance);
+  std::optional<typename Instance::FragmentType> run(Instance& instance);
 
   template <typename CAPIReturn>
   std::optional<std::string> error_if_any(CAPIReturn apirc) const;
@@ -3401,11 +3402,12 @@ void CSparseGlobalOrderFx::create_array(const Instance& instance) {
  * expected result order computed from the input data.
  */
 template <typename Asserter, InstanceType Instance>
-void CSparseGlobalOrderFx::run(Instance& instance) {
+std::optional<typename Instance::FragmentType> CSparseGlobalOrderFx::run(
+    Instance& instance) {
   reset_config();
 
   auto tmparray = run_create<Asserter, Instance>(instance);
-  run_execute<Asserter, Instance>(instance);
+  return run_execute<Asserter, Instance>(instance);
 }
 
 template <typename Asserter, InstanceType Instance>
@@ -3432,10 +3434,11 @@ DeleteArrayGuard CSparseGlobalOrderFx::run_create(Instance& instance) {
 }
 
 template <typename Asserter, InstanceType Instance>
-void CSparseGlobalOrderFx::run_execute(Instance& instance) {
+std::optional<typename Instance::FragmentType>
+CSparseGlobalOrderFx::run_execute(Instance& instance) {
   ASSERTER(instance.num_user_cells > 0);
 
-  std::decay_t<decltype(instance.fragments[0])> expect;
+  typename Instance::FragmentType expect;
 
   // for de-duplicating, track the fragment that each coordinate came from
   // we will use this to select the coordinate from the most recent fragment
@@ -3613,7 +3616,7 @@ void CSparseGlobalOrderFx::run_execute(Instance& instance) {
             }
           }
           tiledb_query_free(&query);
-          return;
+          return std::nullopt;
         }
         if (err->find("Cannot set array memory budget") != std::string::npos) {
           if (!vfs_test_setup_.is_rest()) {
@@ -3626,7 +3629,7 @@ void CSparseGlobalOrderFx::run_execute(Instance& instance) {
             ASSERTER(array_usage > array_budget);
           }
           tiledb_query_free(&query);
-          return;
+          return std::nullopt;
         }
         if constexpr (std::is_same_v<Asserter, AsserterRapidcheck>) {
           if (err->find(
@@ -3636,13 +3639,13 @@ void CSparseGlobalOrderFx::run_execute(Instance& instance) {
             // we can probably make some assertions about what this should have
             // looked like but for now we'll let it go
             tiledb_query_free(&query);
-            return;
+            return std::nullopt;
           }
           if (err->find("Cannot load tile offsets") != std::string::npos) {
             // not enough memory budget for tile offsets, don't bother asserting
             // about it (for now?)
             tiledb_query_free(&query);
-            return;
+            return std::nullopt;
           }
         }
       }
@@ -3788,6 +3791,8 @@ void CSparseGlobalOrderFx::run_execute(Instance& instance) {
       ASSERTER(can_complete.has_value());
     }
   }
+
+  return expect;
 }
 
 // rapidcheck generators and Arbitrary specializations

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -3714,15 +3714,7 @@ CSparseGlobalOrderFx::run_execute(Instance& instance) {
   // Clean up.
   tiledb_query_free(&query);
 
-  std::apply(
-      [outcursor](auto&... outfield) {
-        std::apply(
-            [&](const auto&... field_cursor) {
-              (outfield.finish_multipart_read(field_cursor), ...);
-            },
-            outcursor);
-      },
-      std::tuple_cat(outdims, outatts));
+  templates::query::resize_fields<Asserter>(out, outcursor);
 
   ASSERTER(expect.dimensions() == outdims);
 

--- a/test/src/unit-sparse-global-order-reader.cc
+++ b/test/src/unit-sparse-global-order-reader.cc
@@ -36,6 +36,7 @@
 #include "test/support/src/array_templates.h"
 #include "test/support/src/error_helpers.h"
 #include "test/support/src/helpers.h"
+#include "test/support/src/query_helpers.h"
 #include "test/support/src/vfs_helpers.h"
 #include "tiledb/api/c_api/array/array_api_internal.h"
 #include "tiledb/sm/c_api/tiledb.h"
@@ -147,6 +148,7 @@ struct FxRun1D {
 
   // for evaluating
   std::optional<tdb_unique_ptr<tiledb::sm::ASTNode>> condition;
+  bool condition_use_datafusion = false;
 
   DefaultArray1DConfig<DIMENSION_TYPE> array;
   SparseGlobalOrderReaderMemoryBudget memory;
@@ -258,6 +260,7 @@ struct FxRun2D {
       std::optional<templates::Domain<Coord1Type>>>>
       subarray;
   std::optional<tdb_unique_ptr<tiledb::sm::ASTNode>> condition;
+  bool condition_use_datafusion;
 
   size_t num_user_cells;
 
@@ -271,7 +274,8 @@ struct FxRun2D {
   SparseGlobalOrderReaderMemoryBudget memory;
 
   FxRun2D()
-      : capacity(64)
+      : condition_use_datafusion(false)
+      , capacity(64)
       , allow_dups(true)
       , tile_order_(TILEDB_ROW_MAJOR)
       , cell_order_(TILEDB_ROW_MAJOR) {
@@ -3456,12 +3460,6 @@ CSparseGlobalOrderFx::run_execute(Instance& instance) {
       expect_fragment.insert(expect_fragment.end(), fragment.size(), f);
     } else {
       std::vector<uint64_t> accept;
-      std::optional<
-          templates::QueryConditionEvalSchema<typename Instance::FragmentType>>
-          eval;
-      if (instance.condition.has_value()) {
-        eval.emplace();
-      }
       for (uint64_t i = 0; i < fragment.size(); i++) {
         if (!instance.pass_subarray(fragment, i)) {
           continue;
@@ -3563,10 +3561,17 @@ CSparseGlobalOrderFx::run_execute(Instance& instance) {
   }
 
   if (instance.condition.has_value()) {
-    tiledb::sm::QueryCondition qc(instance.condition->get()->clone());
-    const auto rc =
-        query->query_->set_condition(qc);  // SAFETY: this performs a deep copy
-    ASSERTER(rc.to_string() == "Ok");
+    if (instance.condition_use_datafusion) {
+      const std::string sql = tiledb::test::to_sql(
+          *instance.condition.value().get(),
+          array->array()->array_schema_latest());
+      TRY(context(), tiledb_query_add_predicate(context(), query, sql.c_str()));
+    } else {
+      tiledb::sm::QueryCondition qc(instance.condition->get()->clone());
+      const auto rc = query->query_->set_condition(
+          qc);  // SAFETY: this performs a deep copy
+      ASSERTER(rc.to_string() == "Ok");
+    }
   }
 
   // Prepare output buffer
@@ -3874,20 +3879,22 @@ struct Arbitrary<FxRun1D<DIMENSION_TYPE, ATTR_TYPES...>> {
     auto num_user_cells = gen::inRange(1, 8 * 1024 * 1024);
 
     return gen::apply(
-        [](auto fragments, int num_user_cells) {
+        [](auto fragments, int num_user_cells, bool condition_use_datafusion) {
           FxRun1D instance;
           instance.array.allow_dups_ = std::get<0>(fragments);
           instance.array.dimension_ = std::get<1>(fragments);
           instance.subarray = std::get<2>(fragments);
           instance.fragments = std::move(std::get<3>(fragments).first);
           instance.condition = std::move(std::get<3>(fragments).second);
+          instance.condition_use_datafusion = condition_use_datafusion;
 
           instance.num_user_cells = num_user_cells;
 
           return instance;
         },
         fragments,
-        num_user_cells);
+        num_user_cells,
+        gen::arbitrary<bool>());
   }
 };
 
@@ -3983,7 +3990,8 @@ struct Arbitrary<FxRun2D> {
         [](auto fragments,
            int num_user_cells,
            tiledb_layout_t tile_order,
-           tiledb_layout_t cell_order) {
+           tiledb_layout_t cell_order,
+           bool condition_use_datafusion) {
           FxRun2D instance;
           instance.allow_dups = std::get<0>(fragments);
           instance.d1 = std::get<1>(fragments);
@@ -3991,6 +3999,7 @@ struct Arbitrary<FxRun2D> {
           instance.subarray = std::get<3>(fragments);
           instance.fragments = std::move(std::get<4>(fragments).first);
           instance.condition = std::move(std::get<4>(fragments).second);
+          instance.condition_use_datafusion = condition_use_datafusion;
 
           // TODO: capacity
           instance.num_user_cells = num_user_cells;
@@ -4002,7 +4011,8 @@ struct Arbitrary<FxRun2D> {
         fragments,
         num_user_cells,
         tile_order,
-        cell_order);
+        cell_order,
+        gen::arbitrary<bool>());
   }
 };
 

--- a/test/support/CMakeLists.txt
+++ b/test/support/CMakeLists.txt
@@ -46,6 +46,7 @@ set(TILEDB_TEST_SUPPORT_SOURCES
   src/helpers-dimension.h
   src/mem_helpers.h
   src/mem_helpers.cc
+  src/query_helpers.cc
   src/serialization_wrappers.cc
   src/stats.cc
   src/temporary_local_directory.cc

--- a/test/support/src/array_templates.h
+++ b/test/support/src/array_templates.h
@@ -36,6 +36,7 @@
 
 #include "tiledb.h"
 #include "tiledb/common/unreachable.h"
+#include "tiledb/sm/array_schema/array_schema.h"
 #include "tiledb/sm/query/ast/query_ast.h"
 #include "tiledb/type/datatype_traits.h"
 #include "tiledb/type/range/range.h"
@@ -576,6 +577,18 @@ struct query_buffers<std::optional<T>> {
   std::vector<uint8_t> validity_;
 
   query_buffers() {
+  }
+
+  query_buffers(std::vector<std::optional<T>> cells) {
+    for (const auto& cell : cells) {
+      if (cell.has_value()) {
+        values_.push_back(cell.value());
+        validity_.push_back(1);
+      } else {
+        values_.push_back(T());
+        validity_.push_back(0);
+      }
+    }
   }
 
   query_buffers(const self_type& other) = default;
@@ -1126,6 +1139,56 @@ struct query_buffers<std::optional<std::vector<T>>> {
 };
 
 /**
+ * Specialization of `query_buffers` for variable-length non-nullable cells
+ * whose physical type is `char` and thus the "logical type" of each cell
+ * is `std::string`.
+ *
+ * See `query_buffers<std::vector<T>>`.
+ */
+template <>
+struct query_buffers<std::string> : public query_buffers<std::vector<char>> {
+  query_buffers(std::vector<std::string> cells) {
+    for (const auto& cell : cells) {
+      offsets_.push_back(values_.size());
+      values_.insert(values_.end(), cell.begin(), cell.end());
+    }
+  }
+};
+
+template <AttributeType... Att>
+struct Fragment {
+  std::tuple<query_buffers<Att>...> atts_;
+
+  uint64_t size() const {
+    return std::get<0>(atts_).num_cells();
+  }
+
+  std::tuple<> dimensions() const {
+    return std::tuple<>();
+  }
+
+  std::tuple<const query_buffers<Att>&...> attributes() const {
+    return std::apply(
+        [](const query_buffers<Att>&... attribute) {
+          return std::tuple<const query_buffers<Att>&...>(attribute...);
+        },
+        atts_);
+  }
+
+  std::tuple<> dimensions() {
+    return std::tuple<>();
+  }
+
+  std::tuple<query_buffers<Att>&...> attributes() {
+    return std::apply(
+        [](query_buffers<Att>&... attribute) {
+          return std::tuple<query_buffers<Att>&...>(attribute...);
+        },
+        atts_);
+  }
+};
+
+/**
  * Data for a one-dimensional array
  */
 template <DimensionType D, AttributeType... Att>
@@ -1169,12 +1232,30 @@ struct Fragment1D {
  */
 template <DimensionType D1, DimensionType D2, typename... Att>
 struct Fragment2D {
+  using Self = Fragment2D<D1, D2, Att...>;
+
   query_buffers<D1> d1_;
   query_buffers<D2> d2_;
   std::tuple<query_buffers<Att>...> atts_;
 
   uint64_t size() const {
     return d1_.num_cells();
+  }
+
+  void reserve(uint64_t num_cells) {
+    d1_.reserve(num_cells);
+    d2_.reserve(num_cells);
+    std::apply(
+        [&](query_buffers<Att>&... att) { (att.reserve(num_cells), ...); },
+        atts_);
+  }
+
+  void resize(uint64_t num_cells) {
+    d1_.resize(num_cells);
+    d2_.resize(num_cells);
+    std::apply(
+        [&](query_buffers<Att>&... att) { (att.resize(num_cells), ...); },
+        atts_);
   }
 
   std::tuple<const query_buffers<D1>&, const query_buffers<D2>&> dimensions()
@@ -1202,6 +1283,8 @@ struct Fragment2D {
         },
         atts_);
   }
+
+  bool operator==(const Self& other) const = default;
 };
 
 /**
@@ -1367,6 +1450,25 @@ void set_fields(
         attribute_name,
         split_cursors.second);
   }(fragment.attributes());
+}
+
+template <typename Asserter, FragmentType F>
+void set_fields(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    fragment_field_sizes_t<F>& field_sizes,
+    F& fragment,
+    const tiledb::sm::ArraySchema& schema,
+    const fragment_field_sizes_t<F>& field_cursors =
+        fragment_field_sizes_t<F>()) {
+  std::function<std::string(unsigned)> dim_name = [&](unsigned dim) {
+    return schema.domain().dimension_ptr(dim)->name();
+  };
+  std::function<std::string(unsigned)> att_name = [&](unsigned att) {
+    return schema.attribute(att)->name();
+  };
+  return set_fields<Asserter, F>(
+      ctx, query, field_sizes, fragment, dim_name, att_name, field_cursors);
 }
 
 /**

--- a/test/support/src/array_templates.h
+++ b/test/support/src/array_templates.h
@@ -1379,6 +1379,19 @@ uint64_t num_cells(const F& fragment, const auto& field_sizes) {
   }(std::tuple_cat(fragment.dimensions(), fragment.attributes()));
 }
 
+template <typename Asserter, FragmentType F>
+void resize_fields(F& fragment, const auto& field_sizes) {
+  std::apply(
+      [field_sizes](auto&... outfield) {
+        std::apply(
+            [&](const auto&... field_cursor) {
+              (outfield.finish_multipart_read(field_cursor), ...);
+            },
+            field_sizes);
+      },
+      std::tuple_cat(fragment.dimensions(), fragment.attributes()));
+}
+
 }  // namespace query
 
 }  // namespace tiledb::test::templates

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1636,7 +1636,13 @@ void schema_equiv(
     CHECK(a->name() == b->name());
     CHECK(a->type() == b->type());
     CHECK(a->nullable() == b->nullable());
-    CHECK(a->get_enumeration_name() == b->get_enumeration_name());
+
+    const auto a_enmr = a->get_enumeration_name(),
+               b_enmr = b->get_enumeration_name();
+    CHECK(a_enmr.has_value() == b_enmr.has_value());
+    if (a_enmr.has_value() && b_enmr.has_value()) {
+      CHECK(a_enmr.value().get() == b_enmr.value().get());
+    }
   }
   CHECK(schema1.capacity() == schema2.capacity());
   CHECK(schema1.cell_order() == schema2.cell_order());

--- a/test/support/src/query_helpers.cc
+++ b/test/support/src/query_helpers.cc
@@ -1,0 +1,102 @@
+/**
+ * @file query_helpers.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2025 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+#include "test/support/src/query_helpers.h"
+#include "tiledb/stdx/utility/to_underlying.h"
+#include "tiledb/type/apply_with_type.h"
+
+#include <sstream>
+
+namespace tiledb::test {
+
+using namespace tiledb::sm;
+
+static const char* to_sql_op(QueryConditionOp op) {
+  switch (op) {
+    case QueryConditionOp::LT:
+      return "<";
+    case QueryConditionOp::LE:
+      return "<=";
+    case QueryConditionOp::EQ:
+      return "=";
+    case QueryConditionOp::GE:
+      return ">=";
+    case QueryConditionOp::GT:
+      return ">";
+    case QueryConditionOp::NE:
+      return "<>";
+    default:
+      throw std::logic_error(
+          "Invalid query condition op: " +
+          std::to_string(stdx::to_underlying(op)));
+  }
+}
+
+std::string to_sql(const ASTNode& ast, const ArraySchema& schema) {
+  const ASTNodeVal* valnode = static_cast<const ASTNodeVal*>(&ast);
+  const ASTNodeExpr* exprnode = dynamic_cast<const ASTNodeExpr*>(&ast);
+
+  std::stringstream os;
+  if (valnode) {
+    const auto fname = valnode->get_field_name();
+    const auto op = valnode->get_op();
+    const auto bytes = valnode->get_data();
+
+    std::stringstream value;
+
+    apply_with_type(
+        [&](auto t) {
+          using T = decltype(t);
+          value << *reinterpret_cast<const T*>(bytes.data());
+        },
+        schema.type(fname));
+
+    os << fname << " " << to_sql_op(op) << " " << value.str();
+  } else if (exprnode) {
+    const auto op = exprnode->get_combination_op();
+    const auto& children = exprnode->get_children();
+    if (op == QueryConditionCombinationOp::NOT) {
+      assert(children.size() == 1);
+      os << "NOT ";
+    }
+    for (unsigned i = 0; i < children.size(); i++) {
+      if (i != 0) {
+        os << " " << query_condition_combination_op_str(op) << " ";
+      }
+      os << "(" << to_sql(*children[i].get(), schema) << ")";
+    }
+  } else {
+    throw std::logic_error(
+        "Invalid query condition syntax tree node: " +
+        std::string(typeid(ast).name()));
+  }
+  return os.str();
+}
+
+}  // namespace tiledb::test

--- a/test/support/src/query_helpers.h
+++ b/test/support/src/query_helpers.h
@@ -1,0 +1,50 @@
+/**
+ * @file test/support/src/query_helpers.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2025 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#ifndef TILEDB_TEST_SUPPORT_QUERY_CONDITION_H
+#define TILEDB_TEST_SUPPORT_QUERY_CONDITION_H
+
+#include "tiledb/sm/array_schema/array_schema.h"
+#include "tiledb/sm/query/ast/query_ast.h"
+
+#include <string>
+
+namespace tiledb::test {
+
+/**
+ * @return a SQL representation of the query condition syntax tree
+ */
+std::string to_sql(
+    const tiledb::sm::ASTNode& ast,
+    const tiledb::sm::ArraySchema& array_schema);
+
+}  // namespace tiledb::test
+
+#endif

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -869,7 +869,7 @@ struct VFSTestSetup {
     }
   }
 
-  Context ctx() {
+  Context ctx() const {
     return Context(ctx_c, false);
   }
 

--- a/tiledb/api/c_api/array_schema/array_schema_api.cc
+++ b/tiledb/api/c_api/array_schema/array_schema_api.cc
@@ -250,9 +250,9 @@ capi_return_t tiledb_array_schema_get_enumeration_from_attribute_name(
     return TILEDB_OK;
   }
 
-  array_schema->load_enumeration(ctx, enumeration_name->c_str());
+  array_schema->load_enumeration(ctx, enumeration_name->get().c_str());
 
-  auto ptr = array_schema->get_enumeration(enumeration_name->c_str());
+  auto ptr = array_schema->get_enumeration(enumeration_name->get().c_str());
   *enumeration = tiledb_enumeration_handle_t::make_handle(ptr);
 
   return TILEDB_OK;

--- a/tiledb/api/c_api/attribute/attribute_api_internal.h
+++ b/tiledb/api/c_api/attribute/attribute_api_internal.h
@@ -187,7 +187,12 @@ struct tiledb_attribute_handle_t
    * Facade for `Attribute` function
    */
   [[nodiscard]] std::optional<std::string> get_enumeration_name() const {
-    return attr_->get_enumeration_name();
+    const auto eref = attr_->get_enumeration_name();
+    if (eref.has_value()) {
+      return eref.value().get();
+    } else {
+      return std::nullopt;
+    }
   };
   /**
    * Facade for `Attribute` function

--- a/tiledb/oxidize/CMakeLists.txt
+++ b/tiledb/oxidize/CMakeLists.txt
@@ -40,7 +40,14 @@ cxxbridge(
     sm/query/ast/mod.rs
     sm/misc/mod.rs
     sm/tile/mod.rs
-) 
+)
+
+cxxbridge(
+  NAME
+    session
+  SOURCES
+    lib.rs
+)
 
 cxxbridge(
   NAME
@@ -61,6 +68,7 @@ oxidize(
     arrow
     cxx-interface
     expr
+    session
 )
 
 oxidize(

--- a/tiledb/oxidize/Cargo.lock
+++ b/tiledb/oxidize/Cargo.lock
@@ -2866,6 +2866,7 @@ name = "tiledb-expr"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "cxx",
  "cxx-build",
  "datafusion",

--- a/tiledb/oxidize/Cargo.lock
+++ b/tiledb/oxidize/Cargo.lock
@@ -2842,6 +2842,7 @@ version = "0.1.0"
 dependencies = [
  "tiledb-arrow",
  "tiledb-expr",
+ "tiledb-session",
 ]
 
 [[package]]
@@ -2906,6 +2907,22 @@ dependencies = [
 name = "tiledb-proptest-config"
 version = "0.1.0"
 source = "git+https://github.com/TileDB-Inc/tiledb-rs.git?branch=main#e418936fff551dd608e2a1b5e3c557f4c8e5d29d"
+
+[[package]]
+name = "tiledb-session"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "cxx-build",
+ "datafusion",
+ "itertools",
+ "num-traits",
+ "thiserror 2.0.12",
+ "tiledb-arrow",
+ "tiledb-cxx-interface",
+ "tiledb-expr",
+]
 
 [[package]]
 name = "tiledb-sys-defs"

--- a/tiledb/oxidize/Cargo.toml
+++ b/tiledb/oxidize/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "staticlibs/core-objects",
   "staticlibs/unit-arithmetic",
   "staticlibs/unit-query-condition",
+  "session",
   "test-support/array-schema",
   "test-support/cxx-interface",
   "test-support/ffi",
@@ -38,6 +39,7 @@ tiledb-cxx-interface = { path = "cxx-interface" }
 tiledb-datatype = { path = "datatype" }
 tiledb-expr = { path = "expr" }
 tiledb-pod = { git = "https://github.com/TileDB-Inc/tiledb-rs.git", branch = "main", features = [ "proptest-strategies" ] }
+tiledb-session = { path = "session" }
 tiledb-test-array-schema = { path = "test-support/array-schema" }
 tiledb-test-cells = { package = "cells", git = "https://github.com/TileDB-Inc/tiledb-rs.git", branch = "main", features = [ "proptest-strategies" ] }
 tiledb-test-ffi = { path = "test-support/ffi" }

--- a/tiledb/oxidize/arrow/src/lib.rs
+++ b/tiledb/oxidize/arrow/src/lib.rs
@@ -14,9 +14,12 @@ pub mod ffi {
         type ArrowSchema;
 
         #[cxx_name = "create"]
-        fn array_schema_to_arrow_schema(
+        fn array_schema_create_arrow_schema(schema: &ArraySchema) -> Result<Box<ArrowSchema>>;
+
+        #[cxx_name = "project"]
+        fn array_schema_project_arrow_schema(
             schema: &ArraySchema,
-            select: &CxxVector<CxxString>,
+            select: &Vec<String>,
         ) -> Result<Box<ArrowSchema>>;
     }
 
@@ -37,7 +40,10 @@ pub mod record_batch;
 pub mod schema;
 
 use record_batch::{ArrowRecordBatch, to_record_batch as result_tile_to_record_batch};
-use schema::{ArrowSchema, cxx::to_arrow as array_schema_to_arrow_schema};
+use schema::{
+    ArrowSchema, cxx::project_arrow as array_schema_project_arrow_schema,
+    cxx::to_arrow as array_schema_create_arrow_schema,
+};
 
 unsafe impl cxx::ExternType for ArrowRecordBatch {
     type Id = cxx::type_id!("tiledb::oxidize::arrow::record_batch::ArrowRecordBatch");

--- a/tiledb/oxidize/arrow/src/record_batch.rs
+++ b/tiledb/oxidize/arrow/src/record_batch.rs
@@ -6,7 +6,8 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    self as aa, Array as ArrowArray, FixedSizeListArray, GenericListArray, PrimitiveArray,
+    self as aa, Array as ArrowArray, FixedSizeListArray, GenericListArray, LargeStringArray,
+    PrimitiveArray,
 };
 use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{self as adt, ArrowPrimitiveType, Field};
@@ -39,6 +40,8 @@ pub enum FieldError {
     InternalUnalignedValues,
     #[error("Internal error: invalid variable-length data offsets: {0}")]
     InternalOffsets(#[from] OffsetsError),
+    #[error("Error reading tile: {0}")]
+    InvalidTileData(#[source] arrow::error::ArrowError),
 }
 
 /// Wraps a [RecordBatch] for passing across the FFI boundary.
@@ -221,6 +224,21 @@ unsafe fn to_arrow_array(
                 null_buffer,
             )))
         }
+        DataType::LargeUtf8 => {
+            let Some(var_tile) = var else {
+                return Err(FieldError::ExpectedVarTile);
+            };
+            let offsets = crate::offsets::try_from_bytes(1, fixed.as_slice())?;
+            let values = unsafe {
+                // SAFETY: TODO add comment
+                to_buffer::<UInt8Type>(var_tile)
+            }?;
+
+            Ok(Arc::new(
+                LargeStringArray::try_new(offsets, values.into(), null_buffer)
+                    .map_err(FieldError::InvalidTileData)?,
+            ))
+        }
         DataType::LargeList(value_field) => {
             let Some(var_tile) = var else {
                 return Err(FieldError::ExpectedVarTile);
@@ -263,6 +281,23 @@ unsafe fn to_primitive_array<T>(
 where
     T: ArrowPrimitiveType,
 {
+    let values = unsafe {
+        // SAFETY: TODO add comment
+        to_buffer::<T>(tile)
+    }?;
+    Ok(Arc::new(PrimitiveArray::<T>::new(values, validity)) as Arc<dyn ArrowArray>)
+}
+
+/// Returns a [Buffer] which refers to the data contained inside the [Tile].
+///
+/// # Safety
+///
+/// This function is safe to call as long as the returned [Buffer]
+/// is not used after the argument [Tile] is destructed.
+unsafe fn to_buffer<T>(tile: &Tile) -> Result<ScalarBuffer<T::Native>, FieldError>
+where
+    T: ArrowPrimitiveType,
+{
     let (prefix, values, suffix) = {
         // SAFETY: transmuting u8 to primitive types is safe
         unsafe { tile.as_slice().align_to::<T::Native>() }
@@ -270,31 +305,29 @@ where
     if !(prefix.is_empty() && suffix.is_empty()) {
         return Err(FieldError::InternalUnalignedValues);
     }
-    let tile_buffer = if let Some(ptr) = std::ptr::NonNull::new(values.as_ptr() as *mut u8) {
-        // SAFETY:
-        //
-        // `Buffer::from_custom_allocation` creates a buffer which refers to an existing
-        // memory region whose ownership is tracked by some `Arc<dyn Allocation>`.
-        // `Allocation` is basically any type, whose `drop` implementation is responsible
-        // for freeing the memory.
-        //
-        // The tile memory which we reference lives on the `extern "C++"` side of the
-        // FFI boundary, as such we cannot use `Arc` to track its lifetime.
-        //
-        // As such:
-        // 1) we will use an object with trivial `drop` to set up the memory aliasing
-        // 2) there is an implicit lifetime requirement that the Tile must out-live
-        //    this Buffer, else we shall suffer use after free
-        // 3) the caller is responsible for upholding that guarantee
-        unsafe { Buffer::from_custom_allocation(ptr, tile.size() as usize, Arc::new(())) }
-    } else {
-        Buffer::from_vec(Vec::<T::Native>::new())
-    };
 
-    Ok(Arc::new(PrimitiveArray::<T>::new(
-        ScalarBuffer::from(tile_buffer),
-        validity,
-    )) as Arc<dyn ArrowArray>)
+    Ok(ScalarBuffer::<T::Native>::from(
+        if let Some(ptr) = std::ptr::NonNull::new(values.as_ptr() as *mut u8) {
+            // SAFETY:
+            //
+            // `Buffer::from_custom_allocation` creates a buffer which refers to an existing
+            // memory region whose ownership is tracked by some `Arc<dyn Allocation>`.
+            // `Allocation` is basically any type, whose `drop` implementation is responsible
+            // for freeing the memory.
+            //
+            // The tile memory which we reference lives on the `extern "C++"` side of the
+            // FFI boundary, as such we cannot use `Arc` to track its lifetime.
+            //
+            // As such:
+            // 1) we will use an object with trivial `drop` to set up the memory aliasing
+            // 2) there is an implicit lifetime requirement that the Tile must out-live
+            //    this Buffer, else we shall suffer use after free
+            // 3) the caller is responsible for upholding that guarantee
+            unsafe { Buffer::from_custom_allocation(ptr, tile.size() as usize, Arc::new(())) }
+        } else {
+            Buffer::from_vec(Vec::<T::Native>::new())
+        },
+    ))
 }
 
 /// Returns an [OffsetBuffer] which represents the contents of the [Tile].

--- a/tiledb/oxidize/arrow/src/record_batch.rs
+++ b/tiledb/oxidize/arrow/src/record_batch.rs
@@ -42,6 +42,8 @@ pub enum FieldError {
     InternalOffsets(#[from] OffsetsError),
     #[error("Error reading tile: {0}")]
     InvalidTileData(#[source] arrow::error::ArrowError),
+    #[error("Attributes with enumerations are not supported in text predicates")]
+    EnumerationNotSupported,
 }
 
 /// Wraps a [RecordBatch] for passing across the FFI boundary.
@@ -255,6 +257,13 @@ unsafe fn to_arrow_array(
                 values,
                 null_buffer,
             )))
+        }
+        DataType::Dictionary(_, _) => {
+            // NB: we will do this later,
+            // it will require some refactoring so that we build the enumeration
+            // ArrowArrays just once for the whole query, in addition to the
+            // issues with regards to the enumeration being loaded
+            return Err(FieldError::EnumerationNotSupported);
         }
         _ => {
             // SAFETY: ensured by limited range of return values of `crate::schema::arrow_datatype`

--- a/tiledb/oxidize/arrow/src/record_batch.rs
+++ b/tiledb/oxidize/arrow/src/record_batch.rs
@@ -11,7 +11,7 @@ use arrow::array::{
 };
 use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{self as adt, ArrowPrimitiveType, Field};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use tiledb_cxx_interface::sm::query::readers::{ResultTile, TileTuple};
 use tiledb_cxx_interface::sm::tile::Tile;
 
@@ -122,8 +122,17 @@ pub unsafe fn to_record_batch(
     );
 
     // SAFETY: the four asserts above rule out each of the possible error conditions
-    let arrow = RecordBatch::try_new(Arc::clone(&schema.0), columns)
-        .expect("Logic error: preconditions for constructing RecordBatch not met");
+    let arrow = if columns.is_empty() {
+        RecordBatch::try_new_with_options(
+            Arc::clone(&schema.0),
+            columns,
+            &RecordBatchOptions::new().with_row_count(Some(tile.cell_num() as usize)),
+        )
+    } else {
+        RecordBatch::try_new(Arc::clone(&schema.0), columns)
+    };
+
+    let arrow = arrow.expect("Logic error: preconditions for constructing RecordBatch not met");
 
     Ok(Box::new(ArrowRecordBatch { arrow }))
 }

--- a/tiledb/oxidize/arrow/src/schema.rs
+++ b/tiledb/oxidize/arrow/src/schema.rs
@@ -26,6 +26,8 @@ pub enum FieldError {
     InvalidCellValNum(CellValNum),
     #[error("Internal error: invalid discriminant for data type: {0}")]
     InternalInvalidDatatype(u8),
+    #[error("Internal error: enumeration not found: {0}")]
+    InternalEnumerationNotFound(String),
 }
 
 /// Wraps a [Schema] for passing across the FFI boundary.
@@ -74,8 +76,8 @@ where
         let field_name = f
             .name()
             .map_err(|e| Error::NameNotUtf8(f.name_cxx().as_bytes().to_vec(), e))?;
-        let arrow_type =
-            field_arrow_datatype(&f).map_err(|e| Error::FieldError(field_name.to_owned(), e))?;
+        let arrow_type = field_arrow_datatype(array_schema, &f)
+            .map_err(|e| Error::FieldError(field_name.to_owned(), e))?;
 
         // NB: fields can always be null due to schema evolution
         Ok(ArrowField::new(field_name, arrow_type, true))
@@ -88,29 +90,62 @@ where
 }
 
 /// Returns an [ArrowDataType] which represents the physical data type of `field`.
-pub fn field_arrow_datatype(field: &Field) -> Result<ArrowDataType, FieldError> {
-    match field.cell_val_num() {
-        CellValNum::Single => Ok(arrow_datatype(field.datatype())?),
+pub fn field_arrow_datatype(
+    array_schema: &ArraySchema,
+    field: &Field,
+) -> Result<ArrowDataType, FieldError> {
+    if let Some(e_name) = field.enumeration_name_cxx() {
+        if !array_schema.has_enumeration(e_name) {
+            return Err(FieldError::InternalEnumerationNotFound(
+                e_name.to_string_lossy().into_owned(),
+            ));
+        }
+
+        let enumeration = array_schema.enumeration_cxx(e_name);
+
+        let key_type = arrow_datatype(field.datatype(), field.cell_val_num())?;
+        let value_type = if let Some(enumeration) = enumeration.as_ref() {
+            arrow_datatype(enumeration.datatype(), enumeration.cell_val_num())?
+        } else {
+            // NB: we don't necessarily want to return an error here
+            // because the enumeration might not actually be used
+            // in a predicate. We can return some representation
+            // which we will check later if it is actually used,
+            // and return an error then.
+            ArrowDataType::Null
+        };
+        Ok(ArrowDataType::Dictionary(
+            Box::new(key_type),
+            Box::new(value_type),
+        ))
+    } else {
+        arrow_datatype(field.datatype(), field.cell_val_num())
+    }
+}
+
+pub fn arrow_datatype(
+    datatype: Datatype,
+    cell_val_num: CellValNum,
+) -> Result<ArrowDataType, FieldError> {
+    match cell_val_num {
+        CellValNum::Single => Ok(arrow_primitive_datatype(datatype)?),
         CellValNum::Fixed(nz) => {
             if let Ok(fixed_length) = i32::try_from(nz.get()) {
-                let value_type = arrow_datatype(field.datatype())?;
+                let value_type = arrow_primitive_datatype(datatype)?;
                 Ok(ArrowDataType::FixedSizeList(
                     Arc::new(ArrowField::new_list_field(value_type, false)),
                     fixed_length,
                 ))
             } else {
                 // cell val num greater than i32::MAX
-                Err(FieldError::InvalidCellValNum(field.cell_val_num()))
+                Err(FieldError::InvalidCellValNum(cell_val_num))
             }
         }
         CellValNum::Var => {
-            if matches!(
-                field.datatype(),
-                Datatype::STRING_ASCII | Datatype::STRING_UTF8
-            ) {
+            if matches!(datatype, Datatype::STRING_ASCII | Datatype::STRING_UTF8) {
                 Ok(ArrowDataType::LargeUtf8)
             } else {
-                let value_type = arrow_datatype(field.datatype())?;
+                let value_type = arrow_primitive_datatype(datatype)?;
                 Ok(ArrowDataType::LargeList(Arc::new(
                     ArrowField::new_list_field(value_type, false),
                 )))
@@ -120,7 +155,7 @@ pub fn field_arrow_datatype(field: &Field) -> Result<ArrowDataType, FieldError> 
 }
 
 /// Returns an [ArrowDataType] which represents the physical type of a single value of `datatype`.
-pub fn arrow_datatype(datatype: Datatype) -> Result<ArrowDataType, FieldError> {
+pub fn arrow_primitive_datatype(datatype: Datatype) -> Result<ArrowDataType, FieldError> {
     Ok(match datatype {
         Datatype::INT8 => ArrowDataType::Int8,
         Datatype::INT16 => ArrowDataType::Int16,

--- a/tiledb/oxidize/arrow/src/schema.rs
+++ b/tiledb/oxidize/arrow/src/schema.rs
@@ -41,21 +41,32 @@ impl Deref for ArrowSchema {
 pub mod cxx {
     use super::*;
 
+    pub fn to_arrow(array_schema: &ArraySchema) -> Result<Box<ArrowSchema>, Error> {
+        Ok(Box::new(ArrowSchema(Arc::new(super::project_arrow(
+            array_schema,
+            |_: &Field| true,
+        )?))))
+    }
+
     /// Returns a [Schema] which represents the physical field types of
     /// the fields from `array_schema` which are contained in `select`.
-    pub fn to_arrow(
+    pub fn project_arrow(
         array_schema: &ArraySchema,
-        select: &::cxx::Vector<::cxx::String>,
+        select: &Vec<String>,
     ) -> Result<Box<ArrowSchema>, Error> {
-        Ok(Box::new(ArrowSchema(Arc::new(super::to_arrow(
+        Ok(Box::new(ArrowSchema(Arc::new(super::project_arrow(
             array_schema,
-            |field: &Field| select.iter().any(|s| s == field.name_cxx()),
+            |field: &Field| select.iter().any(|s| s.as_str() == field.name_cxx()),
         )?))))
     }
 }
 
+pub fn to_arrow(array_schema: &ArraySchema) -> Result<Schema, Error> {
+    project_arrow(array_schema, |_: &Field| true)
+}
+
 /// Returns a [Schema] which represents the physical field types of the selected fields from `array_schema`.
-pub fn to_arrow<F>(array_schema: &ArraySchema, select: F) -> Result<Schema, Error>
+pub fn project_arrow<F>(array_schema: &ArraySchema, select: F) -> Result<Schema, Error>
 where
     F: Fn(&Field) -> bool,
 {

--- a/tiledb/oxidize/arrow/src/schema.rs
+++ b/tiledb/oxidize/arrow/src/schema.rs
@@ -104,10 +104,17 @@ pub fn field_arrow_datatype(field: &Field) -> Result<ArrowDataType, FieldError> 
             }
         }
         CellValNum::Var => {
-            let value_type = arrow_datatype(field.datatype())?;
-            Ok(ArrowDataType::LargeList(Arc::new(
-                ArrowField::new_list_field(value_type, false),
-            )))
+            if matches!(
+                field.datatype(),
+                Datatype::STRING_ASCII | Datatype::STRING_UTF8
+            ) {
+                Ok(ArrowDataType::LargeUtf8)
+            } else {
+                let value_type = arrow_datatype(field.datatype())?;
+                Ok(ArrowDataType::LargeList(Arc::new(
+                    ArrowField::new_list_field(value_type, false),
+                )))
+            }
         }
     }
 }

--- a/tiledb/oxidize/cxx-interface/cc/array_schema.cc
+++ b/tiledb/oxidize/cxx-interface/cc/array_schema.cc
@@ -1,8 +1,24 @@
 #include "tiledb/oxidize/cxx-interface/cc/array_schema.h"
 
-namespace tiledb::oxidize {
-
 using namespace tiledb::sm;
+
+namespace tiledb::oxidize::sm {
+
+namespace attribute {
+
+const std::string* enumeration_name_cxx(const Attribute& attribute) {
+  std::optional<std::reference_wrapper<const std::string>> e =
+      attribute.get_enumeration_name();
+  if (e.has_value()) {
+    return &e.value().get();
+  } else {
+    return nullptr;
+  }
+}
+
+}  // namespace attribute
+
+namespace dimension {
 
 void set_domain(Dimension& dimension, rust::Slice<const uint8_t> domain) {
   dimension.set_domain(static_cast<const void*>(domain.data()));
@@ -12,4 +28,6 @@ void set_tile_extent(Dimension& dimension, rust::Slice<const uint8_t> domain) {
   dimension.set_tile_extent(static_cast<const void*>(domain.data()));
 }
 
-}  // namespace tiledb::oxidize
+}  // namespace dimension
+
+}  // namespace tiledb::oxidize::sm

--- a/tiledb/oxidize/cxx-interface/cc/array_schema.h
+++ b/tiledb/oxidize/cxx-interface/cc/array_schema.h
@@ -4,14 +4,28 @@
 #include "tiledb/sm/array_schema/dimension.h"
 #include "tiledb/sm/array_schema/domain.h"
 
-namespace tiledb::oxidize {
+namespace tiledb::oxidize::sm {
 
 using namespace tiledb::sm;
 
+namespace attribute {
+
 using ConstAttribute = const Attribute;
-using ConstDimension = const Dimension;
+
+const std::string* enumeration_name_cxx(const Attribute& attribute);
+
+}  // namespace attribute
+
+namespace dimension {
+
+using namespace tiledb::sm;
+
+using ConstDimension = const tiledb::sm::Dimension;
 
 void set_domain(Dimension& dimension, rust::Slice<const uint8_t> domain);
 void set_tile_extent(Dimension& dimension, rust::Slice<const uint8_t> domain);
 
-}  // namespace tiledb::oxidize
+}  // namespace dimension
+
+}  // namespace tiledb::oxidize::sm
+

--- a/tiledb/oxidize/cxx-interface/cc/array_schema.h
+++ b/tiledb/oxidize/cxx-interface/cc/array_schema.h
@@ -29,3 +29,9 @@ void set_tile_extent(Dimension& dimension, rust::Slice<const uint8_t> domain);
 
 }  // namespace tiledb::oxidize::sm
 
+namespace sm::enumeration {
+using ConstEnumeration = const tiledb::sm::Enumeration;
+}
+
+}  // namespace tiledb::oxidize
+                               

--- a/tiledb/oxidize/cxx-interface/cc/array_schema.h
+++ b/tiledb/oxidize/cxx-interface/cc/array_schema.h
@@ -27,11 +27,8 @@ void set_tile_extent(Dimension& dimension, rust::Slice<const uint8_t> domain);
 
 }  // namespace dimension
 
-}  // namespace tiledb::oxidize::sm
-
-namespace sm::enumeration {
+namespace enumeration {
 using ConstEnumeration = const tiledb::sm::Enumeration;
 }
 
-}  // namespace tiledb::oxidize
-                               
+}  // namespace tiledb::oxidize::sm

--- a/tiledb/oxidize/expr/Cargo.toml
+++ b/tiledb/oxidize/expr/Cargo.toml
@@ -6,6 +6,7 @@ version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+arrow = { workspace = true }
 cxx = { workspace = true }
 datafusion = { workspace = true }
 itertools = { workspace = true }

--- a/tiledb/oxidize/expr/src/lib.rs
+++ b/tiledb/oxidize/expr/src/lib.rs
@@ -24,6 +24,7 @@ mod ffi {
     extern "Rust" {
         type LogicalExpr;
         fn is_predicate(&self, schema: &ArraySchema) -> Result<bool>;
+        fn has_aggregate_functions(&self) -> bool;
         fn to_string(&self) -> String;
 
         fn columns(&self) -> Vec<String>;

--- a/tiledb/oxidize/expr/src/lib.rs
+++ b/tiledb/oxidize/expr/src/lib.rs
@@ -67,3 +67,8 @@ mod query_condition;
 pub use logical_expr::LogicalExpr;
 pub use physical_expr::{PhysicalExpr, PhysicalExprOutput, create_physical_expr};
 pub use query_condition::to_datafusion as query_condition_to_logical_expr;
+
+unsafe impl cxx::ExternType for LogicalExpr {
+    type Id = cxx::type_id!("tiledb::oxidize::datafusion::logical_expr::LogicalExpr");
+    type Kind = cxx::kind::Opaque;
+}

--- a/tiledb/oxidize/expr/src/lib.rs
+++ b/tiledb/oxidize/expr/src/lib.rs
@@ -23,7 +23,7 @@ mod ffi {
     #[namespace = "tiledb::oxidize::datafusion::logical_expr"]
     extern "Rust" {
         type LogicalExpr;
-        fn is_predicate(&self, schema: &ArraySchema) -> bool;
+        fn is_predicate(&self, schema: &ArraySchema) -> Result<bool>;
         fn to_string(&self) -> String;
 
         #[cxx_name = "create"]

--- a/tiledb/oxidize/expr/src/lib.rs
+++ b/tiledb/oxidize/expr/src/lib.rs
@@ -26,11 +26,16 @@ mod ffi {
         fn is_predicate(&self, schema: &ArraySchema) -> Result<bool>;
         fn to_string(&self) -> String;
 
+        fn columns(&self) -> Vec<String>;
+
         #[cxx_name = "create"]
         fn query_condition_to_logical_expr(
             schema: &ArraySchema,
             query_condition: &ASTNode,
         ) -> Result<Box<LogicalExpr>>;
+
+        /// Returns a conjunction of the logical exprs `e1 AND e2 AND ... AND eN`.
+        fn make_conjunction(exprs: &[Box<LogicalExpr>]) -> Box<LogicalExpr>;
     }
 
     #[namespace = "tiledb::oxidize::datafusion::physical_expr"]
@@ -65,7 +70,7 @@ mod logical_expr;
 mod physical_expr;
 mod query_condition;
 
-pub use logical_expr::LogicalExpr;
+pub use logical_expr::{LogicalExpr, make_conjunction};
 pub use physical_expr::{PhysicalExpr, PhysicalExprOutput, create_physical_expr};
 pub use query_condition::to_datafusion as query_condition_to_logical_expr;
 

--- a/tiledb/oxidize/expr/src/lib.rs
+++ b/tiledb/oxidize/expr/src/lib.rs
@@ -23,6 +23,7 @@ mod ffi {
     #[namespace = "tiledb::oxidize::datafusion::logical_expr"]
     extern "Rust" {
         type LogicalExpr;
+        fn is_predicate(&self, schema: &ArraySchema) -> bool;
         fn to_string(&self) -> String;
 
         #[cxx_name = "create"]

--- a/tiledb/oxidize/expr/src/logical_expr.rs
+++ b/tiledb/oxidize/expr/src/logical_expr.rs
@@ -58,8 +58,8 @@ impl Display for LogicalExpr {
 }
 
 pub fn make_conjunction(exprs: &[Box<LogicalExpr>]) -> Box<LogicalExpr> {
-    Box::new(LogicalExpr(dbg!(
+    Box::new(LogicalExpr(
         datafusion::logical_expr::utils::conjunction(exprs.iter().map(|e| e.0.clone()))
-            .unwrap_or(Expr::Literal(ScalarValue::Boolean(Some(true))))
-    )))
+            .unwrap_or(Expr::Literal(ScalarValue::Boolean(Some(true)))),
+    ))
 }

--- a/tiledb/oxidize/expr/src/logical_expr.rs
+++ b/tiledb/oxidize/expr/src/logical_expr.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use arrow::datatypes::DataType as ArrowDataType;
-use datafusion::common::{Column, DFSchema, DataFusionError};
+use datafusion::common::{Column, DFSchema, DataFusionError, ScalarValue};
 use datafusion::logical_expr::{Expr, ExprSchemable};
 use tiledb_cxx_interface::sm::array_schema::ArraySchema;
 
@@ -19,9 +19,17 @@ pub enum TypeError {
 pub struct LogicalExpr(pub Expr);
 
 impl LogicalExpr {
+    pub fn columns(&self) -> Vec<String> {
+        self.0
+            .column_refs()
+            .into_iter()
+            .map(|c| c.name.clone())
+            .collect()
+    }
+
     pub fn output_type(&self, schema: &ArraySchema) -> Result<ArrowDataType, TypeError> {
         let cols = self.0.column_refs();
-        let arrow_schema = tiledb_arrow::schema::to_arrow(schema, |f| {
+        let arrow_schema = tiledb_arrow::schema::project_arrow(schema, |f| {
             let Ok(field_name) = f.name() else {
                 // NB: if the field name is not UTF-8 then it cannot possibly match the column name
                 return false;
@@ -47,4 +55,11 @@ impl Display for LogicalExpr {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         self.0.human_display().fmt(f)
     }
+}
+
+pub fn make_conjunction(exprs: &[Box<LogicalExpr>]) -> Box<LogicalExpr> {
+    Box::new(LogicalExpr(dbg!(
+        datafusion::logical_expr::utils::conjunction(exprs.iter().map(|e| e.0.clone()))
+            .unwrap_or(Expr::Literal(ScalarValue::Boolean(Some(true))))
+    )))
 }

--- a/tiledb/oxidize/expr/src/logical_expr.rs
+++ b/tiledb/oxidize/expr/src/logical_expr.rs
@@ -3,9 +3,16 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use datafusion::logical_expr::Expr;
+use tiledb_cxx_interface::sm::array_schema::ArraySchema;
 
 /// Wraps a DataFusion [Expr] for passing across the FFI boundary.
 pub struct LogicalExpr(pub Expr);
+
+impl LogicalExpr {
+    pub fn is_predicate(&self, schema: &ArraySchema) -> bool {
+        todo!()
+    }
+}
 
 impl Display for LogicalExpr {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {

--- a/tiledb/oxidize/expr/src/logical_expr.rs
+++ b/tiledb/oxidize/expr/src/logical_expr.rs
@@ -2,15 +2,44 @@
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-use datafusion::logical_expr::Expr;
+use arrow::datatypes::DataType as ArrowDataType;
+use datafusion::common::{Column, DFSchema, DataFusionError};
+use datafusion::logical_expr::{Expr, ExprSchemable};
 use tiledb_cxx_interface::sm::array_schema::ArraySchema;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TypeError {
+    #[error("Schema error: {0}")]
+    ArraySchema(#[from] tiledb_arrow::schema::Error),
+    #[error("Expression error: {0}")]
+    Expr(#[from] DataFusionError),
+}
 
 /// Wraps a DataFusion [Expr] for passing across the FFI boundary.
 pub struct LogicalExpr(pub Expr);
 
 impl LogicalExpr {
-    pub fn is_predicate(&self, schema: &ArraySchema) -> bool {
-        todo!()
+    pub fn output_type(&self, schema: &ArraySchema) -> Result<ArrowDataType, TypeError> {
+        let cols = self.0.column_refs();
+        let arrow_schema = tiledb_arrow::schema::to_arrow(schema, |f| {
+            let Ok(field_name) = f.name() else {
+                // NB: if the field name is not UTF-8 then it cannot possibly match the column name
+                return false;
+            };
+            cols.contains(&Column::new_unqualified(field_name))
+        })?;
+        let dfschema = {
+            // SAFETY: the only error we can get from the above is if the arrow schema
+            // has duplicate names, which will not happen since it was constructed from
+            // an ArraySchema which does not allow duplicate names
+            DFSchema::try_from(arrow_schema).unwrap()
+        };
+
+        Ok(self.0.get_type(&dfschema)?)
+    }
+
+    pub fn is_predicate(&self, schema: &ArraySchema) -> Result<bool, TypeError> {
+        Ok(matches!(self.output_type(schema)?, ArrowDataType::Boolean))
     }
 }
 

--- a/tiledb/oxidize/expr/src/logical_expr.rs
+++ b/tiledb/oxidize/expr/src/logical_expr.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
 use arrow::datatypes::DataType as ArrowDataType;
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion, TreeNodeVisitor};
 use datafusion::common::{Column, DFSchema, DataFusionError, ScalarValue};
 use datafusion::logical_expr::{Expr, ExprSchemable};
 use tiledb_cxx_interface::sm::array_schema::ArraySchema;
@@ -46,6 +47,15 @@ impl LogicalExpr {
         Ok(self.0.get_type(&dfschema)?)
     }
 
+    pub fn has_aggregate_functions(&self) -> bool {
+        let rec = self.0.visit(&mut AggregateFunctionChecker::default());
+        let rec = {
+            // SAFETY: AggregateFunctionChecker does not return any errors
+            rec.unwrap()
+        };
+        matches!(rec, TreeNodeRecursion::Stop)
+    }
+
     pub fn is_predicate(&self, schema: &ArraySchema) -> Result<bool, TypeError> {
         Ok(matches!(self.output_type(schema)?, ArrowDataType::Boolean))
     }
@@ -62,4 +72,19 @@ pub fn make_conjunction(exprs: &[Box<LogicalExpr>]) -> Box<LogicalExpr> {
         datafusion::logical_expr::utils::conjunction(exprs.iter().map(|e| e.0.clone()))
             .unwrap_or(Expr::Literal(ScalarValue::Boolean(Some(true)))),
     ))
+}
+
+#[derive(Default)]
+struct AggregateFunctionChecker {}
+
+impl TreeNodeVisitor<'_> for AggregateFunctionChecker {
+    type Node = Expr;
+
+    fn f_down(&mut self, node: &Self::Node) -> Result<TreeNodeRecursion, DataFusionError> {
+        if matches!(node, Expr::AggregateFunction(_)) {
+            Ok(TreeNodeRecursion::Stop)
+        } else {
+            Ok(TreeNodeRecursion::Continue)
+        }
+    }
 }

--- a/tiledb/oxidize/expr/src/physical_expr.rs
+++ b/tiledb/oxidize/expr/src/physical_expr.rs
@@ -86,7 +86,7 @@ impl PhysicalExprOutput {
         &self,
         datatype: Datatype,
     ) -> Result<Box<PhysicalExprOutput>, PhysicalExprOutputError> {
-        let arrow_type = tiledb_arrow::schema::arrow_datatype(datatype)
+        let arrow_type = tiledb_arrow::schema::arrow_primitive_datatype(datatype)
             .map_err(PhysicalExprOutputError::TypeUnavailable)?;
         let columnar_value = match &self.0 {
             ColumnarValue::Scalar(s) => ColumnarValue::Scalar(

--- a/tiledb/oxidize/session/Cargo.toml
+++ b/tiledb/oxidize/session/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tiledb-session"
+edition = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+cxx = { workspace = true }
+datafusion = { workspace = true }
+itertools = { workspace = true }
+num-traits = { workspace = true }
+thiserror = { workspace = true }
+tiledb-arrow = { workspace = true }
+tiledb-cxx-interface = { workspace = true }
+tiledb-expr = { workspace = true }
+
+[build-dependencies]
+cxx-build = { workspace = true }

--- a/tiledb/oxidize/session/build.rs
+++ b/tiledb/oxidize/session/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let _bridge = cxx_build::bridge("src/lib.rs");
+    println!("cargo:rerun-if-changed=src/lib.rs");
+}

--- a/tiledb/oxidize/session/src/lib.rs
+++ b/tiledb/oxidize/session/src/lib.rs
@@ -7,15 +7,6 @@ mod ffi {
         type ArraySchema = tiledb_cxx_interface::sm::array_schema::ArraySchema;
     }
 
-    /*
-    #[namespace = "tiledb::oxidize::datafusion::logical_expr"]
-    extern "C++" {
-        include!("tiledb/oxidize/expr.h");
-
-        type LogicalExpr = tiledb_expr::LogicalExpr;
-    }
-    */
-
     #[namespace = "tiledb::oxidize::datafusion::logical_expr"]
     extern "Rust" {
         type ExternLogicalExpr;

--- a/tiledb/oxidize/session/src/lib.rs
+++ b/tiledb/oxidize/session/src/lib.rs
@@ -74,7 +74,7 @@ impl Session {
     }
 
     fn parse_expr(&self, expr: &str, array_schema: &ArraySchema) -> Result<Expr, ParseExprError> {
-        let arrow_schema = tiledb_arrow::schema::to_arrow(array_schema, |_| true)?;
+        let arrow_schema = tiledb_arrow::schema::to_arrow(array_schema)?;
         let df_schema = {
             // SAFETY: this only errors if the names are not unique,
             // which they will be because `ArraySchema` requires it

--- a/tiledb/oxidize/session/src/lib.rs
+++ b/tiledb/oxidize/session/src/lib.rs
@@ -40,6 +40,7 @@ fn new_session() -> Box<Session> {
 }
 
 use datafusion::common::DFSchema;
+use datafusion::common::tree_node::TreeNode;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::Expr;
@@ -51,7 +52,9 @@ pub enum ParseExprError {
     #[error("Schema error: {0}")]
     Schema(#[from] tiledb_arrow::schema::Error),
     #[error("Parse error: {0}")]
-    Parse(#[from] datafusion::common::DataFusionError),
+    Parse(#[source] datafusion::common::DataFusionError),
+    #[error("Type coercion error: {0}")]
+    TypeCoercion(#[source] datafusion::common::DataFusionError),
 }
 
 /// Wraps a DataFusion [SessionContext] for passing across the FFI boundary.
@@ -80,6 +83,19 @@ impl Session {
             // which they will be because `ArraySchema` requires it
             DFSchema::try_from(arrow_schema).unwrap()
         };
-        Ok(self.0.parse_sql_expr(expr, &df_schema)?)
+
+        let parsed = self
+            .0
+            .parse_sql_expr(expr, &df_schema)
+            .map_err(ParseExprError::Parse)?;
+
+        let mut coercion_rewriter =
+            datafusion::optimizer::analyzer::type_coercion::TypeCoercionRewriter::new(&df_schema);
+        //.map_err(ParseExprError::TypeCoercion)?;
+
+        parsed
+            .rewrite(&mut coercion_rewriter)
+            .map(|t| t.data)
+            .map_err(ParseExprError::TypeCoercion)
     }
 }

--- a/tiledb/oxidize/session/src/lib.rs
+++ b/tiledb/oxidize/session/src/lib.rs
@@ -18,7 +18,8 @@ mod ffi {
 
         fn new_session() -> Box<Session>;
 
-        fn parse_expr(
+        #[cxx_name = "parse_expr"]
+        fn parse_expr_ffi(
             &self,
             expr: &str,
             array_schema: &ArraySchema,
@@ -41,6 +42,7 @@ fn new_session() -> Box<Session> {
 use datafusion::common::DFSchema;
 use datafusion::execution::context::SessionContext;
 use datafusion::execution::session_state::SessionStateBuilder;
+use datafusion::logical_expr::Expr;
 use tiledb_cxx_interface::sm::array_schema::ArraySchema;
 use tiledb_expr::LogicalExpr;
 
@@ -62,19 +64,22 @@ impl Session {
         ))
     }
 
-    pub fn parse_expr(
+    fn parse_expr_ffi(
         &self,
         expr: &str,
         array_schema: &ArraySchema,
     ) -> Result<Box<ExternLogicalExpr>, ParseExprError> {
+        let e = self.parse_expr(expr, array_schema)?;
+        Ok(Box::new(ExternLogicalExpr(LogicalExpr(e))))
+    }
+
+    fn parse_expr(&self, expr: &str, array_schema: &ArraySchema) -> Result<Expr, ParseExprError> {
         let arrow_schema = tiledb_arrow::schema::to_arrow(array_schema, |_| true)?;
         let df_schema = {
             // SAFETY: this only errors if the names are not unique,
             // which they will be because `ArraySchema` requires it
             DFSchema::try_from(arrow_schema).unwrap()
         };
-        Ok(Box::new(ExternLogicalExpr(LogicalExpr(
-            self.0.parse_sql_expr(expr, &df_schema)?,
-        ))))
+        Ok(self.0.parse_sql_expr(expr, &df_schema)?)
     }
 }

--- a/tiledb/oxidize/session/src/lib.rs
+++ b/tiledb/oxidize/session/src/lib.rs
@@ -1,0 +1,89 @@
+#[cxx::bridge]
+mod ffi {
+    #[namespace = "tiledb::sm"]
+    extern "C++" {
+        include!("tiledb/sm/array_schema/array_schema.h");
+
+        type ArraySchema = tiledb_cxx_interface::sm::array_schema::ArraySchema;
+    }
+
+    /*
+    #[namespace = "tiledb::oxidize::datafusion::logical_expr"]
+    extern "C++" {
+        include!("tiledb/oxidize/expr.h");
+
+        type LogicalExpr = tiledb_expr::LogicalExpr;
+    }
+    */
+
+    #[namespace = "tiledb::oxidize::datafusion::logical_expr"]
+    extern "Rust" {
+        type ExternLogicalExpr;
+    }
+
+    #[namespace = "tiledb::oxidize::datafusion::session"]
+    extern "Rust" {
+        type Session;
+
+        fn new_session() -> Box<Session>;
+
+        fn parse_expr(
+            &self,
+            expr: &str,
+            array_schema: &ArraySchema,
+        ) -> Result<Box<ExternLogicalExpr>>;
+    }
+}
+
+#[repr(transparent)]
+struct ExternLogicalExpr(pub LogicalExpr);
+
+unsafe impl cxx::ExternType for ExternLogicalExpr {
+    type Id = cxx::type_id!("tiledb::oxidize::datafusion::logical_expr::LogicalExpr");
+    type Kind = cxx::kind::Opaque;
+}
+
+fn new_session() -> Box<Session> {
+    Box::new(Session::new())
+}
+
+use datafusion::common::DFSchema;
+use datafusion::execution::context::SessionContext;
+use datafusion::execution::session_state::SessionStateBuilder;
+use tiledb_cxx_interface::sm::array_schema::ArraySchema;
+use tiledb_expr::LogicalExpr;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseExprError {
+    #[error("Schema error: {0}")]
+    Schema(#[from] tiledb_arrow::schema::Error),
+    #[error("Parse error: {0}")]
+    Parse(#[from] datafusion::common::DataFusionError),
+}
+
+/// Wraps a DataFusion [SessionContext] for passing across the FFI boundary.
+pub struct Session(pub SessionContext);
+
+impl Session {
+    pub fn new() -> Self {
+        Self(SessionContext::from(
+            SessionStateBuilder::new_with_default_features().build(),
+        ))
+    }
+
+    pub fn parse_expr(
+        &self,
+        expr: &str,
+        array_schema: &ArraySchema,
+    ) -> Result<Box<ExternLogicalExpr>, ParseExprError> {
+        let arrow_schema = tiledb_arrow::schema::to_arrow(array_schema, |_| true)?;
+        let df_schema = {
+            // SAFETY: this only errors if the names are not unique,
+            // which they will be because `ArraySchema` requires it
+            DFSchema::try_from(arrow_schema).unwrap()
+        };
+        Ok(Box::new(ExternLogicalExpr(LogicalExpr(
+            self.0.parse_sql_expr(expr, &df_schema)?,
+        ))))
+    }
+}

--- a/tiledb/oxidize/staticlibs/core-objects/Cargo.toml
+++ b/tiledb/oxidize/staticlibs/core-objects/Cargo.toml
@@ -7,6 +7,7 @@ version = { workspace = true }
 [dependencies]
 tiledb-arrow = { workspace = true }
 tiledb-expr = { workspace = true }
+tiledb-session = { workspace = true }
 
 [lib]
 name = "tiledb_core_objects_rs"

--- a/tiledb/oxidize/staticlibs/core-objects/src/lib.rs
+++ b/tiledb/oxidize/staticlibs/core-objects/src/lib.rs
@@ -1,2 +1,3 @@
 pub use tiledb_arrow;
 pub use tiledb_expr;
+pub use tiledb_session;

--- a/tiledb/sm/array_schema/array_schema.cc
+++ b/tiledb/sm/array_schema/array_schema.cc
@@ -806,13 +806,13 @@ void ArraySchema::add_attribute(
 
   auto enmr_name = attr->get_enumeration_name();
   if (enmr_name.has_value()) {
-    // The referenced enumeration must exist when the attribut is added
-    auto iter = enumeration_map_.find(enmr_name.value());
+    // The referenced enumeration must exist when the attribute is added
+    auto iter = enumeration_map_.find(enmr_name.value().get());
     if (iter == enumeration_map_.end()) {
       std::string msg =
           "Cannot add attribute; Attribute refers to an "
           "unknown enumeration named '" +
-          enmr_name.value() + "'.";
+          enmr_name.value().get() + "'.";
       throw ArraySchemaException(msg);
     }
 
@@ -835,14 +835,15 @@ void ArraySchema::add_attribute(
     auto enmr = get_enumeration(enmr_name.value());
     if (enmr == nullptr) {
       throw ArraySchemaException(
-          "Cannot add attribute referencing enumeration '" + enmr_name.value() +
+          "Cannot add attribute referencing enumeration '" +
+          enmr_name.value().get() +
           "' as the enumeration has not been loaded.");
     }
 
     // The +1 here is because of 0 being a valid index into the enumeration.
     if (datatype_max_integral_value(attr->type()) <= enmr->elem_count()) {
       throw ArraySchemaException(
-          "Unable to use enumeration '" + enmr_name.value() +
+          "Unable to use enumeration '" + enmr_name.value().get() +
           "' for attribute '" + attr->name() +
           "' because the attribute's type is not large enough to represent "
           "all enumeration values.");
@@ -1147,7 +1148,7 @@ void ArraySchema::drop_enumeration(const std::string& enmr_name) {
     if (!attr_enmr_name.has_value()) {
       continue;
     }
-    if (attr_enmr_name.value() == enmr_name) {
+    if (attr_enmr_name.value().get() == enmr_name) {
       throw ArraySchemaException(
           "Unable to drop enumeration '" + enmr_name + "' as it is used by" +
           " attribute '" + attr->name() + "'.");

--- a/tiledb/sm/array_schema/attribute.cc
+++ b/tiledb/sm/array_schema/attribute.cc
@@ -416,7 +416,8 @@ void Attribute::set_enumeration_name(std::optional<std::string> enmr_name) {
   enumeration_name_ = enmr_name;
 }
 
-std::optional<std::string> Attribute::get_enumeration_name() const {
+std::optional<std::reference_wrapper<const std::string>>
+Attribute::get_enumeration_name() const {
   return enumeration_name_;
 }
 
@@ -496,7 +497,7 @@ std::ostream& operator<<(std::ostream& os, const tiledb::sm::Attribute& a) {
   }
   if (a.get_enumeration_name().has_value()) {
     os << std::endl;
-    os << "- Enumeration name: " << a.get_enumeration_name().value();
+    os << "- Enumeration name: " << a.get_enumeration_name().value().get();
   }
   os << std::endl;
 

--- a/tiledb/sm/array_schema/attribute.h
+++ b/tiledb/sm/array_schema/attribute.h
@@ -284,7 +284,8 @@ class Attribute {
   void set_enumeration_name(std::optional<std::string> enmr_name);
 
   /** Get the enumeration for this attribute. */
-  std::optional<std::string> get_enumeration_name() const;
+  std::optional<std::reference_wrapper<const std::string>>
+  get_enumeration_name() const;
 
  private:
   /* ********************************* */

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -584,6 +584,20 @@ int32_t tiledb_query_set_condition(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_query_add_predicate(
+    tiledb_ctx_t* const ctx,
+    tiledb_query_t* const query,
+    const char* const predicate) {
+  // Sanity check
+  if (sanity_check(ctx, query) == TILEDB_ERR) {
+    return TILEDB_ERR;
+  }
+
+  throw_if_not_ok(query->query_->add_predicate(predicate));
+
+  return TILEDB_OK;
+}
+
 int32_t tiledb_query_finalize(tiledb_ctx_t* ctx, tiledb_query_t* query) {
   // Trivial case
   if (query == nullptr)
@@ -2746,6 +2760,15 @@ CAPI_INTERFACE(
     tiledb_query_t* const query,
     const tiledb_query_condition_t* const cond) {
   return api_entry<tiledb::api::tiledb_query_set_condition>(ctx, query, cond);
+}
+
+CAPI_INTERFACE(
+    query_add_predicate,
+    tiledb_ctx_t* const ctx,
+    tiledb_query_t* const query,
+    const char* const predicate) {
+  return api_entry<tiledb::api::tiledb_query_add_predicate>(
+      ctx, query, predicate);
 }
 
 CAPI_INTERFACE(query_finalize, tiledb_ctx_t* ctx, tiledb_query_t* query) {

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -591,6 +591,8 @@ capi_return_t tiledb_query_add_predicate(
   // Sanity check
   if (sanity_check(ctx, query) == TILEDB_ERR) {
     return TILEDB_ERR;
+  } else if (predicate == nullptr) {
+    throw CAPIStatusException("Argument \"predicate\" may not be NULL");
   }
 
   throw_if_not_ok(query->query_->add_predicate(predicate));

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -615,6 +615,22 @@ TILEDB_EXPORT int32_t tiledb_query_set_condition(
     const tiledb_query_condition_t* cond) TILEDB_NOEXCEPT;
 
 /**
+ * Adds a predicate to be applied to a read.
+ *
+ * **Example:**
+ *
+ * TODO
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param predicate A text representation of the desired predicate.
+ */
+TILEDB_EXPORT capi_return_t tiledb_query_add_predicate(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* predicate) TILEDB_NOEXCEPT;
+
+/**
  * Flushes all internal state of a query object and finalizes the query.
  * This is applicable only to global layout writes. It has no effect for
  * any other query type.

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -615,11 +615,19 @@ TILEDB_EXPORT int32_t tiledb_query_set_condition(
     const tiledb_query_condition_t* cond) TILEDB_NOEXCEPT;
 
 /**
- * Adds a predicate to be applied to a read.
+ * Adds a predicate to be applied to a read. The added predicate
+ * will be analyzed and evaluated in the subarray step, query condition
+ * step, or both.
+ *
+ * The predicate is parsed as a SQL expression and must evaluate
+ * to a boolean.
  *
  * **Example:**
  *
- * TODO
+ * @code{.c}
+ * const char* pred = "(row BETWEEN 1 AND 10) OR (column BETWEEN 1 AND 10)";
+ * tiledb_query_add_predicate(ctx, query, pred);
+ * @endcode
  *
  * @param ctx The TileDB context.
  * @param query The TileDB query.

--- a/tiledb/sm/c_api/tiledb.h
+++ b/tiledb/sm/c_api/tiledb.h
@@ -615,30 +615,6 @@ TILEDB_EXPORT int32_t tiledb_query_set_condition(
     const tiledb_query_condition_t* cond) TILEDB_NOEXCEPT;
 
 /**
- * Adds a predicate to be applied to a read. The added predicate
- * will be analyzed and evaluated in the subarray step, query condition
- * step, or both.
- *
- * The predicate is parsed as a SQL expression and must evaluate
- * to a boolean.
- *
- * **Example:**
- *
- * @code{.c}
- * const char* pred = "(row BETWEEN 1 AND 10) OR (column BETWEEN 1 AND 10)";
- * tiledb_query_add_predicate(ctx, query, pred);
- * @endcode
- *
- * @param ctx The TileDB context.
- * @param query The TileDB query.
- * @param predicate A text representation of the desired predicate.
- */
-TILEDB_EXPORT capi_return_t tiledb_query_add_predicate(
-    tiledb_ctx_t* ctx,
-    tiledb_query_t* query,
-    const char* predicate) TILEDB_NOEXCEPT;
-
-/**
  * Flushes all internal state of a query object and finalizes the query.
  * This is applicable only to global layout writes. It has no effect for
  * any other query type.

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -459,7 +459,7 @@ TILEDB_EXPORT int32_t tiledb_query_condition_set_use_enumeration(
 /* ********************************* */
 
 /**
- * Adds a predicate to be applied to a read. The added predicate
+ * Adds a predicate to be applied to a read query. The added predicate
  * will be analyzed and evaluated in the subarray step, query condition
  * step, or both.
  *

--- a/tiledb/sm/c_api/tiledb_experimental.h
+++ b/tiledb/sm/c_api/tiledb_experimental.h
@@ -455,6 +455,34 @@ TILEDB_EXPORT int32_t tiledb_query_condition_set_use_enumeration(
     int use_enumeration) TILEDB_NOEXCEPT;
 
 /* ********************************* */
+/*           QUERY PREDICATE         */
+/* ********************************* */
+
+/**
+ * Adds a predicate to be applied to a read. The added predicate
+ * will be analyzed and evaluated in the subarray step, query condition
+ * step, or both.
+ *
+ * The predicate is parsed as a SQL expression and must evaluate
+ * to a boolean.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * const char* pred = "(row BETWEEN 1 AND 10) OR (column BETWEEN 1 AND 10)";
+ * tiledb_query_add_predicate(ctx, query, pred);
+ * @endcode
+ *
+ * @param ctx The TileDB context.
+ * @param query The TileDB query.
+ * @param predicate A text representation of the desired predicate.
+ */
+TILEDB_EXPORT capi_return_t tiledb_query_add_predicate(
+    tiledb_ctx_t* ctx,
+    tiledb_query_t* query,
+    const char* predicate) TILEDB_NOEXCEPT;
+
+/* ********************************* */
 /*        QUERY STATUS DETAILS       */
 /* ********************************* */
 

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -249,6 +249,13 @@ class Query {
     return *this;
   }
 
+  Query& add_predicate(const std::string& predicate) {
+    auto& ctx = ctx_.get();
+    ctx.handle_error(tiledb_query_add_predicate(
+        ctx.ptr().get(), query_.get(), predicate.c_str()));
+    return *this;
+  }
+
   /** Returns the array of the query. */
   const Array& array() {
     return array_;

--- a/tiledb/sm/cpp_api/query.h
+++ b/tiledb/sm/cpp_api/query.h
@@ -249,6 +249,16 @@ class Query {
     return *this;
   }
 
+  /**
+   * Adds a predicate. The predicate will be analyzed and evaluated
+   * in the subarray step, query condition step, or both.
+   *
+   * The predicate is parsed as a SQL expression and must evaluate
+   * to a boolean.
+   *
+   * @param predicate a SQL representation of the predicate
+   * @return Reference to this Query
+   */
   Query& add_predicate(const std::string& predicate) {
     auto& ctx = ctx_.get();
     ctx.handle_error(tiledb_query_add_predicate(

--- a/tiledb/sm/cpp_api/query_experimental.h
+++ b/tiledb/sm/cpp_api/query_experimental.h
@@ -69,6 +69,24 @@ class QueryExperimental {
   }
 
   /**
+   * Adds a predicate to be applied to a read query. The added predicate
+   * will be analyzed and evaluated in the subarray step, query condition
+   * step, or both.
+   *
+   * The predicate is parsed as a SQL expression and must evaluate
+   * to a boolean.
+   *
+   * @param ctx The TileDB context.
+   * @param query The TileDB query.
+   * @param predicate A text representation of the desired predicate.
+   */
+  static void add_predicate(
+      const Context& ctx, Query& query, const char* predicate) {
+    ctx.handle_error(tiledb_query_add_predicate(
+        ctx.ptr().get(), query.ptr().get(), predicate));
+  }
+
+  /**
    * Get the number of relevant fragments from the subarray. Should only be
    * called after size estimation was asked for.
    *

--- a/tiledb/sm/query/ast/query_ast.cc
+++ b/tiledb/sm/query/ast/query_ast.cc
@@ -199,7 +199,7 @@ void ASTNodeVal::rewrite_for_schema(const ArraySchema& array_schema) {
     return;
   }
 
-  auto enumeration = array_schema.get_enumeration(enmr_name.value());
+  auto enumeration = array_schema.get_enumeration(enmr_name.value().get());
   if (!enumeration) {
     throw std::logic_error(
         "Missing required enumeration for field '" + field_name_ + "'");

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -59,6 +59,10 @@
 #include "tiledb/sm/storage_manager/storage_manager.h"
 #include "tiledb/sm/tile/writer_tile_tuple.h"
 
+#ifdef HAVE_RUST
+#include "tiledb/oxidize/session.h"
+#endif
+
 #include <cassert>
 #include <iostream>
 #include <sstream>
@@ -1494,7 +1498,7 @@ Status Query::set_condition(const QueryCondition& condition) {
   return Status::Ok();
 }
 
-Status Query::add_predicate(const char*) {
+Status Query::add_predicate(const char* predicate) {
   if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
     return logger_->status(Status_QueryError(
         "Cannot add query predicate; Operation not applicable "
@@ -1506,8 +1510,18 @@ Status Query::add_predicate(const char*) {
         "initialized query is not supported."));
   }
 
-  return logger_->status(
-      Status_QueryError("Cannot add a query predicate: not implemented"));
+  try {
+    auto expr = resources_.session().parse_expr(predicate, array_schema());
+    if (!expr.is_predicate(array_schema)) {
+      return Status_QueryError("Expression does not return a boolean value");
+    }
+    predicates_.push_back(std::move(expr));
+  } catch (const rust::Error& e) {
+    return Status_QueryError(
+        "Error adding predicate: " + std::string(e.what()));
+  }
+
+  return Status_QueryError("Not implemented");
 }
 
 Status Query::add_update_value(

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -60,6 +60,7 @@
 #include "tiledb/sm/tile/writer_tile_tuple.h"
 
 #ifdef HAVE_RUST
+#include "tiledb/oxidize/expr.h"
 #include "tiledb/oxidize/session.h"
 #endif
 
@@ -1511,8 +1512,20 @@ Status Query::add_predicate(const char* predicate) {
   }
 
   try {
-    auto expr = resources_.session().parse_expr(predicate, array_schema());
-    if (!expr.is_predicate(array_schema)) {
+    auto box_extern_expr =
+        resources_.session().parse_expr(predicate, array_schema());
+    auto extern_expr = box_extern_expr.into_raw();
+
+    // NB: Rust cxx does not have a way to have crate A construct and return an
+    // opaque Rust type which is defined in crate B. So above we create an
+    // "ExternLogicalExpr" whose representation is exactly that of LogicalExpr,
+    // and we can transmute the raw pointer after un-boxing it. This is all
+    // quite unsafe but that's life at the FFI boundary. For now, hopefully.
+    using LogicalExpr = tiledb::oxidize::datafusion::logical_expr::LogicalExpr;
+    auto expr = rust::Box<LogicalExpr>::from_raw(
+        reinterpret_cast<LogicalExpr*>(extern_expr));
+
+    if (!expr->is_predicate(array_schema())) {
       return Status_QueryError("Expression does not return a boolean value");
     }
     predicates_.push_back(std::move(expr));

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -729,6 +729,27 @@ void Query::init() {
           fragment_name_));
     }
 
+    if (!predicates_.empty()) {
+      try {
+        // treat existing query condition (if any) as datafusion
+        if (condition_.has_value()) {
+          predicates_.push_back(condition_->as_datafusion(array_schema()));
+          condition_.reset();
+        }
+
+        // join them together
+        rust::Slice<const rust::Box<
+            tiledb::oxidize::datafusion::logical_expr::LogicalExpr>>
+            preds(predicates_.data(), predicates_.size());
+        auto conjunction =
+            tiledb::oxidize::datafusion::logical_expr::make_conjunction(preds);
+        condition_.emplace(array_schema(), std::move(conjunction));
+      } catch (const rust::Error& e) {
+        throw QueryException(
+            "Error initializing predicates: " + std::string(e.what()));
+      }
+    }
+
     // Create the query strategy if querying main array and the Subarray does
     // not need to be updated.
     if (!only_dim_label_query() && !subarray_.has_label_ranges()) {
@@ -1534,7 +1555,7 @@ Status Query::add_predicate(const char* predicate) {
         "Error adding predicate: " + std::string(e.what()));
   }
 
-  return Status_QueryError("Not implemented");
+  return Status::Ok();
 }
 
 Status Query::add_update_value(

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -851,7 +851,7 @@ Status Query::process() {
       }
       auto enmr_name = attr->get_enumeration_name();
       if (enmr_name.has_value()) {
-        deduped_enmr_names.insert(enmr_name.value());
+        deduped_enmr_names.insert(enmr_name.value().get());
       }
     }
     std::vector<std::string> enmr_names;

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1537,11 +1537,12 @@ Status Query::add_predicate(const char* predicate) {
         resources_.session().parse_expr(predicate, array_schema());
     auto extern_expr = box_extern_expr.into_raw();
 
-    // NB: Rust cxx does not have a way to have crate A construct and return an
-    // opaque Rust type which is defined in crate B. So above we create an
-    // "ExternLogicalExpr" whose representation is exactly that of LogicalExpr,
-    // and we can transmute the raw pointer after un-boxing it. This is all
-    // quite unsafe but that's life at the FFI boundary. For now, hopefully.
+    // NB: Rust cxx does not have a way to have crate A construct and return
+    // an opaque Rust type which is defined in crate B. So above we create an
+    // "ExternLogicalExpr" whose representation is exactly that of
+    // LogicalExpr, and we can transmute the raw pointer after un-boxing it.
+    // This is all quite unsafe but that's life at the FFI boundary. For now,
+    // hopefully.
     using LogicalExpr = tiledb::oxidize::datafusion::logical_expr::LogicalExpr;
     auto expr = rust::Box<LogicalExpr>::from_raw(
         reinterpret_cast<LogicalExpr*>(extern_expr));
@@ -1725,7 +1726,8 @@ Status Query::submit() {
       throw_if_not_ok(create_strategy());
 
       // Allocate remote buffer storage for global order writes if necessary.
-      // If we cache an entire write a query may be uninitialized for N submits.
+      // If we cache an entire write a query may be uninitialized for N
+      // submits.
       if (!query_remote_buffer_storage_.has_value() &&
           type_ == QueryType::WRITE && layout_ == Layout::GLOBAL_ORDER) {
         query_remote_buffer_storage_.emplace(*this, buffers_);
@@ -1859,8 +1861,8 @@ bool Query::is_aggregate(std::string output_field_name) const {
 /* ****************************** */
 
 Layout Query::effective_layout() const {
-  // If the user has not set a layout, it will default to row-major, which will
-  // use the legacy reader on sparse arrays, and fail if aggregates were
+  // If the user has not set a layout, it will default to row-major, which
+  // will use the legacy reader on sparse arrays, and fail if aggregates were
   // specified. However, if only aggregates are specified and no regular data
   // buffers, the layout doesn't matter and we can transparently switch to the
   // much more efficient unordered layout.
@@ -1944,14 +1946,16 @@ Status Query::create_strategy(bool skip_checks_serialization) {
       all_dense &= frag_md->dense();
     }
 
-    // We are going to deprecate dense arrays with sparse fragments in 2.27 but
-    // log a warning for now.
+    // We are going to deprecate dense arrays with sparse fragments in 2.27
+    // but log a warning for now.
     if (array_schema_->dense() && !all_dense) {
       LOG_WARN(
           "This dense array contains sparse fragments. Support for reading "
-          "sparse fragments in dense arrays will be removed in TileDB version "
+          "sparse fragments in dense arrays will be removed in TileDB "
+          "version "
           "2.27 to be released in September 2024. To make sure this array "
-          "continues to work after an upgrade to version 2.27 or later, please "
+          "continues to work after an upgrade to version 2.27 or later, "
+          "please "
           "consolidate the sparse fragments using a TileDB version 2.26 or "
           "earlier.");
     }
@@ -2076,8 +2080,8 @@ Status Query::check_buffer_names() {
                             "cells to be written"));
     }
 
-    // All attributes/dimensions must be provided unless this query is only for
-    // dimension labels.
+    // All attributes/dimensions must be provided unless this query is only
+    // for dimension labels.
     if (!only_dim_label_query() && !allow_separate_attribute_writes()) {
       auto expected_num = array_schema_->attribute_num();
       expected_num += static_cast<decltype(expected_num)>(

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1494,6 +1494,22 @@ Status Query::set_condition(const QueryCondition& condition) {
   return Status::Ok();
 }
 
+Status Query::add_predicate(const char*) {
+  if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
+    return logger_->status(Status_QueryError(
+        "Cannot add query predicate; Operation not applicable "
+        "to write queries"));
+  }
+  if (status_ != tiledb::sm::QueryStatus::UNINITIALIZED) {
+    return logger_->status(Status_QueryError(
+        "Cannot add query predicate; Adding a predicate to an already "
+        "initialized query is not supported."));
+  }
+
+  return logger_->status(
+      Status_QueryError("Cannot add a query predicate: not implemented"));
+}
+
 Status Query::add_update_value(
     const char* field_name,
     const void* update_value,

--- a/tiledb/sm/query/query.cc
+++ b/tiledb/sm/query/query.cc
@@ -1521,10 +1521,10 @@ Status Query::set_condition(const QueryCondition& condition) {
 }
 
 Status Query::add_predicate(const char* predicate) {
-  if (type_ == QueryType::WRITE || type_ == QueryType::MODIFY_EXCLUSIVE) {
-    return logger_->status(Status_QueryError(
-        "Cannot add query predicate; Operation not applicable "
-        "to write queries"));
+  if (type_ != QueryType::READ) {
+    return logger_->status(
+        Status_QueryError("Cannot add query predicate; Operation only "
+                          "applicable to read queries"));
   }
   if (status_ != tiledb::sm::QueryStatus::UNINITIALIZED) {
     return logger_->status(Status_QueryError(
@@ -1548,6 +1548,10 @@ Status Query::add_predicate(const char* predicate) {
 
     if (!expr->is_predicate(array_schema())) {
       return Status_QueryError("Expression does not return a boolean value");
+    }
+    if (expr->has_aggregate_functions()) {
+      return Status_QueryError(
+          "Aggregate functions in predicate is not supported");
     }
     predicates_.push_back(std::move(expr));
   } catch (const rust::Error& e) {

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -645,6 +645,14 @@ class Query {
   Status set_condition(const QueryCondition& condition);
 
   /**
+   * Adds a predicate for filtering results in a read query.
+   *
+   * @param predicate A string representation of the desired predicate.
+   * @return Status
+   */
+  Status add_predicate(const char* predicate);
+
+  /**
    * Adds an update value for an update query.
    *
    * @param field_name The attribute name.

--- a/tiledb/sm/query/query.h
+++ b/tiledb/sm/query/query.h
@@ -58,7 +58,15 @@
 #include "tiledb/sm/storage_manager/cancellation_source.h"
 #include "tiledb/sm/subarray/subarray.h"
 
+#ifdef HAVE_RUST
+#include "tiledb/oxidize/rust.h"
+#endif
+
 using namespace tiledb::common;
+
+namespace tiledb::oxidize::datafusion::logical_expr {
+class LogicalExpr;
+}
 
 namespace tiledb::sm {
 
@@ -1029,6 +1037,9 @@ class Query {
 
   /** The query condition. */
   std::optional<QueryCondition> condition_;
+
+  std::vector<rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>>
+      predicates_;
 
   /** The update values. */
   std::vector<UpdateValue> update_values_;

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -105,6 +105,19 @@ QueryCondition::QueryCondition(
     , tree_(std::move(tree)) {
 }
 
+#ifdef HAVE_RUST
+QueryCondition::QueryCondition(
+    const ArraySchema& array_schema,
+    rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>&& expr) {
+  const auto columns = expr->columns();
+  for (const auto& c : columns) {
+    field_names_.insert(std::string(c.data(), c.size()));
+  }
+
+  datafusion_.emplace(array_schema, std::move(expr));
+}
+#endif
+
 QueryCondition::QueryCondition(const QueryCondition& rhs)
     : condition_marker_(rhs.condition_marker_)
     , condition_index_(rhs.condition_index_)
@@ -168,19 +181,16 @@ void QueryCondition::rewrite_for_schema(const ArraySchema& array_schema) {
 }
 
 #ifdef HAVE_RUST
+rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>
+QueryCondition::as_datafusion(const ArraySchema& array_schema) {
+  return tiledb::oxidize::datafusion::logical_expr::create(
+      array_schema, *tree_.get());
+}
+
 bool QueryCondition::rewrite_to_datafusion(const ArraySchema& array_schema) {
   if (!datafusion_.has_value()) {
-    std::vector<std::string> select(field_names().begin(), field_names().end());
-
     try {
-      auto logical_expr = tiledb::oxidize::datafusion::logical_expr::create(
-          array_schema, *tree_.get());
-      auto dfschema =
-          tiledb::oxidize::arrow::schema::create(array_schema, select);
-      auto physical_expr = tiledb::oxidize::datafusion::physical_expr::create(
-          *dfschema, std::move(logical_expr));
-
-      datafusion_.emplace(std::move(dfschema), std::move(physical_expr));
+      datafusion_.emplace(array_schema, std::move(as_datafusion(array_schema)));
     } catch (const ::rust::Error& e) {
       throw std::logic_error(
           "Unexpected error compiling expression: " + std::string(e.what()));
@@ -1317,6 +1327,12 @@ Status QueryCondition::apply(
     const std::vector<shared_ptr<FragmentMetadata>>& fragment_metadata,
     std::vector<ResultCellSlab>& result_cell_slabs,
     const uint64_t stride) const {
+#ifdef HAVE_RUST
+  if (!tree_ && datafusion_.has_value()) {
+    throw QueryConditionException("TODO not supported");
+  }
+#endif
+
   if (!tree_) {
     return Status::Ok();
   }
@@ -2960,6 +2976,15 @@ uint64_t QueryCondition::condition_index() const {
 }
 
 #ifdef HAVE_RUST
+QueryCondition::Datafusion::Datafusion(
+    const ArraySchema& array_schema,
+    rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>&& expr)
+    : schema_(tiledb::oxidize::arrow::schema::project(
+          array_schema, expr->columns()))
+    , expr_(tiledb::oxidize::datafusion::physical_expr::create(
+          *schema_, std::move(expr))) {
+}
+
 template <typename BitmapType>
 void QueryCondition::Datafusion::apply(
     const QueryCondition::Params&,
@@ -3023,3 +3048,4 @@ template Status QueryCondition::apply_sparse<uint8_t>(
 template Status QueryCondition::apply_sparse<uint64_t>(
     const QueryCondition::Params&, const ResultTile&, std::span<uint64_t>);
 }  // namespace tiledb::sm
+                          

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -192,7 +192,7 @@ bool QueryCondition::rewrite_to_datafusion(const ArraySchema& array_schema) {
     try {
       datafusion_.emplace(array_schema, std::move(as_datafusion(array_schema)));
     } catch (const ::rust::Error& e) {
-      throw std::logic_error(
+      throw QueryConditionException(
           "Unexpected error compiling expression: " + std::string(e.what()));
     }
     return true;
@@ -2940,7 +2940,7 @@ Status QueryCondition::apply_sparse(
     try {
       datafusion_.value().apply(params, result_tile, result_bitmap);
     } catch (const ::rust::Error& e) {
-      throw std::logic_error(
+      throw QueryConditionException(
           "Unexpected error evaluating expression: " + std::string(e.what()));
     }
   } else {
@@ -3014,7 +3014,7 @@ void QueryCondition::Datafusion::apply(
         result_bitmap[i] *= bitmap[i];
       }
     } else {
-      throw std::logic_error(
+      throw QueryConditionException(
           "Expression evaluation bitmap has unexpected size");
     }
   } else {
@@ -3035,7 +3035,7 @@ void QueryCondition::Datafusion::apply(
         result_bitmap[i] *= bitmap[i];
       }
     } else {
-      throw std::logic_error(
+      throw QueryConditionException(
           "Expression evaluation bitmap has unexpected size");
     }
   }

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -193,7 +193,7 @@ bool QueryCondition::rewrite_to_datafusion(const ArraySchema& array_schema) {
       datafusion_.emplace(array_schema, std::move(as_datafusion(array_schema)));
     } catch (const ::rust::Error& e) {
       throw QueryConditionException(
-          "Unexpected error compiling expression: " + std::string(e.what()));
+          "Error compiling expression: " + std::string(e.what()));
     }
     return true;
   }
@@ -2941,7 +2941,7 @@ Status QueryCondition::apply_sparse(
       datafusion_.value().apply(params, result_tile, result_bitmap);
     } catch (const ::rust::Error& e) {
       throw QueryConditionException(
-          "Unexpected error evaluating expression: " + std::string(e.what()));
+          "Error evaluating expression: " + std::string(e.what()));
     }
   } else {
     apply_tree_sparse<BitmapType>(

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -2161,6 +2161,13 @@ Status QueryCondition::apply_dense(
     return Status_QueryConditionError("The result buffer is null.");
   }
 
+#ifdef HAVE_RUST
+  if (tree_ == nullptr && datafusion_.has_value()) {
+    return Status_QueryConditionError(
+        "tiledb_query_add_predicate is not supported for dense array queries");
+  }
+#endif
+
   span<uint8_t> result_span(result_buffer + start, length);
   apply_tree_dense(
       tree_,

--- a/tiledb/sm/query/query_condition.cc
+++ b/tiledb/sm/query/query_condition.cc
@@ -3055,4 +3055,3 @@ template Status QueryCondition::apply_sparse<uint8_t>(
 template Status QueryCondition::apply_sparse<uint64_t>(
     const QueryCondition::Params&, const ResultTile&, std::span<uint64_t>);
 }  // namespace tiledb::sm
-                          

--- a/tiledb/sm/query/query_condition.h
+++ b/tiledb/sm/query/query_condition.h
@@ -50,6 +50,9 @@ using namespace tiledb::common;
 namespace tiledb::oxidize::arrow::schema {
 struct ArrowSchema;
 }
+namespace tiledb::oxidize::datafusion::logical_expr {
+class LogicalExpr;
+}
 namespace tiledb::oxidize::datafusion::physical_expr {
 struct PhysicalExpr;
 }
@@ -150,6 +153,13 @@ class QueryCondition {
       const std::string& condition_marker,
       tdb_unique_ptr<tiledb::sm::ASTNode>&& tree);
 
+#ifdef HAVE_RUST
+  /** Constructor from a datafusion expression tree */
+  QueryCondition(
+      const ArraySchema& array_schema,
+      rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>&& expr);
+#endif
+
   /** Copy constructor. */
   QueryCondition(const QueryCondition& rhs);
 
@@ -210,6 +220,13 @@ class QueryCondition {
    * @return true if a rewrite occurred, false otherwise
    */
   bool rewrite_to_datafusion(const ArraySchema& array_schema);
+
+  /**
+   * @return an equivalent representation of this condition's expression tree as
+   * a Datafusion logical expression
+   */
+  rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>
+  as_datafusion(const ArraySchema& array_schema);
 #endif
 
   /**
@@ -415,6 +432,11 @@ class QueryCondition {
         : schema_(std::move(schema))
         , expr_(std::move(expr)) {
     }
+
+    Datafusion(
+        const ArraySchema& array_schema,
+        rust::Box<tiledb::oxidize::datafusion::logical_expr::LogicalExpr>&&
+            expr);
 
     template <typename BitmapType>
     void apply(

--- a/tiledb/sm/serialization/array_schema.cc
+++ b/tiledb/sm/serialization/array_schema.cc
@@ -412,7 +412,7 @@ void attribute_to_capnp(
 
   auto enmr_name = attribute->get_enumeration_name();
   if (enmr_name.has_value()) {
-    attribute_builder->setEnumerationName(enmr_name.value());
+    attribute_builder->setEnumerationName(enmr_name.value().get());
   }
 }
 

--- a/tiledb/sm/storage_manager/context_resources.cc
+++ b/tiledb/sm/storage_manager/context_resources.cc
@@ -34,6 +34,10 @@
 #include "tiledb/common/memory_tracker.h"
 #include "tiledb/sm/rest/rest_client.h"
 
+#ifdef HAVE_RUST
+#include "tiledb/oxidize/session.h"
+#endif
+
 using namespace tiledb::common;
 
 namespace tiledb::sm {
@@ -64,7 +68,11 @@ ContextResources::ContextResources(
           config_,
           compute_tp(),
           *logger_.get(),
-          create_memory_tracker())} {
+          create_memory_tracker())}
+#ifdef HAVE_RUST
+    , session_(tiledb::oxidize::datafusion::session::new_session())
+#endif
+{
   ephemeral_memory_tracker_->set_type(MemoryTrackerType::EPHEMERAL);
   serialization_memory_tracker_->set_type(MemoryTrackerType::SERIALIZATION);
 

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -123,6 +123,12 @@ class ContextResources {
     return *memory_tracker_manager_;
   }
 
+#ifdef HAVE_RUST
+  const tiledb::oxidize::datafusion::session::Session& session() const {
+    return *session_;
+  }
+#endif
+
   /**
    * Create a new MemoryTracker
    *

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -39,7 +39,15 @@
 #include "tiledb/sm/filesystem/vfs.h"
 #include "tiledb/sm/stats/global_stats.h"
 
+#ifdef HAVE_RUST
+#include "tiledb/oxidize/rust.h"
+#endif
+
 using namespace tiledb::common;
+
+namespace tiledb::oxidize::datafusion::session {
+class Session;
+}
 
 namespace tiledb::sm {
 
@@ -184,6 +192,10 @@ class ContextResources {
 
   /** The rest client (may be null if none was configured). */
   shared_ptr<RestClient> rest_client_;
+
+#ifdef HAVE_RUST
+  rust::Box<tiledb::oxidize::datafusion::session::Session> session_;
+#endif
 };
 
 }  // namespace tiledb::sm


### PR DESCRIPTION
Resolves CORE-25.

#5546 enabled `QueryCondition` to evaluate datafusion expression trees in its `apply_sparse` function. This was used only in test scenarios, with a configuration parameter which would have `QueryCondition` translate its syntax tree into a datafusion `Expr` and then evaluate it.

This pull request builds upon this capability and connects it to C and C++ level APIs.  We add `tiledb_query_add_predicate(tiledb_ctx_t*, tiledb_query_t*, const char* predicate)` which uses datafusion to parse `predicate` into an `Expr` which can be evaluated by `QueryCondition`.

This enables users to add a much more expressive set of predicates to their queries, which can perform arithmetic, function calls, conditional (`CASE`) expressions, and so on.

# Design

TileDB has a `Context` which contains the resources of a TileDB "session".  Similarly, Datafusion has a `SessionContext` which contains the resources and (importantly) catalog of a Datafusion session.  The `SessionContext` is used to parse and evaluate expressions and is where one registers tables, UDFs, etc.

We will add a Datafusion `SessionContext` to the TileDB `ContextResources`.

The `tiledb_query_add_predicate` implementation finds the Datafusion `SessionContext` from the passed in `ContextResources` and uses it to parse the expression into `LogicalExpr`.  We accumulate a list of `LogicalExpr` and then combine them into a single conjunctive expression tree (possibly together with a `QueryCondition` syntax tree) and embed that in a new `QueryCondition`.

# Testing

- We add examples for the C API and C++ API which demonstrate using this new API for the same conditions used in the `query_condition_sparse` API examples, as well as some more complicated predicates which cannot be expressed as a query condition.
- We add some sanity tests, examples, and API tests in `unit-query-add-predicate.cc`.
- We add a mode to the rapidcheck tests in `unit-sparse-global-order-reader.cc` to optional render the generated `QueryCondition` syntax tree as a SQL string, which we then add as a predicate instead of applying it to the query normally.

# Unsupported

- attributes with enumerations cannot be used in predicates (issue TODO)
- dimension labels are of unknown status (issue TODO)
- we add errors for non-sparse global order reader for now ([CORE-272](https://linear.app/tiledb/issue/CORE-272/implement-datafusion-predicate-evaluation-for-dense-reader), [CORE-273](https://linear.app/tiledb/issue/CORE-273/implement-datafusion-predicate-evaluation-for-legacy-reader))

# Next Steps

This does not analyze predicates for attributes/dimensions to improve R-tree traversal ([CORE-28](https://linear.app/tiledb/issue/CORE-28/query-predicate-bounds-analysis-during-r-tree-traversal)) or add the desired intersection function ([CORE-26](https://linear.app/tiledb/issue/CORE-26/add-spatial-intersection-function)).

# Draft Status

This pull request is still in draft due to:
- additional tests needed
- build system issues

---
TYPE: FEATURE
DESC: add `tiledb_query_add_predicate` API to parse a SQL expression string into a `QueryCondition`
