### PR TITLE
Fix empty array name for URIs with trailing slash.

### DIFF
--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -155,7 +155,8 @@ std::string vfs_array_uri(
     return "tiledb://unit/" + array_name;
   } else if (fs->is_rest() && !legacy) {
     // Include a space in the URI to test URL encoding.
-    return "tiledb://unit workspace/unit teamspace/" + array_name;
+    return "tiledb://unit-workspace/unit-teamspace/" + random_label() + "/" +
+           array_name;
   } else {
     return array_name;
   }

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -865,7 +865,8 @@ struct VFSTestSetup {
       return "tiledb://unit/" + temp_dir + array_name;
     } else {
       // Include a space in the URI to test URL encoding.
-      return "tiledb://unit workspace/unit teamspace/" + temp_dir + array_name;
+      return "tiledb://unit-workspace/unit-teamspace/" + random_label() + "/" +
+             temp_dir + array_name;
     }
   }
 

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -251,8 +251,9 @@ Status URI::get_rest_components(
   const std::string ns_component =
       legacy ? "tiledb://<namespace>" : "tiledb://<workspace>/<teamspace>";
   const auto error_st = Status_RestError(
-      "Invalid array URI for REST service; expected format is " + ns_component +
-      "/<array-name>' or " + ns_component + "/<array-uri>'.");
+      "Invalid array URI for REST service: '" + uri_ +
+      "'; expected format is " + ns_component + "/<array-name>' or " +
+      ns_component + "/<array-uri>'.");
 
   if (!is_tiledb() || uri_.empty() || uri_.find(prefix) == std::string::npos ||
       uri_.size() <= prefix.size()) {

--- a/tiledb/sm/filesystem/uri.cc
+++ b/tiledb/sm/filesystem/uri.cc
@@ -299,7 +299,14 @@ Status URI::get_rest_components(
     std::string ws = uri_.substr(prefix.size(), ws_len);
     std::string ts = uri_.substr(ws_slash + 1, ts_len);
     rest_components->server_namespace = ws + "/" + ts;
+    // If there is a trailing slash in the URI, this returns an empty string.
     auto asset_name = last_path_part();
+    if (asset_name.empty()) {
+      asset_name = last_two_path_parts();
+      if (asset_name.ends_with('/')) {
+        asset_name.pop_back();
+      }
+    }
 
     auto storage_component_index = get_storage_component_index(ts_slash + 1);
     if (!storage_component_index.has_value()) {


### PR DESCRIPTION
If a URI is used with a trailing slash `URI::last_path_part` returns an empty string, which results in an empty array name when constructing the request URL. This ensures an array name is found for this case, and updates REST CI to use folders for storing assets to avoid collisions in the DB.

REST-CI tests are passing locally using this branch against TileDB-Server.

---
TYPE: BUG
DESC: Fix empty array name for URIs with trailing slash.
