### PR TITLE
Remove `ignore_default_via_env` (revert #3788)

### DIFF
--- a/tiledb/sm/config/test/unit_config.cc
+++ b/tiledb/sm/config/test/unit_config.cc
@@ -421,4 +421,3 @@ TEST_CASE(
     CHECK(method == tiledb::sm::RestAuthMethod::TOKEN);
   }
 }
-


### PR DESCRIPTION
https://github.com/TileDB-Inc/TileDB/pull/3788 added `ignore_default_via_env` to defer to the AWS SDK when the `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables are set, instead of defaulting to `us-east-1`.

Since https://github.com/TileDB-Inc/TileDB/pull/5317, the default value of `vfs.s3.region` has been empty, which allows the AWS SDK to determine the region automatically. As a result, this PR removes `ignore_default_via_env`.

As a side effect, this also fixes the failure of centralized-tiledb-nightlies: https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/63.

cc. @jdblischak

---
TYPE: IMPROVEMENT
DESC: Remove `ignore_default_via_env` (revert #3788)