### PR TITLE
Set `MACOSX_DEPLOYMENT_TARGET` on nightly static linkage tests.

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -80,10 +80,13 @@ jobs:
             triplet: x64-windows
           - os: macos-13
             triplet: x64-osx
+            deployment-target: 13
           - os: macos-latest
             triplet: arm64-osx
       fail-fast: false
     name: ${{ matrix.os }} - Static Linkage
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment-target }}
 
     steps:
       - name: Print env


### PR DESCRIPTION
Fixes failures to the `macOS 13 - Static Linkage` nightly job ([ref](https://github.com/TileDB-Inc/TileDB/actions/runs/17797640490/job/50588958902)).

By setting the deployment target to 13, we force using the `std::pmr` polyfill, avoiding a known issue on macOS versions prior to 14.

---
TYPE: NO_HISTORY