### PR TITLE
Minor GCS fix for 0-byte reads.

### DIFF
--- a/tiledb/sm/filesystem/gcs.cc
+++ b/tiledb/sm/filesystem/gcs.cc
@@ -1339,6 +1339,10 @@ Status GCS::flush_object_direct(const URI& uri) {
 
 uint64_t GCS::read(
     const URI& uri, uint64_t offset, void* buffer, uint64_t nbytes) {
+  // ReadRange will return an error on 0-byte reads. Instead, just return here.
+  if (offset + nbytes == 0) {
+    return 0;
+  }
   throw_if_not_ok(init_client());
 
   if (!uri.is_gcs()) {


### PR DESCRIPTION
Integration tests of copy exposed an edge case in which `google::cloud::storage::ReadRange` returns an error if `offset + nbytes == 0`. The function is expected to return `0` bytes-read in this case.  

---
TYPE: BUG
DESC: 0-byte read `GCS` bug fix.

---
Fixes CORE-413
