### PR TITLE
Fix logger name for SparseGlobalOrderReader

### DIFF
--- a/tiledb/sm/query/readers/sparse_global_order_reader.cc
+++ b/tiledb/sm/query/readers/sparse_global_order_reader.cc
@@ -193,7 +193,7 @@ SparseGlobalOrderReader<BitmapType>::SparseGlobalOrderReader(
     : SparseIndexReaderBase(
           "sparse_global_order",
           stats,
-          logger->clone("SparseUnorderedWithDupsReader", ++logger_id_),
+          logger->clone("SparseGlobalOrderReader", ++logger_id_),
           params,
           true)
     , result_tiles_leftover_(array_->fragment_metadata().size())


### PR DESCRIPTION
Fixed incorrect logger name for SparseGlobalOrderReader (was "SparseUnorderedWithDupsReader")

---
TYPE: BUG
DESC: Fix logger name for SparseGlobalOrderReader
