### PR TITLE
Include directories in ls recursive results.

### DIFF
--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -565,7 +565,7 @@ TEMPLATE_LIST_TEST_CASE(
   // Test collecting results with LsInclude predicate.
   auto results = tiledb::VFSExperimental::ls_recursive_filter(
       ctx, vfs, test.temp_dir_.to_string(), include);
-  std::erase_if(expected_results, [&](const auto& object) {
+  std::erase_if(expected_results, [&include](const auto& object) {
     return !include(object.first, object.second);
   });
   std::sort(results.begin(), results.end());

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -566,10 +566,7 @@ TEMPLATE_LIST_TEST_CASE(
   auto results = tiledb::VFSExperimental::ls_recursive_filter(
       ctx, vfs, test.temp_dir_.to_string(), include);
   std::erase_if(expected_results, [&](const auto& object) {
-    if (object.second > 0) {
-      return !include(object.first, object.second);
-    }
-    return !tiledb::sm::accept_all_dirs(object.first);
+    return !include(object.first, object.second);
   });
   std::sort(results.begin(), results.end());
   CHECK(results.size() == expected_results.size());
@@ -608,6 +605,7 @@ TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls_recursive]") {
   };
   tiledb::VFSExperimental::ls_recursive(
       ctx, vfs, s3_test.temp_dir_.to_string(), cb);
+  std::erase_if(expected_results, [](const auto& a) { return a.second == 0; });
   expected_results.resize(cb_count);
   CHECK(ls_objects.size() == cb_count);
   CHECK(ls_objects == expected_results);

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -514,7 +514,7 @@ using ls_recursive_test_types = std::tuple<
     tiledb::test::GCSTest>;
 TEMPLATE_LIST_TEST_CASE(
     "CPP API: VFS ls_recursive filter",
-    "[cppapi][vfs][ls-recursive]",
+    "[cppapi][vfs][ls_recursive]",
     ls_recursive_test_types) {
   using namespace tiledb::test;
   TestType test({10, 100, 0});
@@ -565,8 +565,11 @@ TEMPLATE_LIST_TEST_CASE(
   // Test collecting results with LsInclude predicate.
   auto results = tiledb::VFSExperimental::ls_recursive_filter(
       ctx, vfs, test.temp_dir_.to_string(), include);
-  std::erase_if(expected_results, [&include](const auto& object) {
-    return !include(object.first, object.second);
+  std::erase_if(expected_results, [&](const auto& object) {
+    if (object.second > 0) {
+      return !include(object.first, object.second);
+    }
+    return !tiledb::sm::accept_all_dirs(object.first);
   });
   std::sort(results.begin(), results.end());
   CHECK(results.size() == expected_results.size());
@@ -580,7 +583,7 @@ TEMPLATE_LIST_TEST_CASE(
   CHECK(expected_results == ls_objects);
 }
 
-TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls-recursive]") {
+TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls_recursive]") {
   using namespace tiledb::test;
   S3Test s3_test({10, 50, 15});
   if (!s3_test.is_supported()) {
@@ -610,7 +613,7 @@ TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls-recursive]") {
   CHECK(ls_objects == expected_results);
 }
 
-TEST_CASE("CPP API: Throwing filter", "[cppapi][vfs][ls-recursive]") {
+TEST_CASE("CPP API: Throwing filter", "[cppapi][vfs][ls_recursive]") {
   using namespace tiledb::test;
   S3Test s3_test({0});
   if (!s3_test.is_supported()) {
@@ -653,7 +656,7 @@ TEST_CASE("CPP API: Throwing filter", "[cppapi][vfs][ls-recursive]") {
 
 TEST_CASE(
     "CPP API: CallbackWrapperCPP construction validation",
-    "[ls-recursive][callback][wrapper]") {
+    "[ls_recursive][callback][wrapper]") {
   tiledb::VFSExperimental::LsObjects data;
   auto cb = [&](std::string_view, uint64_t) -> bool { return true; };
   SECTION("Null callback") {
@@ -666,7 +669,7 @@ TEST_CASE(
 
 TEST_CASE(
     "CPP API: CallbackWrapperCPP operator() validation",
-    "[ls-recursive][callback][wrapper]") {
+    "[ls_recursive][callback][wrapper]") {
   tiledb::VFSExperimental::LsObjects data;
   auto cb = [&](std::string_view path, uint64_t object_size) -> bool {
     if (object_size > 100) {

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -830,54 +830,54 @@ TEST_CASE(
     "CPP API: CallbackWrapperCPP LsCallback operator() validation",
     "[ls_recursive][callback][wrapper]") {
   tiledb::VFSExperimental::LsObjects data;
-    auto cb = [&](std::string_view path, uint64_t object_size) -> bool {
-      if (object_size > 100) {
-        // Throw if object size is greater than 100 bytes.
-        throw std::runtime_error("Throwing callback");
-      } else if (!path.ends_with(".txt")) {
-        // Reject non-txt files.
-        return false;
-      }
-      data.emplace_back(path, object_size);
-      return true;
-    };
-    tiledb::VFSExperimental::CallbackWrapperCPP wrapper(cb);
-    SECTION("Callback return true accepts object") {
-      CHECK(wrapper("file.txt", 10) == true);
-      CHECK(data.size() == 1);
+  auto cb = [&](std::string_view path, uint64_t object_size) -> bool {
+    if (object_size > 100) {
+      // Throw if object size is greater than 100 bytes.
+      throw std::runtime_error("Throwing callback");
+    } else if (!path.ends_with(".txt")) {
+      // Reject non-txt files.
+      return false;
     }
-    SECTION("Callback return false rejects object") {
-      CHECK(wrapper("some/dir/", 0) == false);
-      CHECK(data.empty());
-    }
-    SECTION("Callback exception is propagated") {
-      CHECK_THROWS_WITH(wrapper("path", 101), "Throwing callback");
-    }
+    data.emplace_back(path, object_size);
+    return true;
+  };
+  tiledb::VFSExperimental::CallbackWrapperCPP wrapper(cb);
+  SECTION("Callback return true accepts object") {
+    CHECK(wrapper("file.txt", 10) == true);
+    CHECK(data.size() == 1);
+  }
+  SECTION("Callback return false rejects object") {
+    CHECK(wrapper("some/dir/", 0) == false);
+    CHECK(data.empty());
+  }
+  SECTION("Callback exception is propagated") {
+    CHECK_THROWS_WITH(wrapper("path", 101), "Throwing callback");
+  }
 }
 
 TEST_CASE(
     "CPP API: CallbackWrapperCPP LsCallbackV2 operator() validation",
     "[ls_recursive_v2][callback][wrapper]") {
   tiledb::VFSExperimental::LsObjects data;
-    auto cb = [&](std::string_view path, uint64_t object_size, bool) -> bool {
-      if (path == "throw") {
-        throw std::runtime_error("Throwing callback v2");
-      } else if (path == "bad/dir") {
-        return false;
-      }
-      data.emplace_back(path, object_size);
-      return true;
-    };
-    tiledb::VFSExperimental::CallbackWrapperCPP wrapper(cb);
-    SECTION("Callback return true accepts object") {
-      CHECK(wrapper("good/dir", 0, true) == true);
-      CHECK(data.size() == 1);
+  auto cb = [&](std::string_view path, uint64_t object_size, bool) -> bool {
+    if (path == "throw") {
+      throw std::runtime_error("Throwing callback v2");
+    } else if (path == "bad/dir") {
+      return false;
     }
-    SECTION("Callback return false rejects object") {
-      CHECK(wrapper("bad/dir", 0) == false);
-      CHECK(data.empty());
-    }
-    SECTION("Callback exception is propagated") {
-      CHECK_THROWS_WITH(wrapper("throw", 500, false), "Throwing callback");
-    }
+    data.emplace_back(path, object_size);
+    return true;
+  };
+  tiledb::VFSExperimental::CallbackWrapperCPP wrapper(cb);
+  SECTION("Callback return true accepts object") {
+    CHECK(wrapper("good/dir", 0, true) == true);
+    CHECK(data.size() == 1);
+  }
+  SECTION("Callback return false rejects object") {
+    CHECK(wrapper("bad/dir", 0) == false);
+    CHECK(data.empty());
+  }
+  SECTION("Callback exception is propagated") {
+    CHECK_THROWS_WITH(wrapper("throw", 500, false), "Throwing callback");
+  }
 }

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -541,7 +541,7 @@ TEMPLATE_LIST_TEST_CASE(
   };
 
   SECTION("Default filter (include all)") {
-    include = [](std::string_view, uint64_t) { return true; };
+    include = tiledb::sm::LsScanner::accept_all;
   }
   SECTION("Custom filter (include none)") {
     include = [](std::string_view, uint64_t) { return false; };
@@ -561,7 +561,10 @@ TEMPLATE_LIST_TEST_CASE(
     include = [](std::string_view, uint64_t size) { return size <= 50; };
   }
   SECTION("Custom filter (accept only directories)") {
-    include = [](std::string_view, uint64_t size) { return size == 0; };
+    include = tiledb::sm::LsScanner::accept_all_dirs;
+  }
+  SECTION("Custom filter (accept only files)") {
+    include = tiledb::sm::LsScanner::accept_all_files;
   }
 
   // Test collecting results with LsInclude predicate.

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -629,7 +629,6 @@ TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls_recursive]") {
   };
   tiledb::VFSExperimental::ls_recursive(
       ctx, vfs, s3_test.temp_dir_.to_string(), cb);
-  std::erase_if(expected_results, [](const auto& a) { return a.second == 0; });
   expected_results.resize(cb_count);
   CHECK(ls_objects.size() == cb_count);
   CHECK(ls_objects == expected_results);

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -507,7 +507,6 @@ TEST_CASE(
   }
 }
 
-// TODO: LocalFsTest fails
 using ls_recursive_test_types = std::tuple<
     tiledb::test::LocalFsTest,
     tiledb::test::S3Test,
@@ -530,56 +529,47 @@ TEMPLATE_LIST_TEST_CASE(
 
   tiledb::VFSExperimental::LsObjects ls_objects;
   // Predicate filter to apply to ls_recursive.
-  tiledb::VFSExperimental::LsIncludeFile include_file;
-  tiledb::VFSExperimental::LsIncludeDir include_dir = [&](std::string_view) {
-    return true;
-  };
+  tiledb::VFSExperimental::LsInclude include;
   // Callback to populate ls_objects vector using a filter.
-  tiledb::VFSExperimental::LsFileCallback file_cb = [&](std::string_view path,
-                                                        uint64_t size) {
-    if (include_file(path, size)) {
+  tiledb::VFSExperimental::LsCallback cb = [&](std::string_view path,
+                                               uint64_t size) {
+    if (include(path, size)) {
       ls_objects.emplace_back(path, size);
-    }
-    return true;
-  };
-  tiledb::VFSExperimental::LsDirCallback dir_cb = [&](std::string_view path) {
-    if (include_dir(path)) {
-      ls_objects.emplace_back(path, 0);
     }
     return true;
   };
 
   SECTION("Default filter (include all)") {
-    include_file = [](std::string_view, uint64_t) { return true; };
+    include = [](std::string_view, uint64_t) { return true; };
   }
   SECTION("Custom filter (include none)") {
-    include_file = [](std::string_view, uint64_t) { return false; };
+    include = [](std::string_view, uint64_t) { return false; };
   }
 
   SECTION("Custom filter (search for test_file_50)") {
-    include_file = [](std::string_view object_name, uint64_t) {
+    include = [](std::string_view object_name, uint64_t) {
       return object_name.find("test_file_50") != std::string::npos;
     };
   }
   SECTION("Custom filter (search for test_file_1*)") {
-    include_file = [](std::string_view object_name, uint64_t) {
+    include = [](std::string_view object_name, uint64_t) {
       return object_name.find("test_file_1") != std::string::npos;
     };
   }
   SECTION("Custom filter (reject files over 50 bytes)") {
-    include_file = []([[maybe_unused]] std::string_view entry, uint64_t size) {
+    include = []([[maybe_unused]] std::string_view entry, uint64_t size) {
       return size <= 50;
     };
   }
 
   // Test collecting results with LsInclude predicate.
-  auto include_dirs = [](std::string_view) { return true; };
-
   auto results = tiledb::VFSExperimental::ls_recursive_filter(
-      ctx, vfs, test.temp_dir_.to_string(), include_file, include_dirs);
+      ctx, vfs, test.temp_dir_.to_string(), include);
   std::erase_if(expected_results, [&](const auto& object) {
-    // Leave all directories within the expected_results set.
-    return object.second != 0 && !include_file(object.first, object.second);
+    if (object.second > 0) {
+      return !include(object.first, object.second);
+    }
+    return !tiledb::sm::accept_all_dirs(object.first);
   });
   std::sort(results.begin(), results.end());
   CHECK(results.size() == expected_results.size());
@@ -587,10 +577,10 @@ TEMPLATE_LIST_TEST_CASE(
 
   // Test collecting results with LsCallback, writing data into ls_objects.
   tiledb::VFSExperimental::ls_recursive(
-      ctx, vfs, test.temp_dir_.to_string(), file_cb, dir_cb);
+      ctx, vfs, test.temp_dir_.to_string(), cb);
   std::sort(ls_objects.begin(), ls_objects.end());
   CHECK(ls_objects.size() == expected_results.size());
-  CHECK_THAT(expected_results, Catch::Matchers::UnorderedEquals(ls_objects));
+  CHECK(expected_results == ls_objects);
 }
 
 TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls_recursive]") {
@@ -600,7 +590,6 @@ TEST_CASE("CPP API: Callback stops traversal", "[cppapi][vfs][ls_recursive]") {
     return;
   }
   auto expected_results = s3_test.expected_results();
-  std::erase_if(expected_results, [](const auto& a) { return a.second == 0; });
 
   vfs_config cfg;
   tiledb::Context ctx(tiledb::Config(&cfg.config));
@@ -635,13 +624,9 @@ TEST_CASE("CPP API: Throwing filter", "[cppapi][vfs][ls_recursive]") {
   tiledb::Context ctx(tiledb::Config(&cfg.config));
   tiledb::VFS vfs(ctx);
 
-  tiledb::VFSExperimental::LsIncludeFile filter = [](std::string_view,
-                                                     uint64_t) -> bool {
-    throw std::runtime_error("Throwing file filter");
-  };
-  tiledb::VFSExperimental::LsIncludeDir dir_filter =
-      [](std::string_view) -> bool {
-    throw std::runtime_error("Throwing directory filter");
+  tiledb::VFSExperimental::LsInclude filter = [](std::string_view,
+                                                 uint64_t) -> bool {
+    throw std::runtime_error("Throwing filter");
   };
   auto path = s3_test.temp_dir_.to_string();
 
@@ -652,43 +637,20 @@ TEST_CASE("CPP API: Throwing filter", "[cppapi][vfs][ls_recursive]") {
     CHECK_NOTHROW(
         tiledb::VFSExperimental::ls_recursive(ctx, vfs, path, filter));
   }
-  SECTION("Throwing file filter with N objects should throw") {
+  SECTION("Throwing filter with N objects should throw") {
     vfs.touch(s3_test.temp_dir_.join_path("test_file").to_string());
     CHECK_THROWS_AS(
-        tiledb::VFSExperimental::ls_recursive_filter(
-            ctx, vfs, path, filter, dir_filter),
+        tiledb::VFSExperimental::ls_recursive_filter(ctx, vfs, path, filter),
         std::runtime_error);
     CHECK_THROWS_WITH(
-        tiledb::VFSExperimental::ls_recursive_filter(
-            ctx, vfs, path, filter, dir_filter),
-        Catch::Matchers::ContainsSubstring("Throwing file filter"));
+        tiledb::VFSExperimental::ls_recursive_filter(ctx, vfs, path, filter),
+        Catch::Matchers::ContainsSubstring("Throwing filter"));
     CHECK_THROWS_AS(
-        tiledb::VFSExperimental::ls_recursive(
-            ctx, vfs, path, filter, dir_filter),
+        tiledb::VFSExperimental::ls_recursive(ctx, vfs, path, filter),
         std::runtime_error);
     CHECK_THROWS_WITH(
-        tiledb::VFSExperimental::ls_recursive(
-            ctx, vfs, path, filter, dir_filter),
-        Catch::Matchers::ContainsSubstring("Throwing file filter"));
-  }
-  SECTION("Throwing directory filter with N objects should throw") {
-    vfs.touch(s3_test.temp_dir_.join_path("prefix/test_file").to_string());
-    CHECK_THROWS_AS(
-        tiledb::VFSExperimental::ls_recursive_filter(
-            ctx, vfs, path, tiledb::sm::accept_all_files, dir_filter),
-        std::runtime_error);
-    CHECK_THROWS_WITH(
-        tiledb::VFSExperimental::ls_recursive_filter(
-            ctx, vfs, path, tiledb::sm::accept_all_files, dir_filter),
-        Catch::Matchers::ContainsSubstring("Throwing directory filter"));
-    CHECK_THROWS_AS(
-        tiledb::VFSExperimental::ls_recursive(
-            ctx, vfs, path, tiledb::sm::accept_all_files, dir_filter),
-        std::runtime_error);
-    CHECK_THROWS_WITH(
-        tiledb::VFSExperimental::ls_recursive(
-            ctx, vfs, path, tiledb::sm::accept_all_files, dir_filter),
-        Catch::Matchers::ContainsSubstring("Throwing directory filter"));
+        tiledb::VFSExperimental::ls_recursive(ctx, vfs, path, filter),
+        Catch::Matchers::ContainsSubstring("Throwing filter"));
   }
 }
 
@@ -696,17 +658,12 @@ TEST_CASE(
     "CPP API: CallbackWrapperCPP construction validation",
     "[ls_recursive][callback][wrapper]") {
   tiledb::VFSExperimental::LsObjects data;
-  auto file_cb = [&](std::string_view, uint64_t) -> bool { return true; };
-  auto dir_cb = [&](std::string_view) -> bool { return true; };
-  SECTION("Null file callback") {
+  auto cb = [&](std::string_view, uint64_t) -> bool { return true; };
+  SECTION("Null callback") {
     CHECK_THROWS(tiledb::VFSExperimental::CallbackWrapperCPP(nullptr));
-    CHECK_THROWS(tiledb::VFSExperimental::CallbackWrapperCPP(nullptr, dir_cb));
   }
-  SECTION("Null dir callback") {
-    CHECK_THROWS(tiledb::VFSExperimental::CallbackWrapperCPP(file_cb, nullptr));
-  }
-  SECTION("Valid callbacks") {
-    CHECK_NOTHROW(tiledb::VFSExperimental::CallbackWrapperCPP(file_cb, dir_cb));
+  SECTION("Valid callback") {
+    CHECK_NOTHROW(tiledb::VFSExperimental::CallbackWrapperCPP(cb));
   }
 }
 
@@ -714,10 +671,10 @@ TEST_CASE(
     "CPP API: CallbackWrapperCPP operator() validation",
     "[ls_recursive][callback][wrapper]") {
   tiledb::VFSExperimental::LsObjects data;
-  auto file_cb = [&](std::string_view path, uint64_t object_size) -> bool {
+  auto cb = [&](std::string_view path, uint64_t object_size) -> bool {
     if (object_size > 100) {
       // Throw if object size is greater than 100 bytes.
-      throw std::runtime_error("Throwing file callback");
+      throw std::runtime_error("Throwing callback");
     } else if (!path.ends_with(".txt")) {
       // Reject non-txt files.
       return false;
@@ -725,43 +682,17 @@ TEST_CASE(
     data.emplace_back(path, object_size);
     return true;
   };
+  tiledb::VFSExperimental::CallbackWrapperCPP wrapper(cb);
 
-  auto dir_cb = [&](std::string_view path) -> bool {
-    if (path == "bad/dir/") {
-      return false;
-    } else if (path == "throw") {
-      throw std::runtime_error("Throwing directory callback");
-    }
-    data.emplace_back(path, 0);
-    return true;
-  };
-  tiledb::VFSExperimental::CallbackWrapperCPP wrapper(file_cb, dir_cb);
-
-  SECTION("Files") {
-    SECTION("Callback return true accepts object") {
-      CHECK(wrapper("file.txt", 10) == true);
-      CHECK(data.size() == 1);
-    }
-    SECTION("Callback return false rejects object") {
-      CHECK(wrapper("some/dir/", 0) == false);
-      CHECK(data.empty());
-    }
-    SECTION("Callback exception is propagated") {
-      CHECK_THROWS_WITH(wrapper("path", 101) == 0, "Throwing file callback");
-    }
+  SECTION("Callback return true accepts object") {
+    CHECK(wrapper("file.txt", 10) == true);
+    CHECK(data.size() == 1);
   }
-
-  SECTION("Directories") {
-    SECTION("Callback return true accepts object") {
-      CHECK(wrapper("good/dir/") == true);
-      CHECK(data.size() == 1);
-    }
-    SECTION("Callback return false rejects object") {
-      CHECK(wrapper("bad/dir/") == false);
-      CHECK(data.empty());
-    }
-    SECTION("Callback exception is propagated") {
-      CHECK_THROWS_WITH(wrapper("throw") == 0, "Throwing directory callback");
-    }
+  SECTION("Callback return false rejects object") {
+    CHECK(wrapper("some/dir/", 0) == false);
+    CHECK(data.empty());
+  }
+  SECTION("Callback exception is propagated") {
+    CHECK_THROWS_WITH(wrapper("path", 101) == 0, "Throwing callback");
   }
 }

--- a/test/src/unit-cppapi-vfs.cc
+++ b/test/src/unit-cppapi-vfs.cc
@@ -874,10 +874,10 @@ TEST_CASE(
     CHECK(data.size() == 1);
   }
   SECTION("Callback return false rejects object") {
-    CHECK(wrapper("bad/dir", 0) == false);
+    CHECK(wrapper("bad/dir", 0, true) == false);
     CHECK(data.empty());
   }
   SECTION("Callback exception is propagated") {
-    CHECK_THROWS_WITH(wrapper("throw", 500, false), "Throwing callback");
+    CHECK_THROWS_WITH(wrapper("throw", 500, false), "Throwing callback v2");
   }
 }

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -389,7 +389,10 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
   std::vector<Aws::S3::Model::Object> results_vector;
   DYNAMIC_SECTION("Testing with " << max_keys << " max keys from S3") {
     auto scan = s3_test.get_s3().scanner(
-        s3_test.temp_dir_, VFSTest::accept_all_files, recursive, max_keys);
+        s3_test.temp_dir_,
+        tiledb::sm::LsScanner::accept_all,
+        recursive,
+        max_keys);
 
     SECTION("for loop") {
       SECTION("range based for") {

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -371,9 +371,7 @@ TEST_CASE(
 
     CHECK(results_vector.size() == expected.size());
     for (const auto& s3_object : results_vector) {
-      if (s3_object.GetSize() > 0) {
-        CHECK(file_filter(s3_object.GetKey(), s3_object.GetSize()));
-      }
+      CHECK(file_filter(s3_object.GetKey(), s3_object.GetSize()));
       auto uri = s3_test.temp_dir_.to_string() + "/" + s3_object.GetKey();
       CHECK_THAT(
           expected,

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -362,32 +362,23 @@ TEST_CASE(
 
     // Filter expected results to apply file_filter.
     std::erase_if(expected, [&file_filter](const auto& a) {
-      // TODO: Use trailing slash as indicator of prefix instead of size 0
-      if (a.second > 0) {
-        return !file_filter(a.first, a.second);
-      }
-      return !accept_all_dirs(a.first);
+      return !file_filter(a.first, a.second);
     });
 
     auto scan = s3_test.get_s3().scanner(
-        s3_test.temp_dir_, file_filter, accept_all_dirs, recursive, max_keys);
+        s3_test.temp_dir_, file_filter, recursive, max_keys);
     std::vector results_vector(scan.begin(), scan.end());
 
     CHECK(results_vector.size() == expected.size());
-    for (const auto & s3_object : results_vector) {
+    for (const auto& s3_object : results_vector) {
       if (s3_object.GetSize() > 0) {
         CHECK(file_filter(s3_object.GetKey(), s3_object.GetSize()));
-      } else {
-        // TODO: Test with various directory filters
-        CHECK(accept_all_dirs(s3_object.GetKey()));
       }
       auto uri = s3_test.temp_dir_.to_string() + "/" + s3_object.GetKey();
       CHECK_THAT(
           expected,
           Catch::Matchers::Contains(
-              std::make_pair(
-                  uri,
-                  static_cast<size_t>(s3_object.GetSize()))));
+              std::make_pair(uri, static_cast<size_t>(s3_object.GetSize()))));
     }
   }
 }
@@ -400,11 +391,7 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
   std::vector<Aws::S3::Model::Object> results_vector;
   DYNAMIC_SECTION("Testing with " << max_keys << " max keys from S3") {
     auto scan = s3_test.get_s3().scanner(
-        s3_test.temp_dir_,
-        VFSTest::accept_all_files,
-        accept_all_dirs,
-        recursive,
-        max_keys);
+        s3_test.temp_dir_, VFSTest::accept_all_files, recursive, max_keys);
 
     SECTION("for loop") {
       SECTION("range based for") {
@@ -441,9 +428,8 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
         s3_test.temp_dir_.to_string() + "/" + std::string(s3_object.GetKey());
     CHECK_THAT(
         expected,
-        Catch::Matchers::Contains(
-            std::make_pair(
-                full_uri, static_cast<size_t>(s3_object.GetSize()))));
+        Catch::Matchers::Contains(std::make_pair(
+            full_uri, static_cast<size_t>(s3_object.GetSize()))));
   }
 }
 

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -374,7 +374,7 @@ TEST_CASE(
     std::vector results_vector(scan.begin(), scan.end());
 
     CHECK(results_vector.size() == expected.size());
-    for (const auto & s3_object : results_vector) {
+    for (const auto& s3_object : results_vector) {
       if (s3_object.GetSize() > 0) {
         CHECK(file_filter(s3_object.GetKey(), s3_object.GetSize()));
       } else {
@@ -385,9 +385,7 @@ TEST_CASE(
       CHECK_THAT(
           expected,
           Catch::Matchers::Contains(
-              std::make_pair(
-                  uri,
-                  static_cast<size_t>(s3_object.GetSize()))));
+              std::make_pair(uri, static_cast<size_t>(s3_object.GetSize()))));
     }
   }
 }
@@ -441,9 +439,8 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
         s3_test.temp_dir_.to_string() + "/" + std::string(s3_object.GetKey());
     CHECK_THAT(
         expected,
-        Catch::Matchers::Contains(
-            std::make_pair(
-                full_uri, static_cast<size_t>(s3_object.GetSize()))));
+        Catch::Matchers::Contains(std::make_pair(
+            full_uri, static_cast<size_t>(s3_object.GetSize()))));
   }
 }
 

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -439,8 +439,11 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
     const auto& s3_object = results_vector[i];
     auto full_uri =
         s3_test.temp_dir_.to_string() + "/" + std::string(s3_object.GetKey());
-    CHECK(full_uri == expected[i].first);
-    CHECK(static_cast<uint64_t>(s3_object.GetSize()) == expected[i].second);
+    CHECK_THAT(
+        expected,
+        Catch::Matchers::Contains(
+            std::make_pair(
+                full_uri, static_cast<size_t>(s3_object.GetSize()))));
   }
 }
 

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -374,7 +374,7 @@ TEST_CASE(
     std::vector results_vector(scan.begin(), scan.end());
 
     CHECK(results_vector.size() == expected.size());
-    for (const auto& s3_object : results_vector) {
+    for (const auto & s3_object : results_vector) {
       if (s3_object.GetSize() > 0) {
         CHECK(file_filter(s3_object.GetKey(), s3_object.GetSize()));
       } else {
@@ -385,7 +385,9 @@ TEST_CASE(
       CHECK_THAT(
           expected,
           Catch::Matchers::Contains(
-              std::make_pair(uri, static_cast<size_t>(s3_object.GetSize()))));
+              std::make_pair(
+                  uri,
+                  static_cast<size_t>(s3_object.GetSize()))));
     }
   }
 }
@@ -439,8 +441,9 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
         s3_test.temp_dir_.to_string() + "/" + std::string(s3_object.GetKey());
     CHECK_THAT(
         expected,
-        Catch::Matchers::Contains(std::make_pair(
-            full_uri, static_cast<size_t>(s3_object.GetSize()))));
+        Catch::Matchers::Contains(
+            std::make_pair(
+                full_uri, static_cast<size_t>(s3_object.GetSize()))));
   }
 }
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -651,8 +651,8 @@ TEMPLATE_LIST_TEST_CASE(
       << " ls_filtered with recursion: " << (recursive ? "true" : "false")) {
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
-    auto ls_objects =
-        fs.vfs_.ls_filtered(path, accept_all_files, accept_all_dirs, recursive);
+    auto ls_objects = fs.vfs_.ls_filtered(
+        path, accept_all_files, accept_all_dirs, recursive);
 
     auto expected = fs.expected_results();
     if (!recursive) {
@@ -698,7 +698,8 @@ TEST_CASE(
     throw std::logic_error("Throwing FileFilter");
   };
   SECTION("Throwing FileFilter with 0 objects should not throw") {
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter));
+    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
+        vfs_test.temp_dir_, file_filter));
   }
 
   auto dir_filter = [](const std::string_view&) -> bool {
@@ -741,8 +742,7 @@ TEST_CASE(
 
   SECTION("Throwing filters with N objects should throw") {
     REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
-    REQUIRE_NOTHROW(
-        vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
+    REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
     CHECK_THROWS_AS(
         vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter, dir_filter),
         std::logic_error);

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -644,19 +644,17 @@ TEMPLATE_LIST_TEST_CASE(
     return;
   }
 
-  bool recursive = GENERATE(true, false);
   // If testing with recursion use the root directory, otherwise use a subdir.
-  auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
   DYNAMIC_SECTION(fs.temp_dir_.backend_name() << " ls_filtered") {
-    auto ls_objects =
-        fs.vfs_.ls_filtered(path, tiledb::sm::LsScanner::accept_all, recursive);
+    auto ls_objects = fs.vfs_.ls_filtered(
+        fs.temp_dir_, tiledb::sm::LsScanner::accept_all, true);
     auto expected = fs.expected_results();
     CHECK(ls_objects.size() == expected.size());
     CHECK_THAT(ls_objects, Catch::Matchers::UnorderedEquals(expected));
   }
   DYNAMIC_SECTION(fs.temp_dir_.backend_name() << " ls_filtered_v2") {
     auto ls_objects = fs.vfs_.ls_filtered_v2(
-        path, tiledb::sm::LsScanner::accept_all_v2, recursive);
+        fs.temp_dir_, tiledb::sm::LsScanner::accept_all_v2, true);
     auto expected = fs.expected_results_v2();
     CHECK(ls_objects.size() == expected.size());
     CHECK_THAT(ls_objects, Catch::Matchers::UnorderedEquals(expected));

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -686,28 +686,28 @@ TEST_CASE(
 
 TEST_CASE(
     "VFS: Throwing filters for ls_recursive",
-    "[vfs][ls_recursive][file-filter][directory-filter]") {
+    "[vfs][ls_recursive][file-filter]") {
   std::string prefix = GENERATE("s3://", "azure://", "gcs://", "gs://");
   VFSTest vfs_test({0}, prefix);
   if (!vfs_test.is_supported()) {
     return;
   }
 
-  auto file_filter = [](const std::string_view&, uint64_t) -> bool {
-    throw std::logic_error("Throwing FileFilter");
+  auto filter = [](const std::string_view&, uint64_t) -> bool {
+    throw std::logic_error("Throwing filter");
   };
-  SECTION("Throwing FileFilter with 0 objects should not throw") {
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter));
+  SECTION("Throwing filter with 0 objects should not throw") {
+    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, filter));
   }
 
   SECTION("Throwing filter with N objects should throw") {
     REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
     CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, filter),
         std::logic_error);
     CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
-        Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, filter),
+        Catch::Matchers::ContainsSubstring("Throwing filter"));
   }
 
   SECTION("Throwing filter with N objects should throw") {
@@ -715,11 +715,11 @@ TEST_CASE(
     REQUIRE_NOTHROW(
         vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
     CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, filter),
         std::logic_error);
     CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
-        Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, filter),
+        Catch::Matchers::ContainsSubstring("Throwing filter"));
   }
 }
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -682,10 +682,7 @@ TEMPLATE_LIST_TEST_CASE(
     std::erase_if(expected, [](const auto& p) {
       return p.first.find("subdir_1/test_file") == std::string::npos;
     });
-    // S3 ls_filtered V1 does not return common prefixes if non-recursive.
-    if (!path.is_s3()) {
-      expected.emplace_back(subdir2, 0);
-    }
+    expected.emplace_back(subdir2, 0);
     auto ls_objects =
         fs.vfs_.ls_filtered(path, tiledb::sm::LsScanner::accept_all, false);
     CHECK(ls_objects.size() == expected.size());

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -651,14 +651,14 @@ TEMPLATE_LIST_TEST_CASE(
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
     auto ls_objects =
-        fs.vfs_.ls_filtered(path, VFSTestBase::accept_all_files, recursive);
+        fs.vfs_.ls_filtered(path, tiledb::sm::LsScanner::accept_all, recursive);
 
     auto expected = fs.expected_results();
     if (!recursive) {
       // If non-recursive all objects in the first directory should be
       // returned, including the subdir_1/ prefix.
       std::erase_if(expected, [](const auto& p) {
-        return p.first.find("subdir_1/test_file") == std::string::npos;
+        return p.first.find("subdir_1") == std::string::npos;
       });
     }
 
@@ -680,7 +680,7 @@ TEST_CASE(
 
   DYNAMIC_SECTION(backend << " supported backend should not throw") {
     CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, VFSTestBase::accept_all_files));
+        vfs_test.temp_dir_, tiledb::sm::LsScanner::accept_all));
   }
 }
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -651,8 +651,7 @@ TEMPLATE_LIST_TEST_CASE(
       << " ls_filtered with recursion: " << (recursive ? "true" : "false")) {
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
-    auto ls_objects = fs.vfs_.ls_filtered(
-        path, accept_all_files, accept_all_dirs, recursive);
+    auto ls_objects = fs.vfs_.ls_filtered(path, accept_all_files, recursive);
 
     auto expected = fs.expected_results();
     if (!recursive) {
@@ -698,26 +697,10 @@ TEST_CASE(
     throw std::logic_error("Throwing FileFilter");
   };
   SECTION("Throwing FileFilter with 0 objects should not throw") {
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, file_filter));
+    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter));
   }
 
-  auto dir_filter = [](const std::string_view&) -> bool {
-    throw std::logic_error("Throwing DirectoryFilter");
-  };
-  SECTION("Throwing DirectoryFilter with 0 objects should not throw") {
-    // Create an object at root of the bucket; dir_filter shouldn't be called.
-    REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, accept_all_files, dir_filter));
-  }
-
-  SECTION("Throwing filters with 0 objects should not throw") {
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, file_filter, dir_filter));
-  }
-
-  SECTION("Throwing FileFilter with N objects should throw") {
+  SECTION("Throwing filter with N objects should throw") {
     REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
     CHECK_THROWS_AS(
         vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
@@ -727,27 +710,15 @@ TEST_CASE(
         Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
   }
 
-  SECTION("Throwing DirectoryFilter with N objects should throw") {
+  SECTION("Throwing filter with N objects should throw") {
+    REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
     REQUIRE_NOTHROW(
         vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
     CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(
-            vfs_test.temp_dir_, accept_all_files, dir_filter),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
         std::logic_error);
     CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(
-            vfs_test.temp_dir_, accept_all_files, dir_filter),
-        Catch::Matchers::ContainsSubstring("Throwing DirectoryFilter"));
-  }
-
-  SECTION("Throwing filters with N objects should throw") {
-    REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
-    REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
-    CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter, dir_filter),
-        std::logic_error);
-    CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter, dir_filter),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter),
         Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
   }
 }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -651,7 +651,7 @@ TEMPLATE_LIST_TEST_CASE(
       << " ls_filtered with recursion: " << (recursive ? "true" : "false")) {
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
-    auto ls_objects = fs.vfs_.ls_filtered(path, accept_all_files, recursive);
+    auto ls_objects = fs.vfs_.ls_filtered(path, VFSTestBase::accept_all_files, recursive);
 
     auto expected = fs.expected_results();
     if (!recursive) {
@@ -684,9 +684,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "VFS: Throwing filters for ls_recursive",
-    "[vfs][ls_recursive][file-filter]") {
+TEST_CASE("VFS: Throwing filters for ls_recursive", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("s3://", "azure://", "gcs://", "gs://");
   VFSTest vfs_test({0}, prefix);
   if (!vfs_test.is_supported()) {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -656,9 +656,9 @@ TEMPLATE_LIST_TEST_CASE(
     auto expected = fs.expected_results();
     if (!recursive) {
       // If non-recursive all objects in the first directory should be
-      // returned, including the subdir_1/ prefix.
+      // returned, excluding the subdir_1/ prefix.
       std::erase_if(expected, [](const auto& p) {
-        return p.first.find("subdir_1") == std::string::npos;
+        return p.first.find("subdir_1/test_file") == std::string::npos;
       });
     }
 

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -651,7 +651,8 @@ TEMPLATE_LIST_TEST_CASE(
       << " ls_filtered with recursion: " << (recursive ? "true" : "false")) {
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
-    auto ls_objects = fs.vfs_.ls_filtered(path, VFSTestBase::accept_all_files, recursive);
+    auto ls_objects =
+        fs.vfs_.ls_filtered(path, VFSTestBase::accept_all_files, recursive);
 
     auto expected = fs.expected_results();
     if (!recursive) {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -651,8 +651,8 @@ TEMPLATE_LIST_TEST_CASE(
       << " ls_filtered with recursion: " << (recursive ? "true" : "false")) {
     // If testing with recursion use the root directory, otherwise use a subdir.
     auto path = recursive ? fs.temp_dir_ : fs.temp_dir_.join_path("subdir_1");
-    auto ls_objects = fs.vfs_.ls_filtered(
-        path, accept_all_files, accept_all_dirs, recursive);
+    auto ls_objects =
+        fs.vfs_.ls_filtered(path, accept_all_files, accept_all_dirs, recursive);
 
     auto expected = fs.expected_results();
     if (!recursive) {
@@ -698,8 +698,7 @@ TEST_CASE(
     throw std::logic_error("Throwing FileFilter");
   };
   SECTION("Throwing FileFilter with 0 objects should not throw") {
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, file_filter));
+    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter));
   }
 
   auto dir_filter = [](const std::string_view&) -> bool {
@@ -742,7 +741,8 @@ TEST_CASE(
 
   SECTION("Throwing filters with N objects should throw") {
     REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
-    REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
+    REQUIRE_NOTHROW(
+        vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("prefix/file")));
     CHECK_THROWS_AS(
         vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, file_filter, dir_filter),
         std::logic_error);

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -634,8 +634,7 @@ TEST_CASE("VFS: test ls_with_sizes", "[vfs][ls-with-sizes]") {
 }
 
 // Currently only local, S3, Azure and GCS are supported for VFS::ls_recursive.
-// TODO: LocalFsTest currently fails. Fix and re-enable.
-using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest, GCSTest>;
+using TestBackends = std::tuple<LocalFsTest, S3Test, AzureTest, GCSTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: Test internal ls_filtered recursion argument",
     "[vfs][ls_filtered][recursion]",

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -508,6 +508,12 @@ S3Test::S3Test(const std::vector<size_t>& test_tree)
   for (size_t i = 1; i <= test_tree_.size(); i++) {
     sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
     // VFS::create_dir is a no-op for S3; Just create objects.
+    if (test_tree_[i - 1] > 0) {
+      // Do not include an empty prefix in expected results.
+      // The only way to retrieve an empty prefix in ls_recursive results is to
+      // explicitly create an empty prefix object through AWS console or SDK.
+      expected_results().emplace_back(path.to_string(), 0);
+    }
     for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
       auto object_uri = path.join_path("test_file_" + std::to_string(j));
       s3().touch(object_uri);

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -508,6 +508,15 @@ S3Test::S3Test(const std::vector<size_t>& test_tree)
   for (size_t i = 1; i <= test_tree_.size(); i++) {
     sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
     // VFS::create_dir is a no-op for S3; Just create objects.
+    if (test_tree_[i - 1] > 0) {
+      // Do not include an empty prefix in expected results.
+      // AWS won't return an empty prefix for a recursive list objects request.
+      // The only way to retrieve an empty prefix in ls_recursive results is to:
+      // Explicitly create an empty prefix object through AWS console or SDK.
+      // _or_
+      // Issue a non-recursive list objects request with a delimiter set.
+      expected_results().emplace_back(path.to_string(), 0);
+    }
     for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
       auto object_uri = path.join_path("test_file_" + std::to_string(j));
       s3().touch(object_uri);

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -508,15 +508,6 @@ S3Test::S3Test(const std::vector<size_t>& test_tree)
   for (size_t i = 1; i <= test_tree_.size(); i++) {
     sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
     // VFS::create_dir is a no-op for S3; Just create objects.
-    if (test_tree_[i - 1] > 0) {
-      // Do not include an empty prefix in expected results.
-      // AWS won't return an empty prefix for a recursive list objects request.
-      // The only way to retrieve an empty prefix in ls_recursive results is to:
-      // Explicitly create an empty prefix object through AWS console or SDK.
-      // _or_
-      // Issue a non-recursive list objects request with a delimiter set.
-      expected_results().emplace_back(path.to_string(), 0);
-    }
     for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
       auto object_uri = path.join_path("test_file_" + std::to_string(j));
       s3().touch(object_uri);

--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -494,10 +494,10 @@ VFSTest::VFSTest(
       vfs_.open_file(object_uri, sm::VFSMode::VFS_WRITE).ok();
       REQUIRE_NOTHROW(vfs_.write(object_uri, data.data(), data.size()));
       vfs_.close_file(object_uri).ok();
-      expected_results().emplace_back(object_uri.to_string(), data.size());
+      expected_results_.emplace_back(object_uri.to_string(), data.size());
     }
   }
-  std::sort(expected_results().begin(), expected_results().end());
+  std::sort(expected_results_.begin(), expected_results_.end());
 }
 
 S3Test::S3Test(const std::vector<size_t>& test_tree)
@@ -512,7 +512,7 @@ S3Test::S3Test(const std::vector<size_t>& test_tree)
       // Do not include an empty prefix in expected results.
       // The only way to retrieve an empty prefix in ls_recursive results is to
       // explicitly create an empty prefix object through AWS console or SDK.
-      expected_results().emplace_back(path.to_string(), 0);
+      expected_results_.emplace_back(path.to_string(), 0);
     }
     for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
       auto object_uri = path.join_path("test_file_" + std::to_string(j));
@@ -520,10 +520,10 @@ S3Test::S3Test(const std::vector<size_t>& test_tree)
       std::string data(j * 10, 'a');
       s3().write(object_uri, data.data(), data.size());
       s3().flush(object_uri);
-      expected_results().emplace_back(object_uri.to_string(), data.size());
+      expected_results_.emplace_back(object_uri.to_string(), data.size());
     }
   }
-  std::sort(expected_results().begin(), expected_results().end());
+  std::sort(expected_results_.begin(), expected_results_.end());
 #endif
 }
 
@@ -542,7 +542,7 @@ LocalFsTest::LocalFsTest(const std::vector<size_t>& test_tree)
   for (size_t i = 1; i <= test_tree_.size(); i++) {
     sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
     REQUIRE_NOTHROW(vfs_.create_dir(path));
-    expected_results().emplace_back(path.to_string(), 0);
+    expected_results_.emplace_back(path.to_string(), 0);
     for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
       auto object_uri = path.join_path("test_file_" + std::to_string(j));
       REQUIRE_NOTHROW(vfs_.touch(object_uri));
@@ -550,10 +550,10 @@ LocalFsTest::LocalFsTest(const std::vector<size_t>& test_tree)
       vfs_.open_file(object_uri, sm::VFSMode::VFS_WRITE).ok();
       REQUIRE_NOTHROW(vfs_.write(object_uri, data.data(), data.size()));
       vfs_.close_file(object_uri).ok();
-      expected_results().emplace_back(object_uri.to_string(), data.size());
+      expected_results_.emplace_back(object_uri.to_string(), data.size());
     }
   }
-  std::sort(expected_results().begin(), expected_results().end());
+  std::sort(expected_results_.begin(), expected_results_.end());
 }
 
 bool VFSTestSetup::is_legacy_rest() {

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1028,6 +1028,10 @@ class AzureTest : public VFSTestBase {
     for (size_t i = 1; i <= test_tree_.size(); i++) {
       sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
       // VFS::create_dir is a no-op for Azure; Just create objects.
+      if (test_tree_[i - 1] > 0) {
+        // Do not include an empty prefix in expected results.
+        expected_results().emplace_back(path.to_string(), 0);
+      }
       for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
         auto object_uri = path.join_path("test_file_" + std::to_string(j));
         vfs_.touch(object_uri);

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1058,6 +1058,10 @@ class GCSTest : public VFSTestBase {
     for (size_t i = 1; i <= test_tree_.size(); i++) {
       sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
       // VFS::create_dir is a no-op for GCS; Just create objects.
+      if (test_tree_[i - 1] > 0) {
+        // Do not include an empty prefix in expected results.
+        expected_results().emplace_back(path.to_string(), 0);
+      }
       for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
         auto object_uri = path.join_path("test_file_" + std::to_string(j));
         vfs_.touch(object_uri);

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -963,7 +963,7 @@ class VFSTestBase {
    */
   static tiledb::sm::Config create_test_config();
 
-  /** FilePredicate for passing to ls_filtered that accepts all files. */
+  /** FilterPredicate for passing to ls_filtered that accepts all files. */
   static bool accept_all_files(const std::string_view&, uint64_t) {
     return true;
   }

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -963,11 +963,6 @@ class VFSTestBase {
    */
   static tiledb::sm::Config create_test_config();
 
-  /** FilterPredicate for passing to ls_filtered that accepts all files. */
-  static bool accept_all_files(const std::string_view&, uint64_t) {
-    return true;
-  }
-
   std::vector<size_t> test_tree_;
   ThreadPool compute_, io_;
   tiledb::sm::VFS vfs_;

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -1106,14 +1106,4 @@ class MemFsTest : public VFSTestBase {
   }
 };
 }  // namespace tiledb::test
-namespace Catch {
-template <>
-struct StringMaker<std::pair<std::string, size_t>> {
-  static std::string convert(const std::pair<std::string, size_t>& value) {
-    std::ostringstream oss;
-    oss << "(" << value.first << ", " << value.second << ")";
-    return oss.str();
-  }
-};
-}  // namespace Catch
 #endif

--- a/test/support/src/vfs_helpers.h
+++ b/test/support/src/vfs_helpers.h
@@ -997,27 +997,7 @@ class VFSTest : public VFSTestBase {
 /** Test object for tiledb::sm::S3 functionality. */
 class S3Test : public VFSTestBase, protected tiledb::sm::S3_within_VFS {
  public:
-  explicit S3Test(const std::vector<size_t>& test_tree)
-      : VFSTestBase(test_tree, "s3://")
-      , S3_within_VFS(&tiledb::test::g_helper_stats, &io_, vfs_.config()) {
-#ifdef HAVE_S3
-    s3().create_bucket(temp_dir_);
-    for (size_t i = 1; i <= test_tree_.size(); i++) {
-      sm::URI path = temp_dir_.join_path("subdir_" + std::to_string(i));
-      // VFS::create_dir is a no-op for S3; Just create objects.
-      expected_results().emplace_back(path.to_string(), 0);
-      for (size_t j = 1; j <= test_tree_[i - 1]; j++) {
-        auto object_uri = path.join_path("test_file_" + std::to_string(j));
-        s3().touch(object_uri);
-        std::string data(j * 10, 'a');
-        s3().write(object_uri, data.data(), data.size());
-        s3().flush(object_uri);
-        expected_results().emplace_back(object_uri.to_string(), data.size());
-      }
-    }
-    std::sort(expected_results().begin(), expected_results().end());
-#endif
-  }
+  explicit S3Test(const std::vector<size_t>& test_tree);
 
 #ifdef HAVE_S3
   /** Expose protected accessor from S3_within_VFS. */

--- a/test/support/tdb_catch.h
+++ b/test/support/tdb_catch.h
@@ -68,6 +68,15 @@ struct StringMaker<std::optional<T>> {
     }
   }
 };
+
+template <>
+struct StringMaker<std::pair<std::string, size_t>> {
+  static std::string convert(const std::pair<std::string, size_t>& value) {
+    std::ostringstream oss;
+    oss << "(" << value.first << ", " << value.second << ")";
+    return oss.str();
+  }
+};
 }  // namespace Catch
 
 /*

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -43,7 +43,7 @@ using namespace tiledb::test;
 using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest, GCSTest>;
 
 TEMPLATE_LIST_TEST_CASE(
-    "C API: ls_recursive callback", "[vfs][ls-recursive]", TestBackends) {
+    "C API: ls_recursive callback", "[vfs][ls_recursive]", TestBackends) {
   using tiledb::sm::LsObjects;
   TestType test({10, 50});
   if (!test.is_supported()) {
@@ -81,6 +81,7 @@ TEMPLATE_LIST_TEST_CASE(
       // Stop traversal after we collect 10 results.
       return ls_data->size() != 10;
     };
+    std::erase_if(expected, [](const auto& a) { return a.second == 0; });
     expected.resize(10);
   }
 
@@ -93,7 +94,7 @@ TEMPLATE_LIST_TEST_CASE(
 
 TEMPLATE_LIST_TEST_CASE(
     "C API: ls_recursive throwing callback",
-    "[vfs][ls-recursive]",
+    "[vfs][ls_recursive]",
     TestBackends) {
   using tiledb::sm::LsObjects;
   TestType test({10, 50});

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -185,3 +185,39 @@ TEMPLATE_LIST_TEST_CASE(
     CHECK(data.empty());
   }
 }
+
+TEMPLATE_LIST_TEST_CASE(
+    "C API: ls_recursive null data pointer",
+    "[vfs][ls_recursive]",
+    TestBackends) {
+  using tiledb::sm::LsObjects;
+  TestType test({1});
+  if (!test.is_supported()) {
+    return;
+  }
+
+  vfs_config vfs_config;
+  tiledb_ctx_t* ctx;
+  tiledb_ctx_alloc(vfs_config.config, &ctx);
+  tiledb_vfs_t* vfs;
+  tiledb_vfs_alloc(ctx, vfs_config.config, &vfs);
+
+  LsObjects data;
+  SECTION("ls_recursive") {
+    tiledb_ls_callback_t cb =
+        [](const char*, size_t, uint64_t, void*) -> int32_t { return true; };
+    CHECK(
+        tiledb_vfs_ls_recursive(
+            ctx, vfs, test.temp_dir_.c_str(), cb, nullptr) == TILEDB_OK);
+  }
+
+  SECTION("ls_recursive_v2") {
+    tiledb_ls_callback_v2_t cb =
+        [](const char*, size_t, uint64_t, uint8_t, void*) -> int32_t {
+      return true;
+    };
+    CHECK(
+        tiledb_vfs_ls_recursive_v2(
+            ctx, vfs, test.temp_dir_.c_str(), cb, nullptr) == TILEDB_OK);
+  }
+}

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -101,7 +101,6 @@ TEMPLATE_LIST_TEST_CASE(
   if (!test.is_supported()) {
     return;
   }
-  auto expected = test.expected_results();
 
   vfs_config vfs_config;
   tiledb_ctx_t* ctx;

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -43,7 +43,7 @@ using namespace tiledb::test;
 using TestBackends = std::tuple</*LocalFsTest,*/ S3Test, AzureTest, GCSTest>;
 
 TEMPLATE_LIST_TEST_CASE(
-    "C API: ls_recursive callback", "[vfs][ls-recursive]", TestBackends) {
+    "C API: ls_recursive callback", "[vfs][ls_recursive]", TestBackends) {
   using tiledb::sm::LsObjects;
   TestType test({10, 50});
   if (!test.is_supported()) {
@@ -58,12 +58,18 @@ TEMPLATE_LIST_TEST_CASE(
   tiledb_vfs_alloc(ctx, vfs_config.config, &vfs);
 
   LsObjects data;
-  tiledb_ls_callback_t cb = [](const char* path,
-                               size_t path_len,
-                               uint64_t object_size,
-                               void* data) -> int32_t {
+  tiledb_ls_file_callback_t cb = [](const char* path,
+                                    size_t path_len,
+                                    uint64_t object_size,
+                                    void* data) -> int32_t {
     auto* ls_data = static_cast<LsObjects*>(data);
     ls_data->push_back({{path, path_len}, object_size});
+    return 1;
+  };
+  tiledb_ls_dir_callback_t dir_cb =
+      [](const char* path, size_t path_len, void* data) -> int32_t {
+    auto* ls_data = static_cast<LsObjects*>(data);
+    ls_data->push_back({{path, path_len}, 0});
     return 1;
   };
 
@@ -81,26 +87,26 @@ TEMPLATE_LIST_TEST_CASE(
       // Stop traversal after we collect 10 results.
       return ls_data->size() != 10;
     };
+    std::erase_if(expected, [](const auto& a) { return a.second == 0; });
     expected.resize(10);
   }
 
   CHECK(
-      tiledb_vfs_ls_recursive(ctx, vfs, test.temp_dir_.c_str(), cb, &data) ==
-      TILEDB_OK);
+      tiledb_vfs_ls_recursive_v2(
+          ctx, vfs, test.temp_dir_.c_str(), cb, dir_cb, &data) == TILEDB_OK);
   CHECK(data.size() == expected.size());
   CHECK(data == expected);
 }
 
 TEMPLATE_LIST_TEST_CASE(
     "C API: ls_recursive throwing callback",
-    "[vfs][ls-recursive]",
+    "[vfs][ls_recursive]",
     TestBackends) {
   using tiledb::sm::LsObjects;
   TestType test({10, 50});
   if (!test.is_supported()) {
     return;
   }
-  auto expected = test.expected_results();
 
   vfs_config vfs_config;
   tiledb_ctx_t* ctx;
@@ -109,13 +115,18 @@ TEMPLATE_LIST_TEST_CASE(
   tiledb_vfs_alloc(ctx, vfs_config.config, &vfs);
 
   LsObjects data;
-  tiledb_ls_callback_t cb =
+  tiledb_ls_file_callback_t cb =
       [](const char*, size_t, uint64_t, void*) -> int32_t {
-    throw std::runtime_error("Throwing callback");
+    throw std::runtime_error("Throwing file callback");
+  };
+
+  // TODO: Test SECTION
+  tiledb_ls_dir_callback_t dir_cb = [](const char*, size_t, void*) -> int32_t {
+    throw std::runtime_error("Throwing directory callback");
   };
 
   CHECK(
-      tiledb_vfs_ls_recursive(ctx, vfs, test.temp_dir_.c_str(), cb, &data) ==
-      TILEDB_ERR);
+      tiledb_vfs_ls_recursive_v2(
+          ctx, vfs, test.temp_dir_.c_str(), cb, dir_cb, &data) == TILEDB_ERR);
   CHECK(data.empty());
 }

--- a/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_ls_recursive.cc
@@ -81,7 +81,6 @@ TEMPLATE_LIST_TEST_CASE(
       // Stop traversal after we collect 10 results.
       return ls_data->size() != 10;
     };
-    std::erase_if(expected, [](const auto& a) { return a.second == 0; });
     expected.resize(10);
   }
 

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -770,8 +770,8 @@ TEST_CASE(
       "Test ls_recursive_v2 unsupported backend over " << uri.backend_name()) {
     auto cb = [](const char*, size_t, uint64_t, uint8_t, void*) { return 0; };
     CHECK(
-        tiledb_vfs_ls_recursive_v2(vfs.ctx, vfs.vfs, uri.c_str(), cb, &ls_data) ==
-        TILEDB_ERR);
+        tiledb_vfs_ls_recursive_v2(
+            vfs.ctx, vfs.vfs, uri.c_str(), cb, &ls_data) == TILEDB_ERR);
   }
 }
 

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -720,7 +720,7 @@ TEST_CASE("C API: tiledb_vfs_ls_recursive argument validation", "[capi][vfs]") {
 
 TEST_CASE(
     "C API: VFS recursive ls unsupported backends",
-    "[capi][vfs][ls-recursive]") {
+    "[capi][vfs][ls_recursive]") {
   ordinary_vfs vfs;
   int ls_data;
   auto cb = [](const char*, size_t, uint64_t, void*) { return 0; };
@@ -740,7 +740,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C API: CallbackWrapperCAPI operator() validation",
-    "[ls-recursive][callback][wrapper]") {
+    "[ls_recursive][callback][wrapper]") {
   tiledb::sm::LsCallback cb = [](const char* path,
                                  size_t path_len,
                                  uint64_t object_size,
@@ -774,7 +774,7 @@ TEST_CASE(
 
 TEST_CASE(
     "C API: CallbackWrapperCAPI construction validation",
-    "[ls-recursive][callback][wrapper]") {
+    "[ls_recursive][callback][wrapper]") {
   using tiledb::sm::CallbackWrapperCAPI;
   tiledb::sm::LsObjects data;
   auto cb = [](const char*, size_t, uint64_t, void*) -> int32_t { return 1; };

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -720,11 +720,10 @@ TEST_CASE("C API: tiledb_vfs_ls_recursive argument validation", "[capi][vfs]") {
 
 TEST_CASE(
     "C API: VFS recursive ls unsupported backends",
-    "[capi][vfs][ls_recursive]") {
+    "[capi][vfs][ls-recursive]") {
   ordinary_vfs vfs;
   int ls_data;
   auto cb = [](const char*, size_t, uint64_t, void*) { return 0; };
-  auto dir_cb = [](const char*, size_t, void*) { return 0; };
   // Recursive ls is currently only supported for S3.
   tiledb::sm::URI uri{GENERATE(
       "file:///path/", "mem:///path/", "azure://path/", "gcs://path/")};
@@ -736,64 +735,19 @@ TEST_CASE(
     CHECK(
         tiledb_vfs_ls_recursive(vfs.ctx, vfs.vfs, uri.c_str(), cb, &ls_data) ==
         TILEDB_ERR);
-    CHECK(
-        tiledb_vfs_ls_recursive_v2(
-            vfs.ctx, vfs.vfs, uri.c_str(), cb, dir_cb, &ls_data) == TILEDB_ERR);
-  }
-}
-
-TEST_CASE(
-    "C API: tiledb_vfs_ls_recursive_v2 argument validation",
-    "[capi][vfs][ls_recursive_v2]") {
-  /*
-   * No "success" sections here; too much overhead to set up.
-   */
-  ordinary_vfs x;
-  int32_t data;
-  auto cb = [](const char*, size_t, uint64_t, void*) { return 0; };
-  auto dir_cb = [](const char*, size_t, void*) { return 0; };
-  SECTION("null context") {
-    auto rc{tiledb_vfs_ls_recursive_v2(
-        nullptr, x.vfs, TEST_URI, cb, dir_cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_INVALID_CONTEXT);
-  }
-  SECTION("null vfs") {
-    auto rc{tiledb_vfs_ls_recursive_v2(
-        x.ctx, nullptr, TEST_URI, cb, dir_cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null uri") {
-    auto rc{
-        tiledb_vfs_ls_recursive_v2(x.ctx, x.vfs, nullptr, cb, dir_cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null file callback") {
-    auto rc{tiledb_vfs_ls_recursive_v2(
-        x.ctx, x.vfs, TEST_URI, nullptr, dir_cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null directory callback") {
-    auto rc{
-        tiledb_vfs_ls_recursive_v2(x.ctx, x.vfs, TEST_URI, cb, nullptr, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null data ptr") {
-    auto rc{tiledb_vfs_ls_recursive_v2(
-        x.ctx, x.vfs, TEST_URI, cb, dir_cb, nullptr)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
 }
 
 TEST_CASE(
     "C API: CallbackWrapperCAPI operator() validation",
-    "[ls_recursive][callback][wrapper]") {
-  tiledb::sm::LsFileCallback cb = [](const char* path,
-                                     size_t path_len,
-                                     uint64_t object_size,
-                                     void* data) -> int32_t {
+    "[ls-recursive][callback][wrapper]") {
+  tiledb::sm::LsCallback cb = [](const char* path,
+                                 size_t path_len,
+                                 uint64_t object_size,
+                                 void* data) -> int32_t {
     if (object_size > 100) {
       // Throw if object size is greater than 100 bytes.
-      throw std::runtime_error("Throwing file callback");
+      throw std::runtime_error("Throwing callback");
     } else if (!std::string(path, path_len).ends_with(".txt")) {
       // Reject non-txt files.
       return 0;
@@ -802,52 +756,25 @@ TEST_CASE(
     ls_data->push_back({{path, path_len}, object_size});
     return 1;
   };
-  tiledb::sm::LsDirCallback dir_cb =
-      [](const char* path, size_t path_len, void* data) {
-        std::string_view dir{path, path_len};
-        if (dir == "throw") {
-          throw std::runtime_error("Throwing directory callback");
-        } else if (dir == "bad/dir/") {
-          return 0;
-        }
-        auto* ls_data = static_cast<tiledb::sm::LsObjects*>(data);
-        ls_data->push_back({{path, path_len}, 0});
-        return 1;
-      };
+
   tiledb::sm::LsObjects data{};
-  tiledb::sm::CallbackWrapperCAPI wrapper(
-      cb, dir_cb, static_cast<void*>(&data));
+  tiledb::sm::CallbackWrapperCAPI wrapper(cb, static_cast<void*>(&data));
 
-  SECTION("LsFileCallback") {
-    SECTION("Callback return 1 signals to continue traversal") {
-      CHECK(wrapper("file.txt", 10) == 1);
-      CHECK(data.size() == 1);
-    }
-    SECTION("Callback return 0 signals to stop traversal") {
-      CHECK_THROWS_AS(wrapper("some/dir/", 0), tiledb::sm::LsStopTraversal);
-    }
-    SECTION("Callback exception is propagated") {
-      CHECK_THROWS_WITH(wrapper("path", 101), "Throwing file callback");
-    }
+  SECTION("Callback return 1 signals to continue traversal") {
+    CHECK(wrapper("file.txt", 10) == 1);
+    CHECK(data.size() == 1);
   }
-
-  SECTION("LsDirCallback") {
-    SECTION("Callback return 1 signals to continue traversal") {
-      CHECK(wrapper("good/dir/") == 1);
-      CHECK(data.size() == 1);
-    }
-    SECTION("Callback return 0 signals to stop traversal") {
-      CHECK_THROWS_AS(wrapper("bad/dir/"), tiledb::sm::LsStopTraversal);
-    }
-    SECTION("Callback exception is propagated") {
-      CHECK_THROWS_WITH(wrapper("throw"), "Throwing directory callback");
-    }
+  SECTION("Callback return 0 signals to stop traversal") {
+    CHECK_THROWS_AS(wrapper("some/dir/", 0) == 0, tiledb::sm::LsStopTraversal);
+  }
+  SECTION("Callback exception is propagated") {
+    CHECK_THROWS_WITH(wrapper("path", 101) == 0, "Throwing callback");
   }
 }
 
 TEST_CASE(
     "C API: CallbackWrapperCAPI construction validation",
-    "[ls_recursive][callback][wrapper]") {
+    "[ls-recursive][callback][wrapper]") {
   using tiledb::sm::CallbackWrapperCAPI;
   tiledb::sm::LsObjects data;
   auto cb = [](const char*, size_t, uint64_t, void*) -> int32_t { return 1; };

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -690,37 +690,6 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C API: tiledb_vfs_ls_recursive argument validation",
-    "[capi][vfs][ls_recursive]") {
-  /*
-   * No "success" sections here; too much overhead to set up.
-   */
-  ordinary_vfs x;
-  int32_t data;
-  auto cb = [](const char*, size_t, uint64_t, void*) { return 0; };
-  SECTION("null context") {
-    auto rc{tiledb_vfs_ls_recursive(nullptr, x.vfs, TEST_URI, cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_INVALID_CONTEXT);
-  }
-  SECTION("null vfs") {
-    auto rc{tiledb_vfs_ls_recursive(x.ctx, nullptr, TEST_URI, cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null uri") {
-    auto rc{tiledb_vfs_ls_recursive(x.ctx, x.vfs, nullptr, cb, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null callback") {
-    auto rc{tiledb_vfs_ls_recursive(x.ctx, x.vfs, TEST_URI, nullptr, &data)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-  SECTION("null data ptr") {
-    auto rc{tiledb_vfs_ls_recursive(x.ctx, x.vfs, TEST_URI, cb, nullptr)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
-}
-
-TEST_CASE(
     "C API: tiledb_vfs_ls_recursive_v2 argument validation",
     "[capi][vfs][ls_recursive_v2]") {
   /*
@@ -749,19 +718,12 @@ TEST_CASE(
 
 TEST_CASE(
     "C API: VFS recursive ls unsupported backends",
-    "[capi][vfs][ls_recursive][ls_recursive_v2]") {
+    "[capi][vfs][ls_recursive_v2]") {
   ordinary_vfs vfs;
   int ls_data;
   tiledb::sm::URI uri("mem:///tmp/path/");
   REQUIRE_NOTHROW(vfs.vfs->create_dir(uri));
   REQUIRE_NOTHROW(vfs.vfs->touch(uri.join_path("test_file.txt")));
-  DYNAMIC_SECTION(
-      "Test ls_recursive unsupported backend over " << uri.backend_name()) {
-    auto cb = [](const char*, size_t, uint64_t, void*) { return 0; };
-    CHECK(
-        tiledb_vfs_ls_recursive(vfs.ctx, vfs.vfs, uri.c_str(), cb, &ls_data) ==
-        TILEDB_ERR);
-  }
   DYNAMIC_SECTION(
       "Test ls_recursive_v2 unsupported backend over " << uri.backend_name()) {
     auto cb = [](const char*, size_t, uint64_t, uint8_t, void*) { return 0; };
@@ -849,9 +811,6 @@ TEST_CASE(
     SECTION("Null callback") {
       CHECK_THROWS(CallbackWrapperCAPI((tiledb_ls_callback_t) nullptr, &data));
     }
-    SECTION("Null data") {
-      CHECK_THROWS(CallbackWrapperCAPI(cb, nullptr));
-    }
     SECTION("Null callback and data") {
       CHECK_THROWS(
           CallbackWrapperCAPI((tiledb_ls_callback_t) nullptr, nullptr));
@@ -865,9 +824,6 @@ TEST_CASE(
     SECTION("Null callback") {
       CHECK_THROWS(
           CallbackWrapperCAPI((tiledb_ls_callback_v2_t) nullptr, &data));
-    }
-    SECTION("Null data") {
-      CHECK_THROWS(CallbackWrapperCAPI(cb, nullptr));
     }
     SECTION("Null callback and data") {
       CHECK_THROWS(

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -765,10 +765,10 @@ TEST_CASE(
     CHECK(data.size() == 1);
   }
   SECTION("Callback return 0 signals to stop traversal") {
-    CHECK_THROWS_AS(wrapper("some/dir/", 0) == 0, tiledb::sm::LsStopTraversal);
+    CHECK_THROWS_AS(wrapper("some/dir/", 0), tiledb::sm::LsStopTraversal);
   }
   SECTION("Callback exception is propagated") {
-    CHECK_THROWS_WITH(wrapper("path", 101) == 0, "Throwing callback");
+    CHECK_THROWS_WITH(wrapper("path", 101), "Throwing callback");
   }
 }
 

--- a/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
+++ b/tiledb/api/c_api/vfs/test/unit_capi_vfs.cc
@@ -745,10 +745,6 @@ TEST_CASE(
     auto rc{tiledb_vfs_ls_recursive_v2(x.ctx, x.vfs, TEST_URI, nullptr, &data)};
     CHECK(tiledb_status(rc) == TILEDB_ERR);
   }
-  SECTION("null data ptr") {
-    auto rc{tiledb_vfs_ls_recursive_v2(x.ctx, x.vfs, TEST_URI, cb, nullptr)};
-    CHECK(tiledb_status(rc) == TILEDB_ERR);
-  }
 }
 
 TEST_CASE(

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -300,39 +300,17 @@ capi_return_t tiledb_vfs_touch(tiledb_vfs_t* vfs, const char* uri) {
 capi_return_t tiledb_vfs_ls_recursive(
     tiledb_vfs_t* vfs,
     const char* path,
-    tiledb_ls_file_callback_t file_callback,
+    tiledb_ls_callback_t callback,
     void* data) {
   ensure_vfs_is_valid(vfs);
   if (path == nullptr) {
     throw CAPIStatusException("Invalid TileDB object: VFS passed a null path.");
-  } else if (file_callback == nullptr) {
+  } else if (callback == nullptr) {
     throw CAPIStatusException(
-        "Invalid TileDB object: File callback function is null.");
+        "Invalid TileDB object: Callback function is null.");
   }
   ensure_output_pointer_is_valid(data);
-  vfs->ls_recursive(tiledb::sm::URI(path), file_callback, data);
-  return TILEDB_OK;
-}
-
-capi_return_t tiledb_vfs_ls_recursive_v2(
-    tiledb_vfs_t* vfs,
-    const char* path,
-    tiledb_ls_file_callback_t file_callback,
-    tiledb_ls_dir_callback_t dir_callback,
-    void* data) {
-  ensure_vfs_is_valid(vfs);
-  if (path == nullptr) {
-    throw CAPIStatusException("Invalid TileDB object: VFS passed a null path.");
-  } else if (file_callback == nullptr) {
-    throw CAPIStatusException(
-        "Invalid TileDB object: File callback function is null.");
-  } else if (dir_callback == nullptr) {
-    throw CAPIStatusException(
-        "Invalid TileDB object: Directory callback function is null.");
-  }
-  ensure_output_pointer_is_valid(data);
-  vfs->ls_recursive_v2(
-      tiledb::sm::URI(path), file_callback, dir_callback, data);
+  vfs->ls_recursive(tiledb::sm::URI(path), callback, data);
   return TILEDB_OK;
 }
 
@@ -575,20 +553,8 @@ CAPI_INTERFACE(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
-    tiledb_ls_file_callback_t file_callback,
+    tiledb_ls_callback_t callback,
     void* data) {
   return api_entry_context<tiledb::api::tiledb_vfs_ls_recursive>(
-      ctx, vfs, path, file_callback, data);
-}
-
-CAPI_INTERFACE(
-    vfs_ls_recursive_v2,
-    tiledb_ctx_t* ctx,
-    tiledb_vfs_t* vfs,
-    const char* path,
-    tiledb_ls_file_callback_t file_callback,
-    tiledb_ls_dir_callback_t dir_callback,
-    void* data) {
-  return api_entry_context<tiledb::api::tiledb_vfs_ls_recursive_v2>(
-      ctx, vfs, path, file_callback, dir_callback, data);
+      ctx, vfs, path, callback, data);
 }

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -314,6 +314,23 @@ capi_return_t tiledb_vfs_ls_recursive(
   return TILEDB_OK;
 }
 
+capi_return_t tiledb_vfs_ls_recursive_v2(
+    tiledb_vfs_t* vfs,
+    const char* path,
+    tiledb_ls_callback_v2_t callback,
+    void* data) {
+  ensure_vfs_is_valid(vfs);
+  if (path == nullptr) {
+    throw CAPIStatusException("Invalid TileDB object: VFS passed a null path.");
+  } else if (callback == nullptr) {
+    throw CAPIStatusException(
+        "Invalid TileDB object: Callback function is null.");
+  }
+  ensure_output_pointer_is_valid(data);
+  vfs->ls_recursive_v2(tiledb::sm::URI(path), callback, data);
+  return TILEDB_OK;
+}
+
 }  // namespace tiledb::api
 
 using tiledb::api::api_entry_context;
@@ -556,5 +573,16 @@ CAPI_INTERFACE(
     tiledb_ls_callback_t callback,
     void* data) {
   return api_entry_context<tiledb::api::tiledb_vfs_ls_recursive>(
+      ctx, vfs, path, callback, data);
+}
+
+CAPI_INTERFACE(
+    vfs_ls_recursive_v2,
+    tiledb_ctx_t* ctx,
+    tiledb_vfs_t* vfs,
+    const char* path,
+    tiledb_ls_callback_v2_t callback,
+    void* data) {
+  return api_entry_context<tiledb::api::tiledb_vfs_ls_recursive_v2>(
       ctx, vfs, path, callback, data);
 }

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -309,7 +309,6 @@ capi_return_t tiledb_vfs_ls_recursive(
     throw CAPIStatusException(
         "Invalid TileDB object: Callback function is null.");
   }
-  ensure_output_pointer_is_valid(data);
   vfs->ls_recursive(tiledb::sm::URI(path), callback, data);
   return TILEDB_OK;
 }
@@ -326,7 +325,6 @@ capi_return_t tiledb_vfs_ls_recursive_v2(
     throw CAPIStatusException(
         "Invalid TileDB object: Callback function is null.");
   }
-  ensure_output_pointer_is_valid(data);
   vfs->ls_recursive_v2(tiledb::sm::URI(path), callback, data);
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -300,17 +300,39 @@ capi_return_t tiledb_vfs_touch(tiledb_vfs_t* vfs, const char* uri) {
 capi_return_t tiledb_vfs_ls_recursive(
     tiledb_vfs_t* vfs,
     const char* path,
-    tiledb_ls_callback_t callback,
+    tiledb_ls_file_callback_t file_callback,
     void* data) {
   ensure_vfs_is_valid(vfs);
   if (path == nullptr) {
     throw CAPIStatusException("Invalid TileDB object: VFS passed a null path.");
-  } else if (callback == nullptr) {
+  } else if (file_callback == nullptr) {
     throw CAPIStatusException(
-        "Invalid TileDB object: Callback function is null.");
+        "Invalid TileDB object: File callback function is null.");
   }
   ensure_output_pointer_is_valid(data);
-  vfs->ls_recursive(tiledb::sm::URI(path), callback, data);
+  vfs->ls_recursive(tiledb::sm::URI(path), file_callback, data);
+  return TILEDB_OK;
+}
+
+capi_return_t tiledb_vfs_ls_recursive_v2(
+    tiledb_vfs_t* vfs,
+    const char* path,
+    tiledb_ls_file_callback_t file_callback,
+    tiledb_ls_dir_callback_t dir_callback,
+    void* data) {
+  ensure_vfs_is_valid(vfs);
+  if (path == nullptr) {
+    throw CAPIStatusException("Invalid TileDB object: VFS passed a null path.");
+  } else if (file_callback == nullptr) {
+    throw CAPIStatusException(
+        "Invalid TileDB object: File callback function is null.");
+  } else if (dir_callback == nullptr) {
+    throw CAPIStatusException(
+        "Invalid TileDB object: Directory callback function is null.");
+  }
+  ensure_output_pointer_is_valid(data);
+  vfs->ls_recursive_v2(
+      tiledb::sm::URI(path), file_callback, dir_callback, data);
   return TILEDB_OK;
 }
 
@@ -553,8 +575,20 @@ CAPI_INTERFACE(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
-    tiledb_ls_callback_t callback,
+    tiledb_ls_file_callback_t file_callback,
     void* data) {
   return api_entry_context<tiledb::api::tiledb_vfs_ls_recursive>(
-      ctx, vfs, path, callback, data);
+      ctx, vfs, path, file_callback, data);
+}
+
+CAPI_INTERFACE(
+    vfs_ls_recursive_v2,
+    tiledb_ctx_t* ctx,
+    tiledb_vfs_t* vfs,
+    const char* path,
+    tiledb_ls_file_callback_t file_callback,
+    tiledb_ls_dir_callback_t dir_callback,
+    void* data) {
+  return api_entry_context<tiledb::api::tiledb_vfs_ls_recursive_v2>(
+      ctx, vfs, path, file_callback, dir_callback, data);
 }

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -75,8 +75,9 @@ typedef int32_t (*tiledb_ls_callback_v2_t)(
  * on error. The callback is responsible for writing gathered entries into the
  * `data` buffer, for example using a pointer to a user-defined struct.
  *
- * Currently only local filesystem, S3, Azure and GCS are supported, and the
- * `path` must be a valid URI for one of those filesystems.
+ * Currently LocalFS, S3, Azure, and GCS are supported. Objects and
+ * directories will be collected for LocalFS. Only objects will be collected
+ * for cloud storage backends such as S3, Azure, and GCS.
  *
  * **Example:**
  *
@@ -119,8 +120,12 @@ TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive(
  * on error. The callback is responsible for writing gathered entries into the
  * `data` buffer, for example using a pointer to a user-defined struct.
  *
- * Currently only local filesystem, S3, Azure and GCS are supported, and the
- * `path` must be a valid URI for one of those filesystems.
+ * Currently LocalFS, S3, Azure, and GCS are supported. The results will
+ * include objects and directories for all storage backends.
+ *
+ * The LsCallbackV2 used in this API adds an additional parameter for checking
+ * if the current result is a directory. This can be used by the caller to
+ * include or exclude directories as needed during traversal.
  *
  * **Example:**
  *

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -52,6 +52,16 @@ extern "C" {
 typedef int32_t (*tiledb_ls_callback_t)(
     const char* path, size_t path_len, uint64_t object_size, void* data);
 
+/**
+ * Typedef for ls_recursive_v2 callback function invoked on each object
+ * collected.
+ *
+ * @param path The path of a visited object for the relative filesystem.
+ * @param path_len The length of the path.
+ * @param object_size The size of the object at the current path.
+ * @param is_dir 1 if the current object is a directory, else 0.
+ * @param data Data passed to the callback used to store collected results.
+ */
 typedef int32_t (*tiledb_ls_callback_v2_t)(
     const char* path,
     size_t path_len,
@@ -103,6 +113,49 @@ TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive(
     tiledb_ls_callback_t callback,
     void* data) TILEDB_NOEXCEPT;
 
+/**
+ * Visits the children of `path` recursively, invoking the callback for each
+ * entry. The callback should return 1 to continue traversal, 0 to stop, or -1
+ * on error. The callback is responsible for writing gathered entries into the
+ * `data` buffer, for example using a pointer to a user-defined struct.
+ *
+ * Currently only local filesystem, S3, Azure and GCS are supported, and the
+ * `path` must be a valid URI for one of those filesystems.
+ *
+ * **Example:**
+ *
+ * @code{.c}
+ * int my_callback(
+ *     const char* path,
+ *     size_t path_length,
+ *     uint64_t file_size,
+ *     uint8_t is_dir,
+ *     void* data) {
+ *   MyCbStruct cb_data = static_cast<MyCbStruct*>(data);
+ *   // Perform custom callback behavior here.
+ *   return 1;  // Continue traversal to next entry.
+ * }
+ * MyCbStruct* cb_data = allocate_cb_struct();
+ *
+ * tiledb_vfs_ls_recursive_v2(
+ *     ctx, vfs, "s3://bucket/foo", my_callback, &cb_data);
+ * @endcode
+ *
+ * @param[in] ctx The TileDB context.
+ * @param[in] vfs The virtual filesystem object.
+ * @param[in] path The path in which the traversal will occur.
+ * @param[in] callback
+ * The callback function to be applied on every visited object.
+ *     The callback should return `0` if the iteration must stop, and `1`
+ *     if the iteration must continue. It takes as input the currently visited
+ *     path, the length of the currently visited path, the size of the file,
+ *     a uint8 marking the object as a directory or not, and user provided
+ *     buffer for paths and object sizes in the form of a struct pointer. The
+ *     callback returns `-1` upon error. Note that `path` in the callback will
+ *     be an **absolute** path.
+ * @param[in] data Data pointer passed into the callback for storing results.
+ * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
+ */
 TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive_v2(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -49,8 +49,19 @@ extern "C" {
  * @param object_size The size of the object at the current path.
  * @param data Data passed to the callback used to store collected results.
  */
-typedef int32_t (*tiledb_ls_callback_t)(
+typedef int32_t (*tiledb_ls_file_callback_t)(
     const char* path, size_t path_len, uint64_t object_size, void* data);
+
+/**
+ * Typedef for ls_recursive callback function invoked on each directory
+ * collected.
+ *
+ * @param path The path of a visited directory for the relative filesystem.
+ * @param path_len The length of the path.
+ * @param data Data passed to the callback used to store collected results.
+ */
+typedef int32_t (*tiledb_ls_dir_callback_t)(
+    const char* path, size_t path_len, void* data);
 
 /**
  * Visits the children of `path` recursively, invoking the callback for each
@@ -93,7 +104,15 @@ TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
-    tiledb_ls_callback_t callback,
+    tiledb_ls_file_callback_t file_callback,
+    void* data) TILEDB_NOEXCEPT;
+
+TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive_v2(
+    tiledb_ctx_t* ctx,
+    tiledb_vfs_t* vfs,
+    const char* path,
+    tiledb_ls_file_callback_t file_callback,
+    tiledb_ls_dir_callback_t dir_callback,
     void* data) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -49,19 +49,8 @@ extern "C" {
  * @param object_size The size of the object at the current path.
  * @param data Data passed to the callback used to store collected results.
  */
-typedef int32_t (*tiledb_ls_file_callback_t)(
+typedef int32_t (*tiledb_ls_callback_t)(
     const char* path, size_t path_len, uint64_t object_size, void* data);
-
-/**
- * Typedef for ls_recursive callback function invoked on each directory
- * collected.
- *
- * @param path The path of a visited directory for the relative filesystem.
- * @param path_len The length of the path.
- * @param data Data passed to the callback used to store collected results.
- */
-typedef int32_t (*tiledb_ls_dir_callback_t)(
-    const char* path, size_t path_len, void* data);
 
 /**
  * Visits the children of `path` recursively, invoking the callback for each
@@ -104,15 +93,7 @@ TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
-    tiledb_ls_file_callback_t file_callback,
-    void* data) TILEDB_NOEXCEPT;
-
-TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive_v2(
-    tiledb_ctx_t* ctx,
-    tiledb_vfs_t* vfs,
-    const char* path,
-    tiledb_ls_file_callback_t file_callback,
-    tiledb_ls_dir_callback_t dir_callback,
+    tiledb_ls_callback_t callback,
     void* data) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -41,6 +41,7 @@
 extern "C" {
 #endif
 
+#ifndef TILEDB_REMOVE_DEPRECATIONS
 /**
  * Typedef for ls_recursive callback function invoked on each object collected.
  *
@@ -51,23 +52,6 @@ extern "C" {
  */
 typedef int32_t (*tiledb_ls_callback_t)(
     const char* path, size_t path_len, uint64_t object_size, void* data);
-
-/**
- * Typedef for ls_recursive_v2 callback function invoked on each object
- * collected.
- *
- * @param path The path of a visited object for the relative filesystem.
- * @param path_len The length of the path.
- * @param object_size The size of the object at the current path.
- * @param is_dir 1 if the current object is a directory, else 0.
- * @param data Data passed to the callback used to store collected results.
- */
-typedef int32_t (*tiledb_ls_callback_v2_t)(
-    const char* path,
-    size_t path_len,
-    uint64_t object_size,
-    uint8_t is_dir,
-    void* data);
 
 /**
  * Visits the children of `path` recursively, invoking the callback for each
@@ -107,12 +91,30 @@ typedef int32_t (*tiledb_ls_callback_v2_t)(
  * @param[in] data Data pointer passed into the callback for storing results.
  * @return `TILEDB_OK` for success and `TILEDB_ERR` for error.
  */
-TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive(
+TILEDB_DEPRECATED_EXPORT capi_return_t tiledb_vfs_ls_recursive(
     tiledb_ctx_t* ctx,
     tiledb_vfs_t* vfs,
     const char* path,
     tiledb_ls_callback_t callback,
     void* data) TILEDB_NOEXCEPT;
+#endif  // TILEDB_REMOVE_DEPRECATIONS
+
+/**
+ * Typedef for ls_recursive_v2 callback function invoked on each object
+ * collected.
+ *
+ * @param path The path of a visited object for the relative filesystem.
+ * @param path_len The length of the path.
+ * @param object_size The size of the object at the current path.
+ * @param is_dir 1 if the current object is a directory, else 0.
+ * @param data Data passed to the callback used to store collected results.
+ */
+typedef int32_t (*tiledb_ls_callback_v2_t)(
+    const char* path,
+    size_t path_len,
+    uint64_t object_size,
+    uint8_t is_dir,
+    void* data);
 
 /**
  * Visits the children of `path` recursively, invoking the callback for each

--- a/tiledb/api/c_api/vfs/vfs_api_experimental.h
+++ b/tiledb/api/c_api/vfs/vfs_api_experimental.h
@@ -52,6 +52,13 @@ extern "C" {
 typedef int32_t (*tiledb_ls_callback_t)(
     const char* path, size_t path_len, uint64_t object_size, void* data);
 
+typedef int32_t (*tiledb_ls_callback_v2_t)(
+    const char* path,
+    size_t path_len,
+    uint64_t object_size,
+    uint8_t is_dir,
+    void* data);
+
 /**
  * Visits the children of `path` recursively, invoking the callback for each
  * entry. The callback should return 1 to continue traversal, 0 to stop, or -1
@@ -94,6 +101,13 @@ TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive(
     tiledb_vfs_t* vfs,
     const char* path,
     tiledb_ls_callback_t callback,
+    void* data) TILEDB_NOEXCEPT;
+
+TILEDB_EXPORT capi_return_t tiledb_vfs_ls_recursive_v2(
+    tiledb_ctx_t* ctx,
+    tiledb_vfs_t* vfs,
+    const char* path,
+    tiledb_ls_callback_v2_t callback,
     void* data) TILEDB_NOEXCEPT;
 
 #ifdef __cplusplus

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -150,11 +150,24 @@ struct tiledb_vfs_handle_t
 
   void ls_recursive(
       const tiledb::sm::URI& parent,
-      tiledb_ls_callback_t cb,
+      tiledb_ls_file_callback_t file_cb,
       void* data) const {
-    tiledb::sm::CallbackWrapperCAPI wrapper(cb, data);
+    tiledb::sm::CallbackWrapperCAPI wrapper(file_cb, data);
     try {
       vfs_.ls_recursive(parent, wrapper);
+    } catch (const tiledb::sm::LsStopTraversal&) {
+      // Ignore exception
+    }
+  }
+
+  void ls_recursive_v2(
+      const tiledb::sm::URI& parent,
+      tiledb_ls_file_callback_t file_cb,
+      tiledb_ls_dir_callback_t dir_cb,
+      void* data) const {
+    tiledb::sm::CallbackWrapperCAPI wrapper(file_cb, dir_cb, data);
+    try {
+      vfs_.ls_recursive(parent, wrapper, wrapper);
     } catch (const tiledb::sm::LsStopTraversal&) {
       // Ignore exception
     }

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -150,24 +150,11 @@ struct tiledb_vfs_handle_t
 
   void ls_recursive(
       const tiledb::sm::URI& parent,
-      tiledb_ls_file_callback_t file_cb,
+      tiledb_ls_callback_t cb,
       void* data) const {
-    tiledb::sm::CallbackWrapperCAPI wrapper(file_cb, data);
+    tiledb::sm::CallbackWrapperCAPI wrapper(cb, data);
     try {
       vfs_.ls_recursive(parent, wrapper);
-    } catch (const tiledb::sm::LsStopTraversal&) {
-      // Ignore exception
-    }
-  }
-
-  void ls_recursive_v2(
-      const tiledb::sm::URI& parent,
-      tiledb_ls_file_callback_t file_cb,
-      tiledb_ls_dir_callback_t dir_cb,
-      void* data) const {
-    tiledb::sm::CallbackWrapperCAPI wrapper(file_cb, dir_cb, data);
-    try {
-      vfs_.ls_recursive(parent, wrapper, wrapper);
     } catch (const tiledb::sm::LsStopTraversal&) {
       // Ignore exception
     }

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -159,6 +159,18 @@ struct tiledb_vfs_handle_t
       // Ignore exception
     }
   }
+
+  void ls_recursive_v2(
+      const tiledb::sm::URI& parent,
+      tiledb_ls_callback_v2_t cb,
+      void* data) const {
+    tiledb::sm::CallbackWrapperCAPI wrapper(cb, data);
+    try {
+      vfs_.ls_recursive_v2(parent, wrapper);
+    } catch (const tiledb::sm::LsStopTraversal&) {
+      // Ignore exception
+    }
+  }
 };
 
 /** Handle `struct` for API VFS file handle objects. */

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -82,7 +82,7 @@ class VFSExperimental {
    */
   using LsObjects = std::vector<std::pair<std::string, uint64_t>>;
 
-  /** Class to wrap C++ FilePredicate for passing to the C API. */
+  /** Class to wrap C++ FilterPredicate for passing to the C API. */
   class CallbackWrapperCPP {
    public:
     /** Default constructor is deleted */
@@ -97,7 +97,7 @@ class VFSExperimental {
     }
 
     /**
-     * Operator to wrap the FilePredicate used in the C++ API.
+     * Operator to wrap the FilterPredicate used in the C++ API.
      *
      * @param path The path of the object.
      * @param size The size of the object in bytes.

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -58,7 +58,8 @@ class VFSExperimental {
    * @param object_size The size of the object at the current path.
    * @return True if the walk should continue, else false.
    */
-  using LsCallback = std::function<bool(std::string_view, uint64_t)>;
+  using LsFileCallback = std::function<bool(std::string_view, uint64_t)>;
+  using LsDirCallback = std::function<bool(std::string_view)>;
 
   /**
    * Typedef for ls inclusion predicate function used to check if a single
@@ -72,7 +73,8 @@ class VFSExperimental {
    * @param object_size The size of the object at the current path.
    * @return True if the result should be included, else false.
    */
-  using LsInclude = std::function<bool(std::string_view, uint64_t)>;
+  using LsIncludeFile = std::function<bool(std::string_view, uint64_t)>;
+  using LsIncludeDir = std::function<bool(std::string_view)>;
 
   /**
    * Default typedef for objects collected by recursive ls, storing a vector of
@@ -89,26 +91,54 @@ class VFSExperimental {
     CallbackWrapperCPP() = delete;
 
     /** Constructor */
-    CallbackWrapperCPP(LsCallback cb)
-        : cb_(cb) {
-      if (cb_ == nullptr) {
-        throw std::logic_error("ls_recursive callback function cannot be null");
+    explicit CallbackWrapperCPP(LsFileCallback file_cb)
+        : file_cb_(std::move(file_cb))
+        , include_dirs_(false) {
+      if (file_cb_ == nullptr) {
+        throw std::logic_error(
+            "ls_recursive files callback function cannot be null");
+      }
+    }
+
+    /** Constructor */
+    CallbackWrapperCPP(LsFileCallback file_cb, LsDirCallback dir_cb)
+        : file_cb_(std::move(file_cb))
+        , dir_cb_(std::move(dir_cb))
+        , include_dirs_(true) {
+      if (file_cb_ == nullptr) {
+        throw std::logic_error(
+            "ls_recursive files callback function cannot be null");
+      } else if (dir_cb_ == nullptr) {
+        throw std::logic_error(
+            "ls_recursive directory callback function cannot be null");
       }
     }
 
     /**
-     * Operator to wrap the FilePredicate used in the C++ API.
+     * Operator to wrap the FileFilter used in the C++ API.
      *
      * @param path The path of the object.
      * @param size The size of the object in bytes.
      * @return True if the object should be included, False otherwise.
      */
     bool operator()(std::string_view path, uint64_t size) {
-      return cb_(path, size);
+      return file_cb_(path, size);
+    }
+
+    /**
+     * Operator to wrap the DirectoryFilter used in the C++ API.
+     *
+     * @param path The path of the object.
+     * @return True if the directory should be included, False otherwise.
+     */
+    bool operator()(std::string_view path) {
+      return dir_cb_(path);
     }
 
    private:
-    LsCallback cb_;
+    LsFileCallback file_cb_;
+    LsDirCallback dir_cb_;
+    bool include_dirs_;
   };
 
   /* ********************************* */
@@ -145,14 +175,26 @@ class VFSExperimental {
       const Context& ctx,
       const VFS& vfs,
       const std::string& uri,
-      LsCallback cb) {
-    CallbackWrapperCPP wrapper(cb);
-    ctx.handle_error(tiledb_vfs_ls_recursive(
-        ctx.ptr().get(),
-        vfs.ptr().get(),
-        uri.c_str(),
-        ls_callback_wrapper,
-        &wrapper));
+      LsFileCallback file_cb,
+      std::optional<LsDirCallback> dir_cb = std::nullopt) {
+    if (dir_cb.has_value()) {
+      CallbackWrapperCPP wrapper(std::move(file_cb), dir_cb.value());
+      ctx.handle_error(tiledb_vfs_ls_recursive_v2(
+          ctx.ptr().get(),
+          vfs.ptr().get(),
+          uri.c_str(),
+          ls_callback_file_wrapper,
+          ls_callback_dir_wrapper,
+          &wrapper));
+    } else {
+      CallbackWrapperCPP wrapper(std::move(file_cb));
+      ctx.handle_error(tiledb_vfs_ls_recursive(
+          ctx.ptr().get(),
+          vfs.ptr().get(),
+          uri.c_str(),
+          ls_callback_file_wrapper,
+          &wrapper));
+    }
   }
 
   /**
@@ -188,22 +230,26 @@ class VFSExperimental {
       const Context& ctx,
       const VFS& vfs,
       const std::string& uri,
-      std::optional<LsInclude> include = std::nullopt) {
+      std::optional<LsIncludeFile> include_file = std::nullopt,
+      std::optional<LsIncludeDir> include_dir = std::nullopt) {
     LsObjects ls_objects;
-    if (include.has_value()) {
-      auto include_cb = include.value();
-      ls_recursive(ctx, vfs, uri, [&](std::string_view path, uint64_t size) {
-        if (include_cb(path, size)) {
-          ls_objects.emplace_back(path, size);
-        }
-        return true;
-      });
-    } else {
-      ls_recursive(ctx, vfs, uri, [&](std::string_view path, uint64_t size) {
-        ls_objects.emplace_back(path, size);
-        return true;
-      });
-    }
+    // If either of the filters do not have a value, accept all entries.
+    ls_recursive(
+        ctx,
+        vfs,
+        uri,
+        [&](std::string_view path, uint64_t size) {
+          if (!include_file.has_value() || include_file.value()(path, size)) {
+            ls_objects.emplace_back(path, size);
+          }
+          return true;
+        },
+        [&](std::string_view path) {
+          if (!include_dir.has_value() || include_dir.value()(path)) {
+            ls_objects.emplace_back(path, 0);
+          }
+          return true;
+        });
     return ls_objects;
   }
 
@@ -223,10 +269,26 @@ class VFSExperimental {
    *      traversal.
    * @sa tiledb_ls_callback_t
    */
-  static int32_t ls_callback_wrapper(
+  static int32_t ls_callback_file_wrapper(
       const char* path, size_t path_len, uint64_t object_size, void* data) {
     CallbackWrapperCPP* cb = static_cast<CallbackWrapperCPP*>(data);
     return (*cb)({path, path_len}, object_size);
+  }
+
+  /**
+   * Callback function for invoking the C++ ls_recursive callback via C API.
+   *
+   * @param path The path of a visited directory for the relative filesystem.
+   * @param path_len The length of the path.
+   * @param data Data passed to the callback used to store collected results.
+   * @return 1 if the callback should continue to the next object, or 0 to stop
+   *      traversal.
+   * @sa tiledb_ls_callback_t
+   */
+  static int32_t ls_callback_dir_wrapper(
+      const char* path, size_t path_len, void* data) {
+    CallbackWrapperCPP* cb = static_cast<CallbackWrapperCPP*>(data);
+    return (*cb)({path, path_len});
   }
 };
 }  // namespace tiledb

--- a/tiledb/sm/cpp_api/vfs_experimental.h
+++ b/tiledb/sm/cpp_api/vfs_experimental.h
@@ -221,6 +221,10 @@ class VFSExperimental {
    * Currently LocalFS, S3, Azure, and GCS are supported. The results will
    * include objects and directories for all storage backends.
    *
+   * The LsCallbackV2 used in this API adds an additional parameter for checking
+   * if the current result is a directory. This can be used by the caller to
+   * include or exclude directories as needed during traversal.
+   *
    * @code{.c}
    * VFSExperimental::LsObjects ls_objects;
    * VFSExperimental::LsCallbackV2 cb = [&](const std::string_view& path,
@@ -319,10 +323,14 @@ class VFSExperimental {
    * `path` must be a valid URI for one of those filesystems. The results will
    * include objects and directories for all storage backends.
    *
+   * The LsIncludeV2 inclusion predicate used in this API adds an additional
+   * parameter for checking if the current result is a directory. This can be
+   * used by the caller to include or exclude directories as needed.
+   *
    * @code{.c}
-   * VFSExperimental::LsInclude predicate = [](std::string_view path,
-   *                                           uint64_t object_size,
-   *                                           bool is_dir) {
+   * VFSExperimental::LsIncludeV2 predicate = [](std::string_view path,
+   *                                             uint64_t object_size,
+   *                                             bool is_dir) {
    *   return path.find(".txt") != std::string::npos;
    * }
    * // Include only files with '.txt' extension using a custom predicate.

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1077,12 +1077,11 @@ std::string Azure::BlockListUploadState::next_block_id() {
 AzureScanner::AzureScanner(
     const Azure& client,
     const URI& prefix,
-    FileFilter&& file_filter,
-    DirectoryFilter&& dir_filter,
+    ResultFilter&& result_filter,
     bool recursive,
     int max_keys)
     : LsScanner(
-          prefix, std::move(file_filter), std::move(dir_filter), recursive)
+          prefix, std::move(result_filter), recursive)
     , client_(client)
     , max_keys_(max_keys)
     , has_fetched_(false) {
@@ -1105,11 +1104,12 @@ void AzureScanner::next(typename Iterator::pointer& ptr) {
     auto& object = *ptr;
 
     // TODO: Add support for directory pruning.
-    if (this->file_filter_(object.first, object.second)) {
+    if (this->result_filter_(object.first, object.second)) {
       // Iterator is at the next object within results accepted by the filters.
       return;
     } else {
-      // Object was rejected by the FilePredicate, do not include it in results.
+      // Object was rejected by the FilterPredicate, do not include it in
+      // results.
       advance(ptr);
     }
   }

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1092,11 +1092,6 @@ AzureScanner::AzureScanner(
       Azure::parse_azure_uri(prefix.add_trailing_slash());
   fetch_results();
   next(begin_);
-
-  // This case is hit when all files are rejected by the result_filter.
-  if (begin_ == end_ && !collected_prefixes_.empty() && !more_to_fetch()) {
-    next(build_prefix_vector());
-  }
 }
 
 void AzureScanner::next(typename Iterator::pointer& ptr) {
@@ -1110,7 +1105,7 @@ void AzureScanner::next(typename Iterator::pointer& ptr) {
   while (ptr != end_) {
     auto& object = *ptr;
 
-    // Store each unique prefix while scanning S3 objects.
+    // Store each unique prefix while scanning objects.
     if (result_type_ == OBJECT) {
       // The object key contains the azure:// prefix and the bucket name.
       auto prefix = object.first;

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1145,6 +1145,7 @@ AzureScanner::Iterator::pointer AzureScanner::fetch_results() {
     begin_ = end_ = typename Iterator::pointer();
     return end_;
   }
+  result_type_ = OBJECT;
 
   blobs_ = client_.list_blobs_impl(
       container_name_,

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -1080,8 +1080,7 @@ AzureScanner::AzureScanner(
     ResultFilter&& result_filter,
     bool recursive,
     int max_keys)
-    : LsScanner(
-          prefix, std::move(result_filter), recursive)
+    : LsScanner(prefix, std::move(result_filter), recursive)
     , client_(client)
     , max_keys_(max_keys)
     , has_fetched_(false) {

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -161,8 +161,7 @@ class AzureScanner : public LsScanner {
   AzureScanner(
       const Azure& client,
       const URI& prefix,
-      FileFilter&& file_filter,
-      DirectoryFilter&& dir_filter = accept_all_dirs,
+      ResultFilter&& result_filter,
       bool recursive = false,
       int max_keys = 1000);
 
@@ -408,19 +407,15 @@ class Azure : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the FileFilter on each entry collected and the DirectoryFilter on
-   * common prefixes for pruning.
+   * the ResultFilter on each entry collected.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FileFilter to invoke on each object for filtering.
-   * @param d The DirectoryFilter to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
+   * @param f The ResultFilter to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
    */
   LsObjects ls_filtered(
       const URI& parent,
-      FileFilter f,
-      DirectoryFilter d = accept_all_dirs,
+      ResultFilter f,
       bool recursive = false) const override {
     AzureScanner azure_scanner =
         scanner(parent, std::move(f), std::move(d), recursive);
@@ -438,17 +433,14 @@ class Azure : public FilesystemBase {
    * or STL constructors supporting initialization via input iterators.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FileFilter to invoke on each object for filtering.
-   * @param d The DirectoryFilter to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
+   * @param f The ResultFilter to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
    * @param max_keys The maximum number of keys to retrieve per request.
    * @return Fully constructed AzureScanner object.
    */
   AzureScanner scanner(
       const URI& parent,
-      FileFilter&& f,
-      DirectoryFilter&& d = accept_all_dirs,
+      ResultFilter&& f,
       bool recursive = false,
       int max_keys = 1000) const {
     return AzureScanner(

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -442,8 +442,9 @@ class Azure : public FilesystemBase {
     AzureScanner azure_scanner = scanner(parent, std::move(f), recursive);
 
     LsObjects objects;
-    for (auto object : azure_scanner) {
-      objects.push_back(std::move(object));
+    for (const auto& object : azure_scanner) {
+      objects.emplace_back(
+          Azure::remove_trailing_slash(object.first), object.second);
     }
     return objects;
   }
@@ -463,8 +464,9 @@ class Azure : public FilesystemBase {
     AzureScanner azure_scanner = scanner_v2(parent, std::move(f), recursive);
 
     LsObjects objects;
-    for (auto object : azure_scanner) {
-      objects.push_back(std::move(object));
+    for (const auto& object : azure_scanner) {
+      objects.emplace_back(
+          Azure::remove_trailing_slash(object.first), object.second);
     }
     return objects;
   }

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -227,17 +227,7 @@ class AzureScanner : public LsScanner {
    *
    * @returns Iterator to the beginning of the prefix vector.
    */
-  typename Iterator::pointer& build_prefix_vector() {
-    result_type_ = PREFIX;
-    common_prefixes_.resize(collected_prefixes_.size());
-    for (auto& object : common_prefixes_) {
-      auto next = collected_prefixes_.begin();
-      object.first = collected_prefixes_.extract(next).value();
-      object.second = 0;
-    }
-    end_ = common_prefixes_.end();
-    return begin_ = common_prefixes_.begin();
-  }
+  typename Iterator::pointer& build_prefix_vector();
 
   /**
    * Fetch the next batch of results from Azure. This also handles setting the

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -451,11 +451,15 @@ class Azure : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the ResultFilter on each entry collected.
+   * the ResultFilterV2 on each entry collected. Both objects and common
+   * prefixes will be collected.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param result_filter The ResultFilterV2 to invoke on each object for
+   * filtering.
    * @param recursive Whether to recursively list subdirectories.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
    */
   LsObjects ls_filtered_v2(
       const URI& parent,
@@ -496,7 +500,7 @@ class Azure : public FilesystemBase {
    * or STL constructors supporting initialization via input iterators.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param f The ResultFilterV2 to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
    * @param max_keys The maximum number of keys to retrieve per request.
    * @return Fully constructed AzureScanner object.

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -38,7 +38,7 @@ namespace tiledb::sm {
 /*                API                */
 /* ********************************* */
 
-LsObjects FilesystemBase::ls_filtered(const URI&, FileFilter, bool) const {
+LsObjects FilesystemBase::ls_filtered(const URI&, ResultFilter, bool) const {
   throw UnsupportedOperation("ls_filtered");
 }
 

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -42,6 +42,11 @@ LsObjects FilesystemBase::ls_filtered(const URI&, ResultFilter, bool) const {
   throw UnsupportedOperation("ls_filtered");
 }
 
+LsObjects FilesystemBase::ls_filtered_v2(
+    const URI&, ResultFilterV2, bool) const {
+  throw UnsupportedOperation("ls_filtered");
+}
+
 void FilesystemBase::move_file(const URI&, const URI&) const {
   throw UnsupportedOperation("move_file");
 }

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -38,8 +38,7 @@ namespace tiledb::sm {
 /*                API                */
 /* ********************************* */
 
-LsObjects FilesystemBase::ls_filtered(
-    const URI&, FileFilter, DirectoryFilter, bool) const {
+LsObjects FilesystemBase::ls_filtered(const URI&, FileFilter, bool) const {
   throw UnsupportedOperation("ls_filtered");
 }
 

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -154,21 +154,18 @@ class FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the FileFilter on each entry collected and the DirectoryFilter on
-   * common prefixes for pruning.
+   * the FileFilter on each entry collected.
    *
    * Currently this API is only supported for local files, S3 and Azure.
    *
    * @param parent The parent prefix to list sub-paths.
    * @param f The FileFilter to invoke on each object for filtering.
-   * @param d The DirectoryFilter to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
    * @param recursive Whether to list the objects recursively.
    * @return Vector of results with each entry being a pair of the string URI
    *    and object size.
    */
   virtual LsObjects ls_filtered(
-      const URI& parent, FileFilter f, DirectoryFilter d, bool recursive) const;
+      const URI& parent, FileFilter f, bool recursive) const;
 
   /**
    * Renames a file.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -168,6 +168,21 @@ class FilesystemBase {
       const URI& parent, ResultFilter f, bool recursive) const;
 
   /**
+   * Lists objects and object information that start with `prefix`, invoking
+   * the ResultFilter on each entry collected.
+   *
+   * Currently this API is only supported for local files, S3 and Azure.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param recursive Whether to list the objects recursively.
+   * @return Vector of results with each entry being a pair of the string URI
+   *    and object size.
+   */
+  virtual LsObjects ls_filtered_v2(
+      const URI& parent, ResultFilterV2 f, bool recursive) const;
+
+  /**
    * Renames a file.
    * Both URI must be of the same backend type. (e.g. both s3://, file://, etc)
    *

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -154,18 +154,18 @@ class FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the FileFilter on each entry collected.
+   * the ResultFilter on each entry collected.
    *
    * Currently this API is only supported for local files, S3 and Azure.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FileFilter to invoke on each object for filtering.
+   * @param f The ResultFilter to invoke on each object for filtering.
    * @param recursive Whether to list the objects recursively.
    * @return Vector of results with each entry being a pair of the string URI
    *    and object size.
    */
   virtual LsObjects ls_filtered(
-      const URI& parent, FileFilter f, bool recursive) const;
+      const URI& parent, ResultFilter f, bool recursive) const;
 
   /**
    * Renames a file.

--- a/tiledb/sm/filesystem/filesystem_base.h
+++ b/tiledb/sm/filesystem/filesystem_base.h
@@ -156,7 +156,7 @@ class FilesystemBase {
    * Lists objects and object information that start with `prefix`, invoking
    * the ResultFilter on each entry collected.
    *
-   * Currently this API is only supported for local files, S3 and Azure.
+   * Currently this API is only supported for local files, S3, Azure, and GCS.
    *
    * @param parent The parent prefix to list sub-paths.
    * @param f The ResultFilter to invoke on each object for filtering.
@@ -171,10 +171,10 @@ class FilesystemBase {
    * Lists objects and object information that start with `prefix`, invoking
    * the ResultFilter on each entry collected.
    *
-   * Currently this API is only supported for local files, S3 and Azure.
+   * Currently this API is only supported for local files, S3, Azure, and GCS.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param f The ResultFilterV2 to invoke on each object for filtering.
    * @param recursive Whether to list the objects recursively.
    * @return Vector of results with each entry being a pair of the string URI
    *    and object size.

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -580,7 +580,8 @@ LsObjects GCS::ls_filtered(
       } else {
         entry = {
             prefix + bucket_name + "/" +
-                absl::get<std::string>(*object_metadata),
+                remove_front_slash(remove_trailing_slash(
+                    absl::get<std::string>(*object_metadata))),
             0};
       }
       if (result_filter(entry.first, entry.second)) {
@@ -669,18 +670,21 @@ LsObjects GCS::ls_filtered_v2(
       }
 
       LsObjects::value_type entry;
-      if (absl::holds_alternative<google::cloud::storage::ObjectMetadata>(
-              *object_metadata)) {
+      bool is_object =
+          absl::holds_alternative<google::cloud::storage::ObjectMetadata>(
+              *object_metadata);
+      if (is_object) {
         entry = to_directory_entry(
             absl::get<google::cloud::storage::ObjectMetadata>(
                 *object_metadata));
       } else {
         entry = {
             prefix + bucket_name + "/" +
-                absl::get<std::string>(*object_metadata),
+                remove_front_slash(remove_trailing_slash(
+                    absl::get<std::string>(*object_metadata))),
             0};
       }
-      if (result_filter(entry.first, entry.second, false)) {
+      if (result_filter(entry.first, entry.second, !is_object)) {
         result.push_back(std::move(entry));
       }
     }

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -629,7 +629,7 @@ void GCS::move_file(const URI& old_uri, const URI& new_uri) const {
 
 void GCS::copy_dir(const URI& old_uri, const URI& new_uri) const {
   throw_if_not_ok(init_client());
-  auto paths = ls_filtered(old_uri, LsScanner::accept_all, true);
+  auto paths = ls_filtered(old_uri, LsScanner::accept_all_files, true);
   for (auto& path : paths) {
     std::string path_str = std::get<0>(path);
     std::string filename = path_str.substr(old_uri.to_string().length());

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -518,10 +518,7 @@ std::vector<directory_entry> GCS::ls_with_sizes(const URI& uri) const {
 }
 
 LsObjects GCS::ls_filtered(
-    const URI& parent,
-    FileFilter file_filter,
-    DirectoryFilter,
-    bool recursive) const {
+    const URI& parent, ResultFilter result_filter, bool recursive) const {
   throw_if_not_ok(init_client());
 
   const URI uri_dir = parent.add_trailing_slash();
@@ -558,7 +555,7 @@ LsObjects GCS::ls_filtered(
       }
 
       auto entry = to_directory_entry(*object_metadata);
-      if (file_filter(entry.first, entry.second)) {
+      if (result_filter(entry.first, entry.second)) {
         result.emplace_back(std::move(entry));
       }
     }
@@ -586,7 +583,7 @@ LsObjects GCS::ls_filtered(
                 absl::get<std::string>(*object_metadata),
             0};
       }
-      if (file_filter(entry.first, entry.second)) {
+      if (result_filter(entry.first, entry.second)) {
         result.push_back(std::move(entry));
       }
     }

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -567,11 +567,8 @@ LsObjects GCS::ls_filtered(
         if (entry_prefix == parent.to_string() ||
             collected_prefixes.contains(entry_prefix)) {
           break;
-        } else {
-          if (!collected_prefixes.emplace(entry_prefix).second) {
-            throw GCSException(
-                "Failed to emplace prefix: '" + entry_prefix + "'");
-          }
+        } else if (result_filter(entry_prefix, 0)) {
+          collected_prefixes.emplace(entry_prefix, 0);
         }
       }
 
@@ -580,13 +577,10 @@ LsObjects GCS::ls_filtered(
       }
     }
 
-    // Insert the collected prefixes into the results
+    // Insert the collected prefixes into the results.
     for (auto& p : collected_prefixes) {
-      if (result_filter(p, 0)) {
-        result.emplace_back(std::move(p), 0);
-      }
+      result.emplace_back(std::move(p), 0);
     }
-    collected_prefixes.clear();
 
   } else {
     auto it = client_->ListObjectsAndPrefixes(

--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -600,7 +600,7 @@ void GCS::move_file(const URI& old_uri, const URI& new_uri) const {
 
 void GCS::copy_dir(const URI& old_uri, const URI& new_uri) const {
   throw_if_not_ok(init_client());
-  auto paths = ls_filtered(old_uri, accept_all_files, accept_all_dirs, true);
+  auto paths = ls_filtered(old_uri, LsScanner::accept_all, true);
   for (auto& path : paths) {
     std::string path_str = std::get<0>(path);
     std::string filename = path_str.substr(old_uri.to_string().length());

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -323,10 +323,11 @@ class GCS : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the ResultFilter on each entry collected.
+   * the ResultFilterV2 on each entry collected. Both objects and common
+   * prefixes will be collected.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param result_filter The ResultFilter to invoke on each object for
+   * @param result_filter The ResultFilterV2 to invoke on each object for
    * filtering.
    * @param recursive Whether to recursively list subdirectories.
    * @return Vector of results with each entry being a pair of the string URI

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -322,6 +322,22 @@ class GCS : public FilesystemBase {
       bool recursive) const override;
 
   /**
+   * Lists objects and object information that start with `prefix`, invoking
+   * the ResultFilter on each entry collected.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param result_filter The ResultFilter to invoke on each object for
+   * filtering.
+   * @param recursive Whether to recursively list subdirectories.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
+   */
+  LsObjects ls_filtered_v2(
+      const URI& parent,
+      ResultFilterV2 result_filter,
+      bool recursive) const override;
+
+  /**
    *
    * Lists objects and object information that start with `prefix`.
    *

--- a/tiledb/sm/filesystem/gcs.h
+++ b/tiledb/sm/filesystem/gcs.h
@@ -307,23 +307,18 @@ class GCS : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the FileFilter on each entry collected and the DirectoryFilter on
-   * common prefixes for pruning.
+   * the ResultFilter on each entry collected.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param file_filter The FileFilter to invoke on each object for
+   * @param result_filter The ResultFilter to invoke on each object for
    * filtering.
-   * @param directory_filter The DirectoryFilter to invoke on each common
-   * prefix for pruning. This is currently unused, but is kept here for future
-   * support.
    * @param recursive Whether to recursively list subdirectories.
    * @return Vector of results with each entry being a pair of the string URI
    * and object size.
    */
   LsObjects ls_filtered(
       const URI& parent,
-      FileFilter file_filter,
-      DirectoryFilter directory_filter,
+      ResultFilter result_filter,
       bool recursive) const override;
 
   /**
@@ -701,7 +696,7 @@ class GCS : public FilesystemBase {
    * Contains the implementation of ls_filtered.
    *
    * @param uri The parent path to list sub-paths.
-   * @param file_filter The FileFilter to invoke on each object for
+   * @param result_filter The ResultFilter to invoke on each object for
    * filtering.
    * @param recursive Whether to recursively list subdirectories.
    * @return Vector of results with each entry being a pair of the string URI
@@ -709,7 +704,7 @@ class GCS : public FilesystemBase {
    */
   LsObjects ls_filtered_impl(
       const URI& uri,
-      std::function<bool(const std::string_view, uint64_t)> file_filter,
+      std::function<bool(const std::string_view, uint64_t)> result_filter,
       bool recursive) const;
 
   /**

--- a/tiledb/sm/filesystem/local.cc
+++ b/tiledb/sm/filesystem/local.cc
@@ -41,7 +41,7 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 LsObjects LocalFilesystem::ls_filtered(
-    const URI& parent, FileFilter file_filter, bool recursive) const {
+    const URI& parent, ResultFilter result_filter, bool recursive) const {
   /*
    * The input URI was useful to the top-level VFS to identify this is a
    * regular filesystem path, but we don't need the "file://" qualifier
@@ -61,14 +61,11 @@ LsObjects LocalFilesystem::ls_filtered(
     const auto abspath = entry.path().string();
     const auto absuri = URI(abspath);
     if (entry.is_directory()) {
-      if (file_filter(absuri, 0)) {
+      if (result_filter(absuri, 0)) {
         qualifyingPaths.push_back(
             std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
-        if (!recursive) {
-          iter.disable_recursion_pending();
-        }
-      } else {
-        /* do not descend into directories which don't qualify */
+      }
+      if (!recursive) {
         iter.disable_recursion_pending();
       }
     } else {
@@ -77,7 +74,7 @@ LsObjects LocalFilesystem::ls_filtered(
        * (or symbolic link - split to a separate case if we want to descend into
        * them)
        */
-      if (file_filter(absuri, entry.file_size())) {
+      if (result_filter(absuri, entry.file_size())) {
         qualifyingPaths.push_back(
             std::make_pair(absuri.to_string(), entry.file_size()));
       }

--- a/tiledb/sm/filesystem/local.cc
+++ b/tiledb/sm/filesystem/local.cc
@@ -62,8 +62,7 @@ LsObjects LocalFilesystem::ls_filtered(
     const auto absuri = URI(abspath);
     if (entry.is_directory()) {
       if (result_filter(absuri, 0)) {
-        qualifyingPaths.push_back(
-            std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
+        qualifyingPaths.emplace_back(tiledb::sm::URI(abspath).to_string(), 0);
       }
       if (!recursive) {
         iter.disable_recursion_pending();
@@ -75,8 +74,7 @@ LsObjects LocalFilesystem::ls_filtered(
        * them)
        */
       if (result_filter(absuri, entry.file_size())) {
-        qualifyingPaths.push_back(
-            std::make_pair(absuri.to_string(), entry.file_size()));
+        qualifyingPaths.emplace_back(absuri.to_string(), entry.file_size());
       }
     }
   }

--- a/tiledb/sm/filesystem/local.cc
+++ b/tiledb/sm/filesystem/local.cc
@@ -41,10 +41,7 @@ using namespace tiledb::common;
 
 namespace tiledb::sm {
 LsObjects LocalFilesystem::ls_filtered(
-    const URI& parent,
-    FileFilter file_filter,
-    DirectoryFilter directory_filter,
-    bool recursive) const {
+    const URI& parent, FileFilter file_filter, bool recursive) const {
   /*
    * The input URI was useful to the top-level VFS to identify this is a
    * regular filesystem path, but we don't need the "file://" qualifier
@@ -64,7 +61,7 @@ LsObjects LocalFilesystem::ls_filtered(
     const auto abspath = entry.path().string();
     const auto absuri = URI(abspath);
     if (entry.is_directory()) {
-      if (file_filter(absuri, 0) || directory_filter(absuri)) {
+      if (file_filter(absuri, 0)) {
         qualifyingPaths.push_back(
             std::make_pair(tiledb::sm::URI(abspath).to_string(), 0));
         if (!recursive) {

--- a/tiledb/sm/filesystem/local.cc
+++ b/tiledb/sm/filesystem/local.cc
@@ -82,6 +82,48 @@ LsObjects LocalFilesystem::ls_filtered(
   return qualifyingPaths;
 }
 
+LsObjects LocalFilesystem::ls_filtered_v2(
+    const URI& parent, ResultFilterV2 result_filter, bool recursive) const {
+  /*
+   * The input URI was useful to the top-level VFS to identify this is a
+   * regular filesystem path, but we don't need the "file://" qualifier
+   * anymore and can reason with unqualified strings for the rest of the
+   * function.
+   */
+  const auto parentstr = parent.to_path();
+
+  LsObjects qualifyingPaths;
+
+  // awkward way of iterating, avoids bug in OSX
+  auto begin = std::filesystem::recursive_directory_iterator(parentstr);
+  auto end = std::filesystem::recursive_directory_iterator();
+
+  for (auto iter = begin; iter != end; ++iter) {
+    auto& entry = *iter;
+    const auto abspath = entry.path().string();
+    const auto absuri = URI(abspath);
+    if (entry.is_directory()) {
+      if (result_filter(absuri, 0, true)) {
+        qualifyingPaths.emplace_back(tiledb::sm::URI(abspath).to_string(), 0);
+      }
+      if (!recursive) {
+        iter.disable_recursion_pending();
+      }
+    } else {
+      /*
+       * A leaf of the filesystem
+       * (or symbolic link - split to a separate case if we want to descend into
+       * them)
+       */
+      if (result_filter(absuri, entry.file_size(), false)) {
+        qualifyingPaths.emplace_back(absuri.to_string(), entry.file_size());
+      }
+    }
+  }
+
+  return qualifyingPaths;
+}
+
 void LocalFilesystem::copy_file(const URI& old_uri, const URI& new_uri) const {
   std::filesystem::copy_file(
       old_uri.to_path(),

--- a/tiledb/sm/filesystem/local.h
+++ b/tiledb/sm/filesystem/local.h
@@ -48,6 +48,11 @@ class LocalFilesystem : public FilesystemBase {
       ResultFilter result_filter,
       bool recursive) const override;
 
+  LsObjects ls_filtered_v2(
+      const URI& parent,
+      ResultFilterV2 result_filter,
+      bool recursive) const override;
+
   void copy_file(const URI& old_uri, const URI& new_uri) const override;
 
   void copy_dir(const URI& old_uri, const URI& new_uri) const override;

--- a/tiledb/sm/filesystem/local.h
+++ b/tiledb/sm/filesystem/local.h
@@ -44,10 +44,7 @@ namespace tiledb::sm {
 class LocalFilesystem : public FilesystemBase {
  public:
   LsObjects ls_filtered(
-      const URI& parent,
-      FileFilter file_filter,
-      [[maybe_unused]] DirectoryFilter directory_filter,
-      bool recursive) const override;
+      const URI& parent, FileFilter file_filter, bool recursive) const override;
 
   void copy_file(const URI& old_uri, const URI& new_uri) const override;
 

--- a/tiledb/sm/filesystem/local.h
+++ b/tiledb/sm/filesystem/local.h
@@ -44,7 +44,9 @@ namespace tiledb::sm {
 class LocalFilesystem : public FilesystemBase {
  public:
   LsObjects ls_filtered(
-      const URI& parent, FileFilter file_filter, bool recursive) const override;
+      const URI& parent,
+      ResultFilter result_filter,
+      bool recursive) const override;
 
   void copy_file(const URI& old_uri, const URI& new_uri) const override;
 

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -108,7 +108,7 @@ using ResultFilter = std::function<bool(const std::string_view&, uint64_t)>;
  * @return True if the result should be included, else False.
  */
 using ResultFilterV2 =
-    std::function<bool(const std::string_view&, uint64_t, uint8_t)>;
+    std::function<bool(const std::string_view&, uint64_t, bool)>;
 
 /**
  * Typedef for ls C API callback as std::function for passing to C++
@@ -352,8 +352,6 @@ class CallbackWrapperCAPI {
       , data_(data) {
     if (cb_ == nullptr) {
       throw LsScanException("ls_recursive callback function cannot be null");
-    } else if (data_ == nullptr) {
-      throw LsScanException("ls_recursive data cannot be null");
     }
   }
 
@@ -362,8 +360,6 @@ class CallbackWrapperCAPI {
       , data_(data) {
     if (cb_v2_ == nullptr) {
       throw LsScanException("ls_recursive_v2 callback function cannot be null");
-    } else if (data_ == nullptr) {
-      throw LsScanException("ls_recursive_v2 data cannot be null");
     }
   }
 

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -259,6 +259,7 @@ class LsScanner {
   static bool accept_all_dirs(const std::string_view&, uint64_t size) {
     return size == 0;
   }
+
  protected:
   /** URI prefix being scanned and filtered for results. */
   const URI prefix_;

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -268,6 +268,11 @@ class LsScanner {
     return true;
   }
 
+  /** Accept all files and directories from ls_recursive_v2. */
+  static bool accept_all_v2(const std::string_view&, uint64_t, bool) {
+    return true;
+  }
+
   /** Accept only files from ls_recursive_v2, returning no directories. */
   static bool accept_all_files(const std::string_view&, uint64_t, bool is_dir) {
     return !is_dir;

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -61,9 +61,6 @@ concept FilePredicate = std::predicate<F, const std::string_view, uint64_t>;
  *
  * The predicate returns true if items inside the directory should be traversed,
  * and false otherwise.
- *
- * Directory pruning is currently supported only in local filesystem, and not
- * exposed in the user-facing C API.
  */
 template <class D>
 concept DirectoryPredicate = std::predicate<D, const std::string_view>;
@@ -111,7 +108,10 @@ using DirectoryFilter = std::function<bool(const std::string_view&)>;
  * @return 1 if the callback should continue to the next object, 0 to stop
  *      traversal, or -1 if an error occurred.
  */
-using LsCallback = std::function<int32_t(const char*, size_t, uint64_t, void*)>;
+using LsFileCallback =
+    std::function<int32_t(const char*, size_t, uint64_t, void*)>;
+
+using LsDirCallback = std::function<int32_t(const char*, size_t, void*)>;
 
 /** Type defintion for objects returned from ls_recursive. */
 using LsObjects = std::vector<std::pair<std::string, uint64_t>>;
@@ -294,42 +294,90 @@ class CallbackWrapperCAPI {
   CallbackWrapperCAPI() = delete;
 
   /** Constructor */
-  CallbackWrapperCAPI(LsCallback cb, void* data)
-      : cb_(std::move(cb))
-      , data_(data) {
-    if (cb_ == nullptr) {
-      throw LsScanException("ls_recursive callback function cannot be null");
+  CallbackWrapperCAPI(LsFileCallback file_cb, void* data)
+      : file_cb_(std::move(file_cb))
+      , data_(data)
+      , include_dirs_(false) {
+    if (file_cb_ == nullptr) {
+      throw LsScanException(
+          "ls_recursive file callback function cannot be null");
+    } else if (data_ == nullptr) {
+      throw LsScanException("ls_recursive data cannot be null");
+    }
+  }
+
+  /** Constructor */
+  CallbackWrapperCAPI(LsFileCallback file_cb, LsDirCallback dir_cb, void* data)
+      : file_cb_(std::move(file_cb))
+      , dir_cb_(std::move(dir_cb))
+      , data_(data)
+      , include_dirs_(true) {
+    if (file_cb_ == nullptr) {
+      throw LsScanException(
+          "ls_recursive file callback function cannot be null");
+    } else if (dir_cb_ == nullptr) {
+      throw LsScanException("ls_recursive dir callback cannot be null");
     } else if (data_ == nullptr) {
       throw LsScanException("ls_recursive data cannot be null");
     }
   }
 
   /**
-   * Operator to wrap the FilePredicate used in the C++ API.
    * This will throw a LsStopTraversal exception if the user callback returns 0,
    * and will throw a LsScanException if the user callback returns -1.
+   */
+  int check_stop_traversal(int code) const {
+    if (code == 0) {
+      // Throw an exception to stop traversal, which will be caught by the C++
+      // internal ls_recursive implementation to stop traversal.
+      throw LsStopTraversal();
+    } else if (code == -1) {
+      throw LsScanException("Error in user callback");
+    }
+    return code;
+  }
+
+  /**
+   * Operator to wrap the FileFilter used in the C++ API.
+   * This will throw a LsStopTraversal exception if the user callback returns 0,
+   * and will throw a LsScanException if the user callback returns -1.
+   *
+   * This definition of operator() is required to satisfy FilePredicate concept.
    *
    * @param path The path of the object.
    * @param size The size of the object in bytes.
    * @return True if the object should be included, False otherwise.
    */
   bool operator()(std::string_view path, const uint64_t size) const {
-    int ret = cb_(path.data(), path.size(), size, data_);
-    if (ret == 0) {
-      // Throw an exception to stop traversal, which will be caught by the C++
-      // internal ls_recursive implementation to stop traversal.
-      throw LsStopTraversal();
-    } else if (ret == -1) {
-      throw LsScanException("Error in user callback");
-    }
-    return ret;
+    return check_stop_traversal(
+        file_cb_(path.data(), path.size(), size, data_));
+  }
+
+  /**
+   * Operator to wrap the FileFilter used in the C++ API.
+   * This will throw a LsStopTraversal exception if the user callback returns 0,
+   * and will throw a LsScanException if the user callback returns -1.
+   *
+   * This definition of operator() is required to satisfy DirectoryPredicate
+   * concept.
+   *
+   * @param path The path of the object.
+   * @param size The size of the object in bytes.
+   * @return True if the object should be included, False otherwise.
+   */
+  bool operator()(std::string_view path) const {
+    return check_stop_traversal(dir_cb_(path.data(), path.size(), data_));
   }
 
  private:
   /** CAPI callback as function object */
-  LsCallback cb_;
+  LsFileCallback file_cb_;
+  LsDirCallback dir_cb_;
+
   /** User data for callback */
   void* data_;
+
+  bool include_dirs_;
 };
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -95,12 +95,6 @@ using FileFilter = std::function<bool(const std::string_view&, uint64_t)>;
   return true;
 }
 
-using DirectoryFilter = std::function<bool(const std::string_view&)>;
-/** Static DirectoryFilter used as default argument. */
-[[maybe_unused]] static bool accept_all_dirs(const std::string_view&) {
-  return true;
-}
-
 /**
  * Typedef for ls C API callback as std::function for passing to C++
  *
@@ -263,14 +257,9 @@ class LsScanIterator {
 class LsScanner {
  public:
   /** Constructor. */
-  LsScanner(
-      const URI& prefix,
-      FileFilter&& file_filter,
-      DirectoryFilter&& dir_filter,
-      bool recursive = false)
+  LsScanner(const URI& prefix, FileFilter&& file_filter, bool recursive = false)
       : prefix_(prefix)
       , file_filter_(std::move(file_filter))
-      , dir_filter_(std::move(dir_filter))
       , is_recursive_(recursive) {
   }
 
@@ -279,8 +268,6 @@ class LsScanner {
   const URI prefix_;
   /** File predicate used to filter file or object results. */
   const FileFilter file_filter_;
-  /** Directory predicate used to prune directory or prefix results. */
-  const DirectoryFilter dir_filter_;
   /** Whether or not to recursively scan the prefix. */
   const bool is_recursive_;
 };

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -245,10 +245,20 @@ class LsScanner {
       , is_recursive_(recursive) {
   }
 
+  /** Accept all files and directories from ls_recursive. */
   static bool accept_all(const std::string_view&, uint64_t) {
     return true;
   }
 
+  /** Accept only files from ls_recursive, returning no directories. */
+  static bool accept_all_files(const std::string_view&, uint64_t size) {
+    return size > 0;
+  }
+
+  /** Accept only directories from ls_recursive, returning no files. */
+  static bool accept_all_dirs(const std::string_view&, uint64_t size) {
+    return size == 0;
+  }
  protected:
   /** URI prefix being scanned and filtered for results. */
   const URI prefix_;

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -245,6 +245,10 @@ class LsScanner {
       , is_recursive_(recursive) {
   }
 
+  static bool accept_all(const std::string_view&, uint64_t) {
+    return true;
+  }
+
  protected:
   /** URI prefix being scanned and filtered for results. */
   const URI prefix_;

--- a/tiledb/sm/filesystem/ls_scanner.h
+++ b/tiledb/sm/filesystem/ls_scanner.h
@@ -41,7 +41,7 @@
 #include <stdexcept>
 
 /**
- * Inclusion predicate for objects collected by ls.
+ * Inclusion predicate for objects collected by ls_recursive.
  *
  * The predicate accepts:
  * - A string_view of the path to the object.
@@ -53,6 +53,17 @@
 template <class F>
 concept FilterPredicate = std::predicate<F, const std::string_view, uint64_t>;
 
+/**
+ * Inclusion predicate for objects collected by ls_recursive_v2.
+ *
+ * The predicate accepts:
+ * - A string_view of the path to the object.
+ * - The size of the object in bytes.
+ * - Whether or not the current object is a directory / prefix.
+ *
+ * The predicate returns true if the object should be included in the results,
+ * and false otherwise.
+ */
 template <class F>
 concept FilterPredicateV2 =
     std::predicate<F, const std::string_view, uint64_t, uint8_t>;
@@ -78,8 +89,24 @@ class LsStopTraversal : public LsScanException {
   }
 };
 
+/**
+ * Typedef for filter callback invoked on each object collected by ls_recursive.
+ *
+ * @param path The path of the visited object for the relative filesystem.
+ * @param path_len The length of the path.
+ * @return True if the result should be included, else False.
+ */
 using ResultFilter = std::function<bool(const std::string_view&, uint64_t)>;
 
+/**
+ * Typedef for filter callback invoked on each object collected by
+ * ls_recursive_v2.
+ *
+ * @param path The path of the visited object for the relative filesystem.
+ * @param path_len The length of the path.
+ * @param is_dir Whether or not the current object is a directory / prefix.
+ * @return True if the result should be included, else False.
+ */
 using ResultFilterV2 =
     std::function<bool(const std::string_view&, uint64_t, uint8_t)>;
 
@@ -95,6 +122,17 @@ using ResultFilterV2 =
  */
 using LsCallback = std::function<int32_t(const char*, size_t, uint64_t, void*)>;
 
+/**
+ * Typedef for ls C API callback as std::function for passing to C++
+ *
+ * @param path The path of a visited object for the relative filesystem.
+ * @param path_len The length of the path.
+ * @param object_size The size of the object at the current path.
+ * @param is_dir Whether or not the current object is a directory / prefix.
+ * @param data Data passed to the callback used to store collected results.
+ * @return 1 if the callback should continue to the next object, 0 to stop
+ *      traversal, or -1 if an error occurred.
+ */
 using LsCallbackV2 =
     std::function<int32_t(const char*, size_t, uint64_t, uint8_t, void*)>;
 

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2192,7 +2192,7 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
            pos = prefix.rfind('/')) {
         prefix = prefix.substr(0, pos);
         // Do not accept the prefix we are scanning.
-        if (path == prefix_.to_string() ||
+        if (bucket + S3::add_front_slash(prefix) == prefix_.to_string() ||
             collected_prefixes_.contains(prefix)) {
           break;
         } else {

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2087,11 +2087,9 @@ S3Scanner::S3Scanner(
     const shared_ptr<TileDBS3Client>& client,
     const URI& prefix,
     FileFilter&& file_filter,
-    DirectoryFilter&& dir_filter,
     bool recursive,
     int max_keys)
-    : LsScanner(
-          prefix, std::move(file_filter), std::move(dir_filter), recursive)
+    : LsScanner(prefix, std::move(file_filter), recursive)
     , client_(client)
     , result_type_(OBJECT) {
   const auto prefix_dir = prefix.add_trailing_slash();
@@ -2213,9 +2211,7 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
     }
 
     // Advance until we reach a result accepted by a filter predicate.
-    if (result_type_ == OBJECT && this->file_filter_(path, size)) {
-      return;
-    } else if (result_type_ == PREFIX && this->dir_filter_(path)) {
+    if (this->file_filter_(path, size)) {
       return;
     } else {
       advance(ptr);

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2159,8 +2159,7 @@ typename S3Scanner::Iterator::pointer S3Scanner::fetch_results() {
   if (result_filter_v2_ && !more_to_fetch() && !collected_prefixes_.empty()) {
     // Filter prefixes if there are no more results to fetch from S3.
     return build_prefix_vector();
-  } else if (
-      result_filter_v2_ && !is_recursive_ && response_contains_prefixes_) {
+  } else if (!is_recursive_ && response_contains_prefixes_) {
     // If using V2 APIs, collect common prefix results for non-recursive scan.
     response_contains_prefixes_ = false;
     const auto& aws_prefixes =

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2086,10 +2086,10 @@ URI S3::generate_chunk_uri(
 S3Scanner::S3Scanner(
     const shared_ptr<TileDBS3Client>& client,
     const URI& prefix,
-    FileFilter&& file_filter,
+    ResultFilter&& result_filter,
     bool recursive,
     int max_keys)
-    : LsScanner(prefix, std::move(file_filter), recursive)
+    : LsScanner(prefix, std::move(result_filter), recursive)
     , client_(client)
     , result_type_(OBJECT) {
   const auto prefix_dir = prefix.add_trailing_slash();
@@ -2113,7 +2113,7 @@ S3Scanner::S3Scanner(
   fetch_results();
   next(begin_);
 
-  // This case is hit when all files are rejected by the file_filter.
+  // This case is hit when all files are rejected by the result_filter.
   if (begin_ == end_ && !collected_prefixes_.empty() && !more_to_fetch()) {
     next(build_prefix_vector());
   }
@@ -2211,7 +2211,7 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
     }
 
     // Advance until we reach a result accepted by a filter predicate.
-    if (this->file_filter_(path, size)) {
+    if (this->result_filter_(path, size)) {
       return;
     } else {
       advance(ptr);

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2112,11 +2112,6 @@ S3Scanner::S3Scanner(
   }
   fetch_results();
   next(begin_);
-
-  // This case is hit when all files are rejected by the result_filter.
-  if (begin_ == end_ && !collected_prefixes_.empty() && !more_to_fetch()) {
-    next(build_prefix_vector());
-  }
 }
 
 typename S3Scanner::Iterator::pointer S3Scanner::fetch_results() {

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2198,7 +2198,6 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
            pos = prefix.rfind('/')) {
         prefix = prefix.substr(0, pos);
         // Do not accept the prefix we are scanning.
-        // Stop checking this path if we hit a duplicate prefix.
         if (bucket + S3::add_front_slash(prefix) == prefix_.to_string() ||
             collected_prefixes_.contains(prefix)) {
           break;

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2175,11 +2175,10 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
     ptr = fetch_results();
   }
 
+  std::string bucket = "s3://" + std::string(list_objects_request_.GetBucket());
   while (ptr != end_) {
     auto object = *ptr;
     uint64_t size = object.GetSize();
-    std::string bucket =
-        "s3://" + std::string(list_objects_request_.GetBucket());
     std::string path =
         bucket + S3::add_front_slash(std::string(object.GetKey()));
 
@@ -2193,7 +2192,7 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
            pos = prefix.rfind('/')) {
         prefix = prefix.substr(0, pos);
         // Do not accept the prefix we are scanning.
-        if (bucket + S3::add_front_slash(prefix) == prefix_.to_string() ||
+        if (path == prefix_.to_string() ||
             collected_prefixes_.contains(prefix)) {
           break;
         } else {

--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -2192,16 +2192,17 @@ void S3Scanner::next(typename Iterator::pointer& ptr) {
 
     // Store each unique prefix while scanning S3 objects.
     if (result_type_ == OBJECT) {
-      std::string prefix = path;
+      std::string prefix = object.GetKey();
       // Drop last part of the path until we reach the end, or hit a duplicate.
       for (auto pos = prefix.rfind('/'); pos != Aws::String::npos;
            pos = prefix.rfind('/')) {
         prefix = prefix.substr(0, pos);
+        auto full_uri = bucket + S3::add_front_slash(prefix);
         // Do not accept the prefix we are scanning.
-        if (prefix == prefix_.to_string() ||
+        if (full_uri == prefix_.to_string() ||
             collected_prefixes_.contains(prefix)) {
           break;
-        } else if (this->result_filter_(prefix, 0)) {
+        } else if (this->result_filter_(full_uri, 0)) {
           collected_prefixes_.emplace(prefix, 0);
         }
       }

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -422,7 +422,7 @@ class S3Scanner : public LsScanner {
   S3Scanner(
       const std::shared_ptr<TileDBS3Client>& client,
       const URI& prefix,
-      FileFilter&& file_filter,
+      ResultFilter&& result_filter,
       bool recursive = false,
       int max_keys = 1000);
 
@@ -857,17 +857,16 @@ class S3 : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the FileFilter on each entry collected and the DirectoryFilter on
-   * common prefixes for pruning.
+   * the ResultFilter on each entry collected.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FileFilter to invoke on each object for filtering.
-   * @param d The DirectoryFilter to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
+   * @param f The ResultFilter to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
    */
   LsObjects ls_filtered(
-      const URI& parent, FileFilter f, bool recursive = false) const override {
+      const URI& parent,
+      ResultFilter f,
+      bool recursive = false) const override {
     throw_if_not_ok(init_client());
     S3Scanner s3_scanner = scanner(parent, std::move(f), recursive);
     // Prepend each object key with the bucket URI.
@@ -888,16 +887,14 @@ class S3 : public FilesystemBase {
    * or STL constructors supporting initialization via input iterators.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FileFilter to invoke on each object for filtering.
-   * @param d The DirectoryFilter to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
+   * @param f The ResultFilter to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
    * @param max_keys The maximum number of keys to retrieve per request.
    * @return Fully constructed S3Scanner object.
    */
   S3Scanner scanner(
       const URI& parent,
-      FileFilter f,
+      ResultFilter f,
       bool recursive = false,
       int max_keys = 1000) const {
     throw_if_not_ok(init_client());

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -873,11 +873,15 @@ class S3 : public FilesystemBase {
 
   /**
    * Lists objects and object information that start with `prefix`, invoking
-   * the ResultFilter on each entry collected.
+   * the ResultFilterV2 on each entry collected. Both objects and common
+   * prefixes will be collected.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param result_filter The ResultFilterV2 to invoke on each object for
+   * filtering.
    * @param recursive Whether to recursively list subdirectories.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
    */
   LsObjects ls_filtered_v2(
       const URI& parent,
@@ -923,7 +927,7 @@ class S3 : public FilesystemBase {
    * or STL constructors supporting initialization via input iterators.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param f The ResultFilterV2 to invoke on each object for filtering.
    * @param recursive Whether to recursively list subdirectories.
    * @param max_keys The maximum number of keys to retrieve per request.
    * @return Fully constructed S3Scanner object.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -493,17 +493,7 @@ class S3Scanner : public LsScanner {
    *
    * @returns Iterator to the beginning of the prefix vector.
    */
-  typename Iterator::pointer& build_prefix_vector() {
-    result_type_ = PREFIX;
-    common_prefixes_.resize(collected_prefixes_.size());
-    for (auto& object : common_prefixes_) {
-      auto next = collected_prefixes_.begin();
-      object.SetKey(collected_prefixes_.extract(next).value());
-      object.SetSize(0);
-    }
-    end_ = common_prefixes_.end();
-    return begin_ = common_prefixes_.begin();
-  }
+  typename Iterator::pointer& build_prefix_vector();
 
   /**
    * Fetch the next batch of results from S3. This also handles setting the

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -536,7 +536,6 @@ class S3Scanner : public LsScanner {
 
   /**
    * The result type contained by Iterator.
-   * Used for selecting which filter predicate to apply.
    */
   enum ResultType { OBJECT, PREFIX } result_type_ = OBJECT;
 };

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -525,6 +525,7 @@ class S3Scanner : public LsScanner {
   Aws::S3::Model::ListObjectsV2Request list_objects_request_;
   /** The current request outcome being scanned. */
   Aws::S3::Model::ListObjectsV2Outcome list_objects_outcome_;
+  bool response_contains_prefixes_ = false;
 
   /** Move prefixes to this vector usable with Iterator type for filtering. */
   std::vector<Iterator::value_type> common_prefixes_;

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -423,7 +423,6 @@ class S3Scanner : public LsScanner {
       const std::shared_ptr<TileDBS3Client>& client,
       const URI& prefix,
       FileFilter&& file_filter,
-      DirectoryFilter&& dir_filter = accept_all_dirs,
       bool recursive = false,
       int max_keys = 1000);
 
@@ -868,13 +867,9 @@ class S3 : public FilesystemBase {
    * @param recursive Whether to recursively list subdirectories.
    */
   LsObjects ls_filtered(
-      const URI& parent,
-      FileFilter f,
-      DirectoryFilter d = accept_all_dirs,
-      bool recursive = false) const override {
+      const URI& parent, FileFilter f, bool recursive = false) const override {
     throw_if_not_ok(init_client());
-    S3Scanner s3_scanner =
-        scanner(parent, std::move(f), std::move(d), recursive);
+    S3Scanner s3_scanner = scanner(parent, std::move(f), recursive);
     // Prepend each object key with the bucket URI.
     auto prefix = parent.to_string();
     prefix = prefix.substr(0, prefix.find('/', 5));
@@ -903,12 +898,10 @@ class S3 : public FilesystemBase {
   S3Scanner scanner(
       const URI& parent,
       FileFilter f,
-      DirectoryFilter d = accept_all_dirs,
       bool recursive = false,
       int max_keys = 1000) const {
     throw_if_not_ok(init_client());
-    return S3Scanner(
-        client_, parent, std::move(f), std::move(d), recursive, max_keys);
+    return S3Scanner(client_, parent, std::move(f), recursive, max_keys);
   }
 
   /**

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -230,9 +230,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
 
   SECTION("Empty directory") {
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
     CHECK(ls.empty());
   }
 
@@ -243,9 +241,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     testpaths[3].touch();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
     REQUIRE(ls.size() == 4);
     CHECK(testpaths[0].matches(ls[0]));
     CHECK(testpaths[1].matches(ls[1]));
@@ -258,9 +254,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     d1.mkdir();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
 
     CHECK(ls.size() == 1);
     if (ls.size() >= 1) {
@@ -277,9 +271,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     testpaths[3].touch();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
     CHECK(ls.size() == 5);
     if (ls.size() >= 1) {
       CHECK(testpaths[0].matches(ls[0]));
@@ -305,9 +297,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     d1sub1.mkdir();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
 
     CHECK(ls.size() == 2);
     if (ls.size() >= 1) {
@@ -331,9 +321,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     testpaths[7].touch();
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
 
     CHECK(ls.size() == 5);
     if (ls.size() >= 1) {
@@ -368,9 +356,7 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     }
 
     const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_all_files,
-        tiledb::sm::accept_all_dirs));
+        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
     CHECK(ls.size() == testpaths.size() + 4);
 
     if (ls.size() >= 1) {
@@ -460,8 +446,7 @@ TEST_CASE("VFS: ls_recursive file filter", "[vfs][ls_recursive]") {
       return (path.find("log1.txt") != std::string::npos);
     };
 
-    auto ls = vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, log_is_1, tiledb::sm::accept_all_dirs);
+    auto ls = vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, log_is_1);
 
     /* directories appear in the result set, we aren't interested in those,
      * and the callback doesn't (yet?) have a way to descend into a directory
@@ -478,182 +463,183 @@ TEST_CASE("VFS: ls_recursive file filter", "[vfs][ls_recursive]") {
   }
 }
 
-TEST_CASE("VFS: ls_recursive directory filter", "[vfs][ls_recursive]") {
-  std::string prefix = GENERATE("file://");
-  prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
-
-  VFSTest vfs_test({0}, prefix);
-  const auto mkst = vfs_test.mkdir();
-  REQUIRE(mkst.ok());
-
-  std::vector<TestPath> testpaths = {
-      TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
-      TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
-      TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
-      TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
-      TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 50),
-      TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 51),
-      TestPath(vfs_test, "year=2021/month=9/day=29/log1.txt", 60),
-      TestPath(vfs_test, "year=2021/month=9/day=29/log2.txt", 61),
-      TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
-      TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
-      TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
-      TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
-      TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 90),
-      TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 91),
-      TestPath(vfs_test, "year=2022/month=9/day=29/log1.txt", 20),
-      TestPath(vfs_test, "year=2022/month=9/day=29/log2.txt", 21),
-  };
-
-  /* create all files and dirs */
-  for (auto& testpath : testpaths) {
-    testpath.touch(true);
-  }
-
-  SECTION("Directory predicate returning true is filtered from results") {
-    auto month_is_august = [](std::string_view dirname) -> bool {
-      if (dirname.find("month") == std::string::npos) {
-        /* haven't descended far enough yet */
-        return true;
-      } else if (dirname.find("month=8") == std::string::npos) {
-        /* not august */
-        return false;
-      } else {
-        return true;
-      }
-    };
-
-    auto ls = vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_only_regular_files,
-        month_is_august);
-
-    /* directories appear in the result set, we aren't interested in those,
-     * and the callback doesn't (yet?) have a way to descend into a directory
-     * without also including it in the result set */
-    std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
-
-    CHECK(ls.size() == testpaths.size() / 2);
-
-    ls = sort_by_name(ls); /* ensure order matches the testpaths order */
-
-    CHECK(ls.size() == 8);
-    if (ls.size() >= 1) {
-      testpaths[0].matches(ls[0]);
-    }
-    if (ls.size() >= 2) {
-      testpaths[1].matches(ls[1]);
-    }
-    if (ls.size() >= 3) {
-      testpaths[2].matches(ls[2]);
-    }
-    if (ls.size() >= 4) {
-      testpaths[3].matches(ls[3]);
-    }
-    if (ls.size() >= 5) {
-      testpaths[8].matches(ls[4]);
-    }
-    if (ls.size() >= 6) {
-      testpaths[9].matches(ls[5]);
-    }
-    if (ls.size() >= 7) {
-      testpaths[10].matches(ls[6]);
-    }
-    if (ls.size() >= 8) {
-      testpaths[11].matches(ls[7]);
-    }
-  }
-
-  /* note: this should be true for POSIX but is not for S3 without hierarchical
-   * list API */
-  SECTION(
-      "Directory predicate returning true does not descend into directory") {
-    /*
-     * In the test data we only find "day=29" beneath "month=9",
-     * so the `ls` should throw with this directory filter if and only if
-     * we descend into directories with "month=9".
-     */
-    std::string monthstr = "month=9";
-    auto throw_if_day_is_29 = [&monthstr](std::string_view dirname) -> bool {
-      if (dirname.find("month") == std::string::npos) {
-        /* haven't descended far enough yet */
-        return true;
-      } else if (dirname.find(monthstr) == std::string::npos) {
-        /* not august */
-        return false;
-      } else if (dirname.find("day=29") == std::string::npos) {
-        /* not the 29th */
-        return true;
-      } else {
-        /* it is the 29th, throw */
-        throw std::logic_error("Throwing FileFilter: day=29");
-      }
-    };
-
-    CHECK_THROWS_AS(
-        vfs_test.vfs_.ls_recursive(
-            vfs_test.temp_dir_,
-            tiledb::sm::accept_only_regular_files,
-            throw_if_day_is_29),
-        std::logic_error);
-    CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(
-            vfs_test.temp_dir_,
-            tiledb::sm::accept_only_regular_files,
-            throw_if_day_is_29),
-        Catch::Matchers::ContainsSubstring("Throwing FileFilter: day=29"));
-
-    monthstr = "month=8";
-
-    /* now the result should be the same as the first section */
-    auto ls = vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_,
-        tiledb::sm::accept_only_regular_files,
-        throw_if_day_is_29);
-
-    /* directories appear in the result set, we aren't interested in those,
-     * and the callback doesn't (yet?) have a way to descend into a directory
-     * without also including it in the result set */
-    std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
-
-    CHECK(ls.size() == testpaths.size() / 2);
-
-    ls = sort_by_name(ls); /* ensure order matches the testpaths order */
-
-    CHECK(ls.size() == 8);
-    if (ls.size() >= 1) {
-      testpaths[0].matches(ls[0]);
-    }
-    if (ls.size() >= 2) {
-      testpaths[1].matches(ls[1]);
-    }
-    if (ls.size() >= 3) {
-      testpaths[2].matches(ls[2]);
-    }
-    if (ls.size() >= 4) {
-      testpaths[3].matches(ls[3]);
-    }
-    if (ls.size() >= 5) {
-      testpaths[8].matches(ls[4]);
-    }
-    if (ls.size() >= 6) {
-      testpaths[9].matches(ls[5]);
-    }
-    if (ls.size() >= 7) {
-      testpaths[10].matches(ls[6]);
-    }
-    if (ls.size() >= 8) {
-      testpaths[11].matches(ls[7]);
-    }
-  }
-
-  /*
-   * Note that since we throw in the previous section, this check
-   * demonstrates that all directories are closed whether or not we return
-   * from ls_recursive normally
-   */
-  REQUIRE(vfs_test.check_open_files());
-}
+// TEST_CASE("VFS: ls_recursive directory filter", "[vfs][ls_recursive]") {
+//   std::string prefix = GENERATE("file://");
+//   prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
+//
+//   VFSTest vfs_test({0}, prefix);
+//   const auto mkst = vfs_test.mkdir();
+//   REQUIRE(mkst.ok());
+//
+//   std::vector<TestPath> testpaths = {
+//       TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
+//       TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
+//       TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
+//       TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
+//       TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 50),
+//       TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 51),
+//       TestPath(vfs_test, "year=2021/month=9/day=29/log1.txt", 60),
+//       TestPath(vfs_test, "year=2021/month=9/day=29/log2.txt", 61),
+//       TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
+//       TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
+//       TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
+//       TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
+//       TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 90),
+//       TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 91),
+//       TestPath(vfs_test, "year=2022/month=9/day=29/log1.txt", 20),
+//       TestPath(vfs_test, "year=2022/month=9/day=29/log2.txt", 21),
+//   };
+//
+//   /* create all files and dirs */
+//   for (auto& testpath : testpaths) {
+//     testpath.touch(true);
+//   }
+//
+//   SECTION("Directory predicate returning true is filtered from results") {
+//     auto month_is_august = [](std::string_view dirname) -> bool {
+//       if (dirname.find("month") == std::string::npos) {
+//         /* haven't descended far enough yet */
+//         return true;
+//       } else if (dirname.find("month=8") == std::string::npos) {
+//         /* not august */
+//         return false;
+//       } else {
+//         return true;
+//       }
+//     };
+//
+//     auto ls = vfs_test.vfs_.ls_recursive(
+//         vfs_test.temp_dir_,
+//         tiledb::sm::accept_only_regular_files,
+//         month_is_august);
+//
+//     /* directories appear in the result set, we aren't interested in those,
+//      * and the callback doesn't (yet?) have a way to descend into a directory
+//      * without also including it in the result set */
+//     std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
+//
+//     CHECK(ls.size() == testpaths.size() / 2);
+//
+//     ls = sort_by_name(ls); /* ensure order matches the testpaths order */
+//
+//     CHECK(ls.size() == 8);
+//     if (ls.size() >= 1) {
+//       testpaths[0].matches(ls[0]);
+//     }
+//     if (ls.size() >= 2) {
+//       testpaths[1].matches(ls[1]);
+//     }
+//     if (ls.size() >= 3) {
+//       testpaths[2].matches(ls[2]);
+//     }
+//     if (ls.size() >= 4) {
+//       testpaths[3].matches(ls[3]);
+//     }
+//     if (ls.size() >= 5) {
+//       testpaths[8].matches(ls[4]);
+//     }
+//     if (ls.size() >= 6) {
+//       testpaths[9].matches(ls[5]);
+//     }
+//     if (ls.size() >= 7) {
+//       testpaths[10].matches(ls[6]);
+//     }
+//     if (ls.size() >= 8) {
+//       testpaths[11].matches(ls[7]);
+//     }
+//   }
+//
+//   /* note: this should be true for POSIX but is not for S3 without
+//   hierarchical
+//    * list API */
+//   SECTION(
+//       "Directory predicate returning true does not descend into directory") {
+//     /*
+//      * In the test data we only find "day=29" beneath "month=9",
+//      * so the `ls` should throw with this directory filter if and only if
+//      * we descend into directories with "month=9".
+//      */
+//     std::string monthstr = "month=9";
+//     auto throw_if_day_is_29 = [&monthstr](std::string_view dirname) -> bool {
+//       if (dirname.find("month") == std::string::npos) {
+//         /* haven't descended far enough yet */
+//         return true;
+//       } else if (dirname.find(monthstr) == std::string::npos) {
+//         /* not august */
+//         return false;
+//       } else if (dirname.find("day=29") == std::string::npos) {
+//         /* not the 29th */
+//         return true;
+//       } else {
+//         /* it is the 29th, throw */
+//         throw std::logic_error("Throwing FileFilter: day=29");
+//       }
+//     };
+//
+//     CHECK_THROWS_AS(
+//         vfs_test.vfs_.ls_recursive(
+//             vfs_test.temp_dir_,
+//             tiledb::sm::accept_only_regular_files,
+//             throw_if_day_is_29),
+//         std::logic_error);
+//     CHECK_THROWS_WITH(
+//         vfs_test.vfs_.ls_recursive(
+//             vfs_test.temp_dir_,
+//             tiledb::sm::accept_only_regular_files,
+//             throw_if_day_is_29),
+//         Catch::Matchers::ContainsSubstring("Throwing FileFilter: day=29"));
+//
+//     monthstr = "month=8";
+//
+//     /* now the result should be the same as the first section */
+//     auto ls = vfs_test.vfs_.ls_recursive(
+//         vfs_test.temp_dir_,
+//         tiledb::sm::accept_only_regular_files,
+//         throw_if_day_is_29);
+//
+//     /* directories appear in the result set, we aren't interested in those,
+//      * and the callback doesn't (yet?) have a way to descend into a directory
+//      * without also including it in the result set */
+//     std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
+//
+//     CHECK(ls.size() == testpaths.size() / 2);
+//
+//     ls = sort_by_name(ls); /* ensure order matches the testpaths order */
+//
+//     CHECK(ls.size() == 8);
+//     if (ls.size() >= 1) {
+//       testpaths[0].matches(ls[0]);
+//     }
+//     if (ls.size() >= 2) {
+//       testpaths[1].matches(ls[1]);
+//     }
+//     if (ls.size() >= 3) {
+//       testpaths[2].matches(ls[2]);
+//     }
+//     if (ls.size() >= 4) {
+//       testpaths[3].matches(ls[3]);
+//     }
+//     if (ls.size() >= 5) {
+//       testpaths[8].matches(ls[4]);
+//     }
+//     if (ls.size() >= 6) {
+//       testpaths[9].matches(ls[5]);
+//     }
+//     if (ls.size() >= 7) {
+//       testpaths[10].matches(ls[6]);
+//     }
+//     if (ls.size() >= 8) {
+//       testpaths[11].matches(ls[7]);
+//     }
+//   }
+//
+//   /*
+//    * Note that since we throw in the previous section, this check
+//    * demonstrates that all directories are closed whether or not we return
+//    * from ls_recursive normally
+//    */
+//   REQUIRE(vfs_test.check_open_files());
+// }
 
 TEST_CASE("VFS: Throwing FileFilter ls_recursive", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("file://");
@@ -667,8 +653,8 @@ TEST_CASE("VFS: Throwing FileFilter ls_recursive", "[vfs][ls_recursive]") {
     throw std::logic_error("Throwing FileFilter");
   };
   SECTION("Throwing FileFilter with 0 objects should not throw") {
-    CHECK_NOTHROW(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, always_throw_filter, tiledb::sm::accept_all_dirs));
+    CHECK_NOTHROW(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, always_throw_filter));
   }
   SECTION(
       "Throwing FileFilter will not throw if ls_recursive only visits "

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -115,6 +115,11 @@ class VFSTest {
     }
   }
 
+  /** Filter to accept all results from ls_recursive. */
+  static bool accept_all(const std::string_view&, uint64_t) {
+    return true;
+  }
+
   /** Resources needed to construct VFS */
   tiledb::sm::stats::Stats stats_;
   tiledb::common::Logger logger_;
@@ -229,8 +234,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
   };
 
   SECTION("Empty directory") {
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
     CHECK(ls.empty());
   }
 
@@ -240,8 +245,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     testpaths[2].touch();
     testpaths[3].touch();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
     REQUIRE(ls.size() == 4);
     CHECK(testpaths[0].matches(ls[0]));
     CHECK(testpaths[1].matches(ls[1]));
@@ -253,8 +258,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     auto d1 = TestPath(vfs_test, "d1");
     d1.mkdir();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
 
     CHECK(ls.size() == 1);
     if (ls.size() >= 1) {
@@ -270,8 +275,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     testpaths[2].touch();
     testpaths[3].touch();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
     CHECK(ls.size() == 5);
     if (ls.size() >= 1) {
       CHECK(testpaths[0].matches(ls[0]));
@@ -296,8 +301,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     d1.mkdir();
     d1sub1.mkdir();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
 
     CHECK(ls.size() == 2);
     if (ls.size() >= 1) {
@@ -320,8 +325,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
     d1sub1sub1sub1.mkdir();
     testpaths[7].touch();
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
 
     CHECK(ls.size() == 5);
     if (ls.size() >= 1) {
@@ -355,8 +360,8 @@ TEST_CASE("VFS: ls_recursive unfiltered", "[vfs][ls_recursive]") {
       testpaths[i].touch();
     }
 
-    const auto ls = sort_by_name(vfs_test.vfs_.ls_recursive(
-        vfs_test.temp_dir_, tiledb::sm::accept_all_files));
+    const auto ls = sort_by_name(
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all));
     CHECK(ls.size() == testpaths.size() + 4);
 
     if (ls.size() >= 1) {
@@ -453,7 +458,7 @@ TEST_CASE("VFS: ls_recursive file filter", "[vfs][ls_recursive]") {
      * without also including it in the result set */
     std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
 
-    CHECK(ls.size() == testpaths.size() / 2);
+    REQUIRE(ls.size() == testpaths.size() / 2);
 
     ls = sort_by_name(ls); /* ensure order matches the testpaths order */
 
@@ -463,185 +468,7 @@ TEST_CASE("VFS: ls_recursive file filter", "[vfs][ls_recursive]") {
   }
 }
 
-// TEST_CASE("VFS: ls_recursive directory filter", "[vfs][ls_recursive]") {
-//   std::string prefix = GENERATE("file://");
-//   prefix += std::filesystem::current_path().string() + "/ls_recursive_test/";
-//
-//   VFSTest vfs_test({0}, prefix);
-//   const auto mkst = vfs_test.mkdir();
-//   REQUIRE(mkst.ok());
-//
-//   std::vector<TestPath> testpaths = {
-//       TestPath(vfs_test, "year=2021/month=8/day=27/log1.txt", 30),
-//       TestPath(vfs_test, "year=2021/month=8/day=27/log2.txt", 31),
-//       TestPath(vfs_test, "year=2021/month=8/day=28/log1.txt", 40),
-//       TestPath(vfs_test, "year=2021/month=8/day=28/log2.txt", 41),
-//       TestPath(vfs_test, "year=2021/month=9/day=28/log1.txt", 50),
-//       TestPath(vfs_test, "year=2021/month=9/day=28/log2.txt", 51),
-//       TestPath(vfs_test, "year=2021/month=9/day=29/log1.txt", 60),
-//       TestPath(vfs_test, "year=2021/month=9/day=29/log2.txt", 61),
-//       TestPath(vfs_test, "year=2022/month=8/day=27/log1.txt", 70),
-//       TestPath(vfs_test, "year=2022/month=8/day=27/log2.txt", 71),
-//       TestPath(vfs_test, "year=2022/month=8/day=28/log1.txt", 80),
-//       TestPath(vfs_test, "year=2022/month=8/day=28/log2.txt", 81),
-//       TestPath(vfs_test, "year=2022/month=9/day=28/log1.txt", 90),
-//       TestPath(vfs_test, "year=2022/month=9/day=28/log2.txt", 91),
-//       TestPath(vfs_test, "year=2022/month=9/day=29/log1.txt", 20),
-//       TestPath(vfs_test, "year=2022/month=9/day=29/log2.txt", 21),
-//   };
-//
-//   /* create all files and dirs */
-//   for (auto& testpath : testpaths) {
-//     testpath.touch(true);
-//   }
-//
-//   SECTION("Directory predicate returning true is filtered from results") {
-//     auto month_is_august = [](std::string_view dirname) -> bool {
-//       if (dirname.find("month") == std::string::npos) {
-//         /* haven't descended far enough yet */
-//         return true;
-//       } else if (dirname.find("month=8") == std::string::npos) {
-//         /* not august */
-//         return false;
-//       } else {
-//         return true;
-//       }
-//     };
-//
-//     auto ls = vfs_test.vfs_.ls_recursive(
-//         vfs_test.temp_dir_,
-//         tiledb::sm::accept_only_regular_files,
-//         month_is_august);
-//
-//     /* directories appear in the result set, we aren't interested in those,
-//      * and the callback doesn't (yet?) have a way to descend into a directory
-//      * without also including it in the result set */
-//     std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
-//
-//     CHECK(ls.size() == testpaths.size() / 2);
-//
-//     ls = sort_by_name(ls); /* ensure order matches the testpaths order */
-//
-//     CHECK(ls.size() == 8);
-//     if (ls.size() >= 1) {
-//       testpaths[0].matches(ls[0]);
-//     }
-//     if (ls.size() >= 2) {
-//       testpaths[1].matches(ls[1]);
-//     }
-//     if (ls.size() >= 3) {
-//       testpaths[2].matches(ls[2]);
-//     }
-//     if (ls.size() >= 4) {
-//       testpaths[3].matches(ls[3]);
-//     }
-//     if (ls.size() >= 5) {
-//       testpaths[8].matches(ls[4]);
-//     }
-//     if (ls.size() >= 6) {
-//       testpaths[9].matches(ls[5]);
-//     }
-//     if (ls.size() >= 7) {
-//       testpaths[10].matches(ls[6]);
-//     }
-//     if (ls.size() >= 8) {
-//       testpaths[11].matches(ls[7]);
-//     }
-//   }
-//
-//   /* note: this should be true for POSIX but is not for S3 without
-//   hierarchical
-//    * list API */
-//   SECTION(
-//       "Directory predicate returning true does not descend into directory") {
-//     /*
-//      * In the test data we only find "day=29" beneath "month=9",
-//      * so the `ls` should throw with this directory filter if and only if
-//      * we descend into directories with "month=9".
-//      */
-//     std::string monthstr = "month=9";
-//     auto throw_if_day_is_29 = [&monthstr](std::string_view dirname) -> bool {
-//       if (dirname.find("month") == std::string::npos) {
-//         /* haven't descended far enough yet */
-//         return true;
-//       } else if (dirname.find(monthstr) == std::string::npos) {
-//         /* not august */
-//         return false;
-//       } else if (dirname.find("day=29") == std::string::npos) {
-//         /* not the 29th */
-//         return true;
-//       } else {
-//         /* it is the 29th, throw */
-//         throw std::logic_error("Throwing FileFilter: day=29");
-//       }
-//     };
-//
-//     CHECK_THROWS_AS(
-//         vfs_test.vfs_.ls_recursive(
-//             vfs_test.temp_dir_,
-//             tiledb::sm::accept_only_regular_files,
-//             throw_if_day_is_29),
-//         std::logic_error);
-//     CHECK_THROWS_WITH(
-//         vfs_test.vfs_.ls_recursive(
-//             vfs_test.temp_dir_,
-//             tiledb::sm::accept_only_regular_files,
-//             throw_if_day_is_29),
-//         Catch::Matchers::ContainsSubstring("Throwing FileFilter: day=29"));
-//
-//     monthstr = "month=8";
-//
-//     /* now the result should be the same as the first section */
-//     auto ls = vfs_test.vfs_.ls_recursive(
-//         vfs_test.temp_dir_,
-//         tiledb::sm::accept_only_regular_files,
-//         throw_if_day_is_29);
-//
-//     /* directories appear in the result set, we aren't interested in those,
-//      * and the callback doesn't (yet?) have a way to descend into a directory
-//      * without also including it in the result set */
-//     std::erase_if(ls, [](const auto& obj) { return obj.second == 0; });
-//
-//     CHECK(ls.size() == testpaths.size() / 2);
-//
-//     ls = sort_by_name(ls); /* ensure order matches the testpaths order */
-//
-//     CHECK(ls.size() == 8);
-//     if (ls.size() >= 1) {
-//       testpaths[0].matches(ls[0]);
-//     }
-//     if (ls.size() >= 2) {
-//       testpaths[1].matches(ls[1]);
-//     }
-//     if (ls.size() >= 3) {
-//       testpaths[2].matches(ls[2]);
-//     }
-//     if (ls.size() >= 4) {
-//       testpaths[3].matches(ls[3]);
-//     }
-//     if (ls.size() >= 5) {
-//       testpaths[8].matches(ls[4]);
-//     }
-//     if (ls.size() >= 6) {
-//       testpaths[9].matches(ls[5]);
-//     }
-//     if (ls.size() >= 7) {
-//       testpaths[10].matches(ls[6]);
-//     }
-//     if (ls.size() >= 8) {
-//       testpaths[11].matches(ls[7]);
-//     }
-//   }
-//
-//   /*
-//    * Note that since we throw in the previous section, this check
-//    * demonstrates that all directories are closed whether or not we return
-//    * from ls_recursive normally
-//    */
-//   REQUIRE(vfs_test.check_open_files());
-// }
-
-TEST_CASE("VFS: Throwing FileFilter ls_recursive", "[vfs][ls_recursive]") {
+TEST_CASE("VFS: Throwing ResultFilter ls_recursive", "[vfs][ls_recursive]") {
   std::string prefix = GENERATE("file://");
   prefix += std::filesystem::current_path().string() + "/ls_filtered_test";
 
@@ -650,24 +477,24 @@ TEST_CASE("VFS: Throwing FileFilter ls_recursive", "[vfs][ls_recursive]") {
   REQUIRE(mkst.ok());
 
   auto always_throw_filter = [](const std::string_view&, uint64_t) -> bool {
-    throw std::logic_error("Throwing FileFilter");
+    throw std::logic_error("Throwing ResultFilter");
   };
-  SECTION("Throwing FileFilter with 0 objects should not throw") {
+  SECTION("Throwing ResultFilter with 0 objects should not throw") {
     CHECK_NOTHROW(
         vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, always_throw_filter));
   }
   SECTION(
-      "Throwing FileFilter will not throw if ls_recursive only visits "
+      "Throwing ResultFilter will not throw if ls_recursive only visits "
       "directories") {
   }
-  SECTION("Throwing FileFilter with N objects should throw") {
+  SECTION("Throwing ResultFilter with N objects should throw") {
     REQUIRE_NOTHROW(vfs_test.vfs_.touch(vfs_test.temp_dir_.join_path("file")));
     CHECK_THROWS_AS(
         vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, always_throw_filter),
         std::logic_error);
     CHECK_THROWS_WITH(
         vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, always_throw_filter),
-        Catch::Matchers::ContainsSubstring("Throwing FileFilter"));
+        Catch::Matchers::ContainsSubstring("Throwing ResultFilter"));
   }
 
   /* all tests must close all the files that they opened, regardless of
@@ -685,8 +512,7 @@ TEST_CASE(
   std::string backend = vfs_test.temp_dir_.backend_name();
   DYNAMIC_SECTION(backend << " unsupported backend should throw") {
     CHECK_THROWS_WITH(
-        vfs_test.vfs_.ls_recursive(
-            vfs_test.temp_dir_, tiledb::sm::accept_all_files),
+        vfs_test.vfs_.ls_recursive(vfs_test.temp_dir_, VFSTest::accept_all),
         Catch::Matchers::ContainsSubstring("not supported"));
   }
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -359,7 +359,7 @@ std::vector<directory_entry> VFS::ls_with_sizes(const URI& parent) const {
 }
 
 LsObjects VFS::ls_filtered(
-    const URI& parent, FileFilter f, bool recursive) const {
+    const URI& parent, ResultFilter f, bool recursive) const {
   return get_fs(parent).ls_filtered(parent, std::move(f), recursive);
 }
 

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -363,6 +363,11 @@ LsObjects VFS::ls_filtered(
   return get_fs(parent).ls_filtered(parent, std::move(f), recursive);
 }
 
+LsObjects VFS::ls_filtered_v2(
+    const URI& parent, ResultFilterV2 f, bool recursive) const {
+  return get_fs(parent).ls_filtered_v2(parent, std::move(f), recursive);
+}
+
 void VFS::move_file(const URI& old_uri, const URI& new_uri) const {
   auto& old_fs = get_fs(old_uri);
   auto& new_fs = get_fs(new_uri);

--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -359,9 +359,8 @@ std::vector<directory_entry> VFS::ls_with_sizes(const URI& parent) const {
 }
 
 LsObjects VFS::ls_filtered(
-    const URI& parent, FileFilter f, DirectoryFilter d, bool recursive) const {
-  return get_fs(parent).ls_filtered(
-      parent, std::move(f), std::move(d), recursive);
+    const URI& parent, FileFilter f, bool recursive) const {
+  return get_fs(parent).ls_filtered(parent, std::move(f), recursive);
 }
 
 void VFS::move_file(const URI& old_uri, const URI& new_uri) const {

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -621,8 +621,7 @@ class VFS : FilesystemBase,
    *    and object size.
    */
   template <FilePredicate F, DirectoryPredicate D = DirectoryFilter>
-  LsObjects ls_recursive(
-      const URI& parent, F&& f, D&& d = accept_all_dirs) const {
+  LsObjects ls_recursive(const URI& parent, F f, D d = accept_all_dirs) const {
     return ls_filtered(parent, std::move(f), std::move(d), true);
   }
 

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -600,9 +600,33 @@ class VFS : FilesystemBase,
    */
   std::vector<directory_entry> ls_with_sizes(const URI& parent) const override;
 
+  /**
+   * Lists objects and object information that start with `prefix`, invoking
+   * the ResultFilter on each entry collected.
+   *
+   * Both objects and common prefixes will be collected if non-recursive.
+   * For recursive listing cloud backends will not collect prefix results.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param f The ResultFilter to invoke on each object for filtering.
+   * @param recursive Whether to recursively list subdirectories.
+   */
   LsObjects ls_filtered(
       const URI& parent, ResultFilter f, bool recursive) const override;
 
+
+  /**
+   * Lists objects and object information that start with `prefix`, invoking
+   * the ResultFilterV2 on each entry collected. Both objects and common
+   * prefixes will be collected for all storage backends.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param result_filter The ResultFilterV2 to invoke on each object for
+   * filtering.
+   * @param recursive Whether to recursively list subdirectories.
+   * @return Vector of results with each entry being a pair of the string URI
+   * and object size.
+   */
   LsObjects ls_filtered_v2(
       const URI& parent, ResultFilterV2 f, bool recursive) const override;
 

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -621,7 +621,8 @@ class VFS : FilesystemBase,
    *    and object size.
    */
   template <FilePredicate F, DirectoryPredicate D = DirectoryFilter>
-  LsObjects ls_recursive(const URI& parent, F f, D d = accept_all_dirs) const {
+  LsObjects ls_recursive(
+      const URI& parent, F&& f, D&& d = accept_all_dirs) const {
     return ls_filtered(parent, std::move(f), std::move(d), true);
   }
 

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -603,6 +603,9 @@ class VFS : FilesystemBase,
   LsObjects ls_filtered(
       const URI& parent, ResultFilter f, bool recursive) const override;
 
+  LsObjects ls_filtered_v2(
+      const URI& parent, ResultFilterV2 f, bool recursive) const override;
+
   /**
    * Recursively lists objects and object information that start with `prefix`,
    * invoking the FilterPredicate on each entry collected.
@@ -617,6 +620,22 @@ class VFS : FilesystemBase,
   template <FilterPredicate F>
   LsObjects ls_recursive(const URI& parent, F&& f) const {
     return ls_filtered(parent, std::move(f), true);
+  }
+
+  /**
+   * Recursively lists objects and object information that start with `prefix`,
+   * invoking the FilterPredicate on each entry collected.
+   *
+   * Currently this API is only supported for local files, S3, Azure and GCS.
+   *
+   * @param parent The parent prefix to list sub-paths.
+   * @param f The FilterPredicate to invoke on each object for filtering.
+   * @return Vector of results with each entry being a pair of the string URI
+   *    and object size.
+   */
+  template <FilterPredicateV2 F>
+  LsObjects ls_recursive_v2(const URI& parent, F&& f) const {
+    return ls_filtered_v2(parent, std::move(f), true);
   }
 
   /**

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -601,23 +601,20 @@ class VFS : FilesystemBase,
   std::vector<directory_entry> ls_with_sizes(const URI& parent) const override;
 
   LsObjects ls_filtered(
-      const URI& parent, FileFilter f, bool recursive) const override;
+      const URI& parent, ResultFilter f, bool recursive) const override;
 
   /**
    * Recursively lists objects and object information that start with `prefix`,
-   * invoking the FilePredicate on each entry collected and the
-   * DirectoryPredicate on common prefixes for pruning.
+   * invoking the FilterPredicate on each entry collected.
    *
    * Currently this API is only supported for local files, S3, Azure and GCS.
    *
    * @param parent The parent prefix to list sub-paths.
-   * @param f The FilePredicate to invoke on each object for filtering.
-   * @param d The DirectoryPredicate to invoke on each common prefix for
-   *    pruning. This is currently unused, but is kept here for future support.
+   * @param f The FilterPredicate to invoke on each object for filtering.
    * @return Vector of results with each entry being a pair of the string URI
    *    and object size.
    */
-  template <FilePredicate F>
+  template <FilterPredicate F>
   LsObjects ls_recursive(const URI& parent, F&& f) const {
     return ls_filtered(parent, std::move(f), true);
   }

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -614,7 +614,6 @@ class VFS : FilesystemBase,
   LsObjects ls_filtered(
       const URI& parent, ResultFilter f, bool recursive) const override;
 
-
   /**
    * Lists objects and object information that start with `prefix`, invoking
    * the ResultFilterV2 on each entry collected. Both objects and common

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -601,10 +601,7 @@ class VFS : FilesystemBase,
   std::vector<directory_entry> ls_with_sizes(const URI& parent) const override;
 
   LsObjects ls_filtered(
-      const URI& parent,
-      FileFilter f,
-      DirectoryFilter d,
-      bool recursive) const override;
+      const URI& parent, FileFilter f, bool recursive) const override;
 
   /**
    * Recursively lists objects and object information that start with `prefix`,
@@ -620,10 +617,9 @@ class VFS : FilesystemBase,
    * @return Vector of results with each entry being a pair of the string URI
    *    and object size.
    */
-  template <FilePredicate F, DirectoryPredicate D = DirectoryFilter>
-  LsObjects ls_recursive(
-      const URI& parent, F&& f, D&& d = accept_all_dirs) const {
-    return ls_filtered(parent, std::move(f), std::move(d), true);
+  template <FilePredicate F>
+  LsObjects ls_recursive(const URI& parent, F&& f) const {
+    return ls_filtered(parent, std::move(f), true);
   }
 
   /**


### PR DESCRIPTION
This updates ls_recursive to include directories (prefixes) for object storage backends. 

Some performance testing before and after this change built in release mode, I don't see a major performance impact using these test buckets.

```
# Before
Fetched 464846 objects in 60343.9ms from S3 URI: s3://tiledb-shaun
Fetched 6868 objects in 1125.57ms from S3 URI: s3://tiledb-deep-archive
Fetched 998918 objects in 145453ms from S3 URI: s3://genomic-datasets/vcf/giab/datasets/structural-variants/

# After
Fetched 474641 objects in 52456.9ms from S3 URI: s3://tiledb-shaun
Fetched 11929 objects in 1180.48ms from S3 URI: s3://tiledb-deep-archive
Fetched 1068657 objects in 137803ms from S3 URI: s3://genomic-datasets/vcf/giab/datasets/structural-variants/
```

---
TYPE: FEATURE
DESC: Include directories in ls recursive results.