### PR TITLE
VFS::chunked_buffer_io waits for read_task to exit

### DIFF
--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -430,6 +430,7 @@ void VFS::chunked_buffer_io(const URI& src, const URI& dest) {
       } catch (...) {
         // Enqueue caught-exceptions to be handled by the writer.
         buffer_queue.push(std::current_exception());
+        reading = false;
       }
       buffer_count++;
 


### PR DESCRIPTION
In CI one of the address sanitizer jobs has found an issue with `VFS::chunked_buffer_io`.

The read task signals the writer by closing the task queue and then setting `reading = false`:
```
        if (offset >= filesize) {
          buffer_queue.drain();
          reading = false;
          break;
        }
```
The write task can exit as soon as the read queue is empty and closed:
```
    auto buffer_queue_element = buffer_queue.pop_back();
    if (!buffer_queue_element.has_value()) {
      // Stop writing once the queue is empty (reader finished reading file).
      break;
    }
```

There is a race condition wherein the read task can close the queue but stall before updating the `reading` variable.  The write task will observe that the queue is closed, and then exit, and then return, which invalidates the `reading` variable memory.

This pull request fixes this by waiting for the read task to finish before returning.

---
TYPE: NO_HISTORY | BUG
DESC: Fix invalid write from `VFS::chunked_buffer_io`
