### PR TITLE
Fix: Create correct URIs when relative flag is true

### DIFF
--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -351,7 +351,7 @@ void Group::delete_group(const URI& uri, bool recursive) {
         const auto& member = member_entry.second;
         URI member_uri = member->uri();
         if (member->relative()) {
-          member_uri = group_uri_.join_path(member->uri().to_string());
+          member_uri = group_uri_.join_path(member->name().value());
         }
 
         if (member->type() == ObjectType::ARRAY) {

--- a/tiledb/sm/group/group.cc
+++ b/tiledb/sm/group/group.cc
@@ -351,6 +351,10 @@ void Group::delete_group(const URI& uri, bool recursive) {
         const auto& member = member_entry.second;
         URI member_uri = member->uri();
         if (member->relative()) {
+          if (!member->name().has_value()) {
+            throw GroupException("[delete_group] There should be a name when relative is true");
+          }
+
           member_uri = group_uri_.join_path(member->name().value());
         }
 

--- a/tiledb/sm/group/group_details.cc
+++ b/tiledb/sm/group/group_details.cc
@@ -280,6 +280,9 @@ GroupDetails::member_by_index(uint64_t index) {
   auto member = members_vec_->at(index);
   std::string uri = member->uri().to_string();
   if (member->relative()) {
+    if (!member->name().has_value()) {
+      throw GroupDetailsException("[member_by_index] There should be a name when relative is true");
+    }
     uri = group_uri_.to_string() + member->name().value();
   }
 
@@ -302,6 +305,9 @@ GroupDetails::member_by_name(const std::string& name) {
   std::string uri = member->uri().to_string();
   // Relative tiledb URIs are returned in the expected format from REST.
   if (!member->uri().is_tiledb() && member->relative()) {
+    if (!member->name().has_value()) {
+      throw GroupDetailsException("[member_by_name] There should be a name when relative is true");
+    }
     uri = group_uri_.join_path(member->name().value()).to_string();
   }
 

--- a/tiledb/sm/group/group_details.cc
+++ b/tiledb/sm/group/group_details.cc
@@ -280,7 +280,7 @@ GroupDetails::member_by_index(uint64_t index) {
   auto member = members_vec_->at(index);
   std::string uri = member->uri().to_string();
   if (member->relative()) {
-    uri = group_uri_.join_path(member->uri().to_string()).to_string();
+    uri = group_uri_.to_string() + member->name().value();
   }
 
   return {uri, member->type(), member->name()};
@@ -302,7 +302,7 @@ GroupDetails::member_by_name(const std::string& name) {
   std::string uri = member->uri().to_string();
   // Relative tiledb URIs are returned in the expected format from REST.
   if (!member->uri().is_tiledb() && member->relative()) {
-    uri = group_uri_.join_path(member->uri().to_string()).to_string();
+    uri = group_uri_.join_path(member->name().value()).to_string();
   }
 
   return {uri, member->type(), member->name(), member->relative()};


### PR DESCRIPTION
URIs are not constructed correctly when flag `relative` is true. Tested with the following script 

```
    group_parent=f"tiledb://{workspace}/{teamspace}/{fld}/parent/"
    group_member=f"tiledb://{workspace}/{teamspace}/{fld}/parent/group_member"
    array_member=f"tiledb://{workspace}/{teamspace}/{fld}/parent/array_member"

    # Create parent group
    tiledb.Group.create(group_parent)

    # Create a member group inside the parent group (implicit group add)
    tiledb.Group.create(group_member)
    # #
    # # Create a member array inside the parent group (implicit group add)
    domain = tiledb.Domain(tiledb.Dim(domain=(1, 8), tile=2))
    a1 = tiledb.Attr("val", dtype="f8")
    schema = tiledb.ArraySchema(domain=domain, attrs=(a1,))
    tiledb.Array.create(uri=array_member, schema=schema)

    with tiledb.Group(group_parent) as grp:
        print(grp)
        soma_experiment_uris = {mbr.name: mbr.uri for mbr in grp}
        print(soma_experiment_uris)
```

# Before
```
 GROUP
|-- group_member GROUP
|-- array_member ARRAY

{'group_member': 'tiledb://ws01/ts11/test36/parent/tiledb://ws01/ts11/test36/parent/group_member', 'array_member': 'tiledb://ws01/ts11/test36/parent/tiledb://ws01/ts11/test36/parent/array_member'}
```

# After
```
 GROUP
|-- group_member GROUP
|-- array_member ARRAY

{'group_member': 'tiledb://ws01/ts11/test39/parent/group_member', 'array_member': 'tiledb://ws01/ts11/test39/parent/array_member'}

```
---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
