### PR TITLE
Add support for Azure Data Lake Storage.

### DIFF
--- a/cmake/inputs/Config.cmake.in
+++ b/cmake/inputs/Config.cmake.in
@@ -28,6 +28,7 @@ if(NOT @BUILD_SHARED_LIBS@) # NOT BUILD_SHARED_LIBS
   if(@TILEDB_AZURE@) # TILEDB_AZURE
     find_dependency(azure-identity-cpp)
     find_dependency(azure-storage-blobs-cpp)
+    find_dependency(azure-storage-files-datalake-cpp)
   endif()
   if(@TILEDB_GCS@) # TILEDB_GCS
     find_dependency(google_cloud_cpp_storage)

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -725,6 +725,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["vfs.azure.storage_account_key"] = "";
   all_param_values["vfs.azure.storage_sas_token"] = "";
   all_param_values["vfs.azure.blob_endpoint"] = "";
+  all_param_values["vfs.azure.is_data_lake_endpoint"] = "";
   all_param_values["vfs.azure.block_list_block_size"] = "5242880";
   all_param_values["vfs.azure.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -797,6 +798,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   vfs_param_values["azure.storage_account_key"] = "";
   vfs_param_values["azure.storage_sas_token"] = "";
   vfs_param_values["azure.blob_endpoint"] = "";
+  vfs_param_values["azure.is_data_lake_endpoint"] = "";
   vfs_param_values["azure.block_list_block_size"] = "5242880";
   vfs_param_values["azure.max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());
@@ -863,6 +865,7 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   azure_param_values["storage_account_key"] = "";
   azure_param_values["storage_sas_token"] = "";
   azure_param_values["blob_endpoint"] = "";
+  azure_param_values["is_data_lake_endpoint"] = "";
   azure_param_values["block_list_block_size"] = "5242880";
   azure_param_values["max_parallel_ops"] =
       std::to_string(std::thread::hardware_concurrency());

--- a/test/src/unit-cppapi-config.cc
+++ b/test/src/unit-cppapi-config.cc
@@ -77,7 +77,7 @@ TEST_CASE("C++ API: Config iterator", "[cppapi][config]") {
     names.push_back(it->first);
   }
   // Check number of VFS params in default config object.
-  CHECK(names.size() == 67);
+  CHECK(names.size() == 68);
 }
 
 TEST_CASE("C++ API: Config Environment Variables", "[cppapi][config]") {

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -773,6 +773,7 @@ TEST_CASE("VFS: Construct Azure Blob Storage endpoint URIs", "[azure][uri]") {
       config.set("vfs.azure.storage_account_name", "exampleaccount"));
   require_tiledb_ok(config.set("vfs.azure.blob_endpoint", custom_endpoint));
   require_tiledb_ok(config.set("vfs.azure.storage_sas_token", sas_token));
+  require_tiledb_ok(config.set("vfs.azure.is_data_lake_endpoint", "false"));
   if (sas_token.empty()) {
     // If the SAS token is empty, the VFS will try to connect to Microsoft Entra
     // ID to obtain credentials, which can take a long time because of retries.

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -205,7 +205,7 @@ TEST_CASE("VFS: Test long local paths", "[vfs][long-paths]") {
 using AllBackends = std::tuple<LocalFsTest, GCSTest, GSTest, S3Test, AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: URI semantics and file management", "[vfs][uri]", AllBackends) {
-  TestType fs({0});
+  TestType fs({});
   if (!fs.is_supported()) {
     return;
   }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -202,7 +202,7 @@ TEST_CASE("VFS: Test long local paths", "[vfs][long-paths]") {
   }
 }
 
-using AllBackends = std::tuple<AzureTest>;
+using AllBackends = std::tuple<LocalFsTest, GCSTest, GSTest, S3Test, AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: URI semantics and file management", "[vfs][uri]", AllBackends) {
   TestType fs({0});

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -218,19 +218,6 @@ TEMPLATE_LIST_TEST_CASE(
 
   URI path = fs.temp_dir_.add_trailing_slash();
 
-  // Set up
-  if (path.is_gcs() || path.is_s3() || path.is_azure()) {
-    if (vfs.is_bucket(path)) {
-      REQUIRE_NOTHROW(vfs.remove_bucket(path));
-    }
-    REQUIRE_NOTHROW(vfs.create_bucket(path));
-  } else {
-    if (vfs.is_dir(path)) {
-      REQUIRE_NOTHROW(vfs.remove_dir(path));
-    }
-    REQUIRE_NOTHROW(vfs.create_dir(path));
-  }
-
   /* Create the following file hierarchy:
    *
    * path/dir1/subdir/file1
@@ -478,21 +465,6 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   if (path.is_file()) {
     // #TODO Ensure this doesn't fail. This test case seems incorrect.
     CHECK_THROWS(vfs.file_size(non_existent));
-  }
-
-  // Set up
-  if (path.is_gcs() || path.is_s3() || path.is_azure()) {
-    if (vfs.is_bucket(path)) {
-      REQUIRE_NOTHROW(vfs.remove_bucket(path));
-    }
-    REQUIRE_NOTHROW(vfs.create_bucket(path));
-  } else {
-    if (vfs.is_dir(path)) {
-      REQUIRE_NOTHROW(vfs.remove_dir(path));
-    }
-    REQUIRE_NOTHROW(vfs.create_dir(path));
-    // Bucket-specific operations are only valid for object store filesystems.
-    CHECK_THROWS(vfs.create_bucket(path));
   }
 
   // Prepare buffers

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -202,7 +202,7 @@ TEST_CASE("VFS: Test long local paths", "[vfs][long-paths]") {
   }
 }
 
-using AllBackends = std::tuple<LocalFsTest, GCSTest, GSTest, S3Test, AzureTest>;
+using AllBackends = std::tuple<AzureTest>;
 TEMPLATE_LIST_TEST_CASE(
     "VFS: URI semantics and file management", "[vfs][uri]", AllBackends) {
   TestType fs({0});

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -524,10 +524,12 @@ if (TILEDB_AZURE)
 
   find_package(azure-identity-cpp CONFIG REQUIRED)
   find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+  find_package(azure-storage-files-datalake-cpp CONFIG REQUIRED)
   target_link_libraries(TILEDB_CORE_OBJECTS_ILIB
           INTERFACE
           Azure::azure-identity
           Azure::azure-storage-blobs
+          Azure::azure-storage-files-datalake
           )
 endif()
 

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -442,6 +442,12 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    that at least one of these two options must be set (or both if shared
  *    key authentication is used). <br>
  *    **Default**: ""
+ * - `vfs.azure.is_data_lake_endpoint` <br>
+ *    Sets whether the Azure Storage account is known to have hierarchical
+ *    namespace enabled or disabled. This option can be used to reduce latency
+ *    when performing the first Azure request. If not set, the account's
+ *    capabilities will be automatically detected. <br>
+ *    **Default**: <unset>
  * - `vfs.azure.block_list_block_size` <br>
  *    The block size (in bytes) used in Azure blob block list writes.
  *    Any `uint64_t` value is acceptable. Note: `vfs.azure.block_list_block_size

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -439,7 +439,9 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "vfs.azure.storage_sas_token", Config::VFS_AZURE_STORAGE_SAS_TOKEN),
     std::make_pair("vfs.azure.blob_endpoint", Config::VFS_AZURE_BLOB_ENDPOINT),
-    std::make_pair("vfs.azure.is_data_lake_endpoint", Config::VFS_AZURE_IS_DATA_LAKE_ENDPOINT),
+    std::make_pair(
+        "vfs.azure.is_data_lake_endpoint",
+        Config::VFS_AZURE_IS_DATA_LAKE_ENDPOINT),
     std::make_pair(
         "vfs.azure.max_parallel_ops", Config::VFS_AZURE_MAX_PARALLEL_OPS),
     std::make_pair(

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -188,6 +188,7 @@ const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_NAME = "";
 const std::string Config::VFS_AZURE_STORAGE_ACCOUNT_KEY = "";
 const std::string Config::VFS_AZURE_STORAGE_SAS_TOKEN = "";
 const std::string Config::VFS_AZURE_BLOB_ENDPOINT = "";
+const std::string Config::VFS_AZURE_IS_DATA_LAKE_ENDPOINT = "";
 const std::string Config::VFS_AZURE_MAX_PARALLEL_OPS =
     Config::SM_IO_CONCURRENCY_LEVEL;
 const std::string Config::VFS_AZURE_BLOCK_LIST_BLOCK_SIZE = "5242880";
@@ -438,6 +439,7 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "vfs.azure.storage_sas_token", Config::VFS_AZURE_STORAGE_SAS_TOKEN),
     std::make_pair("vfs.azure.blob_endpoint", Config::VFS_AZURE_BLOB_ENDPOINT),
+    std::make_pair("vfs.azure.is_data_lake_endpoint", Config::VFS_AZURE_IS_DATA_LAKE_ENDPOINT),
     std::make_pair(
         "vfs.azure.max_parallel_ops", Config::VFS_AZURE_MAX_PARALLEL_OPS),
     std::make_pair(
@@ -877,6 +879,10 @@ Status Config::sanity_check(
       std::stringstream msg;
       msg << "value " << param << " invalid canned acl for " << param;
       return Status_Error(msg.str());
+    }
+  } else if (param == "vfs.azure.is_data_lake_endpoint") {
+    if (!value.empty()) {
+      RETURN_NOT_OK(utils::parse::convert(value, &v));
     }
   }
 

--- a/tiledb/sm/config/config.h
+++ b/tiledb/sm/config/config.h
@@ -488,6 +488,10 @@ class Config {
   /** Azure blob endpoint. */
   static const std::string VFS_AZURE_BLOB_ENDPOINT;
 
+  /** Whether the Azure storage account is known to support hierarchical
+   * namespace or not. */
+  static const std::string VFS_AZURE_IS_DATA_LAKE_ENDPOINT;
+
   /** Azure max parallel ops. */
   static const std::string VFS_AZURE_MAX_PARALLEL_OPS;
 

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -613,6 +613,12 @@ class Config {
    *    that at least one of these two options must be set (or both if shared
    *    key authentication is used). <br>
    *    **Default**: ""
+   * - `vfs.azure.is_data_lake_endpoint` <br>
+   *    Sets whether the Azure Storage account is known to have hierarchical
+   *    namespace enabled or disabled. This option can be used to reduce latency
+   *    when performing the first Azure request. If not specified, the account's
+   *    capabilities will be automatically detected. <br>
+   *    **Default**: <unset>
    * - `vfs.azure.block_list_block_size` <br>
    *    The block size (in bytes) used in Azure blob block list writes.
    *    Any `uint64_t` value is acceptable. Note:

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -336,7 +336,7 @@ void Azure::AzureClientSingleton::ensure_initialized(
     is_datalake = accountInfo.Value.IsHierarchicalNamespaceEnabled;
   }
 
-  if (*is_datalake) {
+  if (is_datalake.value()) {
     ::Azure::Storage::Files::DataLake::DataLakeClientOptions data_lake_options;
     data_lake_options.Retry = options.Retry;
     data_lake_options.Transport = options.Transport;

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -180,15 +180,6 @@ tiledb::sm::Azure::ServiceCredentialType get_service_credential(
 
   return {};
 }
-
-std::optional<bool> parse_optional_bool(const std::string& str) {
-  if (str.empty()) {
-    return nullopt;
-  }
-  bool result;
-  throw_if_not_ok(tiledb::sm::utils::parse::convert(str, &result));
-  return result;
-}
 }  // namespace
 
 namespace tiledb::sm {
@@ -228,8 +219,9 @@ AzureParameters::AzureParameters(const Config& config)
     , account_key_(get_config_with_env_fallback(
           config, "vfs.azure.storage_account_key", "AZURE_STORAGE_KEY"))
     , blob_endpoint_(get_blob_endpoint(config, account_name_))
-    , is_data_lake_endpoint_(parse_optional_bool(config.get<std::string>(
-          "vfs.azure.is_data_lake_endpoint", Config::must_find)))
+    , is_data_lake_endpoint_(tiledb::sm::utils::parse::convert_optional<bool>(
+          config.get<std::string>(
+              "vfs.azure.is_data_lake_endpoint", Config::must_find)))
     , ssl_cfg_(config)
     , has_sas_token_(
           !get_config_with_env_fallback(

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -580,6 +580,9 @@ bool Azure::is_dir(const URI& uri) const {
   }
 
   std::optional<std::string> continuation_token;
+  if (!blob_path.ends_with('/')) {
+    blob_path.push_back('/');
+  }
   auto paths =
       list_blobs_impl(container_name, blob_path, false, 1, continuation_token);
   return !paths.empty();

--- a/tiledb/sm/filesystem/azure.cc
+++ b/tiledb/sm/filesystem/azure.cc
@@ -508,8 +508,11 @@ bool Azure::is_bucket(const URI& uri) const {
 }
 
 bool Azure::is_dir(const URI& uri) const {
-  std::vector<std::string> paths = ls(uri, "/", 1);
-  return (bool)paths.size();
+  auto [container_name, blob_path] = parse_azure_uri(uri);
+  std::optional<std::string> continuation_token;
+  auto paths =
+      list_blobs_impl(container_name, blob_path, false, 1, continuation_token);
+  return !paths.empty();
 }
 
 bool Azure::is_file(const URI& uri) const {

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -773,11 +773,13 @@ class Azure : public FilesystemBase {
     }
 
    private:
+    /** Contains the logic to initialize the Azure SDK service clients. */
     void ensure_initialized(const AzureParameters& params);
 
     /** The Azure blob service client. */
     tdb_unique_ptr<BlobServiceClientType> client_;
 
+    /** The Azure data lake service client. */
     tdb_unique_ptr<DataLakeServiceClientType> data_lake_client_;
 
     /** Protects from creating the client many times. */

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -556,11 +556,12 @@ class Azure : public FilesystemBase {
   /**
    * Creates a directory.
    *
-   * @param uri The directory's URI.
+   * Calling this function has no effect in storage accounts with
+   * hierarchical namespace disabled.
+   *
+   * @param uri The URI of the directory.
    */
-  void create_dir(const URI&) const override {
-    // No-op. Stub function for other filesystems.
-  }
+  void create_dir(const URI&) const override;
 
   /**
    * Copies the directory at 'old_uri' to `new_uri`.

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -443,14 +443,10 @@ class Azure : public FilesystemBase {
    *
    * @param uri The prefix URI.
    * @param delimiter The delimiter that will
-   * @param max_paths The maximum number of paths to be retrieved. The default
-   *     `-1` indicates that no upper bound is specified.
    * @return The retrieved paths.
    */
   std::vector<std::string> ls(
-      const URI& uri,
-      const std::string& delimiter = "/",
-      int max_paths = -1) const;
+      const URI& uri, const std::string& delimiter = "/") const;
 
   /**
    * Lists objects and object information that start with `uri`.
@@ -466,11 +462,10 @@ class Azure : public FilesystemBase {
    *
    * @param uri The prefix URI.
    * @param delimiter The uri is truncated to the first delimiter
-   * @param max_paths The maximum number of paths to be retrieved
    * @return A list of directory_entry objects
    */
   std::vector<tiledb::common::filesystem::directory_entry> ls_with_sizes(
-      const URI& uri, const std::string& delimiter, int max_paths) const;
+      const URI& uri, const std::string& delimiter) const;
 
   /**
    * Lists objects and object information that start with `prefix`, invoking

--- a/tiledb/sm/filesystem/azure.h
+++ b/tiledb/sm/filesystem/azure.h
@@ -134,6 +134,10 @@ struct AzureParameters {
   /** The Blob Storage endpoint to connect to. */
   std::string blob_endpoint_;
 
+  /** Whether the Azure storage account is known to support hierarchical
+   * namespace or not. */
+  std::optional<bool> is_data_lake_endpoint_;
+
   /** SSL configuration. */
   SSLConfig ssl_cfg_;
 

--- a/tiledb/sm/misc/parse_argument.h
+++ b/tiledb/sm/misc/parse_argument.h
@@ -106,6 +106,23 @@ Status convert(const std::string& str, std::vector<T>* value) {
   return Status::Ok();
 }
 
+template <class T>
+concept Convertible = requires(const std::string& str, T x) {
+  { convert(str, &x) } -> std::convertible_to<Status>;
+};
+
+/** Converts the input string into an std::optional value. Returns nullopt if
+ * the input string is empty. */
+template <Convertible T>
+std::optional<T> convert_optional(const std::string& str) {
+  if (str.empty()) {
+    return nullopt;
+  }
+  T result;
+  throw_if_not_ok(convert(str, &result));
+  return result;
+}
+
 /** Returns `true` if the input string is a (potentially signed) integer. */
 bool is_int(const std::string& str);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,6 +17,7 @@
             "description": "Support Azure Blob Storage",
             "dependencies": [
                 "azure-storage-blobs-cpp",
+                "azure-storage-files-datalake-cpp",
                 "azure-identity-cpp"
             ]
         },


### PR DESCRIPTION
This PR updates the Azure VFS to support storage accounts with [hierarchical namespace](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace) enabled, also known as Azure Data Lake Storage Gen2. Before the first Azure operation, we check whether the account support hierarchical namespace, and if it does, specialize some of the operations to use a `DatalakeServiceClient`. A dependency to `azure-storage-datalake-cpp` was also added.

Automated testing is not currently implemented, due to lack of support by Azurite. Let me know if you want to test this on a real Azure Storage account.

---
TYPE: FEATURE
DESC: Added support for Azure Data Lake Storage.