### PR TITLE
Allow adding relative group members to remote groups.

### DIFF
--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -1116,16 +1116,15 @@ TEST_CASE(
   // Open group in write mode
   {
     auto group = tiledb::Group(ctx, group_name, TILEDB_WRITE);
+    CHECK_NOTHROW(group.add_member("subgroup", true, "subgroup"));
     if (vfs_test_setup.is_rest()) {
       CHECK_THROWS_WITH(
-          group.add_member("subgroup", true, "subgroup"),
-          Catch::Matchers::EndsWith("Cannot add member; Remote groups do not "
-                                    "support members with relative "
-                                    "URIs"));
+          group.close(),
+          Catch::Matchers::ContainsSubstring(
+              "relative paths are not yet supported for cloud groups"));
     } else {
-      CHECK_NOTHROW(group.add_member("subgroup", true, "subgroup"));
+      CHECK_NOTHROW(group.close());
     }
-    group.close();
   }
 
   if (!vfs_test_setup.is_rest()) {

--- a/tiledb/oxidize/cxx-interface/src/sm/array_schema/mod.rs
+++ b/tiledb/oxidize/cxx-interface/src/sm/array_schema/mod.rs
@@ -359,7 +359,7 @@ impl ArraySchema {
     }
 
     /// Returns an iterator over all of the fields of this schema.
-    pub fn fields(&self) -> impl Iterator<Item = Field> {
+    pub fn fields(&self) -> impl Iterator<Item = Field<'_>> {
         self.domain()
             .dimensions()
             .map(Field::Dimension)

--- a/tiledb/oxidize/expr/src/query_condition.rs
+++ b/tiledb/oxidize/expr/src/query_condition.rs
@@ -474,7 +474,7 @@ fn to_datafusion_impl(schema: &ArraySchema, query_condition: &ASTNode) -> Result
                 }
             }
             QueryConditionOp::ALWAYS_FALSE => Ok(Expr::Literal(ScalarValue::Boolean(Some(false)))),
-            invalid => return Err(InternalError::InvalidOp(invalid.repr.into()).into()),
+            invalid => Err(InternalError::InvalidOp(invalid.repr.into()).into()),
         }
     }
 }

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -648,14 +648,6 @@ void Group::mark_member_for_addition(
     throw GroupException("Cannot add member; Group is not open");
   }
 
-  if (remote_ && relative) {
-    // Relative URIs are supported in the capnp serialization format, but the
-    // REST server has not yet implemented the logic.
-    throw GroupException(
-        "Cannot add member; Remote groups do not support members with relative "
-        "URIs");
-  }
-
   // Check mode
   if (query_type_ != QueryType::WRITE &&
       query_type_ != QueryType::MODIFY_EXCLUSIVE) {


### PR DESCRIPTION
This removes the client side error that previously blocked requests to add a relative group member to a remote group, and updates the unit test to expect the new error message from legacy and 3.0 REST servers.

The updated unit test will fail until the REST PR is merged.

---
TYPE: IMPROVEMENT
DESC: Allow adding relative group members to remote groups.
