### PR TITLE
Fix macOS CI jobs after Cmake update in GHA runners

### DIFF
--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -150,11 +150,12 @@ jobs:
         if: inputs.cmake_generator == 'Ninja'
         uses: seanmiddleditch/gha-setup-ninja@v4
 
-      - name: 'Brew setup on macOS' # x-ref c8e49ba8f8b9ce
+      - name: 'Homebrew and SDKROOT setup on macOS' # x-ref c8e49ba8f8b9ce
         if: ${{ startsWith(matrix.os, 'macos-') == true }}
         run: |
           set -e pipefail
           brew install automake
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
 
       - name: 'Configure libtiledb'
         id: configure

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -108,6 +108,11 @@ jobs:
         with:
           arch: x64
 
+      - name: 'Set SDKROOT on macOS'
+        if: ${{ startsWith(matrix.os, 'macos-') }}
+        run: |
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Checkout TileDB
         # v4 uses node 20 which is incompatible with the libc version of the manylinux image
         uses: actions/checkout@v3
-      - name: 'Homebrew setup'
-        run: brew install automake ninja
+      - name: 'Homebrew and SDKROOT setup on macOS'
+        run: |
+          brew install automake ninja
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
         if: ${{ startsWith(matrix.os, 'macos-') == true }}
       - name: Set variables
         id: get-values

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: 'Homebrew setup'
-        run: brew install automake
+      - name: 'Homebrew and SDKROOT setup on macOS'
+        run: |
+          brew install automake
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
         if: ${{ startsWith(matrix.os, 'macos-') }}
 
       - name: Install Ninja


### PR DESCRIPTION
Github Actions macOS runners have been updated end of last week to use the current latest CMake version available in Homebrew, which is 4.* at the moment [[src](https://github.com/actions/runner-images/issues/12934)]. 

This broke our CI because in CMake 4.0, the default value of `CMAKE_OSX_SYSROOT` changed to be empty while previously a default was computed based on the `CMAKE_OSX_DEPLOYMENT_TARGET` or the host platform. [[src](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html)]

So we ended up with errors like:
```
clang: warning: no such sysroot directory: '-mmacosx-version-min=11' [-Wmissing-sysroot]

```
To fix this and pass a macOS SDK via the compiler's `-isysroot` flag, we are now explicitly setting `SDKROOT` in our CI environment for macos runners.


---
TYPE: NO_HISTORY
DESC: Fix macOS CI jobs after Cmake update in GHA runners
