### PR TITLE
[Regression] Build the AWS SDK with hidden symbols

### DIFF
--- a/ports/triplets/arm64-osx-asan.cmake
+++ b/ports/triplets/arm64-osx-asan.cmake
@@ -11,6 +11,12 @@ set(VCPKG_CXX_FLAGS "-fsanitize=address")
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/arm64-osx-release.cmake
+++ b/ports/triplets/arm64-osx-release.cmake
@@ -11,6 +11,12 @@ set(VCPKG_BUILD_TYPE release)
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/arm64-osx-relwithdebinfo.cmake
+++ b/ports/triplets/arm64-osx-relwithdebinfo.cmake
@@ -12,6 +12,12 @@ set(VCPKG_C_FLAGS "-g")
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/arm64-osx.cmake
+++ b/ports/triplets/arm64-osx.cmake
@@ -9,6 +9,12 @@ set(VCPKG_OSX_DEPLOYMENT_TARGET 11)
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-linux-asan.cmake
+++ b/ports/triplets/x64-linux-asan.cmake
@@ -10,6 +10,12 @@ set(VCPKG_CXX_FLAGS "-fsanitize=address")
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-linux-release.cmake
+++ b/ports/triplets/x64-linux-release.cmake
@@ -9,6 +9,12 @@ set(VCPKG_BUILD_TYPE release)
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-linux-relwithdebinfo.cmake
+++ b/ports/triplets/x64-linux-relwithdebinfo.cmake
@@ -10,6 +10,12 @@ set(VCPKG_C_FLAGS "-g")
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-linux.cmake
+++ b/ports/triplets/x64-linux.cmake
@@ -7,6 +7,12 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-osx-asan.cmake
+++ b/ports/triplets/x64-osx-asan.cmake
@@ -11,6 +11,12 @@ set(VCPKG_CXX_FLAGS "-fsanitize=address")
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-osx-release.cmake
+++ b/ports/triplets/x64-osx-release.cmake
@@ -11,6 +11,12 @@ set(VCPKG_BUILD_TYPE release)
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-osx-relwithdebinfo.cmake
+++ b/ports/triplets/x64-osx-relwithdebinfo.cmake
@@ -12,6 +12,12 @@ set(VCPKG_C_FLAGS "-g")
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")

--- a/ports/triplets/x64-osx.cmake
+++ b/ports/triplets/x64-osx.cmake
@@ -9,6 +9,12 @@ set(VCPKG_OSX_DEPLOYMENT_TARGET 11)
 # Fix CMake 4.0 errors in ports supporting very old CMake verions.
 set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
+# Hide symbols in the AWS SDK. Fixes symbol collisions with other libraries
+# like arrow (https://github.com/apache/arrow/issues/42154).
+if("${PORT}" MATCHES "^aws-")
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_CXX_VISIBILITY_PRESET=hidden;-DCMAKE_C_VISIBILITY_PRESET=hidden")
+endif()
+
 # Hide symbols in spdlog. Fixes symbol collisions in downstream projects
 # (https://github.com/gabime/spdlog/pull/3322 was rejected).
 if("${PORT}" MATCHES "spdlog")


### PR DESCRIPTION
PR #5223 fixed a bug where Arrow was causing a [double initialization](https://github.com/apache/arrow/issues/40262) of the AWS SDK, specifically on macOS. Recently PR #5616 removed this fix, causing the nightly VCF macOS CI against TileDB `main` to [fail](https://github.com/TileDB-Inc/TileDB-VCF/issues/855).

To address the issue, I forked this repo and cherry-picking the PR #5223 commit to head. I've confirmed both on a macOS M2 EC2 instance and in a [VCF branch](https://github.com/TileDB-Inc/TileDB-VCF/pull/856) that this resolves the issue.

TYPE: NO_HISTORY