### PR TITLE
Unset conflicting S3 authentication options for `tiledb://` VFS.

### DIFF
--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -85,6 +85,9 @@ tdb_unique_ptr<FilesystemBase> make_tiledbfs(
     throw_if_not_ok(new_config.set("vfs.s3.aws_secret_access_key", "unused"));
   }
   throw_if_not_ok(new_config.set("vfs.s3.use_virtual_addressing", "false"));
+  // Unset irrelevant options that might be set for regular S3 VFS.
+  throw_if_not_ok(new_config.set("vfs.s3.aws_role_arn", ""));
+  throw_if_not_ok(new_config.set("vfs.s3.config_source", "auto"));
   return tdb_unique_ptr<FilesystemBase>(
       tdb_new(S3, parent_stats, tp, new_config));
 }


### PR DESCRIPTION
UDFs can have environment variables for access to both the TileDB server, and S3. Because we use the S3 VFS for `tiledb://` URIs (using access keys), it can be confused by the S3-specific config options. We fix this by unsetting them in the `tiledb://`-specific config copy.

Contributes to CLOUD-3358.

---
TYPE: BUG
DESC: Fixed errors when using the VFS for `tiledb://` URIs, caused by unrelated config options.