### PR TITLE
Fix formatting for error messages.

### DIFF
--- a/tiledb/sm/filesystem/s3.cc
+++ b/tiledb/sm/filesystem/s3.cc
@@ -960,8 +960,9 @@ Status S3::is_object(
     }
     return LOG_STATUS(Status_S3Error(
         "Failed to check for existence of object s3://" +
-        std::string(bucket_name) + "/" + std::string(object_key) +
-        outcome_error_message(head_object_outcome) + additional_context));
+        std::string(remove_trailing_slash(bucket_name)) + "/" +
+        std::string(object_key) + outcome_error_message(head_object_outcome) +
+        additional_context));
   }
 
   *exists = true;


### PR DESCRIPTION
This fixes formatting for some error messages that we've seen recently. Previously ThreadPool would report a conucurrency_limit_ of `0` after being shut down in the catch block, and the S3 error contained a duplicated separator which would incorrectly lead the user to believe they have misconfigured storage settings.

---
TYPE: NO_HISTORY
DESC: Fix formatting for error messages.
