### PR TITLE
[Backport release-2.30] Unset conflicting S3 authentication options for `tiledb://` VFS. (#5740)

### DIFF
--- a/tiledb/sm/filesystem/vfs.cc
+++ b/tiledb/sm/filesystem/vfs.cc
@@ -84,6 +84,9 @@ tdb_unique_ptr<FilesystemBase> make_tiledbfs(
     throw_if_not_ok(new_config.set("vfs.s3.aws_secret_access_key", "unused"));
   }
   throw_if_not_ok(new_config.set("vfs.s3.use_virtual_addressing", "false"));
+  // Unset irrelevant options that might be set for regular S3 VFS.
+  throw_if_not_ok(new_config.set("vfs.s3.aws_role_arn", ""));
+  throw_if_not_ok(new_config.set("vfs.s3.config_source", "auto"));
   return tdb_unique_ptr<FilesystemBase>(
       tdb_new(S3, parent_stats, tp, new_config));
 }


### PR DESCRIPTION
Backport of #5740 to release-2.30

---
TYPE: BUG
DESC: Fixed errors when using the VFS for `tiledb://` URIs, caused by unrelated config options.