### PR TITLE
C API aspect can return object with a destructor which is run after the C API call

### DIFF
--- a/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
+++ b/tiledb/api/c_api_support/exception_wrapper/exception_wrapper.h
@@ -527,6 +527,48 @@ class CAPIFunctionNullAspect {
 };
 
 /**
+ * Adapter for aspect return types which will, via specialization,
+ * allow generic aspects to return `void` or any type `T`.
+ */
+template <typename T>
+struct AspectReturnAdapter {
+  AspectReturnAdapter(T&& value)
+      : value_(std::move(value)) {
+  }
+
+  T value_;
+};
+
+/**
+ * Specialization which allows returning `void` as a value.
+ */
+template <>
+struct AspectReturnAdapter<void> {
+  AspectReturnAdapter() {
+  }
+};
+
+/**
+ * Provides adapters for invoking an aspect `A` and
+ * wrapping the result of its `call` function into `AspectReturnAdapter`.
+ */
+template <typename A>
+struct AspectWrapper {
+  template <typename... Args>
+  using R = decltype(A::call(std::declval<Args>()...));
+
+  template <typename... Args>
+  static AspectReturnAdapter<R<Args...>> call(Args... args) {
+    if constexpr (std::same_as<R<Args...>, void>) {
+      A::call(args...);
+      return AspectReturnAdapter<void>();
+    } else {
+      return AspectReturnAdapter<R<Args...>>(A::call(args...));
+    }
+  }
+};
+
+/**
  * Selection struct defines the default aspect type for CAPIFunction. This class
  * is always used with second template argument as `void`. This definition is
  * for the general case; a specialization can override it.
@@ -586,7 +628,7 @@ class CAPIFunction<f, H, A> {
        * Note that we don't need std::forward here because all the arguments
        * must have "C" linkage.
        */
