### PR TITLE
Use function-local static for logger_prefix_ to ensure safe, single-time initialization.

### DIFF
--- a/tiledb/sm/storage_manager/context.cc
+++ b/tiledb/sm/storage_manager/context.cc
@@ -58,20 +58,30 @@ static common::Logger::Level get_log_level(const Config& config);
 Context::Context(const Config& config)
     : last_error_(nullopt)
     , logger_(make_shared<Logger>(
-          HERE(),
-          logger_prefix_ + std::to_string(++logger_id_),
-          get_log_level(config)))
+      HERE(),
+      logger_prefix_() + std::to_string(++logger_id_),
+      get_log_level(config)))
     , resources_(
-          config,
-          logger_,
-          get_compute_thread_count(config),
-          get_io_thread_count(config),
-          "Context")
+      config,
+      logger_,
+      get_compute_thread_count(config),
+      get_io_thread_count(config),
+      "Context")
     , storage_manager_{resources_, logger_, config} {
   /*
    * Logger class is not yet C.41-compliant
    */
   init_loggers(config);
+}
+
+// Returns the shared logger prefix string (constant for all Context instances).
+const std::string& Context::logger_prefix_() {
+  static const std::string prefix =
+      std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count()) +
+      "-Context: ";
+  return prefix;
 }
 
 /* ****************************** */

--- a/tiledb/sm/storage_manager/context.h
+++ b/tiledb/sm/storage_manager/context.h
@@ -153,12 +153,10 @@ class Context {
   /** The class logger. */
   shared_ptr<Logger> logger_;
 
-  /** The class unique logger prefix */
-  inline static std::string logger_prefix_ =
-      std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(
-                         std::chrono::system_clock::now().time_since_epoch())
-                         .count()) +
-      "-Context: ";
+  /**
+   * Returns the shared logger prefix string (constant for all Context instances).
+   */
+  static const std::string& logger_prefix_();
 
   /**
    * Counter for generating unique identifiers for `Logger` objects.


### PR DESCRIPTION
<long description>

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
