### PR TITLE
Avoid extra directory existence checks in `Win::ls_with_sizes`.

### DIFF
--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -383,7 +383,7 @@ std::vector<directory_entry> Win::ls_with_sizes(const URI& uri) const {
         strcmp(find_data.cFileName, "..") != 0) {
       std::string file_path =
           path + (ends_with_slash ? "" : "\\") + find_data.cFileName;
-      if (is_dir(URI(file_path))) {
+      if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
         entries.emplace_back(file_path, 0, true);
       } else {
         ULARGE_INTEGER size;


### PR DESCRIPTION
The `WIN32_FIND_DATA` structure returned from the Windows API already contains whether the listed entry is a directory; we don't need to call `is_dir` again.

---
TYPE: IMPROVEMENT
DESC: Improved performance of listing files in Windows.