### PR TITLE
chore: use CAPI_INTERFACE_VALUE to wrap all remaining C APIs

### DIFF
--- a/tiledb/api/c_api/datatype/datatype_api.cc
+++ b/tiledb/api/c_api/datatype/datatype_api.cc
@@ -66,6 +66,6 @@ CAPI_INTERFACE(
   return api_entry_plain<tiledb::api::tiledb_datatype_from_str>(str, datatype);
 }
 
-uint64_t tiledb_datatype_size(tiledb_datatype_t type) noexcept {
-  return tiledb::sm::datatype_size(static_cast<tiledb::sm::Datatype>(type));
+CAPI_INTERFACE_VALUE(uint64_t, datatype_size, tiledb_datatype_t type) {
+  return api_entry_plain<tiledb::api::tiledb_datatype_size>(type);
 }

--- a/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
+++ b/tiledb/api/c_api_support/exception_wrapper/capi_definition.h
@@ -63,6 +63,14 @@ void tiledb_##root(__VA_ARGS__) noexcept
 CAPI_PREFIX(root)                 \
 capi_return_t tiledb_##root(void) noexcept
 
+/*
+ * A variant of CAPI_INTERFACE for the handful of functions which return
+ * something other than `capi_return_t`.
+ */
+#define CAPI_INTERFACE_VALUE(R, root, ...) \
+CAPI_PREFIX(root) \
+R tiledb_##root(__VA_ARGS__) noexcept
+
 /* clang-format on */
 
 #endif  // TILEDB_CAPI_DEFINITION_H

--- a/tiledb/sm/c_api/tiledb.cc
+++ b/tiledb/sm/c_api/tiledb.cc
@@ -98,13 +98,6 @@
 #include <memory>
 #include <sstream>
 
-/*
- * The Definition for a "C" function can't be in a header.
- */
-capi_status_t tiledb_status_code(capi_return_t x) {
-  return tiledb_status(x);  // An inline C++ function
-}
-
 /* ****************************** */
 /*  IMPLEMENTATION FUNCTIONS      */
 /* ****************************** */
@@ -121,6 +114,13 @@ capi_status_t tiledb_status_code(capi_return_t x) {
  * the wrapped function.
  */
 namespace tiledb::api {
+
+/*
+ * The Definition for a "C" function can't be in a header.
+ */
+capi_status_t tiledb_status_code(capi_return_t x) {
+  return tiledb_status(x);  // An inline C++ function
+}
 
 /* ****************************** */
 /*       ENUMS TO/FROM STR        */
@@ -2446,65 +2446,9 @@ int32_t tiledb_consolidation_plan_free_json_str(char** out) {
   return TILEDB_OK;
 }
 
-}  // namespace tiledb::api
-
-/* ****************************** */
-/*  C API Interface Functions     */
-/* ****************************** */
-/*
- * Each C API interface function below forwards its arguments to a transformed
- * implementation function of the same name defined in the `tiledb::api`
- * namespace above.
- *
- * Note: `std::forward` is not used here because it's not necessary. The C API
- * uses C linkage, and none of the types used in the signatures of the C API
- * function change with `std::forward`.
- */
-
-using tiledb::api::api_entry_context;
-using tiledb::api::api_entry_plain;
-using tiledb::api::api_entry_void;
-template <auto f>
-constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
-
-/* ****************************** */
-/*       ENUMS TO/FROM STR        */
-/* ****************************** */
-
-CAPI_INTERFACE(
-    query_status_to_str, tiledb_query_status_t query_status, const char** str) {
-  return api_entry_plain<tiledb::api::tiledb_query_status_to_str>(
-      query_status, str);
-}
-
-CAPI_INTERFACE(
-    query_status_from_str,
-    const char* str,
-    tiledb_query_status_t* query_status) {
-  return api_entry_plain<tiledb::api::tiledb_query_status_from_str>(
-      str, query_status);
-}
-
-CAPI_INTERFACE(
-    serialization_type_to_str,
-    tiledb_serialization_type_t serialization_type,
-    const char** str) {
-  return api_entry_plain<tiledb::api::tiledb_serialization_type_to_str>(
-      serialization_type, str);
-}
-
-CAPI_INTERFACE(
-    serialization_type_from_str,
-    const char* str,
-    tiledb_serialization_type_t* serialization_type) {
-  return api_entry_plain<tiledb::api::tiledb_serialization_type_from_str>(
-      str, serialization_type);
-}
-
-/* ****************************** */
-/*            CONSTANTS           */
-/* ****************************** */
-
+/* ***************************** */
+/*         CONSTANTS APIs        */
+/* ***************************** */
 uint32_t tiledb_var_num() noexcept {
   return tiledb::sm::constants::var_num;
 }
@@ -2543,6 +2487,95 @@ void tiledb_version(int32_t* major, int32_t* minor, int32_t* rev) noexcept {
   *major = tiledb::sm::constants::library_version[0];
   *minor = tiledb::sm::constants::library_version[1];
   *rev = tiledb::sm::constants::library_version[2];
+}
+
+}  // namespace tiledb::api
+
+/* ****************************** */
+/*  C API Interface Functions     */
+/* ****************************** */
+/*
+ * Each C API interface function below forwards its arguments to a transformed
+ * implementation function of the same name defined in the `tiledb::api`
+ * namespace above.
+ *
+ * Note: `std::forward` is not used here because it's not necessary. The C API
+ * uses C linkage, and none of the types used in the signatures of the C API
+ * function change with `std::forward`.
+ */
+
+using tiledb::api::api_entry_context;
+using tiledb::api::api_entry_plain;
+using tiledb::api::api_entry_void;
+template <auto f>
+constexpr auto api_entry = tiledb::api::api_entry_with_context<f>;
+
+CAPI_INTERFACE_VALUE(capi_status_t, tiledb_status_code, capi_return_t x) {
+  return api_entry_plain<tiledb::api::tiledb_status_code>(x);
+}
+
+/* ****************************** */
+/*       ENUMS TO/FROM STR        */
+/* ****************************** */
+
+CAPI_INTERFACE(
+    query_status_to_str, tiledb_query_status_t query_status, const char** str) {
+  return api_entry_plain<tiledb::api::tiledb_query_status_to_str>(
+      query_status, str);
+}
+
+CAPI_INTERFACE(
+    query_status_from_str,
+    const char* str,
+    tiledb_query_status_t* query_status) {
+  return api_entry_plain<tiledb::api::tiledb_query_status_from_str>(
+      str, query_status);
+}
+
+CAPI_INTERFACE(
+    serialization_type_to_str,
+    tiledb_serialization_type_t serialization_type,
+    const char** str) {
+  return api_entry_plain<tiledb::api::tiledb_serialization_type_to_str>(
+      serialization_type, str);
+}
+
+CAPI_INTERFACE(
+    serialization_type_from_str,
+    const char* str,
+    tiledb_serialization_type_t* serialization_type) {
+  return api_entry_plain<tiledb::api::tiledb_serialization_type_from_str>(
+      str, serialization_type);
+}
+
+/* ****************************** */
+/*            CONSTANTS           */
+/* ****************************** */
+CAPI_INTERFACE_VALUE(uint32_t, var_num) {
+  return api_entry_plain<tiledb::api::tiledb_var_num>();
+}
+
+CAPI_INTERFACE_VALUE(uint32_t, max_path) {
+  return api_entry_plain<tiledb::api::tiledb_max_path>();
+}
+
+CAPI_INTERFACE_VALUE(uint64_t, offset_size) {
+  return api_entry_plain<tiledb::api::tiledb_offset_size>();
+}
+
+CAPI_INTERFACE_VALUE(uint64_t, timestamp_now_ms) {
+  return api_entry_plain<tiledb::api::tiledb_timestamp_now_ms>();
+}
+
+CAPI_INTERFACE_VALUE(const char*, timestamps) {
+  return api_entry_plain<tiledb::api::tiledb_timestamps>();
+}
+
+/* ****************************** */
+/*            VERSION             */
+/* ****************************** */
+CAPI_INTERFACE_VOID(version, int32_t* major, int32_t* minor, int32_t* rev) {
+  return api_entry_plain<tiledb::api::tiledb_version>(major, minor, rev);
 }
 
 /* ********************************* */


### PR DESCRIPTION
In `tiledb/api/c_api_support/exception_wrapper/capi_definition.h` we have several macros whose purpose is to define C API functions.  Ostensibly the purpose of these is to enable interception and perhaps transformation of the C APIs.

Well, it turns out this is having some amount of payoff, because we intend to do this in the Rust extensions project.  We can use these macros to redefine the C API symbols and intercept them with functions written in Rust.

The problem is that there is a category of functions which are not wrapped by a `CAPI_INTERFACE_THING` macro: functions which return a value other than `capi_return_t` or `void`.  Mostly these are functions which return a constant.

This pull request adds the `CAPI_INTERFACE_VALUE` macro to wrap these functions so that we can intercept them as well.

---
TYPE: NO_HISTORY
DESC: wrap remaining C API functions with `CAPI_INTERFACE_VALUE`
