### PR TITLE
Add missing include into config class.

### DIFF
--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -38,6 +38,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
Add missing include into config class.

---
TYPE: NO_HISTORY
DESC: Add missing include into config class.

---

Resolves CORE-296
