### PR TITLE
chore: fix double delta `expect_overflow` check to use unsigned arithmetic function on unsigned input

### DIFF
--- a/tiledb/sm/filter/test/unit_double_delta_pipeline.cc
+++ b/tiledb/sm/filter/test/unit_double_delta_pipeline.cc
@@ -117,7 +117,7 @@ static bool expect_overflow(
     }
     for (uint64_t i = 1; i < values.size(); i++) {
       std::optional<int64_t> delta =
-          checked_arithmetic<int64_t>::sub_signed(values[i], values[i - 1]);
+          checked_arithmetic<uint64_t>::sub_signed(values[i], values[i - 1]);
       if (delta.has_value()) {
         deltae.push_back(delta.value());
       } else {


### PR DESCRIPTION
Resolves CORE-407.

---
TYPE: NO_HISTORY
DESC:  Fix double delta `expect_overflow` check to use unsigned arithmetic function on unsigned input
