### PR TITLE
Fix nightly ASAN failures.

### DIFF
--- a/tiledb/common/exception/exception.h
+++ b/tiledb/common/exception/exception.h
@@ -233,7 +233,7 @@ class BudgetUnavailable : public StatusException {
   /**
    * Ordinary constructor has same signature as `BudgetExceeded`.
    */
-  BudgetUnavailable(const std::string origin, const std::string message)
+  BudgetUnavailable(const std::string_view origin, const std::string message)
       : StatusException(origin, message) {
   }
 };
@@ -247,7 +247,7 @@ class BudgetExceeded : public StatusException {
   /**
    * Ordinary constructor has same signature as `BudgetUnavailable`.
    */
-  BudgetExceeded(const std::string origin, const std::string message)
+  BudgetExceeded(const std::string_view origin, const std::string message)
       : StatusException(origin, message) {
   }
 };


### PR DESCRIPTION
#5589 changed the type of `StatusException`'s origin field from `string` to `string_view`. However, the constructor parameters of the `BudgetUnavailable` and `BudgetExceeded` subclasses were not updated, leading to them passing to the superclass a `string_view` to a temporary `string`, which causes [ASAN failures](https://github.com/TileDB-Inc/TileDB/actions/runs/17452053705/job/49558602643#step:7:1321).

This PR updates the origin parameter of these two subclasses from `string` to `string_view`.

---
TYPE: NO_HISTORY