### PR TITLE
Bug fix: building tests with s3 enabled.

### DIFF
--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -43,10 +43,6 @@
 #include "tiledb/sm/stats/global_stats.h"
 #include "tiledb/sm/tile/tile.h"
 
-#ifdef HAVE_S3
-#include "tiledb/sm/filesystem/s3.h"
-#endif
-
 #include <iostream>
 #include <list>
 #include <sstream>
@@ -57,10 +53,6 @@ using namespace tiledb::common;
 using namespace tiledb::sm::filesystem;
 
 namespace tiledb::sm {
-
-#ifdef HAVE_S3
-S3_within_VFS::~S3_within_VFS() = default;
-#endif
 
 /* ********************************* */
 /*     CONSTRUCTORS & DESTRUCTORS    */

--- a/tiledb/sm/filesystem/vfs.h
+++ b/tiledb/sm/filesystem/vfs.h
@@ -65,6 +65,10 @@
 #include "tiledb/sm/filesystem/gcs.h"
 #endif  // HAVE_GCS
 
+#ifdef HAVE_S3
+#include "tiledb/sm/filesystem/s3.h"
+#endif  // HAVE_S3
+
 #ifdef HAVE_AZURE
 #include "tiledb/sm/filesystem/azure.h"
 #endif  // HAVE_AZURE
@@ -287,9 +291,6 @@ class GCS_within_VFS {
 
 /** The S3 filesystem. */
 #ifdef HAVE_S3
-
-class S3;
-
 class S3_within_VFS {
   /** Private member variable */
   tdb_unique_ptr<S3> s3_;
@@ -300,7 +301,7 @@ class S3_within_VFS {
       : s3_(tdb_unique_ptr<S3>(tdb_new(S3, std::forward<Args>(args)...))) {
   }
 
-  ~S3_within_VFS();
+  ~S3_within_VFS() = default;
 
   /** Protected accessor for the S3 object. */
   inline S3& s3() {


### PR DESCRIPTION
After #5596, building `tests` was failing with `s3` enabled. This PR provides a quick fix by migrating the `s3` header into the `vfs` header to resolve include paths. 

---
TYPE: BUG
DESC: Bug fix: building `tests` with `s3` enabled.

---
Fixes CORE-362.
