### PR TITLE
Correctly reset budget when initial data already loadad

### DIFF
--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -158,6 +158,11 @@ void CSparseUnorderedWithDupsFx::update_config() {
   REQUIRE(error == nullptr);
 
   REQUIRE(
+      tiledb_config_set(config, "config.logging_level", "5", &error) ==
+      TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  REQUIRE(
       tiledb_config_set(
           config,
           "sm.query.sparse_unordered_with_dups.reader",
@@ -940,6 +945,113 @@ TEST_CASE_METHOD(
             "SparseUnorderedWithDupsReader: Cannot load tile offsets, "
             "computed size") != std::string::npos);
   }
+}
+
+TEST_CASE_METHOD(
+    CSparseUnorderedWithDupsFx,
+    "Sparse unordered with dups reader: increase tile offsets when exceeded",
+    "[sparse-unordered-with-dups][tile-offsets][budget-exceeded][CX-83]") {
+  // Create default array.
+  reset_config();
+  create_default_array_1d();
+
+  // Write a fragment.
+  std::vector<int> coords(200);
+  std::iota(coords.begin(), coords.end(), 1);
+  uint64_t coords_size = coords.size() * sizeof(int);
+
+  std::vector<int> data(200);
+  std::iota(data.begin(), data.end(), 1);
+  uint64_t data_size = data.size() * sizeof(int);
+
+  write_1d_fragment(coords.data(), &coords_size, data.data(), &data_size);
+
+  // We should have 100 tiles (tile offset size 800) which will be bigger than
+  // leftover budget.
+  total_budget_ = "3000";
+  ratio_array_data_ = "0.5";
+  partial_tile_offsets_loading_ = "false";
+  update_config();
+
+  // Try to read.
+  int coords_r[200];
+  int data_r[200];
+  uint64_t coords_r_size = sizeof(coords_r);
+  uint64_t data_r_size = sizeof(data_r);
+
+  // Open array for reading.
+  tiledb_array_t* array;
+  auto rc = tiledb_array_alloc(ctx_, array_name_.c_str(), &array);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_array_open(ctx_, array, TILEDB_READ);
+  CHECK(rc == TILEDB_OK);
+
+  // Create query. First submission with budget that can't fit offsets
+  tiledb_query_t* query;
+  rc = tiledb_query_alloc(ctx_, array, TILEDB_READ, &query);
+  CHECK(rc == TILEDB_OK);
+
+  rc = tiledb_query_set_layout(ctx_, query, TILEDB_UNORDERED);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "a", data_r, &data_r_size);
+  CHECK(rc == TILEDB_OK);
+  rc = tiledb_query_set_data_buffer(ctx_, query, "d", coords_r, &coords_r_size);
+  CHECK(rc == TILEDB_OK);
+
+  // Submit query.
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_ERR);
+
+  // Check we hit the correct error.
+  tiledb_error_t* error = NULL;
+  rc = tiledb_ctx_get_last_error(ctx_, &error);
+  REQUIRE(rc == TILEDB_OK);
+
+  const char* msg;
+  rc = tiledb_error_message(error, &msg);
+  REQUIRE(rc == TILEDB_OK);
+
+  std::string error_str(msg);
+  REQUIRE(
+      error_str.find("SparseUnorderedWithDupsReader: Cannot load tile offsets, "
+                     "computed size") != std::string::npos);
+
+  // Now increase the budget and try again. This should succeed.
+  auto increased_budget = 10 * std::stoi(total_budget_);
+  tiledb_config_t* config;
+  error = nullptr;
+  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  REQUIRE(
+      tiledb_config_set(config, "config.logging_level", "5", &error) ==
+      TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  REQUIRE(
+      tiledb_config_set(
+          config,
+          "sm.mem.total_budget",
+          std::to_string(increased_budget).c_str(),
+          &error) == TILEDB_OK);
+  REQUIRE(error == nullptr);
+
+  // This is needed to simulate the remote server environment where updating
+  // the config of a query that has already been submitted is only allowed.
+  // This is set during deserialization on the remote server.
+  query->query_->set_remote_query();
+
+  rc = tiledb_query_set_config(ctx_, query, config);
+  REQUIRE(rc == TILEDB_OK);
+
+  rc = tiledb_query_submit(ctx_, query);
+  REQUIRE(rc == TILEDB_OK);
+
+  // Clean up.
+  rc = tiledb_array_close(ctx_, array);
+  CHECK(rc == TILEDB_OK);
+  tiledb_array_free(&array);
+  tiledb_query_free(&query);
 }
 
 TEST_CASE_METHOD(

--- a/test/src/unit-sparse-unordered-with-dups-reader.cc
+++ b/test/src/unit-sparse-unordered-with-dups-reader.cc
@@ -158,11 +158,6 @@ void CSparseUnorderedWithDupsFx::update_config() {
   REQUIRE(error == nullptr);
 
   REQUIRE(
-      tiledb_config_set(config, "config.logging_level", "5", &error) ==
-      TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
       tiledb_config_set(
           config,
           "sm.query.sparse_unordered_with_dups.reader",
@@ -1021,11 +1016,6 @@ TEST_CASE_METHOD(
   tiledb_config_t* config;
   error = nullptr;
   REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  REQUIRE(
-      tiledb_config_set(config, "config.logging_level", "5", &error) ==
-      TILEDB_OK);
   REQUIRE(error == nullptr);
 
   REQUIRE(

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -209,18 +209,19 @@ Status SparseIndexReaderBase::load_initial_data() {
   if (initial_data_loaded_) {
     // Set a limit to the array memory.
     if (!array_memory_tracker_->set_budget(
-            memory_budget_.total_budget() *
-            memory_budget_.ratio_array_data())) {
+            memory_budget_.array_data_budget())) {
       throw SparseIndexReaderBaseException(
           "Cannot set array memory budget (" +
-          std::to_string(
-              memory_budget_.total_budget() *
-              memory_budget_.ratio_array_data()) +
+          std::to_string(memory_budget_.array_data_budget()) +
           ") because it is smaller than the current memory usage (" +
           std::to_string(array_memory_tracker_->get_memory_usage()) + ").");
     }
 
-    logger_->debug("Initial data already loaded");
+    logger_->debug(
+        "Initial data already loaded. Total budget: {}, Budget for array data: "
+        "{} ",
+        memory_budget_.total_budget(),
+        memory_budget_.array_data_budget());
 
     return Status::Ok();
   }
@@ -341,12 +342,10 @@ Status SparseIndexReaderBase::load_initial_data() {
   per_frag_tile_offsets_usage_ = tile_offset_sizes();
 
   // Set a limit to the array memory.
-  if (!array_memory_tracker_->set_budget(
-          memory_budget_.total_budget() * memory_budget_.ratio_array_data())) {
+  if (!array_memory_tracker_->set_budget(memory_budget_.array_data_budget())) {
     throw SparseIndexReaderBaseException(
         "Cannot set array memory budget (" +
-        std::to_string(
-            memory_budget_.total_budget() * memory_budget_.ratio_array_data()) +
+        std::to_string(memory_budget_.array_data_budget()) +
         ") because it is smaller than the current memory usage (" +
         std::to_string(array_memory_tracker_->get_memory_usage()) + ").");
   }

--- a/tiledb/sm/query/readers/sparse_index_reader_base.cc
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.cc
@@ -207,6 +207,21 @@ uint64_t SparseIndexReaderBase::get_coord_tiles_size(
 
 Status SparseIndexReaderBase::load_initial_data() {
   if (initial_data_loaded_) {
+    // Set a limit to the array memory.
+    if (!array_memory_tracker_->set_budget(
+            memory_budget_.total_budget() *
+            memory_budget_.ratio_array_data())) {
+      throw SparseIndexReaderBaseException(
+          "Cannot set array memory budget (" +
+          std::to_string(
+              memory_budget_.total_budget() *
+              memory_budget_.ratio_array_data()) +
+          ") because it is smaller than the current memory usage (" +
+          std::to_string(array_memory_tracker_->get_memory_usage()) + ").");
+    }
+
+    logger_->debug("Initial data already loaded");
+
     return Status::Ok();
   }
 

--- a/tiledb/sm/query/readers/sparse_index_reader_base.h
+++ b/tiledb/sm/query/readers/sparse_index_reader_base.h
@@ -164,6 +164,13 @@ class MemoryBudget {
     return tile_upper_memory_limit_;
   }
 
+  /**
+   * @return Portion of the total memory budget dedicated to loading array data.
+   */
+  double array_data_budget() const {
+    return total_budget_ * ratio_array_data_;
+  }
+
  private:
   /* ********************************* */
   /*        PRIVATE ATTRIBUTES         */


### PR DESCRIPTION
In the Server we support retrying query submit with a larger `sm.mem.total_budget` when the initially provisioned budget is not enough for loading tile offsets, which has been sometimes the case in real world use cases in the past in heavy queries/large datasets. This has been tested to work with the `DenseReader`, but not with Sparse readers. 

As a result there is a defect in Sparse that went unnoticed: When a query is retried with increased budget, but the loading of its initial data (E.g. rtrees) has fit in memory in a previous try, we aren't (rightfully) re-loading the initial data, but proceeding directly to loading the offsets that previously didn't fit. However, the logic for resetting the memory budget of the reader to the new increased budget is within the `load_initial_data` method that is now skipped, so the new budget was never applied in practice, and the query was stuck getting retried forever from the server.

This PR is fixing the issue by making sure we always reset the budget to the caller provided value.

Closes CX-83

---
TYPE: BUG
DESC: Correctly reset bugdet when initial data already loadad
