### PR TITLE
fix: config parameter lookup should check if profile file exists before trying to load it, to avoid noise when using `gdb` command `catch throw`

### DIFF
--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -948,15 +948,19 @@ const char* Config::get_from_profile(
     std::optional<std::string> profile_dir =
         found_dir ? std::make_optional(profile_dir_cstr) : std::nullopt;
 
+    const bool isNonDefaultProfile =
+        ((profile_name.has_value() && !profile_name.value().empty()) ||
+         (profile_dir.has_value() && !profile_dir.value().empty()));
     try {
       // Create a Profile object and load the profile
       rest_profile_ = RestProfile(profile_name, profile_dir);
-      rest_profile_.value().load_from_file();
+      if (rest_profile_.value().file_exists() || isNonDefaultProfile) {
+        rest_profile_.value().load_from_file();
+      }
     } catch (const std::exception&) {
       // Throw an exception if the user has specified profile-related
       // parameters but the profile could not be loaded.
-      if ((profile_name.has_value() && !profile_name.value().empty()) ||
-          (profile_dir.has_value() && !profile_dir.value().empty())) {
+      if (isNonDefaultProfile) {
         throw ConfigException(
             "Failed to load the REST profile. "
             "Please check the profile name and directory parameters.");

--- a/tiledb/sm/rest/rest_profile.cc
+++ b/tiledb/sm/rest/rest_profile.cc
@@ -226,8 +226,12 @@ void RestProfile::save_to_file(const bool overwrite) {
   write_file(data, filepath_);
 }
 
+bool RestProfile::file_exists() const {
+  return std::filesystem::exists(filepath_);
+}
+
 void RestProfile::load_from_file() {
-  if (std::filesystem::exists(filepath_)) {
+  if (file_exists()) {
     // If the local file exists, load the profile with the given name.
     load_from_json_file(filepath_);
   } else {

--- a/tiledb/sm/rest/rest_profile.h
+++ b/tiledb/sm/rest/rest_profile.h
@@ -129,6 +129,11 @@ class RestProfile {
   }
 
   /**
+   * @return true if there is a regular file at the file path expected for this
+   */
+  bool file_exists() const;
+
+  /**
    * Saves this profile to the local file.
    *
    * @param overwrite If true, overwrite the existing profile with the same


### PR DESCRIPTION
When debugging with `gdb`, the command `catch throw` instructs program execution to pause whenever an exception is thrown.  This is very useful for identifying root causes of errors in code.  However, if any code is written which throws an exception as part of its non-exceptional control flow, then this command becomes a lot more cumbersome to use because it pauses execution at intentionally uninteresting events. Each pause must be inspected manually which slows the debugging loop down a lot.

If the user does not supply their own profile name or directory, then config parameter lookup will attempt to load a profile stored in a default location.  This ordinary part of control flow is extremely common, occurring up to one time per `Config` instance.  And attempting to load the profile throws an exception if the default profile file does not exist - exactly replicating the pattern described above.

This pull request adds `RestProfile::file_exists` so we can avoid throwing this exception.

Prior to this change, `catch throw` stops once per rapidcheck instance when running `gdb --args ./tiledb_unit --vfs=native "Sparse global order reader: fragment skew"`.  With this change it does not stop at all.

---
TYPE: NO_HISTORY
DESC: Config lookup avoids throwing RestProfileException to improve `catch throw` debugging
