### PR TITLE
Class MemFS inherits FilesystemBase.

### DIFF
--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -124,7 +124,7 @@ TEST_CASE_METHOD(S3Fx, "Test S3 multiupload abort path", "[s3]") {
     CHECK(!exists);
 
     // Flush the file
-    CHECK(!s3_.flush_object(URI(largefile)).ok());
+    CHECK_THROWS(s3_.flush(URI(largefile)));
 
     // After flushing, the file does not exist
     CHECK(s3_.is_object(URI(largefile), &exists).ok());

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -448,6 +448,8 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
       require_tiledb_ok(vfs.remove_dir(path));
     }
     require_tiledb_ok(vfs.create_dir(path));
+    // Bucket-specific operations are only valid for object store filesystems.
+    CHECK_THROWS(vfs.create_bucket(path));
   }
 
   // Prepare buffers
@@ -777,7 +779,7 @@ TEST_CASE(
 
   auto matcher = Catch::Matchers::ContainsSubstring(
       "The Content-Md5 you specified is not valid.");
-  REQUIRE_THROWS_WITH(s3.flush_object(uri), matcher);
+  REQUIRE_THROWS_WITH(s3.flush(uri), matcher);
 }
 #endif
 

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1010,7 +1010,7 @@ class S3Test : public VFSTestBase, protected tiledb::sm::S3_within_VFS {
         s3().touch(object_uri);
         std::string data(j * 10, 'a');
         s3().write(object_uri, data.data(), data.size());
-        s3().flush_object(object_uri).ok();
+        s3().flush(object_uri);
         expected_results().emplace_back(object_uri.to_string(), data.size());
       }
     }

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -183,7 +183,7 @@ capi_return_t tiledb_vfs_file_size(
     tiledb_vfs_t* vfs, const char* uri, uint64_t* size) {
   ensure_vfs_is_valid(vfs);
   ensure_output_pointer_is_valid(size);
-  throw_if_not_ok(vfs->file_size(tiledb::sm::URI(uri), size));
+  *size = vfs->file_size(tiledb::sm::URI(uri));
   return TILEDB_OK;
 }
 

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -115,8 +115,8 @@ struct tiledb_vfs_handle_t
     return vfs_.dir_size(dir_name, dir_size);
   }
 
