### PR TITLE
[Backport release-2.29] Clean up more space for backwards compatibility jobs. (#5658)

### DIFF
--- a/.github/workflows/build-backwards-compatibility.yml
+++ b/.github/workflows/build-backwards-compatibility.yml
@@ -82,7 +82,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo docker image prune --all --force
+          sudo docker builder prune -a
 
       - name: 'Test backward compatibility'
         id: test


### PR DESCRIPTION
Backport of https://github.com/TileDB-Inc/TileDB/pull/5658 to release-2.29

---
TYPE: NO_HISTORY
DESC: Clean up more space for backwards compatibility jobs.
