### PR TITLE
Fix `zip_view` default constructor for C++20 concepts compliance

### DIFF
--- a/tiledb/stdx/__ranges/zip_view.h
+++ b/tiledb/stdx/__ranges/zip_view.h
@@ -87,7 +87,9 @@ class zip_view : public std::ranges::view_interface<zip_view<Rngs...>> {
    ****************************************************************************/
 
   /** Default constructor */
-  zip_view() = default;
+  zip_view()
+    requires(std::default_initializable<Rngs> && ...)
+  = default;
 
   /**
    * Construct a zip view from a set of ranges.  The ranges are stored in a


### PR DESCRIPTION
Fixes GCC 11.2+ errors by constraining `zip_view`'s default constructor to cases where all range types are default-constructible, avoiding static assertions from C++20's stricter `std::ranges::view` checks.

---
TYPE: BUILD
DESC: Fix `zip_view` default constructor for C++20 concepts compliance.
