### PR TITLE
fix: add missing output pointer validation in array schema conversion functions

### DIFF
--- a/tiledb/api/c_api/array_schema/array_schema_api.cc
+++ b/tiledb/api/c_api/array_schema/array_schema_api.cc
@@ -49,6 +49,7 @@ namespace tiledb::api {
 
 capi_return_t tiledb_array_type_to_str(
     tiledb_array_type_t array_type, const char** str) {
+  ensure_output_pointer_is_valid(str);
   const auto& strval =
       tiledb::sm::array_type_str((tiledb::sm::ArrayType)array_type);
   *str = strval.c_str();
@@ -57,6 +58,7 @@ capi_return_t tiledb_array_type_to_str(
 
 capi_return_t tiledb_array_type_from_str(
     const char* str, tiledb_array_type_t* array_type) {
+  ensure_output_pointer_is_valid(array_type);
   tiledb::sm::ArrayType val = tiledb::sm::ArrayType::DENSE;
   if (!tiledb::sm::array_type_enum(str, &val).ok()) {
     return TILEDB_ERR;
@@ -66,12 +68,14 @@ capi_return_t tiledb_array_type_from_str(
 }
 
 capi_return_t tiledb_layout_to_str(tiledb_layout_t layout, const char** str) {
+  ensure_output_pointer_is_valid(str);
   const auto& strval = tiledb::sm::layout_str((tiledb::sm::Layout)layout);
   *str = strval.c_str();
   return strval.empty() ? TILEDB_ERR : TILEDB_OK;
 }
 
 capi_return_t tiledb_layout_from_str(const char* str, tiledb_layout_t* layout) {
+  ensure_output_pointer_is_valid(layout);
   tiledb::sm::Layout val = tiledb::sm::Layout::ROW_MAJOR;
   if (!tiledb::sm::layout_enum(str, &val).ok()) {
     return TILEDB_ERR;


### PR DESCRIPTION
## Summary

Four public C API functions in `array_schema_api.cc` dereference their output pointer parameters without first validating them. Passing `null` for any of these output pointers causes a segfault rather than returning `TILEDB_ERR`:

- `tiledb_array_type_to_str`
- `tiledb_array_type_from_str`
- `tiledb_layout_to_str`
- `tiledb_layout_from_str`

The fix adds `ensure_output_pointer_is_valid()` to each function, matching the pattern used throughout the rest of the C API. The function immediately following these four in the same file (`tiledb_array_schema_alloc`) already uses this validation correctly.

## Test plan

- [ ] Confirm existing array schema C API tests still pass
- [ ] Manually verify that passing `null` to each affected function now returns `TILEDB_ERR` instead of segfaulting

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
TYPE: IMPROVEMENT
DESC: Added extra null pointer validation for a couple of APIs.