### PR TITLE
Pin manylinux version to continue supporting Python 3.9 after EOL.

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -29,20 +29,20 @@ jobs:
           - platform: windows-x86_64
             os: windows-2022
             triplet: x64-windows-release
-          # We can safely use the latest image, since the real job will run in the manylinux container.
+          # Use manylinux image before Python3.9 support was dropped on 10/01/25.
           - platform: linux-x86_64
             os: ubuntu-latest
-            manylinux: quay.io/pypa/manylinux_2_28_x86_64
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64<2025.10.01-1
             triplet: x64-linux-release
           - platform: linux-x86_64-noavx2
             os: ubuntu-latest
             cmake_args: -DCOMPILER_SUPPORTS_AVX2=OFF
             triplet: x64-linux-release
-            manylinux: quay.io/pypa/manylinux_2_28_x86_64
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64<2025.10.01-1
           - platform: linux-aarch64
             os: ubuntu-24.04-arm
             triplet: arm64-linux-release
-            manylinux: quay.io/pypa/manylinux_2_28_aarch64
+            manylinux: quay.io/pypa/manylinux_2_28_aarch64<2025.10.01-1
           - platform: macos-x86_64
             os: macos-latest
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=x86_64


### PR DESCRIPTION
Pin `manylinux` version to continue supporting `Python 3.9` after EOL.

---
TYPE: NO_HISTORY
DESC: Pin `manylinux` version to continue supporting `Python 3.9` after EOL.

---
Resolves CORE-422
