### PR TITLE
Fix semantics of `tiledb_vfs_create_dir` on local filesystem.

### DIFF
--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -238,6 +238,7 @@ TEMPLATE_LIST_TEST_CASE(
    */
   auto dir1 = URI(path.to_string() + "dir1/");
   auto subdir = URI(dir1.to_string() + "subdir/");
+  auto subdir2 = URI(dir1.to_string() + "subdir2/subdir3");
   auto file1 = URI(subdir.to_string() + "file1");
   auto file2 = URI(subdir.to_string() + "file2");
   auto file3 = URI(dir1.to_string() + "file3");
@@ -245,6 +246,7 @@ TEMPLATE_LIST_TEST_CASE(
   auto file5 = URI(path.to_string() + "file5");
   REQUIRE_NOTHROW(vfs.create_dir(URI(dir1)));
   REQUIRE_NOTHROW(vfs.create_dir(URI(subdir)));
+  REQUIRE_NOTHROW(vfs.create_dir(URI(subdir2)));
   REQUIRE_NOTHROW(vfs.touch(file1));
   REQUIRE_NOTHROW(vfs.touch(file2));
   REQUIRE_NOTHROW(vfs.touch(file3));

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -238,7 +238,6 @@ TEMPLATE_LIST_TEST_CASE(
    */
   auto dir1 = URI(path.to_string() + "dir1/");
   auto subdir = URI(dir1.to_string() + "subdir/");
-  auto subdir2 = URI(dir1.to_string() + "subdir2/subdir3");
   auto file1 = URI(subdir.to_string() + "file1");
   auto file2 = URI(subdir.to_string() + "file2");
   auto file3 = URI(dir1.to_string() + "file3");
@@ -246,7 +245,6 @@ TEMPLATE_LIST_TEST_CASE(
   auto file5 = URI(path.to_string() + "file5");
   REQUIRE_NOTHROW(vfs.create_dir(URI(dir1)));
   REQUIRE_NOTHROW(vfs.create_dir(URI(subdir)));
-  REQUIRE_NOTHROW(vfs.create_dir(URI(subdir2)));
   REQUIRE_NOTHROW(vfs.touch(file1));
   REQUIRE_NOTHROW(vfs.touch(file2));
   REQUIRE_NOTHROW(vfs.touch(file3));
@@ -303,7 +301,7 @@ TEMPLATE_LIST_TEST_CASE(
     CHECK(paths.size() == 3);
     paths.clear();
     require_tiledb_ok(vfs.ls(dir1, &paths));
-    CHECK(paths.size() == 3);
+    CHECK(paths.size() == 2);
     paths.clear();
     require_tiledb_ok(vfs.ls(subdir, &paths));
     CHECK(paths.size() == 2);
@@ -327,7 +325,7 @@ TEMPLATE_LIST_TEST_CASE(
     // Normalization only for Windows
     ls_file = URI(tiledb::sm::path_win::uri_from_path(ls_file.to_string()));
 #endif
-    REQUIRE(children.size() == 3);
+    REQUIRE(children.size() == 2);
     CHECK(URI(children[0].path().native()) == ls_file);
     CHECK(
         URI(children[1].path().native()) == ls_subdir.remove_trailing_slash());
@@ -370,6 +368,26 @@ TEMPLATE_LIST_TEST_CASE(
     REQUIRE_NOTHROW(vfs.remove_dir(path));
     REQUIRE(!vfs.is_dir(path));
   }
+}
+
+TEST_CASE("VFS: Create directory", "[vfs][create-dir]") {
+  LocalFsTest fs({0});
+  if (!fs.is_supported()) {
+    return;
+  }
+
+  URI path = fs.temp_dir_.add_trailing_slash();
+
+  URI subdir = URI(path.to_string() + "subdir/");
+  URI subdir2 = URI(path.to_string() + "subdir/nested/nested2/");
+
+  REQUIRE_NOTHROW(fs.vfs_.create_dir(subdir));
+  REQUIRE(fs.vfs_.is_dir(subdir));
+  REQUIRE_NOTHROW(fs.vfs_.create_dir(subdir2));
+  REQUIRE(fs.vfs_.is_dir(subdir2));
+
+  // Try creating existing directory.
+  REQUIRE_NOTHROW(fs.vfs_.create_dir(subdir));
 }
 
 TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -303,7 +303,7 @@ TEMPLATE_LIST_TEST_CASE(
     CHECK(paths.size() == 3);
     paths.clear();
     require_tiledb_ok(vfs.ls(dir1, &paths));
-    CHECK(paths.size() == 2);
+    CHECK(paths.size() == 3);
     paths.clear();
     require_tiledb_ok(vfs.ls(subdir, &paths));
     CHECK(paths.size() == 2);
@@ -327,7 +327,7 @@ TEMPLATE_LIST_TEST_CASE(
     // Normalization only for Windows
     ls_file = URI(tiledb::sm::path_win::uri_from_path(ls_file.to_string()));
 #endif
-    REQUIRE(children.size() == 2);
+    REQUIRE(children.size() == 3);
     CHECK(URI(children[0].path().native()) == ls_file);
     CHECK(
         URI(children[1].path().native()) == ls_subdir.remove_trailing_slash());

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -138,16 +138,16 @@ void Posix::create_dir(const URI& uri) const {
   // If the directory does not exist, create it
   auto path = uri.to_path();
   throw_if_not_ok(ensure_directory(path));
-  if (is_dir(uri)) {
-    throw IOError(
-        std::string("Cannot create directory '") + path +
-        "'; Directory already exists");
-  }
-
-  if (mkdir(path.c_str(), directory_permissions_) != 0) {
+  auto status = mkdir(path.c_str(), directory_permissions_);
+  if (status != 0) {
+    auto err = errno;
+    if (err == EEXIST) {
+      // Do not fail if directory already existed.
+      return;
+    }
     throw IOError(
         std::string("Cannot create directory '") + path + "'; " +
-        strerror(errno));
+        strerror(err));
   }
 }
 

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -137,6 +137,7 @@ Posix::Posix(const Config& config) {
 void Posix::create_dir(const URI& uri) const {
   // If the directory does not exist, create it
   auto path = uri.to_path();
+  throw_if_not_ok(ensure_directory(path));
   if (is_dir(uri)) {
     throw IOError(
         std::string("Cannot create directory '") + path +

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -148,10 +148,6 @@ std::string Win::abs_path(const std::string& path) {
 
 void Win::create_dir(const URI& uri) const {
   auto path = uri.to_path();
-  if (is_dir(uri)) {
-    throw WindowsException(
-        "Cannot create directory '" + path + "'; Directory already exists");
-  }
   std::error_code ec;
   std::filesystem::create_directories(path, ec);
   if (ec) {


### PR DESCRIPTION
Fixes CORE-268.

Tests added. The Windows implementation already creates parent directories.

---
TYPE: BUG
DESC: Fixed the `tiledb_vfs_create_dir` function to automatically create non-existent parent directories on POSIX.

---
TYPE: BUG
DESC: Fixed the `tiledb_vfs_create_dir` function to not fail when the directory already exists.