### PR TITLE
Remove deprecated config param sm.consolidation.buffer_size

### DIFF
--- a/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/performance/msys_handle_leakage/unit-cppapi-consolidation-with-timestamps.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022 TileDB Inc.
+ * @copyright Copyright (c) 2022-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -104,12 +104,8 @@ struct ConsolidationWithTimestampsFx {
 };
 
 ConsolidationWithTimestampsFx::ConsolidationWithTimestampsFx()
-    : vfs_(ctx_) {
-  Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
-  ctx_ = Context(config);
-  sm_ = ctx_.ptr().get()->storage_manager();
-  vfs_ = VFS(ctx_);
+    : vfs_(ctx_)
+    , sm_(ctx_.ptr().get()->storage_manager()) {
 }
 
 ConsolidationWithTimestampsFx::~ConsolidationWithTimestampsFx() {
@@ -117,7 +113,6 @@ ConsolidationWithTimestampsFx::~ConsolidationWithTimestampsFx() {
 
 void ConsolidationWithTimestampsFx::set_legacy() {
   Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
   config.set("sm.query.sparse_global_order.reader", "legacy");
   config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
 

--- a/test/src/test-capi-consolidation-plan.cc
+++ b/test/src/test-capi-consolidation-plan.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -68,9 +68,6 @@ struct ConsolidationPlanFx {
 };
 
 ConsolidationPlanFx::ConsolidationPlanFx() {
-  Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
-  vfs_test_setup_.update_config(config.ptr().get());
   ctx_c_ = vfs_test_setup_.ctx_c;
   ctx_ = vfs_test_setup_.ctx();
   array_name_ = vfs_test_setup_.array_uri("test_consolidation_plan_array");

--- a/test/src/test-cppapi-consolidation-plan.cc
+++ b/test/src/test-cppapi-consolidation-plan.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,7 +84,6 @@ struct CppConsolidationPlanFx {
 
 CppConsolidationPlanFx::CppConsolidationPlanFx()
     : vfs_(ctx_) {
-  cfg_.set("sm.consolidation.buffer_size", "1000");
   ctx_ = Context(cfg_);
   vfs_ = VFS(ctx_);
 

--- a/test/src/unit-capi-config.cc
+++ b/test/src/unit-capi-config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2025 TileDB Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -254,7 +254,6 @@ void check_save_to_file() {
   ss << "sm.compute_concurrency_level " << std::thread::hardware_concurrency()
      << "\n";
   ss << "sm.consolidation.amplification 1.0\n";
-  ss << "sm.consolidation.buffer_size 50000000\n";
   ss << "sm.consolidation.max_fragment_size " << std::to_string(UINT64_MAX)
      << "\n";
   ss << "sm.consolidation.mode fragments\n";
@@ -686,7 +685,6 @@ TEST_CASE("C API: Test config iter", "[capi][config]") {
   all_param_values["sm.consolidation.purge_deleted_cells"] = "false";
   all_param_values["sm.consolidation.step_min_frags"] = "4294967295";
   all_param_values["sm.consolidation.step_max_frags"] = "4294967295";
-  all_param_values["sm.consolidation.buffer_size"] = "50000000";
   all_param_values["sm.consolidation.max_fragment_size"] =
       std::to_string(UINT64_MAX);
   all_param_values["sm.consolidation.step_size_ratio"] = "0.0";

--- a/test/src/unit-capi-string_dims.cc
+++ b/test/src/unit-capi-string_dims.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -1680,21 +1680,10 @@ TEST_CASE_METHOD(
   CHECK(rc == TILEDB_OK);
   CHECK(dirs.num == 2);
 
-  tiledb_config_t* config = nullptr;
-  tiledb_error_t* error = nullptr;
-  REQUIRE(tiledb_config_alloc(&config, &error) == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
-  rc = tiledb_config_set(
-      config, "sm.consolidation.buffer_size", "10000", &error);
-  REQUIRE(rc == TILEDB_OK);
-  REQUIRE(error == nullptr);
-
   // Consolidate
-  rc = tiledb_array_consolidate(ctx_, array_name.c_str(), config);
+  rc = tiledb_array_consolidate(ctx_, array_name.c_str(), nullptr);
   CHECK(rc == TILEDB_OK);
   rc = tiledb_array_vacuum(ctx_, array_name.c_str(), nullptr);
-  tiledb_config_free(&config);
 
   // Check number of fragments
   dirs = {ctx_, vfs_, 0};

--- a/test/src/unit-cppapi-consolidation-sparse.cc
+++ b/test/src/unit-cppapi-consolidation-sparse.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -108,11 +108,9 @@ TEST_CASE(
   read_array(array_name, {1, 2, 3}, {1, 2, 3});
 
   Context ctx;
-  Config config;
-  config["sm.consolidation.buffer_size"] = "8";
-  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 3);
-  REQUIRE_NOTHROW(Array::vacuum(ctx, array_name, &config));
+  REQUIRE_NOTHROW(Array::vacuum(ctx, array_name, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 1);
 
   read_array(array_name, {1, 2, 3}, {1, 2, 3});
@@ -142,9 +140,7 @@ TEST_CASE(
   read_array(array_name, {1, 2, 3}, {1, 2, 3});
 
   Context ctx;
-  Config config;
-  config["sm.consolidation.buffer_size"] = "8";
-  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 3);
 
   read_array(array_name, {1, 2, 3}, {1, 2, 3});

--- a/test/src/unit-cppapi-consolidation-with-timestamps.cc
+++ b/test/src/unit-cppapi-consolidation-with-timestamps.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023 TileDB Inc.
+ * @copyright Copyright (c) 2023-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -94,11 +94,6 @@ struct ConsolidationWithTimestampsFx {
 
 ConsolidationWithTimestampsFx::ConsolidationWithTimestampsFx()
     : vfs_(ctx_) {
-  Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
-  ctx_ = Context(config);
-  resources_ = &ctx_.ptr().get()->resources();
-  vfs_ = VFS(ctx_);
 }
 
 ConsolidationWithTimestampsFx::~ConsolidationWithTimestampsFx() {
@@ -106,10 +101,8 @@ ConsolidationWithTimestampsFx::~ConsolidationWithTimestampsFx() {
 
 void ConsolidationWithTimestampsFx::set_legacy() {
   Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
   config.set("sm.query.sparse_global_order.reader", "legacy");
   config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
-
   ctx_ = Context(config);
   resources_ = &ctx_.ptr().get()->resources();
   vfs_ = VFS(ctx_);

--- a/test/src/unit-cppapi-consolidation.cc
+++ b/test/src/unit-cppapi-consolidation.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -126,11 +126,9 @@ TEST_CASE(
   read_array(array_name, {1, 3}, {1, 2, 3});
 
   Context ctx;
-  Config config;
-  config["sm.consolidation.buffer_size"] = "4";
-  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 3);
-  REQUIRE_NOTHROW(Array::vacuum(ctx, array_name, &config));
+  REQUIRE_NOTHROW(Array::vacuum(ctx, array_name, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 1);
 
   read_array(array_name, {1, 3}, {1, 2, 3});
@@ -222,9 +220,7 @@ TEST_CASE(
   read_array(array_name, {1, 3}, {1, 2, 3});
 
   Context ctx;
-  Config config;
-  config["sm.consolidation.buffer_size"] = "4";
-  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, &config));
+  REQUIRE_NOTHROW(Array::consolidate(ctx, array_name, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 3);
 
   read_array(array_name, {1, 3}, {1, 2, 3});
@@ -246,8 +242,6 @@ TEST_CASE(
   read_array(array_name, {1, 3}, {1, 2, 3});
 
   Context ctx;
-  Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
 
   FragmentInfo fragment_info(ctx, array_name);
   fragment_info.load();
@@ -262,7 +256,7 @@ TEST_CASE(
       short_fragment_name1.c_str(), short_fragment_name2.c_str()};
 
   REQUIRE_NOTHROW(
-      Array::consolidate(ctx, array_name, fragment_uris, 2, &config));
+      Array::consolidate(ctx, array_name, fragment_uris, 2, nullptr));
   CHECK(tiledb::test::num_fragments(array_name) == 3);
 
   read_array(array_name, {1, 3}, {1, 2, 3});
@@ -422,10 +416,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test consolidation with timestamp and max domain",
     "[cppapi][consolidation][timestamp][maxdomain]") {
-  Config cfg;
-  cfg["sm.consolidation.buffer_size"] = "10000";
-
-  Context ctx(cfg);
+  Context ctx;
   VFS vfs(ctx);
   const std::string array_name = "consolidate_timestamp_max_domain";
 

--- a/test/src/unit-cppapi-deletes.cc
+++ b/test/src/unit-cppapi-deletes.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023-2024 TileDB Inc.
+ * @copyright Copyright (c) 2023-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -120,16 +120,12 @@ DeletesFx::DeletesFx()
     , array_name_(vfs_test_setup_.array_uri(SPARSE_ARRAY_NAME))
     , vfs_array_name_(vfs_test_setup_.array_uri(SPARSE_ARRAY_NAME, true))
     , group_name_(vfs_test_setup_.array_uri(GROUP_NAME)) {
-  Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
-  vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
   vfs_ = VFS(ctx_);
 }
 
 void DeletesFx::set_purge_deleted_cells() {
   Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
   config.set("sm.consolidation.purge_deleted_cells", "true");
   vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
@@ -138,7 +134,6 @@ void DeletesFx::set_purge_deleted_cells() {
 
 void DeletesFx::set_legacy() {
   Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
   config.set("sm.query.sparse_global_order.reader", "legacy");
   config.set("sm.query.sparse_unordered_with_dups.reader", "legacy");
   vfs_test_setup_.update_config(config.ptr().get());
@@ -170,14 +165,13 @@ void DeletesFx::create_simple_array(const std::string& path) {
 }
 
 void DeletesFx::create_sparse_array(bool allows_dups, bool encrypt) {
-  Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
   if (encrypt) {
+    Config config;
     config["sm.encryption_type"] = enc_type_str_.c_str();
     config["sm.encryption_key"] = key_;
+    vfs_test_setup_.update_config(config.ptr().get());
   }
 
-  vfs_test_setup_.update_config(config.ptr().get());
   ctx_ = vfs_test_setup_.ctx();
   vfs_ = VFS(ctx_);
 

--- a/test/src/unit-cppapi-hilbert.cc
+++ b/test/src/unit-cppapi-hilbert.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2023 TileDB Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -701,10 +701,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test Hilbert, consolidation",
     "[cppapi][hilbert][consolidation][non-rest]") {
-  Config cfg;
-  cfg["sm.consolidation.buffer_size"] = "10000";
-
-  Context ctx(cfg);
+  Context ctx;
   VFS vfs(ctx);
   std::string array_name = "hilbert_array";
 
@@ -1053,10 +1050,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test Hilbert, 2d, int32, negative, consolidation",
     "[cppapi][hilbert][2d][int32][negative][consolidation]") {
-  Config cfg;
-  cfg["sm.consolidation.buffer_size"] = "10000";
-
-  Context ctx(cfg);
+  Context ctx;
   VFS vfs(ctx);
   std::string array_name = "hilbert_array";
 
@@ -1460,10 +1454,7 @@ TEST_CASE(
 TEST_CASE(
     "C++ API: Test Hilbert, 2d, float32, consolidation",
     "[cppapi][hilbert][2d][float32][consolidation][non-rest]") {
-  Config cfg;
-  cfg["sm.consolidation.buffer_size"] = "10000";
-
-  Context ctx(cfg);
+  Context ctx;
   VFS vfs(ctx);
   std::string array_name = "hilbert_array";
 

--- a/test/src/unit-cppapi-metadata.cc
+++ b/test/src/unit-cppapi-metadata.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -406,14 +406,11 @@ TEST_CASE_METHOD(
     CPPMetadataFx,
     "C++ API: Metadata, multiple metadata and consolidate",
     "[cppapi][metadata][multiple][consolidation]") {
-  Config cfg;
-  cfg["sm.consolidation.buffer_size"] = "10000";
-
   // Create default array
   create_default_array_1d();
 
   // Create and open array in write mode
-  tiledb::Context ctx(cfg);
+  tiledb::Context ctx;
   tiledb::Array array(ctx, array_name_, TILEDB_WRITE);
 
   // Write items

--- a/test/src/unit-cppapi-update-queries.cc
+++ b/test/src/unit-cppapi-update-queries.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2024 TileDB Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -81,7 +81,6 @@ struct UpdatesFx {
 UpdatesFx::UpdatesFx()
     : vfs_(ctx_) {
   Config config;
-  config.set("sm.consolidation.buffer_size", "1000");
   config["sm.allow_updates_experimental"] = "true";
   ctx_ = Context(config);
   vfs_ = VFS(ctx_);

--- a/tiledb/api/c_api/config/config_api_external.h
+++ b/tiledb/api/c_api/config/config_api_external.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2023-2025 TileDB, Inc.
+ * @copyright Copyright (c) 2023-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -166,11 +166,6 @@ TILEDB_EXPORT void tiledb_config_free(tiledb_config_t** config) TILEDB_NOEXCEPT;
  *    fragment will have to fill with the special fill value
  *    (since the resulting fragment is dense). <br>
  *    **Default**: 1.0
- * - `sm.consolidation.buffer_size` <br>
- *    **Deprecated**
- *    The size (in bytes) of the attribute buffers used during
- *    consolidation. <br>
- *    **Default**: 50,000,000
  * - `sm.consolidation.max_fragment_size` <br>
  *    **Experimental** <br>
  *    The size (in bytes) of the maximum on-disk fragment size that will be

--- a/tiledb/sm/config/config.cc
+++ b/tiledb/sm/config/config.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2025 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -355,8 +355,6 @@ const std::map<std::string, std::string> default_config_values = {
     std::make_pair(
         "sm.consolidation.amplification",
         Config::SM_CONSOLIDATION_AMPLIFICATION),
-    std::make_pair(
-        "sm.consolidation.buffer_size", Config::SM_CONSOLIDATION_BUFFER_SIZE),
     std::make_pair(
         "sm.consolidation.max_fragment_size",
         Config::SM_CONSOLIDATION_MAX_FRAGMENT_SIZE),
@@ -797,8 +795,6 @@ Status Config::sanity_check(
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.consolidation.amplification") {
     RETURN_NOT_OK(utils::parse::convert(value, &vf));
-  } else if (param == "sm.consolidation.buffer_size") {
-    RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.consolidation.max_fragment_size") {
     RETURN_NOT_OK(utils::parse::convert(value, &vuint64));
   } else if (param == "sm.consolidation.purge_deleted_cells") {

--- a/tiledb/sm/consolidator/fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/fragment_consolidator.cc
@@ -135,13 +135,8 @@ void FragmentConsolidationWorkspace::resize_buffers(
     buffer_weights.emplace_back(sizeof(uint64_t));
   }
 
-  // If a user set the per-attribute buffer size configuration, we override
-  // the use of the total_budget_size config setting for backwards
-  // compatible behavior.
   auto buffer_num = buffer_weights.size();
-  if (config.buffer_size_ != 0) {
-    total_buffers_budget = config.buffer_size_ * buffer_num;
-  }
+  total_buffers_budget = buffer_num;
 
   // Calculate the size of individual buffers by assigning a weight based
   // percentage of the total buffer size.
@@ -1009,17 +1004,6 @@ Status FragmentConsolidator::set_config(const Config& config) {
       "sm.consolidation.amplification", Config::must_find);
   config_.steps_ =
       merged_config.get<uint32_t>("sm.consolidation.steps", Config::must_find);
-  config_.buffer_size_ = 0;
-  // Only set the buffer_size_ if the user specified a value. Otherwise, we use
-  // the new sm.mem.consolidation.buffers_weight instead.
-  if (merged_config.set_params().count("sm.consolidation.buffer_size") > 0) {
-    logger_->warn(
-        "The `sm.consolidation.buffer_size configuration setting has been "
-        "deprecated. Set consolidation buffer sizes using the newer "
-        "`sm.mem.consolidation.buffers_weight` setting.");
-    config_.buffer_size_ = merged_config.get<uint64_t>(
-        "sm.consolidation.buffer_size", Config::must_find);
-  }
   config_.total_budget_ =
       merged_config.get<uint64_t>("sm.mem.total_budget", Config::must_find);
   config_.buffers_weight_ = merged_config.get<uint64_t>(

--- a/tiledb/sm/consolidator/fragment_consolidator.h
+++ b/tiledb/sm/consolidator/fragment_consolidator.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -78,8 +78,6 @@ struct FragmentConsolidationConfig : Consolidator::ConsolidationConfigBase {
    * (since the resulting fragments is dense).
    */
   float amplification_;
-  /** Attribute buffer size. */
-  uint64_t buffer_size_;
   /** Total memory budget for consolidation operation. */
   uint64_t total_budget_;
   /** Consolidation buffers weight used to partition total budget. */

--- a/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
+++ b/tiledb/sm/consolidator/test/unit_fragment_consolidator.cc
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2022-2024 TileDB, Inc.
+ * @copyright Copyright (c) 2022-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -220,7 +220,6 @@ TEST_CASE(
   FragmentConsolidationConfig cfg;
   cfg.with_timestamps_ = with_timestamps;
   cfg.with_delete_meta_ = with_delete_meta;
-  cfg.buffer_size_ = 1000;
 
   FragmentConsolidationWorkspace cw(tiledb::test::get_test_memory_tracker());
   cw.resize_buffers(&statistics, cfg, *schema, avg_cell_sizes, 1);

--- a/tiledb/sm/cpp_api/config.h
+++ b/tiledb/sm/cpp_api/config.h
@@ -5,7 +5,7 @@
  *
  * The MIT License
  *
- * @copyright Copyright (c) 2017-2025 TileDB, Inc.
+ * @copyright Copyright (c) 2017-2026 TileDB, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -337,11 +337,6 @@ class Config {
    *    fragment will have to fill with the special fill value
    *    (since the resulting fragment is dense). <br>
    *    **Default**: 1.0
-   * - `sm.consolidation.buffer_size` <br>
-   *    **Deprecated**
-   *    The size (in bytes) of the attribute buffers used during
-   *    consolidation. <br>
-   *    **Default**: 50,000,000
    * - `sm.consolidation.max_fragment_size` <br>
    *    **Experimental** <br>
    *    The size (in bytes) of the maximum on-disk fragment size that will be


### PR DESCRIPTION
Remove deprecated configuration parameter `sm.consolidation.buffer_size`.

---
TYPE: NO_HISTORY
DESC: Remove deprecated configuration parameter `sm.consolidation.buffer_size`.

---
Resolves CORE-491
