### PR TITLE
Use `std::filesystem` implementation for local file and directory copying.

### DIFF
--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -33,6 +33,9 @@
 #include <test/support/tdb_catch.h>
 #include "test/support/src/helpers.h"
 #include "test/support/src/temporary_local_directory.h"
+#ifdef HAVE_S3
+#include "tiledb/sm/filesystem/s3.h"
+#endif
 #ifdef HAVE_AZURE
 #include <azure/storage/blobs.hpp>
 #include "tiledb/sm/filesystem/azure.h"

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -466,7 +466,7 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
 
   // Read from the beginning
   auto read_buffer = new char[26];
-  require_tiledb_ok(vfs.read(largefile, 0, read_buffer, 26));
+  require_tiledb_ok(vfs.read_exactly(largefile, 0, read_buffer, 26));
   bool allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + i)) {
@@ -477,7 +477,7 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   CHECK(allok);
 
   // Read from a different offset
-  require_tiledb_ok(vfs.read(largefile, 11, read_buffer, 26));
+  require_tiledb_ok(vfs.read_exactly(largefile, 11, read_buffer, 26));
   allok = true;
   for (int i = 0; i < 26; i++) {
     if (read_buffer[i] != static_cast<char>('a' + (i + 11) % 26)) {

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -45,6 +45,10 @@
 #include "test/support/src/helpers.h"
 #include "test/support/src/vfs_helpers.h"
 
+#if HAVE_S3
+#include "tiledb/sm/filesystem/s3.h"
+#endif
+
 #include "tiledb/sm/rest/rest_client.h"
 
 namespace tiledb::test {
@@ -494,6 +498,27 @@ VFSTest::VFSTest(
     }
   }
   std::sort(expected_results().begin(), expected_results().end());
+}
+
+S3Test::S3Test(const std::vector<size_t>& test_tree)
+    : VFSTestBase(test_tree, "s3://")
+    , S3_within_VFS(&tiledb::test::g_helper_stats, &io_, vfs_.config()) {
+#ifdef HAVE_S3
+  s3().create_bucket(temp_dir_);
+  for (size_t i = 1; i <= test_tree_.size(); i++) {
+    sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
+    // VFS::create_dir is a no-op for S3; Just create objects.
+    for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
+      auto object_uri = path.join_path("test_file_" + std::to_string(j));
+      s3().touch(object_uri);
+      std::string data(j * 10, 'a');
+      s3().write(object_uri, data.data(), data.size());
+      s3().flush(object_uri);
+      expected_results().emplace_back(object_uri.to_string(), data.size());
+    }
+  }
+  std::sort(expected_results().begin(), expected_results().end());
+#endif
 }
 
 LocalFsTest::LocalFsTest(const std::vector<size_t>& test_tree)

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -997,26 +997,7 @@ class VFSTest : public VFSTestBase {
 /** Test object for tiledb::sm::S3 functionality. */
 class S3Test : public VFSTestBase, protected tiledb::sm::S3_within_VFS {
  public:
-  explicit S3Test(const std::vector<size_t>& test_tree)
-      : VFSTestBase(test_tree, "s3://")
-      , S3_within_VFS(&tiledb::test::g_helper_stats, &io_, vfs_.config()) {
-#ifdef HAVE_S3
-    s3().create_bucket(temp_dir_);
-    for (size_t i = 1; i <= test_tree_.size(); i++) {
-      sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
-      // VFS::create_dir is a no-op for S3; Just create objects.
-      for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
-        auto object_uri = path.join_path("test_file_" + std::to_string(j));
-        s3().touch(object_uri);
-        std::string data(j * 10, 'a');
-        s3().write(object_uri, data.data(), data.size());
-        s3().flush(object_uri);
-        expected_results().emplace_back(object_uri.to_string(), data.size());
-      }
-    }
-    std::sort(expected_results().begin(), expected_results().end());
-#endif
-  }
+  explicit S3Test(const std::vector<size_t>& test_tree);
 
 #ifdef HAVE_S3
   /** Expose protected accessor from S3_within_VFS. */

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -338,10 +338,6 @@ TEST_CASE("C API: tiledb_vfs_move_dir argument validation", "[capi][vfs]") {
 }
 
 TEST_CASE("C API: tiledb_vfs_copy_dir argument validation", "[capi][vfs]") {
-  if constexpr (tiledb::platform::is_os_windows) {
-    // This API is not yet supported on Windows.
-    return;
-  }
   ordinary_vfs x;
   SECTION("success") {
     auto rc{tiledb_vfs_copy_dir(x.ctx, x.vfs, TEST_URI, "new_dir")};
@@ -494,10 +490,6 @@ TEST_CASE("C API: tiledb_vfs_move_file argument validation", "[capi][vfs]") {
 }
 
 TEST_CASE("C API: tiledb_vfs_copy_file argument validation", "[capi][vfs]") {
-  if constexpr (tiledb::platform::is_os_windows) {
-    // This API is not yet supported on Windows.
-    return;
-  }
   ordinary_vfs x;
   SECTION("success") {
     auto rc{tiledb_vfs_copy_file(x.ctx, x.vfs, TEST_URI, "new_uri")};

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -153,7 +153,11 @@ struct tiledb_vfs_handle_t
       tiledb_ls_callback_t cb,
       void* data) const {
     tiledb::sm::CallbackWrapperCAPI wrapper(cb, data);
-    vfs_.ls_recursive(parent, wrapper);
+    try {
+      vfs_.ls_recursive(parent, wrapper);
+    } catch (const tiledb::sm::LsStopTraversal&) {
+      // Ignore exception
+    }
   }
 };
 

--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -29,6 +29,7 @@
 #ifndef TILEDB_COMMON_EXCEPTION_H
 #define TILEDB_COMMON_EXCEPTION_H
 
+#include <functional>
 #include <stdexcept>
 #include "tiledb/common/common-std.h"
 #include "tiledb/common/status.h"

--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -182,6 +182,25 @@ inline void throw_if_not_ok(const Status& st) {
   if (!st.ok()) {
     // friend declaration allows calling this private constructor
     throw StatusException(st, std::nothrow);
+  }
+}
+
+/**
+ * Wraps the call of a void-returning function to return a status. This is
+ * effectively the inverse of throw_if_not_ok.
+ *
+ * @return Status::Ok if calling f(args) did not throw, a failing Status if it
+ * threw.
+ */
+template <class F, class... Args>
+inline Status ok_if_not_throw(F&& f, Args&&... args)
+  requires(std::is_invocable_r_v<void, F, Args...>)
+{
+  try {
+    std::invoke(f, std::forward<Args>(args)...);
+    return Status::Ok();
+  } catch (std::exception& e) {
+    return Status_Error(e.what());
   }
 }
 

--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -48,9 +48,11 @@ class StatusException : public std::exception {
   friend void throw_if_not_ok(const Status&);
 
   /**
-   * Vicinity where exception originated
+   * Vicinity where exception originated.
+   *
+   * This is expected to be a statically allocated constant string.
    */
-  std::string origin_;
+  std::string_view origin_;
 
   /**
    * Specific error message
@@ -88,7 +90,7 @@ class StatusException : public std::exception {
    * @param st Status from which to convert
    */
   explicit StatusException(const Status& st, std::nothrow_t) noexcept
-      : StatusException(std::string(st.origin()), st.message()) {
+      : StatusException(st.origin(), st.message()) {
   }
 
   /**
@@ -120,11 +122,11 @@ class StatusException : public std::exception {
    * Ordinary constructor separates origin and error message in order to
    * support subclass constructors.
    *
-   * @param code Legacy status code
+   * @param origin Legacy status code
    * @param what Error message
    * @pre Argument `what` must be a C-style null-terminated string
    */
-  StatusException(const std::string origin, const std::string message)
+  StatusException(const std::string_view origin, const std::string message)
       : origin_(origin)
       , message_(message) {
   }
@@ -160,9 +162,6 @@ class StatusException : public std::exception {
 
   /**
    * Extract a `Status` object from this exception.
-   *
-   * The lifespan of the status must be shorter than that of this exception from
-   * which it is extracted.
    */
   Status extract_status() const {
     return {origin_, message_};

--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -200,6 +200,8 @@ inline Status ok_if_not_throw(F&& f, Args&&... args)
   try {
     std::invoke(f, std::forward<Args>(args)...);
     return Status::Ok();
+  } catch (StatusException& e) {
+    return e.extract_status();
   } catch (std::exception& e) {
     return Status_Error(e.what());
   }

--- a/tiledb/sm/array/array_directory.cc
+++ b/tiledb/sm/array/array_directory.cc
@@ -733,7 +733,7 @@ ArrayDirectory::load_consolidated_commit_uris(
       std::string names;
       names.resize(size);
       RETURN_NOT_OK_TUPLE(
-          resources_.get().vfs().read(uri, 0, &names[0], size, false),
+          resources_.get().vfs().read_exactly(uri, 0, &names[0], size),
           nullopt,
           nullopt);
       std::stringstream ss(names);
@@ -757,7 +757,7 @@ ArrayDirectory::load_consolidated_commit_uris(
       auto& names = meta_files.back().second;
       names.resize(size);
       RETURN_NOT_OK_TUPLE(
-          resources_.get().vfs().read(uri, 0, &names[0], size, false),
+          resources_.get().vfs().read_exactly(uri, 0, &names[0], size),
           nullopt,
           nullopt);
       std::stringstream ss(names);
@@ -1086,7 +1086,7 @@ ArrayDirectory::compute_uris_to_vacuum(
     uint64_t size = vfs.file_size(vac_files[i]);
     std::string names;
     names.resize(size);
-    throw_if_not_ok(vfs.read(vac_files[i], 0, &names[0], size, false));
+    throw_if_not_ok(vfs.read_exactly(vac_files[i], 0, &names[0], size));
     std::stringstream ss(names);
     bool vacuum_vac_file = true;
     for (std::string uri_str; std::getline(ss, uri_str);) {

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -768,7 +768,6 @@ void read_file_header(
   const tiledb::sm::URI uri_obj = tiledb::sm::URI(uri);
   throw_if_not_ok(vfs.open_file(uri_obj, tiledb::sm::VFSMode::VFS_READ));
   throw_if_not_ok(vfs.read_exactly(uri_obj, 0, header.data(), header.size()));
-  throw_if_not_ok(vfs.close_file(uri_obj));
 }
 
 std::pair<std::string, std::string> strip_file_extension(const char* file_uri) {

--- a/tiledb/sm/c_api/tiledb_filestore.cc
+++ b/tiledb/sm/c_api/tiledb_filestore.cc
@@ -323,8 +323,8 @@ int32_t tiledb_filestore_uri_import(
     if (start + buffer.size() > file_size) {
       readlen = file_size - start;
     }
-    throw_if_not_ok(
-        vfs.read(tiledb::sm::URI(file_uri), start, buffer.data(), readlen));
+    throw_if_not_ok(vfs.read_exactly(
+        tiledb::sm::URI(file_uri), start, buffer.data(), readlen));
     return readlen;
   };
 
@@ -767,7 +767,7 @@ void read_file_header(
     tiledb::sm::VFS& vfs, const char* uri, std::vector<char>& header) {
   const tiledb::sm::URI uri_obj = tiledb::sm::URI(uri);
   throw_if_not_ok(vfs.open_file(uri_obj, tiledb::sm::VFSMode::VFS_READ));
-  throw_if_not_ok(vfs.read(uri_obj, 0, header.data(), header.size()));
+  throw_if_not_ok(vfs.read_exactly(uri_obj, 0, header.data(), header.size()));
   throw_if_not_ok(vfs.close_file(uri_obj));
 }
 

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -293,8 +293,8 @@ void Consolidator::write_consolidated_commits_file(
             uri.to_string(), constants::delete_file_suffix)) {
       memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
       file_index += sizeof(storage_size_t);
-      throw_if_not_ok(
-          resources.vfs().read(uri, 0, &data[file_index], file_sizes[i]));
+      throw_if_not_ok(resources.vfs().read_exactly(
+          uri, 0, &data[file_index], file_sizes[i]));
       file_index += file_sizes[i];
     }
   }

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -273,6 +273,10 @@ Azure::AzureClientSingleton::get(const AzureParameters& params) {
   return *client_;
 }
 
+bool Azure::supports_uri(const URI& uri) const {
+  return uri.is_azure();
+}
+
 void Azure::create_bucket(const URI& uri) const {
   const auto& c = client();
   if (!uri.is_azure()) {

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -519,14 +519,9 @@ class Azure : public FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Deletes a container.

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -513,36 +513,20 @@ class Azure : FilesystemBase {
   uint64_t file_size(const URI& uri) const;
 
   /**
-   * Reads data from an object into a buffer.
+   * Reads from a file.
    *
-   * @param uri The URI of the object to be read.
-   * @param offset The offset in the object from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param length The size of the data to be read from the object.
-   * @param read_ahead_length The additional length to read ahead.
-   * @param length_returned Returns the total length read into `buffer`.
-   * @return Status
+   * @param uri The URI of the file.
+   * @param offset The offset where the read begins.
+   * @param buffer The buffer to read into.
+   * @param nbytes Number of bytes to read.
+   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
-  Status read_impl(
+  uint64_t read(
       const URI& uri,
-      off_t offset,
+      uint64_t offset,
       void* buffer,
-      uint64_t length,
-      uint64_t read_ahead_length,
-      uint64_t* length_returned) const;
-
-  /**
-   * Reads data from an object into a buffer.
-   *
-   * @param uri The URI of the object to be read.
-   * @param offset The offset in the object from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param length The size of the data to be read from the object.
-   * @param use_read_ahead Whether to use the read-ahead cache.
-   */
-  void read(const URI&, uint64_t, void*, uint64_t, bool) const {
-    // #TODO. Currently a no-op until read refactor.
-  }
+      uint64_t nbytes,
+      uint64_t read_ahead_nbytes = 0);
 
   /**
    * Deletes a container.

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -296,6 +296,14 @@ class Azure : FilesystemBase {
   /* ********************************* */
 
   /**
+   * Checks if this filesystem supports the given URI.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const;
+
+  /**
    * Creates a container.
    *
    * @param container The name of the container to be created.

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -265,7 +265,7 @@ class AzureScanner : public LsScanner<F, D> {
  * same. All internal methods have been renamed to use the "bucket" and "file"
  * verbiage in compliance with the FilesystemBase class.
  */
-class Azure : FilesystemBase {
+class Azure : public FilesystemBase {
   template <FilePredicate, DirectoryPredicate>
   friend class AzureScanner;
 

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -835,66 +835,6 @@ class Azure : public FilesystemBase {
   static std::string remove_trailing_slash(const std::string& path);
 };
 
-inline AzureScanner::AzureScanner(
-    const Azure& client,
-    const URI& prefix,
-    FileFilter&& file_filter,
-    DirectoryFilter&& dir_filter,
-    bool recursive,
-    int max_keys)
-    : LsScanner(
-          prefix, std::move(file_filter), std::move(dir_filter), recursive)
-    , client_(client)
-    , max_keys_(max_keys)
-    , has_fetched_(false) {
-  if (!prefix.is_azure()) {
-    throw AzureException("URI is not an Azure URI: " + prefix.to_string());
-  }
-
-  std::tie(container_name_, blob_path_) =
-      Azure::parse_azure_uri(prefix.add_trailing_slash());
-  fetch_results();
-  next(begin_);
-}
-
-inline void AzureScanner::next(typename Iterator::pointer& ptr) {
-  if (ptr == end_) {
-    ptr = fetch_results();
-  }
-
-  while (ptr != end_) {
-    auto& object = *ptr;
-
-    // TODO: Add support for directory pruning.
-    if (this->file_filter_(object.first, object.second)) {
-      // Iterator is at the next object within results accepted by the filters.
-      return;
-    } else {
-      // Object was rejected by the FilePredicate, do not include it in results.
-      advance(ptr);
-    }
-  }
-}
-
-inline AzureScanner::Iterator::pointer AzureScanner::fetch_results() {
-  if (!more_to_fetch()) {
-    begin_ = end_ = typename Iterator::pointer();
-    return end_;
-  }
-
-  blobs_ = client_.list_blobs_impl(
-      container_name_,
-      blob_path_,
-      this->is_recursive_,
-      max_keys_,
-      continuation_token_);
-  has_fetched_ = true;
-  // Update pointers to the newly fetched results.
-  begin_ = blobs_.begin();
-  end_ = blobs_.end();
-
-  return begin_;
-}
 }  // namespace tiledb::sm
 
 #endif  // HAVE_AZURE

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -149,24 +149,20 @@ class Azure;
  *      with the iterator returned by the previous request. Batch number can be
  *      tracked by the total number of times we submit a ListBlobs request
  *      within fetch_results().
- *
- * @tparam F The FilePredicate type used to filter object results.
- * @tparam D The DirectoryPredicate type used to prune prefix results.
  */
-template <FilePredicate F, DirectoryPredicate D = DirectoryFilter>
-class AzureScanner : public LsScanner<F, D> {
+class AzureScanner : public LsScanner {
  public:
   /** Declare LsScanIterator as a friend class for access to call next(). */
   template <class scanner_type, class T, class Allocator>
   friend class LsScanIterator;
-  using Iterator = LsScanIterator<AzureScanner<F, D>, LsObjects::value_type>;
+  using Iterator = LsScanIterator<AzureScanner, LsObjects::value_type>;
 
   /** Constructor. */
   AzureScanner(
       const Azure& client,
       const URI& prefix,
-      F file_filter,
-      D dir_filter = accept_all_dirs,
+      FileFilter&& file_filter,
+      DirectoryFilter&& dir_filter = accept_all_dirs,
       bool recursive = false,
       int max_keys = 1000);
 
@@ -266,7 +262,6 @@ class AzureScanner : public LsScanner<F, D> {
  * verbiage in compliance with the FilesystemBase class.
  */
 class Azure : public FilesystemBase {
-  template <FilePredicate, DirectoryPredicate>
   friend class AzureScanner;
 
  public:
@@ -413,22 +408,22 @@ class Azure : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the FilePredicate on each entry collected and the DirectoryPredicate on
+   * the FileFilter on each entry collected and the DirectoryFilter on
    * common prefixes for pruning.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FilePredicate to invoke on each object for filtering.
-   * @param d The DirectoryPredicate to invoke on each common prefix for
+   * @param f The FileFilter to invoke on each object for filtering.
+   * @param d The DirectoryFilter to invoke on each common prefix for
    *    pruning. This is currently unused, but is kept here for future support.
    * @param recursive Whether to recursively list subdirectories.
    */
-  template <FilePredicate F, DirectoryPredicate D>
   LsObjects ls_filtered(
       const URI& parent,
-      F f,
-      D d = accept_all_dirs,
-      bool recursive = false) const {
-    AzureScanner<F, D> azure_scanner(*this, parent, f, d, recursive);
+      FileFilter f,
+      DirectoryFilter d = accept_all_dirs,
+      bool recursive = false) const override {
+    AzureScanner azure_scanner =
+        scanner(parent, std::move(f), std::move(d), recursive);
 
     LsObjects objects;
     for (auto object : azure_scanner) {
@@ -450,14 +445,14 @@ class Azure : public FilesystemBase {
    * @param max_keys The maximum number of keys to retrieve per request.
    * @return Fully constructed AzureScanner object.
    */
-  template <FilePredicate F, DirectoryPredicate D>
-  AzureScanner<F, D> scanner(
+  AzureScanner scanner(
       const URI& parent,
-      F f,
-      D d = accept_all_dirs,
+      FileFilter&& f,
+      DirectoryFilter&& d = accept_all_dirs,
       bool recursive = false,
       int max_keys = 1000) const {
-    return AzureScanner<F, D>(*this, parent, f, d, recursive, max_keys);
+    return AzureScanner(
+        *this, parent, std::move(f), std::move(d), recursive, max_keys);
   }
 
   /**
@@ -840,15 +835,15 @@ class Azure : public FilesystemBase {
   static std::string remove_trailing_slash(const std::string& path);
 };
 
-template <FilePredicate F, DirectoryPredicate D>
-AzureScanner<F, D>::AzureScanner(
+inline AzureScanner::AzureScanner(
     const Azure& client,
     const URI& prefix,
-    F file_filter,
-    D dir_filter,
+    FileFilter&& file_filter,
+    DirectoryFilter&& dir_filter,
     bool recursive,
     int max_keys)
-    : LsScanner<F, D>(prefix, file_filter, dir_filter, recursive)
+    : LsScanner(
+          prefix, std::move(file_filter), std::move(dir_filter), recursive)
     , client_(client)
     , max_keys_(max_keys)
     , has_fetched_(false) {
@@ -856,16 +851,13 @@ AzureScanner<F, D>::AzureScanner(
     throw AzureException("URI is not an Azure URI: " + prefix.to_string());
   }
 
-  auto [container_name, blob_path] =
+  std::tie(container_name_, blob_path_) =
       Azure::parse_azure_uri(prefix.add_trailing_slash());
-  container_name_ = container_name;
-  blob_path_ = blob_path;
   fetch_results();
   next(begin_);
 }
 
-template <FilePredicate F, DirectoryPredicate D>
-void AzureScanner<F, D>::next(typename Iterator::pointer& ptr) {
+inline void AzureScanner::next(typename Iterator::pointer& ptr) {
   if (ptr == end_) {
     ptr = fetch_results();
   }
@@ -884,9 +876,7 @@ void AzureScanner<F, D>::next(typename Iterator::pointer& ptr) {
   }
 }
 
-template <FilePredicate F, DirectoryPredicate D>
-typename AzureScanner<F, D>::Iterator::pointer
-AzureScanner<F, D>::fetch_results() {
+inline AzureScanner::Iterator::pointer AzureScanner::fetch_results() {
   if (!more_to_fetch()) {
     begin_ = end_ = typename Iterator::pointer();
     return end_;

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -301,17 +301,17 @@ class Azure : public FilesystemBase {
    * @param uri The URI to check.
    * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
    */
-  bool supports_uri(const URI& uri) const;
+  bool supports_uri(const URI& uri) const override;
 
   /**
    * Creates a container.
    *
    * @param container The name of the container to be created.
    */
-  void create_bucket(const URI& container) const;
+  void create_bucket(const URI& container) const override;
 
   /** Removes the contents of an Azure container. */
-  void empty_bucket(const URI& container) const;
+  void empty_bucket(const URI& container) const override;
 
   /**
    * Flushes a blob to Azure, finalizing the upload.
@@ -319,7 +319,7 @@ class Azure : public FilesystemBase {
    * @param uri The URI of the blob to be flushed.
    * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
-  void flush(const URI& uri, bool finalize);
+  void flush(const URI& uri, bool finalize) override;
 
   /**
    * Check if a container is empty.
@@ -327,7 +327,7 @@ class Azure : public FilesystemBase {
    * @param container The name of the container.
    * @return `true` if the container is empty, `false` otherwise.
    */
-  bool is_empty_bucket(const URI& uri) const;
+  bool is_empty_bucket(const URI& uri) const override;
 
   /**
    * Check if a container exists.
@@ -335,7 +335,7 @@ class Azure : public FilesystemBase {
    * @param container The name of the container.
    * @return `true` if `uri` is a container, `false` otherwise.
    */
-  bool is_bucket(const URI& uri) const;
+  bool is_bucket(const URI& uri) const override;
 
   /**
    * Checks if there is an object with prefix `uri/`. For instance, suppose
@@ -354,7 +354,7 @@ class Azure : public FilesystemBase {
    * @param uri The URI to check.
    * @return `true` if the above mentioned condition holds, `false` otherwise.
    */
-  bool is_dir(const URI& uri) const;
+  bool is_dir(const URI& uri) const override;
 
   /**
    * Checks if the given URI is an existing Azure blob.
@@ -362,7 +362,7 @@ class Azure : public FilesystemBase {
    * @param uri The URI of the object to be checked.
    * @return `true` if `uri` is an existing blob, `false` otherwise.
    */
-  bool is_file(const URI& uri) const;
+  bool is_file(const URI& uri) const override;
 
   /**
    * Lists the objects that start with `uri`. Full URI paths are
@@ -398,7 +398,7 @@ class Azure : public FilesystemBase {
    * @return All entries that are contained in the prefix URI.
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
-      const URI& uri) const;
+      const URI& uri) const override;
 
   /**
    * Lists objects and object information that start with `uri`.
@@ -465,7 +465,7 @@ class Azure : public FilesystemBase {
    *
    * @param uri The directory's URI.
    */
-  void create_dir(const URI&) const {
+  void create_dir(const URI&) const override {
     // No-op. Stub function for other filesystems.
   }
 
@@ -475,7 +475,7 @@ class Azure : public FilesystemBase {
    * @param old_uri The directory's current URI.
    * @param new_uri The directory's URI to move to.
    */
-  void copy_dir(const URI&, const URI&) const;
+  void copy_dir(const URI&, const URI&) const override;
 
   /**
    * Copies the blob at 'old_uri' to `new_uri`.
@@ -483,7 +483,7 @@ class Azure : public FilesystemBase {
    * @param old_uri The blob's current URI.
    * @param new_uri The blob's URI to move to.
    */
-  void copy_file(const URI& old_uri, const URI& new_uri) const;
+  void copy_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Renames an object.
@@ -491,7 +491,7 @@ class Azure : public FilesystemBase {
    * @param old_uri The URI of the old path.
    * @param new_uri The URI of the new path.
    */
-  void move_file(const URI& old_uri, const URI& new_uri) const;
+  void move_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Renames a directory. Note that this is an expensive operation.
@@ -502,7 +502,7 @@ class Azure : public FilesystemBase {
    * @param old_uri The URI of the old path.
    * @param new_uri The URI of the new path.
    */
-  void move_dir(const URI& old_uri, const URI& new_uri) const;
+  void move_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Returns the size of the input blob with a given URI in bytes.
@@ -510,7 +510,7 @@ class Azure : public FilesystemBase {
    * @param uri The URI of the blob.
    * @return The size of the input blob, in bytes
    */
-  uint64_t file_size(const URI& uri) const;
+  uint64_t file_size(const URI& uri) const override;
 
   /**
    * Reads from a file.
@@ -526,21 +526,21 @@ class Azure : public FilesystemBase {
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0);
+      uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Deletes a container.
    *
    * @param uri The URI of the container to be deleted.
    */
-  void remove_bucket(const URI& uri) const;
+  void remove_bucket(const URI& uri) const override;
 
   /**
    * Deletes an blob with a given URI.
    *
    * @param uri The URI of the blob to be deleted.
    */
-  void remove_file(const URI& uri) const;
+  void remove_file(const URI& uri) const override;
 
   /**
    * Deletes all objects with prefix `uri/` (if the ending `/` does not
@@ -566,14 +566,14 @@ class Azure : public FilesystemBase {
    *
    * @param uri The prefix uri of the objects to be deleted.
    */
-  void remove_dir(const URI& uri) const;
+  void remove_dir(const URI& uri) const override;
 
   /**
    * Creates an empty blob.
    *
    * @param uri The URI of the blob to be created.
    */
-  void touch(const URI& uri) const;
+  void touch(const URI& uri) const override;
 
   /**
    * Writes the input buffer to an Azure object. Note that this is essentially
@@ -588,7 +588,7 @@ class Azure : public FilesystemBase {
       const URI& uri,
       const void* buffer,
       uint64_t length,
-      bool remote_global_order_write);
+      bool remote_global_order_write) override;
 
   /**
    * Initializes the Azure blob service client and returns a reference to it.

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -38,6 +38,11 @@ namespace tiledb::sm {
 /*                API                */
 /* ********************************* */
 
+LsObjects FilesystemBase::ls_filtered(
+    const URI& parent, FileFilter f, DirectoryFilter d, bool recursive) const {
+  throw UnsupportedOperation("ls_filtered");
+}
+
 void FilesystemBase::move_file(const URI&, const URI&) const {
   throw UnsupportedOperation("move_file");
 }

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,10 @@ namespace tiledb::sm {
 /* ********************************* */
 /*                API                */
 /* ********************************* */
+
+bool FilesystemBase::supports_uri(const URI& uri) const {
+  throw UnsupportedURI(uri.to_string());
+}
 
 void FilesystemBase::sync(const URI&) const {
   throw UnsupportedOperation("sync");

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -38,10 +38,6 @@ namespace tiledb::sm {
 /*                API                */
 /* ********************************* */
 
-bool FilesystemBase::operator==(const FilesystemBase& fs) const {
-  return typeid(this) == typeid(fs);
-}
-
 void FilesystemBase::move_file(const URI&, const URI&) const {
   throw UnsupportedOperation("move_file");
 }

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -39,7 +39,7 @@ namespace tiledb::sm {
 /* ********************************* */
 
 LsObjects FilesystemBase::ls_filtered(
-    const URI& parent, FileFilter f, DirectoryFilter d, bool recursive) const {
+    const URI&, FileFilter, DirectoryFilter, bool) const {
   throw UnsupportedOperation("ls_filtered");
 }
 

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -38,8 +38,8 @@ namespace tiledb::sm {
 /*                API                */
 /* ********************************* */
 
-bool FilesystemBase::supports_uri(const URI& uri) const {
-  throw UnsupportedURI(uri.to_string());
+bool FilesystemBase::operator==(const FilesystemBase& fs) const {
+  return typeid(this) == typeid(fs);
 }
 
 void FilesystemBase::move_file(const URI&, const URI&) const {
@@ -56,6 +56,10 @@ void FilesystemBase::copy_file(const URI&, const URI&) const {
 
 void FilesystemBase::copy_dir(const URI&, const URI&) const {
   throw UnsupportedOperation("copy_dir");
+}
+
+bool FilesystemBase::use_read_ahead_cache() const {
+  return true;
 }
 
 void FilesystemBase::sync(const URI&) const {

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -42,6 +42,22 @@ bool FilesystemBase::supports_uri(const URI& uri) const {
   throw UnsupportedURI(uri.to_string());
 }
 
+void FilesystemBase::move_file(const URI&, const URI&) const {
+  throw UnsupportedOperation("move_file");
+}
+
+void FilesystemBase::move_dir(const URI&, const URI&) const {
+  throw UnsupportedOperation("move_dir");
+}
+
+void FilesystemBase::copy_file(const URI&, const URI&) const {
+  throw UnsupportedOperation("copy_file");
+}
+
+void FilesystemBase::copy_dir(const URI&, const URI&) const {
+  throw UnsupportedOperation("copy_dir");
+}
+
 void FilesystemBase::sync(const URI&) const {
   throw UnsupportedOperation("sync");
 }

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -158,7 +158,7 @@ class FilesystemBase {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  virtual void move_file(const URI& old_uri, const URI& new_uri) const = 0;
+  virtual void move_file(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Renames a directory.
@@ -167,7 +167,7 @@ class FilesystemBase {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  virtual void move_dir(const URI& old_uri, const URI& new_uri) const = 0;
+  virtual void move_dir(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Copies a file.
@@ -176,7 +176,7 @@ class FilesystemBase {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  virtual void copy_file(const URI& old_uri, const URI& new_uri) const = 0;
+  virtual void copy_file(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Copies directory.
@@ -185,7 +185,7 @@ class FilesystemBase {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  virtual void copy_dir(const URI& old_uri, const URI& new_uri) const = 0;
+  virtual void copy_dir(const URI& old_uri, const URI& new_uri) const;
 
   /**
    * Reads from a file.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -75,9 +75,6 @@ class FilesystemBase {
 
   virtual ~FilesystemBase() = default;
 
-  /** Checks to see if 2 FilesystemBases have the same underlying type. */
-  bool operator==(const FilesystemBase& fs) const;
-
   /**
    * Checks if the filesystem supports the given URI.
    *
@@ -204,14 +201,9 @@ class FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
   virtual uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) = 0;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) = 0;
 
   /**
    * Flushes an object store file.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -35,6 +35,7 @@
 
 #include "tiledb/common/exception/exception.h"
 #include "tiledb/common/filesystem/directory_entry.h"
+#include "tiledb/sm/filesystem/ls_scanner.h"
 #include "uri.h"
 
 #include <vector>
@@ -150,6 +151,24 @@ class FilesystemBase {
    */
   virtual std::vector<tiledb::common::filesystem::directory_entry>
   ls_with_sizes(const URI& parent) const = 0;
+
+  /**
+   * Lists objects and object information that start with `prefix`, invoking
+   * the FileFilter on each entry collected and the DirectoryFilter on
+   * common prefixes for pruning.
+   *
+   * Currently this API is only supported for local files, S3 and Azure.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param f The FileFilter to invoke on each object for filtering.
+   * @param d The DirectoryFilter to invoke on each common prefix for
+   *    pruning. This is currently unused, but is kept here for future support.
+   * @param recursive Whether to list the objects recursively.
+   * @return Vector of results with each entry being a pair of the string URI
+   *    and object size.
+   */
+  virtual LsObjects ls_filtered(
+      const URI& parent, FileFilter f, DirectoryFilter d, bool recursive) const;
 
   /**
    * Renames a file.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -75,6 +75,9 @@ class FilesystemBase {
 
   virtual ~FilesystemBase() = default;
 
+  /** Checks to see if 2 FilesystemBases have the same underlying type. */
+  bool operator==(const FilesystemBase& fs) const;
+
   /**
    * Checks if the filesystem supports the given URI.
    *
@@ -84,7 +87,7 @@ class FilesystemBase {
    * @param uri The URI to check.
    * @return `true` if `uri` is supported on the filesystem, `false` otherwise.
    */
-  virtual bool supports_uri(const URI& uri) const;
+  virtual bool supports_uri(const URI& uri) const = 0;
 
   /**
    * Creates a directory.
@@ -186,6 +189,13 @@ class FilesystemBase {
    * @param new_uri The new URI.
    */
   virtual void copy_dir(const URI& old_uri, const URI& new_uri) const;
+
+  /**
+   * Whether or not to use the read-ahead cache.
+   *
+   * Defaults to `true` for object-store, `false` for local filesystems.
+   */
+  virtual bool use_read_ahead_cache() const;
 
   /**
    * Reads from a file.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -47,11 +47,25 @@ class IOError : public StatusException {
   }
 };
 
-class UnsupportedOperation : public IOError {
+class FilesystemException : public StatusException {
+ public:
+  explicit FilesystemException(const std::string& message)
+      : StatusException("Filesystem", message) {
+  }
+};
+
+class UnsupportedOperation : public FilesystemException {
  public:
   explicit UnsupportedOperation(const std::string& operation)
-      : IOError(std::string(
+      : FilesystemException(std::string(
             operation + " is not supported on the given filesystem.")) {
+  }
+};
+
+class UnsupportedURI : public FilesystemException {
+ public:
+  explicit UnsupportedURI(const std::string& uri)
+      : FilesystemException("Unsupported URI scheme: " + uri) {
   }
 };
 
@@ -60,6 +74,17 @@ class FilesystemBase {
   FilesystemBase() = default;
 
   virtual ~FilesystemBase() = default;
+
+  /**
+   * Checks if the filesystem supports the given URI.
+   *
+   * - s3.supports_uri(s3://test) will return true.
+   * - posix.supports_uri(s3://test) will return false.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on the filesystem, `false` otherwise.
+   */
+  virtual bool supports_uri(const URI& uri) const;
 
   /**
    * Creates a directory.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -194,14 +194,14 @@ class FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param use_read_ahead Whether to use the read-ahead cache.
+   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
-  virtual void read(
+  virtual uint64_t read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead = true) const = 0;
+      uint64_t read_ahead_nbytes = 0) = 0;
 
   /**
    * Flushes an object store file.

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -242,6 +242,10 @@ Status GCS::init_client() const {
   return Status::Ok();
 }
 
+bool GCS::supports_uri(const URI& uri) const {
+  return uri.is_gcs();
+}
+
 void GCS::create_bucket(const URI& uri) const {
   throw_if_not_ok(init_client());
 

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -517,13 +517,14 @@ std::vector<directory_entry> GCS::ls_with_sizes(const URI& uri) const {
   return ls_with_sizes(uri, "/", -1);
 }
 
-LsObjects GCS::ls_filtered_impl(
-    const URI& uri,
-    std::function<bool(const std::string_view, uint64_t)> file_filter,
+LsObjects GCS::ls_filtered(
+    const URI& parent,
+    FileFilter file_filter,
+    DirectoryFilter,
     bool recursive) const {
   throw_if_not_ok(init_client());
 
-  const URI uri_dir = uri.add_trailing_slash();
+  const URI uri_dir = parent.add_trailing_slash();
 
   if (!uri_dir.is_gcs()) {
     throw GCSException(
@@ -552,7 +553,7 @@ LsObjects GCS::ls_filtered_impl(
     for (const auto& object_metadata : it) {
       if (!object_metadata) {
         throw GCSException(std::string(
-            "List objects failed on: " + uri.to_string() + " (" +
+            "List objects failed on: " + parent.to_string() + " (" +
             object_metadata.status().message() + ")"));
       }
 
@@ -569,7 +570,7 @@ LsObjects GCS::ls_filtered_impl(
     for (const auto& object_metadata : it) {
       if (!object_metadata) {
         throw GCSException(std::string(
-            "List objects failed on: " + uri.to_string() + " (" +
+            "List objects failed on: " + parent.to_string() + " (" +
             object_metadata.status().message() + ")"));
       }
 

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -417,14 +417,9 @@ class GCS : public FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Returns the size of the input object with a given URI in bytes.

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -154,7 +154,7 @@ struct GCSParameters {
   uint64_t max_direct_upload_size_;
 };
 
-class GCS : FilesystemBase {
+class GCS : public FilesystemBase {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -176,6 +176,14 @@ class GCS : FilesystemBase {
   /* ********************************* */
 
   /**
+   * Checks if this filesystem supports the given URI.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const;
+
+  /**
    * Creates a bucket.
    *
    * @param uri The uri of the bucket to be created.

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -411,36 +411,20 @@ class GCS : FilesystemBase {
       bool remote_global_order_write);
 
   /**
-   * Reads data from an object into a buffer.
+   * Reads from a file.
    *
-   * @param uri The URI of the object to be read.
-   * @param offset The offset in the object from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param length The size of the data to be read from the object.
-   * @param read_ahead_length The additional length to read ahead.
-   * @param length_returned Returns the total length read into `buffer`.
-   * @return Status
+   * @param uri The URI of the file.
+   * @param offset The offset where the read begins.
+   * @param buffer The buffer to read into.
+   * @param nbytes Number of bytes to read.
+   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
-  Status read_impl(
+  uint64_t read(
       const URI& uri,
-      off_t offset,
+      uint64_t offset,
       void* buffer,
-      uint64_t length,
-      uint64_t read_ahead_length,
-      uint64_t* length_returned) const;
-
-  /**
-   * Reads data from an object into a buffer.
-   *
-   * @param uri The URI of the object to be read.
-   * @param offset The offset in the object from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param length The size of the data to be read from the object.
-   * @param use_read_ahead Whether to use the read-ahead cache.
-   */
-  void read(const URI&, uint64_t, void*, uint64_t, bool) const {
-    // #TODO. Currently a no-op until read refactor.
-  }
+      uint64_t nbytes,
+      uint64_t read_ahead_nbytes = 0);
 
   /**
    * Returns the size of the input object with a given URI in bytes.

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -311,25 +311,20 @@ class GCS : public FilesystemBase {
    * common prefixes for pruning.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param file_filter The FilePredicate to invoke on each object for
+   * @param file_filter The FileFilter to invoke on each object for
    * filtering.
-   * @param directory_filter The DirectoryPredicate to invoke on each common
+   * @param directory_filter The DirectoryFilter to invoke on each common
    * prefix for pruning. This is currently unused, but is kept here for future
    * support.
    * @param recursive Whether to recursively list subdirectories.
    * @return Vector of results with each entry being a pair of the string URI
    * and object size.
    */
-  template <FilePredicate F, DirectoryPredicate D>
   LsObjects ls_filtered(
-      const URI& uri,
-      F file_filter,
-      [[maybe_unused]] D directory_filter = accept_all_dirs,
-      bool recursive = false) const {
-    // We use the constructor of std::function that accepts an F&& to convert
-    // the generic F to a polymorphic std::function.
-    return ls_filtered_impl(uri, std::move(file_filter), recursive);
-  }
+      const URI& parent,
+      FileFilter file_filter,
+      DirectoryFilter directory_filter,
+      bool recursive) const override;
 
   /**
    *

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -181,17 +181,17 @@ class GCS : public FilesystemBase {
    * @param uri The URI to check.
    * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
    */
-  bool supports_uri(const URI& uri) const;
+  bool supports_uri(const URI& uri) const override;
 
   /**
    * Creates a bucket.
    *
    * @param uri The uri of the bucket to be created.
    */
-  void create_bucket(const URI& uri) const;
+  void create_bucket(const URI& uri) const override;
 
   /** Removes the contents of a GCS bucket. */
-  void empty_bucket(const URI& uri) const;
+  void empty_bucket(const URI& uri) const override;
 
   /**
    * Check if a bucket is empty.
@@ -199,7 +199,7 @@ class GCS : public FilesystemBase {
    * @param bucket The name of the bucket.
    * @return `true` if the bucket is empty, `false` otherwise.
    */
-  bool is_empty_bucket(const URI& uri) const;
+  bool is_empty_bucket(const URI& uri) const override;
 
   /**
    * Check if a bucket exists.
@@ -207,7 +207,7 @@ class GCS : public FilesystemBase {
    * @param bucket The name of the bucket.
    * @return `true` if `uri` is a bucket, `false` otherwise.
    */
-  bool is_bucket(const URI& uri) const;
+  bool is_bucket(const URI& uri) const override;
 
   /**
    * Check if 'uri' is an object on GCS.
@@ -215,7 +215,7 @@ class GCS : public FilesystemBase {
    * @param uri URI of the object.
    * @return `true` if `uri` is an obkect on GCS, `false` otherwise.
    */
-  bool is_file(const URI& uri) const;
+  bool is_file(const URI& uri) const override;
 
   /**
    * Checks if there is an object with prefix `uri/`. For instance, suppose
@@ -234,21 +234,21 @@ class GCS : public FilesystemBase {
    * @param uri The URI to check.
    * @return`true` if the above mentioned condition holds, `false` otherwise.
    */
-  bool is_dir(const URI& uri) const;
+  bool is_dir(const URI& uri) const override;
 
   /**
    * Deletes a bucket.
    *
    * @param uri The URI of the bucket to be deleted.
    */
-  void remove_bucket(const URI& uri) const;
+  void remove_bucket(const URI& uri) const override;
 
   /**
    * Deletes an object with a given URI.
    *
    * @param uri The URI of the object to be deleted.
    */
-  void remove_file(const URI& uri) const;
+  void remove_file(const URI& uri) const override;
 
   /**
    * Deletes all objects with prefix `uri/` (if the ending `/` does not
@@ -274,7 +274,7 @@ class GCS : public FilesystemBase {
    *
    * @param uri The prefix uri of the objects to be deleted.
    */
-  void remove_dir(const URI& uri) const;
+  void remove_dir(const URI& uri) const override;
 
   /**
    * Lists the objects that start with `uri`. Full URI paths are
@@ -351,7 +351,7 @@ class GCS : public FilesystemBase {
    * @return A list of directory_entry objects.
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
-      const URI& uri) const;
+      const URI& uri) const override;
 
   /**
    * Copies the directory at 'old_uri' to `new_uri`.
@@ -359,7 +359,7 @@ class GCS : public FilesystemBase {
    * @param old_uri The directory's current URI.
    * @param new_uri The directory's URI to move to.
    */
-  void copy_dir(const URI&, const URI&) const;
+  void copy_dir(const URI&, const URI&) const override;
 
   /**
    * Copies the blob at 'old_uri' to `new_uri`.
@@ -367,7 +367,7 @@ class GCS : public FilesystemBase {
    * @param old_uri The blob's current URI.
    * @param new_uri The blob's URI to move to.
    */
-  void copy_file(const URI& old_uri, const URI& new_uri) const;
+  void copy_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Renames an object.
@@ -375,7 +375,7 @@ class GCS : public FilesystemBase {
    * @param old_uri The URI of the old path.
    * @param new_uri The URI of the new path.
    */
-  void move_file(const URI& old_uri, const URI& new_uri) const;
+  void move_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Renames a directory. Note that this is an expensive operation.
@@ -386,14 +386,14 @@ class GCS : public FilesystemBase {
    * @param old_uri The URI of the old path.
    * @param new_uri The URI of the new path.
    */
-  void move_dir(const URI& old_uri, const URI& new_uri) const;
+  void move_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Creates an empty object.
    *
    * @param uri The URI of the object to be created.
    */
-  void touch(const URI& uri) const;
+  void touch(const URI& uri) const override;
 
   /**
    * Writes the input buffer to an GCS object. Note that this is essentially
@@ -408,7 +408,7 @@ class GCS : public FilesystemBase {
       const URI& uri,
       const void* buffer,
       uint64_t length,
-      bool remote_global_order_write);
+      bool remote_global_order_write) override;
 
   /**
    * Reads from a file.
@@ -424,7 +424,7 @@ class GCS : public FilesystemBase {
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0);
+      uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Returns the size of the input object with a given URI in bytes.
@@ -432,7 +432,7 @@ class GCS : public FilesystemBase {
    * @param uri The URI of the object.
    * @return The size of the object.
    */
-  uint64_t file_size(const URI& uri) const;
+  uint64_t file_size(const URI& uri) const override;
 
   /**
    * Flushes an object to GCS, finalizing the upload.
@@ -440,7 +440,7 @@ class GCS : public FilesystemBase {
    * @param uri The URI of the object to be flushed.
    * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
-  void flush(const URI& uri, bool finalize);
+  void flush(const URI& uri, bool finalize) override;
 
   /**
    * Creates a GCS credentials object.
@@ -458,7 +458,7 @@ class GCS : public FilesystemBase {
    *
    * @param uri The directory's URI.
    */
-  void create_dir(const URI&) const {
+  void create_dir(const URI&) const override {
     // No-op. Stub function for other filesystems.
   }
 

--- a/tiledb/sm/filesystem/local.cc
+++ b/tiledb/sm/filesystem/local.cc
@@ -40,6 +40,56 @@
 using namespace tiledb::common;
 
 namespace tiledb::sm {
+LsObjects LocalFilesystem::ls_filtered(
+    const URI& parent,
+    FileFilter file_filter,
+    DirectoryFilter directory_filter,
+    bool recursive) const {
+  /*
+   * The input URI was useful to the top-level VFS to identify this is a
+   * regular filesystem path, but we don't need the "file://" qualifier
+   * anymore and can reason with unqualified strings for the rest of the
+   * function.
+   */
+  const auto parentstr = parent.to_path();
+
+  LsObjects qualifyingPaths;
+
+  // awkward way of iterating, avoids bug in OSX
+  auto begin = std::filesystem::recursive_directory_iterator(parentstr);
+  auto end = std::filesystem::recursive_directory_iterator();
+
+  for (auto iter = begin; iter != end; ++iter) {
+    auto& entry = *iter;
+    const auto abspath = entry.path().string();
+    const auto absuri = URI(abspath);
+    if (entry.is_directory()) {
+      if (file_filter(absuri, 0) || directory_filter(absuri)) {
+        qualifyingPaths.push_back(
+            std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
+        if (!recursive) {
+          iter.disable_recursion_pending();
+        }
+      } else {
+        /* do not descend into directories which don't qualify */
+        iter.disable_recursion_pending();
+      }
+    } else {
+      /*
+       * A leaf of the filesystem
+       * (or symbolic link - split to a separate case if we want to descend into
+       * them)
+       */
+      if (file_filter(absuri, entry.file_size())) {
+        qualifyingPaths.push_back(
+            std::make_pair(absuri.to_string(), entry.file_size()));
+      }
+    }
+  }
+
+  return qualifyingPaths;
+}
+
 Status LocalFilesystem::ensure_directory(const std::string& path) {
   std::filesystem::path p{path};
   if (p.has_parent_path()) {

--- a/tiledb/sm/filesystem/local.cc
+++ b/tiledb/sm/filesystem/local.cc
@@ -40,6 +40,21 @@
 using namespace tiledb::common;
 
 namespace tiledb::sm {
+void LocalFilesystem::copy_file(const URI& old_uri, const URI& new_uri) const {
+  std::filesystem::copy_file(
+      old_uri.to_path(),
+      new_uri.to_path(),
+      std::filesystem::copy_options::overwrite_existing);
+}
+
+void LocalFilesystem::copy_dir(const URI& old_uri, const URI& new_uri) const {
+  std::filesystem::copy(
+      old_uri.to_path(),
+      new_uri.to_path(),
+      std::filesystem::copy_options::overwrite_existing |
+          std::filesystem::copy_options::recursive);
+}
+
 LsObjects LocalFilesystem::ls_filtered(
     const URI& parent,
     FileFilter file_filter,

--- a/tiledb/sm/filesystem/local.h
+++ b/tiledb/sm/filesystem/local.h
@@ -34,13 +34,21 @@
 
 #include "tiledb/common/common.h"
 #include "tiledb/common/status.h"
+#include "tiledb/sm/filesystem/filesystem_base.h"
 
 namespace tiledb::sm {
 /**
  * Contains the local filesystem code shared by the Windows and POSIX
  * filesystems.
  */
-class LocalFilesystem {
+class LocalFilesystem : public FilesystemBase {
+ public:
+  LsObjects ls_filtered(
+      const URI& parent,
+      FileFilter file_filter,
+      [[maybe_unused]] DirectoryFilter directory_filter,
+      bool recursive) const override;
+
  protected:
   /**
    * Creates the containing directories of a path if they do not exist.

--- a/tiledb/sm/filesystem/local.h
+++ b/tiledb/sm/filesystem/local.h
@@ -43,6 +43,10 @@ namespace tiledb::sm {
  */
 class LocalFilesystem : public FilesystemBase {
  public:
+  void copy_file(const URI& old_uri, const URI& new_uri) const override;
+
+  void copy_dir(const URI& old_uri, const URI& new_uri) const override;
+
   LsObjects ls_filtered(
       const URI& parent,
       FileFilter file_filter,

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -259,19 +259,18 @@ class LsScanIterator {
  * the given file and directory predicates. This should be used as a common
  * base class for future filesystem scanner implementations, similar to
  * S3Scanner.
- *
- * @tparam F The FilePredicate type used to filter object results.
- * @tparam D The DirectoryPredicate type used to prune prefix results.
  */
-template <FilePredicate F, DirectoryPredicate D>
 class LsScanner {
  public:
   /** Constructor. */
   LsScanner(
-      const URI& prefix, F file_filter, D dir_filter, bool recursive = false)
+      const URI& prefix,
+      FileFilter&& file_filter,
+      DirectoryFilter&& dir_filter,
+      bool recursive = false)
       : prefix_(prefix)
-      , file_filter_(file_filter)
-      , dir_filter_(dir_filter)
+      , file_filter_(std::move(file_filter))
+      , dir_filter_(std::move(dir_filter))
       , is_recursive_(recursive) {
   }
 
@@ -279,9 +278,9 @@ class LsScanner {
   /** URI prefix being scanned and filtered for results. */
   const URI prefix_;
   /** File predicate used to filter file or object results. */
-  const F file_filter_;
+  const FileFilter file_filter_;
   /** Directory predicate used to prune directory or prefix results. */
-  const D dir_filter_;
+  const DirectoryFilter dir_filter_;
   /** Whether or not to recursively scan the prefix. */
   const bool is_recursive_;
 };

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -471,12 +471,8 @@ void MemFilesystem::move_file(const URI& old_uri, const URI& new_uri) const {
   move(old_uri.to_path(), new_uri.to_path());
 }
 
-void MemFilesystem::read(
-    const URI& uri,
-    uint64_t offset,
-    void* buffer,
-    uint64_t nbytes,
-    bool) const {
+uint64_t MemFilesystem::read(
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
   FSNode* node;
   std::unique_lock<std::mutex> node_lock;
   auto path = uri.to_path();
@@ -487,6 +483,7 @@ void MemFilesystem::read(
   }
 
   throw_if_not_ok(node->read(offset, buffer, nbytes));
+  return nbytes;
 }
 
 void MemFilesystem::remove(const std::string& path, const bool is_dir) const {

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -334,6 +334,10 @@ MemFilesystem::MemFilesystem()
 MemFilesystem::~MemFilesystem() {
 }
 
+bool MemFilesystem::supports_uri(const URI& uri) const {
+  return uri.is_memfs();
+}
+
 void MemFilesystem::create_dir(const URI& uri) const {
   create_dir_internal(uri.to_path());
 }
@@ -377,7 +381,7 @@ Status MemFilesystem::ls(
     const std::string& path, std::vector<std::string>* const paths) const {
   iassert(paths);
 
-  for (auto& fs : ls_with_sizes(URI("mem://" + path))) {
+  for (auto& fs : ls_with_sizes(URI(path))) {
     paths->emplace_back(fs.path().native());
   }
 

--- a/tiledb/sm/filesystem/mem_filesystem.cc
+++ b/tiledb/sm/filesystem/mem_filesystem.cc
@@ -476,7 +476,7 @@ void MemFilesystem::move_file(const URI& old_uri, const URI& new_uri) const {
 }
 
 uint64_t MemFilesystem::read(
-    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) {
   FSNode* node;
   std::unique_lock<std::mutex> node_lock;
   auto path = uri.to_path();

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -69,7 +69,7 @@ class MemFSException : public StatusException {
  * @invariant The MemFilesystem is associated with a single VFS instance.
  * @invariant The MemFilesystem exists on a single, global Context.
  */
-class MemFilesystem : FilesystemBase {
+class MemFilesystem : public FilesystemBase {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -106,7 +106,7 @@ class MemFilesystem : FilesystemBase {
    *
    * @param uri The URI of the directory to be created.
    */
-  void create_dir(const URI& uri) const;
+  void create_dir(const URI& uri) const override;
 
   /**
    * Returns the size of an existing file.
@@ -114,7 +114,7 @@ class MemFilesystem : FilesystemBase {
    * @param uri The URI of the file to retrieve the size of.
    * @return The size of the file.
    */
-  uint64_t file_size(const URI& uri) const;
+  uint64_t file_size(const URI& uri) const override;
 
   /**
    * Checks if a URI corresponds to an existing directory.
@@ -122,7 +122,7 @@ class MemFilesystem : FilesystemBase {
    * @param uri The URI to the directory to be checked
    * @return *True* if *uri* is an existing directory,  *False* otherwise
    */
-  bool is_dir(const URI& uri) const;
+  bool is_dir(const URI& uri) const override;
 
   /**
    * Checks if a URI corresponds to an existing file.
@@ -130,7 +130,7 @@ class MemFilesystem : FilesystemBase {
    * @param uri The URI to the file to be checked
    * @return *True* if *uri* is an existing file, *false* otherwise
    */
-  bool is_file(const URI& uri) const;
+  bool is_file(const URI& uri) const override;
 
   /**
    *
@@ -151,7 +151,7 @@ class MemFilesystem : FilesystemBase {
    * @return A list of directory_entry objects
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
-      const URI& path) const;
+      const URI& path) const override;
 
   /**
    * Move a given filesystem path.
@@ -167,7 +167,7 @@ class MemFilesystem : FilesystemBase {
    * @param old_uri The old uri.
    * @param new_uri The new uri.
    */
-  void move_dir(const URI& old_uri, const URI& new_uri) const;
+  void move_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Move a given directory.
@@ -175,7 +175,7 @@ class MemFilesystem : FilesystemBase {
    * @param old_uri The old uri.
    * @param new_uri The new uri.
    */
-  void move_file(const URI& old_uri, const URI& new_uri) const;
+  void move_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Reads data from a file into a buffer.
@@ -191,7 +191,7 @@ class MemFilesystem : FilesystemBase {
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead) const;
+      bool use_read_ahead) const override;
 
   /**
    * Removes a given path and its contents.
@@ -206,21 +206,21 @@ class MemFilesystem : FilesystemBase {
    *
    * @param uri The URI of the directory to be deleted.
    */
-  void remove_dir(const URI& uri) const;
+  void remove_dir(const URI& uri) const override;
 
   /**
    * Removes a file.
    *
    * @param uri The URI of the file to be deleted.
    */
-  void remove_file(const URI& uri) const;
+  void remove_file(const URI& uri) const override;
 
   /**
    * Creates an empty file.
    *
    * @param uri The URI of the file to be created.
    */
-  void touch(const URI& path) const;
+  void touch(const URI& path) const override;
 
   /**
    * Writes the input buffer to a file.
@@ -237,7 +237,7 @@ class MemFilesystem : FilesystemBase {
       const URI& uri,
       const void* buffer,
       uint64_t buffer_size,
-      bool remote_global_order_write);
+      bool remote_global_order_write) override;
 
   /**
    * Copies a directory.
@@ -245,7 +245,7 @@ class MemFilesystem : FilesystemBase {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void copy_dir(const URI&, const URI&) const {
+  void copy_dir(const URI&, const URI&) const override {
     // No-op for MemFS; stub function for other filesystems.
   }
 
@@ -255,7 +255,7 @@ class MemFilesystem : FilesystemBase {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void copy_file(const URI&, const URI&) const {
+  void copy_file(const URI&, const URI&) const override {
     // No-op for MemFS; stub function for other filesystems.
   }
 
@@ -267,7 +267,7 @@ class MemFilesystem : FilesystemBase {
    * @param uri The URI of the file.
    * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
-  void flush(const URI&, bool) {
+  void flush(const URI&, bool) override {
     // No-op for MemFS; stub function for local filesystems.
   }
 
@@ -278,7 +278,7 @@ class MemFilesystem : FilesystemBase {
    *
    * @param uri The URI of the file.
    */
-  void sync(const URI&) const {
+  void sync(const URI&) const override {
     // No-op for MemFS; stub function for local filesystems.
   }
 

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -102,6 +102,14 @@ class MemFilesystem : public FilesystemBase {
   /* ********************************* */
 
   /**
+   * Checks if this filesystem supports the given URI.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const override;
+
+  /**
    * Creates a new directory.
    *
    * @param uri The URI of the directory to be created.
@@ -176,6 +184,11 @@ class MemFilesystem : public FilesystemBase {
    * @param new_uri The new uri.
    */
   void move_file(const URI& old_uri, const URI& new_uri) const override;
+
+  /** Whether or not to use the read-ahead cache. */
+  bool use_read_ahead_cache() const override {
+    return false;
+  }
 
   /**
    * Reads from a file.

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -197,14 +197,9 @@ class MemFilesystem : public FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead. Unused.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Removes a given path and its contents.

--- a/tiledb/sm/filesystem/mem_filesystem.h
+++ b/tiledb/sm/filesystem/mem_filesystem.h
@@ -178,20 +178,20 @@ class MemFilesystem : public FilesystemBase {
   void move_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
-   * Reads data from a file into a buffer.
+   * Reads from a file.
    *
    * @param uri The URI of the file.
-   * @param offset The offset in the file from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param nbytes The number of bytes to be read from the file.
-   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
+   * @param offset The offset where the read begins.
+   * @param buffer The buffer to read into.
+   * @param nbytes Number of bytes to read.
+   * @param read_ahead_nbytes The number of bytes to read ahead. Unused.
    */
-  void read(
+  uint64_t read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead) const override;
+      uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Removes a given path and its contents.

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -226,9 +226,6 @@ uint64_t Posix::file_size(const URI& uri) const {
 }
 
 void Posix::move_file(const URI& old_path, const URI& new_path) const {
-  if (this->is_file(new_path)) {
-    remove_file(new_path);
-  }
   auto new_uri_path = new_path.to_path();
   throw_if_not_ok(ensure_directory(new_uri_path));
   if (rename(old_path.to_path().c_str(), new_path.to_path().c_str()) != 0) {

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -134,6 +134,10 @@ Posix::Posix(const Config& config) {
   directory_permissions_ = std::strtol(permissions.c_str(), nullptr, 8);
 }
 
+bool Posix::supports_uri(const URI& uri) const {
+  return uri.is_file();
+}
+
 void Posix::create_dir(const URI& uri) const {
   // If the directory does not exist, create it
   auto path = uri.to_path();
@@ -222,6 +226,9 @@ uint64_t Posix::file_size(const URI& uri) const {
 }
 
 void Posix::move_file(const URI& old_path, const URI& new_path) const {
+  if (this->is_file(new_path)) {
+    remove_file(new_path);
+  }
   auto new_uri_path = new_path.to_path();
   throw_if_not_ok(ensure_directory(new_uri_path));
   if (rename(old_path.to_path().c_str(), new_path.to_path().c_str()) != 0) {
@@ -234,6 +241,9 @@ void Posix::move_dir(const URI& old_uri, const URI& new_uri) const {
 }
 
 void Posix::copy_file(const URI& old_uri, const URI& new_uri) const {
+  if (this->is_file(new_uri)) {
+    remove_file(new_uri);
+  }
   std::ifstream src(old_uri.to_path(), std::ios::binary);
   auto new_uri_path = new_uri.to_path();
   throw_if_not_ok(ensure_directory(new_uri_path));

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -281,12 +281,8 @@ void Posix::copy_dir(const URI& old_uri, const URI& new_uri) const {
   }
 }
 
-void Posix::read(
-    const URI& uri,
-    uint64_t offset,
-    void* buffer,
-    uint64_t nbytes,
-    [[maybe_unused]] bool use_read_ahead) const {
+uint64_t Posix::read(
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
   // Checks
   auto path = uri.to_path();
   uint64_t file_size = this->file_size(URI(path));
@@ -297,7 +293,7 @@ void Posix::read(
         offset,
         nbytes,
         file_size,
-        uri.to_path()));
+        path));
   }
 
   // Open file
@@ -321,6 +317,7 @@ void Posix::read(
     LOG_STATUS_NO_RETURN_VALUE(
         Status_IOError(std::string("Cannot close file; ") + strerror(errno)));
   }
+  return nbytes;
 }
 
 void Posix::flush(const URI& uri, bool) {

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -279,7 +279,7 @@ void Posix::copy_dir(const URI& old_uri, const URI& new_uri) const {
 }
 
 uint64_t Posix::read(
-    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) {
   // Checks
   auto path = uri.to_path();
   uint64_t file_size = this->file_size(URI(path));

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -237,47 +237,6 @@ void Posix::move_dir(const URI& old_uri, const URI& new_uri) const {
   move_file(old_uri, new_uri);
 }
 
-void Posix::copy_file(const URI& old_uri, const URI& new_uri) const {
-  if (this->is_file(new_uri)) {
-    remove_file(new_uri);
-  }
-  std::ifstream src(old_uri.to_path(), std::ios::binary);
-  auto new_uri_path = new_uri.to_path();
-  throw_if_not_ok(ensure_directory(new_uri_path));
-  std::ofstream dst(new_uri_path, std::ios::binary);
-  dst << src.rdbuf();
-}
-
-void Posix::copy_dir(const URI& old_uri, const URI& new_uri) const {
-  auto old_path = old_uri.to_path();
-  auto new_path = new_uri.to_path();
-  create_dir(new_uri);
-  std::vector<std::string> paths;
-  throw_if_not_ok(ls(old_path, &paths));
-
-  std::queue<std::string> path_queue;
-  for (auto& path : paths)
-    path_queue.emplace(std::move(path));
-
-  while (!path_queue.empty()) {
-    const std::string file_name_abs = path_queue.front();
-    const std::string file_name = file_name_abs.substr(old_path.length());
-    path_queue.pop();
-
-    if (is_dir(URI(file_name_abs))) {
-      create_dir(URI(new_path + "/" + file_name));
-      std::vector<std::string> child_paths;
-      throw_if_not_ok(ls(file_name_abs, &child_paths));
-      for (auto& path : child_paths)
-        path_queue.emplace(std::move(path));
-    } else {
-      passert(is_file(URI(file_name_abs)), "file_name_abs = {}", file_name_abs);
-      copy_file(
-          URI(old_path + "/" + file_name), URI(new_path + "/" + file_name));
-    }
-  }
-}
-
 uint64_t Posix::read(
     const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) {
   // Checks

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -203,14 +203,9 @@ class Posix : public FilesystemBase, public LocalFilesystem {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead. Unused.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Flushes a file or directory.

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -191,6 +191,11 @@ class Posix : public FilesystemBase, public LocalFilesystem {
    */
   void copy_dir(const URI& old_uri, const URI& new_uri) const override;
 
+  /** Whether or not to use the read-ahead cache. */
+  bool use_read_ahead_cache() const override {
+    return false;
+  }
+
   /**
    * Reads from a file.
    *

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -192,20 +192,20 @@ class Posix : public FilesystemBase, public LocalFilesystem {
   void copy_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
-   * Reads data from a file into a buffer.
+   * Reads from a file.
    *
-   * @param path The name of the file.
-   * @param offset The offset in the file from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param nbytes The size of the data to be read from the file.
-   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
+   * @param uri The URI of the file.
+   * @param offset The offset where the read begins.
+   * @param buffer The buffer to read into.
+   * @param nbytes Number of bytes to read.
+   * @param read_ahead_nbytes The number of bytes to read ahead. Unused.
    */
-  void read(
+  uint64_t read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead) const override;
+      uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Flushes a file or directory.

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -40,7 +40,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <filesystem>
 #include <functional>
 #include <string>
 #include <vector>
@@ -66,7 +65,7 @@ class URI;
 /**
  * This class implements the POSIX filesystem functions.
  */
-class Posix : public FilesystemBase, public LocalFilesystem {
+class Posix : public LocalFilesystem {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -248,29 +247,6 @@ class Posix : public FilesystemBase, public LocalFilesystem {
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
       const URI& uri) const override;
-
-  /**
-   * Lists objects and object information that start with `prefix`, invoking
-   * the FilePredicate on each entry collected and the DirectoryPredicate on
-   * common prefixes for pruning.
-   *
-   * @param parent The parent prefix to list sub-paths.
-   * @param f The FilePredicate to invoke on each object for filtering.
-   * @param d The DirectoryPredicate to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
-   * @param recursive Whether to recursively list subdirectories.
-   *
-   * Note: the return type LsObjects does not match the other "ls" methods so as
-   * to match the S3 equivalent API.
-   */
-  template <FilePredicate F, DirectoryPredicate D>
-  LsObjects ls_filtered(
-      const URI& parent,
-      F f,
-      D d = accept_all_dirs,
-      bool recursive = false) const {
-    return std_filesystem_ls_filtered<F, D>(parent, f, d, recursive);
-  }
 
   /**
    * Lists files one level deep under a given path.

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -68,6 +68,10 @@ class URI;
  */
 class Posix : public FilesystemBase, public LocalFilesystem {
  public:
+  /* ********************************* */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
+  /* ********************************* */
+
   /** Default constructor. */
   Posix()
       : Posix(Config()) {
@@ -78,6 +82,18 @@ class Posix : public FilesystemBase, public LocalFilesystem {
 
   /** Destructor. */
   ~Posix() override = default;
+
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
+  /**
+   * Checks if this filesystem supports the given URI.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const override;
 
   /**
    * Creates a new directory.

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -172,24 +172,6 @@ class Posix : public LocalFilesystem {
    */
   void move_dir(const URI& old_uri, const URI& new_uri) const override;
 
-  /**
-   * Copy a given filesystem file.
-   * Both URI must be of the same file:// backend type.
-   *
-   * @param old_uri The old URI.
-   * @param new_uri The new URI.
-   */
-  void copy_file(const URI& old_uri, const URI& new_uri) const override;
-
-  /**
-   * Copy a given filesystem directory.
-   * Both URI must be of the same file:// backend type.
-   *
-   * @param old_uri The old URI.
-   * @param new_uri The new URI.
-   */
-  void copy_dir(const URI& old_uri, const URI& new_uri) const override;
-
   /** Whether or not to use the read-ahead cache. */
   bool use_read_ahead_cache() const override {
     return false;

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -477,14 +477,52 @@ void S3::copy_dir(const URI& old_uri, const URI& new_uri) const {
   }
 }
 
-void S3::read(
+uint64_t S3::read(
     const URI& uri,
     uint64_t offset,
     void* buffer,
     uint64_t nbytes,
-    bool) const {
-  uint64_t nbytes_read = 0;
-  throw_if_not_ok(read_impl(uri, offset, buffer, nbytes, 0, &nbytes_read));
+    uint64_t read_ahead_nbytes) {
+  throw_if_not_ok(init_client());
+
+  if (!uri.is_s3()) {
+    throw S3Exception("URI is not an S3 URI: " + uri.to_string());
+  }
+
+  Aws::Http::URI aws_uri = uri.c_str();
+  Aws::S3::Model::GetObjectRequest get_object_request;
+  get_object_request.WithBucket(aws_uri.GetAuthority())
+      .WithKey(aws_uri.GetPath());
+  get_object_request.SetRange(Aws::String(
+      "bytes=" + std::to_string(offset) + "-" +
+      std::to_string(offset + nbytes + read_ahead_nbytes - 1)));
+  get_object_request.SetResponseStreamFactory(
+      [buffer, nbytes, read_ahead_nbytes]() {
+        return Aws::New<PreallocatedIOStream>(
+            constants::s3_allocation_tag.c_str(),
+            buffer,
+            nbytes + read_ahead_nbytes);
+      });
+
+  if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
+    get_object_request.SetRequestPayer(request_payer_);
+
+  auto get_object_outcome = client_->GetObject(get_object_request);
+  if (!get_object_outcome.IsSuccess()) {
+    throw S3Exception(std::string(
+        std::string("Failed to read S3 object ") + uri.c_str() +
+        outcome_error_message(get_object_outcome)));
+  }
+
+  uint64_t length_returned =
+      static_cast<uint64_t>(get_object_outcome.GetResult().GetContentLength());
+  if (length_returned < nbytes) {
+    throw S3Exception(std::string(
+        std::string("Read operation returned different size of bytes ") +
+        std::to_string(length_returned) + " vs " + std::to_string(nbytes)));
+  }
+
+  return length_returned;
 }
 
 void S3::remove_bucket(const URI& bucket) const {
@@ -863,14 +901,15 @@ void S3::finalize_and_flush_object(const URI& uri) {
     std::vector<std::byte> merged(sum_sizes);
     throw_if_not_ok(parallel_for(
         vfs_thread_pool_, 0, intermediate_chunks.size(), [&](size_t i) {
-          uint64_t length_returned;
-          throw_if_not_ok(read_impl(
-              URI(intermediate_chunks[i].uri),
-              0,
-              merged.data() + offsets[i],
-              intermediate_chunks[i].size,
-              0,
-              &length_returned));
+          uint64_t length_read;
+          RETURN_NOT_OK(ok_if_not_throw([&]() {
+            length_read = read(
+                URI(intermediate_chunks[i].uri),
+                0,
+                merged.data() + offsets[i],
+                intermediate_chunks[i].size,
+                0);
+          }));
           return Status::Ok();
         }));
 
@@ -1115,56 +1154,6 @@ uint64_t S3::file_size(const URI& uri) const {
       head_object_outcome.GetResult().GetContentLength());
 }
 
-Status S3::read_impl(
-    const URI& uri,
-    const off_t offset,
-    void* const buffer,
-    const uint64_t length,
-    const uint64_t read_ahead_length,
-    uint64_t* const length_returned) const {
-  RETURN_NOT_OK(init_client());
-
-  if (!uri.is_s3()) {
-    return LOG_STATUS(Status_S3Error(
-        std::string("URI is not an S3 URI: " + uri.to_string())));
-  }
-
-  Aws::Http::URI aws_uri = uri.c_str();
-  Aws::S3::Model::GetObjectRequest get_object_request;
-  get_object_request.WithBucket(aws_uri.GetAuthority())
-      .WithKey(aws_uri.GetPath());
-  get_object_request.SetRange(Aws::String(
-      "bytes=" + std::to_string(offset) + "-" +
-      std::to_string(offset + length + read_ahead_length - 1)));
-  get_object_request.SetResponseStreamFactory(
-      [buffer, length, read_ahead_length]() {
-        return Aws::New<PreallocatedIOStream>(
-            constants::s3_allocation_tag.c_str(),
-            buffer,
-            length + read_ahead_length);
-      });
-
-  if (request_payer_ != Aws::S3::Model::RequestPayer::NOT_SET)
-    get_object_request.SetRequestPayer(request_payer_);
-
-  auto get_object_outcome = client_->GetObject(get_object_request);
-  if (!get_object_outcome.IsSuccess()) {
-    return LOG_STATUS(Status_S3Error(
-        std::string("Failed to read S3 object ") + uri.c_str() +
-        outcome_error_message(get_object_outcome)));
-  }
-
-  *length_returned =
-      static_cast<uint64_t>(get_object_outcome.GetResult().GetContentLength());
-  if (*length_returned < length) {
-    return LOG_STATUS(Status_S3Error(
-        std::string("Read operation returned different size of bytes ") +
-        std::to_string(*length_returned) + " vs " + std::to_string(length)));
-  }
-
-  return Status::Ok();
-}
-
 void S3::global_order_write_buffered(
     const URI& uri, const void* buffer, uint64_t length) {
   throw_if_not_ok(init_client());
@@ -1266,14 +1255,15 @@ void S3::global_order_write(
   std::vector<std::byte> merged(sum_sizes);
   throw_if_not_ok(parallel_for(
       vfs_thread_pool_, 0, intermediate_chunks.size(), [&](size_t i) {
-        uint64_t length_returned;
-        throw_if_not_ok(read_impl(
-            URI(intermediate_chunks[i].uri),
-            0,
-            merged.data() + offsets[i],
-            intermediate_chunks[i].size,
-            0,
-            &length_returned));
+        uint64_t length_read;
+        RETURN_NOT_OK(ok_if_not_throw([&]() {
+          length_read = read(
+              URI(intermediate_chunks[i].uri),
+              0,
+              merged.data() + offsets[i],
+              intermediate_chunks[i].size,
+              0);
+        }));
         return Status::Ok();
       }));
   std::memcpy(merged.data() + offsets.back(), buffer, length);

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -346,6 +346,10 @@ S3::~S3() {
 /*                 API               */
 /* ********************************* */
 
+bool S3::supports_uri(const URI& uri) const {
+  return uri.is_s3();
+}
+
 void S3::create_bucket(const URI& bucket) const {
   throw_if_not_ok(init_client());
 

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2083,6 +2083,61 @@ URI S3::generate_chunk_uri(
   return buffering_dir.join_path(chunk_name);
 }
 
+S3Scanner::S3Scanner(
+    const shared_ptr<TileDBS3Client>& client,
+    const URI& prefix,
+    FileFilter&& file_filter,
+    DirectoryFilter&& dir_filter,
+    bool recursive,
+    int max_keys)
+    : LsScanner(
+          prefix, std::move(file_filter), std::move(dir_filter), recursive)
+    , client_(client) {
+  const auto prefix_dir = prefix.add_trailing_slash();
+  auto prefix_str = prefix_dir.to_string();
+  Aws::Http::URI aws_uri = prefix_str.c_str();
+  if (!prefix_dir.is_s3()) {
+    throw S3Exception("URI is not an S3 URI: " + prefix_str);
+  }
+
+  list_objects_request_.SetBucket(aws_uri.GetAuthority());
+  list_objects_request_.SetPrefix(S3::remove_front_slash(aws_uri.GetPath()));
+  // Empty delimiter returns recursive results from S3.
+  list_objects_request_.SetDelimiter(delimiter());
+  // The default max_keys for ListObjects is 1000.
+  list_objects_request_.SetMaxKeys(max_keys);
+
+  if (client_->requester_pays()) {
+    list_objects_request_.SetRequestPayer(
+        Aws::S3::Model::RequestPayer::requester);
+  }
+  fetch_results();
+  next(begin_);
+}
+
+void S3Scanner::next(typename Iterator::pointer& ptr) {
+  if (ptr == end_) {
+    ptr = fetch_results();
+  }
+
+  while (ptr != end_) {
+    auto object = *ptr;
+    uint64_t size = object.GetSize();
+    std::string path = "s3://" +
+                       std::string(list_objects_request_.GetBucket()) +
+                       S3::add_front_slash(std::string(object.GetKey()));
+
+    // TODO: Add support for directory pruning.
+    if (this->file_filter_(path, size)) {
+      // Iterator is at the next object within results accepted by the filters.
+      return;
+    } else {
+      // Object was rejected by the FilePredicate, do not include it in results.
+      advance(ptr);
+    }
+  }
+}
+
 }  // namespace tiledb::sm
 
 #endif

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2115,6 +2115,47 @@ S3Scanner::S3Scanner(
   next(begin_);
 }
 
+typename S3Scanner::Iterator::pointer S3Scanner::fetch_results() {
+  // If this is our first request, GetIsTruncated() will be false.
+  if (more_to_fetch()) {
+    // If results are truncated on a subsequent request, we set the next
+    // continuation token before resubmitting our request.
+    Aws::String next_marker =
+        list_objects_outcome_.GetResult().GetNextContinuationToken();
+    if (next_marker.empty()) {
+      throw S3Exception(
+          "Failed to retrieve next continuation token for ListObjectsV2 "
+          "request.");
+    }
+    list_objects_request_.SetContinuationToken(std::move(next_marker));
+  } else if (list_objects_outcome_.IsSuccess()) {
+    // If we have previously submitted a successful request and there are no
+    // more results, we've reached the end of the scan.
+    begin_ = end_ = typename Iterator::pointer();
+    return end_;
+  }
+
+  list_objects_outcome_ = client_->ListObjectsV2(list_objects_request_);
+  if (!list_objects_outcome_.IsSuccess()) {
+    throw S3Exception(
+        std::string("Error while listing with prefix '") +
+        this->prefix_.add_trailing_slash().to_string() + "' and delimiter '" +
+        delimiter() + "'" + outcome_error_message(list_objects_outcome_));
+  }
+  // Update pointers to the newly fetched results.
+  begin_ = list_objects_outcome_.GetResult().GetContents().begin();
+  end_ = list_objects_outcome_.GetResult().GetContents().end();
+
+  if (list_objects_outcome_.GetResult().GetContents().empty()) {
+    // If the request returned no results, we've reached the end of the scan.
+    // We hit this case when the number of objects in the bucket is a multiple
+    // of the current max_keys.
+    return end_;
+  }
+
+  return begin_;
+}
+
 void S3Scanner::next(typename Iterator::pointer& ptr) {
   if (ptr == end_) {
     ptr = fetch_results();

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -662,14 +662,14 @@ class S3 : FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
+   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
-  void read(
+  uint64_t read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead) const override;
+      uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Deletes a bucket.
@@ -942,25 +942,6 @@ class S3 : FilesystemBase {
    * @return The size of the object in bytes.
    */
   uint64_t file_size(const URI& uri) const override;
-
-  /**
-   * Reads data from an object into a buffer.
-   *
-   * @param uri The URI of the object to be read.
-   * @param offset The offset in the object from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param length The size of the data to be read from the object.
-   * @param read_ahead_length The additional length to read ahead.
-   * @param length_returned Returns the total length read into `buffer`.
-   * @return Status
-   */
-  Status read_impl(
-      const URI& uri,
-      const off_t offset,
-      void* const buffer,
-      const uint64_t length,
-      const uint64_t read_ahead_length,
-      uint64_t* const length_returned) const;
 
   /**
    * Writes the input buffer to an S3 object. This function buffers in memory

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -591,6 +591,14 @@ class S3 : FilesystemBase {
   /* ********************************* */
 
   /**
+   * Checks if this filesystem supports the given URI.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const override;
+
+  /**
    * Creates a bucket.
    *
    * @param bucket The name of the bucket to be created.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -662,14 +662,9 @@ class S3 : FilesystemBase {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Deletes a bucket.

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -701,7 +701,7 @@ TEST_CASE(
     CHECK_THROWS_WITH(
         vfs_test.vfs_.ls_recursive(
             vfs_test.temp_dir_, tiledb::sm::accept_all_files),
-        Catch::Matchers::ContainsSubstring("storage backend is not supported"));
+        Catch::Matchers::ContainsSubstring("not supported"));
   }
 
   REQUIRE(vfs_test.check_open_files());

--- a/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
+++ b/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ TEST_CASE("VFS Read Log Modes", "[vfs][read-logging-modes]") {
     for (auto& uri : uris_to_read) {
       // None of these files exist, so we expect every read to fail.
       REQUIRE_THROWS(
-          throw_if_not_ok(res.vfs().read(URI(uri), 123, buffer, 456)));
+          throw_if_not_ok(res.vfs().read_exactly(URI(uri), 123, buffer, 456)));
     }
   }
 }

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -350,6 +350,12 @@ std::vector<directory_entry> VFS::ls_with_sizes(const URI& parent) const {
   return entries;
 }
 
+LsObjects VFS::ls_filtered(
+    const URI& parent, FileFilter f, DirectoryFilter d, bool recursive) const {
+  return get_fs(parent).ls_filtered(
+      parent, std::move(f), std::move(d), recursive);
+}
+
 void VFS::move_file(const URI& old_uri, const URI& new_uri) const {
   auto& old_fs = get_fs(old_uri);
   auto& new_fs = get_fs(new_uri);

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -680,12 +680,6 @@ std::vector<directory_entry> VFS::ls_with_sizes(const URI& parent) const {
 }
 
 void VFS::move_file(const URI& old_uri, const URI& new_uri) const {
-  auto instrument = make_log_duration_instrument(old_uri, new_uri);
-  // If new_uri exists, delete it or raise an error based on `force`
-  if (this->is_file(new_uri)) {
-    remove_file(new_uri);
-  }
-
   // File
   if (old_uri.is_file()) {
     if (new_uri.is_file()) {
@@ -807,11 +801,6 @@ void VFS::move_dir(const URI& old_uri, const URI& new_uri) const {
 
 void VFS::copy_file(const URI& old_uri, const URI& new_uri) const {
   auto instrument = make_log_duration_instrument(old_uri, new_uri);
-  // If new_uri exists, delete it or raise an error based on `force`
-  if (this->is_file(new_uri)) {
-    remove_file(new_uri);
-  }
-
   // File
   if (old_uri.is_file()) {
     if (new_uri.is_file()) {

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -411,7 +411,7 @@ Status VFS::read_exactly(
 }
 
 uint64_t VFS::read(
-    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) {
   stats_->add_counter("read_byte_num", nbytes);
 
   // Ensure that each thread is responsible for at least min_parallel_size
@@ -480,7 +480,7 @@ Status VFS::read_impl(
 
   // Do not read-ahead on local filesystems, or if disabled by the caller.
   if (!(fs.use_read_ahead_cache() && use_read_ahead)) {
-    *length_read = fs.read(uri, offset, buffer, nbytes, 0);
+    *length_read = fs.read(uri, offset, buffer, nbytes);
     return Status::Ok();
   }
 
@@ -494,7 +494,7 @@ Status VFS::read_impl(
   // 3. It saves us a copy. We must make a copy of the buffer at
   //    some point (one for the user, one for the cache).
   if (nbytes >= vfs_params_.read_ahead_size_) {
-    *length_read = fs.read(uri, offset, buffer, nbytes, 0);
+    *length_read = fs.read(uri, offset, buffer, nbytes);
     return Status::Ok();
   }
 
@@ -520,7 +520,7 @@ Status VFS::read_impl(
   const uint64_t ra_nbytes = vfs_params_.read_ahead_size_ - nbytes;
 
   // Read into `ra_buffer`.
-  *length_read = fs.read(uri, offset, ra_buffer.data(), nbytes, ra_nbytes);
+  *length_read = fs.read(uri, offset, ra_buffer.data(), nbytes + ra_nbytes);
 
   // Copy the requested read range back into the caller's output `buffer`.
   iassert(

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -505,6 +505,7 @@ Status VFS::read_impl(
   bool success;
   RETURN_NOT_OK(read_ahead_cache_->read(uri, offset, buffer, nbytes, &success));
   if (success) {
+    *length_read = nbytes;
     return Status::Ok();
   }
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -397,7 +397,7 @@ Status VFS::read_exactly(
     const uint64_t offset,
     void* const buffer,
     const uint64_t nbytes) {
-  uint64_t length_read;
+  uint64_t length_read = 0;
   RETURN_NOT_OK(ok_if_not_throw(
       [&]() { length_read = read(uri, offset, buffer, nbytes); }));
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -43,6 +43,10 @@
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/tile/tile.h"
 
+#ifdef HAVE_S3
+#include "tiledb/sm/filesystem/s3.h"
+#endif
+
 #include <iostream>
 #include <list>
 #include <sstream>
@@ -53,6 +57,10 @@ using namespace tiledb::common;
 using namespace tiledb::sm::filesystem;
 
 namespace tiledb::sm {
+
+#ifdef HAVE_S3
+S3_within_VFS::~S3_within_VFS() = default;
+#endif
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -65,10 +65,6 @@
 #include "tiledb/sm/filesystem/gcs.h"
 #endif  // HAVE_GCS
 
-#ifdef HAVE_S3
-#include "tiledb/sm/filesystem/s3.h"
-#endif  // HAVE_S3
-
 #ifdef HAVE_AZURE
 #include "tiledb/sm/filesystem/azure.h"
 #endif  // HAVE_AZURE
@@ -291,24 +287,29 @@ class GCS_within_VFS {
 
 /** The S3 filesystem. */
 #ifdef HAVE_S3
+
+class S3;
+
 class S3_within_VFS {
   /** Private member variable */
-  S3 s3_;
+  tdb_unique_ptr<S3> s3_;
 
  protected:
   template <typename... Args>
   S3_within_VFS(Args&&... args)
-      : s3_(std::forward<Args>(args)...) {
+      : s3_(tdb_unique_ptr<S3>(tdb_new(S3, std::forward<Args>(args)...))) {
   }
+
+  ~S3_within_VFS();
 
   /** Protected accessor for the S3 object. */
   inline S3& s3() {
-    return s3_;
+    return *s3_;
   }
 
   /** Protected accessor for the const S3 object. */
   inline const S3& s3() const {
-    return s3_;
+    return *s3_;
   }
 };
 #else

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -395,6 +395,14 @@ class VFS : FilesystemBase,
   /* ********************************* */
 
   /**
+   * Returns the filesystem which corresponds to the given URI.
+   *
+   * @param uri The URI which may correspond to a filesystem.
+   * @return The filesystem on which `uri` is stored.
+   */
+  const FilesystemBase& get_fs(const URI& uri) const;
+
+  /**
    * Returns the absolute path of the input string (mainly useful for
    * posix URI's).
    *

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -718,15 +718,9 @@ class VFS : FilesystemBase,
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead on object store.
-   * Not intended for use by user. Calculated internally for object store reads.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      [[maybe_unused]] uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Reads the specified number of bytes from a file.

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -699,31 +699,27 @@ class VFS : FilesystemBase,
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param use_read_ahead Whether to use the read-ahead cache.
+   * @param read_ahead_nbytes The number of bytes to read ahead on object store.
+   * Not intended for use by user. Calculated internally for object store reads.
    */
-  void read(
+  uint64_t read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead = true) const;
+      [[maybe_unused]] uint64_t read_ahead_nbytes = 0);
 
   /**
-   * Reads from a file.
+   * Reads the specified number of bytes from a file.
    *
    * @param uri The URI of the file.
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param use_read_ahead Whether to use the read-ahead cache.
    * @return Status
    */
-  Status read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      bool use_read_ahead = true);
+  Status read_exactly(
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes);
 
   /** Checks if a given filesystem is supported. */
   bool supports_fs(Filesystem fs) const;
@@ -1065,27 +1061,8 @@ class VFS : FilesystemBase,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead);
-
-  /**
-   * Executes a read, using the read-ahead cache as necessary.
-   *
-   * @param read_fn The read routine to execute.
-   * @param uri The URI of the file.
-   * @param offset The offset where the read begins.
-   * @param buffer The buffer to read into.
-   * @param nbytes Number of bytes to read.
-   * @param use_read_ahead Whether to use the read-ahead cache.
-   * @return Status
-   */
-  Status read_ahead_impl(
-      const std::function<Status(
-          const URI&, off_t, void*, uint64_t, uint64_t, uint64_t*)>& read_fn,
-      const URI& uri,
-      const uint64_t offset,
-      void* const buffer,
-      const uint64_t nbytes,
-      const bool use_read_ahead);
+      bool use_read_ahead,
+      uint64_t* length_read);
 
   /**
    * Retrieves the backend-specific max number of parallel operations for VFS

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -403,6 +403,14 @@ class VFS : FilesystemBase,
   const FilesystemBase& get_fs(const URI& uri) const;
 
   /**
+   * Returns the filesystem which corresponds to the given URI.
+   *
+   * @param uri The URI which may correspond to a filesystem.
+   * @return The filesystem on which `uri` is stored.
+   */
+  FilesystemBase& get_fs(const URI uri);
+
+  /**
    * Returns the absolute path of the input string (mainly useful for
    * posix URI's).
    *
@@ -418,18 +426,29 @@ class VFS : FilesystemBase,
   Config config() const;
 
   /**
+   * Checks if the filesystem supports the given URI.
+   *
+   * - s3.supports_uri(s3://test) will return true.
+   * - posix.supports_uri(s3://test) will return false.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on the filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const override;
+
+  /**
    * Creates a directory.
    *
    * @param uri The URI of the directory.
    */
-  void create_dir(const URI& uri) const;
+  void create_dir(const URI& uri) const override;
 
   /**
    * Creates an empty file.
    *
    * @param uri The URI of the file.
    */
-  void touch(const URI& uri) const;
+  void touch(const URI& uri) const override;
 
   /**
    * Cancels all background or queued tasks.
@@ -441,7 +460,7 @@ class VFS : FilesystemBase,
    *
    * @param uri The name of the bucket to be created.
    */
-  void create_bucket(const URI& uri) const;
+  void create_bucket(const URI& uri) const override;
 
   /**
    * Returns the size of the files in the input directory.
@@ -461,21 +480,21 @@ class VFS : FilesystemBase,
    *
    * @param uri The name of the bucket to be deleted.
    */
-  void remove_bucket(const URI& uri) const;
+  void remove_bucket(const URI& uri) const override;
 
   /**
    * Deletes the contents of an object store bucket.
    *
    * @param uri The name of the bucket to be emptied.
    */
-  void empty_bucket(const URI& uri) const;
+  void empty_bucket(const URI& uri) const override;
 
   /**
    * Removes a given directory (recursive)
    *
    * @param uri The uri of the directory to be removed.
    */
-  void remove_dir(const URI& uri) const;
+  void remove_dir(const URI& uri) const override;
 
   /**
    * Removes a given empty directory. No exceptions are raised if the directory
@@ -500,7 +519,7 @@ class VFS : FilesystemBase,
    *
    * @param uri The URI of the file.
    */
-  void remove_file(const URI& uri) const;
+  void remove_file(const URI& uri) const override;
 
   /**
    * Deletes files in parallel from the given vector of files.
@@ -525,7 +544,7 @@ class VFS : FilesystemBase,
    * @param uri The URI of the file.
    * @return The file size.
    */
-  uint64_t file_size(const URI& uri) const;
+  uint64_t file_size(const URI& uri) const override;
 
   /**
    * Checks if a directory exists.
@@ -537,7 +556,7 @@ class VFS : FilesystemBase,
    * @param uri The URI of the directory.
    * @return `true` if the directory exists and `false` otherwise.
    */
-  bool is_dir(const URI& uri) const;
+  bool is_dir(const URI& uri) const override;
 
   /**
    * Checks if a file exists.
@@ -545,7 +564,7 @@ class VFS : FilesystemBase,
    * @param uri The URI of the file.
    * @return `true` if the file exists and `false` otherwise.
    */
-  bool is_file(const URI& uri) const;
+  bool is_file(const URI& uri) const override;
 
   /**
    * Checks if an object store bucket exists.
@@ -553,7 +572,7 @@ class VFS : FilesystemBase,
    * @param uri The name of the object store bucket.
    * @return `true` if the bucket exists and `false` otherwise.
    */
-  bool is_bucket(const URI& uri) const;
+  bool is_bucket(const URI& uri) const override;
 
   /**
    * Checks if an object-store bucket is empty.
@@ -561,7 +580,7 @@ class VFS : FilesystemBase,
    * @param uri The name of the object store bucket.
    * @return `true` if the bucket is empty and `false` otherwise.
    */
-  bool is_empty_bucket(const URI& uri) const;
+  bool is_empty_bucket(const URI& uri) const override;
 
   /**
    * Retrieves all the URIs that have the first input as parent.
@@ -578,7 +597,7 @@ class VFS : FilesystemBase,
    * @param parent The target directory to list.
    * @return All entries that are contained in the parent
    */
-  std::vector<directory_entry> ls_with_sizes(const URI& parent) const;
+  std::vector<directory_entry> ls_with_sizes(const URI& parent) const override;
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
@@ -666,7 +685,7 @@ class VFS : FilesystemBase,
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void move_file(const URI& old_uri, const URI& new_uri) const;
+  void move_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Renames a directory.
@@ -674,7 +693,7 @@ class VFS : FilesystemBase,
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void move_dir(const URI& old_uri, const URI& new_uri) const;
+  void move_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Copies a file.
@@ -682,7 +701,7 @@ class VFS : FilesystemBase,
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void copy_file(const URI& old_uri, const URI& new_uri) const;
+  void copy_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Copies directory.
@@ -690,7 +709,7 @@ class VFS : FilesystemBase,
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void copy_dir(const URI& old_uri, const URI& new_uri) const;
+  void copy_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Reads from a file.
@@ -707,7 +726,7 @@ class VFS : FilesystemBase,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      [[maybe_unused]] uint64_t read_ahead_nbytes = 0);
+      [[maybe_unused]] uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Reads the specified number of bytes from a file.
@@ -734,7 +753,7 @@ class VFS : FilesystemBase,
    *
    * @param uri The URI of the file.
    */
-  void sync(const URI& uri) const;
+  void sync(const URI& uri) const override;
 
   /**
    * Opens a file in a given mode.
@@ -770,7 +789,7 @@ class VFS : FilesystemBase,
    * @param finalize For s3 objects only. If `true`, flushes as a result of a
    * remote global order write `finalize()` call.
    */
-  void flush(const URI& uri, [[maybe_unused]] bool finalize = false);
+  void flush(const URI& uri, [[maybe_unused]] bool finalize = false) override;
 
   /**
    * Closes a file, flushing its contents to persistent storage.
@@ -798,7 +817,7 @@ class VFS : FilesystemBase,
       const URI& uri,
       const void* buffer,
       uint64_t buffer_size,
-      bool remote_global_order_write = false);
+      bool remote_global_order_write = false) override;
 
   /**
    * Used in serialization to share the multipart upload state

--- a/tiledb/sm/filesystem/vfs_file_handle.cc
+++ b/tiledb/sm/filesystem/vfs_file_handle.cc
@@ -96,7 +96,7 @@ Status VFSFileHandle::read(uint64_t offset, void* buffer, uint64_t nbytes) {
     return LOG_STATUS(st);
   }
 
-  return vfs_->read(uri_, offset, buffer, nbytes);
+  return vfs_->read_exactly(uri_, offset, buffer, nbytes);
 }
 
 Status VFSFileHandle::sync() {

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -448,12 +448,8 @@ void Win::move_file(const URI& old_uri, const URI& new_uri) const {
   move_path(old_uri, new_uri);
 }
 
-void Win::read(
-    const URI& uri,
-    uint64_t offset,
-    void* buffer,
-    uint64_t nbytes,
-    bool) const {
+uint64_t Win::read(
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
   auto path = uri.to_path();
   // Open the file (OPEN_EXISTING with CreateFile() will only open, not create,
   // the file).
@@ -514,6 +510,7 @@ void Win::read(
         "Cannot read from file '" + path + "'; File closing error " +
         get_last_error_msg("CloseHandle"));
   }
+  return (uint64_t)num_bytes_read;
 }
 
 void Win::flush(const URI& uri, bool) {

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -146,6 +146,10 @@ std::string Win::abs_path(const std::string& path) {
   return str_result;
 }
 
+bool Win::supports_uri(const URI& uri) const {
+  return uri.is_file();
+}
+
 void Win::create_dir(const URI& uri) const {
   auto path = uri.to_path();
   if (is_dir(uri)) {

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -449,7 +449,7 @@ void Win::move_file(const URI& old_uri, const URI& new_uri) const {
 }
 
 uint64_t Win::read(
-    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes, uint64_t) {
+    const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) {
   auto path = uri.to_path();
   // Open the file (OPEN_EXISTING with CreateFile() will only open, not create,
   // the file).

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -468,6 +468,7 @@ uint64_t Win::read(
   }
 
   char* byte_buffer = reinterpret_cast<char*>(buffer);
+  uint64_t length_returned = 0;
   do {
     LARGE_INTEGER offset_lg_int;
     offset_lg_int.QuadPart = offset;
@@ -504,13 +505,14 @@ uint64_t Win::read(
     byte_buffer += num_bytes_read;
     offset += num_bytes_read;
     nbytes -= num_bytes_read;
+    length_returned += num_bytes_read;
   } while (nbytes > 0);
   if (CloseHandle(file_h) == 0) {
     throw WindowsException(
         "Cannot read from file '" + path + "'; File closing error " +
         get_last_error_msg("CloseHandle"));
   }
-  return (uint64_t)num_bytes_read;
+  return length_returned;
 }
 
 void Win::flush(const URI& uri, bool) {

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -351,15 +351,6 @@ bool Win::is_file(const URI& uri) const {
   return PathFileExists(path.c_str()) && !PathIsDirectory(path.c_str());
 }
 
-void Win::copy_file(const URI&, const URI&) const {
-  throw WindowsException("Copying files on Windows is not yet supported.");
-}
-
-void Win::copy_dir(const URI&, const URI&) const {
-  throw WindowsException(
-      "Copying directories on Windows is not yet supported.");
-}
-
 Status Win::ls(const std::string& path, std::vector<std::string>* paths) const {
   for (auto& fs : ls_with_sizes(URI(path))) {
     paths->emplace_back(fs.path().native());

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -218,22 +218,6 @@ class Win : public LocalFilesystem {
    */
   void move_file(const URI& old_uri, const URI& new_uri) const override;
 
-  /**
-   * Copies a directory.
-   *
-   * @param old_uri The old URI.
-   * @param new_uri The new URI.
-   */
-  void copy_dir(const URI&, const URI&) const override;
-
-  /**
-   * Copies a file.
-   *
-   * @param old_uri The old URI.
-   * @param new_uri The new URI.
-   */
-  void copy_file(const URI&, const URI&) const override;
-
   /** Whether or not to use the read-ahead cache. */
   bool use_read_ahead_cache() const override {
     return false;

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -70,7 +70,7 @@ typedef void* HANDLE;
 /**
  * This class implements Windows filesystem functions.
  */
-class Win : FilesystemBase, LocalFilesystem {
+class Win : public FilesystemBase, LocalFilesystem {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -70,7 +70,7 @@ typedef void* HANDLE;
 /**
  * This class implements Windows filesystem functions.
  */
-class Win : public FilesystemBase, LocalFilesystem {
+class Win : public LocalFilesystem {
  public:
   /* ********************************* */
   /*     CONSTRUCTORS & DESTRUCTORS    */
@@ -193,29 +193,6 @@ class Win : public FilesystemBase, LocalFilesystem {
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
       const URI& path) const override;
-
-  /**
-   * Lists objects and object information that start with `prefix`, invoking
-   * the FilePredicate on each entry collected and the DirectoryPredicate on
-   * common prefixes for pruning.
-   *
-   * @param parent The parent prefix to list sub-paths.
-   * @param f The FilePredicate to invoke on each object for filtering.
-   * @param d The DirectoryPredicate to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
-   * @param recursive Whether to recursively list subdirectories.
-   *
-   * Note: the return type LsObjects does not match the other "ls" methods so as
-   * to match the S3 equivalent API.
-   */
-  template <FilePredicate F, DirectoryPredicate D>
-  LsObjects ls_filtered(
-      const URI& parent,
-      F f,
-      D d = accept_all_dirs,
-      bool recursive = false) const {
-    return std_filesystem_ls_filtered<F, D>(parent, f, d, recursive);
-  }
 
   /**
    * Move a given filesystem path.

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -258,20 +258,20 @@ class Win : FilesystemBase, LocalFilesystem {
   void copy_file(const URI&, const URI&) const override;
 
   /**
-   * Reads data from a file into a buffer.
+   * Reads from a file.
    *
-   * @param uri The uri of the file.
-   * @param offset The offset in the file from which the read will start.
-   * @param buffer The buffer into which the data will be written.
-   * @param nbytes The size of the data to be read from the file.
-   * @param use_read_ahead Whether to use a read-ahead cache. Unused internally.
+   * @param uri The URI of the file.
+   * @param offset The offset where the read begins.
+   * @param buffer The buffer to read into.
+   * @param nbytes Number of bytes to read.
+   * @param read_ahead_nbytes The number of bytes to read ahead. Unused.
    */
-  void read(
+  uint64_t read(
       const URI& uri,
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      bool use_read_ahead = false) const;
+      uint64_t read_ahead_nbytes = 0);
 
   /**
    * Flushes a file or directory.

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -103,21 +103,21 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param uri The URI to check.
    * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
    */
-  bool supports_uri(const URI& uri) const;
+  bool supports_uri(const URI& uri) const override;
 
   /**
    * Creates a new directory.
    *
    * @param uri The URI of the directory to be created.
    */
-  void create_dir(const URI& uri) const;
+  void create_dir(const URI& uri) const override;
 
   /**
    * Creates an empty file.
    *
    * @param uri The uri of the file to be created.
    */
-  void touch(const URI& uri) const;
+  void touch(const URI& uri) const override;
 
   /**
    * Returns the directory where the program is executed.
@@ -133,7 +133,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    *
    * @param uri The uri of the directory to be deleted.
    */
-  void remove_dir(const URI& uri) const;
+  void remove_dir(const URI& uri) const override;
 
   /**
    * Removes a given empty directory.
@@ -148,7 +148,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    *
    * @param uri The uri of the file to be deleted.
    */
-  void remove_file(const URI& uri) const;
+  void remove_file(const URI& uri) const override;
 
   /**
    * Returns the size of the input file.
@@ -156,7 +156,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param uri The uri of the file whose size is to be retrieved.
    * @return The size of the input file.
    */
-  uint64_t file_size(const URI& uri) const;
+  uint64_t file_size(const URI& uri) const override;
 
   /**
    * Checks if the input is an existing directory.
@@ -164,7 +164,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param uri The uri of the directory to be checked.
    * @return `true` if `dir` is an existing directory, `false` otherwise.
    */
-  bool is_dir(const URI& uri) const;
+  bool is_dir(const URI& uri) const override;
 
   /**
    * Checks if the input is an existing file.
@@ -172,7 +172,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param uri The uri of the file to be checked.
    * @return `true` if `file` is an existing file, `false` otherwise.
    */
-  bool is_file(const URI& uri) const;
+  bool is_file(const URI& uri) const override;
 
   /**
    *
@@ -192,7 +192,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @return A list of directory_entry objects
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
-      const URI& path) const;
+      const URI& path) const override;
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
@@ -231,7 +231,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void move_dir(const URI& old_uri, const URI& new_uri) const;
+  void move_dir(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Renames a file.
@@ -239,7 +239,7 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param old_uri The old URI.
    * @param new_uri The new URI.
    */
-  void move_file(const URI& old_uri, const URI& new_uri) const;
+  void move_file(const URI& old_uri, const URI& new_uri) const override;
 
   /**
    * Copies a directory.
@@ -257,6 +257,11 @@ class Win : public FilesystemBase, LocalFilesystem {
    */
   void copy_file(const URI&, const URI&) const override;
 
+  /** Whether or not to use the read-ahead cache. */
+  bool use_read_ahead_cache() const override {
+    return false;
+  }
+
   /**
    * Reads from a file.
    *
@@ -271,7 +276,7 @@ class Win : public FilesystemBase, LocalFilesystem {
       uint64_t offset,
       void* buffer,
       uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0);
+      uint64_t read_ahead_nbytes = 0) override;
 
   /**
    * Flushes a file or directory.
@@ -279,14 +284,14 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param uri The URI of the file.
    * @param finalize Unused flag. Reserved for finalizing S3 object upload only.
    */
-  void flush(const URI& uri, bool finalize);
+  void flush(const URI& uri, bool finalize) override;
 
   /**
    * Syncs a file or directory.
    *
    * @param uri The uri of the file.
    */
-  void sync(const URI& uri) const;
+  void sync(const URI& uri) const override;
 
   /**
    * Writes the input buffer to a file.
@@ -303,7 +308,7 @@ class Win : public FilesystemBase, LocalFilesystem {
       const URI& uri,
       const void* buffer,
       uint64_t buffer_size,
-      bool remote_global_order_write = false);
+      bool remote_global_order_write = false) override;
 
  private:
   /**

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -73,7 +73,7 @@ typedef void* HANDLE;
 class Win : FilesystemBase, LocalFilesystem {
  public:
   /* ********************************* */
-  /*                 API               */
+  /*     CONSTRUCTORS & DESTRUCTORS    */
   /* ********************************* */
 
   /**
@@ -87,11 +87,23 @@ class Win : FilesystemBase, LocalFilesystem {
   Win(const Config&) {
   }
 
+  /* ********************************* */
+  /*                 API               */
+  /* ********************************* */
+
   /**
    * Returns the absolute (string) path of the input in the
    * form of a Windows path.
    */
   static std::string abs_path(const std::string& path);
+
+  /**
+   * Checks if this filesystem supports the given URI.
+   *
+   * @param uri The URI to check.
+   * @return `true` if `uri` is supported on this filesystem, `false` otherwise.
+   */
+  bool supports_uri(const URI& uri) const;
 
   /**
    * Creates a new directory.

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -269,14 +269,9 @@ class Win : public FilesystemBase, LocalFilesystem {
    * @param offset The offset where the read begins.
    * @param buffer The buffer to read into.
    * @param nbytes Number of bytes to read.
-   * @param read_ahead_nbytes The number of bytes to read ahead. Unused.
    */
   uint64_t read(
-      const URI& uri,
-      uint64_t offset,
-      void* buffer,
-      uint64_t nbytes,
-      uint64_t read_ahead_nbytes = 0) override;
+      const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) override;
 
   /**
    * Flushes a file or directory.

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -1679,7 +1679,7 @@ void FragmentMetadata::get_footer_offset_and_size(
     URI fragment_metadata_uri = fragment_uri_.join_path(
         std::string(constants::fragment_metadata_filename));
     uint64_t size_offset = meta_file_size_ - sizeof(uint64_t);
-    throw_if_not_ok(resources_->vfs().read(
+    throw_if_not_ok(resources_->vfs().read_exactly(
         fragment_metadata_uri, size_offset, size, sizeof(uint64_t)));
     *offset = meta_file_size_ - *size - sizeof(uint64_t);
     resources_->stats().add_counter("read_frag_meta_size", sizeof(uint64_t));
@@ -2758,7 +2758,7 @@ void FragmentMetadata::read_file_footer(
   }
 
   // Read footer
-  throw_if_not_ok(resources_->vfs().read(
+  throw_if_not_ok(resources_->vfs().read_exactly(
       fragment_metadata_uri,
       *footer_offset,
       tile->data_as<uint8_t>(),

--- a/tiledb/sm/group/group_directory.cc
+++ b/tiledb/sm/group/group_directory.cc
@@ -314,7 +314,7 @@ GroupDirectory::compute_uris_to_vacuum(const std::vector<URI>& uris) const {
     uint64_t size = vfs_.file_size(vac_files[i]);
     std::string names;
     names.resize(size);
-    throw_if_not_ok(vfs_.read(vac_files[i], 0, &names[0], size, false));
+    throw_if_not_ok(vfs_.read_exactly(vac_files[i], 0, &names[0], size));
     std::stringstream ss(names);
     bool vacuum_vac_file = true;
     for (std::string uri_str; std::getline(ss, uri_str);) {

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -395,7 +395,7 @@ class FilteredData {
     auto size{block.size()};
     URI uri{file_uri(fragment_metadata_[block.frag_idx()].get(), type)};
     auto task = resources_.io_tp().execute([this, offset, data, size, uri]() {
-      throw_if_not_ok(resources_.vfs().read(uri, offset, data, size, false));
+      throw_if_not_ok(resources_.vfs().read_exactly(uri, offset, data, size));
       return Status::Ok();
     });
     read_tasks_.push_back(std::move(task));

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -124,7 +124,7 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO));
 
   // Read the tile.
-  throw_if_not_ok(resources_.vfs().read(
+  throw_if_not_ok(resources_.vfs().read_exactly(
       uri_,
       file_offset + tile_data_offset,
       tile->filtered_data(),
@@ -144,8 +144,8 @@ GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
 
   std::vector<uint8_t> base_buf(GenericTileHeader::BASE_SIZE);
 
-  throw_if_not_ok(
-      resources.vfs().read(uri, file_offset, base_buf.data(), base_buf.size()));
+  throw_if_not_ok(resources.vfs().read_exactly(
+      uri, file_offset, base_buf.data(), base_buf.size()));
 
   Deserializer base_deserializer(base_buf.data(), base_buf.size());
 
@@ -159,7 +159,7 @@ GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
 
   // Read header filter pipeline.
   std::vector<uint8_t> filter_pipeline_buf(header.filter_pipeline_size);
-  throw_if_not_ok(resources.vfs().read(
+  throw_if_not_ok(resources.vfs().read_exactly(
       uri,
       file_offset + GenericTileHeader::BASE_SIZE,
       filter_pipeline_buf.data(),


### PR DESCRIPTION
> [!NOTE]
> Depends on #5596.

Fixes CORE-323.
Fixes CORE-324.

---
TYPE: IMPROVEMENT
DESC: Added support for `tiledb_vfs_copy_file` and `tiledb_vfs_copy_dir` on Windows.