### PR TITLE
Do not retry SSL-related Curl error codes.

### DIFF
--- a/tiledb/sm/rest/curl.cc
+++ b/tiledb/sm/rest/curl.cc
@@ -641,11 +641,29 @@ bool Curl::should_retry_based_on_curl_code(CURLcode curl_code) const {
   switch (curl_code) {
     // Curl status of okay or non transient errors shouldn't be retried
     case CURLE_OK:
-    case CURLE_URL_MALFORMAT:       /* 3 */
+    case CURLE_URL_MALFORMAT:        /* 3 */
+    case CURLE_SSL_ENGINE_NOTFOUND:  /* 53 - SSL crypto engine not found */
+    case CURLE_SSL_ENGINE_SETFAILED: /* 54 - can not set SSL crypto engine as
+                                       default */
+    case CURLE_SSL_CERTPROBLEM: /* 58 - problem with the local certificate */
+    case CURLE_SSL_CIPHER:      /* 59 - couldn't use specified cipher */
+    case CURLE_PEER_FAILED_VERIFICATION: /* 60 - peer's certificate or
+                                           fingerprint wasn't verified fine */
+    case CURLE_SSL_ENGINE_INITFAILED:    /* 66 - failed to initialise ENGINE */
+    case CURLE_SSL_CACERT_BADFILE:  /* 77 - could not load CACERT file, missing
+                                      or wrong format */
     case CURLE_SSL_SHUTDOWN_FAILED: /* 80 - Failed to shut down the SSL
                                       connection */
-    case CURLE_AUTH_ERROR: /* 94 - an authentication function returned an
-                             error */
+    case CURLE_SSL_CRL_BADFILE:     /* 82 - could not load CRL file, missing or
+                                      wrong format (Added in 7.19.0) */
+    case CURLE_SSL_ISSUER_ERROR:    /* 83 - Issuer check failed.  (Added in
+                                      7.19.0) */
+    case CURLE_SSL_PINNEDPUBKEYNOTMATCH: /* 90 - specified pinned public key did
+                                         not match */
+    case CURLE_SSL_INVALIDCERTSTATUS:    /* 91 - invalid certificate status */
+    case CURLE_AUTH_ERROR:     /* 94 - an authentication function returned an
+                                 error */
+    case CURLE_SSL_CLIENTCERT: /* 98 - client-side certificate required */
       return false;
     case CURLE_UNSUPPORTED_PROTOCOL:  /* 1 */
     case CURLE_FAILED_INIT:           /* 2 */
@@ -706,23 +724,15 @@ bool Curl::should_retry_based_on_curl_code(CURLcode curl_code) const {
     case CURLE_OBSOLETE50:           /* 50 - NOT USED */
     case CURLE_OBSOLETE51:           /* 51 - NOT USED */
     case CURLE_GOT_NOTHING:          /* 52 - when this is a specific error */
-    case CURLE_SSL_ENGINE_NOTFOUND:  /* 53 - SSL crypto engine not found */
-    case CURLE_SSL_ENGINE_SETFAILED: /* 54 - can not set SSL crypto engine as
-                                       default */
     case CURLE_SEND_ERROR:           /* 55 - failed sending network data */
-    case CURLE_RECV_ERROR:      /* 56 - failure in receiving network data */
-    case CURLE_OBSOLETE57:      /* 57 - NOT IN USE */
-    case CURLE_SSL_CERTPROBLEM: /* 58 - problem with the local certificate */
-    case CURLE_SSL_CIPHER:      /* 59 - couldn't use specified cipher */
-    case CURLE_PEER_FAILED_VERIFICATION: /* 60 - peer's certificate or
-                                           fingerprint wasn't verified fine */
-    case CURLE_BAD_CONTENT_ENCODING:     /* 61 - Unrecognized/bad encoding */
-    case CURLE_OBSOLETE62:               /* 62 - NOT IN USE since 7.82.0 */
-    case CURLE_FILESIZE_EXCEEDED:        /* 63 - Maximum file size exceeded */
+    case CURLE_RECV_ERROR: /* 56 - failure in receiving network data */
+    case CURLE_OBSOLETE57: /* 57 - NOT IN USE */
+    case CURLE_BAD_CONTENT_ENCODING:  /* 61 - Unrecognized/bad encoding */
+    case CURLE_OBSOLETE62:            /* 62 - NOT IN USE since 7.82.0 */
+    case CURLE_FILESIZE_EXCEEDED:     /* 63 - Maximum file size exceeded */
     case CURLE_USE_SSL_FAILED:        /* 64 - Requested FTP SSL level failed */
     case CURLE_SEND_FAIL_REWIND:      /* 65 - Sending the data requires a rewind
                                         that failed */
-    case CURLE_SSL_ENGINE_INITFAILED: /* 66 - failed to initialise ENGINE */
     case CURLE_LOGIN_DENIED:          /* 67 - user, password or similar was not
                                         accepted and we failed to login */
     case CURLE_TFTP_NOTFOUND:         /* 68 - file not found on server */
@@ -734,8 +744,6 @@ bool Curl::should_retry_based_on_curl_code(CURLcode curl_code) const {
     case CURLE_TFTP_NOSUCHUSER:       /* 74 - No such user */
     case CURLE_OBSOLETE75:            /* 75 - NOT IN USE since 7.82.0 */
     case CURLE_OBSOLETE76:            /* 76 - NOT IN USE since 7.82.0 */
-    case CURLE_SSL_CACERT_BADFILE: /* 77 - could not load CACERT file, missing
-                                     or wrong format */
     case CURLE_REMOTE_FILE_NOT_FOUND: /* 78 - remote file not found */
     case CURLE_SSH:                   /* 79 - error from the SSH layer, somewhat
                                         generic so the error message will be of
@@ -744,20 +752,13 @@ bool Curl::should_retry_based_on_curl_code(CURLcode curl_code) const {
     case CURLE_AGAIN:              /* 81 - socket is not ready for send/recv,
                                      wait till it's ready and try again (Added
                                      in 7.18.2) */
-    case CURLE_SSL_CRL_BADFILE:    /* 82 - could not load CRL file, missing or
-                                     wrong format (Added in 7.19.0) */
-    case CURLE_SSL_ISSUER_ERROR:   /* 83 - Issuer check failed.  (Added in
-                                     7.19.0) */
     case CURLE_FTP_PRET_FAILED:    /* 84 - a PRET command failed */
     case CURLE_RTSP_CSEQ_ERROR:    /* 85 - mismatch of RTSP CSeq numbers */
     case CURLE_RTSP_SESSION_ERROR: /* 86 - mismatch of RTSP Session Ids */
     case CURLE_FTP_BAD_FILE_LIST:  /* 87 - unable to parse FTP file list */
     case CURLE_CHUNK_FAILED:       /* 88 - chunk callback reported error */
-    case CURLE_NO_CONNECTION_AVAILABLE:  /* 89 - No connection available, the
-                                         session will be queued */
-    case CURLE_SSL_PINNEDPUBKEYNOTMATCH: /* 90 - specified pinned public key did
-                                         not match */
-    case CURLE_SSL_INVALIDCERTSTATUS:    /* 91 - invalid certificate status */
+    case CURLE_NO_CONNECTION_AVAILABLE: /* 89 - No connection available, the
+                                        session will be queued */
     case CURLE_HTTP2_STREAM:       /* 92 - stream error in HTTP/2 framing layer
                                     */
     case CURLE_RECURSIVE_API_CALL: /* 93 - an api function was called from
@@ -765,7 +766,6 @@ bool Curl::should_retry_based_on_curl_code(CURLcode curl_code) const {
     case CURLE_HTTP3:              /* 95 - An HTTP/3 layer problem */
     case CURLE_QUIC_CONNECT_ERROR: /* 96 - QUIC connection error */
     case CURLE_PROXY:              /* 97 - proxy handshake error */
-    case CURLE_SSL_CLIENTCERT:     /* 98 - client-side certificate required */
     case CURLE_UNRECOVERABLE_POLL: /* 99 - poll/select returned fatal error */
     case CURLE_TOO_LARGE:          /* 100 - a value/data met its maximum */
     case CURLE_ECH_REQUIRED:       /* 101 - ECH tried but failed */


### PR DESCRIPTION
This PR updates `Curl::should_retry_based_on_curl_code` to not retry most error codes related to SSL. These are usually the result of misconfiguration in either end of the connection, and retrying them is not likely to change anything.

---
TYPE: IMPROVEMENT
DESC: Do not retry most SSL-related failures in the REST client.