### PR TITLE
Remove filesystem member variables from VFS.

### DIFF
--- a/test/src/unit-capi-sparse_array.cc
+++ b/test/src/unit-capi-sparse_array.cc
@@ -7162,6 +7162,6 @@ TEST_CASE_METHOD(
       deserialized_array_dir->timestamp_start() == array_dir.timestamp_start());
   REQUIRE(deserialized_array_dir->timestamp_end() == array_dir.timestamp_end());
 
-  REQUIRE_NOTHROW(resources.vfs().remove_dir(tiledb::sm::URI(array_name)));
+  REQUIRE_NOTHROW(resources.vfs()->remove_dir(tiledb::sm::URI(array_name)));
 #endif
 }

--- a/test/src/unit-enumerations.cc
+++ b/test/src/unit-enumerations.cc
@@ -3108,8 +3108,8 @@ bool EnumerationFx::vec_cmp(std::vector<T> v1, std::vector<T> v2) {
 }
 
 void EnumerationFx::rm_array() {
-  if (ctx_.resources().vfs().is_dir(uri_)) {
-    ctx_.resources().vfs().remove_dir(uri_);
+  if (ctx_.resources().vfs()->is_dir(uri_)) {
+    ctx_.resources().vfs()->remove_dir(uri_);
   }
 }
 

--- a/test/src/unit-request-handlers.cc
+++ b/test/src/unit-request-handlers.cc
@@ -432,8 +432,8 @@ void RequestHandlerFx::create_array() {
 }
 
 void RequestHandlerFx::delete_array() {
-  if (ctx_.resources().vfs().is_dir(uri_)) {
-    ctx_.resources().vfs().remove_dir(uri_);
+  if (ctx_.resources().vfs()->is_dir(uri_)) {
+    ctx_.resources().vfs()->remove_dir(uri_);
   }
 }
 

--- a/test/src/unit-s3.cc
+++ b/test/src/unit-s3.cc
@@ -365,8 +365,9 @@ TEST_CASE(
       return !result_filter(a.first, a.second);
     });
 
-    auto scan = s3_test.get_s3().scanner(
-        s3_test.temp_dir_, result_filter, recursive, max_keys);
+    auto scan =
+        s3_test.get_fs(s3_test.temp_dir_)
+            .scanner(s3_test.temp_dir_, result_filter, recursive, max_keys);
     std::vector results_vector(scan.begin(), scan.end());
 
     CHECK(results_vector.size() == expected.size());
@@ -388,11 +389,12 @@ TEST_CASE("S3: S3Scanner iterator", "[s3][ls-scan-iterator]") {
 
   std::vector<Aws::S3::Model::Object> results_vector;
   DYNAMIC_SECTION("Testing with " << max_keys << " max keys from S3") {
-    auto scan = s3_test.get_s3().scanner(
-        s3_test.temp_dir_,
-        tiledb::sm::LsScanner::accept_all,
-        recursive,
-        max_keys);
+    auto scan = s3_test.get_fs(s3_test.temp_dir_)
+                    .scanner(
+                        s3_test.temp_dir_,
+                        tiledb::sm::LsScanner::accept_all,
+                        recursive,
+                        max_keys);
 
     SECTION("for loop") {
       SECTION("range based for") {

--- a/test/src/unit-ssl-config.cc
+++ b/test/src/unit-ssl-config.cc
@@ -242,9 +242,9 @@ std::string get_test_ca_file() {
 
 void check_failure(Filesystem fs, Config& cfg) {
   Context ctx(cfg);
-  auto& vfs = ctx.resources().vfs();
+  auto vfs = ctx.resources().vfs();
 
-  if (!vfs.supports_fs(fs)) {
+  if (!vfs->supports_fs(fs)) {
     return;
   }
 
@@ -266,7 +266,7 @@ void check_failure(Filesystem fs, Config& cfg) {
   std::vector<URI> uris;
 
   try {
-    st = vfs.ls(bucket_uri, &uris);
+    st = vfs->ls(bucket_uri, &uris);
   } catch (...) {
     // Some backends throw exceptions to signal SSL error conditions
     // so we pass the test by returning early here.
@@ -279,9 +279,9 @@ void check_failure(Filesystem fs, Config& cfg) {
 
 void check_success(Filesystem fs, Config& cfg) {
   Context ctx(cfg);
-  auto& vfs = ctx.resources().vfs();
+  auto vfs = ctx.resources().vfs();
 
-  if (!vfs.supports_fs(fs)) {
+  if (!vfs->supports_fs(fs)) {
     return;
   }
 
@@ -298,9 +298,9 @@ void check_success(Filesystem fs, Config& cfg) {
   }
 
   URI bucket_uri = URI(scheme + "://" + bucket_name);
-  if (vfs.is_bucket(bucket_uri)) {
-    vfs.remove_bucket(bucket_uri);
+  if (vfs->is_bucket(bucket_uri)) {
+    vfs->remove_bucket(bucket_uri);
   }
-  vfs.create_bucket(bucket_uri);
-  REQUIRE(vfs.is_bucket(bucket_uri));
+  vfs->create_bucket(bucket_uri);
+  REQUIRE(vfs->is_bucket(bucket_uri));
 }

--- a/test/src/unit-vfs.cc
+++ b/test/src/unit-vfs.cc
@@ -141,8 +141,15 @@ std::string local_path() {
 TEST_CASE("VFS: Test long local paths", "[vfs][long-paths]") {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
+  Config config;
+  Context ctx(config);
   VFS vfs{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, Config{}};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
 
   SECTION("- Deep hierarchy") {
     // Create a nested path with a long total length
@@ -210,8 +217,14 @@ TEST_CASE("VFS: copy_file", "[vfs][copy_file]") {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
   Config config = set_config_params();
+  Context ctx(config);
   VFS vfs{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, config};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
 
   size_t test_str_size = 0;
   SECTION("Filesize = 0 MB") {
@@ -292,8 +305,14 @@ TEST_CASE("VFS: copy_dir", "[vfs][copy_dir]") {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
   Config config = set_config_params();
+  Context ctx(config);
   VFS vfs{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, config};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
 
   /* Create the following file hierarchy:
    *
@@ -400,8 +419,14 @@ TEMPLATE_LIST_TEST_CASE(
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
   Config config = set_config_params();
+  Context ctx(config);
   VFS vfs{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, config};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
 
   URI path = fs.temp_dir_.add_trailing_slash();
 
@@ -643,8 +668,14 @@ TEMPLATE_LIST_TEST_CASE("VFS: File I/O", "[vfs][uri][file_io]", AllBackends) {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
   Config config = set_config_params(disable_multipart, max_parallel_ops);
+  Context ctx(config);
   VFS vfs{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, config};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
 
   // Getting file_size on a nonexistent blob shouldn't crash on Azure
   URI non_existent = URI(path.to_string() + "non_existent");
@@ -731,9 +762,14 @@ TEST_CASE("VFS: Test end-to-end", "[.vfs-e2e]") {
   ThreadPool io_tp(1);
   // Will be configured from environment variables.
   Config config;
-
+  Context ctx(config);
   VFS vfs{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, config};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
   REQUIRE(vfs.supports_uri_scheme(test_file));
   CHECK(vfs.file_size(test_file) > 0);
 }
@@ -741,8 +777,15 @@ TEST_CASE("VFS: Test end-to-end", "[.vfs-e2e]") {
 TEST_CASE("VFS: test ls_with_sizes", "[vfs][ls-with-sizes]") {
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
+  Config config;
+  Context ctx(config);
   VFS vfs_ls{
-      &g_helper_stats, g_helper_logger().get(), &compute_tp, &io_tp, Config{}};
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &compute_tp,
+      &io_tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &io_tp, config)};
 
   std::string path = local_path();
   std::string dir = path + "ls_dir";
@@ -898,7 +941,15 @@ TEST_CASE("VFS: Throwing filters for ls_recursive", "[vfs][ls_recursive]") {
 
 TEST_CASE("VFS: Test remove_dir_if_empty", "[vfs][remove-dir-if-empty]") {
   ThreadPool tp(1);
-  VFS vfs{&g_helper_stats, g_helper_logger().get(), &tp, &tp, Config{}};
+  Config config;
+  Context ctx(config);
+  VFS vfs{
+      &g_helper_stats,
+      g_helper_logger().get(),
+      &tp,
+      &tp,
+      config,
+      ctx.resources().make_filesystems(&g_helper_stats, &tp, config)};
 
   std::string path = local_path();
   std::string dir = path + "remove_dir_if_empty/";

--- a/tiledb/api/c_api/context/context_api.cc
+++ b/tiledb/api/c_api/context/context_api.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@
 #include "context_api_external.h"
 #include "context_api_internal.h"
 #include "tiledb/api/c_api_support/c_api_support.h"
+#include "tiledb/sm/enums/filesystem.h"
 #include "tiledb/sm/rest/rest_client.h"
 
 namespace tiledb::api {
@@ -119,8 +120,7 @@ capi_return_t tiledb_ctx_get_last_error(
 capi_return_t tiledb_ctx_is_supported_fs(
     tiledb_ctx_t* ctx, tiledb_filesystem_t fs, int32_t* is_supported) {
   ensure_output_pointer_is_valid(is_supported);
-
-  *is_supported = (int32_t)ctx->context().resources().vfs().supports_fs(
+  *is_supported = (int32_t)ctx->context().resources().vfs()->supports_fs(
       static_cast<tiledb::sm::Filesystem>(fs));
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/filesystem/filesystem_api_enum.h
+++ b/tiledb/api/c_api/filesystem/filesystem_api_enum.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,4 +40,6 @@
     TILEDB_FILESYSTEM_ENUM(GCS) = 3,
     /** In-memory filesystem */
     TILEDB_FILESYSTEM_ENUM(MEMFS) = 4,
+    /** Local filesystem */
+    TILEDB_FILESYSTEM_ENUM(LOCAL) = 5,
 #endif

--- a/tiledb/api/c_api/vfs/vfs_api.cc
+++ b/tiledb/api/c_api/vfs/vfs_api.cc
@@ -67,7 +67,12 @@ capi_return_t tiledb_vfs_alloc(
     ctx_config.inherit((config->config()));
   }
   *vfs = tiledb_vfs_t::make_handle(
-      &stats, logger, &compute_tp, &io_tp, ctx_config);
+      &stats,
+      logger,
+      &compute_tp,
+      &io_tp,
+      ctx_config,
+      resources.make_filesystems(&stats, &io_tp, ctx_config));
 
   return TILEDB_OK;
 }

--- a/tiledb/api/c_api/vfs/vfs_api_internal.h
+++ b/tiledb/api/c_api/vfs/vfs_api_internal.h
@@ -59,8 +59,15 @@ struct tiledb_vfs_handle_t
       Logger* logger,
       ThreadPool* compute_tp,
       ThreadPool* io_tp,
-      const tiledb::sm::Config& config)
-      : vfs_{parent_stats, logger, compute_tp, io_tp, config} {
+      const tiledb::sm::Config& config,
+      std::vector<std::unique_ptr<tiledb::sm::FilesystemBase>>&& filesystems)
+      : vfs_{
+            parent_stats,
+            logger,
+            compute_tp,
+            io_tp,
+            config,
+            std::move(filesystems)} {
   }
 
   vfs_type* vfs() {

--- a/tiledb/sm/array/array.cc
+++ b/tiledb/sm/array/array.cc
@@ -216,41 +216,41 @@ void Array::create(
   }
 
   // Create array directory
-  resources.vfs().create_dir(array_uri);
+  resources.vfs()->create_dir(array_uri);
 
   // Create array schema directory
   URI array_schema_dir_uri =
       array_uri.join_path(constants::array_schema_dir_name);
-  resources.vfs().create_dir(array_schema_dir_uri);
+  resources.vfs()->create_dir(array_schema_dir_uri);
 
   // Create the enumerations directory inside the array schema directory
   URI array_enumerations_uri =
       array_schema_dir_uri.join_path(constants::array_enumerations_dir_name);
-  resources.vfs().create_dir(array_enumerations_uri);
+  resources.vfs()->create_dir(array_enumerations_uri);
 
   // Create commit directory
   URI array_commit_uri = array_uri.join_path(constants::array_commits_dir_name);
-  resources.vfs().create_dir(array_commit_uri);
+  resources.vfs()->create_dir(array_commit_uri);
 
   // Create fragments directory
   URI array_fragments_uri =
       array_uri.join_path(constants::array_fragments_dir_name);
-  resources.vfs().create_dir(array_fragments_uri);
+  resources.vfs()->create_dir(array_fragments_uri);
 
   // Create array metadata directory
   URI array_metadata_uri =
       array_uri.join_path(constants::array_metadata_dir_name);
-  resources.vfs().create_dir(array_metadata_uri);
+  resources.vfs()->create_dir(array_metadata_uri);
 
   // Create fragment metadata directory
   URI array_fragment_metadata_uri =
       array_uri.join_path(constants::array_fragment_meta_dir_name);
-  resources.vfs().create_dir(array_fragment_metadata_uri);
+  resources.vfs()->create_dir(array_fragment_metadata_uri);
 
   // Create dimension label directory
   URI array_dimension_labels_uri =
       array_uri.join_path(constants::array_dimension_labels_dir_name);
-  resources.vfs().create_dir(array_dimension_labels_uri);
+  resources.vfs()->create_dir(array_dimension_labels_uri);
 
   // Store the array schema
   try {
@@ -282,7 +282,7 @@ void Array::create(
       store_array_schema(resources, array_schema, encryption_key);
     }
   } catch (...) {
-    resources.vfs().remove_dir(array_uri);
+    resources.vfs()->remove_dir(array_uri);
     throw;
   }
 }
@@ -688,7 +688,7 @@ void Array::delete_fragments(
   }
 
   // Delete fragments and commits
-  auto vfs = &(resources.vfs());
+  auto vfs = resources.vfs();
   throw_if_not_ok(parallel_for(
       &resources.compute_tp(), 0, fragment_uris.size(), [&](size_t i) {
         vfs->remove_dir(fragment_uris[i].uri_);
@@ -719,7 +719,7 @@ void Array::delete_fragments(
 }
 
 void Array::delete_array(ContextResources& resources, const URI& uri) {
-  auto& vfs = resources.vfs();
+  auto vfs = resources.vfs();
   auto array_dir =
       ArrayDirectory(resources, uri, 0, std::numeric_limits<uint64_t>::max());
 
@@ -729,9 +729,9 @@ void Array::delete_array(ContextResources& resources, const URI& uri) {
 
   // Delete array metadata, fragment metadata and array schema files
   // Note: metadata files may not be present, try to delete anyway
-  vfs.remove_files(&resources.compute_tp(), array_dir.array_meta_uris());
-  vfs.remove_files(&resources.compute_tp(), array_dir.fragment_meta_uris());
-  vfs.remove_files(&resources.compute_tp(), array_dir.array_schema_uris());
+  vfs->remove_files(&resources.compute_tp(), array_dir.array_meta_uris());
+  vfs->remove_files(&resources.compute_tp(), array_dir.fragment_meta_uris());
+  vfs->remove_files(&resources.compute_tp(), array_dir.array_schema_uris());
 
   // Delete all tiledb child directories
   // Note: using vfs.ls() here could delete user data
@@ -740,8 +740,8 @@ void Array::delete_array(ContextResources& resources, const URI& uri) {
   for (auto array_dir_name : constants::array_dir_names) {
     dirs.emplace_back(URI(parent_dir + array_dir_name));
   }
-  vfs.remove_dirs(&resources.compute_tp(), dirs);
-  vfs.remove_dir_if_empty(array_dir.uri());
+  vfs->remove_dirs(&resources.compute_tp(), dirs);
+  vfs->remove_dir_if_empty(array_dir.uri());
 }
 
 void Array::delete_array(const URI& uri) {
@@ -1788,7 +1788,7 @@ Array::open_for_writes() {
   auto timer_se =
       resources_.stats().start_timer("array_open_write_load_schemas");
   // Checks
-  if (!resources_.vfs().supports_uri_scheme(array_uri_)) {
+  if (!resources_.vfs()->supports_uri_scheme(array_uri_)) {
     throw ArrayException("Cannot open array; URI scheme unsupported.");
   }
 
@@ -1954,7 +1954,7 @@ void Array::upgrade_version(
     // Create array schema directory if necessary
     URI array_schema_dir_uri =
         array_uri.join_path(constants::array_schema_dir_name);
-    resources.vfs().create_dir(array_schema_dir_uri);
+    resources.vfs()->create_dir(array_schema_dir_uri);
 
     // Store array schema
     store_array_schema(resources, array_schema, encryption_key_cfg);
@@ -1962,17 +1962,17 @@ void Array::upgrade_version(
     // Create commit directory if necessary
     URI array_commit_uri =
         array_uri.join_path(constants::array_commits_dir_name);
-    resources.vfs().create_dir(array_commit_uri);
+    resources.vfs()->create_dir(array_commit_uri);
 
     // Create fragments directory if necessary
     URI array_fragments_uri =
         array_uri.join_path(constants::array_fragments_dir_name);
-    resources.vfs().create_dir(array_fragments_uri);
+    resources.vfs()->create_dir(array_fragments_uri);
 
     // Create fragment metadata directory if necessary
     URI array_fragment_metadata_uri =
         array_uri.join_path(constants::array_fragment_meta_dir_name);
-    resources.vfs().create_dir(array_fragment_metadata_uri);
+    resources.vfs()->create_dir(array_fragment_metadata_uri);
   }
 }
 

--- a/tiledb/sm/array/test/unit_consistency.cc
+++ b/tiledb/sm/array/test/unit_consistency.cc
@@ -185,7 +185,7 @@ TEST_CASE(
   REQUIRE(x.is_open(uri) == false);
 
   // Clean up
-  REQUIRE_NOTHROW(resources.vfs().remove_dir(uri));
+  REQUIRE_NOTHROW(resources.vfs()->remove_dir(uri));
 }
 
 TEST_CASE(
@@ -225,7 +225,7 @@ TEST_CASE(
 
   // Clean up
   for (auto uri : uris) {
-    REQUIRE_NOTHROW(resources.vfs().remove_dir(uri));
+    REQUIRE_NOTHROW(resources.vfs()->remove_dir(uri));
   }
 }
 
@@ -280,5 +280,5 @@ TEST_CASE(
   REQUIRE(array.get()->close().ok());
   REQUIRE(x.registry_size() == 0);
   REQUIRE(x.is_open(uri) == false);
-  REQUIRE_NOTHROW(resources.vfs().remove_dir(uri));
+  REQUIRE_NOTHROW(resources.vfs()->remove_dir(uri));
 }

--- a/tiledb/sm/array_schema/array_schema_operations.cc
+++ b/tiledb/sm/array_schema/array_schema_operations.cc
@@ -176,16 +176,16 @@ void store_array_schema(
   resources.stats().add_counter("write_array_schema_size", tile->size());
 
   // Delete file if it exists already
-  if (resources.vfs().is_file(schema_uri)) {
-    resources.vfs().remove_file(schema_uri);
+  if (resources.vfs()->is_file(schema_uri)) {
+    resources.vfs()->remove_file(schema_uri);
   }
 
   // Check if the array schema directory exists
   // If not create it, this is caused by a pre-v10 array
   URI array_schema_dir_uri =
       array_schema->array_uri().join_path(constants::array_schema_dir_name);
-  if (!resources.vfs().is_dir(array_schema_dir_uri)) {
-    resources.vfs().create_dir(array_schema_dir_uri);
+  if (!resources.vfs()->is_dir(array_schema_dir_uri)) {
+    resources.vfs()->create_dir(array_schema_dir_uri);
   }
 
   GenericTileIO::store_data(resources, schema_uri, tile, encryption_key);
@@ -195,8 +195,8 @@ void store_array_schema(
   // array created before version 19.
   URI array_enumerations_dir_uri =
       array_schema_dir_uri.join_path(constants::array_enumerations_dir_name);
-  if (!resources.vfs().is_dir(array_enumerations_dir_uri)) {
-    resources.vfs().create_dir(array_enumerations_dir_uri);
+  if (!resources.vfs()->is_dir(array_enumerations_dir_uri)) {
+    resources.vfs()->create_dir(array_enumerations_dir_uri);
   }
 
   // Serialize all enumerations into the `__enumerations` directory

--- a/tiledb/sm/array_schema/test/unit_current_domain.cc
+++ b/tiledb/sm/array_schema/test/unit_current_domain.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023-2024 TileDB Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -109,8 +109,8 @@ CurrentDomainFx<T>::~CurrentDomainFx() {
 
 template <class T>
 void CurrentDomainFx<T>::rm_array() {
-  if (ctx_.resources().vfs().is_dir(uri_)) {
-    ctx_.resources().vfs().remove_dir(uri_);
+  if (ctx_.resources().vfs()->is_dir(uri_)) {
+    ctx_.resources().vfs()->remove_dir(uri_);
   }
 }
 

--- a/tiledb/sm/consolidator/array_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/array_meta_consolidator.cc
@@ -119,8 +119,8 @@ Status ArrayMetaConsolidator::consolidate(
   throw_if_not_ok(array_for_writes.close());
 
   // Write vacuum file
-  resources_.vfs().write(vac_uri, data.c_str(), data.size());
-  throw_if_not_ok(resources_.vfs().close_file(vac_uri));
+  resources_.vfs()->write(vac_uri, data.c_str(), data.size());
+  throw_if_not_ok(resources_.vfs()->close_file(vac_uri));
 
   return Status::Ok();
 }
@@ -132,14 +132,14 @@ void ArrayMetaConsolidator::vacuum(const char* array_name) {
   }
 
   // Get the array metadata URIs and vacuum file URIs to be vacuum
-  auto& vfs = resources_.vfs();
+  auto vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
   auto array_dir = ArrayDirectory(
       resources_, URI(array_name), 0, std::numeric_limits<uint64_t>::max());
 
   // Delete the array metadata and vacuum files
-  vfs.remove_files(&compute_tp, array_dir.array_meta_uris_to_vacuum());
-  vfs.remove_files(&compute_tp, array_dir.array_meta_vac_uris_to_vacuum());
+  vfs->remove_files(&compute_tp, array_dir.array_meta_uris_to_vacuum());
+  vfs->remove_files(&compute_tp, array_dir.array_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/consolidator/commits_consolidator.cc
+++ b/tiledb/sm/consolidator/commits_consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -116,10 +116,10 @@ void CommitsConsolidator::vacuum(const char* array_name) {
       ArrayDirectoryMode::COMMITS);
 
   // Delete the commits and vacuum files
-  auto& vfs = resources_.vfs();
+  auto vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
-  vfs.remove_files(&compute_tp, array_dir.commit_uris_to_vacuum());
-  vfs.remove_files(
+  vfs->remove_files(&compute_tp, array_dir.commit_uris_to_vacuum());
+  vfs->remove_files(
       &compute_tp, array_dir.consolidated_commits_uris_to_vacuum());
 }
 

--- a/tiledb/sm/consolidator/consolidator.cc
+++ b/tiledb/sm/consolidator/consolidator.cc
@@ -272,7 +272,7 @@ void Consolidator::write_consolidated_commits_file(
     // the size variable.
     if (stdx::string::ends_with(
             uri.to_string(), constants::delete_file_suffix)) {
-      file_sizes[i] = resources.vfs().file_size(uri);
+      file_sizes[i] = resources.vfs()->file_size(uri);
       total_size += file_sizes[i];
       total_size += sizeof(storage_size_t);
     }
@@ -293,7 +293,7 @@ void Consolidator::write_consolidated_commits_file(
             uri.to_string(), constants::delete_file_suffix)) {
       memcpy(&data[file_index], &file_sizes[i], sizeof(storage_size_t));
       file_index += sizeof(storage_size_t);
-      throw_if_not_ok(resources.vfs().read_exactly(
+      throw_if_not_ok(resources.vfs()->read_exactly(
           uri, 0, &data[file_index], file_sizes[i]));
       file_index += file_sizes[i];
     }
@@ -303,8 +303,8 @@ void Consolidator::write_consolidated_commits_file(
   URI consolidated_commits_uri =
       array_dir.get_commits_dir(write_version)
           .join_path(name + constants::con_commits_file_suffix);
-  resources.vfs().write(consolidated_commits_uri, data.data(), data.size());
-  throw_if_not_ok(resources.vfs().close_file(consolidated_commits_uri));
+  resources.vfs()->write(consolidated_commits_uri, data.data(), data.size());
+  throw_if_not_ok(resources.vfs()->close_file(consolidated_commits_uri));
 }
 
 void Consolidator::array_vacuum(

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -522,24 +522,24 @@ void FragmentConsolidator::vacuum(const char* array_name) {
   }
 
   // Delete fragment directories
-  auto& vfs = resources_.vfs();
+  auto vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
   throw_if_not_ok(parallel_for(
       &compute_tp, 0, fragment_uris_to_vacuum.size(), [&](size_t i) {
         // Remove the commit file, if present.
         auto commit_uri = array_dir.get_commit_uri(fragment_uris_to_vacuum[i]);
-        if (vfs.is_file(commit_uri)) {
-          vfs.remove_file(commit_uri);
+        if (vfs->is_file(commit_uri)) {
+          vfs->remove_file(commit_uri);
         }
-        if (vfs.is_dir(fragment_uris_to_vacuum[i])) {
-          vfs.remove_dir(fragment_uris_to_vacuum[i]);
+        if (vfs->is_dir(fragment_uris_to_vacuum[i])) {
+          vfs->remove_dir(fragment_uris_to_vacuum[i]);
         }
 
         return Status::Ok();
       }));
 
   // Delete the vacuum files.
-  vfs.remove_files(
+  vfs->remove_files(
       &compute_tp, filtered_fragment_uris.fragment_vac_uris_to_vacuum());
 }
 
@@ -664,8 +664,8 @@ Status FragmentConsolidator::consolidate_internal(
   // Finalize write query
   auto st = query_w->finalize();
   if (!st.ok()) {
-    if (resources_.vfs().is_dir(*new_fragment_uri))
-      resources_.vfs().remove_dir(*new_fragment_uri);
+    if (resources_.vfs()->is_dir(*new_fragment_uri))
+      resources_.vfs()->remove_dir(*new_fragment_uri);
     return st;
   }
 
@@ -676,8 +676,8 @@ Status FragmentConsolidator::consolidate_internal(
       vac_uri,
       to_consolidate);
   if (!st.ok()) {
-    if (resources_.vfs().is_dir(*new_fragment_uri))
-      resources_.vfs().remove_dir(*new_fragment_uri);
+    if (resources_.vfs()->is_dir(*new_fragment_uri))
+      resources_.vfs()->remove_dir(*new_fragment_uri);
     return st;
   }
 
@@ -1084,8 +1084,8 @@ Status FragmentConsolidator::write_vacuum_file(
   }
 
   auto data = ss.str();
-  resources_.vfs().write(vac_uri, data.c_str(), data.size());
-  throw_if_not_ok(resources_.vfs().close_file(vac_uri));
+  resources_.vfs()->write(vac_uri, data.c_str(), data.size());
+  throw_if_not_ok(resources_.vfs()->close_file(vac_uri));
 
   return Status::Ok();
 }

--- a/tiledb/sm/consolidator/fragment_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_meta_consolidator.cc
@@ -96,7 +96,7 @@ Status FragmentMetaConsolidator::consolidate(
       first, last, write_version);
 
   auto frag_md_uri = array_dir.get_fragment_metadata_dir(write_version);
-  resources_.vfs().create_dir(frag_md_uri);
+  resources_.vfs()->create_dir(frag_md_uri);
   uri = URI(frag_md_uri.to_string() + name + constants::meta_file_suffix);
 
   // Get the consolidated fragment metadata version
@@ -173,7 +173,7 @@ Status FragmentMetaConsolidator::consolidate(
   GenericTileIO tile_io(resources_, uri);
   [[maybe_unused]] uint64_t nbytes = 0;
   tile_io.write_generic(tile, enc_key, &nbytes);
-  throw_if_not_ok(resources_.vfs().close_file(uri));
+  throw_if_not_ok(resources_.vfs()->close_file(uri));
 
   return Status::Ok();
 }
@@ -200,7 +200,7 @@ void FragmentMetaConsolidator::vacuum(const char* array_name) {
   }
 
   // Vacuum
-  auto& vfs = resources_.vfs();
+  auto vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
   throw_if_not_ok(
       parallel_for(&compute_tp, 0, fragment_meta_uris.size(), [&](size_t i) {
@@ -208,7 +208,7 @@ void FragmentMetaConsolidator::vacuum(const char* array_name) {
         FragmentID fragment_id{uri};
         auto timestamp_range{fragment_id.timestamp_range()};
         if (timestamp_range.second != t_latest) {
-          vfs.remove_file(uri);
+          vfs->remove_file(uri);
         }
         return Status::Ok();
       }));

--- a/tiledb/sm/consolidator/group_meta_consolidator.cc
+++ b/tiledb/sm/consolidator/group_meta_consolidator.cc
@@ -107,8 +107,8 @@ Status GroupMetaConsolidator::consolidate(
   group_for_writes.close();
 
   // Write vacuum file
-  resources_.vfs().write(vac_uri, data.c_str(), data.size());
-  throw_if_not_ok(resources_.vfs().close_file(vac_uri));
+  resources_.vfs()->write(vac_uri, data.c_str(), data.size());
+  throw_if_not_ok(resources_.vfs()->close_file(vac_uri));
 
   return Status::Ok();
 }
@@ -120,18 +120,18 @@ void GroupMetaConsolidator::vacuum(const char* group_name) {
   }
 
   // Get the group metadata URIs and vacuum file URIs to be vacuumed
-  auto& vfs = resources_.vfs();
+  auto vfs = resources_.vfs();
   auto& compute_tp = resources_.compute_tp();
   GroupDirectory group_dir(
-      vfs,
+      *vfs.get(),
       compute_tp,
       URI(group_name),
       0,
       std::numeric_limits<uint64_t>::max());
 
   // Delete the group metadata and vacuum files
-  vfs.remove_files(&compute_tp, group_dir.group_meta_uris_to_vacuum());
-  vfs.remove_files(&compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
+  vfs->remove_files(&compute_tp, group_dir.group_meta_uris_to_vacuum());
+  vfs->remove_files(&compute_tp, group_dir.group_meta_vac_uris_to_vacuum());
 }
 
 /* ****************************** */

--- a/tiledb/sm/enums/filesystem.h
+++ b/tiledb/sm/enums/filesystem.h
@@ -36,8 +36,7 @@
 
 #include "tiledb/sm/misc/constants.h"
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Defines a filesystem. */
 enum class Filesystem : uint8_t {
@@ -59,6 +58,8 @@ inline const std::string& filesystem_str(Filesystem filesystem_type) {
       return constants::filesystem_type_gcs_str;
     case Filesystem::MEMFS:
       return constants::filesystem_type_mem_str;
+    case Filesystem::LOCAL:
+      return constants::filesystem_type_local_str;
     default:
       return constants::empty_str;
   }
@@ -77,13 +78,14 @@ inline Status filesystem_enum(
     *filesystem_type = Filesystem::GCS;
   else if (filesystem_type_str == constants::filesystem_type_mem_str)
     *filesystem_type = Filesystem::MEMFS;
+  else if (filesystem_type_str == constants::filesystem_type_local_str)
+    *filesystem_type = Filesystem::LOCAL;
   else
     return Status_Error("Invalid Filesystem " + filesystem_type_str);
 
   return Status::Ok();
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_FILESYSTEM_H

--- a/tiledb/sm/filesystem/filesystem_base.cc
+++ b/tiledb/sm/filesystem/filesystem_base.cc
@@ -47,6 +47,10 @@ LsObjects FilesystemBase::ls_filtered_v2(
   throw UnsupportedOperation("ls_filtered");
 }
 
+void FilesystemBase::remove_dir_if_empty(const URI&) const {
+  throw UnsupportedOperation("remove_dir_if_empty");
+}
+
 void FilesystemBase::move_file(const URI&, const URI&) const {
   throw UnsupportedOperation("move_file");
 }
@@ -69,6 +73,20 @@ bool FilesystemBase::use_read_ahead_cache() const {
 
 void FilesystemBase::sync(const URI&) const {
   throw UnsupportedOperation("sync");
+}
+
+void FilesystemBase::set_multipart_upload_state(
+    const URI&, const MultiPartUploadState&) {
+  throw UnsupportedOperation("set_multipart_upload_state");
+}
+
+std::optional<FilesystemBase::MultiPartUploadState>
+FilesystemBase::multipart_upload_state(const URI&) {
+  throw UnsupportedOperation("multipart_upload_state");
+}
+
+void FilesystemBase::flush_multipart_file_buffer(const URI&) {
+  throw UnsupportedOperation("flush_multipart_file_buffer");
 }
 
 bool FilesystemBase::is_bucket(const URI&) const {

--- a/tiledb/sm/filesystem/local.h
+++ b/tiledb/sm/filesystem/local.h
@@ -57,6 +57,17 @@ class LocalFilesystem : public FilesystemBase {
 
   void copy_dir(const URI& old_uri, const URI& new_uri) override;
 
+  void set_multipart_upload_state(
+      const URI&, const MultiPartUploadState&) override {
+    // No-op for local filesystems.
+  }
+
+  std::optional<MultiPartUploadState> multipart_upload_state(
+      const URI&) override {
+    // No-op for local filesystems.
+    return {};
+  }
+
  protected:
   /**
    * Creates the containing directories of a path if they do not exist.

--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -191,16 +191,16 @@ void Posix::remove_dir(const URI& uri) const {
   }
 }
 
-bool Posix::remove_dir_if_empty(const std::string& path) const {
+void Posix::remove_dir_if_empty(const URI& uri) const {
+  auto path = uri.to_path();
   if (rmdir(path.c_str()) != 0) {
     if (errno == ENOTEMPTY) {
-      return false;
+      return;
     }
     throw IOError(
         std::string("Failed to delete path '") + path + "';  " +
         strerror(errno));
   }
-  return true;
 }
 
 void Posix::remove_file(const URI& uri) const {

--- a/tiledb/sm/filesystem/posix.h
+++ b/tiledb/sm/filesystem/posix.h
@@ -135,9 +135,8 @@ class Posix : public LocalFilesystem {
    * Removes a given empty directory.
    *
    * @param path The path of the directory.
-   * @return true if the directory was removed, false otherwise.
    */
-  bool remove_dir_if_empty(const std::string& path) const;
+  void remove_dir_if_empty(const URI& path) const override;
 
   /**
    * Removes a given path.

--- a/tiledb/sm/filesystem/s3.h
+++ b/tiledb/sm/filesystem/s3.h
@@ -738,6 +738,37 @@ class S3 : public FilesystemBase {
   void sync(const URI&) const override {
     // No-op for S3.
   }
+
+  /**
+   * Used in serialization of global order writes to set the multipart upload
+   * state in the internal maps of cloud backends during deserialization.
+   *
+   * @param uri The file uri used as key in the internal map of the backend.
+   * @param state The multipart upload state info.
+   */
+  void set_multipart_upload_state(
+      const URI& uri,
+      const FilesystemBase::MultiPartUploadState& state) override;
+
+  /**
+   * Used in serialization to share the multipart upload state among cloud
+   * executors during global order writes.
+   *
+   * @param uri The file uri used as key in the internal map of the backend.
+   * @return A MultiPartUploadState object.
+   */
+  std::optional<FilesystemBase::MultiPartUploadState> multipart_upload_state(
+      const URI& uri) override;
+
+  /**
+   * Used in remote global order writes to flush the internal
+   * in-memory buffer for an URI that backends maintain to modulate the
+   * frequency of multipart upload requests.
+   *
+   * @param uri The file uri identifying the backend file buffer.
+   */
+  void flush_multipart_file_buffer(const URI& uri) override;
+
   /**
    * Retrieves all the entries contained in the parent.
    *
@@ -1560,9 +1591,8 @@ class S3 : public FilesystemBase {
    *
    * @param uri The file uri used as key in the internal map
    * @param state The multipart upload state info
-   * @return Status
    */
-  Status set_multipart_upload_state(
+  void set_multipart_upload_state_internal(
       const std::string& uri, S3::MultiPartUploadState& state);
 
   /**
@@ -1571,7 +1601,7 @@ class S3 : public FilesystemBase {
    * @param uri The URI of the multipart state
    * @return an optional MultiPartUploadState object
    */
-  std::optional<S3::MultiPartUploadState> multipart_upload_state(
+  std::optional<S3::MultiPartUploadState> multipart_upload_state_internal(
       const URI& uri);
 
   /**

--- a/tiledb/sm/filesystem/test/CMakeLists.txt
+++ b/tiledb/sm/filesystem/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # The MIT License
 #
-# Copyright (c) 2021-2022 TileDB, Inc.
+# Copyright (c) 2021-2025 TileDB, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,8 +26,13 @@
 include(unit_test)
 
 commence(unit_test vfs)
-    this_target_object_libraries(vfs)
-    this_target_sources(main.cc unit_uri.cc unit_ls_filtered.cc)
+    this_target_object_libraries(context_resources)
+    this_target_sources(main.cc unit_uri.cc)
+conclude(unit_test)
+
+commence(unit_test vfs_ls_filtered)
+    this_target_object_libraries(context_resources)
+    this_target_sources(main.cc unit_ls_filtered.cc)
 conclude(unit_test)
 
 commence(unit_test vfs_read_log_modes)

--- a/tiledb/sm/filesystem/test/compile_vfs_main.cc
+++ b/tiledb/sm/filesystem/test/compile_vfs_main.cc
@@ -29,11 +29,15 @@
 #include "../vfs.h"
 #include "tiledb/common/logger.h"
 
+using namespace tiledb::sm;
+
 int main() {
-  static tiledb::sm::stats::Stats stats("test");
+  static stats::Stats stats("test");
   static tiledb::common::Logger logger("test");
   ThreadPool compute_tp(4);
   ThreadPool io_tp(4);
-  tiledb::sm::VFS x{&stats, &logger, &compute_tp, &io_tp, tiledb::sm::Config{}};
+  std::vector<std::unique_ptr<FilesystemBase>> fses;
+  fses.emplace_back(std::make_unique<MemFilesystem>());
+  VFS x{&stats, &logger, &compute_tp, &io_tp, Config{}, std::move(fses)};
   return 0;
 }

--- a/tiledb/sm/filesystem/test/unit_ls_filtered.cc
+++ b/tiledb/sm/filesystem/test/unit_ls_filtered.cc
@@ -35,6 +35,7 @@
 #include "tiledb/common/logger.h"
 #include "tiledb/sm/config/config.h"
 #include "tiledb/sm/filesystem/vfs.h"
+#include "tiledb/sm/storage_manager/context_resources.h"
 
 namespace tiledb::sm {
 /**
@@ -63,7 +64,14 @@ class VFSTest {
       , logger_("unit_ls_filtered")
       , io_(4)
       , compute_(4)
-      , vfs_(&stats_, &logger_, &io_, &compute_, tiledb::sm::Config())
+      , vfs_(
+            &stats_,
+            &logger_,
+            &io_,
+            &compute_,
+            tiledb::sm::Config(),
+            tiledb::sm::ContextResources::make_filesystems(
+                &stats_, &io_, tiledb::sm::Config()))
       , test_tree_(test_tree)
       , prefix_(prefix)
       , temp_dir_(prefix_)

--- a/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
+++ b/tiledb/sm/filesystem/test/unit_vfs_read_log_modes.cc
@@ -75,7 +75,7 @@ TEST_CASE("VFS Read Log Modes", "[vfs][read-logging-modes]") {
     for (auto& uri : uris_to_read) {
       // None of these files exist, so we expect every read to fail.
       REQUIRE_THROWS(
-          throw_if_not_ok(res.vfs().read_exactly(URI(uri), 123, buffer, 456)));
+          throw_if_not_ok(res.vfs()->read_exactly(URI(uri), 123, buffer, 456)));
     }
   }
 }

--- a/tiledb/sm/filesystem/win.cc
+++ b/tiledb/sm/filesystem/win.cc
@@ -289,17 +289,17 @@ void Win::remove_dir(const URI& uri) const {
   }
 }
 
-bool Win::remove_dir_if_empty(const std::string& path) const {
+void Win::remove_dir_if_empty(const URI& uri) const {
+  auto path = uri.to + path();
   if (!RemoveDirectoryA(path.c_str())) {
     auto gle = GetLastError();
     if (gle == ERROR_DIR_NOT_EMPTY) {
-      return false;
+      return;
     }
     throw IOError(
         std::string("Failed to delete directory '") + path + "' " +
         get_last_error_msg(gle, "RemoveDirectory"));
   }
-  return true;
 }
 
 void Win::remove_file(const URI& uri) const {

--- a/tiledb/sm/filesystem/win.h
+++ b/tiledb/sm/filesystem/win.h
@@ -139,9 +139,8 @@ class Win : public LocalFilesystem {
    * Removes a given empty directory.
    *
    * @param path The path of the directory.
-   * @return true if the directory was removed, false otherwise.
    */
-  bool remove_dir_if_empty(const std::string& path) const;
+  void remove_dir_if_empty(const URI& uri) const override;
 
   /**
    * Removes a given path.

--- a/tiledb/sm/fragment/fragment_info.cc
+++ b/tiledb/sm/fragment/fragment_info.cc
@@ -1113,7 +1113,7 @@ Status FragmentInfo::set_default_timestamp_range() {
 tuple<Status, optional<SingleFragmentInfo>> FragmentInfo::load(
     const URI& new_fragment_uri) const {
   SingleFragmentInfo ret;
-  auto& vfs = resources_->vfs();
+  auto vfs = resources_->vfs();
   const auto& array_schema_latest =
       single_fragment_info_vec_.back().meta()->array_schema();
 
@@ -1127,7 +1127,7 @@ tuple<Status, optional<SingleFragmentInfo>> FragmentInfo::load(
     URI coords_uri =
         new_fragment_uri.join_path(constants::coords + constants::file_suffix);
     try {
-      vfs.is_file(coords_uri);
+      vfs->is_file(coords_uri);
     } catch (std::exception& e) {
       return {Status_Error(e.what()), nullopt};
     }

--- a/tiledb/sm/fragment/fragment_metadata.cc
+++ b/tiledb/sm/fragment/fragment_metadata.cc
@@ -679,7 +679,7 @@ uint64_t FragmentMetadata::fragment_size() const {
   if (meta_file_size == 0) {
     auto meta_uri = fragment_uri_.join_path(
         std::string(constants::fragment_metadata_filename));
-    meta_file_size = resources_->vfs().file_size(meta_uri);
+    meta_file_size = resources_->vfs()->file_size(meta_uri);
   }
   // Validate that the meta_file_size is not zero, either preloaded or fetched
   // above
@@ -777,7 +777,7 @@ std::vector<shared_ptr<FragmentMetadata>> FragmentMetadata::load(
               sf.uri_,
               sf.timestamp_range_,
               memory_tracker,
-              !resources.vfs().is_file(coords_uri));
+              !resources.vfs()->is_file(coords_uri));
         } else {
           // Fragment format version > 2
           metadata = make_shared<FragmentMetadata>(
@@ -827,7 +827,7 @@ void FragmentMetadata::load(
   // Load the metadata file size when we are not reading from consolidated
   // buffer
   if (fragment_metadata_tile == nullptr) {
-    meta_file_size_ = resources_->vfs().file_size(meta_uri);
+    meta_file_size_ = resources_->vfs()->file_size(meta_uri);
   }
 
   // Get fragment name version
@@ -928,7 +928,7 @@ void FragmentMetadata::store_v7_v10(const EncryptionKey& encryption_key) {
   store_footer(encryption_key);
 
   // Close file
-  throw_if_not_ok(resources_->vfs().close_file(fragment_metadata_uri));
+  throw_if_not_ok(resources_->vfs()->close_file(fragment_metadata_uri));
 }
 
 void FragmentMetadata::store_v11(const EncryptionKey& encryption_key) {
@@ -1010,7 +1010,7 @@ void FragmentMetadata::store_v11(const EncryptionKey& encryption_key) {
   store_footer(encryption_key);
 
   // Close file
-  throw_if_not_ok(resources_->vfs().close_file(fragment_metadata_uri));
+  throw_if_not_ok(resources_->vfs()->close_file(fragment_metadata_uri));
 }
 
 void FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
@@ -1097,7 +1097,7 @@ void FragmentMetadata::store_v12_v14(const EncryptionKey& encryption_key) {
   store_footer(encryption_key);
 
   // Close file
-  throw_if_not_ok(resources_->vfs().close_file(fragment_metadata_uri));
+  throw_if_not_ok(resources_->vfs()->close_file(fragment_metadata_uri));
 }
 
 void FragmentMetadata::store_v15_or_higher(
@@ -1190,7 +1190,7 @@ void FragmentMetadata::store_v15_or_higher(
   store_footer(encryption_key);
 
   // Close file
-  throw_if_not_ok(resources_->vfs().close_file(fragment_metadata_uri));
+  throw_if_not_ok(resources_->vfs()->close_file(fragment_metadata_uri));
 }
 
 void FragmentMetadata::set_num_tiles(uint64_t num_tiles) {
@@ -1679,7 +1679,7 @@ void FragmentMetadata::get_footer_offset_and_size(
     URI fragment_metadata_uri = fragment_uri_.join_path(
         std::string(constants::fragment_metadata_filename));
     uint64_t size_offset = meta_file_size_ - sizeof(uint64_t);
-    throw_if_not_ok(resources_->vfs().read_exactly(
+    throw_if_not_ok(resources_->vfs()->read_exactly(
         fragment_metadata_uri, size_offset, size, sizeof(uint64_t)));
     *offset = meta_file_size_ - *size - sizeof(uint64_t);
     resources_->stats().add_counter("read_frag_meta_size", sizeof(uint64_t));
@@ -2758,7 +2758,7 @@ void FragmentMetadata::read_file_footer(
   }
 
   // Read footer
-  throw_if_not_ok(resources_->vfs().read_exactly(
+  throw_if_not_ok(resources_->vfs()->read_exactly(
       fragment_metadata_uri,
       *footer_offset,
       tile->data_as<uint8_t>(),
@@ -2781,11 +2781,11 @@ void FragmentMetadata::write_footer_to_file(shared_ptr<WriterTile> tile) const {
       std::string(constants::fragment_metadata_filename));
 
   uint64_t size = tile->size();
-  resources_->vfs().write(fragment_metadata_uri, tile->data(), tile->size());
+  resources_->vfs()->write(fragment_metadata_uri, tile->data(), tile->size());
 
   // Write the size in the end if there is at least one var-sized dimension
   if (!array_schema_->domain().all_dims_fixed() || version_ >= 10) {
-    resources_->vfs().write(fragment_metadata_uri, &size, sizeof(uint64_t));
+    resources_->vfs()->write(fragment_metadata_uri, &size, sizeof(uint64_t));
   }
 }
 
@@ -3464,8 +3464,8 @@ void FragmentMetadata::clean_up() {
   auto fragment_metadata_uri =
       fragment_uri_.join_path(constants::fragment_metadata_filename);
 
-  throw_if_not_ok(resources_->vfs().close_file(fragment_metadata_uri));
-  resources_->vfs().remove_file(fragment_metadata_uri);
+  throw_if_not_ok(resources_->vfs()->close_file(fragment_metadata_uri));
+  resources_->vfs()->remove_file(fragment_metadata_uri);
 }
 
 const shared_ptr<const ArraySchema>& FragmentMetadata::array_schema() const {

--- a/tiledb/sm/group/group_details.cc
+++ b/tiledb/sm/group/group_details.cc
@@ -228,9 +228,9 @@ void GroupDetails::store(
 
   // Check if the array schema directory exists
   // If not create it, this is caused by a pre-v10 array
-  auto& vfs = resources.vfs();
-  if (!vfs.is_dir(group_detail_folder_uri)) {
-    vfs.create_dir(group_detail_folder_uri);
+  auto vfs = resources.vfs();
+  if (!vfs->is_dir(group_detail_folder_uri)) {
+    vfs->create_dir(group_detail_folder_uri);
   }
   GenericTileIO::store_data(resources, group_detail_uri, tile, encryption_key);
 }

--- a/tiledb/sm/misc/constants.cc
+++ b/tiledb/sm/misc/constants.cc
@@ -670,6 +670,9 @@ const std::string filesystem_type_gcs_str = "GCS";
 /** The string representation for in-memory filesystem */
 const std::string filesystem_type_mem_str = "MEM";
 
+/** The string representation for local filesystem */
+const std::string filesystem_type_local_str = "LOCALß";
+
 /** The string representation for WalkOrder preorder. */
 const std::string walkorder_preorder_str = "PREORDER";
 

--- a/tiledb/sm/misc/constants.h
+++ b/tiledb/sm/misc/constants.h
@@ -666,6 +666,9 @@ extern const std::string filesystem_type_gcs_str;
 /** The string representation for in-memory filesystem. */
 extern const std::string filesystem_type_mem_str;
 
+/** The string representation for local filesystem. */
+extern const std::string filesystem_type_local_str;
+
 /** The string representation for WalkOrder preorder. */
 extern const std::string walkorder_preorder_str;
 

--- a/tiledb/sm/object/object.cc
+++ b/tiledb/sm/object/object.cc
@@ -59,13 +59,13 @@ bool is_array(ContextResources& resources, const URI& uri) {
     return exists.value();
   } else {
     // Check if the schema directory exists or not
-    auto& vfs = resources.vfs();
-    if (vfs.is_dir(uri.join_path(constants::array_schema_dir_name))) {
+    auto vfs = resources.vfs();
+    if (vfs->is_dir(uri.join_path(constants::array_schema_dir_name))) {
       return true;
     }
 
     // If there is no schema directory, we check schema file
-    return vfs.is_file(uri.join_path(constants::array_schema_filename));
+    return vfs->is_file(uri.join_path(constants::array_schema_filename));
   }
 }
 
@@ -78,13 +78,13 @@ bool is_group(ContextResources& resources, const URI& uri) {
     return exists.value();
   } else {
     // Check for new group details directory
-    auto& vfs = resources.vfs();
-    if (vfs.is_dir(uri.join_path(constants::group_detail_dir_name))) {
+    auto vfs = resources.vfs();
+    if (vfs->is_dir(uri.join_path(constants::group_detail_dir_name))) {
       return true;
     }
 
     // Fall back to older group file to check for legacy (pre-format 12) groups
-    return vfs.is_file(uri.join_path(constants::group_filename));
+    return vfs->is_file(uri.join_path(constants::group_filename));
   }
 }
 
@@ -99,7 +99,7 @@ ObjectType object_type(ContextResources& resources, const URI& uri) {
         URI(utils::parse::ends_with(uri_str, "/") ? uri_str : (uri_str + "/"));
   } else if (!uri.is_tiledb()) {
     // For non public cloud backends, listing a non-directory is an error.
-    if (!resources.vfs().is_dir(uri)) {
+    if (!resources.vfs()->is_dir(uri)) {
       return ObjectType::INVALID;
     }
   }
@@ -134,7 +134,7 @@ void object_move(
         "'; Invalid TileDB object");
   }
 
-  resources.vfs().move_dir(old_uri, new_uri);
+  resources.vfs()->move_dir(old_uri, new_uri);
 }
 
 void object_remove(ContextResources& resources, const char* path) {
@@ -150,7 +150,7 @@ void object_remove(ContextResources& resources, const char* path) {
         "'; Invalid TileDB object");
   }
 
-  resources.vfs().remove_dir(uri);
+  resources.vfs()->remove_dir(uri);
 }
 
 }  // namespace tiledb::sm

--- a/tiledb/sm/object/object_iter.cc
+++ b/tiledb/sm/object/object_iter.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2024 TileDB, Inc.
+ * @copyright Copyright (c) 2024-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,7 @@ ObjectIter* object_iter_begin(
 
   // Get all contents of path
   std::vector<URI> uris;
-  throw_if_not_ok(resources.vfs().ls(path_uri, &uris));
+  throw_if_not_ok(resources.vfs()->ls(path_uri, &uris));
 
   // Create a new object iterator
   ObjectIter* obj_iter = tdb_new(ObjectIter);
@@ -90,7 +90,7 @@ ObjectIter* object_iter_begin(ContextResources& resources, const char* path) {
 
   // Get all contents of path
   std::vector<URI> uris;
-  throw_if_not_ok(resources.vfs().ls(path_uri, &uris));
+  throw_if_not_ok(resources.vfs()->ls(path_uri, &uris));
 
   // Create a new object iterator
   ObjectIter* obj_iter = tdb_new(ObjectIter);
@@ -158,7 +158,7 @@ Status object_iter_next_postorder(
     do {
       obj_num = obj_iter->objs_.size();
       std::vector<URI> uris;
-      throw_if_not_ok(resources.vfs().ls(obj_iter->objs_.front(), &uris));
+      throw_if_not_ok(resources.vfs()->ls(obj_iter->objs_.front(), &uris));
       obj_iter->expanded_.front() = true;
 
       // Push the new TileDB objects in the front of the iterator's list
@@ -209,7 +209,7 @@ Status object_iter_next_preorder(
 
   // Get all contents of the next URI
   std::vector<URI> uris;
-  throw_if_not_ok(resources.vfs().ls(front_uri, &uris));
+  throw_if_not_ok(resources.vfs()->ls(front_uri, &uris));
 
   // Push the new TileDB objects in the front of the iterator's list
   ObjectType obj_type;

--- a/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
+++ b/tiledb/sm/query/deletes_and_updates/deletes_and_updates.cc
@@ -141,7 +141,7 @@ Status DeletesAndUpdates::dowork() {
   // Create the commit URI if needed.
   auto& array_dir = array_->array_directory();
   auto commit_uri = array_dir.get_commits_dir(write_version);
-  resources_.vfs().create_dir(commit_uri);
+  resources_.vfs()->create_dir(commit_uri);
 
   // Serialize the negated condition (aud update values if they are not empty)
   // and write to disk.

--- a/tiledb/sm/query/readers/filtered_data.h
+++ b/tiledb/sm/query/readers/filtered_data.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -395,7 +395,7 @@ class FilteredData {
     auto size{block.size()};
     URI uri{file_uri(fragment_metadata_[block.frag_idx()].get(), type)};
     auto task = resources_.io_tp().execute([this, offset, data, size, uri]() {
-      throw_if_not_ok(resources_.vfs().read_exactly(uri, offset, data, size));
+      throw_if_not_ok(resources_.vfs()->read_exactly(uri, offset, data, size));
       return Status::Ok();
     });
     read_tasks_.push_back(std::move(task));

--- a/tiledb/sm/query/writers/global_order_writer.h
+++ b/tiledb/sm/query/writers/global_order_writer.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,8 +43,9 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
+
+using MultiPartUploadState = FilesystemBase::MultiPartUploadState;
 
 /** Processes write queries. */
 class GlobalOrderWriter : public WriterBase {
@@ -106,7 +107,7 @@ class GlobalOrderWriter : public WriterBase {
      * A mapping of buffer names to multipart upload state used by clients
      * to track the write state in remote global order writes
      */
-    std::unordered_map<std::string, VFS::MultiPartUploadState>
+    std::unordered_map<std::string, MultiPartUploadState>
         multipart_upload_state_;
   };
 
@@ -168,7 +169,7 @@ class GlobalOrderWriter : public WriterBase {
    * or from within the cloud backend internal mappings if the code is executed
    * on the rest server.
    */
-  std::pair<Status, std::unordered_map<std::string, VFS::MultiPartUploadState>>
+  std::pair<Status, std::unordered_map<std::string, MultiPartUploadState>>
   multipart_upload_state(bool client);
 
   /**
@@ -182,9 +183,7 @@ class GlobalOrderWriter : public WriterBase {
    * @return Status
    */
   Status set_multipart_upload_state(
-      const std::string& uri,
-      const VFS::MultiPartUploadState& state,
-      bool client);
+      const std::string& uri, const MultiPartUploadState& state, bool client);
 
  private:
   /* ********************************* */
@@ -393,7 +392,6 @@ class GlobalOrderWriter : public WriterBase {
   Status start_new_fragment();
 };
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm
 
 #endif  // TILEDB_GLOBAL_ORDER_WRITER_H

--- a/tiledb/sm/query/writers/ordered_writer.cc
+++ b/tiledb/sm/query/writers/ordered_writer.cc
@@ -149,7 +149,7 @@ std::string OrderedWriter::name() {
 
 void OrderedWriter::clean_up() {
   if (frag_uri_.has_value()) {
-    resources_.vfs().remove_dir(frag_uri_.value());
+    resources_.vfs()->remove_dir(frag_uri_.value());
   }
 }
 
@@ -281,7 +281,7 @@ Status OrderedWriter::ordered_write() {
 
   // The following will make the fragment visible
   URI commit_uri = array_->array_directory().get_commit_uri(frag_uri_.value());
-  resources_.vfs().touch(commit_uri);
+  resources_.vfs()->touch(commit_uri);
 
   return Status::Ok();
 }

--- a/tiledb/sm/query/writers/unordered_writer.cc
+++ b/tiledb/sm/query/writers/unordered_writer.cc
@@ -179,7 +179,7 @@ Status UnorderedWriter::alloc_frag_meta() {
 
 void UnorderedWriter::clean_up() {
   if (frag_uri_.has_value()) {
-    resources_.vfs().remove_dir(frag_uri_.value());
+    resources_.vfs()->remove_dir(frag_uri_.value());
   }
 }
 
@@ -724,7 +724,7 @@ Status UnorderedWriter::unordered_write() {
     // The following will make the fragment visible
     URI commit_uri =
         array_->array_directory().get_commit_uri(frag_uri_.value());
-    resources_.vfs().touch(commit_uri);
+    resources_.vfs()->touch(commit_uri);
 
     // Clear some data to prevent it from being serialized.
     cell_pos_.clear();

--- a/tiledb/sm/query/writers/writer_base.cc
+++ b/tiledb/sm/query/writers/writer_base.cc
@@ -601,9 +601,9 @@ Status WriterBase::close_files(shared_ptr<FragmentMetadata> meta) const {
         const auto& file_uri = file_uris[i];
         if (layout_ == Layout::GLOBAL_ORDER && remote_query()) {
           // flush with finalize == true
-          resources_.vfs().flush(file_uri, true);
+          resources_.vfs()->flush(file_uri, true);
         } else {
-          throw_if_not_ok(resources_.vfs().close_file(file_uri));
+          throw_if_not_ok(resources_.vfs()->close_file(file_uri));
         }
         return Status::Ok();
       });
@@ -767,9 +767,9 @@ Status WriterBase::create_fragment(
   // Create the directories.
   // Create the fragment directory, the directory for the new fragment
   // URI, and the commit directory.
-  resources_.vfs().create_dir(array_dir.get_fragments_dir(write_version));
-  resources_.vfs().create_dir(fragment_uri_);
-  resources_.vfs().create_dir(array_dir.get_commits_dir(write_version));
+  resources_.vfs()->create_dir(array_dir.get_fragments_dir(write_version));
+  resources_.vfs()->create_dir(fragment_uri_);
+  resources_.vfs()->create_dir(array_dir.get_commits_dir(write_version));
 
   // Create fragment metadata.
   auto timestamp_range = std::pair<uint64_t, uint64_t>(timestamp, timestamp);
@@ -1105,7 +1105,7 @@ Status WriterBase::write_tiles(
        ++i, ++tile_id) {
     auto& tile = (*tiles)[i];
     auto& t = var_size ? tile.offset_tile() : tile.fixed_tile();
-    resources_.vfs().write(
+    resources_.vfs()->write(
         uri,
         t.filtered_buffer().data(),
         t.filtered_buffer().size(),
@@ -1115,7 +1115,7 @@ Status WriterBase::write_tiles(
 
     if (var_size) {
       auto& t_var = tile.var_tile();
-      resources_.vfs().write(
+      resources_.vfs()->write(
           var_uri,
           t_var.filtered_buffer().data(),
           t_var.filtered_buffer().size(),
@@ -1140,7 +1140,7 @@ Status WriterBase::write_tiles(
 
     if (nullable) {
       auto& t_val = tile.validity_tile();
-      resources_.vfs().write(
+      resources_.vfs()->write(
           validity_uri,
           t_val.filtered_buffer().data(),
           t_val.filtered_buffer().size(),
@@ -1169,10 +1169,10 @@ Status WriterBase::write_tiles(
         // requirement of remote global order writes, it should only be
         // done if this code is executed as a result of a remote query
         if (remote_query()) {
-          throw_if_not_ok(resources_.vfs().flush_multipart_file_buffer(u));
+          resources_.vfs()->flush_multipart_file_buffer(u);
         }
       } else {
-        throw_if_not_ok(resources_.vfs().close_file(u));
+        throw_if_not_ok(resources_.vfs()->close_file(u));
       }
     }
   }

--- a/tiledb/sm/serialization/query.cc
+++ b/tiledb/sm/serialization/query.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  * @copyright Copyright (c) 2016 MIT and Intel Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -2969,7 +2969,7 @@ Status global_write_state_from_capnp(
     auto multipart_reader = state_reader.getMultiPartUploadStates();
     if (multipart_reader.hasEntries()) {
       for (auto entry : multipart_reader.getEntries()) {
-        VFS::MultiPartUploadState deserialized_state;
+        FilesystemBase::MultiPartUploadState deserialized_state;
         auto state = entry.getValue();
         auto buffer_uri =
             std::string_view{entry.getKey().cStr(), entry.getKey().size()};

--- a/tiledb/sm/storage_manager/context_resources.h
+++ b/tiledb/sm/storage_manager/context_resources.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2018-2022 TileDB, Inc.
+ * @copyright Copyright (c) 2018-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -103,7 +103,7 @@ class ContextResources {
     return *(stats_.get());
   }
 
-  [[nodiscard]] inline VFS& vfs() const {
+  [[nodiscard]] inline shared_ptr<VFS> vfs() const {
     return vfs_;
   }
 
@@ -144,6 +144,20 @@ class ContextResources {
    */
   shared_ptr<MemoryTracker> serialization_memory_tracker() const;
 
+  /**
+   * Return the vector of supported filesystems.
+   *
+   * @param stats The parent stats to inherit from.
+   * @param io_tp Thread pool for io-bound tasks.
+   * @param config Configuration parameters.
+   *
+   * @return The vector of supported filesystems.
+   */
+  static std::vector<std::unique_ptr<FilesystemBase>> make_filesystems(
+      [[maybe_unused]] stats::Stats* parent_stats,
+      [[maybe_unused]] ThreadPool* io_tp,
+      const Config& config);
+
  private:
   /* ********************************* */
   /*         PRIVATE ATTRIBUTES        */
@@ -180,7 +194,7 @@ class ContextResources {
    * Virtual filesystem handler. It directs queries to the appropriate
    * filesystem backend. Note that this is stateful.
    */
-  mutable VFS vfs_;
+  shared_ptr<VFS> vfs_;
 
   /** The rest client (may be null if none was configured). */
   shared_ptr<RestClient> rest_client_;

--- a/tiledb/sm/storage_manager/storage_manager.cc
+++ b/tiledb/sm/storage_manager/storage_manager.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2025 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,7 @@ StorageManagerCanonical::StorageManagerCanonical(
     const shared_ptr<Logger>&,  // unused
     const Config& config)
     : global_state_(global_state::GlobalState::GetGlobalState())
-    , vfs_(resources.vfs())
+    , vfs_(*resources.vfs().get())
     , cancellation_in_progress_(false)
     , config_(config)
     , queries_in_progress_(0) {

--- a/tiledb/sm/tile/generic_tile_io.cc
+++ b/tiledb/sm/tile/generic_tile_io.cc
@@ -45,8 +45,7 @@
 
 using namespace tiledb::common;
 
-namespace tiledb {
-namespace sm {
+namespace tiledb::sm {
 
 /** Class for locally generated status exceptions. */
 class GenericTileIOException : public StatusException {
@@ -124,7 +123,7 @@ shared_ptr<Tile> GenericTileIO::read_generic(
       memory_tracker->get_resource(MemoryType::GENERIC_TILE_IO));
 
   // Read the tile.
-  throw_if_not_ok(resources_.vfs().read_exactly(
+  throw_if_not_ok(resources_.vfs()->read_exactly(
       uri_,
       file_offset + tile_data_offset,
       tile->filtered_data(),
@@ -144,7 +143,7 @@ GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
 
   std::vector<uint8_t> base_buf(GenericTileHeader::BASE_SIZE);
 
-  throw_if_not_ok(resources.vfs().read_exactly(
+  throw_if_not_ok(resources.vfs()->read_exactly(
       uri, file_offset, base_buf.data(), base_buf.size()));
 
   Deserializer base_deserializer(base_buf.data(), base_buf.size());
@@ -159,7 +158,7 @@ GenericTileIO::GenericTileHeader GenericTileIO::read_generic_tile_header(
 
   // Read header filter pipeline.
   std::vector<uint8_t> filter_pipeline_buf(header.filter_pipeline_size);
-  throw_if_not_ok(resources.vfs().read_exactly(
+  throw_if_not_ok(resources.vfs()->read_exactly(
       uri,
       file_offset + GenericTileHeader::BASE_SIZE,
       filter_pipeline_buf.data(),
@@ -184,7 +183,7 @@ void GenericTileIO::store_data(
   GenericTileIO tile_io(resources, uri);
   uint64_t nbytes = 0;
   tile_io.write_generic(tile, encryption_key, &nbytes);
-  throw_if_not_ok(resources.vfs().close_file(uri));
+  throw_if_not_ok(resources.vfs()->close_file(uri));
 }
 
 void GenericTileIO::write_generic(
@@ -204,7 +203,7 @@ void GenericTileIO::write_generic(
 
   write_generic_tile_header(&header);
 
-  resources_.vfs().write(
+  resources_.vfs()->write(
       uri_, tile->filtered_buffer().data(), tile->filtered_buffer().size());
 
   *nbytes = GenericTileIO::GenericTileHeader::BASE_SIZE +
@@ -237,7 +236,7 @@ void GenericTileIO::write_generic_tile_header(GenericTileHeader* header) {
   serialize_generic_tile_header(serializer, *header);
 
   // Write buffer to file
-  resources_.vfs().write(uri_, data.data(), data.size());
+  resources_.vfs()->write(uri_, data.data(), data.size());
 }
 
 void GenericTileIO::configure_encryption_filter(
@@ -278,5 +277,4 @@ void GenericTileIO::init_generic_tile_header(
       &header->filters, encryption_key));
 }
 
-}  // namespace sm
-}  // namespace tiledb
+}  // namespace tiledb::sm


### PR DESCRIPTION
As part of the longstanding `class VFS` refactoring, remove all `FS_within_VFS` and `#ifdef` logic for demultiplexing individual filesystems on the VFS. Instead, the `ContextResources` will establish a vector of supported FSes and pass it into the single `VFS` via a new constructor parameter. The final refactoring step will be to remove the remaining `SupportedFS` logic.

---
TYPE: IMPROVEMENT
DESC: Remove filesystem member variables from `class VFS`.

---

Resolves CORE-300.
