### PR TITLE
Fix deserialization of relative group member URI

### DIFF
--- a/tiledb/sm/serialization/group.cc
+++ b/tiledb/sm/serialization/group.cc
@@ -127,8 +127,8 @@ group_member_from_capnp(capnp::GroupMember::Reader* group_member_reader) {
     name = group_member_reader->getName().cStr();
   }
 
-  tdb_shared_ptr<GroupMember> group_member =
-      tdb::make_shared<GroupMemberV1>(HERE(), URI(uri), type, relative, name);
+  tdb_shared_ptr<GroupMember> group_member = tdb::make_shared<GroupMemberV1>(
+      HERE(), URI(uri, !relative), type, relative, name);
 
   return {Status::Ok(), group_member};
 }

--- a/tiledb/sm/serialization/group.h
+++ b/tiledb/sm/serialization/group.h
@@ -36,6 +36,7 @@
 #include <unordered_map>
 
 #include "tiledb/common/status.h"
+#include "tiledb/sm/group/group_member.h"
 
 using namespace tiledb::common;
 
@@ -159,6 +160,26 @@ Status group_metadata_serialize(
     SerializationType serialize_type,
     SerializationBuffer& serialized_buffer,
     bool load);
+
+/**
+ * Convert Cap'n Proto message to GroupMember object
+ *
+ * @param group_member_reader cap'n proto class.
+ * @return Status and GroupMember object
+ */
+std::tuple<Status, std::optional<tdb_shared_ptr<GroupMember>>>
+group_member_from_capnp(capnp::GroupMember::Reader* group_member_reader);
+
+/**
+ * Convert GroupMember object to Cap'n Proto message.
+ *
+ * @param group_member GroupMember to serialize info from
+ * @param group_member_builder cap'n proto class.
+ * @return Status
+ */
+Status group_member_to_capnp(
+    const tdb_shared_ptr<GroupMember>& group_member,
+    capnp::GroupMember::Builder* group_member_builder);
 
 }  // namespace serialization
 }  // namespace sm

--- a/tiledb/sm/serialization/test/CMakeLists.txt
+++ b/tiledb/sm/serialization/test/CMakeLists.txt
@@ -50,3 +50,11 @@ commence(unit_test capnp_nonempty_domain)
   # Enable serialization
   target_compile_definitions(unit_capnp_nonempty_domain PRIVATE -DTILEDB_SERIALIZATION)
 conclude(unit_test)
+
+commence(unit_test capnp_group)
+  this_target_sources(main.cc unit_capnp_group.cc)
+  this_target_link_libraries(tiledb_test_support_lib)
+
+  # Enable serialization
+  target_compile_definitions(unit_capnp_group PRIVATE -DTILEDB_SERIALIZATION)
+conclude(unit_test)

--- a/tiledb/sm/serialization/test/unit_capnp_group.cc
+++ b/tiledb/sm/serialization/test/unit_capnp_group.cc
@@ -1,0 +1,74 @@
+/**
+ * @file tiledb/sm/serialization/test/unit_capnp_group.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2023 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file contains serialization tests for groups
+ */
+
+#include <capnp/message.h>
+
+#include <test/support/tdb_catch.h>
+
+#include "test/support/src/mem_helpers.h"
+#include "tiledb/sm/group/group_member.h"
+
+#include "tiledb/sm/serialization/capnp_utils.h"
+#include "tiledb/sm/serialization/group.h"
+
+using namespace tiledb::common;
+using namespace tiledb::sm;
+
+TEST_CASE(
+    "Check group member serialization correctly handles relative uris",
+    "[group][serialization][relative_uri][regression]") {
+  auto group_member = tdb::make_shared<GroupMember>(
+      HERE(),
+      URI("relative_member", false),
+      ObjectType::ARRAY,
+      2,
+      true,
+      std::nullopt,
+      false);
+
+  // Serialize
+  ::capnp::MallocMessageBuilder message;
+  tiledb::sm::serialization::capnp::GroupMember::Builder builder =
+      message.initRoot<tiledb::sm::serialization::capnp::GroupMember>();
+
+  auto rc =
+      tiledb::sm::serialization::group_member_to_capnp(group_member, &builder);
+  REQUIRE(rc.ok());
+
+  tiledb::sm::serialization::capnp::GroupMember::Reader reader =
+      (tiledb::sm::serialization::capnp::GroupMember::Reader)builder;
+  auto&& [status, clone] =
+      tiledb::sm::serialization::group_member_from_capnp(&reader);
+  REQUIRE(status.ok());
+
+  REQUIRE(clone.value()->uri().to_string() == "relative_member");
+}


### PR DESCRIPTION
When testing relative members with the Server, we noticed the URIs returned from certain group member getter APIs were incorrect. This is because we used a constructor for `URI` that implicitly converts paths to absolute paths.

This PR is fixing this issue by checking if the URI is relative and skips absolute path conversion in that case. It also adds a regression test.

---
TYPE: BUG
DESC: Fix deserialization of relative group member URI
