### PR TITLE
Add support for relative URI remote group members.

### DIFF
--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -1117,7 +1117,7 @@ TEST_CASE(
   {
     auto group = tiledb::Group(ctx, group_name, TILEDB_WRITE);
     CHECK_NOTHROW(group.add_member("subgroup", true, "subgroup"));
-    if (vfs_test_setup.is_rest()) {
+    if (vfs_test_setup.is_rest() && vfs_test_setup.is_legacy_rest()) {
       CHECK_THROWS_WITH(
           group.close(),
           Catch::Matchers::ContainsSubstring(

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -1215,6 +1215,8 @@ TEST_CASE(
   {
     auto group = tiledb::Group(ctx, group_uri, TILEDB_WRITE);
     CHECK_NOTHROW(group.add_member("relative_group", true, "relative_group"));
+    CHECK_NOTHROW(
+        group.add_member("relative_group", true, "relative_group_rename"));
     if (vfs_test_setup.is_rest() && vfs_test_setup.is_legacy_rest()) {
       CHECK_THROWS_WITH(
           group.close(),
@@ -1227,13 +1229,16 @@ TEST_CASE(
 
   if (!vfs_test_setup.is_rest() || !vfs_test_setup.is_legacy_rest()) {
     auto group = tiledb::Group(ctx, group_uri, TILEDB_READ);
-    auto member = group.member("relative_group");
-    CHECK(member.type() == tiledb::Object::Type::Group);
-    CHECK(member.name() == "relative_group");
-    std::string expected_uri =
-        build_tiledb_uri(sub_uri, "groups_relative/relative_group");
-    CHECK(member.uri() == expected_uri);
-    CHECK(group.is_relative("relative_group"));
+    CHECK(group.member_count() == 2);
+    for (const auto& name : {"relative_group", "relative_group_rename"}) {
+      auto member = group.member(name);
+      CHECK(member.type() == tiledb::Object::Type::Group);
+      CHECK(member.name() == name);
+      std::string expected_uri =
+          build_tiledb_uri(sub_uri, std::string("groups_relative/") + name);
+      CHECK(member.uri() == expected_uri);
+      CHECK(group.is_relative(name));
+    }
   }
 }
 
@@ -1274,6 +1279,8 @@ TEST_CASE(
   {
     auto group = tiledb::Group(ctx, group_uri, TILEDB_WRITE);
     CHECK_NOTHROW(group.add_member("relative_array", true, "relative_array"));
+    CHECK_NOTHROW(
+        group.add_member("relative_array", true, "relative_array_rename"));
     if (vfs_test_setup.is_rest() && vfs_test_setup.is_legacy_rest()) {
       CHECK_THROWS_WITH(
           group.close(),
@@ -1286,12 +1293,15 @@ TEST_CASE(
 
   if (!vfs_test_setup.is_rest() || !vfs_test_setup.is_legacy_rest()) {
     auto group = tiledb::Group(ctx, group_uri, TILEDB_READ);
-    auto member = group.member("relative_array");
-    CHECK(member.type() == tiledb::Object::Type::Array);
-    CHECK(member.name() == "relative_array");
-    std::string expected_uri =
-        build_tiledb_uri(sub_uri, "groups_relative/relative_array");
-    CHECK(member.uri() == expected_uri);
-    CHECK(group.is_relative("relative_array"));
+    CHECK(group.member_count() == 2);
+    for (const auto& name : {"relative_array", "relative_array_rename"}) {
+      auto member = group.member(name);
+      CHECK(member.type() == tiledb::Object::Type::Array);
+      CHECK(member.name() == name);
+      std::string expected_uri =
+          build_tiledb_uri(sub_uri, std::string("groups_relative/") + name);
+      CHECK(member.uri() == expected_uri);
+      CHECK(group.is_relative(name));
+    }
   }
 }

--- a/test/src/unit-cppapi-group.cc
+++ b/test/src/unit-cppapi-group.cc
@@ -1102,7 +1102,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C++ API: Group with Relative URI members, write/read, rest",
+    "C++ API: Group with relative URI members, write/read, rest",
     "[cppapi][group][create][relative][rest]") {
   VFSTestSetup vfs_test_setup;
   if (!vfs_test_setup.is_rest()) {
@@ -1150,7 +1150,7 @@ TEST_CASE(
 }
 
 TEST_CASE(
-    "C++ API: Group add_member with Relative URI members, write/read, rest",
+    "C++ API: Group add_member with relative URI members, write/read, rest",
     "[cppapi][group][add_member][relative][rest]") {
   VFSTestSetup vfs_test_setup;
   tiledb::Context ctx{vfs_test_setup.ctx()};
@@ -1164,7 +1164,14 @@ TEST_CASE(
   // Create parent group using tiledb URI.
   tiledb::create_group(ctx, group_uri);
   // Create child group using S3 URI.
-  tiledb::create_group(ctx, components.asset_storage);
+  SECTION("Create the child group using S3 URI") {
+    // Checks that we handle a not registered group correctly.
+    REQUIRE_NOTHROW(tiledb::create_group(ctx, components.asset_storage));
+  }
+  SECTION("Create the child group on REST using tiledb URI") {
+    // Checks that we handle a pre-registered group correctly.
+    REQUIRE_NOTHROW(tiledb::create_group(ctx, subgroup_uri));
+  }
 
   // Open group in write mode and add the relative member.
   {

--- a/test/support/src/helpers.cc
+++ b/test/support/src/helpers.cc
@@ -1651,6 +1651,16 @@ void schema_equiv(
   CHECK(schema1.array_uri().to_string() == schema2.array_uri().to_string());
 }
 
+std::string build_tiledb_uri(const URI& uri, const std::string& path) {
+  URI::RESTURIComponents components;
+  CHECK(uri.get_rest_components(false, &components).ok());
+  components.server_path.resize(components.server_path.find_first_of('/'));
+  components.server_path += path.starts_with('/') ? path : "/" + path;
+
+  return "tiledb://" + components.server_namespace + "/" +
+         components.server_path;
+}
+
 template void check_subarray<int8_t>(
     tiledb::sm::Subarray& subarray, const SubarrayRanges<int8_t>& ranges);
 template void check_subarray<uint8_t>(

--- a/test/support/src/helpers.h
+++ b/test/support/src/helpers.h
@@ -965,6 +965,21 @@ void read_sparse_v11(
 void schema_equiv(
     const sm::ArraySchema& schema1, const sm::ArraySchema& schema2);
 
+/**
+ * Helper function to build a tiledb URI using the provided asset path,
+ * following the randomly generated top-level directory used in all 3.0 REST
+ * tests.
+ *
+ * This helper only applies to 3.0 REST, there is no concept of asset paths in
+ * legacy REST.
+ *
+ * @param uri The URI to update.
+ * @param path The new asset path to use after the randomly generated top-level
+ *    directory.
+ * @return The tiledb URI built from the provided asset path.
+ */
+std::string build_tiledb_uri(const sm::URI& uri, const std::string& path);
+
 }  // namespace tiledb::test
 
 #endif

--- a/tiledb/sm/group/group_details.cc
+++ b/tiledb/sm/group/group_details.cc
@@ -322,7 +322,8 @@ GroupDetails::member_by_name(const std::string& name) {
 
   auto member = it->second;
   std::string uri = member->uri().to_string();
-  if (member->relative()) {
+  // Relative tiledb URIs are returned in the expected format from REST.
+  if (!member->uri().is_tiledb() && member->relative()) {
     uri = group_uri_.join_path(member->uri().to_string()).to_string();
   }
 

--- a/tiledb/sm/group/group_details.cc
+++ b/tiledb/sm/group/group_details.cc
@@ -111,10 +111,15 @@ void GroupDetails::mark_member_for_addition(
       URI::RESTURIComponents components;
       throw_if_not_ok(absolute_group_member_uri.get_rest_components(
           resources.rest_client()->rest_legacy(), &components));
+      // The asset is not registered on REST, so we set the object type using
+      // the asset storage location.
       if (!components.asset_storage.empty()) {
         URI storage_uri = URI(components.asset_storage);
-        if (!is_array(resources, storage_uri) &&
-            !is_group(resources, storage_uri)) {
+        if (is_array(resources, storage_uri)) {
+          obj_type = ObjectType::ARRAY;
+        } else if (is_group(resources, storage_uri)) {
+          obj_type = ObjectType::GROUP;
+        } else {
           throw GroupDetailsException(
               "Cannot add group member at " + components.asset_storage +
               "; The member does not exist at the backend storage location.");

--- a/tiledb/sm/object/object.cc
+++ b/tiledb/sm/object/object.cc
@@ -104,10 +104,10 @@ ObjectType object_type(ContextResources& resources, const URI& uri) {
     }
   }
 
-  if (is_array(resources, uri)) {
+  if (is_array(resources, dir_uri)) {
     return ObjectType::ARRAY;
   }
-  if (is_group(resources, uri)) {
+  if (is_group(resources, dir_uri)) {
     return ObjectType::GROUP;
   }
 

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -1516,6 +1516,15 @@ Status RestClientRemote::patch_group_to_rest(const URI& uri, Group* group) {
   RETURN_NOT_OK(
       serialization::group_update_serialize(group, serialization_type_, buff));
 
+  // Credential name for adding group members that are not registered on REST.
+  const auto creation_access_credentials_name{
+    config_->get<std::string>("rest.creation_access_credentials_name")};
+  if (creation_access_credentials_name.has_value()) {
+    add_header(
+        "X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME",
+        creation_access_credentials_name.value());
+  }
+
   // Init curl and form the URL
   Curl curlc(logger_);
   URI::RESTURIComponents rest_uri;

--- a/tiledb/sm/rest/rest_client_remote.cc
+++ b/tiledb/sm/rest/rest_client_remote.cc
@@ -1436,6 +1436,15 @@ Status RestClientRemote::post_group_create_to_rest(
   RETURN_NOT_OK(serialization::group_create_serialize(
       group, serialization_type_, buff, rest_legacy()));
 
+  // Credential used for creating a group as a child of an existing REST group.
+  const auto creation_access_credentials_name{
+      config_->get<std::string>("rest.creation_access_credentials_name")};
+  if (creation_access_credentials_name.has_value()) {
+    add_header(
+        "X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME",
+        creation_access_credentials_name.value());
+  }
+
   // Init curl and form the URL
   Curl curlc(logger_);
   URI::RESTURIComponents rest_uri;
@@ -1518,7 +1527,7 @@ Status RestClientRemote::patch_group_to_rest(const URI& uri, Group* group) {
 
   // Credential name for adding group members that are not registered on REST.
   const auto creation_access_credentials_name{
-    config_->get<std::string>("rest.creation_access_credentials_name")};
+      config_->get<std::string>("rest.creation_access_credentials_name")};
   if (creation_access_credentials_name.has_value()) {
     add_header(
         "X-TILEDB-CLOUD-ACCESS-CREDENTIALS-NAME",


### PR DESCRIPTION
This adds support for using relative URIs when adding group members to a remote group in TileDB-Server. This support will not be added for legacy REST.

Fixes [ENG-112](https://linear.app/tiledb/issue/ENG-112/support-relative-uri-for-members-in-carrara-server)

---
TYPE: FEATURE
DESC: Add support for relative URI remote group members.
