### PR TITLE
Add missing SDKROOT definition to some nightly jobs

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Checkout TileDB `dev`
         uses: actions/checkout@v3
 
+      - name: 'Set SDKROOT on macOS'
+        if: ${{ startsWith(matrix.os, 'macos-') }}
+        run: |
+          echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+
       - name: Configure TileDB CMake (not-Windows)
         if: ${{ ! contains(matrix.os, 'windows') }}
         env:


### PR DESCRIPTION
This is a follow up to https://github.com/TileDB-Inc/TileDB/pull/5633, I have missed to add the `SDKROOT` definition step to all nightlies.

---
TYPE: NO_HISTORY
DESC: Add missing SDKROOT definition to some nightly jobs
