### PR TITLE
Clean up more space for backwards compatibility jobs

### DIFF
--- a/.github/workflows/build-backwards-compatibility.yml
+++ b/.github/workflows/build-backwards-compatibility.yml
@@ -82,7 +82,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
 
       - name: 'Test backward compatibility'
         id: test


### PR DESCRIPTION
Backwards compatibility jobs have been failing in CI with:
```
fatal: sha1 file '/home/runner/work/TileDB/TileDB/test/inputs/arrays/read_compatibility_test/.git/index.lock' write error. Out of diskspace
warning: Clone succeeded, but checkout failed.
```

This PR is cleaning up more unused libraries and tools from runners so that checkout succeeds again. I got good results with this fix here: https://github.com/TileDB-Inc/TileDB/actions/runs/18308399162

---
TYPE: NO_HISTORY
DESC: Clean up more space for backwards compatibility jobs
