### PR TITLE
Replace deprecated `macos-13` GHA image with latest x64 image

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -78,7 +78,7 @@ jobs:
             triplet: x64-linux
           - os: windows-2022
             triplet: x64-windows
-          - os: macos-13
+          - os: macos-15-intel
             triplet: x64-osx
             deployment-target: 13
           - os: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             triplet: arm64-linux-release
             manylinux: quay.io/pypa/manylinux_2_28_aarch64
           - platform: macos-x86_64
-            os: macos-15-intel
+            os: macos-latest
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             triplet: arm64-linux-release
             manylinux: quay.io/pypa/manylinux_2_28_aarch64
           - platform: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release


### PR DESCRIPTION
`macos-13` will soon be removed from github actions [[src](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)]. We are replacing it in our nightlies and release workflows with `macos-15-intel` which according to https://github.com/actions/runner-images/issues/13045 is now available for building on x64.

However, let's keep in mind that "Apple has discontinued support for the x86_64 (Intel) architecture. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027." [[src](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#notice-of-macos-x86_64-intel-architecture-deprecation)]

---
TYPE: NO_HISTORY