### PR TITLE
Do not use `O_SYNC` in `Posix::touch`.

### DIFF
--- a/tiledb/sm/filesystem/posix.cc
+++ b/tiledb/sm/filesystem/posix.cc
@@ -163,7 +163,6 @@ void Posix::touch(const URI& uri) const {
   int fd = ::open(filename.c_str(), O_WRONLY | O_CREAT, file_permissions_);
   if (fd == -1) {
     auto err = errno;
-    ::close(fd);
     throw IOError(
         std::string("Failed to create file '") + filename + "'; " +
         strerror(err));


### PR DESCRIPTION
Instead, `fsync` the file after creating it.

---
TYPE: BUG
DESC: Fix compatibility with POSIX filesystems that do not support `O_SYNC`.