### PR TITLE
Update ARM64 images in the release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
             triplet: x64-linux-release
             manylinux: quay.io/pypa/manylinux_2_28_x86_64
           - platform: linux-aarch64
-            os: linux-arm64-ubuntu24
+            os: ubuntu-24.04-arm
             triplet: arm64-linux-release
             manylinux: quay.io/pypa/manylinux_2_28_aarch64
           - platform: macos-x86_64


### PR DESCRIPTION
This PR updates the release workflow to use the Linux-ARM64 images as described [here](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

---
TYPE: NO_HISTORY