### PR TITLE
ci: Turn Rust off for CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,7 +55,7 @@ jobs:
       TILEDB_SERIALIZATION: ${{ matrix.TILEDB_SERIALIZATION }} #serialization }}
       TILEDB_WEBP: ${{ matrix.TILEDB_WEBP }}
       TILEDB_CMAKE_BUILD_TYPE: 'Release'
-      TILEDB_RUST: 'ON'
+      TILEDB_RUST: 'OFF'
     steps:
       - name: 'tiledb env prep'
         run: |

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -57,11 +57,13 @@ jobs:
           components: clippy, rustfmt
 
       - name: Check Rust Formatting
+        if: ${{ inputs.rust }}
         run: |
           cd $GITHUB_WORKSPACE/tiledb/oxidize
           cargo fmt --quiet --check
 
       - name: Rust Lint
+        if: ${{ inputs.rust }}
         run: |
           cd $GITHUB_WORKSPACE/tiledb/oxidize
           cargo clippy --no-deps --all-targets --all-features -- -Dwarnings

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -47,7 +47,7 @@ on:
         required: false
         type: boolean
       rust:
-        default: true
+        default: false
         description: 'Enable Rust'
         required: false
         type: boolean

--- a/.github/workflows/unit-test-runs.yml
+++ b/.github/workflows/unit-test-runs.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         build_type: [Release]
+        rust: [OFF]
       fail-fast: false
     name: Build - ${{ matrix.os }} (${{ matrix.build_type }})
     timeout-minutes: 90
@@ -42,6 +43,7 @@ jobs:
           pip install pyarrow pybind11[global] numpy
 
       - name: Install Rust Stable
+        if: ${{ inputs.rust }}
         uses: dtolnay/rust-toolchain@stable
 
       - name: Setup MSVC toolset
@@ -72,7 +74,7 @@ jobs:
             -DTILEDB_SERIALIZATION=ON \
             -DTILEDB_ASSERTIONS=ON \
             -DTILEDB_ARROW_TESTS=ON \
-            -DTILEDB_RUST=ON
+            -DTILEDB_RUST="${{ matrix.rust }}"
         if: ${{ !startsWith(matrix.os, 'windows-') }}
 
       - name: 'Build standalone unit tests (non-windows)'
@@ -96,7 +98,7 @@ jobs:
             -DTILEDB_SERIALIZATION=ON `
             -DTILEDB_ASSERTIONS=ON `
             -DTILEDB_ARROW_TESTS=ON `
-            -DTILEDB_RUST=OFF
+            -DTILEDB_RUST="${{ inputs.rust }}"
         if: ${{ startsWith(matrix.os, 'windows-') }}
 
       - name: 'Build standalone unit tests (Windows)'


### PR DESCRIPTION
Now that we're looking to take our Rust to an external repository, we do not expect to maintain the `tiledb/oxidize` code any more.  We aren't going to remove it at this point, but there's also no reason it should make CI take a lot longer.  This pull request turns it off by default for all jobs.

---
TYPE: NO_HISTORY
DESC: Disable Rust components by default in CI