-      A::call(args...);
+      [[maybe_unused]] const auto bind = AspectWrapper<A>::call(args...);
       if constexpr (std::same_as<R, void>) {
         f(args...);
         h.action_on_success();

--- a/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
+++ b/tiledb/api/c_api_support/exception_wrapper/test/CMakeLists.txt
@@ -64,24 +64,29 @@ commence(unit_test capi_ew_without_hook)
 conclude(unit_test)
 
 # Hook tests with the hook included.
-commence(unit_test capi_ew_with_hook)
-  this_target_sources(
-      unit_capi_hook.cc
-      unit_capi_hook_with.cc
-      ../../../c_api/config/config_api.cc
-      ../../../c_api/context/context_api.cc
-      ../../../c_api/error/error_api.cc
-      ../../../../sm/storage_manager/context.cc
-      ../../../../sm/storage_manager/context_resources.cc
-  )
-  this_target_link_libraries(export)
-  this_target_object_libraries(
-      exception_wrapper
-      rest_client
-      storage_manager_stub
-      vfs
-  )
-  target_compile_definitions(unit_capi_ew_with_hook PUBLIC WITH_HOOK)
-  target_include_directories(
-      unit_capi_ew_with_hook PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/hook)
-conclude(unit_test)
+function (hook_test hookdef)
+  commence(unit_test capi_ew_with_${hookdef})
+    this_target_sources(
+        unit_capi_hook.cc
+        unit_capi_hook_with_${hookdef}.cc
+        ../../../c_api/config/config_api.cc
+        ../../../c_api/context/context_api.cc
+        ../../../c_api/error/error_api.cc
+        ../../../../sm/storage_manager/context.cc
+        ../../../../sm/storage_manager/context_resources.cc
+    )
+    this_target_link_libraries(export)
+    this_target_object_libraries(
+        exception_wrapper
+        rest_client
+        storage_manager_stub
+        vfs
+    )
+    target_compile_options(unit_capi_ew_with_${hookdef} PUBLIC "-DWITH_HOOK=\"${hookdef}\"")
+    target_include_directories(
+        unit_capi_ew_with_${hookdef} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/hook)
+  conclude(unit_test)
+endfunction ()
+
+hook_test(logger)
+hook_test(tracer)

--- a/tiledb/api/c_api_support/exception_wrapper/test/hook_common.h
+++ b/tiledb/api/c_api_support/exception_wrapper/test/hook_common.h
@@ -33,13 +33,26 @@
 #ifndef TILEDB_EXCEPTION_WRAPPER_TEST_HOOK_COMMON_H
 #define TILEDB_EXCEPTION_WRAPPER_TEST_HOOK_COMMON_H
 
+#ifndef WITH_HOOK
+#define WITH_HOOK ""
+#endif
+
+enum class WhichHook { None, Logger, Tracer };
+
+constexpr WhichHook get_constexpr_which_hook() {
+  constexpr std::string_view view(WITH_HOOK);
+  if (view == "logger") {
+    return WhichHook::Logger;
+  } else if (view == "tracer") {
+    return WhichHook::Tracer;
+  } else {
+    return WhichHook::None;
+  }
+}
+
 /*
  * Convert the possible command line argument WITH_HOOK into a C++ constant.
  */
-#if defined(WITH_HOOK)
-constexpr bool compiled_with_hook{true};
-#else
-constexpr bool compiled_with_hook{false};
-#endif
+constexpr WhichHook which_hook = get_constexpr_which_hook();
 
 #endif  // TILEDB_EXCEPTION_WRAPPER_TEST_HOOK_COMMON_H

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_logger.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_logger.cc
@@ -32,6 +32,6 @@
 
 #include "hook_common.h"
 
-TEST_CASE("Compile definition - with hook") {
-  CHECK(compiled_with_hook == true);
+TEST_CASE("Compile definition - with hook logger") {
+  CHECK(which_hook == WhichHook::Logger);
 }

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_logger.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_logger.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_tracer.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_tracer.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_tracer.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with_tracer.cc
@@ -1,0 +1,37 @@
+/**
+ * @file tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_with.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ */
+
+#include <test/support/tdb_catch.h>
+
+#include "hook_common.h"
+
+TEST_CASE("Compile definition - with tracer") {
+  CHECK(which_hook == WhichHook::Tracer);
+}

--- a/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
+++ b/tiledb/api/c_api_support/exception_wrapper/test/unit_capi_hook_without.cc
@@ -33,6 +33,6 @@
 
 #include "hook_common.h"
 
-TEST_CASE("Compile definition - without hook") {
-  CHECK(compiled_with_hook == false);
+TEST_CASE("Compile definition - no hook") {
+  CHECK(which_hook == WhichHook::None);
 }

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -2635,11 +2635,12 @@ CAPI_INTERFACE(
       ctx, array_schema_evolution, expanded_domain);
 }
 
-TILEDB_EXPORT int32_t tiledb_array_schema_evolution_set_timestamp_range(
+CAPI_INTERFACE(
+    array_schema_evolution_set_timestamp_range,
     tiledb_ctx_t* ctx,
     tiledb_array_schema_evolution_t* array_schema_evolution,
     uint64_t lo,
-    uint64_t hi) noexcept {
+    uint64_t hi) {
   return api_entry<
       tiledb::api::tiledb_array_schema_evolution_set_timestamp_range>(
       ctx, array_schema_evolution, lo, hi);


### PR DESCRIPTION
My work on CORE-290 intends to use opentelemetry tracing into the core library. When we introduce tracing, we will want to record each C API call as a span under which nested operations occur.

The C API calls can be intercepted via aspect template (#4430). A build process which compiles TileDB core from source can use this aspect to inject code which runs prior to each C API call.

One use of this is in the TileDB-Server repository, which *also* wants to add [opentelemetry tracing to each C API call](https://github.com/TileDB-Inc/TileDB-Server/blob/main/docker/tracing-hook/capi_function_override.cc).  However, this implementation is lacking because the aspects do not allow a span to encompass the whole C API call.  The instrumentation linked starts and ends the span before invoking the API.  It cannot do any better because the aspect `call` template function return value is not used, so a non-trivial value returned would have its destructor run right away.

This pull request modifies the template invoking the aspect `call` function to bind its result to a value on the stack.  This runs the destructor after returning from the C API call, which will allow the aspect `call` function to return a tracing span object.

There is no tracing in this pull request, but the added test demonstrates the principle, modifying the existing logging hook test into a "tracing hook" which pushes messages onto a simple log before and after each C API call.

---
TYPE: NO_HISTORY
DESC: Enable C API aspect templates to return a non-trivial