-  Status file_size(const tiledb::sm::URI& uri, uint64_t* size) const {
-    return vfs_.file_size(uri, size);
+  uint64_t file_size(const tiledb::sm::URI& uri) const {
+    return vfs_.file_size(uri);
   }
 
   Status move_file(

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -727,9 +727,7 @@ ArrayDirectory::load_consolidated_commit_uris(
   for (auto& uri : commits_dir_uris) {
     if (stdx::string::ends_with(
             uri.to_string(), constants::ignore_file_suffix)) {
-      uint64_t size = 0;
-      RETURN_NOT_OK_TUPLE(
-          resources_.get().vfs().file_size(uri, &size), nullopt, nullopt);
+      uint64_t size = resources_.get().vfs().file_size(uri);
       std::string names;
       names.resize(size);
       RETURN_NOT_OK_TUPLE(
@@ -751,9 +749,7 @@ ArrayDirectory::load_consolidated_commit_uris(
     auto& uri = commits_dir_uris[i];
     if (stdx::string::ends_with(
             uri.to_string(), constants::con_commits_file_suffix)) {
-      uint64_t size = 0;
-      RETURN_NOT_OK_TUPLE(
-          resources_.get().vfs().file_size(uri, &size), nullopt, nullopt);
+      uint64_t size = resources_.get().vfs().file_size(uri);
       meta_files.emplace_back(uri, std::string());
 
       auto& names = meta_files.back().second;
@@ -1084,9 +1080,8 @@ ArrayDirectory::compute_uris_to_vacuum(
   std::vector<int32_t> to_vacuum_vac_files_vec(vac_files.size(), 0);
   auto& tp = resources_.get().compute_tp();
   auto status = parallel_for(&tp, 0, vac_files.size(), [&](size_t i) {
-    uint64_t size = 0;
     auto& vfs = resources_.get().vfs();
-    throw_if_not_ok(vfs.file_size(vac_files[i], &size));
+    uint64_t size = vfs.file_size(vac_files[i]);
     std::string names;
     names.resize(size);
     throw_if_not_ok(vfs.read(vac_files[i], 0, &names[0], size, false));

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -89,8 +89,7 @@ int32_t tiledb_filestore_schema_create(
     // The user provided a uri, let's examine the file and get some insights
     // Get the file size, calculate a reasonable tile extent
     auto& vfs = ctx->resources().vfs();
-    uint64_t file_size;
-    throw_if_not_ok(vfs.file_size(tiledb::sm::URI(uri), &file_size));
+    uint64_t file_size = vfs.file_size(tiledb::sm::URI(uri));
     if (file_size) {
       tile_extent = compute_tile_extent_based_on_file_size(file_size);
     }
@@ -197,8 +196,7 @@ int32_t tiledb_filestore_uri_import(
 
   // Get the file size
   auto& vfs = ctx->resources().vfs();
-  uint64_t file_size;
-  throw_if_not_ok(vfs.file_size(tiledb::sm::URI(file_uri), &file_size));
+  uint64_t file_size = vfs.file_size(tiledb::sm::URI(file_uri));
   if (!file_size) {
     return TILEDB_OK;  // NOOP
   }

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -272,7 +272,7 @@ void Consolidator::write_consolidated_commits_file(
     // the size variable.
     if (stdx::string::ends_with(
             uri.to_string(), constants::delete_file_suffix)) {
-      throw_if_not_ok(resources.vfs().file_size(uri, &file_sizes[i]));
+      file_sizes[i] = resources.vfs().file_size(uri);
       total_size += file_sizes[i];
       total_size += sizeof(storage_size_t);
     }

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -31,3 +31,35 @@
  */
 
 #include "filesystem_base.h"
+
+namespace tiledb::sm {
+
+/* ********************************* */
+/*                API                */
+/* ********************************* */
+
+void FilesystemBase::sync(const URI&) const {
+  throw UnsupportedOperation("sync");
+}
+
+bool FilesystemBase::is_bucket(const URI&) const {
+  throw UnsupportedOperation("is_bucket");
+}
+
+bool FilesystemBase::is_empty_bucket(const URI&) const {
+  throw UnsupportedOperation("is_empty_bucket");
+}
+
+void FilesystemBase::create_bucket(const URI&) const {
+  throw UnsupportedOperation("create_bucket");
+}
+
+void FilesystemBase::remove_bucket(const URI&) const {
+  throw UnsupportedOperation("remove_bucket");
+}
+
+void FilesystemBase::empty_bucket(const URI&) const {
+  throw UnsupportedOperation("empty_bucket");
+}
+
+}  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -105,9 +105,9 @@ class FilesystemBase {
    * Retrieves the size of a file.
    *
    * @param uri The URI of the file.
-   * @param size The file size to be retrieved.
+   * @return The file size.
    */
-  virtual void file_size(const URI& uri, uint64_t* size) const = 0;
+  virtual uint64_t file_size(const URI& uri) const = 0;
 
   /**
    * Retrieves all the entries contained in the parent.
@@ -115,7 +115,7 @@ class FilesystemBase {
    * @param parent The target directory to list.
    * @return All entries that are contained in the parent
    */
-  virtual std::vector<filesystem::directory_entry> ls_with_sizes(
+  virtual std::vector<common::filesystem::directory_entry> ls_with_sizes(
       const URI& parent) const = 0;
 
   /**
@@ -171,7 +171,21 @@ class FilesystemBase {
       bool use_read_ahead = true) const = 0;
 
   /**
-   * Syncs (flushes) a file. Note that for S3 this is a noop.
+   * Flushes an object store file.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The URI of the file.
+   * @param finalize For s3 objects only. If `true`, flushes as a result of a
+   * remote global order write `finalize()` call.
+   */
+  virtual void flush(
+      const URI& uri, [[maybe_unused]] bool finalize = false) = 0;
+
+  /**
+   * Syncs a local file.
+   *
+   * @invariant No-op for non-local Filesystems.
    *
    * @param uri The URI of the file.
    */
@@ -194,6 +208,8 @@ class FilesystemBase {
   /**
    * Checks if an object store bucket exists.
    *
+   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   *
    * @param uri The name of the object store bucket.
    * @return True if the bucket exists, false otherwise.
    */
@@ -201,6 +217,8 @@ class FilesystemBase {
 
   /**
    * Checks if an object-store bucket is empty.
+   *
+   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
    *
    * @param uri The name of the object store bucket.
    * @return True if the bucket is empty, false otherwise.
@@ -210,6 +228,8 @@ class FilesystemBase {
   /**
    * Creates an object store bucket.
    *
+   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   *
    * @param uri The name of the bucket to be created.
    */
   virtual void create_bucket(const URI& uri) const = 0;
@@ -217,12 +237,16 @@ class FilesystemBase {
   /**
    * Deletes an object store bucket.
    *
+   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   *
    * @param uri The name of the bucket to be deleted.
    */
   virtual void remove_bucket(const URI& uri) const = 0;
 
   /**
    * Deletes the contents of an object store bucket.
+   *
+   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
    *
    * @param uri The name of the bucket to be emptied.
    */

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -47,6 +47,14 @@ class IOError : public StatusException {
   }
 };
 
+class UnsupportedOperation : public IOError {
+ public:
+  explicit UnsupportedOperation(const std::string& operation)
+      : IOError(std::string(
+            operation + " is not supported on the given filesystem.")) {
+  }
+};
+
 class FilesystemBase {
  public:
   FilesystemBase() = default;
@@ -173,10 +181,10 @@ class FilesystemBase {
   /**
    * Flushes an object store file.
    *
-   * @invariant No-op for non-object store Filesystems.
+   * @invariant Performs a sync on local filesystem files.
    *
    * @param uri The URI of the file.
-   * @param finalize For s3 objects only. If `true`, flushes as a result of a
+   * @param finalize For S3 objects only. If `true`, flushes as a result of a
    * remote global order write `finalize()` call.
    */
   virtual void flush(
@@ -185,11 +193,11 @@ class FilesystemBase {
   /**
    * Syncs a local file.
    *
-   * @invariant No-op for non-local Filesystems.
+   * @invariant Valid only for local filesystems.
    *
    * @param uri The URI of the file.
    */
-  virtual void sync(const URI& uri) const = 0;
+  virtual void sync(const URI& uri) const;
 
   /**
    * Writes the contents of a buffer into a file.
@@ -197,7 +205,7 @@ class FilesystemBase {
    * @param uri The URI of the file.
    * @param buffer The buffer to write from.
    * @param buffer_size The buffer size.
-   * @param remote_global_order_write Remote global order write
+   * @param remote_global_order_write Remote global order write.
    */
   virtual void write(
       const URI& uri,
@@ -208,49 +216,49 @@ class FilesystemBase {
   /**
    * Checks if an object store bucket exists.
    *
-   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   * @invariant Valid only for object store filesystems.
    *
    * @param uri The name of the object store bucket.
    * @return True if the bucket exists, false otherwise.
    */
-  virtual bool is_bucket(const URI& uri) const = 0;
+  virtual bool is_bucket(const URI& uri) const;
 
   /**
    * Checks if an object-store bucket is empty.
    *
-   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   * @invariant Valid only for object store filesystems.
    *
    * @param uri The name of the object store bucket.
    * @return True if the bucket is empty, false otherwise.
    */
-  virtual bool is_empty_bucket(const URI& uri) const = 0;
+  virtual bool is_empty_bucket(const URI& uri) const;
 
   /**
    * Creates an object store bucket.
    *
-   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   * @invariant Valid only for object store filesystems.
    *
    * @param uri The name of the bucket to be created.
    */
-  virtual void create_bucket(const URI& uri) const = 0;
+  virtual void create_bucket(const URI& uri) const;
 
   /**
    * Deletes an object store bucket.
    *
-   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   * @invariant Valid only for object store filesystems.
    *
    * @param uri The name of the bucket to be deleted.
    */
-  virtual void remove_bucket(const URI& uri) const = 0;
+  virtual void remove_bucket(const URI& uri) const;
 
   /**
    * Deletes the contents of an object store bucket.
    *
-   * @invariant Valid _only_ for object store Filesystems. No-op otherwise.
+   * @invariant Valid only for object store filesystems.
    *
    * @param uri The name of the bucket to be emptied.
    */
-  virtual void empty_bucket(const URI& uri) const = 0;
+  virtual void empty_bucket(const URI& uri) const;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -863,9 +863,8 @@ Status GCS::write(
   return Status::Ok();
 }
 
-Status GCS::object_size(const URI& uri, uint64_t* const nbytes) const {
-  RETURN_NOT_OK(init_client());
-  iassert(nbytes);
+uint64_t GCS::file_size(const URI& uri) const {
+  throw_if_not_ok(init_client());
 
   if (!uri.is_gcs()) {
     throw GCSException("URI is not a GCS URI: " + uri.to_string());
@@ -873,7 +872,7 @@ Status GCS::object_size(const URI& uri, uint64_t* const nbytes) const {
 
   std::string bucket_name;
   std::string object_path;
-  RETURN_NOT_OK(parse_gcs_uri(uri, &bucket_name, &object_path));
+  throw_if_not_ok(parse_gcs_uri(uri, &bucket_name, &object_path));
 
   google::cloud::StatusOr<google::cloud::storage::ObjectMetadata>
       object_metadata = client_->GetObjectMetadata(bucket_name, object_path);
@@ -886,9 +885,7 @@ Status GCS::object_size(const URI& uri, uint64_t* const nbytes) const {
         ")");
   }
 
-  *nbytes = object_metadata->size();
-
-  return Status::Ok();
+  return object_metadata->size();
 }
 
 Buffer* GCS::get_write_cache_buffer(const std::string& uri) {

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -407,10 +407,9 @@ class GCS {
    * Returns the size of the input object with a given URI in bytes.
    *
    * @param uri The URI of the object.
-   * @param nbytes Pointer to `uint64_t` bytes to return.
-   * @return Status
+   * @return The size of the object.
    */
-  Status object_size(const URI& uri, uint64_t* nbytes) const;
+  uint64_t file_size(const URI& uri) const;
 
   /**
    * Flushes an object to GCS, finalizing the upload.

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2020-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2020-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@
 #include "tiledb/common/exception/exception.h"
 #include "tiledb/common/macros.h"
 #include "tiledb/common/status.h"
+#include "tiledb/sm/filesystem/filesystem_base.h"
 
 using namespace tiledb::common;
 
@@ -67,7 +68,7 @@ class MemFSException : public StatusException {
  * @invariant The MemFilesystem is associated with a single VFS instance.
  * @invariant The MemFilesystem exists on a single, global Context.
  */
-class MemFilesystem {
+class MemFilesystem : FilesystemBase {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -102,35 +103,33 @@ class MemFilesystem {
   /**
    * Creates a new directory.
    *
-   * @param path The full name of the directory to be created
-   * @return Status
+   * @param uri The URI of the directory to be created.
    */
-  Status create_dir(const std::string& path) const;
+  void create_dir(const URI& uri) const;
 
   /**
    * Returns the size of an existing file.
    *
-   * @param path The full name of the file to retrieve the size of
-   * @param nbytes A pointer to retrun the size of the file
-   * @return Status
+   * @param uri The URI of the file to retrieve the size of.
+   * @return The size of the file.
    */
-  Status file_size(const std::string& path, uint64_t* size) const;
+  uint64_t file_size(const URI& uri) const;
 
   /**
-   * Checks if a path corresponds to an existing directory.
+   * Checks if a URI corresponds to an existing directory.
    *
-   * @param path The path to the directory to be checked
-   * @return *True* if *path* is an existing directory,  *False* otherwise
+   * @param uri The URI to the directory to be checked
+   * @return *True* if *uri* is an existing directory,  *False* otherwise
    */
-  bool is_dir(const std::string& path) const;
+  bool is_dir(const URI& uri) const;
 
   /**
-   * if a path corresponds to an existing file.
+   * Checks if a URI corresponds to an existing file.
    *
-   * @param path The path to the file to be checked
-   * @return *True* if *path* is an existing file, *false* otherwise
+   * @param uri The URI to the file to be checked
+   * @return *True* if *uri* is an existing file, *false* otherwise
    */
-  bool is_file(const std::string& path) const;
+  bool is_file(const URI& uri) const;
 
   /**
    *
@@ -150,48 +149,77 @@ class MemFilesystem {
    * @param path  The parent path to list sub-paths
    * @return A list of directory_entry objects
    */
-  std::vector<filesystem::directory_entry> ls_with_sizes(const URI& path) const;
+  std::vector<common::filesystem::directory_entry> ls_with_sizes(
+      const URI& path) const;
 
   /**
    * Move a given filesystem path.
    *
    * @param old_path The old path.
    * @param new_path The new path.
-   * @return Status
    */
-  Status move(const std::string& old_path, const std::string& new_path) const;
+  void move(const std::string& old_path, const std::string& new_path) const;
+
+  /**
+   * Move a given file.
+   *
+   * @param old_uri The old uri.
+   * @param new_uri The new uri.
+   */
+  void move_dir(const URI& old_uri, const URI& new_uri) const;
+
+  /**
+   * Move a given directory.
+   *
+   * @param old_uri The old uri.
+   * @param new_uri The new uri.
+   */
+  void move_file(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Reads data from a file into a buffer.
    *
-   * @param path The full name of the file
-   * @param offset The offset in the file from which the read will start
-   * @param buffer The buffer into which the data will be written
-   * @param nbytes The number of bytes to be read from the file
-   * @return Status.
+   * @param uri The URI of the file.
+   * @param offset The offset in the file from which the read will start.
+   * @param buffer The buffer into which the data will be written.
+   * @param nbytes The number of bytes to be read from the file.
+   * @param unused Unused flag. Reserved for the base class virtual function.
    */
-  Status read(
-      const std::string& path,
-      const uint64_t offset,
+  void read(
+      const URI& uri,
+      uint64_t offset,
       void* buffer,
-      const uint64_t nbytes) const;
+      uint64_t nbytes,
+      bool unused) const;
 
   /**
    * Removes a given path and its contents.
    *
-   * @param path The full name of the directory/file to be deleted
+   * @param path The full path of the directory/file to be deleted.
    * @param is_dir *True* if *path* is a directory, *false* if it's a file
-   * @return Status
    */
-  Status remove(const std::string& path, bool is_dir) const;
+  void remove(const std::string& path, bool is_dir) const;
+
+  /**
+   * Removes a directory and its contents.
+   *
+   * @param uri The URI of the directory to be deleted.
+   */
+  void remove_dir(const URI& uri) const;
+
+  /**
+   * Removes a file.
+   *
+   * @param uri The URI of the file to be deleted.
+   */
+  void remove_file(const URI& uri) const;
 
   /**
    * Creates an empty file.
    *
-   * @param path The full name of the file to be created
-   * @return Status
+   * @param uri The URI of the file to be created.
    */
-  Status touch(const std::string& path) const;
+  void touch(const URI& path) const;
 
   /**
    * Writes the input buffer to a file.
@@ -199,13 +227,109 @@ class MemFilesystem {
    * If the file does not exist than it is created with data as content.
    * If the file exits than the data is appended to the end of the file.
    *
-   * @param path The full name of the file
-   * @param data The input data
-   * @param nbytes The size of the input buffer in bytes
-   * @return Status
+   * @param uri The URI of the file.
+   * @param buffer The buffer to write from.
+   * @param buffer_size The size of the input buffer in bytes.
+   * @param unused Unused flag. Reserved for the base class virtual function.
    */
-  Status write(
-      const std::string& path, const void* data, const uint64_t nbytes);
+  void write(
+      const URI& uri, const void* buffer, uint64_t buffer_size, bool unused);
+
+  /**
+   * Copies a directory.
+   *
+   * @param old_uri The old URI.
+   * @param new_uri The new URI.
+   */
+  void copy_dir(const URI&, const URI&) const {
+    // No-op for MemFS; stub function for other filesystems.
+  }
+
+  /**
+   * Copies a file.
+   *
+   * @param old_uri The old URI.
+   * @param new_uri The new URI.
+   */
+  void copy_file(const URI&, const URI&) const {
+    // No-op for MemFS; stub function for other filesystems.
+  }
+
+  /**
+   * Flushes an object store file.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The URI of the file.
+   * @param unused Unused flag. Reserved for S3 objects only.
+   */
+  void flush(const URI&, bool) {
+  }
+
+  /**
+   * Syncs a local file.
+   *
+   * @invariant No-op for non-local Filesystems.
+   *
+   * @param uri The URI of the file.
+   */
+  void sync(const URI&) const {
+    // No-op for MemFS; stub function for local filesystems.
+  }
+
+  /**
+   * Checks if an object store bucket exists.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The name of the object store bucket.
+   * @return True if the bucket exists, false otherwise.
+   */
+  bool is_bucket(const URI&) const {
+    return false;
+  }
+
+  /**
+   * Checks if an object-store bucket is empty.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The name of the object store bucket.
+   * @return True if the bucket is empty, false otherwise.
+   */
+  bool is_empty_bucket(const URI&) const {
+    return true;
+  }
+
+  /**
+   * Creates an object store bucket.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The name of the bucket to be created.
+   */
+  void create_bucket(const URI&) const {
+  }
+
+  /**
+   * Deletes an object store bucket.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The name of the bucket to be deleted.
+   */
+  void remove_bucket(const URI&) const {
+  }
+
+  /**
+   * Deletes the contents of an object store bucket.
+   *
+   * @invariant No-op for non-object store Filesystems.
+   *
+   * @param uri The name of the bucket to be emptied.
+   */
+  void empty_bucket(const URI&) const {
+  }
 
  private:
   /* ********************************* */
@@ -275,9 +399,8 @@ class MemFilesystem {
    * @param path The full name of the directory to be created.
    * @param node Optional output argument to the node of the
    *    created directory.
-   * @return Status
    */
-  Status create_dir_internal(
+  void create_dir_internal(
       const std::string& path, FSNode** node = nullptr) const;
 
   /**
@@ -286,9 +409,8 @@ class MemFilesystem {
    * @param path The full name of the file to be created.
    * @param node Optional output argument to the node of the
    *    created file.
-   * @return Status
    */
-  Status touch_internal(const std::string& path, FSNode** node = nullptr) const;
+  void touch_internal(const std::string& path, FSNode** node = nullptr) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -183,14 +183,14 @@ class MemFilesystem : FilesystemBase {
    * @param offset The offset in the file from which the read will start.
    * @param buffer The buffer into which the data will be written.
    * @param nbytes The number of bytes to be read from the file.
-   * @param unused Unused flag. Reserved for the base class virtual function.
+   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
    */
   void read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool unused) const;
+      bool use_read_ahead) const;
 
   /**
    * Removes a given path and its contents.
@@ -230,10 +230,13 @@ class MemFilesystem : FilesystemBase {
    * @param uri The URI of the file.
    * @param buffer The buffer to write from.
    * @param buffer_size The size of the input buffer in bytes.
-   * @param unused Unused flag. Reserved for the base class virtual function.
+   * @param remote_global_order_write Unused flag. Reserved for S3 objects only.
    */
   void write(
-      const URI& uri, const void* buffer, uint64_t buffer_size, bool unused);
+      const URI& uri,
+      const void* buffer,
+      uint64_t buffer_size,
+      bool remote_global_order_write);
 
   /**
    * Copies a directory.
@@ -258,77 +261,24 @@ class MemFilesystem : FilesystemBase {
   /**
    * Flushes an object store file.
    *
-   * @invariant No-op for non-object store Filesystems.
+   * @invariant Performs a sync for local filesystems.
    *
    * @param uri The URI of the file.
-   * @param unused Unused flag. Reserved for S3 objects only.
+   * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
   void flush(const URI&, bool) {
+    // No-op for MemFS; stub function for local filesystems.
   }
 
   /**
    * Syncs a local file.
    *
-   * @invariant No-op for non-local Filesystems.
+   * @invariant Valid only for local filesystems.
    *
    * @param uri The URI of the file.
    */
   void sync(const URI&) const {
     // No-op for MemFS; stub function for local filesystems.
-  }
-
-  /**
-   * Checks if an object store bucket exists.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the object store bucket.
-   * @return True if the bucket exists, false otherwise.
-   */
-  bool is_bucket(const URI&) const {
-    return false;
-  }
-
-  /**
-   * Checks if an object-store bucket is empty.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the object store bucket.
-   * @return True if the bucket is empty, false otherwise.
-   */
-  bool is_empty_bucket(const URI&) const {
-    return true;
-  }
-
-  /**
-   * Creates an object store bucket.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the bucket to be created.
-   */
-  void create_bucket(const URI&) const {
-  }
-
-  /**
-   * Deletes an object store bucket.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the bucket to be deleted.
-   */
-  void remove_bucket(const URI&) const {
-  }
-
-  /**
-   * Deletes the contents of an object store bucket.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the bucket to be emptied.
-   */
-  void empty_bucket(const URI&) const {
   }
 
  private:
@@ -394,23 +344,20 @@ class MemFilesystem : FilesystemBase {
       const std::string& path, const char delim = '/');
 
   /**
-   * Creates a new directory without acquiring the lock
+   * Creates a new directory without acquiring the lock.
    *
    * @param path The full name of the directory to be created.
-   * @param node Optional output argument to the node of the
-   *    created directory.
+   * @return The node of the created directory.
    */
-  void create_dir_internal(
-      const std::string& path, FSNode** node = nullptr) const;
+  FSNode* create_dir_internal(const std::string& path) const;
 
   /**
-   * Creates an empty file without acquiring the lock
+   * Creates an empty file without acquiring the lock.
    *
    * @param path The full name of the file to be created.
-   * @param node Optional output argument to the node of the
-   *    created file.
+   * @return The node of the created file.
    */
-  void touch_internal(const std::string& path, FSNode** node = nullptr) const;
+  FSNode* touch_internal(const std::string& path) const;
 };
 
 }  // namespace sm

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -352,10 +352,7 @@ void Posix::sync(const URI& uri) const {
 }
 
 void Posix::write(
-    const URI& uri,
-    const void* buffer,
-    uint64_t buffer_size,
-    [[maybe_unused]] bool remote_global_order_write) {
+    const URI& uri, const void* buffer, uint64_t buffer_size, bool) {
   auto path = uri.to_path();
   // Check for valid inputs before attempting the actual
   // write system call. This is to avoid a bug on macOS

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -182,19 +182,20 @@ class Posix : public FilesystemBase, public LocalFilesystem {
    * @param offset The offset in the file from which the read will start.
    * @param buffer The buffer into which the data will be written.
    * @param nbytes The size of the data to be read from the file.
+   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
    */
   void read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead = true) const override;
+      bool use_read_ahead) const override;
 
   /**
    * Flushes a file or directory.
    *
    * @param uri The URI of the file.
-   * @param unused An unused flag, reserved for use by the virtual function.
+   * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
   void flush(const URI& uri, bool unused) override;
 
@@ -214,66 +215,13 @@ class Posix : public FilesystemBase, public LocalFilesystem {
    * @param path The name of the file.
    * @param buffer The input buffer.
    * @param buffer_size The size of the input buffer.
+   * @param remote_global_order_write Unused flag. Reserved for S3 objects only.
    */
   void write(
       const URI& uri,
       const void* buffer,
       uint64_t buffer_size,
-      bool remote_global_order_write = false) override;
-
-  /**
-   * Checks if an object store bucket exists.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the object store bucket.
-   * @return True if the bucket exists, false otherwise.
-   */
-  bool is_bucket(const URI&) const override {
-    return false;
-  }
-
-  /**
-   * Checks if an object-store bucket is empty.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the object store bucket.
-   * @return True if the bucket is empty, false otherwise.
-   */
-  bool is_empty_bucket(const URI&) const override {
-    return true;
-  }
-
-  /**
-   * Creates an object store bucket.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the bucket to be created.
-   */
-  void create_bucket(const URI&) const override {
-  }
-
-  /**
-   * Deletes an object store bucket.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the bucket to be deleted.
-   */
-  void remove_bucket(const URI&) const override {
-  }
-
-  /**
-   * Deletes the contents of an object store bucket.
-   *
-   * @invariant No-op for non-object store Filesystems.
-   *
-   * @param uri The name of the bucket to be emptied.
-   */
-  void empty_bucket(const URI&) const override {
-  }
+      bool remote_global_order_write) override;
 
   /**
    *

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -135,9 +135,9 @@ class Posix : public FilesystemBase, public LocalFilesystem {
    * Returns the size of the input file.
    *
    * @param path The name of the file whose size is to be retrieved.
-   * @param nbytes Pointer to a value
+   * @return The size of the file.
    */
-  void file_size(const URI& path, uint64_t* size) const override;
+  uint64_t file_size(const URI& path) const override;
 
   /**
    * Move a given filesystem path.
@@ -191,6 +191,14 @@ class Posix : public FilesystemBase, public LocalFilesystem {
       bool use_read_ahead = true) const override;
 
   /**
+   * Flushes a file or directory.
+   *
+   * @param uri The URI of the file.
+   * @param unused An unused flag, reserved for use by the virtual function.
+   */
+  void flush(const URI& uri, bool unused) override;
+
+  /**
    * Syncs a file or directory.
    *
    * @param path The name of the file.
@@ -216,50 +224,55 @@ class Posix : public FilesystemBase, public LocalFilesystem {
   /**
    * Checks if an object store bucket exists.
    *
+   * @invariant No-op for non-object store Filesystems.
+   *
    * @param uri The name of the object store bucket.
    * @return True if the bucket exists, false otherwise.
    */
   bool is_bucket(const URI&) const override {
-    // No concept of buckets for Posix.
     return false;
   }
 
   /**
    * Checks if an object-store bucket is empty.
    *
+   * @invariant No-op for non-object store Filesystems.
+   *
    * @param uri The name of the object store bucket.
    * @return True if the bucket is empty, false otherwise.
    */
   bool is_empty_bucket(const URI&) const override {
-    // No concept of buckets for Posix.
     return true;
   }
 
   /**
    * Creates an object store bucket.
    *
+   * @invariant No-op for non-object store Filesystems.
+   *
    * @param uri The name of the bucket to be created.
    */
   void create_bucket(const URI&) const override {
-    // No-op for Posix, stub function for cloud filesystems.
   }
 
   /**
    * Deletes an object store bucket.
    *
+   * @invariant No-op for non-object store Filesystems.
+   *
    * @param uri The name of the bucket to be deleted.
    */
   void remove_bucket(const URI&) const override {
-    // No-op for Posix, stub function for cloud filesystems.
   }
 
   /**
    * Deletes the contents of an object store bucket.
    *
+   * @invariant No-op for non-object store Filesystems.
+   *
    * @param uri The name of the bucket to be emptied.
    */
   void empty_bucket(const URI&) const override {
-    // No-op for Posix, stub function for cloud filesystems.
   }
 
   /**

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -730,21 +730,26 @@ Status S3::disconnect() {
   return ret_st;
 }
 
-Status S3::flush_object(const URI& uri) {
-  RETURN_NOT_OK(init_client());
+void S3::flush_object(const URI& uri, bool finalize) {
+  if (finalize) {
+    finalize_and_flush_object(uri);
+    return;
+  }
+
+  throw_if_not_ok(init_client());
   if (!s3_params_.use_multipart_upload_) {
-    return flush_direct(uri);
+    throw_if_not_ok(flush_direct(uri));
+    return;
   }
   if (!uri.is_s3()) {
-    return LOG_STATUS(Status_S3Error(
-        std::string("URI is not an S3 URI: " + uri.to_string())));
+    throw S3Exception(std::string("URI is not an S3 URI: " + uri.to_string()));
   }
 
   // Flush and delete file buffer. For multipart requests, we must
   // continue even if 'flush_file_buffer' fails. In that scenario,
   // we will send an abort request.
   auto buff = (Buffer*)nullptr;
-  RETURN_NOT_OK(get_file_buffer(uri, &buff));
+  throw_if_not_ok(get_file_buffer(uri, &buff));
   const Status flush_st = flush_file_buffer(uri, buff, true);
 
   Aws::Http::URI aws_uri = uri.c_str();
@@ -756,8 +761,8 @@ Status S3::flush_object(const URI& uri) {
   // Do nothing - empty object
   auto state_iter = multipart_upload_states_.find(path);
   if (state_iter == multipart_upload_states_.end()) {
-    RETURN_NOT_OK(flush_st);
-    return Status::Ok();
+    throw_if_not_ok(flush_st);
+    return;
   }
 
   const MultiPartUploadState* state = &multipart_upload_states_.at(path);
@@ -770,9 +775,9 @@ Status S3::flush_object(const URI& uri) {
         make_multipart_complete_request(*state);
     auto outcome = client_->CompleteMultipartUpload(complete_request);
     if (!outcome.IsSuccess()) {
-      return LOG_STATUS(Status_S3Error(
+      throw S3Exception(
           std::string("Failed to flush S3 object ") + uri.c_str() +
-          outcome_error_message(outcome)));
+          outcome_error_message(outcome));
     }
 
     auto bucket = state->bucket;
@@ -782,7 +787,7 @@ Status S3::flush_object(const URI& uri) {
 
     throw_if_not_ok(wait_for_object_to_propagate(move(bucket), move(key)));
 
-    return finish_flush_object(std::move(outcome), uri, buff, false);
+    throw_if_not_ok(finish_flush_object(std::move(outcome), uri, buff, false));
   } else {
     Aws::S3::Model::AbortMultipartUploadRequest abort_request =
         make_multipart_abort_request(*state);
@@ -791,7 +796,7 @@ Status S3::flush_object(const URI& uri) {
 
     state_lck.unlock();
 
-    return finish_flush_object(std::move(outcome), uri, buff, true);
+    throw_if_not_ok(finish_flush_object(std::move(outcome), uri, buff, true));
   }
 }
 

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -231,7 +231,7 @@ struct S3Parameters {
       , object_acl_str_(config.get<std::string>(
             "vfs.s3.object_canned_acl", Config::must_find))
       , config_source_(config.get<std::string>(
-            "vfs.s3.config_source", Config::must_find)) {};
+            "vfs.s3.config_source", Config::must_find)){};
 
   ~S3Parameters() = default;
 
@@ -806,9 +806,10 @@ class S3 : FilesystemBase {
    * Flushes an object to S3, finalizing the multipart upload.
    *
    * @param uri The URI of the object to be flushed.
-   * @return Status
+   * @param finalize If `true`, flushes as a result of a remote global order
+   * write `finalize()` call.
    */
-  Status flush_object(const URI& uri);
+  void flush_object(const URI& uri, bool finalize);
 
   /**
    * Flushes an s3 object as a result of a remote global order write
@@ -1142,7 +1143,7 @@ class S3 : FilesystemBase {
   struct MakeUploadPartCtx {
     /** Constructor. */
     MakeUploadPartCtx()
-        : upload_part_num(0) {};
+        : upload_part_num(0){};
     MakeUploadPartCtx(
         Aws::S3::Model::UploadPartOutcome&& in_upload_part_outcome,
         const int in_upload_part_num)
@@ -1221,7 +1222,7 @@ class S3 : FilesystemBase {
   struct MultiPartUploadState {
     MultiPartUploadState()
         : part_number(0)
-        , st(Status::Ok()) {};
+        , st(Status::Ok()){};
     /** Constructor. */
     MultiPartUploadState(
         const int in_part_number,
@@ -1234,7 +1235,7 @@ class S3 : FilesystemBase {
         , key(std::move(in_key))
         , upload_id(std::move(in_upload_id))
         , completed_parts(std::move(in_completed_parts))
-        , st(Status::Ok()) {};
+        , st(Status::Ok()){};
 
     MultiPartUploadState(MultiPartUploadState&& other) noexcept {
       this->part_number = other.part_number;

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -747,16 +747,6 @@ class S3 : FilesystemBase {
   }
 
   /**
-   * Retrieves the size of a file.
-   *
-   * @param uri The URI of the file.
-   * @param size The file size to be retrieved.
-   */
-  void file_size(const URI& uri, uint64_t* size) const override {
-    throw_if_not_ok(object_size(uri, size));
-  }
-
-  /**
    * Renames a file.
    * Both URI must be of the same backend type. (e.g. both s3://, file://, etc)
    *
@@ -809,7 +799,7 @@ class S3 : FilesystemBase {
    * @param finalize If `true`, flushes as a result of a remote global order
    * write `finalize()` call.
    */
-  void flush_object(const URI& uri, bool finalize);
+  void flush(const URI& uri, bool finalize) override;
 
   /**
    * Flushes an s3 object as a result of a remote global order write
@@ -965,10 +955,9 @@ class S3 : FilesystemBase {
    * Returns the size of the input object with a given URI in bytes.
    *
    * @param uri The URI of the object.
-   * @param nbytes Pointer to `uint64_t` bytes to return.
-   * @return Status
+   * @return The size of the object in bytes.
    */
-  Status object_size(const URI& uri, uint64_t* nbytes) const;
+  uint64_t file_size(const URI& uri) const override;
 
   /**
    * Reads data from an object into a buffer.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -649,14 +649,14 @@ class S3 : FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param use_read_ahead Whether to use the read-ahead cache.
+   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
    */
   void read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead = true) const override;
+      bool use_read_ahead) const override;
 
   /**
    * Deletes a bucket.
@@ -704,7 +704,7 @@ class S3 : FilesystemBase {
    * @param uri The URI of the object to be written to.
    * @param buffer The input buffer.
    * @param length The size of the input buffer.
-   * @param remote_global_order_write
+   * @param remote_global_order_write Whether to perform a global order write.
    */
   void write(
       const URI& uri,
@@ -799,7 +799,7 @@ class S3 : FilesystemBase {
    * @param finalize If `true`, flushes as a result of a remote global order
    * write `finalize()` call.
    */
-  void flush(const URI& uri, bool finalize) override;
+  void flush(const URI& uri, bool finalize = false) override;
 
   /**
    * Flushes an s3 object as a result of a remote global order write

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -231,7 +231,7 @@ struct S3Parameters {
       , object_acl_str_(config.get<std::string>(
             "vfs.s3.object_canned_acl", Config::must_find))
       , config_source_(config.get<std::string>(
-            "vfs.s3.config_source", Config::must_find)){};
+            "vfs.s3.config_source", Config::must_find)) {};
 
   ~S3Parameters() = default;
 
@@ -1143,7 +1143,7 @@ class S3 : FilesystemBase {
   struct MakeUploadPartCtx {
     /** Constructor. */
     MakeUploadPartCtx()
-        : upload_part_num(0){};
+        : upload_part_num(0) {};
     MakeUploadPartCtx(
         Aws::S3::Model::UploadPartOutcome&& in_upload_part_outcome,
         const int in_upload_part_num)
@@ -1222,7 +1222,7 @@ class S3 : FilesystemBase {
   struct MultiPartUploadState {
     MultiPartUploadState()
         : part_number(0)
-        , st(Status::Ok()){};
+        , st(Status::Ok()) {};
     /** Constructor. */
     MultiPartUploadState(
         const int in_part_number,
@@ -1235,7 +1235,7 @@ class S3 : FilesystemBase {
         , key(std::move(in_key))
         , upload_id(std::move(in_upload_id))
         , completed_parts(std::move(in_completed_parts))
-        , st(Status::Ok()){};
+        , st(Status::Ok()) {};
 
     MultiPartUploadState(MultiPartUploadState&& other) noexcept {
       this->part_number = other.part_number;

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -179,7 +179,8 @@ Status VFS::create_dir(const URI& uri) const {
     }
   }
   if (uri.is_memfs()) {
-    return memfs_.create_dir(uri.to_path());
+    memfs_.create_dir(uri);
+    return Status::Ok();
   }
   throw UnsupportedURI(uri.to_string());
 }
@@ -247,7 +248,8 @@ Status VFS::touch(const URI& uri) const {
 #endif
   }
   if (uri.is_memfs()) {
-    return memfs_.touch(uri.to_path());
+    memfs_.touch(uri);
+    return Status::Ok();
   }
   throw UnsupportedURI(uri.to_string());
 }
@@ -396,7 +398,8 @@ Status VFS::remove_dir(const URI& uri) const {
     throw BuiltWithout("GCS");
 #endif
   } else if (uri.is_memfs()) {
-    return memfs_.remove(uri.to_path(), true);
+    memfs_.remove_dir(uri);
+    return Status::Ok();
   } else {
     throw UnsupportedURI(uri.to_string());
   }
@@ -459,7 +462,8 @@ Status VFS::remove_file(const URI& uri) const {
 #endif
   }
   if (uri.is_memfs()) {
-    return memfs_.remove(uri.to_path(), false);
+    memfs_.remove_file(uri);
+    return Status::Ok();
   }
   throw UnsupportedURI(uri.to_string());
 }
@@ -497,20 +501,23 @@ Status VFS::max_parallel_ops(const URI& uri, uint64_t* ops) const {
   return Status::Ok();
 }
 
-Status VFS::file_size(const URI& uri, uint64_t* size) const {
+uint64_t VFS::file_size(const URI& uri) const {
   auto instrument = make_log_duration_instrument(uri, "file_size");
   stats_->add_counter("file_size_num", 1);
   if (uri.is_file()) {
 #ifdef _WIN32
-    return win_.file_size(uri.to_path(), size);
+    uint64_t size;
+    throw_if_not_ok(win_.file_size(uri.to_path(), &size));
+    return size;
 #else
-    posix_.file_size(uri, size);
-    return Status::Ok();
+    return posix_.file_size(uri);
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
-    return s3().object_size(uri, size);
+    uint64_t size;
+    throw_if_not_ok(s3().object_size(uri, &size));
+    return size;
 #else
     throw BuiltWithout("S3");
 #endif
@@ -518,7 +525,7 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     try {
-      *size = azure().blob_size(uri);
+      return azure().blob_size(uri);
     } catch (std::exception& e) {
       return Status_Error(e.what());
     }
@@ -530,7 +537,9 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
     try {
-      return gcs().object_size(uri, size);
+      uint64_t size;
+      throw_if_not_ok(gcs().object_size(uri, &size));
+      return size;
     } catch (std::exception& e) {
       return Status_Error(e.what());
     }
@@ -539,7 +548,7 @@ Status VFS::file_size(const URI& uri, uint64_t* size) const {
 #endif
   }
   if (uri.is_memfs()) {
-    return memfs_.file_size(uri.to_path(), size);
+    return memfs_.file_size(uri);
   }
   throw UnsupportedURI(uri.to_string());
 }
@@ -580,7 +589,7 @@ Status VFS::is_dir(const URI& uri, bool* is_dir) const {
 #endif
   }
   if (uri.is_memfs()) {
-    *is_dir = memfs_.is_dir(uri.to_path());
+    *is_dir = memfs_.is_dir(uri);
     return Status::Ok();
   }
   throw UnsupportedURI(uri.to_string());
@@ -624,7 +633,7 @@ Status VFS::is_file(const URI& uri, bool* is_file) const {
 #endif
   }
   if (uri.is_memfs()) {
-    *is_file = memfs_.is_file(uri.to_path());
+    *is_file = memfs_.is_file(uri);
     return Status::Ok();
   }
   throw UnsupportedURI(uri.to_string());
@@ -786,7 +795,8 @@ Status VFS::move_file(const URI& old_uri, const URI& new_uri) {
   // In-memory filesystem
   if (old_uri.is_memfs()) {
     if (new_uri.is_memfs()) {
-      return memfs_.move(old_uri.to_path(), new_uri.to_path());
+      memfs_.move_file(old_uri, new_uri);
+      return Status::Ok();
     }
     throw UnsupportedOperation("Moving files");
   }
@@ -849,7 +859,8 @@ Status VFS::move_dir(const URI& old_uri, const URI& new_uri) {
   // In-memory filesystem
   if (old_uri.is_memfs()) {
     if (new_uri.is_memfs()) {
-      return memfs_.move(old_uri.to_path(), new_uri.to_path());
+      memfs_.move_dir(old_uri, new_uri);
+      return Status::Ok();
     }
     throw UnsupportedOperation("Moving directories");
   }
@@ -1112,7 +1123,8 @@ Status VFS::read_impl(
 #endif
   }
   if (uri.is_memfs()) {
-    return memfs_.read(uri.to_path(), offset, buffer, nbytes);
+    memfs_.read(uri, offset, buffer, nbytes, use_read_ahead);
+    return Status::Ok();
   }
 
   throw UnsupportedURI(uri.to_string());
@@ -1284,19 +1296,21 @@ Status VFS::open_file(const URI& uri, VFSMode mode) {
   return Status::Ok();
 }
 
-Status VFS::close_file(const URI& uri) {
-  auto instrument = make_log_duration_instrument(uri, "close_file");
+void VFS::flush(const URI& uri, bool finalize) {
+  auto instrument = make_log_duration_instrument(uri, "flush");
   if (uri.is_file()) {
 #ifdef _WIN32
-    return win_.sync(uri.to_path());
+    win_.flush(uri);
+    return;
 #else
-    posix_.sync(uri);
-    return Status::Ok();
+    posix_.flush(uri, finalize);
+    return;
 #endif
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
-    return s3().flush_object(uri);
+    s3().flush_object(uri, finalize);
+    return;
 #else
     throw BuiltWithout("S3");
 #endif
@@ -1304,34 +1318,28 @@ Status VFS::close_file(const URI& uri) {
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
     azure().flush_blob(uri);
-    return Status::Ok();
+    return;
 #else
     throw BuiltWithout("Azure");
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
-    return gcs().flush_object(uri);
+    throw_if_not_ok(gcs().flush_object(uri));
+    return;
 #else
     throw BuiltWithout("GCS");
 #endif
   }
   if (uri.is_memfs()) {
-    return Status::Ok();
+    return;
   }
   throw UnsupportedURI(uri.to_string());
 }
 
-void VFS::finalize_and_close_file(const URI& uri) {
-  if (uri.is_s3()) {
-#ifdef HAVE_S3
-    s3().finalize_and_flush_object(uri);
-    return;
-#else
-    throw BuiltWithout("S3");
-#endif
-  }
-  throw_if_not_ok(close_file(uri));
+Status VFS::close_file(const URI& uri) {
+  flush(uri);
+  return Status::Ok();
 }
 
 Status VFS::write(
@@ -1375,7 +1383,8 @@ Status VFS::write(
 #endif
   }
   if (uri.is_memfs()) {
-    return memfs_.write(uri.to_path(), buffer, buffer_size);
+    memfs_.write(uri, buffer, buffer_size, remote_global_order_write);
+    return Status::Ok();
   }
   throw UnsupportedURI(uri.to_string());
 }

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -1287,7 +1287,7 @@ void VFS::flush(const URI& uri, bool finalize) {
   auto instrument = make_log_duration_instrument(uri, "flush");
   if (uri.is_file()) {
 #ifdef _WIN32
-    win_.flush(uri);
+    win_.flush(uri, finalize);
     return;
 #else
     posix_.flush(uri, finalize);
@@ -1342,7 +1342,7 @@ Status VFS::write(
 #ifdef _WIN32
     return win_.write(uri.to_path(), buffer, buffer_size);
 #else
-    posix_.write(uri, buffer, buffer_size);
+    posix_.write(uri, buffer, buffer_size, remote_global_order_write);
     return Status::Ok();
 #endif
   }

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -524,25 +524,16 @@ uint64_t VFS::file_size(const URI& uri) const {
   }
   if (uri.is_azure()) {
 #ifdef HAVE_AZURE
-    try {
-      return azure().blob_size(uri);
-    } catch (std::exception& e) {
-      return Status_Error(e.what());
-    }
-    return Status::Ok();
+    return azure().blob_size(uri);
 #else
     throw BuiltWithout("Azure");
 #endif
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
-    try {
-      uint64_t size;
-      throw_if_not_ok(gcs().object_size(uri, &size));
-      return size;
-    } catch (std::exception& e) {
-      return Status_Error(e.what());
-    }
+    uint64_t size;
+    throw_if_not_ok(gcs().object_size(uri, &size));
+    return size;
 #else
     throw BuiltWithout("GCS");
 #endif

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -529,9 +529,7 @@ uint64_t VFS::file_size(const URI& uri) const {
   }
   if (uri.is_gcs()) {
 #ifdef HAVE_GCS
-    uint64_t size;
-    throw_if_not_ok(gcs().object_size(uri, &size));
-    return size;
+    return gcs().file_size(uri);
 #else
     throw BuiltWithout("GCS");
 #endif

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -515,9 +515,7 @@ uint64_t VFS::file_size(const URI& uri) const {
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
-    uint64_t size;
-    throw_if_not_ok(s3().object_size(uri, &size));
-    return size;
+    return s3().file_size(uri);
 #else
     throw BuiltWithout("S3");
 #endif
@@ -1300,7 +1298,7 @@ void VFS::flush(const URI& uri, bool finalize) {
   }
   if (uri.is_s3()) {
 #ifdef HAVE_S3
-    s3().flush_object(uri, finalize);
+    s3().flush(uri, finalize);
     return;
 #else
     throw BuiltWithout("S3");

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -217,7 +217,7 @@ struct VFSBase {
   VFSBase() = delete;
 
   VFSBase(stats::Stats* const parent_stats)
-      : stats_(parent_stats->create_child("VFS")) {};
+      : stats_(parent_stats->create_child("VFS")){};
 
   ~VFSBase() = default;
 
@@ -524,10 +524,9 @@ class VFS : private VFSBase,
    * Retrieves the size of a file.
    *
    * @param uri The URI of the file.
-   * @param size The file size to be retrieved.
-   * @return Status
+   * @return The file size.
    */
-  Status file_size(const URI& uri, uint64_t* size) const;
+  uint64_t file_size(const URI& uri) const;
 
   /**
    * Checks if a directory exists.
@@ -758,21 +757,31 @@ class VFS : private VFSBase,
   Status open_file(const URI& uri, VFSMode mode);
 
   /**
+   * Flushes a file's contents to persistent storage.
+   *
+   * @note The `finalize` flag provides special S3 logic, tailored to work best
+   * with remote global order writes.
+   *
+   * @invariant This method currently closes local files. This is a known
+   * limitation that is being tracked and slated for improvement.
+   *
+   * @param uri The URI of the file.
+   * @param finalize For s3 objects only. If `true`, flushes as a result of a
+   * remote global order write `finalize()` call.
+   */
+  void flush(const URI& uri, [[maybe_unused]] bool finalize = false);
+
+  /**
    * Closes a file, flushing its contents to persistent storage.
+   *
+   * @note This method is simply a wrapper around flush(). Until the file handle
+   * close semantics are ironed out, we will maintain this method for backward
+   * compatibility.
    *
    * @param uri The URI of the file.
    * @return Status
    */
   Status close_file(const URI& uri);
-
-  /**
-   * Closes a file, flushing its contents to persistent storage.
-   * This function has special S3 logic tailored to work best with remote
-   * global order writes.
-   *
-   * @param uri The URI of the file.
-   */
-  void finalize_and_close_file(const URI& uri);
 
   /**
    * Writes the contents of a buffer into a file.

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -789,7 +789,9 @@ class VFS : private VFSBase,
    * @param uri The URI of the file.
    * @param buffer The buffer to write from.
    * @param buffer_size The buffer size.
-   * @param remote_global_order_write Remote global order write
+   * @param remote_global_order_write
+   *    Whether to perform a remote global order write.
+   *    Reserved for S3 objects only.
    * @return Status
    */
   Status write(

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -217,7 +217,7 @@ struct VFSBase {
   VFSBase() = delete;
 
   VFSBase(stats::Stats* const parent_stats)
-      : stats_(parent_stats->create_child("VFS")){};
+      : stats_(parent_stats->create_child("VFS")) {};
 
   ~VFSBase() = default;
 

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -498,6 +498,10 @@ Status Win::read(
   return Status::Ok();
 }
 
+void Win::flush(const URI& uri, bool) {
+  throw_if_not_ok(sync(uri.to_path()));
+}
+
 Status Win::sync(const std::string& path) const {
   if (!is_file(path)) {
     return Status::Ok();

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -224,9 +224,9 @@ class Win : LocalFilesystem {
    * Flushes a file or directory.
    *
    * @param uri The URI of the file.
-   * @param unused An unused flag, reserved for use by the virtual function.
+   * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
-  void flush(const URI& uri, bool unused);
+  void flush(const URI& uri, bool finalize);
 
   /**
    * Syncs a file or directory.

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -219,6 +219,14 @@ class Win : LocalFilesystem {
       uint64_t offset,
       void* buffer,
       uint64_t nbytes) const;
+
+  /**
+   * Flushes a file or directory.
+   *
+   * @param uri The URI of the file.
+   * @param unused An unused flag, reserved for use by the virtual function.
+   */
+  void flush(const URI& uri, bool unused);
 
   /**
    * Syncs a file or directory.

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -679,7 +679,7 @@ uint64_t FragmentMetadata::fragment_size() const {
   if (meta_file_size == 0) {
     auto meta_uri = fragment_uri_.join_path(
         std::string(constants::fragment_metadata_filename));
-    throw_if_not_ok(resources_->vfs().file_size(meta_uri, &meta_file_size));
+    meta_file_size = resources_->vfs().file_size(meta_uri);
   }
   // Validate that the meta_file_size is not zero, either preloaded or fetched
   // above
@@ -829,7 +829,7 @@ void FragmentMetadata::load(
   // Load the metadata file size when we are not reading from consolidated
   // buffer
   if (fragment_metadata_tile == nullptr) {
-    throw_if_not_ok(resources_->vfs().file_size(meta_uri, &meta_file_size_));
+    meta_file_size_ = resources_->vfs().file_size(meta_uri);
   }
 
   // Get fragment name version

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -272,8 +272,7 @@ GroupDirectory::compute_uris_to_vacuum(const std::vector<URI>& uris) const {
   std::vector<int32_t> to_vacuum_vec(uris.size(), 0);
   std::vector<int32_t> to_vacuum_vac_files_vec(vac_files.size(), 0);
   auto status = parallel_for(&tp_, 0, vac_files.size(), [&](size_t i) {
-    uint64_t size = 0;
-    throw_if_not_ok(vfs_.file_size(vac_files[i], &size));
+    uint64_t size = vfs_.file_size(vac_files[i]);
     std::string names;
     names.resize(size);
     throw_if_not_ok(vfs_.read(vac_files[i], 0, &names[0], size, false));

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -600,7 +600,8 @@ Status WriterBase::close_files(shared_ptr<FragmentMetadata> meta) const {
       parallel_for(&resources_.io_tp(), 0, file_uris.size(), [&](uint64_t i) {
         const auto& file_uri = file_uris[i];
         if (layout_ == Layout::GLOBAL_ORDER && remote_query()) {
-          resources_.vfs().finalize_and_close_file(file_uri);
+          // flush with finalize == true
+          resources_.vfs().flush(file_uri, true);
         } else {
           throw_if_not_ok(resources_.vfs().close_file(file_uri));
         }


### PR DESCRIPTION
Class `MemFS` inherits base class `FilesystemBase`.

This is the first PR in the `VFS` refactor work. The primary goal is for `MemFS` to inherit the base class, `FilesystemBase`. Some additional changes were made to the base class and to `VFS` to ease this transition for all other filesystems. 

---

TYPE: IMPROVEMENT
DESC: Class `MemFS` inherits base class `FilesystemBase`. 

---

Resolves CORE-289