### PR TITLE
Do not override VFS config options in REST CI.

### DIFF
--- a/test/support/src/vfs_helpers.cc
+++ b/test/support/src/vfs_helpers.cc
@@ -173,6 +173,10 @@ Status SupportedFsS3::prepare_config(
     [[maybe_unused]] tiledb_config_t* config,
     [[maybe_unused]] tiledb_error_t* error) {
 #ifndef TILEDB_TESTS_AWS_S3_CONFIG
+  if (rest_) {
+    // REST CI gets configured by environment variables.
+    return Status::Ok();
+  }
   REQUIRE(
       tiledb_config_set(
           config, "vfs.s3.endpoint_override", "localhost:9999", &error) ==


### PR DESCRIPTION
Extracts 4e56a79c5d6e64d11229e13b5e11c8b8f9f4bf32 from #5631, in order to unblock changes to REST CI needed for that PR.

---
TYPE: NO_HISTORY